### PR TITLE
feat(engine): friendly error when rocky.toml is missing

### DIFF
--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -26,9 +26,14 @@ pub fn validate(config_path: &Path, json: bool) -> Result<()> {
 fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
     let mut out = ValidateOutput::new();
 
-    // Check file exists
+    // Check file exists. Return the typed ConfigError so the CLI
+    // error reporter can upgrade it to a rich miette diagnostic with
+    // `rocky init` / `rocky playground` hints.
     if !config_path.exists() {
-        anyhow::bail!("Config file not found: {}", config_path.display());
+        return Err(rocky_core::config::ConfigError::FileNotFound {
+            path: config_path.to_path_buf(),
+        }
+        .into());
     }
 
     // Parse config (with env var substitution)

--- a/engine/crates/rocky-cli/src/error_reporter.rs
+++ b/engine/crates/rocky-cli/src/error_reporter.rs
@@ -18,13 +18,17 @@ use rocky_core::config::ConfigError;
 
 /// A miette-compatible diagnostic wrapping a Rocky config error with
 /// source context.
+///
+/// The `src` field is optional so that errors which happen before the
+/// config file can be read (e.g., [`ConfigError::FileNotFound`]) can still
+/// render a friendly message and help section without a source snippet.
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 #[error("{message}")]
 pub struct ConfigDiagnostic {
     message: String,
 
     #[source_code]
-    src: miette::NamedSource<String>,
+    src: Option<miette::NamedSource<String>>,
 
     #[label("{label}")]
     span: Option<SourceSpan>,
@@ -61,6 +65,21 @@ pub fn try_upgrade_config_error(
     // `.context()` layers.
     let config_err = err.downcast_ref::<ConfigError>()?;
 
+    if let ConfigError::FileNotFound { path } = config_err {
+        return Some(ConfigDiagnostic {
+            message: format!("No rocky.toml found at '{}'", path.display()),
+            src: None,
+            span: None,
+            label: String::new(),
+            help: Some(
+                "Run `rocky init` to create a new project, or use `--config <path>` \
+                 to specify a config file.\n\
+                 Run `rocky playground` to try Rocky with a sample DuckDB project."
+                    .to_string(),
+            ),
+        });
+    }
+
     let source_text = std::fs::read_to_string(config_path).ok()?;
     let named_source = miette::NamedSource::new(config_path.display().to_string(), source_text);
 
@@ -70,7 +89,7 @@ pub fn try_upgrade_config_error(
 
             Some(ConfigDiagnostic {
                 message: format!("environment variable '{name}' is not set"),
-                src: named_source,
+                src: Some(named_source),
                 span: miette_span,
                 label: format!("${{{name}}} referenced here"),
                 help: Some(format!(
@@ -84,7 +103,7 @@ pub fn try_upgrade_config_error(
 
             Some(ConfigDiagnostic {
                 message: format!("invalid TOML syntax: {toml_err}"),
-                src: named_source,
+                src: Some(named_source),
                 span: miette_span,
                 label: "parse error here".to_string(),
                 help: Some(
@@ -97,6 +116,7 @@ pub fn try_upgrade_config_error(
         }
         // ReadFile and InvalidPattern don't have span info — let the
         // caller fall through to standard anyhow rendering.
+        // FileNotFound is handled above.
         _ => None,
     }
 }
@@ -176,6 +196,41 @@ type = "databricks"
 
         let diag = try_upgrade_config_error(&err, &config_path);
         assert!(diag.is_none(), "ReadFile should fall through to anyhow");
+    }
+
+    #[test]
+    fn file_not_found_produces_diagnostic_without_source() {
+        let missing_path = std::path::PathBuf::from("/definitely/not/real/rocky.toml");
+        let err: anyhow::Error = ConfigError::FileNotFound {
+            path: missing_path.clone(),
+        }
+        .into();
+
+        let diag = try_upgrade_config_error(&err, &missing_path);
+        assert!(
+            diag.is_some(),
+            "should produce a diagnostic for FileNotFound even when the file cannot be read"
+        );
+        let diag = diag.unwrap();
+        assert!(diag.message.contains("No rocky.toml found"));
+        assert!(diag.message.contains("/definitely/not/real/rocky.toml"));
+        let help = diag.help.as_ref().unwrap();
+        assert!(help.contains("rocky init"));
+        assert!(help.contains("rocky playground"));
+        assert!(help.contains("--config"));
+        assert!(diag.src.is_none());
+        assert!(diag.span.is_none());
+    }
+
+    #[test]
+    fn load_rocky_config_returns_file_not_found_for_missing_path() {
+        use rocky_core::config::load_rocky_config;
+        let missing = std::path::PathBuf::from("/definitely/not/real/rocky.toml");
+        let err = load_rocky_config(&missing).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::FileNotFound { .. }),
+            "expected FileNotFound, got: {err:?}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use indexmap::IndexMap;
@@ -147,6 +147,9 @@ fn navigate_to_table_mut<'a>(
 /// Errors from loading and parsing pipeline configuration.
 #[derive(Debug, Error)]
 pub enum ConfigError {
+    #[error("No rocky.toml found at '{}'", .path.display())]
+    FileNotFound { path: PathBuf },
+
     #[error("failed to read config file: {0}")]
     ReadFile(#[from] std::io::Error),
 
@@ -1436,7 +1439,15 @@ pub struct PipelineTargetConfig {
 /// deprecation warnings programmatically (e.g., `rocky doctor`, `rocky
 /// validate`) can use [`check_config_deprecations`] on the raw TOML string.
 pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
-    let raw = std::fs::read_to_string(path)?;
+    let raw = std::fs::read_to_string(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            ConfigError::FileNotFound {
+                path: path.to_path_buf(),
+            }
+        } else {
+            ConfigError::ReadFile(e)
+        }
+    })?;
     let substituted = substitute_env_vars(&raw)?;
     let mut value: toml::Value = toml::from_str(&substituted)?;
     apply_deprecations(&mut value);


### PR DESCRIPTION
## Summary

Addresses #20. When a user runs a `rocky` command without a `rocky.toml` in the current directory (or the path passed via `--config`), they now get an actionable error pointing at the right next step instead of a bare "file not found".

Before:
```
Error: Config file not found: rocky.toml
```

After (text mode):
```
  × No rocky.toml found at 'rocky.toml'
  help: Run `rocky init` to create a new project, or use `--config <path>` to
        specify a config file.
        Run `rocky playground` to try Rocky with a sample DuckDB project.
```

JSON mode keeps the compact `Error: No rocky.toml found at 'rocky.toml'` form so orchestrators (Dagster) still see a stable, structured error.

## Changes

- **rocky-core**: add `ConfigError::FileNotFound { path }` variant. `load_rocky_config` now maps `io::ErrorKind::NotFound` to this variant, leaving other IO errors on `ReadFile`.
- **rocky-cli (error_reporter)**: `ConfigDiagnostic::src` is now `Option<NamedSource>` so the diagnostic can render without a file to read. A new match arm turns `FileNotFound` into a miette diagnostic with the `init` / `--config` / `playground` hints.
- **rocky-cli (validate)**: the hardcoded `anyhow::bail!("Config file not found: ...")` becomes a `ConfigError::FileNotFound` return so the reporter can upgrade it consistently with every other config error.

## Test plan

- [x] `cargo test -p rocky-core -p rocky-cli` — 889 tests pass (including 2 new: `file_not_found_produces_diagnostic_without_source`, `load_rocky_config_returns_file_not_found_for_missing_path`)
- [x] `cargo clippy -p rocky-core -p rocky-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke: `rocky -o table validate` in an empty directory shows the new miette-formatted error with the help block
- [x] Manual smoke: `rocky -o table --config /does/not/exist.toml validate` also renders nicely with the absolute path
- [x] Manual smoke: `rocky validate` (default JSON mode) still returns the compact `Error: No rocky.toml found...` so orchestrators are unaffected
- [x] Manual smoke: `rocky -o table plan` also gets the upgrade (validates that the upgrade works through the `.context()` wrapping in other commands)

Fixes #20