### PR TITLE
fix: add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to vscode-release

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 defaults:
   run:
     working-directory: editors/vscode


### PR DESCRIPTION
## Summary
- Add missing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var to vscode-release workflow
- This is required by GitHub Actions and was causing immediate "workflow file issue" failures

## Test plan
- [ ] Re-push vscode-v1.0.0 tag after merge to verify workflow runs