### PR TITLE
feat(engine): complete LoaderAdapter trait and load pipeline

### DIFF
--- a/engine/crates/rocky-cli/src/commands/load.rs
+++ b/engine/crates/rocky-cli/src/commands/load.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result, bail};
 use tracing::info;
 
 use rocky_adapter_sdk::{FileFormat, LoadOptions, LoaderAdapter, TableRef};
+use rocky_core::state::{LoadedFileRecord, StateStore};
 
 use crate::output::{LoadFileOutput, LoadOutput, print_json};
 use crate::registry::{AdapterRegistry, resolve_pipeline};
@@ -21,9 +22,12 @@ use crate::registry::{AdapterRegistry, resolve_pipeline};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Execute `rocky load`: discover files, load them into the target table(s).
+///
+/// CLI args override values from the load pipeline config. When `--source-dir`
+/// is omitted, the pipeline's `source_dir` from `rocky.toml` is used.
 pub async fn run_load(
     config_path: &Path,
-    source_dir: &Path,
+    cli_source_dir: Option<&Path>,
     format: Option<&str>,
     target_table: Option<&str>,
     pipeline: Option<&str>,
@@ -31,17 +35,6 @@ pub async fn run_load(
     json: bool,
 ) -> Result<()> {
     let start = Instant::now();
-
-    // Validate source directory exists.
-    if !source_dir.is_dir() {
-        bail!("source directory does not exist: {}", source_dir.display());
-    }
-
-    // Parse the requested format (if any).
-    let requested_format = match format {
-        Some(f) => Some(parse_format(f)?),
-        None => None,
-    };
 
     // Load config and build adapter registry.
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
@@ -51,8 +44,62 @@ pub async fn run_load(
     let registry = AdapterRegistry::from_config(&rocky_cfg)?;
 
     // Resolve pipeline to get the target adapter.
-    let (_pipeline_name, pipeline_cfg) =
+    let (pipeline_name, pipeline_cfg) =
         resolve_pipeline(&rocky_cfg, pipeline).context("failed to resolve pipeline for load")?;
+    let load_cfg = pipeline_cfg.as_load();
+
+    // Resolve source directory: CLI overrides config.
+    let config_dir = config_path.parent().unwrap_or(Path::new("."));
+    let source_dir_buf;
+    let source_dir: &Path = if let Some(dir) = cli_source_dir {
+        dir
+    } else if let Some(lc) = load_cfg {
+        source_dir_buf = config_dir.join(&lc.source_dir);
+        &source_dir_buf
+    } else {
+        bail!(
+            "no --source-dir provided and the pipeline is not type = \"load\"; \
+             either pass --source-dir or configure a load pipeline in rocky.toml"
+        );
+    };
+
+    if !source_dir.is_dir() {
+        bail!("source directory does not exist: {}", source_dir.display());
+    }
+
+    // Resolve format: CLI > config > auto-detect.
+    let requested_format = match format {
+        Some(f) => Some(parse_format(f)?),
+        None => load_cfg
+            .as_ref()
+            .and_then(|lc| lc.format)
+            .map(config_format_to_sdk),
+    };
+
+    // Resolve target catalog/schema from config, falling back to defaults.
+    let target_catalog = load_cfg
+        .as_ref()
+        .map(|lc| lc.target.catalog.as_str())
+        .unwrap_or("");
+    let target_schema = load_cfg
+        .as_ref()
+        .map(|lc| lc.target.schema.as_str())
+        .unwrap_or("main");
+    let config_target_table = load_cfg.as_ref().and_then(|lc| lc.target.table.as_deref());
+
+    // Resolve load options from config, with CLI overrides.
+    let base_options = load_cfg
+        .as_ref()
+        .map(|lc| config_options_to_sdk(&lc.options))
+        .unwrap_or_default();
+
+    // Open the state store for tracking loaded files.
+    let state_path = config_dir.join(".rocky_state");
+    let state_store = StateStore::open(&state_path).context(format!(
+        "failed to open state store at {}",
+        state_path.display()
+    ))?;
+
     let adapter_name = pipeline_cfg.target_adapter();
 
     // Build a DuckDB loader adapter if the adapter type is DuckDB.
@@ -91,13 +138,15 @@ pub async fn run_load(
     // Discover files in the source directory.
     let files = discover_files(source_dir, requested_format)?;
 
+    let format_label = format.unwrap_or("auto");
+
     if files.is_empty() {
         if json {
             let output = LoadOutput {
                 version: VERSION.into(),
                 command: "load".into(),
                 source_dir: source_dir.display().to_string(),
-                format: format.unwrap_or("auto").to_string(),
+                format: format_label.to_string(),
                 files_loaded: 0,
                 files_failed: 0,
                 total_rows: 0,
@@ -125,25 +174,33 @@ pub async fn run_load(
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
 
-        // Derive the target table name: use the explicit target or the file stem.
-        let table_name = target_table.unwrap_or(file_name);
+        // Derive the target table name: CLI > config > file stem.
+        let table_name = target_table.or(config_target_table).unwrap_or(file_name);
 
         let target = TableRef {
-            catalog: String::new(),
-            schema: "main".into(),
+            catalog: target_catalog.to_string(),
+            schema: target_schema.to_string(),
             table: table_name.to_string(),
         };
 
+        let target_display = if target_catalog.is_empty() {
+            format!("{target_schema}.{table_name}")
+        } else {
+            format!("{target_catalog}.{target_schema}.{table_name}")
+        };
+
         let options = LoadOptions {
-            format: requested_format,
-            create_table: true,
-            truncate_first: truncate,
-            ..Default::default()
+            format: requested_format.or(base_options.format),
+            create_table: base_options.create_table,
+            truncate_first: truncate || base_options.truncate_first,
+            batch_size: base_options.batch_size,
+            csv_delimiter: base_options.csv_delimiter,
+            csv_has_header: base_options.csv_has_header,
         };
 
         info!(
             file = %file_path.display(),
-            target = %table_name,
+            target = %target_display,
             "loading file"
         );
 
@@ -159,9 +216,30 @@ pub async fn run_load(
                 );
                 total_rows += result.rows_loaded;
                 total_bytes += result.bytes_read;
+
+                // Record the loaded file in the state store for incremental tracking.
+                let record = LoadedFileRecord {
+                    loaded_at: chrono::Utc::now(),
+                    rows_loaded: result.rows_loaded,
+                    bytes_read: result.bytes_read,
+                    duration_ms: duration,
+                    file_hash: None,
+                };
+                if let Err(e) = state_store.record_loaded_file(
+                    pipeline_name,
+                    &file_path.display().to_string(),
+                    &record,
+                ) {
+                    tracing::warn!(
+                        error = %e,
+                        file = %file_path.display(),
+                        "failed to record loaded file in state store"
+                    );
+                }
+
                 file_results.push(LoadFileOutput {
                     file: file_path.display().to_string(),
-                    target: format!("main.{table_name}"),
+                    target: target_display,
                     rows_loaded: result.rows_loaded,
                     bytes_read: result.bytes_read,
                     duration_ms: duration,
@@ -179,7 +257,7 @@ pub async fn run_load(
                 );
                 file_results.push(LoadFileOutput {
                     file: file_path.display().to_string(),
-                    target: format!("main.{table_name}"),
+                    target: target_display,
                     rows_loaded: 0,
                     bytes_read: 0,
                     duration_ms: duration,
@@ -197,7 +275,7 @@ pub async fn run_load(
             version: VERSION.into(),
             command: "load".into(),
             source_dir: source_dir.display().to_string(),
-            format: format.unwrap_or("auto").to_string(),
+            format: format_label.to_string(),
             files_loaded,
             files_failed,
             total_rows,
@@ -229,6 +307,27 @@ pub async fn run_load(
     }
 
     Ok(())
+}
+
+/// Convert a config `LoadFileFormat` to the adapter SDK `FileFormat`.
+fn config_format_to_sdk(fmt: rocky_core::config::LoadFileFormat) -> FileFormat {
+    match fmt {
+        rocky_core::config::LoadFileFormat::Csv => FileFormat::Csv,
+        rocky_core::config::LoadFileFormat::Parquet => FileFormat::Parquet,
+        rocky_core::config::LoadFileFormat::JsonLines => FileFormat::JsonLines,
+    }
+}
+
+/// Convert config `LoadOptionsConfig` to the adapter SDK `LoadOptions`.
+fn config_options_to_sdk(opts: &rocky_core::config::LoadOptionsConfig) -> LoadOptions {
+    LoadOptions {
+        batch_size: opts.batch_size,
+        create_table: opts.create_table,
+        truncate_first: opts.truncate_first,
+        format: None,
+        csv_delimiter: opts.csv_delimiter.chars().next().unwrap_or(','),
+        csv_has_header: opts.csv_has_header,
+    }
 }
 
 /// Parse a format string into a [`FileFormat`].
@@ -346,5 +445,160 @@ mod tests {
     fn test_discover_files_nonexistent_dir() {
         let result = discover_files(Path::new("/nonexistent/path"), None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_format_to_sdk() {
+        assert_eq!(
+            config_format_to_sdk(rocky_core::config::LoadFileFormat::Csv),
+            FileFormat::Csv
+        );
+        assert_eq!(
+            config_format_to_sdk(rocky_core::config::LoadFileFormat::Parquet),
+            FileFormat::Parquet
+        );
+        assert_eq!(
+            config_format_to_sdk(rocky_core::config::LoadFileFormat::JsonLines),
+            FileFormat::JsonLines
+        );
+    }
+
+    #[test]
+    fn test_config_options_to_sdk_defaults() {
+        let config_opts = rocky_core::config::LoadOptionsConfig::default();
+        let sdk_opts = config_options_to_sdk(&config_opts);
+        assert_eq!(sdk_opts.batch_size, 10_000);
+        assert!(sdk_opts.create_table);
+        assert!(!sdk_opts.truncate_first);
+        assert_eq!(sdk_opts.csv_delimiter, ',');
+        assert!(sdk_opts.csv_has_header);
+    }
+
+    #[test]
+    fn test_config_options_to_sdk_custom() {
+        let config_opts = rocky_core::config::LoadOptionsConfig {
+            batch_size: 5000,
+            create_table: false,
+            truncate_first: true,
+            csv_delimiter: "\t".to_string(),
+            csv_has_header: false,
+        };
+        let sdk_opts = config_options_to_sdk(&config_opts);
+        assert_eq!(sdk_opts.batch_size, 5000);
+        assert!(!sdk_opts.create_table);
+        assert!(sdk_opts.truncate_first);
+        assert_eq!(sdk_opts.csv_delimiter, '\t');
+        assert!(!sdk_opts.csv_has_header);
+    }
+
+    /// Config-driven round-trip: parse load pipeline config, construct loader,
+    /// load a file, verify data and state tracking.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn test_config_driven_load_roundtrip() {
+        use rocky_duckdb::loader::DuckDbLoaderAdapter;
+
+        // Create a temp directory with a CSV file and a rocky.toml.
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+
+        let csv_path = data_dir.join("orders.csv");
+        std::fs::write(
+            &csv_path,
+            "id,product,qty\n1,Widget,10\n2,Gadget,5\n3,Doohickey,3\n",
+        )
+        .unwrap();
+
+        let toml_content = r#"
+[adapter.default]
+type = "duckdb"
+
+[pipeline.ingest]
+type = "load"
+source_dir = "data/"
+format = "csv"
+
+[pipeline.ingest.target]
+adapter = "default"
+catalog = ""
+schema = "main"
+
+[pipeline.ingest.options]
+batch_size = 1000
+create_table = true
+"#;
+        let config_path = dir.path().join("rocky.toml");
+        std::fs::write(&config_path, toml_content).unwrap();
+
+        // Parse the config.
+        let rocky_cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let pipeline = rocky_cfg.pipelines.get("ingest").unwrap();
+        let load_cfg = pipeline.as_load().unwrap();
+
+        // Verify config values parsed correctly.
+        assert_eq!(load_cfg.source_dir, "data/");
+        assert_eq!(
+            load_cfg.format,
+            Some(rocky_core::config::LoadFileFormat::Csv)
+        );
+        assert_eq!(load_cfg.target.schema, "main");
+        assert_eq!(load_cfg.options.batch_size, 1000);
+
+        // Build the loader adapter from the config.
+        let loader = DuckDbLoaderAdapter::in_memory().unwrap();
+
+        // Convert config options to SDK options.
+        let options = config_options_to_sdk(&load_cfg.options);
+        let target = rocky_adapter_sdk::TableRef {
+            catalog: load_cfg.target.catalog.clone(),
+            schema: load_cfg.target.schema.clone(),
+            table: "orders".into(),
+        };
+
+        // Load the file.
+        let result = loader
+            .load_file(&csv_path, &target, &options)
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows_loaded, 3);
+        assert!(result.bytes_read > 0);
+
+        // Verify data in the table.
+        let conn = loader.shared_connector();
+        let guard = conn.lock().unwrap();
+        let qr = guard
+            .execute_sql("SELECT product FROM main.orders ORDER BY id")
+            .unwrap();
+        assert_eq!(qr.rows.len(), 3);
+        assert_eq!(qr.rows[0][0], "Widget");
+        assert_eq!(qr.rows[1][0], "Gadget");
+        assert_eq!(qr.rows[2][0], "Doohickey");
+
+        // Verify state tracking round-trip.
+        let state_path = dir.path().join(".rocky_state");
+        let state_store = StateStore::open(&state_path).unwrap();
+        let record = LoadedFileRecord {
+            loaded_at: chrono::Utc::now(),
+            rows_loaded: result.rows_loaded,
+            bytes_read: result.bytes_read,
+            duration_ms: result.duration_ms,
+            file_hash: None,
+        };
+        state_store
+            .record_loaded_file("ingest", &csv_path.display().to_string(), &record)
+            .unwrap();
+
+        // Confirm the state was recorded.
+        let retrieved = state_store
+            .get_loaded_file("ingest", &csv_path.display().to_string())
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.rows_loaded, 3);
+
+        // Confirm listing works.
+        let files = state_store.list_loaded_files("ingest").unwrap();
+        assert_eq!(files.len(), 1);
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -26,6 +26,13 @@ const PARTITIONS: TableDefinition<&str, &[u8]> = TableDefinition::new("partition
 /// is deleted; when the grace period expires the column is dropped from
 /// the target and the record is removed.
 const GRACE_PERIODS: TableDefinition<&str, &[u8]> = TableDefinition::new("grace_periods");
+/// Per-file load tracking for the `load` pipeline type.
+///
+/// Key format: `"{pipeline_name}|{file_path}"` (e.g.
+/// `"ingest|data/orders.csv"`). Value: serialized [`LoadedFileRecord`].
+/// Used for incremental loads: files already recorded with a matching hash
+/// can be skipped.
+const LOADED_FILES: TableDefinition<&str, &[u8]> = TableDefinition::new("loaded_files");
 /// Key/value store for internal metadata (e.g. `"schema_version"`).
 const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 
@@ -34,7 +41,7 @@ const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 /// Increment this constant whenever a table is added, removed, or structurally
 /// changed in a way that is incompatible with an older binary. Rocky will
 /// refuse to open a database whose stored version exceeds this value.
-const CURRENT_SCHEMA_VERSION: u32 = 2;
+const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -128,7 +135,7 @@ impl StateStore {
                 }
                 None => {
                     // Fresh database or pre-versioning database — stamp the version.
-                    metadata.insert("schema_version", "2")?;
+                    metadata.insert("schema_version", "3")?;
                 }
             }
 
@@ -140,6 +147,7 @@ impl StateStore {
             let _table = txn.open_table(RUN_PROGRESS)?;
             let _table = txn.open_table(PARTITIONS)?;
             let _table = txn.open_table(GRACE_PERIODS)?;
+            let _table = txn.open_table(LOADED_FILES)?;
         }
         txn.commit()?;
 
@@ -822,6 +830,104 @@ impl StateStore {
         txn.commit()?;
         Ok(removed)
     }
+
+    // ------------------------------------------------------------------
+    // Loaded-files tracking (load pipeline)
+    // ------------------------------------------------------------------
+
+    /// Records a successfully loaded file for a pipeline.
+    ///
+    /// Key: `"{pipeline}|{file_path}"`.
+    pub fn record_loaded_file(
+        &self,
+        pipeline: &str,
+        file_path: &str,
+        record: &LoadedFileRecord,
+    ) -> Result<(), StateError> {
+        let key = loaded_file_key(pipeline, file_path);
+        let bytes = serde_json::to_vec(record)?;
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(LOADED_FILES)?;
+            table.insert(key.as_str(), bytes.as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Gets the record for a previously loaded file.
+    pub fn get_loaded_file(
+        &self,
+        pipeline: &str,
+        file_path: &str,
+    ) -> Result<Option<LoadedFileRecord>, StateError> {
+        let key = loaded_file_key(pipeline, file_path);
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(LOADED_FILES)?;
+        match table.get(key.as_str())? {
+            Some(value) => {
+                let record: LoadedFileRecord = serde_json::from_slice(value.value())?;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Lists all loaded files for a pipeline.
+    pub fn list_loaded_files(
+        &self,
+        pipeline: &str,
+    ) -> Result<Vec<(String, LoadedFileRecord)>, StateError> {
+        let prefix = format!("{pipeline}|");
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(LOADED_FILES)?;
+        let mut results = Vec::new();
+        for entry in table.iter()? {
+            let (key, value) = entry?;
+            let key_str = key.value();
+            if key_str.starts_with(&prefix) {
+                let file_path = key_str[prefix.len()..].to_string();
+                let record: LoadedFileRecord = serde_json::from_slice(value.value())?;
+                results.push((file_path, record));
+            }
+        }
+        Ok(results)
+    }
+
+    /// Deletes the record for a loaded file.
+    /// Returns true if a record was removed.
+    pub fn delete_loaded_file(&self, pipeline: &str, file_path: &str) -> Result<bool, StateError> {
+        let key = loaded_file_key(pipeline, file_path);
+        let txn = self.db.begin_write()?;
+        let removed;
+        {
+            let mut table = txn.open_table(LOADED_FILES)?;
+            removed = table.remove(key.as_str())?.is_some();
+        }
+        txn.commit()?;
+        Ok(removed)
+    }
+}
+
+/// Builds the key for the LOADED_FILES table.
+fn loaded_file_key(pipeline: &str, file_path: &str) -> String {
+    format!("{pipeline}|{file_path}")
+}
+
+/// Record of a successfully loaded file, stored in the state database.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LoadedFileRecord {
+    /// Timestamp of the load operation.
+    pub loaded_at: chrono::DateTime<chrono::Utc>,
+    /// Number of rows loaded from this file.
+    pub rows_loaded: u64,
+    /// Size of the source file in bytes.
+    pub bytes_read: u64,
+    /// Duration of the load in milliseconds.
+    pub duration_ms: u64,
+    /// SHA-256 hash of the file content (hex-encoded).
+    /// Used for change detection on incremental loads.
+    pub file_hash: Option<String>,
 }
 
 /// A historical row count snapshot for anomaly detection.
@@ -1623,6 +1729,127 @@ mod tests {
         assert!(
             store
                 .get_partition("fct", "orders|2026-04")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    // --- Loaded-files tracking tests ---
+
+    fn make_loaded_file_record(rows: u64, bytes: u64) -> LoadedFileRecord {
+        LoadedFileRecord {
+            loaded_at: Utc::now(),
+            rows_loaded: rows,
+            bytes_read: bytes,
+            duration_ms: 100,
+            file_hash: Some("abc123".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_record_and_get_loaded_file() {
+        let (store, _dir) = temp_store();
+        let rec = make_loaded_file_record(1000, 50_000);
+
+        store
+            .record_loaded_file("ingest", "data/orders.csv", &rec)
+            .unwrap();
+
+        let retrieved = store
+            .get_loaded_file("ingest", "data/orders.csv")
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.rows_loaded, 1000);
+        assert_eq!(retrieved.bytes_read, 50_000);
+        assert_eq!(retrieved.file_hash.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn test_get_nonexistent_loaded_file() {
+        let (store, _dir) = temp_store();
+        assert!(
+            store
+                .get_loaded_file("ingest", "data/nope.csv")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_record_loaded_file_overwrites() {
+        let (store, _dir) = temp_store();
+        let rec1 = make_loaded_file_record(100, 5000);
+        store
+            .record_loaded_file("ingest", "data/orders.csv", &rec1)
+            .unwrap();
+
+        let rec2 = make_loaded_file_record(200, 10_000);
+        store
+            .record_loaded_file("ingest", "data/orders.csv", &rec2)
+            .unwrap();
+
+        let retrieved = store
+            .get_loaded_file("ingest", "data/orders.csv")
+            .unwrap()
+            .unwrap();
+        assert_eq!(retrieved.rows_loaded, 200);
+    }
+
+    #[test]
+    fn test_list_loaded_files_filters_by_pipeline() {
+        let (store, _dir) = temp_store();
+        store
+            .record_loaded_file("pipe_a", "a.csv", &make_loaded_file_record(10, 100))
+            .unwrap();
+        store
+            .record_loaded_file("pipe_a", "b.csv", &make_loaded_file_record(20, 200))
+            .unwrap();
+        store
+            .record_loaded_file("pipe_b", "c.csv", &make_loaded_file_record(30, 300))
+            .unwrap();
+
+        let a_files = store.list_loaded_files("pipe_a").unwrap();
+        assert_eq!(a_files.len(), 2);
+
+        let b_files = store.list_loaded_files("pipe_b").unwrap();
+        assert_eq!(b_files.len(), 1);
+        assert_eq!(b_files[0].0, "c.csv");
+    }
+
+    #[test]
+    fn test_list_loaded_files_empty() {
+        let (store, _dir) = temp_store();
+        let files = store.list_loaded_files("nonexistent").unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn test_delete_loaded_file() {
+        let (store, _dir) = temp_store();
+        store
+            .record_loaded_file("ingest", "data/x.csv", &make_loaded_file_record(10, 100))
+            .unwrap();
+        assert!(store.delete_loaded_file("ingest", "data/x.csv").unwrap());
+        assert!(
+            store
+                .get_loaded_file("ingest", "data/x.csv")
+                .unwrap()
+                .is_none()
+        );
+        // Second delete is a no-op.
+        assert!(!store.delete_loaded_file("ingest", "data/x.csv").unwrap());
+    }
+
+    #[test]
+    fn test_loaded_file_key_namespacing() {
+        // Files from different pipelines must not collide.
+        let (store, _dir) = temp_store();
+        store
+            .record_loaded_file("pipe_a", "data.csv", &make_loaded_file_record(10, 100))
+            .unwrap();
+        assert!(
+            store
+                .get_loaded_file("pipe_b", "data.csv")
                 .unwrap()
                 .is_none()
         );

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -225,9 +225,9 @@ enum Command {
 
     /// Load files (CSV, Parquet, JSONL) from a directory into the warehouse
     Load {
-        /// Source directory containing data files
+        /// Source directory containing data files (overrides pipeline config)
         #[arg(long)]
-        source_dir: PathBuf,
+        source_dir: Option<PathBuf>,
         /// File format: csv, parquet, jsonl (default: auto-detect from extension)
         #[arg(long)]
         format: Option<String>,
@@ -866,7 +866,7 @@ async fn main() -> Result<()> {
         } => {
             rocky_cli::commands::run_load(
                 &cli.config,
-                &source_dir,
+                source_dir.as_deref(),
                 format.as_deref(),
                 target.as_deref(),
                 pipeline.as_deref(),


### PR DESCRIPTION
## Summary

- Wire `rocky load` to read from `LoadPipelineConfig` in `rocky.toml` -- `--source-dir` is now optional (falls back to config), target catalog/schema/options all resolve from config with CLI overrides
- Add `LOADED_FILES` state table in redb for per-pipeline file load tracking (`LoadedFileRecord` with rows/bytes/duration/hash), enabling future incremental loads
- Record each successful file load in the state store during `run_load`
- Bump state schema version to 3

## Test plan

- [x] 7 new state store unit tests for loaded-file CRUD (record, get, list, delete, key namespacing)
- [x] Config-to-SDK conversion tests (`config_format_to_sdk`, `config_options_to_sdk`)
- [x] Full config-driven round-trip integration test: parse `rocky.toml` with `type = "load"`, construct DuckDB loader, load CSV, verify data + state
- [x] All existing tests pass (820 rocky-core, 133 rocky-cli, 54 rocky-duckdb)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean