### PR TITLE
fix(engine): smoke test bugs — validate exit code, doctor status, plan governance

### DIFF
--- a/RELEASE_SMOKE.md
+++ b/RELEASE_SMOKE.md
@@ -39,7 +39,7 @@ section.
 
 ```bash
 cd examples/playground/pocs/00-foundations/00-playground-default
-rocky validate -c rocky.toml
+rocky -c rocky.toml validate
 ```
 
 | | |
@@ -147,7 +147,7 @@ rocky -c rocky.toml state
 ### 1.10 Doctor
 
 ```bash
-rocky doctor -c rocky.toml
+rocky -c rocky.toml doctor
 ```
 
 | | |
@@ -177,8 +177,8 @@ Use the dedicated snapshot POC:
 
 ```bash
 cd examples/playground/pocs/01-quality/05-snapshot-scd2
-duckdb poc.duckdb < data/seed.sql
-rocky snapshot -c rocky.toml --dry-run
+duckdb poc.duckdb < data/seed_v1.sql
+rocky -c rocky.toml snapshot --dry-run
 ```
 
 | | |
@@ -192,7 +192,7 @@ rocky snapshot -c rocky.toml --dry-run
 If the playground POC has a `seeds/` directory with CSV files:
 
 ```bash
-rocky seed -c rocky.toml
+rocky -c rocky.toml seed
 ```
 
 | | |
@@ -247,7 +247,7 @@ rocky -c rocky-databricks.toml run --filter <key>=<value>
 ### 2.4 Seed
 
 ```bash
-rocky seed -c rocky-databricks.toml --seeds seeds/
+rocky -c rocky-databricks.toml seed --seeds seeds/
 ```
 
 | | |
@@ -261,7 +261,7 @@ rocky seed -c rocky-databricks.toml --seeds seeds/
 Requires a `type = "snapshot"` pipeline in the config with Databricks adapter.
 
 ```bash
-rocky snapshot -c rocky-databricks.toml --dry-run
+rocky -c rocky-databricks.toml snapshot --dry-run
 ```
 
 | | |
@@ -273,7 +273,7 @@ rocky snapshot -c rocky-databricks.toml --dry-run
 ### 2.6 Doctor
 
 ```bash
-rocky doctor -c rocky-databricks.toml
+rocky -c rocky-databricks.toml doctor
 ```
 
 | | |
@@ -340,7 +340,7 @@ rocky -c rocky-snowflake.toml run --filter <key>=<value>
 ### 3.4 Seed
 
 ```bash
-rocky seed -c rocky-snowflake.toml --seeds seeds/
+rocky -c rocky-snowflake.toml seed --seeds seeds/
 ```
 
 | | |
@@ -352,7 +352,7 @@ rocky seed -c rocky-snowflake.toml --seeds seeds/
 ### 3.5 Snapshot
 
 ```bash
-rocky snapshot -c rocky-snowflake.toml --dry-run
+rocky -c rocky-snowflake.toml snapshot --dry-run
 ```
 
 | | |
@@ -364,7 +364,7 @@ rocky snapshot -c rocky-snowflake.toml --dry-run
 ### 3.6 Doctor
 
 ```bash
-rocky doctor -c rocky-snowflake.toml
+rocky -c rocky-snowflake.toml doctor
 ```
 
 | | |
@@ -468,7 +468,7 @@ rocky -c rocky-bigquery.toml run --filter <key>=<value>
 ### 5.4 Doctor
 
 ```bash
-rocky doctor -c rocky-bigquery.toml
+rocky -c rocky-bigquery.toml doctor
 ```
 
 | | |
@@ -504,7 +504,7 @@ Spot-check that `--output table` renders without panics:
 ```bash
 rocky -c rocky.toml discover --output table
 rocky -c rocky.toml state --output table
-rocky doctor -c rocky.toml --output table
+rocky -c rocky.toml doctor --output table
 ```
 
 | | |
@@ -532,8 +532,8 @@ rocky run --help
 Verify non-zero exits for expected failures:
 
 ```bash
-rocky validate -c /nonexistent/rocky.toml; echo "exit: $?"
-rocky run -c rocky.toml --filter source=NONEXISTENT; echo "exit: $?"
+rocky -c /nonexistent/rocky.toml validate; echo "exit: $?"
+rocky -c rocky.toml run --filter source=NONEXISTENT; echo "exit: $?"
 ```
 
 | | |

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "redis",
  "serde",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "logos",
  "miette",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "miette",
  "regex",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.0.2"
