### PR TITLE
fix(engine): resolve clippy and fmt warnings

### DIFF
--- a/engine/crates/rocky-airbyte/src/adapter.rs
+++ b/engine/crates/rocky-airbyte/src/adapter.rs
@@ -144,7 +144,7 @@ mod tests {
             source_id: "src_test".into(),
             destination_id: "dst_test".into(),
             status,
-            namespace_format: namespace.map(|s| s.to_string()),
+            namespace_format: namespace.map(ToString::to_string),
             configurations: if streams.is_empty() {
                 None
             } else {

--- a/engine/crates/rocky-airbyte/src/client.rs
+++ b/engine/crates/rocky-airbyte/src/client.rs
@@ -257,10 +257,8 @@ mod tests {
 
     #[test]
     fn test_debug_hides_secrets() {
-        let client = AirbyteClient::new(
-            "https://api.airbyte.com".into(),
-            Some("secret_token_value".into()),
-        );
+        let client =
+            AirbyteClient::new("https://api.airbyte.com", Some("secret_token_value".into()));
         let debug = format!("{client:?}");
         assert!(!debug.contains("secret_token_value"));
         assert!(debug.contains("***"));

--- a/engine/crates/rocky-compiler/src/resolve.rs
+++ b/engine/crates/rocky-compiler/src/resolve.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_classify_bare_name_model() {
         let models: HashSet<String> = ["orders", "customers"]
             .iter()
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect();
         assert_eq!(
             classify_table_ref("orders", &models),
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_classify_bare_name_unknown() {
-        let models: HashSet<String> = ["orders"].iter().map(|s| s.to_string()).collect();
+        let models: HashSet<String> = ["orders"].iter().map(ToString::to_string).collect();
         assert_eq!(
             classify_table_ref("unknown_table", &models),
             TableRefKind::RawRef("unknown_table".to_string())

--- a/engine/crates/rocky-wasm/src/lib.rs
+++ b/engine/crates/rocky-wasm/src/lib.rs
@@ -70,9 +70,11 @@ pub fn get_parse_errors(source: &str) -> String {
                     found,
                     offset,
                 } => (*offset, expected.clone(), found.clone()),
-                rocky_lang::ParseError::UnexpectedEof { expected } => {
-                    (source.len().saturating_sub(1), expected.clone(), "EOF".to_string())
-                }
+                rocky_lang::ParseError::UnexpectedEof { expected } => (
+                    source.len().saturating_sub(1),
+                    expected.clone(),
+                    "EOF".to_string(),
+                ),
                 rocky_lang::ParseError::InvalidNumber { value } => {
                     (0, "valid number".to_string(), value.clone())
                 }


### PR DESCRIPTION
## Summary

- **rocky-airbyte**: replace redundant `|s| s.to_string()` closure with `ToString::to_string`, remove useless `.into()` on `&str`
- **rocky-compiler**: replace redundant closures with method references in test code
- **rocky-wasm**: reformat match arm to satisfy `rustfmt`

Fixes the `engine-ci` failures from clippy (`redundant_closure_for_method_calls`, `useless_conversion`) and `cargo fmt --check`.

## Test plan

- [ ] `engine-ci` passes (clippy + fmt + test)