### PR TITLE
fix(engine): resolve clippy warnings from Rust 1.94

### DIFF
--- a/engine/crates/rocky-cli/src/commands/export_schemas.rs
+++ b/engine/crates/rocky-cli/src/commands/export_schemas.rs
@@ -172,7 +172,7 @@ mod tests {
 
         let committed: HashSet<String> = std::fs::read_dir(&schemas_dir)
             .expect("reading schemas/ directory")
-            .filter_map(std::result::Result::ok)
+            .filter_map(Result::ok)
             .filter_map(|e| e.file_name().into_string().ok())
             .filter(|n| n.ends_with(".schema.json"))
             .collect();

--- a/engine/crates/rocky-core/src/schema.rs
+++ b/engine/crates/rocky-core/src/schema.rs
@@ -590,10 +590,7 @@ mod tests {
                 "tenant mismatch for {schema_name}"
             );
 
-            let regions: Vec<String> = expected_regions
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect();
+            let regions: Vec<String> = expected_regions.iter().map(ToString::to_string).collect();
             assert_eq!(
                 parsed.get_multiple("regions"),
                 Some(regions.as_slice()),


### PR DESCRIPTION
## Summary
- Remove `useless_conversion` (`.into()` on `&str` already matching parameter type) in rocky-iceberg client tests
- Replace `vec![...]` with array literals where the `Vec` is unnecessary (3 sites in rocky-iceberg adapter tests)
- Replace redundant closure `.map(|s| s.to_string())` with `.map(ToString::to_string)` in rocky-core schema tests
- Rename inner `mod tests` to `mod unit_tests` in rocky-core `tests.rs` to fix `module_inception` lint
- Replace `.filter_map(|e| e.ok())` with `.filter_map(Result::ok)` in rocky-cli export_schemas
- Replace `&[file.clone()]` with `std::slice::from_ref(&file)` in rocky-cli fmt tests (2 sites)

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `cargo test -p rocky-iceberg -p rocky-core -p rocky-cli` all pass