### PR TITLE
fix(vscode): use correct publisher ID in integration tests

### DIFF
--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -6,7 +6,7 @@ suite("Rocky Extension", () => {
     this.timeout(20000);
     // Activation is otherwise lazy (gated on .rocky files in the workspace),
     // which would leave commands unregistered for the assertions below.
-    const ext = vscode.extensions.getExtension("rocky-dev.rocky");
+    const ext = vscode.extensions.getExtension("rocky-data.rocky");
     if (ext && !ext.isActive) {
       await ext.activate();
     }


### PR DESCRIPTION
## Summary

- The integration test `suiteSetup` was calling `getExtension("rocky-dev.rocky")` but the publisher changed to `rocky-data`. The lookup returned `undefined`, silently skipped activation, and all 5 command-registration assertions failed.
- This has been the cause of the `vscode-ci` failures (`xvfb-run exit code 5`).

## Test plan

- [ ] `vscode-ci` workflow passes after merge