### PR TITLE
docs: update dagster CLI references to uv + dg dev

### DIFF
--- a/docs/src/content/docs/dagster/installation.md
+++ b/docs/src/content/docs/dagster/installation.md
@@ -8,12 +8,6 @@ sidebar:
 ## Install the package
 
 ```bash
-pip install dagster-rocky
-```
-
-Or with `uv`:
-
-```bash
 uv add dagster-rocky
 ```
 

--- a/docs/src/content/docs/guides/ci-cd.md
+++ b/docs/src/content/docs/guides/ci-cd.md
@@ -312,10 +312,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Python dependencies
-        run: pip install dagster dagster-rocky
+        run: uv add dagster dagster-rocky
 
       - name: Validate Dagster definitions
-        run: dagster definitions validate
+        run: uv run dg check defs
 ```
 
 Rocky's `ci` command validates the models independently. Dagster's `definitions validate` ensures the orchestration layer can load and wire the models into assets.

--- a/engine/examples/dagster-integration/README.md
+++ b/engine/examples/dagster-integration/README.md
@@ -10,7 +10,7 @@ Dagster (orchestrator)
   +-- dagster-rocky.RockyComponent
   |     |
   |     +-- rocky discover  -->  AssetSpecs (cached, no API calls on reload)
-  |     +-- rocky plan      -->  Preview SQL
+  |     +-- rocky dag       -->  Full unified DAG (dag_mode)
   |     +-- rocky run       -->  Execute pipeline
   |
   +-- rocky.toml (Rocky config)
@@ -40,6 +40,8 @@ dagster-integration/
 1. **`write_state_to_path()`** calls `rocky discover`, serializes to JSON, and saves to a state file
 2. **`build_defs_from_state()`** reads the cached JSON and creates `AssetSpec` objects without API calls
 
+With `dag_mode=True`, the component also calls `rocky dag` to build a fully connected asset graph where every pipeline stage (source, load, transformation) becomes a Dagster asset with resolved dependencies.
+
 ### RockyResource
 
 `RockyResource` wraps the Rocky CLI binary. Use it inside asset functions to run discover, plan, and run commands.
@@ -48,21 +50,17 @@ dagster-integration/
 
 ```bash
 # Install dagster-rocky
-pip install dagster-rocky
+uv add dagster-rocky
 
 # Ensure rocky binary is on PATH
-cargo install rocky
+rocky --version
 
 # Start Dagster dev server
-dagster dev -f definitions.py
+uv run dg dev
 ```
 
 ## Running
 
 ```bash
-# Preview what Dagster will see
-dagster dev -f definitions.py
-
-# Or use dg CLI
-dg dev
+uv run dg dev
 ```

--- a/integrations/dagster/README.md
+++ b/integrations/dagster/README.md
@@ -10,8 +10,6 @@ and quality metrics surfaced as native Dagster events.
 
 ```bash
 uv add dagster-rocky
-# or
-pip install dagster-rocky
 ```
 
 You'll also need the Rocky CLI on your `$PATH`:


### PR DESCRIPTION
## Summary

Replace stale dagster CLI references across 4 files:

- `pip install dagster-rocky` → `uv add dagster-rocky`
- `dagster dev -f definitions.py` → `uv run dg dev`
- `dagster definitions validate` → `uv run dg check defs`
- Update `engine/examples/dagster-integration/README.md` to mention `dag_mode`

The `dg` CLI is the canonical interface for dagster 1.13.0+.

## Test plan

- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)