### PR TITLE
fix: scrub private paths and stale references

### DIFF
--- a/docs/src/content/docs/guides/ide-setup.md
+++ b/docs/src/content/docs/guides/ide-setup.md
@@ -24,7 +24,7 @@ npm install
 npm run compile
 ```
 
-Open the `rocky-vscode` folder in VS Code, then press **F5**. This launches a new VS Code window with the extension loaded. Changes to the TypeScript source are picked up on the next F5 launch.
+Open the `editors/vscode` folder in VS Code, then press **F5**. This launches a new VS Code window with the extension loaded. Changes to the TypeScript source are picked up on the next F5 launch.
 
 ### Method B: Install from VSIX
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -35,7 +35,7 @@ There are three ways to use this extension locally:
 This launches a separate VS Code window with the extension loaded.
 
 ```bash
-cd ~/Developer/rocky-vscode
+cd editors/vscode
 npm install
 npm run compile
 ```
@@ -63,7 +63,7 @@ To set this up, create `.vscode/launch.json`:
 Package the extension as a `.vsix` file and install it directly:
 
 ```bash
-cd ~/Developer/rocky-vscode
+cd editors/vscode
 npm install
 npm run compile
 npx @vscode/vsce package
@@ -88,7 +88,7 @@ npm run compile && npx @vscode/vsce package && code --install-extension rocky-0.
 Create a symlink from the VS Code extensions directory to your local clone:
 
 ```bash
-ln -s ~/Developer/rocky-vscode ~/.vscode/extensions/rocky-dev.rocky-0.1.0
+ln -s "$(pwd)/editors/vscode" ~/.vscode/extensions/rocky-dev.rocky-0.1.0
 ```
 
 Then restart VS Code. This is the least friction for iteration — changes to JSON files (grammar, snippets, language config) take effect on reload. TypeScript changes still require `npm run compile`.
@@ -112,7 +112,7 @@ Then restart VS Code. This is the least friction for iteration — changes to JS
 ## Project Structure
 
 ```
-rocky-vscode/
+editors/vscode/
 ├── package.json                    # Extension manifest
 ├── tsconfig.json                   # TypeScript config
 ├── language-configuration.json     # Brackets, comments, folding

--- a/examples/playground/CLAUDE.md
+++ b/examples/playground/CLAUDE.md
@@ -123,4 +123,4 @@ Credential-gated POCs should fail fast with a clear `: "${VAR:?Set VAR before ru
 
 - Match `../../engine/CLAUDE.md`: conventional commits (`feat:`, `fix:`, etc.), no `Co-Authored-By` trailers.
 - Scope by POC when relevant: `feat(02-performance/01-incremental-watermark): add seed delta`
-- Don't push to remote without explicit user confirmation. This directory is part of the `rocky-data/rocky` monorepo (private) on GitHub.
+- Don't push to remote without explicit user confirmation.

--- a/examples/playground/benchmarks/REPORT.md
+++ b/examples/playground/benchmarks/REPORT.md
@@ -362,7 +362,7 @@ To reproduce these exact results:
 
 ```bash
 # Build Rocky in release mode (must include commit 7fa9086 or later)
-cd ~/Developer/rocky-data/rocky
+cd engine
 git log --oneline | head -3   # confirm 7fa9086 is in history
 cargo build --release
 

--- a/scripts/build_rocky_linux.sh
+++ b/scripts/build_rocky_linux.sh
@@ -25,7 +25,7 @@
 #
 # Downstream consumers copy from vendor/rocky-linux-amd64 into their
 # own vendor/ directory:
-#   cp ~/Developer/rocky-data/vendor/rocky-linux-amd64 ./vendor/
+#   cp vendor/rocky-linux-amd64 /path/to/consumer/vendor/
 
 set -euo pipefail
 

--- a/scripts/lint-adapter-boundary.sh
+++ b/scripts/lint-adapter-boundary.sh
@@ -9,8 +9,7 @@
 #   - run.rs      — still uses rocky_databricks::batch for performance
 #                   optimisation (TODO: remove when batch is genericised)
 #
-# This enforces the boundary established by Plans 01 + 02 from
-# rocky-plans/rocky-improvements/ and prevents regression.
+# This enforces the adapter abstraction boundary and prevents regression.
 #
 # Usage: bash scripts/lint-adapter-boundary.sh
 # Exit 0 = clean, Exit 1 = forbidden imports found
@@ -45,7 +44,6 @@ if [ -n "$VIOLATIONS" ]; then
     echo "  - SqlDialect        (create_catalog_sql, create_schema_sql, ...)"
     echo
     echo "Trait definitions: engine/crates/rocky-core/src/traits.rs"
-    echo "See Plans 01 + 02 in rocky-plans/rocky-improvements/ for the refactoring pattern."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Remove references to private `rocky-plans/` directory from `scripts/lint-adapter-boundary.sh`
- Replace hardcoded `~/Developer/rocky-data/` and `~/Developer/rocky-vscode` paths with monorepo-relative paths in scripts and docs
- Remove stale "(private)" label from `examples/playground/CLAUDE.md`
- Update `editors/vscode/README.md` project structure and dev instructions to reflect monorepo layout

## Test plan

- [ ] `bash scripts/lint-adapter-boundary.sh` still runs correctly
- [ ] No remaining `~/Developer` or `rocky-plans` references in committed files (verified via `grep -r`)