### PR TITLE
refactor(engine/rocky-cli): follow-up cleanup from #61

### DIFF
--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -26,17 +26,10 @@ pub fn validate(config_path: &Path, json: bool) -> Result<()> {
 fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
     let mut out = ValidateOutput::new();
 
-    // Check file exists. Return the typed ConfigError so the CLI
-    // error reporter can upgrade it to a rich miette diagnostic with
-    // `rocky init` / `rocky playground` hints.
-    if !config_path.exists() {
-        return Err(rocky_core::config::ConfigError::FileNotFound {
-            path: config_path.to_path_buf(),
-        }
-        .into());
-    }
-
-    // Parse config (with env var substitution)
+    // Parse config (with env var substitution).
+    // load_rocky_config returns ConfigError::FileNotFound for missing
+    // files, which the CLI error reporter upgrades to a rich miette
+    // diagnostic with `rocky init` / `rocky playground` hints.
     let cfg = match rocky_core::config::load_rocky_config(config_path) {
         Ok(cfg) => {
             out.push(ValidateMessage {

--- a/engine/crates/rocky-cli/src/error_reporter.rs
+++ b/engine/crates/rocky-cli/src/error_reporter.rs
@@ -234,6 +234,22 @@ type = "databricks"
     }
 
     #[test]
+    fn file_not_found_found_through_context_wrapping() {
+        let missing_path = std::path::PathBuf::from("/not/real/rocky.toml");
+        let err: anyhow::Error = ConfigError::FileNotFound {
+            path: missing_path.clone(),
+        }
+        .into();
+        let wrapped = err.context("failed to load config from /not/real/rocky.toml");
+
+        let diag = try_upgrade_config_error(&wrapped, &missing_path);
+        assert!(
+            diag.is_some(),
+            "should find FileNotFound through .context() wrapping"
+        );
+    }
+
+    #[test]
     fn did_you_mean_finds_close_match() {
         assert_eq!(
             did_you_mean("databrik", KNOWN_ADAPTER_TYPES),


### PR DESCRIPTION
## Summary

Follow-up to #61 (friendly error when rocky.toml is missing). Two small cleanups from the code review:

- **Remove redundant `config_path.exists()` pre-check in `validate.rs`** — now that `load_rocky_config` returns `ConfigError::FileNotFound` for missing files, the explicit existence check is redundant and introduces a minor TOCTOU race. The function already calls `load_rocky_config` on the next line, which handles this case.
- **Add test for `.context()`-wrapped `FileNotFound` errors** — every command except `validate` wraps `load_rocky_config` with `.context("failed to load config from ...")`. The new test locks in that `try_upgrade_config_error` finds `FileNotFound` through the `.context()` layer via `downcast_ref`.

## Test plan

- [x] `cargo test -p rocky-cli` — 136 tests pass (including 1 new: `file_not_found_found_through_context_wrapping`)
- [x] `cargo clippy -p rocky-cli --all-targets -- -D warnings` clean