### PR TITLE
chore: bump dependencies across all subprojects

### DIFF
--- a/editors/vscode/src/__tests__/driftDiagnostics.test.ts
+++ b/editors/vscode/src/__tests__/driftDiagnostics.test.ts
@@ -7,7 +7,7 @@ const mockDiagnosticCollection = {
   dispose: vi.fn(),
 };
 
-const mockSubscriptions: { push: ReturnType<typeof vi.fn> } = {
+const _mockSubscriptions: { push: ReturnType<typeof vi.fn> } = {
   push: vi.fn(),
 };
 


### PR DESCRIPTION
## Summary

- **Engine (Rust):** `toml` 0.8→1.1, `criterion` 0.7→0.8 (dev), `cargo update` (rayon 1.12, tokio 1.52, rand 0.9.4, axum 0.8.9, + transitive bumps). Fixed ~30 clippy warnings surfaced by updated toolchain (redundant closures, needless pass-by-value).
- **VS Code:** `@viz-js/viz` 3.25→3.26, `@vscode/vsce` 3.7→3.8
- **Dagster:** `uv lock --upgrade` — pydantic 2.12→2.13, rich 14→15, docstring-parser 0.17→0.18
- **CI:** `actions/checkout` v4→v6.0.2, `astral-sh/setup-uv` v7→v8.0.0, `extractions/setup-just` v3→v4.0.0

Supersedes the individual Dependabot PRs for rayon, toml, axum, indexmap, tokio, viz-js, vsce, checkout, setup-uv, and setup-just.

## Test plan

- [x] `cargo test` — 1,586 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `npm run compile && npm run test:unit` — 20 tests pass (vscode)
- [x] `uv run pytest -v` — 284 tests pass (dagster)
- [x] `npm audit` — 0 vulnerabilities (vscode)