+version = "1.0.3"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.0.2"
+version = "1.0.3"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.0.2"
+version = "1.0.3"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.0.2"
+version = "1.0.3"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.0.2"
+version = "1.0.3"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -324,7 +324,7 @@ pub async fn doctor(
     let overall = if has_critical {
         "critical"
     } else if has_warning {
-        "degraded"
+        "warning"
     } else {
         "healthy"
     };
@@ -364,8 +364,6 @@ pub async fn doctor(
 
     if has_critical {
         std::process::exit(2);
-    } else if has_warning {
-        std::process::exit(1);
     }
 
     Ok(())

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -75,31 +75,35 @@ pub async fn plan(
             String::new()
         };
 
-        // Catalog creation — only when the dialect supports catalogs.
-        if let Some(create_cat) = dialect.create_catalog_sql(&target_catalog) {
-            let sql = create_cat.map_err(|e| anyhow::anyhow!("create_catalog: {e}"))?;
-            output.statements.push(PlannedStatement {
-                purpose: "create_catalog".into(),
-                target: target_catalog.clone(),
-                sql,
-            });
+        // Catalog creation — only when governance enables it and the dialect supports catalogs.
+        if pipeline.target.governance.auto_create_catalogs {
+            if let Some(create_cat) = dialect.create_catalog_sql(&target_catalog) {
+                let sql = create_cat.map_err(|e| anyhow::anyhow!("create_catalog: {e}"))?;
+                output.statements.push(PlannedStatement {
+                    purpose: "create_catalog".into(),
+                    target: target_catalog.clone(),
+                    sql,
+                });
+            }
         }
 
-        // Schema creation — pass empty catalog when the dialect is catalog-less.
-        if let Some(create_sch) =
-            dialect.create_schema_sql(&effective_target_catalog, &target_schema)
-        {
-            let sql = create_sch.map_err(|e| anyhow::anyhow!("create_schema: {e}"))?;
-            let target_label = if effective_target_catalog.is_empty() {
-                target_schema.clone()
-            } else {
-                format!("{effective_target_catalog}.{target_schema}")
-            };
-            output.statements.push(PlannedStatement {
-                purpose: "create_schema".into(),
-                target: target_label,
-                sql,
-            });
+        // Schema creation — only when governance enables it.
+        if pipeline.target.governance.auto_create_schemas {
+            if let Some(create_sch) =
+                dialect.create_schema_sql(&effective_target_catalog, &target_schema)
+            {
+                let sql = create_sch.map_err(|e| anyhow::anyhow!("create_schema: {e}"))?;
+                let target_label = if effective_target_catalog.is_empty() {
+                    target_schema.clone()
+                } else {
+                    format!("{effective_target_catalog}.{target_schema}")
+                };
+                output.statements.push(PlannedStatement {
+                    purpose: "create_schema".into(),
+                    target: target_label,
+                    sql,
+                });
+            }
         }
 
         // Per-table copy SQL

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -20,6 +20,10 @@ pub fn validate(config_path: &Path, json: bool) -> Result<()> {
         render_text(&output);
     }
 
+    if !output.valid {
+        std::process::exit(1);
+    }
+
     Ok(())
 }
 

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.0.2"
+version = "1.0.3"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.0.2"
+version = "1.0.3"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.0.2"
+version = "1.0.3"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.0.2"
+version = "1.0.3"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.0.2"
+version = "1.0.3"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.0.2"
+version = "1.0.3"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.0.2"
+version = "1.0.3"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.0.2"
+version = "1.0.3"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.0.2"
+version = "1.0.3"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.0.2"
+version = "1.0.3"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.0.2"
+version = "1.0.3"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.0.2"
+version = "1.0.3"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.0.2"
+version = "1.0.3"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.0.2"
+version = "1.0.3"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/examples/playground/pocs/00-foundations/00-playground-default/rocky.toml
+++ b/examples/playground/pocs/00-foundations/00-playground-default/rocky.toml
@@ -14,6 +14,9 @@ path = "playground.duckdb"
 strategy = "full_refresh"
 timestamp_column = "_updated_at"
 
+[pipeline.playground.source.discovery]
+adapter = "default"
+
 [pipeline.playground.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -22,6 +25,9 @@ components = ["source"]
 [pipeline.playground.target]
 catalog_template = "playground"
 schema_template = "staging__{source}"
+
+[pipeline.playground.target.governance]
+auto_create_schemas = true
 
 [pipeline.playground.checks]
 row_count = false

--- a/examples/playground/pocs/01-quality/03-anomaly-detection/rocky.toml
+++ b/examples/playground/pocs/01-quality/03-anomaly-detection/rocky.toml
@@ -5,6 +5,9 @@ path = "poc.duckdb"
 [pipeline.poc]
 strategy = "full_refresh"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -13,6 +16,9 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
 
 [pipeline.poc.checks]
 enabled = true

--- a/examples/playground/pocs/02-performance/01-incremental-watermark/rocky.toml
+++ b/examples/playground/pocs/02-performance/01-incremental-watermark/rocky.toml
@@ -6,6 +6,9 @@ path = "poc.duckdb"
 strategy = "incremental"
 timestamp_column = "occurred_at"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -14,3 +17,6 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/02-performance/03-partition-checksum/rocky.toml
+++ b/examples/playground/pocs/02-performance/03-partition-checksum/rocky.toml
@@ -18,6 +18,9 @@ path = "poc.duckdb"
 [pipeline.poc]
 strategy = "full_refresh"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -26,3 +29,6 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/02-performance/05-optimize-recommendations/rocky.toml
+++ b/examples/playground/pocs/02-performance/05-optimize-recommendations/rocky.toml
@@ -5,6 +5,9 @@ path = "poc.duckdb"
 [pipeline.poc]
 strategy = "full_refresh"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -13,6 +16,9 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
 
 [cost]
 storage_cost_per_gb_month = 0.023

--- a/examples/playground/pocs/02-performance/06-schema-drift-recover/rocky.toml
+++ b/examples/playground/pocs/02-performance/06-schema-drift-recover/rocky.toml
@@ -6,6 +6,9 @@ path = "poc.duckdb"
 strategy = "incremental"
 timestamp_column = "_updated_at"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -14,3 +17,6 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -847,11 +847,11 @@ from .types_generated import (  # noqa: E402, F401
     ChecksConfigOutput,
     CiDiffOutput,
     CiOutput,
-    DiffResult,
-    DiffSummary,
     ColumnLineageOutput,
     ColumnTrendPoint,
     CompileOutput,
+    DiffResult,
+    DiffSummary,
     DiscoverOutput,
     DoctorOutput,
     DriftActionOutput,
@@ -884,7 +884,6 @@ from .types_generated import (  # noqa: E402, F401
     TestFailure,
     TestOutput,
 )
-
 
 # ---------------------------------------------------------------------------
 # Union type and parser

--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,23 +9,59 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:15.056301Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
-  "check_results": [],
+  "check_results": [
+    {
+      "asset_key": [
+        "duckdb",
+        "events",
+        "events"
+      ],
+      "checks": [
+        {
+          "name": "row_count",
+          "passed": true,
+          "source_count": 500,
+          "target_count": 500
+        }
+      ]
+    }
+  ],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +69,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,23 +9,59 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:15.162332Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
-  "check_results": [],
+  "check_results": [
+    {
+      "asset_key": [
+        "duckdb",
+        "events",
+        "events"
+      ],
+      "checks": [
+        {
+          "name": "row_count",
+          "passed": true,
+          "source_count": 500,
+          "target_count": 500
+        }
+      ]
+    }
+  ],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +69,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,23 +9,59 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:15.265925Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
-  "check_results": [],
+  "check_results": [
+    {
+      "asset_key": [
+        "duckdb",
+        "events",
+        "events"
+      ],
+      "checks": [
+        {
+          "name": "row_count",
+          "passed": true,
+          "source_count": 500,
+          "target_count": 500
+        }
+      ]
+    }
+  ],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +69,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,23 +9,68 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:15.371220Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
-  "check_results": [],
+  "check_results": [
+    {
+      "asset_key": [
+        "duckdb",
+        "events",
+        "events"
+      ],
+      "checks": [
+        {
+          "name": "row_count",
+          "passed": true,
+          "source_count": 5,
+          "target_count": 5
+        }
+      ]
+    }
+  ],
+  "anomalies": [
+    {
+      "table": "poc.staging__events.events",
+      "current_count": 5,
+      "baseline_avg": 376.25,
+      "deviation_pct": 98.67109634551495,
+      "reason": "row count dropped 98.7% (expected ~376, got 5)"
+    }
+  ],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 1,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +78,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,
@@ -23,6 +23,20 @@
         "catalog": "playground",
         "schema": "staging",
         "table": "raw_orders"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_date",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_date' ends with '_date' (timestamp pattern)"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 10000,
+        "estimated_bytes": 2560000,
+        "estimated_cost_usd": 2.28e-05,
+        "confidence": "high"
       }
     },
     {
@@ -34,6 +48,20 @@
         "catalog": "playground",
         "schema": "gold",
         "table": "revenue_summary"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "customer_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'customer_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 6400,
+        "estimated_bytes": 1638400,
+        "estimated_cost_usd": 0.0001128,
+        "confidence": "medium"
       }
     },
     {
@@ -45,6 +73,20 @@
         "catalog": "playground",
         "schema": "silver",
         "table": "customer_orders"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "customer_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'customer_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 8000,
+        "estimated_bytes": 2048000,
+        "estimated_cost_usd": 7.280000000000001e-05,
+        "confidence": "medium"
       }
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,
@@ -40,6 +40,20 @@
         "catalog": "poc",
         "schema": "demo",
         "table": "broken_metrics"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 8000,
+        "estimated_bytes": 2048000,
+        "estimated_cost_usd": 7.280000000000001e-05,
+        "confidence": "medium"
       }
     },
     {
@@ -51,6 +65,20 @@
         "catalog": "poc",
         "schema": "demo",
         "table": "good_metrics"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 8000,
+        "estimated_bytes": 2048000,
+        "estimated_cost_usd": 7.280000000000001e-05,
+        "confidence": "medium"
       }
     },
     {
@@ -62,6 +90,20 @@
         "catalog": "poc",
         "schema": "staging",
         "table": "raw_orders"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 10000,
+        "estimated_bytes": 2560000,
+        "estimated_cost_usd": 2.28e-05,
+        "confidence": "high"
       }
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -1,6 +1,6 @@
 {
   "command": "doctor",
-  "overall": "degraded",
+  "overall": "warning",
   "checks": [
     {
       "name": "config",
@@ -11,7 +11,7 @@
     {
       "name": "state",
       "status": "healthy",
-      "message": "State store healthy (0 watermarks)",
+      "message": "State store healthy (1 watermarks)",
       "duration_ms": 0
     },
     {
@@ -30,6 +30,24 @@
       "name": "state_sync",
       "status": "warning",
       "message": "State backend: local",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth/default",
+      "status": "healthy",
+      "message": "Authenticated to default",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth",
+      "status": "healthy",
+      "message": "All 1 warehouse adapter(s) authenticated",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth/default",
+      "status": "healthy",
+      "message": "Discovery adapter default reachable",
       "duration_ms": 0
     }
   ],

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -1,6 +1,6 @@
 {
   "command": "doctor",
-  "overall": "degraded",
+  "overall": "warning",
   "checks": [
     {
       "name": "config",
@@ -30,6 +30,24 @@
       "name": "state_sync",
       "status": "warning",
       "message": "State backend: local",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth/default",
+      "status": "healthy",
+      "message": "Authenticated to default",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth",
+      "status": "healthy",
+      "message": "All 1 warehouse adapter(s) authenticated",
+      "duration_ms": 0
+    },
+    {
+      "name": "auth/default",
+      "status": "healthy",
+      "message": "Discovery adapter default reachable",
       "duration_ms": 0
     }
   ],

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,24 +9,43 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "incremental",
-        "watermark": "2026-04-01T01:40:00Z"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:14.146401Z",
+        "target_table_full_name": "poc.staging__orders.orders"
       }
     }
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -37,9 +57,9 @@
     "tables_drifted": 1,
     "actions_taken": [
       {
-        "table": "staging__orders.orders",
+        "table": "poc.staging__orders.orders",
         "action": "drop_and_recreate",
-        "reason": "1 column(s) had unsafe type changes"
+        "reason": "column 'amount' changed VARCHAR \u2192 DECIMAL(10,2)"
       }
     ]
   }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,24 +9,43 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "incremental",
