### PR TITLE
feat(engine/rocky-wasm): complete WASM exports with transpilation, formatting, and model compilation

### DIFF
--- a/engine/crates/rocky-wasm/src/lib.rs
+++ b/engine/crates/rocky-wasm/src/lib.rs
@@ -42,17 +42,19 @@ pub fn transpile_sql(sql: &str, from_dialect: &str, to_dialect: &str) -> String 
     let from = match parse_dialect(from_dialect) {
         Some(d) => d,
         None => {
-            return format!(
-                r#"{{"error":"unknown source dialect: {from_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb"}}"#
-            );
+            return serde_json::json!({
+                "error": format!("unknown source dialect: {from_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb")
+            })
+            .to_string();
         }
     };
     let to = match parse_dialect(to_dialect) {
         Some(d) => d,
         None => {
-            return format!(
-                r#"{{"error":"unknown target dialect: {to_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb"}}"#
-            );
+            return serde_json::json!({
+                "error": format!("unknown target dialect: {to_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb")
+            })
+            .to_string();
         }
     };
 

--- a/engine/crates/rocky-wasm/src/lib.rs
+++ b/engine/crates/rocky-wasm/src/lib.rs
@@ -1,13 +1,19 @@
 //! WASM bindings for Rocky's pure-Rust compiler pipeline.
 //!
-//! Exposes a minimal API surface for in-browser use:
+//! Exposes an API surface for in-browser use:
 //! - SQL lineage extraction (`rocky-sql`)
-//! - Rocky DSL parsing and lowering (`rocky-lang`)
+//! - Rocky DSL parsing, lowering, and formatting (`rocky-lang`)
 //! - SQL identifier validation (`rocky-sql`)
+//! - SQL transpilation between dialects (`rocky-sql`)
+//! - Combined model compilation (parse + lower + lineage)
 //!
 //! All functions exchange data as JSON strings for simplest WASM interop.
 
 use wasm_bindgen::prelude::*;
+
+// ---------------------------------------------------------------------------
+// SQL exports
+// ---------------------------------------------------------------------------
 
 /// Extract column-level lineage from a SQL SELECT statement.
 ///
@@ -21,6 +27,68 @@ pub fn compile_sql(sql: &str) -> String {
         Err(e) => format!(r#"{{"error":{}}}"#, serde_json::json!(e)),
     }
 }
