### PR TITLE
chore(vscode): bump version to 1.1.0

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump VS Code extension version from 1.0.1 to 1.1.0

Since v1.0.1 the extension gained several features and fixes that warrant a minor version bump:

- **Command palette** (`Cmd+Shift+R`) with grouped quick pick (#68)
- **Fixed model name extraction** for CLI commands (#57)
- **New generated types** from engine codegen: `ci_diff`, `estimate` (cost hints), `optimize` (incrementality hints)
- Bumped vendored viz.js from 3.25.0 to 3.26.0 (#47)
- Fixed publisher ID in integration tests (#44)

## Test plan

- [x] `npm run compile` passes cleanly
- [ ] Verify `npm run package` produces a valid VSIX with version 1.1.0
- [ ] Smoke-test extension in Extension Development Host (F5)