### PR TITLE
chore: add author email to dagster-rocky

### DIFF
--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -5,7 +5,7 @@ description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-authors = [{ name = "Hugo Correia" }]
+authors = [{ name = "Hugo Correia", email = "hello@rocky-data.dev" }]
 keywords = ["dagster", "data-engineering", "sql", "transformation", "rocky", "dbt"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Add hello@rocky-data.dev as author email. Also triggers dagster-ci workflow registration.