-        "watermark": "2026-04-01T01:40:00Z"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:14.047398Z",
+        "target_table_full_name": "poc.staging__orders.orders"
       }
     }
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -33,7 +53,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,24 +9,43 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "incremental",
-        "watermark": "2026-04-01T08:20:00Z"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:14.301359Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -33,7 +53,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,24 +9,43 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
         "strategy": "incremental",
-        "watermark": "2026-05-01T00:25:00Z"
+        "watermark": "2026-04-15T21:54:14.458696Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "state",
   "watermarks": [
     {
-      "table": "staging__events.events",
-      "last_value": "2026-04-01T08:20:00Z",
+      "table": "poc.staging__events.events",
+      "last_value": "2026-04-15T21:54:14.301359Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "state",
   "watermarks": [
     {
-      "table": "staging__events.events",
-      "last_value": "2026-05-01T00:25:00Z",
+      "table": "poc.staging__events.events",
+      "last_value": "2026-04-15T21:54:14.458696Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,
@@ -8,7 +8,11 @@
       "severity": "Info",
       "code": "I001",
       "message": "SELECT * used \u2014 consider explicit column list for stability",
-      "span": null,
+      "span": {
+        "file": "models/stg_orders.rocky",
+        "line": 1,
+        "col": 1
+      },
       "model": "stg_orders",
       "suggestion": null
     }
@@ -32,6 +36,20 @@
         "catalog": "poc",
         "schema": "staging",
         "table": "raw_orders"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 10000,
+        "estimated_bytes": 2560000,
+        "estimated_cost_usd": 2.28e-05,
+        "confidence": "high"
       }
     },
     {
@@ -43,6 +61,20 @@
         "catalog": "poc",
         "schema": "demo",
         "table": "fct_revenue"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "customer_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'customer_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 6400,
+        "estimated_bytes": 1638400,
+        "estimated_cost_usd": 0.0001128,
+        "confidence": "medium"
       }
     },
     {
@@ -54,6 +86,20 @@
         "catalog": "poc",
         "schema": "demo",
         "table": "stg_orders"
+      },
+      "incrementality_hint": {
+        "is_candidate": true,
+        "recommended_column": "order_id",
+        "confidence": "medium",
+        "signals": [
+          "column name 'order_id' matches auto-increment ID pattern"
+        ]
+      },
+      "cost_hint": {
+        "estimated_rows": 8000,
+        "estimated_bytes": 2048000,
+        "estimated_cost_usd": 7.280000000000001e-05,
+        "confidence": "medium"
       }
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",
@@ -13,7 +13,7 @@
         "model": "fct_revenue",
         "column": "total"
       },
