### PR TITLE
fix(engine): make --filter optional for plan/run/compare

### DIFF
--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -22,7 +22,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn compare(
     config_path: &Path,
-    filter: &str,
+    filter: Option<&str>,
     pipeline_name_arg: Option<&str>,
     shadow_config: &ShadowConfig,
     thresholds: &ComparisonThresholds,
@@ -38,7 +38,7 @@ pub async fn compare(
     let adapter = registry.warehouse_adapter(&pipeline.target.adapter)?;
 
     let pattern = pipeline.schema_pattern()?;
-    let (filter_key, filter_value) = parse_filter(filter)?;
+    let parsed_filter = filter.map(parse_filter).transpose()?;
 
     // Discover connectors to find table pairs
     let connectors = if let Some(ref disc) = pipeline.source.discovery {
@@ -57,7 +57,7 @@ pub async fn compare(
     let mut output = CompareOutput {
         version: VERSION.to_string(),
         command: "compare".to_string(),
-        filter: filter.to_string(),
+        filter: filter.unwrap_or("").to_string(),
         tables_compared: 0,
         tables_passed: 0,
         tables_warned: 0,
@@ -72,8 +72,10 @@ pub async fn compare(
             Err(_) => continue,
         };
 
-        if !matches_filter(conn, &parsed, &filter_key, &filter_value) {
-            continue;
+        if let Some((ref filter_key, ref filter_value)) = parsed_filter {
+            if !matches_filter(conn, &parsed, filter_key, filter_value) {
+                continue;
+            }
         }
 
         let target_sep = pipeline

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -13,7 +13,7 @@ use super::{matches_filter, parse_filter};
 /// Execute `rocky plan` — dry-run SQL generation.
 pub async fn plan(
     config_path: &Path,
-    filter: &str,
+    filter: Option<&str>,
     pipeline_name: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
@@ -23,7 +23,7 @@ pub async fn plan(
     ))?;
     let (_name, pipeline) = registry::resolve_replication_pipeline(&rocky_cfg, pipeline_name)?;
     let pattern = pipeline.schema_pattern()?;
-    let (filter_key, filter_value) = parse_filter(filter)?;
+    let parsed_filter = filter.map(parse_filter).transpose()?;
 
     let adapter_registry = registry::AdapterRegistry::from_config(&rocky_cfg)?;
     let warehouse_adapter = adapter_registry.warehouse_adapter(&pipeline.target.adapter)?;
@@ -39,7 +39,7 @@ pub async fn plan(
         anyhow::bail!("no discovery adapter configured for this pipeline")
     };
 
-    let mut output = PlanOutput::new(filter.to_string());
+    let mut output = PlanOutput::new(filter.unwrap_or("").to_string());
 
     // Detect whether this dialect supports catalogs. Dialects without catalog
     // support (DuckDB, Postgres, ...) return `None` from `create_catalog_sql`,
@@ -53,8 +53,10 @@ pub async fn plan(
             Err(_) => continue,
         };
 
-        if !matches_filter(conn, &parsed, &filter_key, &filter_value) {
-            continue;
+        if let Some((ref filter_key, ref filter_value)) = parsed_filter {
+            if !matches_filter(conn, &parsed, filter_key, filter_value) {
+                continue;
+            }
         }
 
         let target_sep = pipeline

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -196,7 +196,7 @@ impl<'a> ExecutionContext<'a> {
 #[tracing::instrument(skip_all, name = "run")]
 pub async fn run(
     config_path: &Path,
-    filter: &str,
+    filter: Option<&str>,
     pipeline_name_arg: Option<&str>,
     state_path: &Path,
     governance_override: Option<&GovernanceOverride>,
@@ -274,7 +274,7 @@ pub async fn run(
     // instead of batched queries.
 
     let pattern = pipeline.schema_pattern()?;
-    let (filter_key, filter_value) = parse_filter(filter)?;
+    let parsed_filter = filter.map(parse_filter).transpose()?;
 
     // Download state from remote storage (S3/Valkey) if configured
     if let Err(e) = rocky_core::state_sync::download_state(&rocky_cfg.state, state_path) {
@@ -341,7 +341,7 @@ pub async fn run(
     .await?;
 
     let concurrency = pipeline.execution.concurrency.max(1);
-    let mut output = RunOutput::new(filter.to_string(), 0, concurrency);
+    let mut output = RunOutput::new(filter.unwrap_or("").to_string(), 0, concurrency);
     output.shadow = shadow_config.is_some();
     let mut catalogs_created: usize = 0;
     let mut schemas_created: usize = 0;
@@ -377,8 +377,10 @@ pub async fn run(
                 Err(_) => continue,
             };
 
-            if !matches_filter(conn, &parsed, &filter_key, &filter_value) {
-                continue;
+            if let Some((ref filter_key, ref filter_value)) = parsed_filter {
+                if !matches_filter(conn, &parsed, filter_key, filter_value) {
+                    continue;
+                }
             }
 
             let components = parsed_to_json_map(&parsed);

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -133,7 +133,7 @@ enum Command {
     Plan {
         /// Filter sources by component value (e.g., --filter client=acme)
         #[arg(long, long_help = FILTER_LONG_HELP)]
-        filter: String,
+        filter: Option<String>,
         /// Pipeline name (required if multiple pipelines are defined)
         #[arg(long)]
         pipeline: Option<String>,
@@ -143,7 +143,7 @@ enum Command {
     Run {
         /// Filter sources by component value (e.g., --filter client=acme)
         #[arg(long, long_help = FILTER_LONG_HELP)]
-        filter: String,
+        filter: Option<String>,
         /// Pipeline name (required if multiple pipelines are defined)
         #[arg(long)]
         pipeline: Option<String>,
@@ -208,7 +208,7 @@ enum Command {
     Compare {
         /// Filter sources by component value (e.g., --filter client=acme)
         #[arg(long, long_help = FILTER_LONG_HELP)]
-        filter: String,
+        filter: Option<String>,
         /// Pipeline name (required if multiple pipelines are defined)
         #[arg(long)]
         pipeline: Option<String>,
@@ -724,7 +724,8 @@ async fn main() -> Result<()> {
             rocky_cli::commands::discover(&cli.config, pipeline.as_deref(), json).await
         }
         Command::Plan { filter, pipeline } => {
-            rocky_cli::commands::plan(&cli.config, &filter, pipeline.as_deref(), json).await
+            rocky_cli::commands::plan(&cli.config, filter.as_deref(), pipeline.as_deref(), json)
+                .await
         }
         Command::Run {
             filter,
@@ -785,7 +786,7 @@ async fn main() -> Result<()> {
 
             let run_future = rocky_cli::commands::run(
                 &cli.config,
-                &filter,
+                filter.as_deref(),
                 pipeline.as_deref(),
                 &cli.state_path,
                 gov_override.as_ref(),
@@ -825,7 +826,7 @@ async fn main() -> Result<()> {
             };
             rocky_cli::commands::compare(
                 &cli.config,
-                &filter,
+                filter.as_deref(),
                 pipeline.as_deref(),
                 &shadow_cfg,
                 &thresholds,


### PR DESCRIPTION
## Summary
- Make `--filter` optional (`Option<String>`) on `rocky plan`, `rocky run`, and `rocky compare` commands
- When omitted, all discovered sources are processed (replication pipelines) or all models are executed (transformation/quality/snapshot pipelines)
- Transformation pipelines already dispatch before filter parsing, so they never needed `--filter` — but clap enforced it as required
- Verified that tracing already writes to stderr via `.with_writer(std::io::stderr)` in `rocky-observe/src/tracing_setup.rs` — no fix needed there

## Changed files
- `engine/rocky/src/main.rs` — `filter: String` → `filter: Option<String>` in `Plan`, `Run`, `Compare` variants
- `engine/crates/rocky-cli/src/commands/plan.rs` — `filter: &str` → `filter: Option<&str>`, conditional filtering
- `engine/crates/rocky-cli/src/commands/run.rs` — same treatment
- `engine/crates/rocky-cli/src/commands/compare.rs` — same treatment

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (all 1,717 tests)
- [x] `cargo fmt -- --check` passes
- [ ] Manual: `rocky run --config rocky.toml` without `--filter` executes all models in a transformation pipeline
- [ ] Manual: `rocky run --config rocky.toml --filter client=acme` still works for replication pipelines