+
+/// Transpile SQL between warehouse dialects.
+///
+/// Supported dialects: `"snowflake"`, `"databricks"`, `"bigquery"`, `"duckdb"`.
+///
+/// Returns a JSON object on success:
+/// ```json
+/// {"sql": "...", "warnings": [...], "replacements": 3}
+/// ```
+/// Returns `{"error": "..."}` on failure (e.g., unknown dialect name).
+#[wasm_bindgen]
+pub fn transpile_sql(sql: &str, from_dialect: &str, to_dialect: &str) -> String {
+    let from = match parse_dialect(from_dialect) {
+        Some(d) => d,
+        None => {
+            return format!(
+                r#"{{"error":"unknown source dialect: {from_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb"}}"#
+            );
+        }
+    };
+    let to = match parse_dialect(to_dialect) {
+        Some(d) => d,
+        None => {
+            return format!(
+                r#"{{"error":"unknown target dialect: {to_dialect}. Expected one of: snowflake, databricks, bigquery, duckdb"}}"#
+            );
+        }
+    };
+
+    let result = rocky_sql::transpile::transpile(sql, from, to);
+
+    let warnings: Vec<serde_json::Value> = result
+        .warnings
+        .iter()
+        .map(|w| {
+            serde_json::json!({
+                "original": w.original,
+                "reason": w.reason,
+                "suggestion": w.suggestion,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "sql": result.sql,
+        "warnings": warnings,
+        "replacements": result.replacements,
+    })
+    .to_string()
+}
+
+/// Validate whether a string is a legal SQL identifier.
+///
+/// Returns `true` if the identifier matches `^[a-zA-Z0-9_]+$`.
+#[wasm_bindgen]
+pub fn validate_identifier(name: &str) -> bool {
+    rocky_sql::validation::validate_identifier(name).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Rocky DSL exports
+// ---------------------------------------------------------------------------
 
 /// Parse a Rocky DSL source string into a JSON AST.
 ///
@@ -49,6 +117,18 @@ pub fn lower_rocky_to_sql(source: &str) -> String {
         Ok(sql) => sql,
         Err(e) => format!(r#"{{"error":{}}}"#, serde_json::json!(e)),
     }
+}
+
+/// Format a Rocky DSL source string.
+///
+/// Normalizes indentation, collapses excessive blank lines, and ensures
+/// a single trailing newline. The `indent` parameter controls the
+/// indentation string (e.g., `"    "` for 4 spaces, `"\t"` for tabs).
+///
+/// Returns the formatted source text.
+#[wasm_bindgen]
+pub fn format_rocky(source: &str, indent: &str) -> String {
+    rocky_lang::fmt::format_rocky(source, indent)
 }
 
 /// Return parse errors with positions for a Rocky DSL source string.
@@ -99,6 +179,119 @@ pub fn get_parse_errors(source: &str) -> String {
     }
 }
 
+/// Compile a Rocky DSL model end-to-end: parse, lower to SQL, extract lineage.
+///
+/// Returns a JSON object combining all phases:
+/// ```json
+/// {
+///   "ast": { ... },
+///   "sql": "SELECT ...",
+///   "lineage": { "source_tables": [...], "columns": [...] },
+///   "errors": []
+/// }
+/// ```
+///
+/// If parsing fails, `ast`, `sql`, and `lineage` are `null` and `errors`
+/// contains the parse error. If lowering fails, `sql` and `lineage` are
+/// `null`. If lineage extraction fails, `lineage` is `null` with a warning
+/// in `errors`.
+#[wasm_bindgen]
+pub fn compile_rocky_model(source: &str) -> String {
+    let mut errors: Vec<serde_json::Value> = Vec::new();
+
+    // Phase 1: Parse
+    let ast = match rocky_lang::parse(source) {
+        Ok(ast) => ast,
+        Err(e) => {
+            let (offset, expected, found) = match &e {
+                rocky_lang::ParseError::UnexpectedToken {
+                    expected,
+                    found,
+                    offset,
+                } => (*offset, expected.clone(), found.clone()),
+                rocky_lang::ParseError::UnexpectedEof { expected } => (
+                    source.len().saturating_sub(1),
+                    expected.clone(),
+                    "EOF".to_string(),
+                ),
+                rocky_lang::ParseError::InvalidNumber { value } => {
+                    (0, "valid number".to_string(), value.clone())
+                }
+                rocky_lang::ParseError::EmptyFile => {
+                    (0, "pipeline step".to_string(), "empty file".to_string())
+                }
+            };
+            let (line, col) = byte_offset_to_line_col(source, offset);
+
+            errors.push(serde_json::json!({
+                "phase": "parse",
+                "severity": "error",
+                "offset": offset,
+                "line": line,
+                "column": col,
+                "message": e.to_string(),
+                "expected": expected,
+                "found": found,
+            }));
+
+            return serde_json::json!({
+                "ast": null,
+                "sql": null,
+                "lineage": null,
+                "errors": errors,
+            })
+            .to_string();
+        }
+    };
+
+    let ast_json = serde_json::to_value(&ast).ok();
+
+    // Phase 2: Lower to SQL
+    let sql = match rocky_lang::lower::lower_to_sql(&ast) {
+        Ok(sql) => sql,
+        Err(e) => {
+            errors.push(serde_json::json!({
+                "phase": "lower",
+                "severity": "error",
+                "message": e,
+            }));
+
+            return serde_json::json!({
+                "ast": ast_json,
+                "sql": null,
+                "lineage": null,
+                "errors": errors,
+            })
+            .to_string();
+        }
+    };
+
+    // Phase 3: Extract lineage from lowered SQL
+    let lineage = match rocky_sql::lineage::extract_lineage(&sql) {
+        Ok(result) => serde_json::to_value(&result).ok(),
+        Err(e) => {
+            errors.push(serde_json::json!({
+                "phase": "lineage",
+                "severity": "warning",
+                "message": format!("lineage extraction failed: {e}"),
+            }));
+            None
+        }
+    };
+
+    serde_json::json!({
+        "ast": ast_json,
+        "sql": sql,
+        "lineage": lineage,
+        "errors": errors,
+    })
+    .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 /// Convert a byte offset to 1-based line and column numbers.
 fn byte_offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
     let before = &source[..offset.min(source.len())];
@@ -107,17 +300,22 @@ fn byte_offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
     (line, col)
 }
 
-/// Validate whether a string is a legal SQL identifier.
-///
-/// Returns `true` if the identifier matches `^[a-zA-Z0-9_]+$`.
-#[wasm_bindgen]
-pub fn validate_identifier(name: &str) -> bool {
-    rocky_sql::validation::validate_identifier(name).is_ok()
+/// Parse a dialect name string into the transpile `Dialect` enum.
+fn parse_dialect(name: &str) -> Option<rocky_sql::transpile::Dialect> {
+    match name.to_lowercase().as_str() {
+        "snowflake" => Some(rocky_sql::transpile::Dialect::Snowflake),
+        "databricks" => Some(rocky_sql::transpile::Dialect::Databricks),
+        "bigquery" => Some(rocky_sql::transpile::Dialect::BigQuery),
+        "duckdb" => Some(rocky_sql::transpile::Dialect::DuckDB),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- SQL lineage ----
 
     #[test]
     fn test_compile_sql_success() {
@@ -134,6 +332,57 @@ mod tests {
         assert!(parsed.get("error").is_some());
     }
 
+    // ---- Transpile ----
+
+    #[test]
+    fn test_transpile_sql_snowflake_to_bigquery() {
+        let result = transpile_sql(
+            "SELECT NVL(a, b), LEN(name) FROM t",
+            "snowflake",
+            "bigquery",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let sql = parsed["sql"].as_str().unwrap();
+        assert!(sql.contains("IFNULL(a, b)"));
+        assert!(sql.contains("LENGTH(name)"));
+        assert!(parsed["replacements"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn test_transpile_sql_same_dialect() {
+        let result = transpile_sql("SELECT 1", "duckdb", "duckdb");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["sql"].as_str().unwrap(), "SELECT 1");
+        assert_eq!(parsed["replacements"].as_u64().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_transpile_sql_unknown_dialect() {
+        let result = transpile_sql("SELECT 1", "postgres", "duckdb");
+        assert!(result.contains("error"));
+        assert!(result.contains("postgres"));
+    }
+
+    #[test]
+    fn test_transpile_sql_with_warnings() {
+        let result = transpile_sql(
+            "SELECT * FROM t QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) = 1",
+            "snowflake",
+            "duckdb",
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let warnings = parsed["warnings"].as_array().unwrap();
+        assert!(!warnings.is_empty());
+        assert!(
+            warnings[0]["original"]
+                .as_str()
+                .unwrap()
+                .contains("QUALIFY")
+        );
+    }
+
+    // ---- Rocky DSL parse ----
+
     #[test]
     fn test_parse_rocky_success() {
         let result = parse_rocky("from orders\nselect { id, total }");
@@ -147,6 +396,8 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.get("error").is_some());
     }
+
+    // ---- Rocky DSL lower ----
 
     #[test]
     fn test_lower_rocky_to_sql_success() {
@@ -162,6 +413,31 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.get("error").is_some());
     }
+
+    // ---- Rocky DSL format ----
+
+    #[test]
+    fn test_format_rocky_normalizes_indentation() {
+        let messy = "group customer_id {\ntotal: sum(amount),\ncount: count()\n}\n";
+        let formatted = format_rocky(messy, "    ");
+        assert!(formatted.contains("    total: sum(amount),"));
+        assert!(formatted.contains("    count: count()"));
+    }
+
+    #[test]
+    fn test_format_rocky_already_formatted() {
+        let input = "from raw_orders\nwhere status != \"cancelled\"\n";
+        assert_eq!(format_rocky(input, "    "), input);
+    }
+
+    #[test]
+    fn test_format_rocky_trailing_whitespace() {
+        let input = "from raw_orders   \nselect { id }  \n";
+        let formatted = format_rocky(input, "    ");
+        assert!(!formatted.contains("   \n"));
+    }
+
+    // ---- Parse errors ----
 
     #[test]
     fn test_get_parse_errors_success() {
@@ -190,6 +466,8 @@ mod tests {
         assert_eq!(arr[0]["found"], "empty file");
     }
 
+    // ---- Identifier validation ----
+
     #[test]
     fn test_validate_identifier_valid() {
         assert!(validate_identifier("my_table"));
@@ -203,5 +481,83 @@ mod tests {
         assert!(!validate_identifier("has space"));
         assert!(!validate_identifier("has-dash"));
         assert!(!validate_identifier("DROP TABLE users--"));
+    }
+
+    // ---- Compile model (end-to-end) ----
+
+    #[test]
+    fn test_compile_rocky_model_success() {
+        let result = compile_rocky_model("from orders\nselect { id, total }");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        // AST should be present
+        assert!(parsed["ast"].is_object());
+        assert!(parsed["ast"]["pipeline"].is_array());
+
+        // SQL should be generated
+        let sql = parsed["sql"].as_str().unwrap();
+        assert!(sql.to_uppercase().contains("SELECT"));
+
+        // Errors should be empty
+        let errors = parsed["errors"].as_array().unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_compile_rocky_model_parse_error() {
+        let result = compile_rocky_model("invalid @@@ garbage");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert!(parsed["ast"].is_null());
+        assert!(parsed["sql"].is_null());
+        assert!(parsed["lineage"].is_null());
+
+        let errors = parsed["errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0]["phase"], "parse");
+        assert_eq!(errors[0]["severity"], "error");
+        assert!(errors[0].get("line").is_some());
+        assert!(errors[0].get("column").is_some());
+    }
+
+    #[test]
+    fn test_compile_rocky_model_empty_file() {
+        let result = compile_rocky_model("");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert!(parsed["ast"].is_null());
+        let errors = parsed["errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0]["phase"], "parse");
+    }
+
+    #[test]
+    fn test_compile_rocky_model_with_aggregation() {
+        let source = "from orders\ngroup customer_id {\n  total: sum(amount),\n  cnt: count()\n}";
+        let result = compile_rocky_model(source);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert!(parsed["ast"].is_object());
+        assert!(parsed["sql"].is_string());
+        let errors = parsed["errors"].as_array().unwrap();
+        assert!(errors.is_empty());
+    }
+
+    // ---- Helpers ----
+
+    #[test]
+    fn test_parse_dialect_valid() {
+        assert!(parse_dialect("snowflake").is_some());
+        assert!(parse_dialect("Snowflake").is_some());
+        assert!(parse_dialect("DATABRICKS").is_some());
+        assert!(parse_dialect("bigquery").is_some());
+        assert!(parse_dialect("duckdb").is_some());
+    }
+
+    #[test]
+    fn test_parse_dialect_invalid() {
+        assert!(parse_dialect("postgres").is_none());
+        assert!(parse_dialect("mysql").is_none());
+        assert!(parse_dialect("").is_none());
     }
 }

--- a/engine/playground/index.html
+++ b/engine/playground/index.html
@@ -308,6 +308,7 @@
   <div class="mode-tabs">
     <button class="mode-tab active" data-mode="sql">SQL</button>
     <button class="mode-tab" data-mode="rocky">Rocky DSL</button>
+    <button class="mode-tab" data-mode="transpile">Transpile</button>
     <button class="mode-tab" data-mode="identifier">Identifier</button>
   </div>
   <div class="toolbar-sep"></div>
@@ -330,6 +331,10 @@
       <option value="sql-lineage">column lineage (JOIN)</option>
       <option value="sql-join">JOIN lineage (GROUP BY)</option>
     </optgroup>
+    <optgroup label="Transpile">
+      <option value="transpile-snowflake">Snowflake SQL</option>
+      <option value="transpile-bigquery">BigQuery SQL</option>
+    </optgroup>
     <optgroup label="Identifiers">
       <option value="identifier-valid">valid identifier</option>
       <option value="identifier-invalid">invalid identifier</option>
@@ -342,9 +347,29 @@
     <button id="btn-parse" disabled title="Parse Rocky DSL into JSON AST (parse_rocky)">Parse Rocky</button>
     <button id="btn-lower" disabled title="Lower Rocky DSL to SQL (lower_rocky_to_sql)">Lower to SQL</button>
     <button id="btn-check" disabled title="Check Rocky DSL for parse errors (get_parse_errors)">Check Syntax</button>
+    <button id="btn-format" disabled title="Format Rocky DSL source (format_rocky)">Format</button>
+    <button id="btn-compile-model" disabled title="Full pipeline: parse + lower + lineage (compile_rocky_model)">Compile Model</button>
+    <button id="btn-transpile" disabled title="Transpile SQL between dialects (transpile_sql)">Transpile</button>
     <button id="btn-validate" disabled title="Check if text is a valid SQL identifier (validate_identifier)">Validate</button>
   </div>
   <div class="toolbar-sep"></div>
+  <span id="dialect-controls" style="display:none">
+    <label>From</label>
+    <select id="from-dialect" title="Source dialect">
+      <option value="snowflake">Snowflake</option>
+      <option value="databricks">Databricks</option>
+      <option value="bigquery">BigQuery</option>
+      <option value="duckdb">DuckDB</option>
+    </select>
+    <label>To</label>
+    <select id="to-dialect" title="Target dialect">
+      <option value="bigquery">BigQuery</option>
+      <option value="databricks">Databricks</option>
+      <option value="snowflake">Snowflake</option>
+      <option value="duckdb">DuckDB</option>
+    </select>
+    <div class="toolbar-sep"></div>
+  </span>
   <button id="btn-clear" title="Clear the output panel">Clear Output</button>
 </div>
 
@@ -384,17 +409,19 @@ WHERE o.order_date >= '2024-01-01'</textarea>
   let wasmReady = false;
 
   const modeButtons = {
-    sql:        { enabled: ['btn-compile'],                              primary: 'btn-compile' },
-    rocky:      { enabled: ['btn-parse', 'btn-lower', 'btn-check'],     primary: 'btn-lower' },
-    identifier: { enabled: ['btn-validate'],                            primary: 'btn-validate' },
+    sql:        { enabled: ['btn-compile'],                                                        primary: 'btn-compile' },
+    rocky:      { enabled: ['btn-parse', 'btn-lower', 'btn-check', 'btn-format', 'btn-compile-model'], primary: 'btn-compile-model' },
+    transpile:  { enabled: ['btn-transpile'],                                                      primary: 'btn-transpile' },
+    identifier: { enabled: ['btn-validate'],                                                       primary: 'btn-validate' },
   };
 
-  const allActionIds = ['btn-compile', 'btn-parse', 'btn-lower', 'btn-check', 'btn-validate'];
+  const allActionIds = ['btn-compile', 'btn-parse', 'btn-lower', 'btn-check', 'btn-format', 'btn-compile-model', 'btn-transpile', 'btn-validate'];
 
   // Map snippet keys to modes
   function snippetMode(key) {
     if (key.startsWith('rocky-')) return 'rocky';
     if (key.startsWith('sql-')) return 'sql';
+    if (key.startsWith('transpile-')) return 'transpile';
     if (key.startsWith('identifier-')) return 'identifier';
     return null;
   }
@@ -415,6 +442,10 @@ WHERE o.order_date >= '2024-01-01'</textarea>
       btn.classList.toggle('primary', id === cfg.primary);
     });
 
+    // Show/hide dialect controls for transpile mode
+    document.getElementById('dialect-controls').style.display =
+      mode === 'transpile' ? '' : 'none';
+
     // Filter snippet picker to show relevant optgroup
     filterSnippets(mode);
 
@@ -427,7 +458,7 @@ WHERE o.order_date >= '2024-01-01'</textarea>
   const optgroups = snippetPicker.querySelectorAll('optgroup');
 
   function filterSnippets(mode) {
-    const groupMap = { sql: 'SQL Lineage', rocky: 'Rocky DSL', identifier: 'Identifiers' };
+    const groupMap = { sql: 'SQL Lineage', rocky: 'Rocky DSL', transpile: 'Transpile', identifier: 'Identifiers' };
     optgroups.forEach(og => {
       og.style.display = og.label === groupMap[mode] ? '' : 'none';
     });
@@ -629,6 +660,71 @@ WHERE o.order_date >= '2024-01-01'</textarea>
     }
   });
 
+  document.getElementById('btn-format').addEventListener('click', () => {
+    const input = getInput();
+    const t0 = performance.now();
+    const result = wasm.format_rocky(input, '    ');
+    const ms = (performance.now() - t0).toFixed(1);
+    editorEl.value = result;
+    updateParseStatus();
+    setOutput(
+      '<span class="out-comment">// format_rocky (' + ms + ' ms)</span>\n\n' +
+      '<span class="out-success">Source formatted in-place.</span>'
+    );
+  });
+
+  document.getElementById('btn-compile-model').addEventListener('click', () => {
+    const input = getInput();
+    const t0 = performance.now();
+    const result = wasm.compile_rocky_model(input);
+    const ms = (performance.now() - t0).toFixed(1);
+    const parsed = JSON.parse(result);
+    const hasErrors = parsed.errors && parsed.errors.length > 0;
+    const label = hasErrors
+      ? '<span class="out-error">Compile Errors</span>'
+      : '<span class="out-success">Compiled Model</span>';
+    setOutput(
+      '<span class="out-comment">// compile_rocky_model (' + ms + ' ms)</span>\n' +
+      label + '\n\n' +
+      highlightJson(result)
+    );
+  });
+
+  document.getElementById('btn-transpile').addEventListener('click', () => {
+    const input = getInput();
+    const from = document.getElementById('from-dialect').value;
+    const to = document.getElementById('to-dialect').value;
+    const t0 = performance.now();
+    const result = wasm.transpile_sql(input, from, to);
+    const ms = (performance.now() - t0).toFixed(1);
+    const parsed = JSON.parse(result);
+
+    if (parsed.error) {
+      setOutput(
+        '<span class="out-comment">// transpile_sql (' + ms + ' ms)</span>\n' +
+        '<span class="out-error">Error</span>\n\n' +
+        '<span class="out-error">' + escHtml(parsed.error) + '</span>'
+      );
+    } else {
+      let warningText = '';
+      if (parsed.warnings && parsed.warnings.length > 0) {
+        warningText = '\n\n<span class="out-comment">Warnings:</span>\n';
+        parsed.warnings.forEach(w => {
+          warningText += '<span class="out-error">  ' + escHtml(w.original) + ':</span> ' + escHtml(w.reason) + '\n';
+          if (w.suggestion) {
+            warningText += '<span class="out-comment">    Suggestion: ' + escHtml(w.suggestion) + '</span>\n';
+          }
+        });
+      }
+      setOutput(
+        '<span class="out-comment">// transpile_sql ' + escHtml(from) + ' -> ' + escHtml(to) + ' (' + ms + ' ms, ' + parsed.replacements + ' replacements)</span>\n' +
+        '<span class="out-success">Transpiled SQL</span>\n\n' +
+        highlightSql(parsed.sql) +
+        warningText
+      );
+    }
+  });
+
   document.getElementById('btn-clear').addEventListener('click', () => {
     setOutput('<span class="out-comment">-- Output cleared.</span>');
   });
@@ -758,6 +854,24 @@ JOIN catalog.sales.order_items AS oi
     ON p.product_id = oi.product_id
 GROUP BY p.product_id, p.product_name
 ORDER BY revenue DESC`,
+    'transpile-snowflake':
+`-- Snowflake SQL (try transpiling to BigQuery or Databricks)
+SELECT
+    NVL(customer_name, 'Unknown') AS customer_name,
+    DATEDIFF(day, first_order, last_order) AS days_active,
+    LEN(customer_name) AS name_length,
+    TO_VARCHAR(created_at, 'YYYY-MM-DD') AS created_date
+FROM warehouse.analytics.customers
+WHERE created_at >= '2024-01-01'`,
+    'transpile-bigquery':
+`-- BigQuery SQL (try transpiling to Snowflake or Databricks)
+SELECT
+    IFNULL(customer_name, 'Unknown') AS customer_name,
+    DATE_DIFF(last_order, first_order, DAY) AS days_active,
+    LENGTH(customer_name) AS name_length,
+    FORMAT_TIMESTAMP('%Y-%m-%d', created_at) AS created_date
+FROM \`project.dataset.customers\`
+WHERE created_at >= '2024-01-01'`,
     'identifier-valid': 'my_table_name',
     'identifier-invalid': 'DROP TABLE users--'
   };


### PR DESCRIPTION
## Summary
- Add 3 new wasm-bindgen exports: `transpile_sql` (cross-dialect SQL transpilation), `format_rocky` (DSL source formatting), and `compile_rocky_model` (end-to-end parse + lower + lineage pipeline with phased error reporting)
- Update playground HTML with Transpile mode (dialect dropdowns), Format/Compile Model buttons in Rocky mode, and transpile snippet examples
- Total WASM exports: 8 (up from 5). Test count: 24 (up from 10)

## Test plan
- [x] `cargo clippy -p rocky-wasm --all-targets -- -D warnings` passes clean
- [x] `cargo test -p rocky-wasm` -- all 24 tests pass
- [x] `cargo fmt -p rocky-wasm -- --check` passes
- [ ] Verify playground loads correctly after `wasm-pack build` (requires WASM toolchain)

## Notes
- `rocky-compiler` is intentionally NOT added as a dependency -- it pulls in `redb`, `rayon`, and `std::fs` which don't work on `wasm32-unknown-unknown`. Full type-checking in WASM requires abstracting the file loader behind a trait first (Plan 46 step 2).
- No new crate dependencies needed -- all new exports use existing `rocky-sql` and `rocky-lang` APIs.