### PR TITLE
chore(dagster): bump version to 1.1.0

### DIFF
--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.0.0"
+version = "1.1.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump dagster-rocky from 1.0.0 to 1.1.0
- Includes: CiDiffOutput import fix, new generated types (ci_diff, cost hints, incrementality hints, compact_dedup scope)
- All 284 tests pass