### PR TITLE
chore(engine): bump version to 1.0.1

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "redis",
  "serde",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "logos",
  "miette",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "miette",
  "regex",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.0.0"
+version = "1.0.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.0.0"
+version = "1.0.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.0.0"
+version = "1.0.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.0.0"
+version = "1.0.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.0.0"
+version = "1.0.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.0.0"
+version = "1.0.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.0.0"
+version = "1.0.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.0.0"
+version = "1.0.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.0.0"
+version = "1.0.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.0.0"
+version = "1.0.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.0.0"
+version = "1.0.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.0.0"
+version = "1.0.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.0.0"
+version = "1.0.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.0.0"
+version = "1.0.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump all 19 engine workspace crates and the `rocky` binary crate from 1.0.0 to 1.0.1
- Cargo.lock updated accordingly
- `rocky-bigquery` intentionally left at 0.1.0 (still in early development)

## Changes since engine-v1.0.0

- #49: LSP server startup race fix
- #50: Clippy warnings fix
- #51: Newline position tracking in lexer
- #52: Refactored infer_expr_type
- #53: --output global flag + --stdio for LSP
- #54: blake3 --calibrate-bytes
- #56: Miette error reporting
- #57: VS Code model name fixes
- #58: --filter made optional
- #59: Scope dedup to managed tables
- #60: Docs IDE setup fix
- #62: Inferred incrementality
- #63: Grace-period column drops

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo clippy --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test` — all 44 test suites pass with 0 failures
- [ ] Tag `engine-v1.0.1` after merge to trigger release workflow