### PR TITLE
feat(engine/rocky-server): add column lineage to LSP hover

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3327,6 +3327,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
+ "indexmap",
  "notify",
  "reqwest",
  "rocky-compiler",

--- a/engine/crates/rocky-compiler/src/semantic.rs
+++ b/engine/crates/rocky-compiler/src/semantic.rs
@@ -169,6 +169,18 @@ impl SemanticGraph {
 
         result
     }
+
+    /// Find downstream consumers of a column: edges where `source` matches `(model, column)`.
+    ///
+    /// Returns edges whose `source.model == model` and `source.column == column`,
+    /// i.e. models that read this column as input. O(E) scan — acceptable for
+    /// hover latency; add an `edges_by_source_column` index if profiling shows need.
+    pub fn column_consumers(&self, model: &str, column: &str) -> Vec<&LineageEdge> {
+        self.edges
+            .iter()
+            .filter(|e| &*e.source.model == model && &*e.source.column == column)
+            .collect()
+    }
 }
 
 /// Build a semantic graph from a resolved project.
@@ -520,5 +532,59 @@ mod tests {
             .find(|e| &*e.target.model == "b" && &*e.target.column == "amount_int");
         assert!(cast_edge.is_some());
         assert_eq!(cast_edge.unwrap().transform, TransformKind::Cast);
+    }
+
+    #[test]
+    fn test_column_consumers() {
+        let models = vec![
+            make_model("a", "SELECT id, name FROM source.raw.users"),
+            make_model("b", "SELECT id, name FROM a"),
+            make_model("c", "SELECT id FROM a"),
+        ];
+
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        // a.id is consumed by both b and c
+        let consumers = graph.column_consumers("a", "id");
+        let consumer_models: Vec<&str> = consumers.iter().map(|e| &*e.target.model).collect();
+        assert!(consumer_models.contains(&"b"));
+        assert!(consumer_models.contains(&"c"));
+        assert_eq!(consumers.len(), 2);
+
+        // a.name is consumed by b only
+        let name_consumers = graph.column_consumers("a", "name");
+        assert_eq!(name_consumers.len(), 1);
+        assert_eq!(&*name_consumers[0].target.model, "b");
+
+        // c.id has no consumers (leaf model)
+        let leaf_consumers = graph.column_consumers("c", "id");
+        assert!(leaf_consumers.is_empty());
+    }
+
+    #[test]
+    fn test_column_consumers_diamond() {
+        let models = vec![
+            make_model("a", "SELECT id, value FROM source.raw.data"),
+            make_model("b", "SELECT id, value AS b_value FROM a"),
+            make_model("c", "SELECT id, value AS c_value FROM a"),
+            make_model(
+                "d",
+                "SELECT b.id, b.b_value, c.c_value FROM b JOIN c ON b.id = c.id",
+            ),
+        ];
+
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        // b.id is consumed by d
+        let consumers = graph.column_consumers("b", "id");
+        assert_eq!(consumers.len(), 1);
+        assert_eq!(&*consumers[0].target.model, "d");
+
+        // b.b_value is consumed by d
+        let bv_consumers = graph.column_consumers("b", "b_value");
+        assert_eq!(bv_consumers.len(), 1);
+        assert_eq!(&*bv_consumers[0].target.model, "d");
     }
 }

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true }
 reqwest = { workspace = true }
