### PR TITLE
feat(vscode): add Rocky command palette

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -85,6 +85,11 @@
     },
     "commands": [
       {
+        "command": "rocky.commandPalette",
+        "title": "Rocky Command Palette",
+        "category": "Rocky"
+      },
+      {
         "command": "rocky.codeLens.runModel",
         "title": "Run Model (Terminal)",
         "category": "Rocky"
@@ -372,7 +377,14 @@
           "group": "2_inspect@4"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "rocky.commandPalette",
+        "key": "ctrl+shift+r",
+        "mac": "cmd+shift+r"
+      }
+    ]
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/editors/vscode/src/commands/commandPalette.ts
+++ b/editors/vscode/src/commands/commandPalette.ts
@@ -1,0 +1,78 @@
+import * as vscode from "vscode";
+
+/** QuickPick item that carries the VS Code command ID to execute on selection. */
+interface CommandPickItem extends vscode.QuickPickItem {
+  commandId: string;
+}
+
+/** Separator-only item for grouping categories in the QuickPick. */
+function separator(label: string): vscode.QuickPickItem {
+  return { label, kind: vscode.QuickPickItemKind.Separator };
+}
+
+/** A command entry with its display label, description, and backing command ID. */
+function cmd(
+  label: string,
+  description: string,
+  commandId: string,
+): CommandPickItem {
+  return { label, description, commandId };
+}
+
+/**
+ * Builds the grouped list of Rocky commands for the QuickPick.
+ *
+ * Categories match the logical groupings in commands/index.ts:
+ *   Pipeline → run, plan, discover, compare
+ *   Model    → compile, test, lineage, metrics, optimize
+ *   Infra    → doctor, compact, archive, profile storage
+ *   AI       → AI explain, AI sync, AI test, AI generate
+ */
+function buildItems(): (vscode.QuickPickItem | CommandPickItem)[] {
+  return [
+    // --- Pipeline ---
+    separator("Pipeline"),
+    cmd("$(play) Run", "Execute the full pipeline", "rocky.run"),
+    cmd("$(eye) Plan", "Preview SQL (dry run)", "rocky.plan"),
+    cmd("$(search) Discover", "List connectors and tables", "rocky.discover"),
+    cmd("$(diff) Compare", "Shadow vs production comparison", "rocky.compare"),
+
+    // --- Model ---
+    separator("Model"),
+    cmd("$(check) Compile", "Type-check models, validate contracts", "rocky.compile"),
+    cmd("$(beaker) Test", "Run local tests via DuckDB", "rocky.test"),
+    cmd("$(type-hierarchy) Lineage", "Render model DAG as interactive SVG", "rocky.showLineage"),
+    cmd("$(graph) Metrics", "Quality metrics with alerts", "rocky.metrics"),
+    cmd("$(lightbulb) Optimize", "Cost & strategy analysis", "rocky.optimize"),
+
+    // --- Infra ---
+    separator("Infra"),
+    cmd("$(heart) Doctor", "Run health checks", "rocky.doctor"),
+    cmd("$(archive) Compact", "Generate OPTIMIZE/VACUUM SQL", "rocky.compact"),
+
+    // --- AI ---
+    separator("AI"),
+    cmd("$(comment-discussion) AI Explain", "Generate intent docs from model", "rocky.aiExplain"),
+    cmd("$(sync) AI Sync", "Detect + propose schema changes", "rocky.aiSync"),
+    cmd("$(test-view-icon) AI Test", "Generate test cases from intent", "rocky.aiTest"),
+    cmd("$(sparkle) AI Generate", "Create model from natural language", "rocky.aiGenerate"),
+  ];
+}
+
+/**
+ * Shows the Rocky Command Palette — a grouped QuickPick of all user-facing
+ * commands. Bound to Cmd+Shift+R (Mac) / Ctrl+Shift+R (Win/Linux).
+ */
+export async function commandPalette(): Promise<void> {
+  const items = buildItems();
+
+  const picked = await vscode.window.showQuickPick(items, {
+    title: "Rocky Command Palette",
+    placeHolder: "Type to filter commands...",
+    matchOnDescription: true,
+  });
+
+  if (picked && "commandId" in picked) {
+    await vscode.commands.executeCommand(picked.commandId);
+  }
+}

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { restartLspClient } from "../lspClient";
 import { aiExplain, aiGenerate, aiSync, aiTest } from "./ai";
+import { commandPalette } from "./commandPalette";
 import { ci, compile, validate } from "./compile";
 import { hooksList, hooksTest } from "./hooks";
 import { history, metrics } from "./inspect";
@@ -17,6 +18,9 @@ import { test } from "./test";
  */
 export function registerCommands(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
+    // Command palette (Cmd+Shift+R / Ctrl+Shift+R)
+    vscode.commands.registerCommand("rocky.commandPalette", commandPalette),
+
     // LSP lifecycle
     vscode.commands.registerCommand("rocky.restartServer", restartLspClient),
 


### PR DESCRIPTION
## Summary
- Add a `rocky.commandPalette` command that shows a grouped QuickPick with all user-facing Rocky commands organized by category: Pipeline, Model, Infra, and AI
- Each item shows a codicon icon, command name, and description; selecting an item executes the corresponding command
- Bind to `Cmd+Shift+R` (Mac) / `Ctrl+Shift+R` (Windows/Linux) as a default keybinding

## Files changed
- **`editors/vscode/src/commands/commandPalette.ts`** — new file implementing the QuickPick with `QuickPickItemKind.Separator` for category headers
- **`editors/vscode/src/commands/index.ts`** — import and register `rocky.commandPalette`
- **`editors/vscode/package.json`** — add command entry and `contributes.keybindings` array

## Test plan
- [ ] Open the extension in the Extension Development Host (F5)
- [ ] Press `Cmd+Shift+R` — the Rocky Command Palette should appear
- [ ] Verify all four category separators (Pipeline, Model, Infra, AI) are visible
- [ ] Type to filter commands — both label and description should match
- [ ] Select a command and verify it executes (e.g., selecting "Doctor" runs `rocky.doctor`)
- [ ] Open the VS Code Command Palette (`Cmd+Shift+P`) and search for "Rocky Command Palette" — it should appear with the `Rocky:` category prefix
- [ ] Pressing Escape dismisses the QuickPick without running anything