### PR TITLE
fix(vscode): add wasm-unsafe-eval CSP for lineage webview

### DIFF
--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -142,7 +142,7 @@ function renderLineageHtml(
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'none';
                  style-src ${webview.cspSource} 'unsafe-inline';
-                 script-src ${webview.cspSource} 'nonce-${nonce}';
+                 script-src ${webview.cspSource} 'nonce-${nonce}' 'wasm-unsafe-eval';
                  img-src ${webview.cspSource} data:;" />
   <title>Lineage: ${escapeHtml(modelName)}</title>
   <style nonce="${nonce}">


### PR DESCRIPTION
## Summary
- Add `'wasm-unsafe-eval'` to the lineage webview's Content Security Policy `script-src` directive
- viz.js uses `WebAssembly.instantiate()` which requires this CSP permission — without it, every lineage render crashes with a `CompileError`

## Test plan
- [ ] Open a Rocky project in VS Code, run **Rocky: Show Lineage** on any model
- [ ] Verify the DAG renders as an interactive SVG (pan, zoom, export all work)
- [ ] Verify no CSP errors in the webview developer tools console