### PR TITLE
feat(dagster): shadow suffix + structured drift Pipes events

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "redis",
  "serde",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "logos",
  "miette",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "miette",
  "regex",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.0.1"
+version = "1.0.2"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.0.1"
+version = "1.0.2"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.0.1"
+version = "1.0.2"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.0.1"
+version = "1.0.2"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.0.1"
+version = "1.0.2"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3057,7 +3057,7 @@ mod tests {
         };
 
         let output = RunOutput {
-            version: "1.0.1".into(),
+            version: "1.0.2".into(),
             command: "run".into(),
             pipeline_type: None,
             filter: "tenant=acme".into(),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1724,11 +1724,23 @@ pub(super) fn emit_pipes_events(pipes: &crate::pipes::PipesEmitter, output: &Run
         }
     }
 
-    // Drift actions: surface as log messages so they appear in the
-    // Dagster run viewer's structured logs. Drift is a structural
-    // event, not pass/fail; the dagster-rocky integration converts
-    // these to AssetObservation events on its own side.
+    // Drift actions: emit as asset checks (severity=WARN, passed=true)
+    // so they surface as structured events in the Dagster run viewer.
+    // The check name is "drift" (grouped per table); action details go
+    // into metadata so the UI doesn't fragment by action type.
+    // Also emit a log line for human-readable visibility.
     for action in &output.drift.actions_taken {
+        pipes.report_asset_check(
+            &action.table,
+            "drift",
+            true,
+            crate::pipes::PipesCheckSeverity::Warn,
+            &json!({
+                "table": action.table,
+                "action": action.action,
+                "reason": action.reason,
+            }),
+        );
         pipes.log(
             "WARN",
             &format!(
@@ -3022,5 +3034,102 @@ mod tests {
 
         // Verify metrics
         assert_eq!(throttle.rate_limits_total(), 2);
+    }
+
+    #[test]
+    fn test_emit_pipes_drift_produces_structured_check_and_log() {
+        use crate::output::{
+            DriftActionOutput, DriftSummary, ExecutionSummary, PermissionSummary, RunOutput,
+        };
+        use crate::pipes::PipesEmitter;
+        use std::io::Read;
+        use std::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pipes_drift.txt");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+        let emitter = PipesEmitter {
+            channel: Mutex::new(Box::new(file)),
+        };
+
+        let output = RunOutput {
+            version: "1.0.1".into(),
+            command: "run".into(),
+            pipeline_type: None,
+            filter: "tenant=acme".into(),
+            duration_ms: 100,
+            tables_copied: 0,
+            tables_failed: 0,
+            tables_skipped: 0,
+            excluded_tables: vec![],
+            resumed_from: None,
+            shadow: false,
+            materializations: vec![],
+            check_results: vec![],
+            anomalies: vec![],
+            errors: vec![],
+            execution: ExecutionSummary {
+                concurrency: 1,
+                tables_processed: 0,
+                tables_failed: 0,
+                adaptive_concurrency: false,
+                final_concurrency: None,
+                rate_limits_detected: None,
+            },
+            metrics: None,
+            permissions: PermissionSummary {
+                grants_added: 0,
+                grants_revoked: 0,
+                catalogs_created: 0,
+                schemas_created: 0,
+            },
+            drift: DriftSummary {
+                tables_checked: 1,
+                tables_drifted: 1,
+                actions_taken: vec![DriftActionOutput {
+                    table: "acme.raw_orders".into(),
+                    action: "add_column".into(),
+                    reason: "column 'email' found in source but not target".into(),
+                }],
+            },
+            partition_summaries: vec![],
+        };
+
+        emit_pipes_events(&emitter, &output);
+
+        let mut content = String::new();
+        std::fs::File::open(&path)
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+        let lines: Vec<serde_json::Value> = content
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+
+        // Should produce 2 messages: one report_asset_check + one log
+        assert_eq!(lines.len(), 2);
+
+        // First: structured check
+        let check = &lines[0];
+        assert_eq!(check["method"], "report_asset_check");
+        assert_eq!(check["params"]["check_name"], "drift");
+        assert_eq!(check["params"]["passed"], true);
+        assert_eq!(check["params"]["severity"], "WARN");
+        assert_eq!(check["params"]["metadata"]["table"], "acme.raw_orders");
+        assert_eq!(check["params"]["metadata"]["action"], "add_column");
+
+        // Second: human-readable log
+        let log = &lines[1];
+        assert_eq!(log["method"], "log");
+        assert_eq!(log["params"]["level"], "WARN");
+        let msg = log["params"]["message"].as_str().unwrap();
+        assert!(msg.contains("acme.raw_orders"));
+        assert!(msg.contains("add_column"));
     }
 }

--- a/engine/crates/rocky-cli/src/pipes.rs
+++ b/engine/crates/rocky-cli/src/pipes.rs
@@ -69,7 +69,7 @@ pub struct PipesEmitter {
     /// File handle protected by a mutex so multiple threads (e.g. the
     /// `--parallel` partition execution path) can emit concurrently
     /// without interleaving lines.
-    channel: Mutex<Box<dyn Write + Send>>,
+    pub(crate) channel: Mutex<Box<dyn Write + Send>>,
 }
 
 impl std::fmt::Debug for PipesEmitter {

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.0.1"
+version = "1.0.2"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.0.1"
+version = "1.0.2"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.0.1"
+version = "1.0.2"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.0.1"
+version = "1.0.2"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.0.1"
+version = "1.0.2"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.0.1"
+version = "1.0.2"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.0.1"
+version = "1.0.2"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.0.1"
+version = "1.0.2"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.0.1"
+version = "1.0.2"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.0.1"
+version = "1.0.2"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.0.1"
+version = "1.0.2"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.0.1"
+version = "1.0.2"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.0.1"
+version = "1.0.2"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.1.0"
+version = "1.1.1"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -288,13 +288,11 @@ class RockyResource(dg.ConfigurableResource):
         in the Dagster run viewer in real time, and the integration
         gets the typed result back at the end.
 
-        Note: this is "Pipes-style" rather than full Dagster Pipes
-        because rocky-cli does not yet emit Dagster Pipes protocol
-        messages. When the engine adds that, this method can be
-        upgraded to use ``PipesSubprocessClient`` for per-model
-        materialization-event streaming. Until then, what users get is
-        live log streaming + final result parsing — a meaningful
-        improvement over the buffered ``run()`` path.
+        For full Dagster Pipes integration with structured per-model
+        materialization and check events, use
+        :meth:`RockyResource.run_pipes` instead. This method provides
+        live log streaming + final result parsing without requiring
+        the Pipes protocol.
 
         Args:
             args: CLI arguments after the global flags. ``--config``,
@@ -418,6 +416,7 @@ class RockyResource(dg.ConfigurableResource):
         missing: bool = False,
         lookback: int | None = None,
         parallel: int | None = None,
+        shadow_suffix: str | None = None,
     ) -> RunResult:
         """Run ``rocky run --filter <key=value>`` and return the parsed result.
 
@@ -448,6 +447,9 @@ class RockyResource(dg.ConfigurableResource):
                 the selected ones. Overrides the model's TOML ``lookback``.
             parallel: Run N partitions concurrently (warehouse-query
                 parallelism only). Defaults to 1 on the engine side.
+            shadow_suffix: When set, enables shadow mode and uses the given
+                suffix for shadow table names (e.g. ``"_dagster_pr_42"``).
+                Typically derived from :func:`.branch_deploy.branch_deploy_shadow_suffix`.
         """
         args = self._build_run_args(
             filter,
@@ -460,6 +462,7 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
+            shadow_suffix=shadow_suffix,
         )
         return RunResult.model_validate_json(self._run_rocky(args, allow_partial=True))
 
@@ -477,8 +480,9 @@ class RockyResource(dg.ConfigurableResource):
         missing: bool = False,
         lookback: int | None = None,
         parallel: int | None = None,
+        shadow_suffix: str | None = None,
     ) -> RunResult:
-        """Pipes-style ``rocky run`` with live stderr streaming to ``context.log``.
+        """``rocky run`` with live stderr streaming to ``context.log``.
 
         Same semantics as :meth:`run` but spawns the binary via
         ``subprocess.Popen`` and forwards rocky's stderr (where the
@@ -488,15 +492,11 @@ class RockyResource(dg.ConfigurableResource):
         Use this method from inside a Dagster ``@multi_asset`` /
         ``@op`` for runs longer than a few seconds — users will see
         progress in the run viewer as it happens, instead of waiting
-        for the full output to buffer at the end.
+        for the full output to buffer at the end. For full Dagster
+        Pipes integration with structured materialization and check
+        events, use :meth:`run_pipes` instead.
 
-        Background: this is "Pipes-style" rather than full Dagster
-        Pipes (``PipesSubprocessClient``) because rocky-cli does not
-        yet emit the Dagster Pipes message protocol. When the engine
-        adds Pipes message emission, this method can be upgraded to
-        use ``PipesSubprocessClient`` for per-model materialization
-        events streaming live (instead of all at once at the end).
-        Until then, what users get from this method is:
+        What users get from this method:
 
         * Live stderr → ``context.log.info`` streaming (every Rust
           ``info!()`` / ``warn!()`` macro shows up in the run viewer
@@ -518,6 +518,7 @@ class RockyResource(dg.ConfigurableResource):
             partition / partition_from / partition_to / latest /
             missing / lookback / parallel: Same as :meth:`run` —
                 Phase 3 partition selection flags.
+            shadow_suffix: Same as :meth:`run`.
 
         Returns:
             The parsed :class:`RunResult` from stdout after the
@@ -534,6 +535,7 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
+            shadow_suffix=shadow_suffix,
         )
         return RunResult.model_validate_json(
             self._run_rocky_streaming(args, context, allow_partial=True)
@@ -552,21 +554,24 @@ class RockyResource(dg.ConfigurableResource):
         missing: bool,
         lookback: int | None,
         parallel: int | None,
+        shadow_suffix: str | None = None,
     ) -> list[str]:
-        """Shared argv builder used by both :meth:`run` and :meth:`run_streaming`.
+        """Shared argv builder used by :meth:`run`, :meth:`run_streaming`, and :meth:`run_pipes`.
 
-        Single source of truth for the partition flag plumbing so
-        adding a new flag is a one-place change. The flags are
-        defensive: ``partition_from`` without ``partition_to`` emits
-        neither (rocky requires both for range mode), and the engine
-        enforces mutual-exclusion via clap so we trust it to error
-        helpfully if multiple selection flags are passed simultaneously.
+        Single source of truth for the flag plumbing so adding a new
+        flag is a one-place change. The flags are defensive:
+        ``partition_from`` without ``partition_to`` emits neither
+        (rocky requires both for range mode), and the engine enforces
+        mutual-exclusion via clap so we trust it to error helpfully if
+        multiple selection flags are passed simultaneously.
         """
         args = ["run", "--filter", filter]
         if governance_override:
             args.extend(["--governance-override", json.dumps(governance_override)])
         if run_models:
             args.extend(["--models", self.models_dir, "--all"])
+        if shadow_suffix is not None:
+            args.extend(["--shadow", "--shadow-suffix", shadow_suffix])
         if partition is not None:
             args.extend(["--partition", partition])
         if partition_from is not None and partition_to is not None:
@@ -595,6 +600,7 @@ class RockyResource(dg.ConfigurableResource):
         missing: bool = False,
         lookback: int | None = None,
         parallel: int | None = None,
+        shadow_suffix: str | None = None,
         pipes_client: dg.PipesSubprocessClient | None = None,
     ) -> dg.PipesClientCompletedInvocation:
         """Full Dagster Pipes execution: structured events streamed via the protocol.
@@ -610,9 +616,9 @@ class RockyResource(dg.ConfigurableResource):
         * ``MaterializationEvent`` per copied table (with rocky/strategy,
           duration_ms, rows_copied, target_table_full_name, sql_hash,
           partition_key when set)
-        * ``AssetCheckEvaluation`` per Rocky check
+        * ``AssetCheckEvaluation`` per Rocky check and drift observation
         * ``log`` events for the rocky run starting / completing
-          messages and any drift actions
+          messages and drift action details
 
         Use this method from a ``@dg.asset`` or ``@dg.multi_asset``
         when you want **structured** Dagster events from the rocky
@@ -638,7 +644,8 @@ class RockyResource(dg.ConfigurableResource):
                 :meth:`run_streaming` — required for Pipes context
                 injection (run id, partition key, asset keys, etc.).
             filter: Component filter (e.g. ``"tenant=acme"``).
