### PR TITLE
fix(ci): upgrade GitHub Actions to resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
 

--- a/.github/workflows/dagster-release.yml
+++ b/.github/workflows/dagster-release.yml
@@ -25,7 +25,7 @@ jobs:
     name: Ensure GitHub Release exists
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create release if missing
         env:

--- a/.github/workflows/engine-bench.yml
+++ b/.github/workflows/engine-bench.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
           key: bench

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
       - name: Free disk space and add swap
@@ -51,7 +51,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
       - name: Free disk space and add swap

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
           key: release-${{ matrix.target }}
@@ -119,7 +119,7 @@ jobs:
         run: Compress-Archive -Path target/${{ matrix.target }}/release/rocky.exe -DestinationPath ${{ matrix.archive }}
 
       - name: Attach to GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: engine/${{ matrix.archive }}
 

--- a/.github/workflows/engine-wasm-release.yml
+++ b/.github/workflows/engine-wasm-release.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
           key: wasm

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
       - name: Free disk space and add swap
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
       - name: Free disk space and add swap

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -32,10 +32,7 @@ jobs:
       - run: npm ci
       - run: npm run compile
       - name: Run tests
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
-        with:
-          working-directory: editors/vscode
-          run: npm test
+        run: xvfb-run -a npm test
 
   lint:
     name: Lint

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -65,7 +65,7 @@ jobs:
         run: npx @vscode/vsce package
 
       - name: Attach VSIX to GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: editors/vscode/*.vsix
 


### PR DESCRIPTION
## Summary
- **Swatinem/rust-cache** bumped to v2.9.1 (Node 24) across 6 workflows
- **actions/checkout** in dagster-release upgraded from v4 to v6.0.2
- **softprops/action-gh-release** comment corrected to v3 (SHA already was v3.0.0)
- **coactions/setup-xvfb** replaced with `xvfb-run -a` (pre-installed on Ubuntu runners, eliminates Node 20 dependency)

Only remaining Node 20 action is `mlugg/setup-zig@v2.2.1` (no upgrade available yet), already covered by `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` in engine-release.yml.

## Test plan
- [ ] CI passes on this PR (the workflows themselves are the test)