### PR TITLE
fix(engine): make --output global and add --stdio to lsp

### DIFF
--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -64,7 +64,7 @@ struct Cli {
     config: PathBuf,
 
     /// Output format
-    #[arg(short, long, default_value = "json")]
+    #[arg(short, long, default_value = "json", global = true)]
     output: OutputFormat,
 
     /// State store path
@@ -271,8 +271,8 @@ enum Command {
         #[arg(long, default_value = "models")]
         models: PathBuf,
         /// Output file path (default: docs/catalog.html)
-        #[arg(long, default_value = "docs/catalog.html")]
-        output: PathBuf,
+        #[arg(long = "output-path", default_value = "docs/catalog.html")]
+        output_path: PathBuf,
     },
 
     /// Show stored watermarks
@@ -427,7 +427,11 @@ enum Command {
     },
 
     /// Start Language Server Protocol server for IDE integration
-    Lsp,
+    Lsp {
+        /// Accept --stdio for compatibility (stdio is always the transport)
+        #[arg(long, hide = true)]
+        stdio: bool,
+    },
 
     /// Run local model tests via DuckDB (no warehouse needed)
     ///
@@ -862,9 +866,10 @@ async fn main() -> Result<()> {
         Command::Snapshot { pipeline, dry_run } => {
             rocky_cli::commands::run_snapshot(&cli.config, pipeline.as_deref(), dry_run, json).await
         }
-        Command::Docs { models, output } => {
-            rocky_cli::commands::run_docs(&cli.config, &models, &output, json)
-        }
+        Command::Docs {
+            models,
+            output_path,
+        } => rocky_cli::commands::run_docs(&cli.config, &models, &output_path, json),
         Command::State => rocky_cli::commands::state_show(&cli.state_path, json),
         Command::Compile {
             models,
@@ -955,7 +960,7 @@ async fn main() -> Result<()> {
             };
             rocky_cli::commands::run_serve(&models, contracts.as_deref(), config, port, watch).await
         }
-        Command::Lsp => rocky_cli::commands::run_lsp().await,
+        Command::Lsp { stdio: _ } => rocky_cli::commands::run_lsp().await,
         #[cfg(feature = "duckdb")]
         Command::Test {
             models,


### PR DESCRIPTION
## Summary

- Make the `--output` CLI flag `global = true` so it can appear after the subcommand name (e.g. `rocky history --output json` instead of requiring `rocky --output json history`). This fixes all VS Code extension commands that pass `--output` after the subcommand.
- Add a hidden `--stdio` flag to `rocky lsp` so the extension's stdio transport hint is accepted without error.
- Rename `rocky docs --output` to `--output-path` to avoid collision with the now-global `--output` flag.

## Context

The VS Code extension was completely broken -- the language server wouldn't start because:
1. `rocky history --output json` failed with "unexpected argument '--output'"
2. `rocky discover --output json` failed with "unexpected argument '--output'"
3. `rocky lsp --stdio` failed with "unexpected argument '--stdio'"

The root cause was that `--output` was defined on the parent `Cli` struct but clap requires parent-level args to appear *before* the subcommand unless `global = true` is set. The extension passes args after the subcommand name (e.g. `["history", "--output", "json"]`).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test -p rocky` passes
- [x] `cargo test -p rocky-cli` passes (110 tests)
- [ ] Manual: verify `rocky history --output json` no longer errors
- [ ] Manual: verify `rocky lsp --stdio` no longer errors
- [ ] Manual: verify VS Code extension starts successfully