### PR TITLE
feat(dagster): wire executable multi_assets for dag_mode

### DIFF
--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/README.md
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/README.md
@@ -1,0 +1,97 @@
+# 07-dagster-dag-mode — Full Lineage from Rocky's Unified DAG
+
+> **Category:** 05-orchestration
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s
+> **Rocky features:** rocky dag, dag_mode, dagster-rocky, lineage
+
+## What it shows
+
+Demonstrates `dag_mode=True` on `RockyComponent`: Rocky reports the full unified DAG (source, load, transformation stages) via `rocky dag`, and dagster-rocky renders it as a single connected asset graph in the Dagster UI with zero hand-written asset definitions.
+
+## Why it's distinctive
+
+- `rocky.toml` + model sidecars + SQL files **are** the asset definition. No Python per-asset boilerplate.
+- The Dagster asset graph shows the full pipeline lineage: source → load → staging → gold.
+
+## Layout
+
+```
+.
+├── README.md              this file
+├── definitions.py         Dagster code location (< 10 lines)
+├── rocky.toml             Pipeline config: ingest (replication) + transform
+├── run.sh                 Seeds data, runs pipeline, prints DAG
+├── data/
+│   └── seed.sql           200-row orders table
+└── models/
+    ├── _defaults.toml     Shared target defaults
+    ├── stg_orders.sql     Staging model (filters cancelled orders)
+    ├── stg_orders.toml    Target: staging schema
+    ├── fct_customer_revenue.sql   Gold model (customer aggregation)
+    └── fct_customer_revenue.toml  Target: gold schema, depends_on stg_orders
+```
+
+## Prerequisites
+
+- `rocky` on PATH (>= 1.1.0)
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- `dagster-rocky` >= 1.2.0 (for `dag_mode`)
+- `dagster` >= 1.13.0
+
+## Run
+
+```bash
+# Verify the DAG structure
+./run.sh
+
+# Launch Dagster UI
+dagster dev -f definitions.py
+```
+
+Open http://localhost:3000 and verify:
+1. Asset graph shows `source:ingest` → `load:ingest` → `stg_orders` → `fct_customer_revenue`
+2. Click any node to see upstream/downstream dependencies
+3. "Materialize all" executes the full pipeline
+
+## Expected output
+
+```text
+=== Dagster dag_mode — full lineage from Rocky's unified DAG ===
+
+1. Seeding DuckDB with sample data...
+   done (200 orders in raw__orders.orders)
+
+2. Running replication pipeline...
+   done (source tables replicated)
+
+3. Rocky DAG output:
+   Nodes: 4
+   Edges: 3
+   Layers: 4
+
+   [source          ] ingest (source)
+   [load            ] ingest (load) <- ['source:ingest']
+   [transformation  ] stg_orders <- ['load:ingest']
+   [transformation  ] fct_customer_revenue <- ['transformation:stg_orders']
+
+4. Compiling models...
+   Models: 2
+   Layers: 2
+   - stg_orders (full_refresh)
+   - fct_customer_revenue (full_refresh) depends_on=['stg_orders']
+```
+
+## What happened
+
+1. `run.sh` seeds a DuckDB file with 200 orders
+2. `rocky run` replicates the source table via the `ingest` pipeline
+3. `rocky dag` produces the full unified DAG: 4 nodes, 3 edges, 4 execution layers
+4. `rocky compile` verifies model dependencies (`fct_customer_revenue` depends on `stg_orders`)
+5. `definitions.py` uses `RockyComponent(dag_mode=True)` — Dagster reads the cached DAG and builds a connected asset graph automatically
+
+## Related
+
+- dagster-rocky: [`integrations/dagster/`](https://github.com/rocky-data/rocky/tree/main/integrations/dagster)
+- DAG builder: [`integrations/dagster/src/dagster_rocky/dag_assets.py`](https://github.com/rocky-data/rocky/tree/main/integrations/dagster/src/dagster_rocky/dag_assets.py)
+- Basic Dagster example: [`engine/examples/dagster-integration/`](https://github.com/rocky-data/rocky/tree/main/engine/examples/dagster-integration)

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/data/seed.sql
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/data/seed.sql
@@ -1,0 +1,15 @@
+-- Seed data for the dag_mode POC.
+-- Creates a small orders table that the replication pipeline copies
+-- and the transformation models aggregate.
+
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    1 + (i % 30) AS customer_id,
+    ROUND(CAST(10.0 + random() * 490.0 AS DECIMAL(10,2)), 2) AS amount,
+    CASE WHEN random() < 0.05 THEN 'cancelled' ELSE 'completed' END AS status,
+    CAST(TIMESTAMP '2025-06-01' + INTERVAL (i * 3600) SECOND AS DATE) AS order_date,
+    TIMESTAMP '2026-01-01' + INTERVAL (i * 60) SECOND AS _updated_at
+FROM generate_series(1, 200) AS t(i);

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/definitions.py
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/definitions.py
@@ -1,0 +1,33 @@
+"""Dagster dag_mode smoke test.
+
+Demonstrates Rocky's DAG-driven asset builder: a single `rocky dag` call
+produces the full connected asset graph in Dagster — sources through
+transformations — with zero hand-written Python asset definitions.
+
+Run:
+    cd examples/playground/pocs/05-orchestration/07-dagster-dag-mode
+    ./run.sh          # seeds data + caches state
+    dagster dev -f definitions.py
+
+Then open http://localhost:3000 and verify:
+    1. The asset graph shows: source:ingest → load:ingest → stg_orders → fct_customer_revenue
+    2. Clicking any asset shows its upstream/downstream dependencies
+    3. "Materialize all" runs the full pipeline successfully
+"""
+
+from __future__ import annotations
+
+from dagster_rocky import RockyComponent
+
+# dag_mode=True: builds assets from `rocky dag` instead of the
+# discover-only flow. Every pipeline stage (source, load, model)
+# becomes a Dagster asset with resolved dependencies.
+component = RockyComponent(
+    binary_path="rocky",
+    config_path="rocky.toml",
+    state_path=".rocky-state.redb",
+    models_dir="models",
+    dag_mode=True,
+)
+
+defs = component.build_defs()

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/_defaults.toml
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/_defaults.toml
@@ -1,0 +1,6 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "staging"

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/fct_customer_revenue.sql
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/fct_customer_revenue.sql
@@ -1,0 +1,7 @@
+SELECT
+    customer_id,
+    SUM(amount) AS total_revenue,
+    COUNT(*) AS order_count,
+    MIN(order_date) AS first_order
+FROM stg_orders
+GROUP BY customer_id

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/fct_customer_revenue.toml
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/fct_customer_revenue.toml
@@ -1,0 +1,4 @@
+depends_on = ["stg_orders"]
+
+[target]
+schema = "gold"

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/stg_orders.sql
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/stg_orders.sql
@@ -1,0 +1,8 @@
+SELECT
+    order_id,
+    customer_id,
+    amount,
+    status,
+    order_date
+FROM raw__orders.orders
+WHERE status != 'cancelled'

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/stg_orders.toml
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/models/stg_orders.toml
@@ -1,0 +1,2 @@
+[target]
+schema = "staging"

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/rocky.toml
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/rocky.toml
@@ -1,0 +1,36 @@
+# Dagster dag_mode — full lineage from Rocky's unified DAG
+#
+# This pipeline defines both replication and transformation stages so
+# `rocky dag` produces a connected graph: source → load → models.
+# dagster-rocky's `dag_mode=True` renders this as a single connected
+# asset graph in the Dagster UI.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.ingest]
+strategy = "full_refresh"
+timestamp_column = "_updated_at"
+
+[pipeline.ingest.source.discovery]
+adapter = "default"
+
+[pipeline.ingest.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.ingest.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"
+
+[pipeline.ingest.target.governance]
+auto_create_schemas = true
+
+[pipeline.transform]
+type = "transformation"
+depends_on = ["ingest"]
+
+[pipeline.transform.target]
+adapter = "default"

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/run.sh
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Dagster dag_mode — end-to-end demo
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+echo "=== Dagster dag_mode — full lineage from Rocky's unified DAG ==="
+echo ""
+echo "This POC verifies that rocky dag produces a connected DAG and that"
+echo "dagster-rocky's dag_mode can consume it."
+echo ""
+
+# --- Cleanup ---
+rm -f poc.duckdb .rocky-state.redb
+mkdir -p expected
+
+# --- Seed ---
+echo "1. Seeding DuckDB with sample data..."
+duckdb poc.duckdb < data/seed.sql
+echo "   done (200 orders in raw__orders.orders)"
+
+# --- Rocky pipeline (replication) ---
+echo ""
+echo "2. Running replication pipeline..."
+rocky -c rocky.toml run --pipeline ingest --filter source=orders --output json > expected/run.json 2>/dev/null
+echo "   done (source tables replicated)"
+
+# --- Rocky DAG ---
+echo ""
+echo "3. Rocky DAG output:"
+rocky -c rocky.toml dag --models models --output json 2>/dev/null | tee expected/dag.json | python3 -c "
+import json, sys
+dag = json.load(sys.stdin)
+print(f'   Nodes: {dag[\"summary\"][\"total_nodes\"]}')
+print(f'   Edges: {dag[\"summary\"][\"total_edges\"]}')
+print(f'   Layers: {dag[\"summary\"][\"execution_layers\"]}')
+print()
+for node in dag['nodes']:
+    deps = node.get('depends_on', [])
+    dep_str = f' <- {deps}' if deps else ''
+    print(f'   [{node[\"kind\"]:16s}] {node[\"label\"]}{dep_str}')
+"
+
+# --- Rocky compile (verify models) ---
+echo ""
+echo "4. Compiling models..."
+rocky compile --models models --output json 2>/dev/null | tee expected/compile.json | python3 -c "
+import json, sys
+result = json.load(sys.stdin)
+print(f'   Models: {result[\"models\"]}')
+print(f'   Layers: {result[\"execution_layers\"]}')
+for m in result.get('models_detail', []):
+    deps = m.get('depends_on', [])
+    dep_str = f' depends_on={deps}' if deps else ''
+    print(f'   - {m[\"name\"]} ({m[\"strategy\"][\"type\"]}){dep_str}')
+"
+
+# --- Dagster instructions ---
+echo ""
+echo "=== Dagster smoke test ==="
+echo ""
+echo "To test dag_mode in the Dagster UI:"
+echo ""
+echo "  cd $HERE"
+echo "  dagster dev -f definitions.py"
+echo ""
+echo "Then open http://localhost:3000 and verify:"
+echo "  1. Asset graph shows: source:ingest -> load:ingest -> stg_orders -> fct_customer_revenue"
+echo "  2. Dependencies are connected (click any node to see upstream/downstream)"
+echo "  3. 'Materialize all' executes successfully"
+echo ""
+
+# --- Cleanup ---
+rm -f poc.duckdb .rocky-state.redb
+echo "POC complete."

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -28,6 +28,7 @@ from .contracts import (
 )
 from .dag_assets import (
     DagAssetGroup,
+    build_dag_multi_assets,
     build_dag_specs,
     split_dag_specs_by_group,
 )
@@ -166,6 +167,7 @@ __all__ = [
     "contract_check_results_from_diagnostics",
     # DAG-driven asset builder
     "DagAssetGroup",
+    "build_dag_multi_assets",
     "build_dag_specs",
     "split_dag_specs_by_group",
     "DagResult",

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -377,31 +377,36 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         except dg.Failure:
             return None
 
-    def _build_defs_from_dag(self, state_path: Path) -> dg.Definitions:
+    def _build_defs_from_dag(
+        self,
+        context: dg.ComponentLoadContext,
+        state_path: Path,
+    ) -> dg.Definitions:
         """Build asset definitions from the cached ``rocky dag`` output.
 
         Falls back to the discover-based flow if the DAG slot is missing
         from the cached state (e.g., first run before ``dag_mode`` was set).
         """
-        from .dag_assets import build_dag_specs
+        from .dag_assets import build_dag_multi_assets
 
         raw = json.loads(state_path.read_text(encoding="utf-8"))
         if "dag" not in raw:
             # Graceful fallback: re-enter the non-DAG path.
             self.dag_mode = False
-            return self.build_defs_from_state(None, state_path)
+            return self.build_defs_from_state(context, state_path)
 
         dag_result = DagResult.model_validate(raw["dag"])
         translator = self._get_translator()
         rocky = self._get_rocky_resource()
 
-        specs, node_id_to_key = build_dag_specs(
+        assets = build_dag_multi_assets(
             dag_result,
+            rocky=rocky,
             translator=translator,
         )
 
         return dg.Definitions(
-            assets=specs,
+            assets=assets,
             resources={"rocky": rocky},
         )
 
@@ -420,7 +425,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
 
         # DAG-mode: build the full connected asset graph from ``rocky dag``.
         if self.dag_mode:
-            return self._build_defs_from_dag(state_path)
+            return self._build_defs_from_dag(context, state_path)
 
         discover, compile_result, optimize_result = _load_state(state_path)
         compile_state = _CompileState.from_result(compile_result)

--- a/integrations/dagster/src/dagster_rocky/dag_assets.py
+++ b/integrations/dagster/src/dagster_rocky/dag_assets.py
@@ -11,11 +11,13 @@ rather than becoming standalone assets.
 Usage::
 
     from dagster_rocky import RockyResource, RockyDagsterTranslator
-    from dagster_rocky.dag_assets import build_dag_specs
+    from dagster_rocky.dag_assets import build_dag_multi_assets
 
     rocky = RockyResource(config_path="rocky.toml")
     dag = rocky.dag(column_lineage=True)
-    specs, node_map = build_dag_specs(dag, translator=RockyDagsterTranslator())
+    assets = build_dag_multi_assets(
+        dag, rocky=rocky, translator=RockyDagsterTranslator(),
+    )
 """
 
 from __future__ import annotations
@@ -28,13 +30,17 @@ import dagster as dg
 from .freshness import freshness_policy_from_model
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from .contracts import ContractRules
+    from .resource import RockyResource
     from .translator import RockyDagsterTranslator
     from .types import (
         DagNodeOutput,
         DagResult,
         LineageEdgeRecord,
         OptimizeResult,
+        RunResult,
     )
 
 
@@ -55,40 +61,9 @@ class DagAssetGroup:
     shape_key: str = "unpartitioned"
 
 
-def _asset_key_for_node(
-    node: DagNodeOutput,
-    translator: RockyDagsterTranslator,
-) -> dg.AssetKey:
-    """Derive a Dagster AssetKey from a DAG node based on its kind."""
-    if node.kind == "transformation" and node.target is not None:
-        return dg.AssetKey(
-            [
-                node.target.catalog,
-                node.target.schema_,
-                node.target.table,
-            ]
-        )
-    if node.kind == "seed":
-        return dg.AssetKey(["seed", node.label])
-    if node.kind == "source":
-        return dg.AssetKey([node.pipeline or "default", "source", node.label])
-    if node.kind == "load":
-        return dg.AssetKey([node.pipeline or "default", node.label])
-    if node.kind == "quality":
-        return dg.AssetKey(["quality", node.pipeline or "default", node.label])
-    if node.kind == "snapshot":
-        return dg.AssetKey(["snapshot", node.pipeline or "default", node.label])
-    # Fallback: use the node ID as-is.
-    return dg.AssetKey([node.id])
-
-
-def _group_name_for_node(node: DagNodeOutput) -> str:
-    """Derive a Dagster group name from a DAG node."""
-    if node.kind == "transformation" and node.target is not None:
-        return node.target.schema_
-    if node.pipeline is not None:
-        return node.pipeline
-    return "default"
+# ---------------------------------------------------------------------------
+# Partition helpers
+# ---------------------------------------------------------------------------
 
 
 def _partitions_def_for_node(
@@ -105,18 +80,7 @@ def _partitions_def_for_node(
         return dg.HourlyPartitionsDefinition(start_date=start)
     if grain == "monthly":
         return dg.MonthlyPartitionsDefinition(start_date=start)
-    if grain == "yearly":
-        # Dagster doesn't have a built-in YearlyPartitionsDefinition.
-        # Fall back to unpartitioned.
-        return None
     return None
-
-
-def _freshness_for_node(node: DagNodeOutput) -> dg.FreshnessPolicy | None:
-    """Map a node's freshness config to a Dagster FreshnessPolicy."""
-    if node.freshness is None:
-        return None
-    return freshness_policy_from_model(node.freshness)
 
 
 def _shape_key_for_node(node: DagNodeOutput) -> str:
@@ -124,6 +88,11 @@ def _shape_key_for_node(node: DagNodeOutput) -> str:
     if node.partition_shape is None:
         return "unpartitioned"
     return node.partition_shape.granularity
+
+
+# ---------------------------------------------------------------------------
+# Column lineage
+# ---------------------------------------------------------------------------
 
 
 def _build_column_lineage_metadata(
@@ -135,20 +104,15 @@ def _build_column_lineage_metadata(
     if not column_lineage_edges:
         return None
 
-    # Filter edges targeting this node's model.
     model_edges = [e for e in column_lineage_edges if e.target.model == node.label]
     if not model_edges:
         return None
 
-    # Build a synthetic ModelLineageResult-like object for the existing
-    # build_column_lineage helper.
     deps_by_column: dict[str, list[dg.TableColumnDep]] = {}
     for edge in model_edges:
-        # Find the asset key for the source model.
         source_node_id = f"transformation:{edge.source.model}"
         source_key = node_id_to_key.get(source_node_id)
         if source_key is None:
-            # Try seed.
             source_key = node_id_to_key.get(f"seed:{edge.source.model}")
         if source_key is None:
             continue
@@ -164,6 +128,11 @@ def _build_column_lineage_metadata(
         return None
 
     return {"dagster/column_lineage": dg.TableColumnLineage(deps_by_column=deps_by_column)}
+
+
+# ---------------------------------------------------------------------------
+# Spec building
+# ---------------------------------------------------------------------------
 
 
 def build_dag_specs(
@@ -182,11 +151,11 @@ def build_dag_specs(
     node_id_to_key: dict[str, dg.AssetKey] = {}
     column_lineage_edges = dag_result.column_lineage or []
 
-    # First pass: compute all asset keys so we can resolve dependencies.
+    # First pass: compute all asset keys via the translator.
     for node in dag_result.nodes:
         if node.kind == "test":
             continue
-        key = _asset_key_for_node(node, translator)
+        key = translator.get_dag_node_asset_key(node)
         node_id_to_key[node.id] = key
 
     # Second pass: build specs with resolved dependencies.
@@ -197,11 +166,9 @@ def build_dag_specs(
 
         key = node_id_to_key[node.id]
 
-        # Resolve upstream dependencies.
         deps_list = node.depends_on or []
         deps = [node_id_to_key[dep_id] for dep_id in deps_list if dep_id in node_id_to_key]
 
-        # Build metadata.
         metadata: dict[str, object] = {
             "rocky/node_id": node.id,
             "rocky/kind": node.kind,
@@ -209,7 +176,6 @@ def build_dag_specs(
         if node.pipeline is not None:
             metadata["rocky/pipeline"] = node.pipeline
 
-        # Column lineage.
         col_lineage_meta = _build_column_lineage_metadata(
             node,
             column_lineage_edges,
@@ -218,15 +184,17 @@ def build_dag_specs(
         if col_lineage_meta:
             metadata.update(col_lineage_meta)
 
+        freshness = None
+        if node.freshness is not None:
+            freshness = freshness_policy_from_model(node.freshness)
+
         spec = dg.AssetSpec(
             key=key,
             deps=deps if deps else None,
-            group_name=_group_name_for_node(node),
-            tags={
-                "rocky/kind": node.kind,
-            },
+            group_name=translator.get_dag_group_name(node),
+            tags={"rocky/kind": node.kind},
             metadata=metadata,
-            freshness_policy=_freshness_for_node(node),
+            freshness_policy=freshness,
             kinds={"rocky", node.kind},
         )
         specs.append(spec)
@@ -234,17 +202,16 @@ def build_dag_specs(
     return specs, node_id_to_key
 
 
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
 def split_dag_specs_by_group(
     specs: list[dg.AssetSpec],
     dag_result: DagResult,
 ) -> list[DagAssetGroup]:
-    """Group specs by (execution kind, partition shape) for multi_asset compat.
-
-    Dagster's ``multi_asset`` requires all specs to share one
-    ``PartitionsDefinition``. This function groups specs by their partition
-    shape so each group can become one ``multi_asset``.
-    """
-    # Build node lookup.
+    """Group specs by (execution kind, partition shape) for multi_asset compat."""
     node_by_id: dict[str, DagNodeOutput] = {}
     for node in dag_result.nodes:
         node_by_id[node.id] = node
@@ -274,3 +241,210 @@ def split_dag_specs_by_group(
             groups[group_key].node_ids.append(node.id)
 
     return list(groups.values())
+
+
+# ---------------------------------------------------------------------------
+# Executable multi_asset construction
+# ---------------------------------------------------------------------------
+
+
+def _safe_asset_name(name: str) -> str:
+    """Sanitize a string for use as a Dagster asset name."""
+    return name.replace("-", "_").replace(".", "_").replace(" ", "_").replace(":", "_")
+
+
+def _partition_kwargs_from_context(
+    context: dg.AssetExecutionContext,
+    partitions_def: dg.PartitionsDefinition | None,
+) -> dict[str, object]:
+    """Extract partition selection kwargs from the Dagster execution context."""
+    if partitions_def is None:
+        return {}
+    if context.has_partition_key_range:
+        key_range = context.partition_key_range
+        return {"partition_from": key_range.start, "partition_to": key_range.end}
+    if context.has_partition_key:
+        return {"partition": context.partition_key}
+    return {}
+
+
+def _emit_model_results(
+    result: RunResult,
+    selected_keys: set[dg.AssetKey],
+) -> Iterator[dg.MaterializeResult]:
+    """Yield MaterializeResult for model materializations in the run output."""
+    from .component import RockyMetadataSet
+
+    for mat in result.materializations:
+        asset_key = dg.AssetKey(mat.asset_key)
+        if asset_key not in selected_keys:
+            continue
+        metadata: dict[str, dg.MetadataValue] = {
+            **RockyMetadataSet(
+                strategy=mat.metadata.strategy if mat.metadata else None,
+                duration_ms=mat.duration_ms,
+                rows_copied=mat.rows_copied,
+                watermark=(
+                    mat.metadata.watermark.isoformat()
+                    if mat.metadata is not None and mat.metadata.watermark is not None
+                    else None
+                ),
+                target_table_full_name=(
+                    mat.metadata.target_table_full_name if mat.metadata else None
+                ),
+                sql_hash=mat.metadata.sql_hash if mat.metadata else None,
+                column_count=mat.metadata.column_count if mat.metadata else None,
+                compile_time_ms=mat.metadata.compile_time_ms if mat.metadata else None,
+            ),
+            "dagster/duration_ms": dg.MetadataValue.int(mat.duration_ms),
+        }
+        if mat.rows_copied is not None:
+            metadata["dagster/row_count"] = dg.MetadataValue.int(mat.rows_copied)
+        if mat.partition is not None:
+            metadata["rocky/partition_key"] = dg.MetadataValue.text(mat.partition.key)
+        yield dg.MaterializeResult(asset_key=asset_key, metadata=metadata)
+
+
+def build_dag_multi_assets(
+    dag_result: DagResult,
+    *,
+    rocky: RockyResource,
+    translator: RockyDagsterTranslator,
+    optimize_result: OptimizeResult | None = None,
+    contract_rules_by_model: dict[str, ContractRules] | None = None,
+) -> list[dg.AssetsDefinition]:
+    """Build executable multi_assets from the unified DAG.
+
+    Groups nodes by (kind, partition_shape). Each group becomes one
+    ``@dg.multi_asset`` with ``can_subset=True``. Within each multi_asset,
+    materialization dispatches to the right Rocky CLI command based on
+    node kind:
+
+    - ``transformation`` → ``rocky.run_model(model_name)``
+    - ``source`` / ``load`` → ``rocky.run(filter=pipeline_name)``
+    - ``seed`` → placeholder (yields MaterializeResult directly)
+    - ``quality`` / ``snapshot`` → ``rocky.run(filter=pipeline_name)``
+    """
+    specs, node_id_to_key = build_dag_specs(
+        dag_result,
+        translator=translator,
+        optimize_result=optimize_result,
+        contract_rules_by_model=contract_rules_by_model,
+    )
+
+    groups = split_dag_specs_by_group(specs, dag_result)
+
+    # Build a node lookup for the execution bodies.
+    node_by_id: dict[str, DagNodeOutput] = {}
+    for node in dag_result.nodes:
+        node_by_id[node.id] = node
+
+    assets: list[dg.AssetsDefinition] = []
+    for group in groups:
+        asset_def = _make_dag_group_asset(
+            group=group,
+            node_by_id=node_by_id,
+            rocky=rocky,
+        )
+        assets.append(asset_def)
+
+    return assets
+
+
+def _make_dag_group_asset(
+    *,
+    group: DagAssetGroup,
+    node_by_id: dict[str, DagNodeOutput],
+    rocky: RockyResource,
+) -> dg.AssetsDefinition:
+    """Create one multi_asset for a group of DAG nodes."""
+    asset_name = f"rocky_dag_{_safe_asset_name(group.name)}"
+
+    # Build a spec-key → node-id lookup for the execution body.
+    spec_key_to_node_id: dict[dg.AssetKey, str] = {}
+    for spec, node_id in zip(group.specs, group.node_ids, strict=False):
+        spec_key_to_node_id[spec.key] = node_id
+
+    @dg.multi_asset(
+        name=asset_name,
+        specs=group.specs,
+        can_subset=True,
+        partitions_def=group.partitions_def,
+    )
+    def _asset(context):
+        selected_keys = set(context.selected_asset_keys)
+        partition_kwargs = _partition_kwargs_from_context(context, group.partitions_def)
+
+        for spec_key in selected_keys:
+            node_id = spec_key_to_node_id.get(spec_key)
+            if node_id is None:
+                yield dg.MaterializeResult(asset_key=spec_key)
+                continue
+
+            node = node_by_id.get(node_id)
+            if node is None:
+                yield dg.MaterializeResult(asset_key=spec_key)
+                continue
+
+            if node.kind == "transformation":
+                context.log.info(f"Executing rocky run --model {node.label}")
+                result = rocky.run_model(
+                    node.label,
+                    **partition_kwargs,  # type: ignore[arg-type]
+                )
+                context.log.info(
+                    f"Model {node.label}: {result.tables_copied} copied, "
+                    f"{result.tables_failed} failed in {result.duration_ms}ms"
+                )
+                emitted = False
+                for mr in _emit_model_results(result, {spec_key}):
+                    emitted = True
+                    yield mr
+                if not emitted:
+                    yield dg.MaterializeResult(
+                        asset_key=spec_key,
+                        metadata={
+                            "dagster/duration_ms": dg.MetadataValue.int(result.duration_ms),
+                        },
+                    )
+
+            elif node.kind in ("source", "load"):
+                # Source/load nodes are materialized via the replication
+                # pipeline. Use the pipeline name as the filter hint.
+                pipeline_name = node.pipeline or "default"
+                context.log.info(
+                    f"Executing rocky run --filter pipeline={pipeline_name} "
+                    f"for {node.kind} node {node.label}"
+                )
+                result = rocky.run(
+                    filter=f"pipeline={pipeline_name}",
+                    **partition_kwargs,  # type: ignore[arg-type]
+                )
+                context.log.info(
+                    f"{node.kind} {node.label}: {result.tables_copied} copied in "
+                    f"{result.duration_ms}ms"
+                )
+                emitted = False
+                for mr in _emit_model_results(result, {spec_key}):
+                    emitted = True
+                    yield mr
+                if not emitted:
+                    yield dg.MaterializeResult(
+                        asset_key=spec_key,
+                        metadata={
+                            "dagster/duration_ms": dg.MetadataValue.int(result.duration_ms),
+                        },
+                    )
+
+            else:
+                # seed, quality, snapshot — emit a placeholder result.
+                # Full execution support for these node kinds is a
+                # follow-up; for now they participate in the DAG graph
+                # but materialization is a no-op.
+                context.log.info(
+                    f"Node {node.label} ({node.kind}): materialization "
+                    f"placeholder (execution not yet wired)"
+                )
+                yield dg.MaterializeResult(asset_key=spec_key)
+
+    return _asset

--- a/integrations/dagster/src/dagster_rocky/translator.py
+++ b/integrations/dagster/src/dagster_rocky/translator.py
@@ -2,9 +2,23 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import dagster as dg
 
 from .types import ModelDetail, SourceInfo, TableInfo
+
+if TYPE_CHECKING:
+    from .types import DagNodeOutput
+
+import re
+
+_INVALID_CHARS = re.compile(r"[^A-Za-z0-9_]")
+
+
+def _sanitize_key_part(s: str) -> str:
+    """Replace characters invalid in Dagster names with underscores."""
+    return _INVALID_CHARS.sub("_", s)
 
 
 class RockyDagsterTranslator:
@@ -154,3 +168,48 @@ class RockyDagsterTranslator:
                 str(model.strategy.get("type", "")) if isinstance(model.strategy, dict) else ""
             ),
         }
+
+    # ------------------------------------------------------------------ #
+    # DAG-mode translation (unified DAG nodes)                           #
+    # ------------------------------------------------------------------ #
+
+    def get_dag_node_asset_key(self, node: DagNodeOutput) -> dg.AssetKey:
+        """Returns the Dagster asset key for a unified DAG node.
+
+        Dispatches by node kind:
+
+        - ``transformation`` → ``[catalog, schema, table]`` from target
+        - ``seed`` → ``["seed", label]``
+        - ``source`` → ``[pipeline, "source", label]``
+        - ``load`` → ``[pipeline, label]``
+        - ``quality`` → ``["quality", pipeline, label]``
+        - ``snapshot`` → ``["snapshot", pipeline, label]``
+
+        Override to customize key derivation for your pipeline layout.
+        """
+        pipeline = node.pipeline or "default"
+        if node.kind == "transformation" and node.target is not None:
+            return dg.AssetKey([node.target.catalog, node.target.schema_, node.target.table])
+        if node.kind == "seed":
+            return dg.AssetKey(["seed", node.label])
+        if node.kind == "source":
+            return dg.AssetKey([pipeline, "source"])
+        if node.kind == "load":
+            return dg.AssetKey([pipeline, "load"])
+        if node.kind == "quality":
+            return dg.AssetKey(["quality", pipeline])
+        if node.kind == "snapshot":
+            return dg.AssetKey(["snapshot", pipeline])
+        return dg.AssetKey([_sanitize_key_part(node.id)])
+
+    def get_dag_group_name(self, node: DagNodeOutput) -> str:
+        """Returns the Dagster group name for a unified DAG node.
+
+        Default: target schema for transformation nodes, pipeline name
+        for everything else, ``"default"`` as fallback.
+        """
+        if node.kind == "transformation" and node.target is not None:
+            return node.target.schema_
+        if node.pipeline is not None:
+            return node.pipeline
+        return "default"

--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:15.056301Z",
+        "watermark": "2026-04-16T00:24:54.173571Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:15.162332Z",
+        "watermark": "2026-04-16T00:24:54.287753Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:15.265925Z",
+        "watermark": "2026-04-16T00:24:54.397239Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:15.371220Z",
+        "watermark": "2026-04-16T00:24:54.506389Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0.3",
+  "command": "dag",
+  "nodes": [
+    {
+      "id": "source:playground",
+      "kind": "source",
+      "label": "playground (source)",
+      "pipeline": "playground"
+    },
+    {
+      "id": "load:playground",
+      "kind": "load",
+      "label": "playground (load)",
+      "pipeline": "playground",
+      "depends_on": [
+        "source:playground"
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "from": "source:playground",
+      "to": "load:playground",
+      "edge_type": "data"
+    }
+  ],
+  "execution_layers": [
+    [
+      "source:playground"
+    ],
+    [
+      "load:playground"
+    ]
+  ],
+  "summary": {
+    "total_nodes": 2,
+    "total_edges": 1,
+    "execution_layers": 2,
+    "counts_by_kind": {
+      "source": 1,
+      "load": 1
+    }
+  }
+}

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:14.146401Z",
+        "watermark": "2026-04-16T00:24:53.217839Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:14.047398Z",
+        "watermark": "2026-04-16T00:24:53.112771Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:14.301359Z",
+        "watermark": "2026-04-16T00:24:53.378556Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "incremental",
-        "watermark": "2026-04-15T21:54:14.458696Z",
+        "watermark": "2026-04-16T00:24:53.545139Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "state",
   "watermarks": [
     {
       "table": "poc.staging__events.events",
-      "last_value": "2026-04-15T21:54:14.301359Z",
+      "last_value": "2026-04-16T00:24:53.378556Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "state",
   "watermarks": [
     {
       "table": "poc.staging__events.events",
-      "last_value": "2026-04-15T21:54:14.458696Z",
+      "last_value": "2026-04-16T00:24:53.545139Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:14.634174Z",
+        "watermark": "2026-04-16T00:24:53.727366Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:13.768364Z",
+        "watermark": "2026-04-16T00:24:52.818544Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:13.918358Z",
+        "watermark": "2026-04-16T00:24:52.974832Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:13.676219Z",
+        "watermark": "2026-04-16T00:24:52.719353Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-15T21:54:13.040748Z",
+        "watermark": "2026-04-16T00:24:51.995399Z",
         "target_table_full_name": "playground.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "state",
   "watermarks": [
     {
       "table": "playground.staging__orders.orders",
-      "last_value": "2026-04-15T21:54:13.040748Z",
+      "last_value": "2026-04-16T00:24:51.995399Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/test_dag_assets.py
+++ b/integrations/dagster/tests/test_dag_assets.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import dagster as dg
 
 from dagster_rocky.dag_assets import (
+    build_dag_multi_assets,
     build_dag_specs,
     split_dag_specs_by_group,
 )
 from dagster_rocky.translator import RockyDagsterTranslator
-from dagster_rocky.types import DagResult
+from dagster_rocky.types import DagNodeOutput, DagResult
 
 
 def _make_dag_result(
@@ -330,3 +331,125 @@ def test_dag_result_in_parse_rocky_output():
     )
     result = parse_rocky_output(payload)
     assert isinstance(result, DagResult)
+
+
+# ---------------------------------------------------------------------------
+# Translator DAG-mode methods
+# ---------------------------------------------------------------------------
+
+
+def test_translator_get_dag_node_asset_key_transformation():
+    """Translator maps transformation nodes to [catalog, schema, table]."""
+    translator = RockyDagsterTranslator()
+    node = DagNodeOutput.model_validate(
+        {
+            "id": "transformation:orders",
+            "kind": "transformation",
+            "label": "orders",
+            "target": {"catalog": "w", "schema": "marts", "table": "orders"},
+        }
+    )
+    assert translator.get_dag_node_asset_key(node) == dg.AssetKey(["w", "marts", "orders"])
+
+
+def test_translator_get_dag_node_asset_key_source():
+    """Translator maps source nodes to [pipeline, 'source']."""
+    translator = RockyDagsterTranslator()
+    node = DagNodeOutput.model_validate(
+        {"id": "source:raw", "kind": "source", "label": "raw (source)", "pipeline": "raw"}
+    )
+    assert translator.get_dag_node_asset_key(node) == dg.AssetKey(["raw", "source"])
+
+
+def test_translator_get_dag_group_name():
+    """Translator group name uses target schema for transformations, pipeline for others."""
+    translator = RockyDagsterTranslator()
+    transform_node = DagNodeOutput.model_validate(
+        {
+            "id": "transformation:m1",
+            "kind": "transformation",
+            "label": "m1",
+            "target": {"catalog": "w", "schema": "staging", "table": "m1"},
+        }
+    )
+    assert translator.get_dag_group_name(transform_node) == "staging"
+
+    source_node = DagNodeOutput.model_validate(
+        {"id": "source:raw", "kind": "source", "label": "raw", "pipeline": "ingest"}
+    )
+    assert translator.get_dag_group_name(source_node) == "ingest"
+
+
+def test_translator_override_dag_node_asset_key():
+    """Custom translator can override DAG node key derivation."""
+
+    class PrefixedTranslator(RockyDagsterTranslator):
+        def get_dag_node_asset_key(self, node):
+            base = super().get_dag_node_asset_key(node)
+            return dg.AssetKey(["my_prefix", *base.path])
+
+    translator = PrefixedTranslator()
+    node = DagNodeOutput.model_validate(
+        {"id": "seed:countries", "kind": "seed", "label": "countries"}
+    )
+    assert translator.get_dag_node_asset_key(node) == dg.AssetKey(
+        ["my_prefix", "seed", "countries"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_dag_multi_assets
+# ---------------------------------------------------------------------------
+
+
+def test_build_dag_multi_assets_returns_assets_definitions():
+    """build_dag_multi_assets returns AssetsDefinition objects, not bare specs."""
+    from unittest.mock import MagicMock
+
+    dag = _make_dag_result(
+        nodes=[
+            {"id": "source:raw", "kind": "source", "label": "raw (source)", "pipeline": "raw"},
+            {
+                "id": "transformation:m1",
+                "kind": "transformation",
+                "label": "m1",
+                "target": {"catalog": "w", "schema": "s", "table": "m1"},
+                "depends_on": ["source:raw"],
+            },
+        ]
+    )
+    mock_rocky = MagicMock()
+    assets = build_dag_multi_assets(
+        dag,
+        rocky=mock_rocky,
+        translator=RockyDagsterTranslator(),
+    )
+    assert len(assets) > 0
+    for asset in assets:
+        assert isinstance(asset, dg.AssetsDefinition)
+
+
+def test_build_dag_multi_assets_groups_by_kind():
+    """Multi-assets are grouped by node kind."""
+    from unittest.mock import MagicMock
+
+    dag = _make_dag_result(
+        nodes=[
+            {"id": "source:raw", "kind": "source", "label": "raw", "pipeline": "raw"},
+            {"id": "load:raw", "kind": "load", "label": "raw (load)", "pipeline": "raw"},
+            {
+                "id": "transformation:m1",
+                "kind": "transformation",
+                "label": "m1",
+                "target": {"catalog": "w", "schema": "s", "table": "m1"},
+            },
+        ]
+    )
+    mock_rocky = MagicMock()
+    assets = build_dag_multi_assets(
+        dag,
+        rocky=mock_rocky,
+        translator=RockyDagsterTranslator(),
+    )
+    # source, load, and transformation are different kinds → 3 groups.
+    assert len(assets) == 3

--- a/integrations/dagster/tests/test_generated_fixtures.py
+++ b/integrations/dagster/tests/test_generated_fixtures.py
@@ -32,6 +32,7 @@ from dagster_rocky.types import (
     CiResult,
     ColumnLineageResult,
     CompileResult,
+    DagResult,
     DiscoverResult,
     DoctorResult,
     HistoryResult,
@@ -66,6 +67,7 @@ EXPECTED_TYPES: dict[str, type] = {
     "metrics": MetricsResult,
     "optimize": OptimizeResult,
     "doctor": DoctorResult,
+    "dag": DagResult,
 }
 
 

--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -137,6 +137,7 @@ capture doctor doctor
 capture history history
 capture metrics metrics revenue_summary
 capture optimize optimize
+capture dag dag --models models
 
 # Drift detection requires the engine to detect schema changes against an
 # already-existing target. The 00-playground-default POC always uses


### PR DESCRIPTION
## Summary

Completes the dag_mode execution layer from PR #88 so materializing assets in the Dagster UI actually runs Rocky commands.

- **Executable multi_assets**: Transformation nodes call `rocky.run_model()`, source/load nodes call `rocky.run()`. Seed/quality/snapshot participate in the graph but have placeholder execution (follow-up)
- **Fallback bug fix**: `_build_defs_from_dag` now correctly threads the `context` parameter instead of passing `None`
- **Translator extensions**: `get_dag_node_asset_key()` and `get_dag_group_name()` on `RockyDagsterTranslator` — overridable by users for custom key derivation
- **Asset key sanitization**: Node labels with spaces/parentheses no longer cause Dagster invalid-name errors
- **Fixture regeneration**: `dag` added to `regen_fixtures.sh`, captured from live binary, added to `test_generated_fixtures.py`

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pytest -v` — 307 tests pass (18 dag_assets tests)
- [ ] End-to-end smoke test with `dagster dev` and `dag_mode=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)