### PR TITLE
fix: don't reference secrets in step-level if conditions

### DIFF
--- a/.github/workflows/engine-wasm-release.yml
+++ b/.github/workflows/engine-wasm-release.yml
@@ -107,7 +107,7 @@ jobs:
         working-directory: engine
 
       - name: Publish to npm
-        if: ${{ secrets.NPM_TOKEN != '' }}
+        if: env.NODE_AUTH_TOKEN != ''
         working-directory: engine/crates/rocky-wasm/pkg
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -70,5 +70,7 @@ jobs:
           files: editors/vscode/*.vsix
 
       - name: Publish to VS Code Marketplace
-        if: ${{ secrets.VSCE_PAT != '' }}
-        run: npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }}
+        if: env.VSCE_PAT != ''
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx @vscode/vsce publish --pat "$VSCE_PAT"


### PR DESCRIPTION
GitHub Actions disallows `secrets` context in step `if` conditions on public repos. Pass through env var instead. Fixes vscode-release and engine-wasm-release parse failures.