### PR TITLE
fix(vscode): extract model name correctly for CLI commands

### DIFF
--- a/editors/vscode/src/commands/inspect.ts
+++ b/editors/vscode/src/commands/inspect.ts
@@ -1,13 +1,18 @@
 import * as vscode from "vscode";
 import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
 import type { HistoryResult, MetricsResult } from "../types/rockyJson";
-import { ensureWorkspace, promptForInput, showJsonInEditor } from "./ui";
+import {
+  ensureWorkspace,
+  promptForInput,
+  resolveModelName,
+  showJsonInEditor,
+} from "./ui";
 
-export async function history(modelArg?: string): Promise<void> {
+export async function history(modelArg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
   const model =
-    modelArg ??
+    resolveModelName(modelArg) ??
     (await promptForInput(
       "Filter to a specific model (leave empty for all runs)",
       { placeHolder: "e.g., customer_orders" },
@@ -33,11 +38,11 @@ export async function history(modelArg?: string): Promise<void> {
   }
 }
 
-export async function metrics(modelArg?: string): Promise<void> {
+export async function metrics(modelArg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
   const model =
-    modelArg ??
+    resolveModelName(modelArg) ??
     (await promptForInput("Model to inspect", {
       placeHolder: "e.g., fct_daily_revenue",
       required: true,

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -3,17 +3,23 @@ import * as vscode from "vscode";
 import { getWorkspaceFolder } from "../config";
 import { getExtensionUri } from "../extensionState";
 import { runRocky } from "../rockyCli";
+import { resolveModelName } from "./ui";
 
-export async function showLineage(): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    vscode.window.showWarningMessage("Open a Rocky model file first.");
-    return;
+export async function showLineage(arg?: unknown): Promise<void> {
+  // When invoked from the tree-view context menu, `arg` is a ModelTreeItem.
+  // When invoked from the command palette, fall back to the active editor.
+  let modelName = resolveModelName(arg);
+
+  if (!modelName) {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showWarningMessage("Open a Rocky model file first.");
+      return;
+    }
+    modelName = path
+      .basename(editor.document.fileName)
+      .replace(/\.(rocky|sql)$/, "");
   }
-
-  const modelName = path
-    .basename(editor.document.fileName)
-    .replace(/\.(rocky|sql)$/, "");
   if (!modelName) return;
 
   const workspaceFolder = getWorkspaceFolder();

--- a/editors/vscode/src/commands/ops.ts
+++ b/editors/vscode/src/commands/ops.ts
@@ -6,7 +6,7 @@ import {
 } from "../rockyCli";
 import type { DoctorResult } from "../types/rockyJson";
 import { showDoctorResult } from "../webviews/doctor";
-import { ensureWorkspace, showJsonInEditor } from "./ui";
+import { ensureWorkspace, resolveModelName, showJsonInEditor } from "./ui";
 
 export async function doctor(): Promise<void> {
   if (!ensureWorkspace()) return;
@@ -23,11 +23,11 @@ export async function doctor(): Promise<void> {
   }
 }
 
-export async function optimize(modelArg?: string): Promise<void> {
+export async function optimize(modelArg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
   const model =
-    modelArg ??
+    resolveModelName(modelArg) ??
     (await vscode.window.showInputBox({
       prompt: "Model to analyze (leave empty for all)",
       placeHolder: "e.g., customer_orders",

--- a/editors/vscode/src/commands/test.ts
+++ b/editors/vscode/src/commands/test.ts
@@ -2,18 +2,18 @@ import * as vscode from "vscode";
 import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
 import { getOutputChannel } from "../output";
 import type { TestResult } from "../types/rockyJson";
-import { ensureWorkspace, promptForInput } from "./ui";
+import { ensureWorkspace, promptForInput, resolveModelName } from "./ui";
 
 /**
  * Phase 2: simple shell-out that surfaces a pass/fail toast and writes failure
  * detail to the output channel. Phase 3 will replace this with a real Test
  * Explorer integration backed by `vscode.tests.createTestController`.
  */
-export async function test(modelArg?: string): Promise<void> {
+export async function test(modelArg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
   const model =
-    modelArg ??
+    resolveModelName(modelArg) ??
     (await promptForInput(
       "Filter to a specific model (leave empty for all)",
       { placeHolder: "e.g., customer_orders" },

--- a/editors/vscode/src/commands/ui.ts
+++ b/editors/vscode/src/commands/ui.ts
@@ -67,6 +67,29 @@ export function ensureWorkspace(): boolean {
 }
 
 /**
+ * Extract a model name from the argument passed to a command handler.
+ *
+ * When a command fires from a tree-view context menu, VS Code passes the
+ * TreeItem object — not a string. This normaliser handles:
+ *  - string argument (returned as-is)
+ *  - object with a `label` string property (e.g. ModelTreeItem)
+ *  - undefined / null / anything else → undefined (so the caller can fall
+ *    back to an input box or the active editor)
+ */
+export function resolveModelName(arg: unknown): string | undefined {
+  if (typeof arg === "string" && arg.length > 0) return arg;
+  if (
+    arg != null &&
+    typeof arg === "object" &&
+    "label" in arg &&
+    typeof (arg as Record<string, unknown>).label === "string"
+  ) {
+    return (arg as Record<string, unknown>).label as string;
+  }
+  return undefined;
+}
+
+/**
  * Prompt the user with an input box and validate emptiness.
  * Returns undefined when the user cancels or the input is blank.
  */


### PR DESCRIPTION
## Summary

- **Bug 1 (lineage):** When invoked from the models tree-view context menu, `showLineage` ignored the `ModelTreeItem` argument and fell back to the active editor's file name. If the active "editor" was the output channel, this produced garbage like `extension-output-rocky-data.rocky-#2-Rocky` as the model name.
- **Bug 2 ([object Object]):** `history`, `metrics`, `test`, and `optimize` accepted a `string` parameter but received a `ModelTreeItem` object from the context menu, which `.toString()`-ed to `[object Object]` and was passed as the `--model` flag.
- **Fix:** Added `resolveModelName()` helper in `ui.ts` that normalises the command argument (string passthrough, `object.label` extraction, or `undefined` fallback). All five affected command handlers now use it.

## Test plan

- [x] `npm run compile` passes with no errors
- [x] `npm run test:unit` passes (20/20 tests)
- [ ] Manual: right-click a model in the sidebar tree view and invoke Lineage, Test, History, Metrics, Optimize — verify the correct model name is passed to the CLI
- [ ] Manual: invoke the same commands from the command palette with no file open — verify the input prompt still appears