### PR TITLE
feat(engine): add miette error reporting with span tracking and suggestions

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3152,8 +3152,11 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strsim",
  "tempfile",
+ "thiserror",
  "tokio",
+ "toml",
  "tracing",
 ]
 

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 miette = { workspace = true }
+thiserror = { workspace = true }
+strsim = { workspace = true }
 futures = { workspace = true }
 base64 = { workspace = true }
 notify = { workspace = true }
@@ -42,6 +44,7 @@ blake3 = { workspace = true }
 async-trait = { workspace = true }
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
+toml = { workspace = true }
 
 [[bench]]
 name = "compile"

--- a/engine/crates/rocky-cli/src/error_reporter.rs
+++ b/engine/crates/rocky-cli/src/error_reporter.rs
@@ -1,0 +1,208 @@
+//! Miette-based error reporter for rich CLI diagnostics.
+//!
+//! Converts `anyhow::Error` chains originating from `rocky-core` into
+//! [`miette::Diagnostic`] values with source spans, pointer annotations,
+//! and actionable suggestions.  Errors that don't carry span information
+//! fall through unchanged — the caller renders them with the default
+//! anyhow formatting.
+//!
+//! This module is the **only** place where `miette` types appear.  The
+//! library crates (`rocky-core`, adapters) stay on plain `thiserror` +
+//! `Option<Range<usize>>` spans; the conversion to `miette::SourceSpan`
+//! happens here.
+
+use std::path::Path;
+
+use miette::SourceSpan;
+use rocky_core::config::ConfigError;
+
+/// A miette-compatible diagnostic wrapping a Rocky config error with
+/// source context.
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[error("{message}")]
+pub struct ConfigDiagnostic {
+    message: String,
+
+    #[source_code]
+    src: miette::NamedSource<String>,
+
+    #[label("{label}")]
+    span: Option<SourceSpan>,
+
+    label: String,
+
+    #[help]
+    help: Option<String>,
+}
+
+/// Known adapter type names for "did you mean?" suggestions.
+pub const KNOWN_ADAPTER_TYPES: &[&str] = &[
+    "databricks",
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "fivetran",
+    "airbyte",
+    "iceberg",
+    "manual",
+];
+
+/// Attempt to convert an `anyhow::Error` into a rich [`ConfigDiagnostic`].
+///
+/// Walks the error chain looking for a [`ConfigError`]. If one is found
+/// **and** it carries enough context to produce a span-annotated
+/// diagnostic, returns `Some`. Otherwise returns `None` and the caller
+/// should fall through to the default anyhow rendering.
+pub fn try_upgrade_config_error(
+    err: &anyhow::Error,
+    config_path: &Path,
+) -> Option<ConfigDiagnostic> {
+    // Walk the chain — ConfigError may be wrapped behind one or more
+    // `.context()` layers.
+    let config_err = err.downcast_ref::<ConfigError>()?;
+
+    let source_text = std::fs::read_to_string(config_path).ok()?;
+    let named_source = miette::NamedSource::new(config_path.display().to_string(), source_text);
+
+    match config_err {
+        ConfigError::MissingEnvVar { name, span } => {
+            let miette_span = span.as_ref().map(|r| SourceSpan::from(r.start..r.end));
+
+            Some(ConfigDiagnostic {
+                message: format!("environment variable '{name}' is not set"),
+                src: named_source,
+                span: miette_span,
+                label: format!("${{{name}}} referenced here"),
+                help: Some(format!(
+                    "Add {name} to your shell environment or .env file, \
+                     or use a default: ${{{name}:-default_value}}"
+                )),
+            })
+        }
+        ConfigError::ParseToml(toml_err) => {
+            let miette_span = toml_err.span().map(|r| SourceSpan::from(r.start..r.end));
+
+            Some(ConfigDiagnostic {
+                message: format!("invalid TOML syntax: {toml_err}"),
+                src: named_source,
+                span: miette_span,
+                label: "parse error here".to_string(),
+                help: Some(
+                    "Check the TOML syntax — common mistakes include \
+                     missing quotes around strings, unclosed brackets, \
+                     or duplicate keys"
+                        .to_string(),
+                ),
+            })
+        }
+        // ReadFile and InvalidPattern don't have span info — let the
+        // caller fall through to standard anyhow rendering.
+        _ => None,
+    }
+}
+
+/// Find the best "did you mean?" suggestion for `input` among
+/// `candidates` using Jaro-Winkler similarity.
+///
+/// Returns `Some(candidate)` if the best match exceeds the threshold
+/// (0.8), otherwise `None`.
+pub fn did_you_mean<'a>(input: &str, candidates: &[&'a str]) -> Option<&'a str> {
+    let input_lower = input.to_lowercase();
+    candidates
+        .iter()
+        .map(|c| (*c, strsim::jaro_winkler(&input_lower, &c.to_lowercase())))
+        .filter(|(_, score)| *score > 0.8)
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|(candidate, _)| candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_env_var_produces_diagnostic() {
+        let err = ConfigError::MissingEnvVar {
+            name: "MY_TOKEN".to_string(),
+            span: Some(10..22),
+        };
+        let anyhow_err: anyhow::Error = err.into();
+
+        // Write a temp config to disk for the reporter to read.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        let config_text = r#"[adapter]
+token = "${MY_TOKEN}"
+type = "databricks"
+"#;
+        std::fs::write(&config_path, config_text).unwrap();
+
+        let diag = try_upgrade_config_error(&anyhow_err, &config_path);
+        assert!(
+            diag.is_some(),
+            "should produce a diagnostic for MissingEnvVar"
+        );
+        let diag = diag.unwrap();
+        assert!(diag.message.contains("MY_TOKEN"));
+        assert!(diag.help.as_ref().unwrap().contains(".env"));
+        assert!(diag.span.is_some());
+    }
+
+    #[test]
+    fn toml_parse_error_produces_diagnostic() {
+        let bad_toml = "[adapter\ntype = 'databricks'";
+        let toml_err = toml::from_str::<toml::Value>(bad_toml).unwrap_err();
+        let err: anyhow::Error = ConfigError::ParseToml(toml_err).into();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(&config_path, bad_toml).unwrap();
+
+        let diag = try_upgrade_config_error(&err, &config_path);
+        assert!(diag.is_some(), "should produce a diagnostic for ParseToml");
+        let diag = diag.unwrap();
+        assert!(diag.message.contains("TOML"));
+        assert!(diag.help.is_some());
+    }
+
+    #[test]
+    fn io_error_returns_none() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let err: anyhow::Error = ConfigError::ReadFile(io_err).into();
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let diag = try_upgrade_config_error(&err, &config_path);
+        assert!(diag.is_none(), "ReadFile should fall through to anyhow");
+    }
+
+    #[test]
+    fn did_you_mean_finds_close_match() {
+        assert_eq!(
+            did_you_mean("databrik", KNOWN_ADAPTER_TYPES),
+            Some("databricks")
+        );
+        assert_eq!(did_you_mean("duckbd", KNOWN_ADAPTER_TYPES), Some("duckdb"));
+        assert_eq!(
+            did_you_mean("snowflak", KNOWN_ADAPTER_TYPES),
+            Some("snowflake")
+        );
+    }
+
+    #[test]
+    fn did_you_mean_returns_none_for_distant() {
+        assert_eq!(did_you_mean("postgres", KNOWN_ADAPTER_TYPES), None);
+        assert_eq!(did_you_mean("zzzzzzz", KNOWN_ADAPTER_TYPES), None);
+    }
+
+    #[test]
+    fn did_you_mean_case_insensitive() {
+        assert_eq!(
+            did_you_mean("DATABRICKS", KNOWN_ADAPTER_TYPES),
+            Some("databricks")
+        );
+        assert_eq!(did_you_mean("DuckDB", KNOWN_ADAPTER_TYPES), Some("duckdb"));
+    }
+}

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod error_reporter;
 pub mod output;
 pub mod pipes;
 pub mod registry;

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use tracing::warn;
 