+indexmap = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -815,33 +815,13 @@ impl LanguageServer for RockyLsp {
                 // Look for the column in the current model's typed columns
                 if let Some(typed_cols) = result.type_check.typed_models.get(model_name) {
                     if let Some(col) = typed_cols.iter().find(|c| c.name == *w) {
-                        let nullable = if col.nullable { "?" } else { "" };
-                        let mut info_lines = vec![format!(
-                            "**Column:** `{}`: `{:?}{}`",
-                            col.name, col.data_type, nullable
-                        )];
-
-                        // Trace lineage for this column
-                        let edges = result.semantic_graph.trace_column(model_name, w);
-                        if !edges.is_empty() {
-                            info_lines.push(String::new());
-                            info_lines.push("**Lineage:**".to_string());
-                            for edge in &edges {
-                                info_lines.push(format!(
-                                    "- `{}.{}` \u{2190} `{}.{}` ({})",
-                                    edge.target.model,
-                                    edge.target.column,
-                                    edge.source.model,
-                                    edge.source.column,
-                                    edge.transform,
-                                ));
-                            }
-                        }
+                        let value =
+                            build_column_hover_markdown(col, model_name, &result.semantic_graph);
 
                         return Ok(Some(Hover {
                             contents: HoverContents::Markup(MarkupContent {
                                 kind: MarkupKind::Markdown,
-                                value: info_lines.join("\n"),
+                                value,
                             }),
                             range: None,
                         }));
@@ -853,14 +833,16 @@ impl LanguageServer for RockyLsp {
                     for upstream_name in &schema.upstream {
                         if let Some(up_cols) = result.type_check.typed_models.get(upstream_name) {
                             if let Some(col) = up_cols.iter().find(|c| c.name == *w) {
-                                let nullable = if col.nullable { "?" } else { "" };
+                                let value = build_column_hover_markdown(
+                                    col,
+                                    upstream_name,
+                                    &result.semantic_graph,
+                                );
+
                                 return Ok(Some(Hover {
                                     contents: HoverContents::Markup(MarkupContent {
                                         kind: MarkupKind::Markdown,
-                                        value: format!(
-                                            "**Column:** `{}` from `{}`\n\n**Type:** `{:?}{}`",
-                                            col.name, upstream_name, col.data_type, nullable
-                                        ),
+                                        value,
                                     }),
                                     range: None,
                                 }));
@@ -1641,6 +1623,55 @@ fn find_column_line_in_sql(sql: &str, column_name: &str) -> u32 {
     0
 }
 
+/// Build rich Markdown hover content for a column, including type, upstream
+/// lineage chain, and downstream consumers.
+///
+/// Extracted as a pure function so it can be unit-tested without spinning up
+/// the async LSP server.
+fn build_column_hover_markdown(
+    col: &rocky_compiler::types::TypedColumn,
+    model_name: &str,
+    graph: &rocky_compiler::semantic::SemanticGraph,
+) -> String {
+    let nullable = if col.nullable { "?" } else { "" };
+    let mut lines = vec![format!(
+        "**Column:** `{}.{}` : `{:?}{}`",
+        model_name, col.name, col.data_type, nullable
+    )];
+
+    // ── Upstream sources ──────────────────────────────────────────────
+    let trace = graph.trace_column(model_name, &col.name);
+    if !trace.is_empty() {
+        lines.push(String::new());
+        lines.push("**Upstream sources:**".to_string());
+        for edge in &trace {
+            lines.push(format!(
+                "- `{}.{}` \u{2190} `{}.{}` ({})",
+                edge.target.model,
+                edge.target.column,
+                edge.source.model,
+                edge.source.column,
+                edge.transform,
+            ));
+        }
+    }
+
+    // ── Downstream consumers ──────────────────────────────────────────
+    let consumers = graph.column_consumers(model_name, &col.name);
+    if !consumers.is_empty() {
+        lines.push(String::new());
+        lines.push("**Downstream consumers:**".to_string());
+        for edge in &consumers {
+            lines.push(format!(
+                "- `{}.{}` ({})",
+                edge.target.model, edge.target.column, edge.transform,
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
 /// Collect inlay hints from a query's SELECT clause using AST expression spans.
 fn collect_inlay_hints_from_select(
     query: &ast::Query,
@@ -2005,4 +2036,190 @@ pub async fn run_lsp() {
     });
 
     Server::new(stdin, stdout, socket).serve(service).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+    use rocky_compiler::semantic::{
+        ColumnDef, LineageEdge, ModelSchema, QualifiedColumn, SemanticGraph,
+    };
+    use rocky_compiler::types::{RockyType, TypedColumn};
+    use rocky_sql::lineage::TransformKind;
+    use std::sync::Arc;
+
+    fn make_graph() -> SemanticGraph {
+        let mut models = IndexMap::new();
+        models.insert(
+            "source_table".to_string(),
+            ModelSchema {
+                columns: vec![
+                    ColumnDef {
+                        name: "id".to_string(),
+                    },
+                    ColumnDef {
+                        name: "name".to_string(),
+                    },
+                ],
+                has_star: false,
+                upstream: vec![],
+                downstream: vec!["staging".to_string()],
+                intent: None,
+            },
+        );
+        models.insert(
+            "staging".to_string(),
+            ModelSchema {
+                columns: vec![
+                    ColumnDef {
+                        name: "id".to_string(),
+                    },
+                    ColumnDef {
+                        name: "name".to_string(),
+                    },
+                ],
+                has_star: false,
+                upstream: vec!["source_table".to_string()],
+                downstream: vec!["mart".to_string()],
+                intent: None,
+            },
+        );
+        models.insert(
+            "mart".to_string(),
+            ModelSchema {
+                columns: vec![ColumnDef {
+                    name: "id".to_string(),
+                }],
+                has_star: false,
+                upstream: vec!["staging".to_string()],
+                downstream: vec![],
+                intent: None,
+            },
+        );
+
+        let edges = vec![
+            LineageEdge {
+                source: QualifiedColumn {
+                    model: Arc::from("source_table"),
+                    column: Arc::from("id"),
+                },
+                target: QualifiedColumn {
+                    model: Arc::from("staging"),
+                    column: Arc::from("id"),
+                },
+                transform: TransformKind::Direct,
+            },
+            LineageEdge {
+                source: QualifiedColumn {
+                    model: Arc::from("source_table"),
+                    column: Arc::from("name"),
+                },
+                target: QualifiedColumn {
+                    model: Arc::from("staging"),
+                    column: Arc::from("name"),
+                },
+                transform: TransformKind::Direct,
+            },
+            LineageEdge {
+                source: QualifiedColumn {
+                    model: Arc::from("staging"),
+                    column: Arc::from("id"),
+                },
+                target: QualifiedColumn {
+                    model: Arc::from("mart"),
+                    column: Arc::from("id"),
+                },
+                transform: TransformKind::Cast,
+            },
+        ];
+
+        SemanticGraph::new(models, edges)
+    }
+
+    #[test]
+    fn test_column_hover_with_upstream_and_downstream() {
+        let graph = make_graph();
+        let col = TypedColumn {
+            name: "id".to_string(),
+            data_type: RockyType::Int64,
+            nullable: false,
+        };
+
+        let md = build_column_hover_markdown(&col, "staging", &graph);
+
+        // Type header
+        assert!(md.contains("**Column:** `staging.id` : `Int64`"));
+        // Upstream section
+        assert!(md.contains("**Upstream sources:**"));
+        assert!(md.contains("`source_table.id`"));
+        // Downstream section
+        assert!(md.contains("**Downstream consumers:**"));
+        assert!(md.contains("`mart.id`"));
+    }
+
+    #[test]
+    fn test_column_hover_leaf_model_no_downstream() {
+        let graph = make_graph();
+        let col = TypedColumn {
+            name: "id".to_string(),
+            data_type: RockyType::Int64,
+            nullable: false,
+        };
+
+        let md = build_column_hover_markdown(&col, "mart", &graph);
+
+        assert!(md.contains("**Column:** `mart.id` : `Int64`"));
+        // Has upstream
+        assert!(md.contains("**Upstream sources:**"));
+        assert!(md.contains("`staging.id`"));
+        // No downstream
+        assert!(!md.contains("**Downstream consumers:**"));
+    }
+
+    #[test]
+    fn test_column_hover_source_no_upstream() {
+        let graph = make_graph();
+        let col = TypedColumn {
+            name: "id".to_string(),
+            data_type: RockyType::Int64,
+            nullable: true,
+        };
+
+        let md = build_column_hover_markdown(&col, "source_table", &graph);
+
+        assert!(md.contains("**Column:** `source_table.id` : `Int64?`"));
+        // No upstream
+        assert!(!md.contains("**Upstream sources:**"));
+        // Has downstream
+        assert!(md.contains("**Downstream consumers:**"));
+        assert!(md.contains("`staging.id`"));
+    }
+
+    #[test]
+    fn test_column_hover_nullable_marker() {
+        let graph = make_graph();
+        let col = TypedColumn {
+            name: "name".to_string(),
+            data_type: RockyType::String,
+            nullable: true,
+        };
+
+        let md = build_column_hover_markdown(&col, "staging", &graph);
+        assert!(md.contains("`String?`"));
+    }
+
+    #[test]
+    fn test_column_hover_transform_kind_shown() {
+        let graph = make_graph();
+        let col = TypedColumn {
+            name: "id".to_string(),
+            data_type: RockyType::Int64,
+            nullable: false,
+        };
+
+        let md = build_column_hover_markdown(&col, "mart", &graph);
+        // The edge from staging -> mart is a Cast transform
+        assert!(md.contains("(cast)"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add **column-level lineage** to the LSP hover tooltip (plan 34): hovering a column in `.sql` or `.rocky` files now shows upstream source chain and downstream consumers alongside the column type
- Add `SemanticGraph::column_consumers()` method for forward lineage lookup (reverse of the existing `trace_column()`)
- Extract `build_column_hover_markdown()` as a testable pure function for hover content generation
- 7 new unit tests: 2 for `column_consumers` in `semantic.rs`, 5 for hover markdown in `lsp.rs`

**Example hover output:**

```
Column: staging.id : Int64

Upstream sources:
- staging.id <- source_table.id (direct)

Downstream consumers:
- mart.id (cast)
```

## Test plan

- [x] `cargo test -p rocky-compiler -- semantic::tests` (9 tests pass, including 2 new)
- [x] `cargo test -p rocky-server -- lsp::tests` (5 new tests pass)
- [x] `cargo test` full suite (all pass, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)