-            governance_override / run_models / partition / ... :
+            governance_override / run_models / partition /
+            shadow_suffix / ... :
                 Same as :meth:`run` and :meth:`run_streaming`. Threaded
                 into the rocky CLI command via :meth:`_build_run_args`.
             pipes_client: Optional pre-configured
@@ -667,6 +674,7 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
+            shadow_suffix=shadow_suffix,
         )
         client = pipes_client or dg.PipesSubprocessClient()
         return client.run(

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -686,6 +686,82 @@ def test_run_default_omits_all_partition_flags():
         assert flag not in args, f"unexpected {flag} in {args}"
 
 
+# ---------------------------------------------------------------------------
+# Shadow suffix plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_run_with_shadow_suffix_appends_shadow_flags():
+    """shadow_suffix enables shadow mode and passes the suffix to the CLI."""
+    rocky = RockyResource()
+    captured, fake_run = _capture_run_args()
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme", shadow_suffix="_dagster_pr_42")
+    args = captured[0]
+    assert "--shadow" in args
+    shadow_idx = args.index("--shadow-suffix")
+    assert args[shadow_idx + 1] == "_dagster_pr_42"
+
+
+def test_run_without_shadow_suffix_omits_shadow_flags():
+    """When shadow_suffix is None, no --shadow flags appear."""
+    rocky = RockyResource()
+    captured, fake_run = _capture_run_args()
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+    args = captured[0]
+    assert "--shadow" not in args
+    assert "--shadow-suffix" not in args
+
+
+def test_run_streaming_with_shadow_suffix():
+    """run_streaming threads shadow_suffix through to the CLI command."""
+    rocky = RockyResource()
+    context = _captured_log_context()
+    proc = _streaming_popen_mock(stdout=_run_json(), stderr_lines=[])
+
+    captured_cmd: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        captured_cmd.append(cmd)
+        return proc
+
+    with (
+        patch.object(RockyResource, "_verify_engine_version"),
+        patch("dagster_rocky.resource.subprocess.Popen", side_effect=fake_popen),
+    ):
+        rocky.run_streaming(
+            context,
+            filter="tenant=acme",
+            shadow_suffix="_dagster_pr_99",
+        )
+
+    cmd = captured_cmd[0]
+    assert "--shadow" in cmd
+    shadow_idx = cmd.index("--shadow-suffix")
+    assert cmd[shadow_idx + 1] == "_dagster_pr_99"
+
+
+def test_run_pipes_with_shadow_suffix():
+    """run_pipes threads shadow_suffix through to the CLI command."""
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+
+    rocky.run_pipes(
+        context,
+        filter="tenant=acme",
+        shadow_suffix="_dagster_pr_7",
+        pipes_client=fake_client,
+    )
+
+    cmd = fake_client.run.call_args.kwargs["command"]
+    assert "--shadow" in cmd
+    shadow_idx = cmd.index("--shadow-suffix")
+    assert cmd[shadow_idx + 1] == "_dagster_pr_7"
+
+
 def test_compile_uses_http_when_server_url_is_set():
     rocky = RockyResource(server_url="http://localhost:8080")
     payload = (

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

- **Shadow suffix**: Wire `shadow_suffix` parameter through `run()`, `run_streaming()`, and `run_pipes()` so callers can route data to shadow tables via `--shadow --shadow-suffix`. The `branch_deploy` module already derives the suffix — this closes the last-mile integration gap.
- **Structured drift in Pipes**: Upgrade drift emission from unstructured `log("WARN", ...)` to `report_asset_check(check_name="drift", severity=WARN, passed=true)` so drift observations surface as `AssetCheckEvaluation` events in the Dagster run viewer. Human-readable log line kept alongside.
- **Version bumps**: Engine `1.0.1` → `1.0.2`, dagster-rocky `1.1.0` → `1.1.1`
- **Stale docstring fix**: `run_streaming()` and `_run_rocky_streaming()` no longer claim "rocky-cli does not yet emit Dagster Pipes"

## Test plan

- [x] 4 new Python tests: shadow_suffix through run/run_streaming/run_pipes + absent-when-None
- [x] 1 new Rust test: drift action produces `report_asset_check` + `log` messages with correct shape
- [x] All 65 existing resource + branch_deploy tests pass
- [x] All 7 Pipes-related Rust tests pass
- [x] clippy clean, ruff clean (pre-existing import sort issue unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)