+use crate::error_reporter;
+
 use rocky_core::config::{AdapterConfig, RockyConfig};
 use rocky_core::traits::{DiscoveryAdapter, WarehouseAdapter};
 
@@ -261,9 +263,17 @@ impl AdapterRegistry {
                     warehouse.insert(name.clone(), Arc::new(adapter));
                 }
                 other => {
-                    bail!(
-                        "adapters.{name}: unsupported adapter type '{other}'. Supported: databricks, duckdb, snowflake, bigquery, fivetran, airbyte, iceberg, manual"
+                    let mut msg = format!(
+                        "adapters.{name}: unsupported adapter type '{other}'. \
+                         Supported: databricks, duckdb, snowflake, bigquery, \
+                         fivetran, airbyte, iceberg, manual"
                     );
+                    if let Some(suggestion) =
+                        error_reporter::did_you_mean(other, error_reporter::KNOWN_ADAPTER_TYPES)
+                    {
+                        msg.push_str(&format!(". Did you mean '{suggestion}'?"));
+                    }
+                    bail!(msg);
                 }
             }
         }
@@ -342,11 +352,18 @@ pub fn resolve_pipeline<'a>(
 ) -> Result<(&'a str, &'a rocky_core::config::PipelineConfig)> {
     match pipeline_name {
         Some(name) => {
-            let pipeline = config
-                .pipelines
-                .get(name)
-                .context(format!("pipeline '{name}' not found in config"))?;
-            Ok((name, pipeline))
+            let pipeline = config.pipelines.get(name);
+            match pipeline {
+                Some(p) => Ok((name, p)),
+                None => {
+                    let known: Vec<&str> = config.pipelines.keys().map(String::as_str).collect();
+                    let mut msg = format!("pipeline '{name}' not found in config");
+                    if let Some(suggestion) = error_reporter::did_you_mean(name, &known) {
+                        msg.push_str(&format!(". Did you mean '{suggestion}'?"));
+                    }
+                    bail!(msg)
+                }
+            }
         }
         None => {
             if config.pipelines.len() == 1 {

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -154,7 +154,12 @@ pub enum ConfigError {
     ParseToml(#[from] toml::de::Error),
 
     #[error("environment variable '{name}' not set (referenced in config)")]
-    MissingEnvVar { name: String },
+    MissingEnvVar {
+        name: String,
+        /// Byte range of the `${VAR}` placeholder in the raw config file.
+        /// Used by the CLI error reporter to render source spans.
+        span: Option<std::ops::Range<usize>>,
+    },
 
     #[error("invalid schema pattern: {0}")]
     InvalidPattern(#[from] crate::schema::SchemaError),
@@ -593,49 +598,66 @@ static ENV_VAR_RE: LazyLock<Regex> =
 /// - `${VAR:-fallback}` — uses `fallback` if VAR is not set or empty
 pub fn substitute_env_vars(input: &str) -> Result<String, ConfigError> {
     let re = &*ENV_VAR_RE;
-    let mut output_lines = Vec::new();
-    let mut errors = Vec::new();
+    let mut result = String::with_capacity(input.len());
+    let mut last_end = 0;
+    // Track the first missing env var and its byte span for diagnostics.
+    let mut first_missing: Option<(String, std::ops::Range<usize>)> = None;
 
-    for line in input.lines() {
-        // Skip TOML comment lines — don't substitute env vars in comments
-        if line.trim_start().starts_with('#') {
-            output_lines.push(line.to_string());
+    for cap in re.captures_iter(input) {
+        let full_match = cap.get(0).expect("capture group 0 always exists");
+        let match_start = full_match.start();
+        let match_end = full_match.end();
+
+        // Check if this match is inside a TOML comment line — find the line
+        // containing this match and skip if it starts with '#'.
+        let line_start = input[..match_start].rfind('\n').map_or(0, |p| p + 1);
+        if input[line_start..].trim_start().starts_with('#') {
+            // Inside a comment — copy verbatim and skip substitution.
+            result.push_str(&input[last_end..match_end]);
+            last_end = match_end;
             continue;
         }
 
-        let mut result_line = line.to_string();
-        for cap in re.captures_iter(line) {
-            let expr = &cap[1];
+        // Copy everything between the last match and this one.
+        result.push_str(&input[last_end..match_start]);
 
-            if let Some(sep_pos) = expr.find(":-") {
-                let var_name = &expr[..sep_pos];
-                let default_value = &expr[sep_pos + 2..];
-                let value = std::env::var(var_name)
-                    .ok()
-                    .filter(|v| !v.is_empty())
-                    .unwrap_or_else(|| default_value.to_string());
-                result_line = result_line.replace(&cap[0], &value);
-            } else {
-                match std::env::var(expr) {
-                    Ok(value) => {
-                        result_line = result_line.replace(&cap[0], &value);
+        let expr = &cap[1];
+        if let Some(sep_pos) = expr.find(":-") {
+            let var_name = &expr[..sep_pos];
+            let default_value = &expr[sep_pos + 2..];
+            let value = std::env::var(var_name)
+                .ok()
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| default_value.to_string());
+            result.push_str(&value);
+        } else {
+            match std::env::var(expr) {
+                Ok(value) => {
+                    result.push_str(&value);
+                }
+                Err(_) => {
+                    if first_missing.is_none() {
+                        first_missing = Some((expr.to_string(), match_start..match_end));
                     }
-                    Err(_) => {
-                        errors.push(expr.to_string());
-                    }
+                    // Keep the placeholder verbatim so the rest of the string
+                    // stays intact for context.
+                    result.push_str(&input[match_start..match_end]);
                 }
             }
         }
-        output_lines.push(result_line);
+        last_end = match_end;
     }
 
-    if let Some(first_missing) = errors.into_iter().next() {
+    if let Some((name, span)) = first_missing {
         return Err(ConfigError::MissingEnvVar {
-            name: first_missing,
+            name,
+            span: Some(span),
         });
     }
 
-    Ok(output_lines.join("\n"))
+    // Copy the tail of the input after the last match.
+    result.push_str(&input[last_end..]);
+    Ok(result)
 }
 
 // ===========================================================================

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -715,7 +715,9 @@ async fn main() -> Result<()> {
     // Init structured logging (JSON when output is JSON, human-readable otherwise)
     rocky_observe::tracing_setup::init_tracing(json);
 
-    match cli.command {
+    let config_path = cli.config.clone();
+
+    let result: Result<()> = match cli.command {
         Command::Init { path, template } => rocky_cli::commands::init(&path, Some(&template)),
         Command::Validate => rocky_cli::commands::validate(&cli.config, json),
         Command::Discover { pipeline } => {
@@ -1108,7 +1110,23 @@ async fn main() -> Result<()> {
         }
         Command::Fmt { paths, check } => rocky_cli::commands::run_fmt(&paths, check),
         Command::ExportSchemas { output } => rocky_cli::commands::export_schemas(&output),
+    };
+
+    // In text mode, try to upgrade config errors to rich miette diagnostics
+    // with source spans and suggestions. JSON mode returns structured errors
+    // unchanged for orchestrators (e.g., Dagster).
+    if let Err(ref err) = result {
+        if !json {
+            if let Some(diagnostic) =
+                rocky_cli::error_reporter::try_upgrade_config_error(err, &config_path)
+            {
+                eprintln!("{:?}", miette::Report::new(diagnostic));
+                std::process::exit(1);
+            }
+        }
     }
+
+    result
 }
 
 /// Waits for SIGTERM (K8s pod termination) or SIGINT (Ctrl+C).


### PR DESCRIPTION
## Summary

- Add `error_reporter` module to `rocky-cli` that converts `anyhow::Error` chains into rich miette diagnostics with source spans, pointer annotations, and actionable suggestions
- Extend `ConfigError::MissingEnvVar` with optional byte span for precise source location
- Rewrite `substitute_env_vars` to track byte offsets of `${VAR}` placeholders (whole-string iteration instead of line-by-line)
- Add "Did you mean?" suggestions (Jaro-Winkler) for unknown adapter types and pipeline names
- Wire error reporter into `main.rs` — intercepts errors before anyhow's default rendering (text mode only, JSON output unchanged)

## What it looks like

For a missing env var in `rocky.toml`:
```
  x environment variable 'MY_TOKEN' is not set
   ,-[rocky.toml:2:1]
 2 | token = "${MY_TOKEN}"
   :          ^^^^^^^^^^^^ ${MY_TOKEN} referenced here
   `----
  help: Add MY_TOKEN to your shell environment or .env file,
        or use a default: ${MY_TOKEN:-default_value}
```

For a TOML syntax error:
```
  x invalid TOML syntax: expected `.`, `## `, or `]`
   ,-[rocky.toml:1:1]
 1 | [adapter
   :         ^ parse error here
   `----
  help: Check the TOML syntax -- common mistakes include
        missing quotes around strings, unclosed brackets,
        or duplicate keys
```

For an unknown adapter type:
```
Error: adapters.default: unsupported adapter type 'databrik'.
Supported: databricks, duckdb, snowflake, bigquery, fivetran,
airbyte, iceberg, manual. Did you mean 'databricks'?
```

## Key constraints

- **JSON mode unchanged** — `--output json` still returns structured errors for orchestrators (Dagster)
- **No miette in rocky-core** — library crates stay on `thiserror` + `Option<Range<usize>>`; miette types only appear in the CLI layer
- **Non-breaking** — `ConfigError::MissingEnvVar` gains an optional `span` field; existing match arms using `{ .. }` are unaffected

## Test plan

- [x] 6 new unit tests in `error_reporter::tests` covering: MissingEnvVar diagnostic, TOML parse diagnostic, IO error fallthrough, did-you-mean close/distant/case-insensitive
- [x] All 76 existing config tests pass (including env var substitution)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Full `cargo test` suite passes (all crates, 0 failures)