### PR TITLE
fix(vscode): bundle vscode-languageclient in VSIX, bump 1.0.1

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,7 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
-node_modules/**
+node_modules/.package-lock.json
 tsconfig.json
 .gitignore
 **/*.ts

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] — 2026-04-14
+
+### Fixed
+
+- Fix extension failing to activate — `.vscodeignore` was stripping the `vscode-languageclient` runtime dependency from the VSIX package, causing a crash on `require("vscode-languageclient/node")` before `activate()` could run. No commands, output channel, or LSP client would register.
+- Add dedicated monochrome activity bar icon (`rocky-activity-bar.svg`) so the sidebar icon renders correctly with VS Code theme colors instead of showing a solid dark square.
+
 ## [1.0.0] — 2026-04-13
 
 ### Changed — Phase 2 schema codegen integration

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- `.vscodeignore` had `node_modules/**` which stripped `vscode-languageclient` (the sole runtime dependency) from the VSIX package. The extension crashed on `require("vscode-languageclient/node")` before `activate()` could run — no commands, no output channel, no LSP client.
- Replace the blanket exclusion with `node_modules/.package-lock.json` so `vsce` includes production dependencies (~1 MB) while excluding dev tooling.
- Bump version to 1.0.1, update CHANGELOG.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run compile` — passes
- [x] `npm run test:unit` — 20/20 pass
- [x] `npx vsce package` — VSIX now includes `node_modules/` (201 files, 1.06 MB)
- [ ] Install VSIX locally (`npm run install:local`) → extension activates, status bar shows "Rocky: Ready", commands available in palette