### PR TITLE
fix: bump engines.vscode to match @types/vscode

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
     "directory": "editors/vscode"
   },
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.115.0"
   },
   "icon": "icons/rocky-icon-128.png",
   "galleryBanner": {


### PR DESCRIPTION
Dependabot bumped @types/vscode to ^1.115.0 but engines.vscode was still at ^1.110.0, causing vsce package to fail.