-      "transform": "aggregation(\"sum\")"
+      "transform": "aggregation: sum"
     },
     {
       "source": {

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [
@@ -35,7 +35,7 @@
         "model": "fct_revenue",
         "column": "total"
       },
-      "transform": "aggregation(\"sum\")"
+      "transform": "aggregation: sum"
     }
   ]
 }

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,23 +9,43 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__events",
+        "duckdb",
+        "events",
         "events"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:14.634174Z",
+        "target_table_full_name": "poc.staging__events.events"
       }
     }
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +53,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,
@@ -28,6 +28,12 @@
         "catalog": "",
         "schema": "marts",
         "table": "fct_daily_orders"
+      },
+      "cost_hint": {
+        "estimated_rows": 10000,
+        "estimated_bytes": 2560000,
+        "estimated_cost_usd": 2.28e-05,
+        "confidence": "high"
       }
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,13 +9,16 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:13.768364Z",
+        "target_table_full_name": "poc.staging__orders.orders"
       }
     },
     {
@@ -26,7 +30,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "a8975e5a44e05fc9",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-04",
@@ -43,7 +51,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "6841226935681d42",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-05",
@@ -60,7 +72,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "43c5cc76b5aad342",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-06",
@@ -77,7 +93,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "ce0fd1a2df2e4b0d",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-07",
@@ -94,7 +114,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "d0e9a49c9722f466",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-08",
@@ -105,11 +129,28 @@
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -117,7 +158,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,13 +9,16 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:13.918358Z",
+        "target_table_full_name": "poc.staging__orders.orders"
       }
     },
     {
@@ -26,7 +30,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "ce0fd1a2df2e4b0d",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-07",
@@ -37,11 +45,28 @@
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -49,7 +74,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,13 +9,16 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:13.676219Z",
+        "target_table_full_name": "poc.staging__orders.orders"
       }
     },
     {
@@ -26,7 +30,11 @@
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "time_interval"
+        "strategy": "time_interval",
+        "target_table_full_name": ".marts.fct_daily_orders",
+        "sql_hash": "ce0fd1a2df2e4b0d",
+        "column_count": 3,
+        "compile_time_ms": 0
       },
       "partition": {
         "key": "2026-04-07",
@@ -37,11 +45,28 @@
   ],
   "check_results": [],
   "execution": {
-    "concurrency": 8,
+    "concurrency": 32,
     "tables_processed": 1,
-    "tables_failed": 0
+    "tables_failed": 0,
+    "adaptive_concurrency": true,
+    "final_concurrency": 32,
+    "rate_limits_detected": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -49,7 +74,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   },

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,6 +1,7 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "run",
+  "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,
   "tables_copied": 1,
@@ -8,13 +9,16 @@
   "materializations": [
     {
       "asset_key": [
-        "staging__orders",
+        "duckdb",
+        "orders",
         "orders"
       ],
       "rows_copied": null,
       "duration_ms": 0,
       "metadata": {
-        "strategy": "full_refresh"
+        "strategy": "full_refresh",
+        "watermark": "2026-04-15T21:54:13.040748Z",
+        "target_table_full_name": "playground.staging__orders.orders"
       }
     }
   ],
@@ -24,7 +28,21 @@
     "tables_processed": 1,
     "tables_failed": 0
   },
-  "metrics": null,
+  "metrics": {
+    "tables_processed": 1,
+    "tables_failed": 0,
+    "error_rate_pct": 0.0,
+    "statements_executed": 0,
+    "retries_attempted": 0,
+    "retries_succeeded": 0,
+    "anomalies_detected": 0,
+    "table_duration_p50_ms": 0,
+    "table_duration_p95_ms": 0,
+    "table_duration_max_ms": 0,
+    "query_duration_p50_ms": 0,
+    "query_duration_p95_ms": 0,
+    "query_duration_max_ms": 0
+  },
   "permissions": {
     "grants_added": 0,
     "grants_revoked": 0,
@@ -32,7 +50,7 @@
     "schemas_created": 1
   },
   "drift": {
-    "tables_checked": 0,
+    "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
   }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,5 +1,11 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "state",
-  "watermarks": []
+  "watermarks": [
+    {
+      "table": "playground.staging__orders.orders",
+      "last_value": "2026-04-15T21:54:13.040748Z",
+      "updated_at": "2000-01-01T00:00:00Z"
+    }
+  ]
 }

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "1.0.2",
   "command": "test",
   "total": 3,
   "passed": 3,


### PR DESCRIPTION
## Summary

- **`validate` exits 1 on failure** — was always exiting 0 even when `valid: false`
- **`doctor` overall "degraded" → "warning"** — non-critical checks (e.g. local state backend) no longer produce "degraded" or exit 1
- **`plan` respects governance flags** — `CREATE SCHEMA`/`CREATE CATALOG` only appear in plan output when `auto_create_schemas`/`auto_create_catalogs` are enabled, matching `run` behavior
- **6 DuckDB POC configs fixed** — added `[source.discovery]` and `auto_create_schemas = true` so discover/plan/run work out of the box
- **RELEASE_SMOKE.md corrected** — `-c` flag placement (13 instances), snapshot seed filename
- **dagster types.py import sort** — ruff I001 fix
- **Version bump** — engine 1.0.2 → 1.0.3
- **36 dagster fixtures regenerated**

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `pytest` — 288/288 pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] No schema drift (`export-schemas` matches committed schemas)
- [x] Smoke tested against live Databricks + Fivetran (OAuth M2M, 47 sources discovered, 2 tables replicated and cleaned up)