### PR TITLE
feat(engine/rocky-core): make adapter role perceptible via kind field

### DIFF
--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -50,6 +50,18 @@ Substitution happens in `rocky-core/src/config.rs` before serde sees the value.
 
 An unnamed `[adapter]` with a `type` key auto-wraps as `adapter.default`. Pipeline adapter refs default to `"default"` — so you can omit `adapter = "default"` lines everywhere.
 
+### The `kind` field
+
+`kind` declares the role an `[adapter.*]` block plays. Two valid values: `"data"` (warehouse read/write) and `"discovery"` (metadata enumeration).
+
+| Adapter type | `kind` rule |
+|---|---|
+| `databricks`, `snowflake`, `bigquery` | Optional — defaults to `"data"`. Setting `"discovery"` is a parse error. |
+| `fivetran`, `airbyte`, `iceberg`, `manual` | **Required — must be `"discovery"`.** Omitting it is a parse error: these adapters have no data path. |
+| `duckdb` | Optional — absent means "register both roles" (the common DuckDB case). Setting `"data"` or `"discovery"` narrows to a single role. |
+
+Requiring `kind` on discovery-only adapter types is deliberate: a reader should be able to tell from the raw config alone that `[adapter.fivetran]` is metadata-only, without knowing the Rust trait surface.
+
 ### DuckDB (no credentials)
 
 ```toml
@@ -91,15 +103,18 @@ private_key_path = "${SNOWFLAKE_KEY_PATH}"
 # password = "${SNOWFLAKE_PASSWORD}"
 ```
 
-### Fivetran (source adapter)
+### Fivetran (discovery-only)
 
 ```toml
 [adapter.fivetran]
 type           = "fivetran"
+kind           = "discovery"                     # required: fivetran has no data path
 destination_id = "${FIVETRAN_DESTINATION_ID}"
 api_key        = "${FIVETRAN_API_KEY}"
 api_secret     = "${FIVETRAN_API_SECRET}"
 ```
+
+Use this block in `pipeline.*.source.discovery.adapter` to let Rocky query the Fivetran REST API for the list of schemas to sync. Data itself flows through whichever warehouse adapter is referenced by `pipeline.*.source.adapter` (usually Databricks or Snowflake — the destination Fivetran populates).
 
 ### Named adapters (multi-adapter configs)
 
@@ -110,6 +125,7 @@ type = "databricks"
 
 [adapter.source]
 type = "fivetran"
+kind = "discovery"
 # …
 
 [pipeline.raw]

--- a/.claude/skills/rocky-new-adapter/SKILL.md
+++ b/.claude/skills/rocky-new-adapter/SKILL.md
@@ -109,6 +109,7 @@ The `SqlDialect` trait is where adapters actually diverge. Things to get right:
 - [ ] Auth module with env-var auto-detection
 - [ ] Conformance test wired up (`rocky test-adapter <name>` passes)
 - [ ] Factory registration so `rocky.toml` `type = "<name>"` resolves
+- [ ] Capability entry added to `engine/crates/rocky-core/src/adapter_capability.rs::capability_for` (data / discovery / both). Drives `kind`-field validation in `rocky.toml` and feeds the `rocky-config` skill table.
 - [ ] Env vars documented in `engine/README.md` and/or `docs/src/content/docs/adapters/<name>.md`
 - [ ] `cargo test -p rocky-<name>` green
 - [ ] `cargo clippy -p rocky-<name> -- -D warnings` clean

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -102,6 +102,11 @@
           "enum": ["databricks", "fivetran", "duckdb", "snowflake"],
           "description": "Adapter type"
         },
+        "kind": {
+          "type": "string",
+          "enum": ["data", "discovery"],
+          "description": "Role this adapter block plays: 'data' for warehouse read/write, 'discovery' for metadata-only connector enumeration. Required on discovery-only adapter types (fivetran, airbyte, iceberg, manual). Optional for warehouse types (defaults to 'data') and for dual-role DuckDB (absent means both)."
+        },
         "host": {
           "type": "string",
           "description": "Databricks workspace host (e.g., 'adb-1234567890.12.azuredatabricks.net')"

--- a/engine/crates/rocky-cli/src/commands/init.rs
+++ b/engine/crates/rocky-cli/src/commands/init.rs
@@ -150,6 +150,10 @@ token = "${DATABRICKS_TOKEN:-}"
 
 [adapter.fivetran_main]
 type = "fivetran"
+# Fivetran is metadata-only: Rocky calls the Fivetran REST API to
+# enumerate connectors. It does not move data — that's the warehouse
+# adapter above.
+kind = "discovery"
 destination_id = "${FIVETRAN_DESTINATION_ID}"
 api_key = "${FIVETRAN_API_KEY}"
 api_secret = "${FIVETRAN_API_SECRET}"

--- a/engine/crates/rocky-core/src/adapter_capability.rs
+++ b/engine/crates/rocky-core/src/adapter_capability.rs
@@ -1,0 +1,107 @@
+//! Canonical adapter-capability table.
+//!
+//! Answers a narrow question: for a given `adapter_type` string (as it
+//! appears in `[adapter.*]` `type = "..."`), which Rocky traits can that
+//! adapter fulfil — [`WarehouseAdapter`](crate::traits::WarehouseAdapter)
+//! (data movement) and/or [`DiscoveryAdapter`](crate::traits::DiscoveryAdapter)
+//! (metadata enumeration)?
+//!
+//! Used by [`config`](crate::config) to validate the `kind` field on
+//! `[adapter.*]` blocks and the target of
+//! `[pipeline.*.source.discovery]` references at parse time, before
+//! the CLI registry tries to instantiate anything.
+
+/// Which Rocky roles an adapter type can play.
+///
+/// Note the asymmetry:
+///
+/// - An adapter can support **both** roles (e.g. DuckDB serves as a local
+///   warehouse *and* enumerates its own schemas for discovery).
+/// - An adapter can support **only** one (e.g. Fivetran has no data path
+///   at all — its sole job is to enumerate Fivetran connectors via the
+///   Fivetran REST API).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdapterCapability {
+    /// Implements [`WarehouseAdapter`](crate::traits::WarehouseAdapter) —
+    /// reads and writes table data.
+    pub supports_data: bool,
+
+    /// Implements [`DiscoveryAdapter`](crate::traits::DiscoveryAdapter) —
+    /// enumerates source schemas / connectors.
+    pub supports_discovery: bool,
+}
+
+impl AdapterCapability {
+    const DATA_ONLY: Self = Self {
+        supports_data: true,
+        supports_discovery: false,
+    };
+    const DISCOVERY_ONLY: Self = Self {
+        supports_data: false,
+        supports_discovery: true,
+    };
+    const BOTH: Self = Self {
+        supports_data: true,
+        supports_discovery: true,
+    };
+}
+
+/// Returns the capability profile for a known adapter type.
+///
+/// Returns `None` for unknown types — callers should surface an
+/// "unsupported adapter type" error with the list of known types.
+///
+/// Keep this table in lockstep with the match arms in
+/// `rocky_cli::registry::AdapterRegistry::from_config` and with the
+/// adapter implementations in the workspace.
+pub fn capability_for(adapter_type: &str) -> Option<AdapterCapability> {
+    let cap = match adapter_type {
+        "databricks" | "snowflake" | "bigquery" => AdapterCapability::DATA_ONLY,
+        "fivetran" | "airbyte" | "iceberg" | "manual" => AdapterCapability::DISCOVERY_ONLY,
+        "duckdb" => AdapterCapability::BOTH,
+        _ => return None,
+    };
+    Some(cap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_only_adapters() {
+        for adapter_type in ["databricks", "snowflake", "bigquery"] {
+            let cap = capability_for(adapter_type).expect("known type");
+            assert!(cap.supports_data, "{adapter_type} should support data");
+            assert!(
+                !cap.supports_discovery,
+                "{adapter_type} should not support discovery"
+            );
+        }
+    }
+
+    #[test]
+    fn discovery_only_adapters() {
+        for adapter_type in ["fivetran", "airbyte", "iceberg", "manual"] {
+            let cap = capability_for(adapter_type).expect("known type");
+            assert!(!cap.supports_data, "{adapter_type} should not support data");
+            assert!(
+                cap.supports_discovery,
+                "{adapter_type} should support discovery"
+            );
+        }
+    }
+
+    #[test]
+    fn duckdb_supports_both() {
+        let cap = capability_for("duckdb").expect("known type");
+        assert!(cap.supports_data);
+        assert!(cap.supports_discovery);
+    }
+
+    #[test]
+    fn unknown_returns_none() {
+        assert!(capability_for("snowpipe").is_none());
+        assert!(capability_for("").is_none());
+    }
+}

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -166,6 +166,32 @@ pub enum ConfigError {
 
     #[error("invalid schema pattern: {0}")]
     InvalidPattern(#[from] crate::schema::SchemaError),
+
+    #[error(
+        "adapter '{name}' (type '{adapter_type}') is discovery-only; \
+         add `kind = \"discovery\"` to the [adapter.{name}] block"
+    )]
+    AdapterMissingDiscoveryKind { name: String, adapter_type: String },
+
+    #[error(
+        "adapter '{name}' has `kind = \"{declared}\"` but type '{adapter_type}' only supports {supported}"
+    )]
+    AdapterKindUnsupported {
+        name: String,
+        adapter_type: String,
+        declared: String,
+        supported: String,
+    },
+
+    #[error(
+        "pipeline '{pipeline}' source.adapter = '{adapter}' points to an adapter whose `kind` excludes data movement"
+    )]
+    PipelineSourceAdapterNotData { pipeline: String, adapter: String },
+
+    #[error(
+        "pipeline '{pipeline}' source.discovery.adapter = '{adapter}' points to an adapter whose `kind` excludes discovery"
+    )]
+    PipelineDiscoveryAdapterNotDiscovery { pipeline: String, adapter: String },
 }
 
 /// Concurrency strategy for table processing.
@@ -822,6 +848,25 @@ pub struct RockyConfig {
     pub schema_evolution: SchemaEvolutionConfig,
 }
 
+/// Role an adapter block plays in the pipeline.
+///
+/// Set via `kind = "data"` or `kind = "discovery"` in an `[adapter.*]`
+/// block. Required on discovery-only adapter types (`fivetran`,
+/// `airbyte`, `iceberg`, `manual`) so the adapter's role is self-evident
+/// in the raw config file — a reader shouldn't have to know the Rust
+/// trait surface of each adapter to tell whether it moves data.
+///
+/// Optional on single-role warehouse types (defaults to `Data`) and on
+/// the dual-capable DuckDB adapter (absent means "register both roles").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AdapterKind {
+    /// Warehouse data movement (reads / writes table bytes).
+    Data,
+    /// Metadata-only discovery (enumerates source schemas / connectors).
+    Discovery,
+}
+
 /// Configuration for a named adapter instance.
 ///
 /// The `type` field determines which adapter crate handles this config.
@@ -835,6 +880,11 @@ pub struct AdapterConfig {
     /// Adapter type: "databricks", "fivetran", "duckdb", etc.
     #[serde(rename = "type")]
     pub adapter_type: String,
+
+    /// Role this adapter block plays. See [`AdapterKind`] for the
+    /// required-vs-optional rules per adapter type.
+    #[serde(default)]
+    pub kind: Option<AdapterKind>,
 
     // -- Databricks fields --
     pub host: Option<String>,
@@ -889,6 +939,7 @@ impl std::fmt::Debug for AdapterConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AdapterConfig")
             .field("adapter_type", &self.adapter_type)
+            .field("kind", &self.kind)
             .field("host", &self.host)
             .field("http_path", &self.http_path)
             .field("token", &self.token.as_ref().map(|_| "***"))
@@ -1547,6 +1598,118 @@ pub struct PipelineTargetConfig {
     pub governance: GovernanceConfig,
 }
 
+/// Validates the `kind` field on every adapter block and every
+/// `source.adapter` / `source.discovery.adapter` reference.
+///
+/// Runs after deserialization so parse-time errors point readers at the
+/// exact config fix (e.g. "add `kind = \"discovery\"` to
+/// [adapter.fivetran_main]") rather than failing deep inside the CLI
+/// adapter registry at runtime.
+///
+/// Orthogonal to [`crate::config`]-level issues like unknown adapter types
+/// or missing pipeline adapter references — those are surfaced by the
+/// `rocky validate` command as rich diagnostics and by the CLI registry
+/// at instantiation time. This function narrows its focus to the `kind`
+/// invariants so the two error paths don't double-report.
+pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
+    use crate::adapter_capability::capability_for;
+
+    for (name, adapter) in &config.adapters {
+        let Some(cap) = capability_for(&adapter.adapter_type) else {
+            continue;
+        };
+
+        match (adapter.kind, cap.supports_data, cap.supports_discovery) {
+            // Discovery-only type — `kind = "discovery"` is required so
+            // the role is self-evident in the raw config file.
+            (None, false, true) => {
+                return Err(ConfigError::AdapterMissingDiscoveryKind {
+                    name: name.clone(),
+                    adapter_type: adapter.adapter_type.clone(),
+                });
+            }
+            // Declared `kind` must be a role the adapter actually supports.
+            (Some(AdapterKind::Data), false, _) => {
+                return Err(ConfigError::AdapterKindUnsupported {
+                    name: name.clone(),
+                    adapter_type: adapter.adapter_type.clone(),
+                    declared: "data".to_owned(),
+                    supported: "discovery".to_owned(),
+                });
+            }
+            (Some(AdapterKind::Discovery), _, false) => {
+                return Err(ConfigError::AdapterKindUnsupported {
+                    name: name.clone(),
+                    adapter_type: adapter.adapter_type.clone(),
+                    declared: "discovery".to_owned(),
+                    supported: "data".to_owned(),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    for (pipeline_name, pipeline) in &config.pipelines {
+        let PipelineConfig::Replication(replication) = pipeline else {
+            continue;
+        };
+
+        // Skip missing / unknown-type references — those are reported by
+        // `rocky validate` (V022 / V017) or by the registry at runtime.
+        if let Some(source_cfg) = config.adapters.get(&replication.source.adapter) {
+            if capability_for(&source_cfg.adapter_type).is_some()
+                && !adapter_role_active(source_cfg, AdapterKind::Data)
+            {
+                return Err(ConfigError::PipelineSourceAdapterNotData {
+                    pipeline: pipeline_name.clone(),
+                    adapter: replication.source.adapter.clone(),
+                });
+            }
+        }
+
+        if let Some(discovery) = &replication.source.discovery {
+            if let Some(disc_cfg) = config.adapters.get(&discovery.adapter) {
+                if capability_for(&disc_cfg.adapter_type).is_some()
+                    && !adapter_role_active(disc_cfg, AdapterKind::Discovery)
+                {
+                    return Err(ConfigError::PipelineDiscoveryAdapterNotDiscovery {
+                        pipeline: pipeline_name.clone(),
+                        adapter: discovery.adapter.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Does this adapter actively serve `role`?
+///
+/// An adapter block actively serves a role when:
+/// - its type supports that role, AND
+/// - the user hasn't narrowed `kind` to a *different* role.
+///
+/// `kind = None` on a dual-role type (DuckDB) means both roles are active.
+fn adapter_role_active(adapter: &AdapterConfig, role: AdapterKind) -> bool {
+    let Some(cap) = crate::adapter_capability::capability_for(&adapter.adapter_type) else {
+        return false;
+    };
+
+    let supports = match role {
+        AdapterKind::Data => cap.supports_data,
+        AdapterKind::Discovery => cap.supports_discovery,
+    };
+    if !supports {
+        return false;
+    }
+
+    match adapter.kind {
+        None => true,
+        Some(declared) => declared == role,
+    }
+}
+
 /// Loads and parses a Rocky configuration from a TOML file (v2 format only).
 ///
 /// Environment variables are substituted before parsing. Supports both named
@@ -1558,6 +1721,9 @@ pub struct PipelineTargetConfig {
 /// a `tracing::warn!` is emitted for each one. Callers that need to surface
 /// deprecation warnings programmatically (e.g., `rocky doctor`, `rocky
 /// validate`) can use [`check_config_deprecations`] on the raw TOML string.
+///
+/// Also validates adapter `kind` fields and pipeline adapter references —
+/// see [`validate_adapter_kinds`].
 pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     let raw = std::fs::read_to_string(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -1573,6 +1739,7 @@ pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     apply_deprecations(&mut value);
     normalize_toml_shorthands(&mut value);
     let config: RockyConfig = value.try_into()?;
+    validate_adapter_kinds(&config)?;
     Ok(config)
 }
 
@@ -1737,6 +1904,204 @@ mod tests {
         ));
     }
 
+    // --- adapter kind validation ---
+
+    fn parse(toml_str: &str) -> RockyConfig {
+        let mut value: toml::Value = toml::from_str(toml_str).unwrap();
+        normalize_toml_shorthands(&mut value);
+        value.try_into().unwrap()
+    }
+
+    #[test]
+    fn discovery_only_adapter_requires_kind_field() {
+        let cfg = parse(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+"#,
+        );
+        let err = validate_adapter_kinds(&cfg).unwrap_err();
+        match err {
+            ConfigError::AdapterMissingDiscoveryKind { name, adapter_type } => {
+                assert_eq!(name, "fivetran_main");
+                assert_eq!(adapter_type, "fivetran");
+            }
+            other => panic!("expected AdapterMissingDiscoveryKind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn discovery_only_adapter_with_kind_field_validates() {
+        let cfg = parse(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+kind = "discovery"
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+"#,
+        );
+        validate_adapter_kinds(&cfg).expect("config should validate");
+    }
+
+    #[test]
+    fn data_only_adapter_rejects_discovery_kind() {
+        let cfg = parse(
+            r#"
+[adapter.db]
+type = "databricks"
+kind = "discovery"
+host = "h"
+http_path = "p"
+token = "t"
+"#,
+        );
+        let err = validate_adapter_kinds(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::AdapterKindUnsupported { ref declared, .. }
+                if declared == "discovery"
+        ));
+    }
+
+    #[test]
+    fn data_only_adapter_without_kind_validates() {
+        let cfg = parse(
+            r#"
+[adapter.db]
+type = "databricks"
+host = "h"
+http_path = "p"
+token = "t"
+"#,
+        );
+        validate_adapter_kinds(&cfg).expect("config should validate");
+    }
+
+    #[test]
+    fn duckdb_without_kind_validates_as_both_roles() {
+        let cfg = parse(
+            r#"
+[adapter.local]
+type = "duckdb"
+
+[pipeline.poc]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.poc.source]
+adapter = "local"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.source.discovery]
+adapter = "local"
+
+[pipeline.poc.target]
+adapter = "local"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        validate_adapter_kinds(&cfg).expect("duckdb should serve both roles without kind");
+    }
+
+    #[test]
+    fn pipeline_discovery_reference_to_data_only_adapter_errors() {
+        let cfg = parse(
+            r#"
+[adapter.db]
+type = "databricks"
+host = "h"
+http_path = "p"
+token = "t"
+
+[pipeline.poc]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.poc.source]
+adapter = "db"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.source.discovery]
+adapter = "db"
+
+[pipeline.poc.target]
+adapter = "db"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        let err = validate_adapter_kinds(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::PipelineDiscoveryAdapterNotDiscovery { .. }
+        ));
+    }
+
+    #[test]
+    fn pipeline_source_reference_to_discovery_only_adapter_errors() {
+        // Fivetran's role is narrowed to discovery; trying to use it as
+        // a data source at `source.adapter` should be rejected at parse.
+        let cfg = parse(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+kind = "discovery"
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+
+[pipeline.poc]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.poc.source]
+adapter = "fivetran_main"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+adapter = "fivetran_main"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        let err = validate_adapter_kinds(&cfg).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::PipelineSourceAdapterNotData { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_adapter_type_is_ignored_by_kind_validation() {
+        // Unknown adapter types are reported by `rocky validate` (V017)
+        // and by the registry at runtime — not by kind validation.
+        let cfg = parse(
+            r#"
+[adapter.mystery]
+type = "postgres"
+"#,
+        );
+        validate_adapter_kinds(&cfg).expect("unknown adapter type is someone else's problem");
+    }
+
     // --- v2 config tests ---
 
     #[test]
@@ -1755,6 +2120,7 @@ timeout_secs = 300
 
 [adapter.fivetran_main]
 type = "fivetran"
+kind = "discovery"
 destination_id = "dest_123"
 api_key = "key_abc"
 api_secret = "secret_xyz"
@@ -3003,6 +3369,7 @@ table = "customers_history"
     fn adapter_config_debug_hides_secrets() {
         let cfg = AdapterConfig {
             adapter_type: "databricks".into(),
+            kind: None,
             host: Some("workspace.cloud.databricks.com".into()),
             http_path: Some("/sql/1.0/warehouses/abc".into()),
             token: Some(RedactedString::new("dapi_SUPER_SECRET_TOKEN".into())),

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -482,6 +482,7 @@ mod tests {
     fn adapter(adapter_type: &str) -> AdapterConfig {
         AdapterConfig {
             adapter_type: adapter_type.to_owned(),
+            kind: None,
             host: None,
             http_path: None,
             token: None,

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod access;
+pub mod adapter_capability;
 pub mod arrow_loader;
 pub mod bridge;
 pub mod catalog;

--- a/engine/rocky.toml
+++ b/engine/rocky.toml
@@ -12,6 +12,7 @@ client_secret = "${DATABRICKS_CLIENT_SECRET}"
 
 [adapter.fivetran_main]
 type = "fivetran"
+kind = "discovery"
 destination_id = "${FIVETRAN_DESTINATION_ID}"
 api_key = "${FIVETRAN_API_KEY}"
 api_secret = "${FIVETRAN_API_SECRET}"

--- a/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/rocky.toml
+++ b/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/rocky.toml
@@ -6,6 +6,7 @@ token = "${DATABRICKS_TOKEN}"
 
 [adapter.fivetran_main]
 type = "fivetran"
+kind = "discovery"
 destination_id = "${FIVETRAN_DESTINATION_ID}"
 api_key = "${FIVETRAN_API_KEY}"
 api_secret = "${FIVETRAN_API_SECRET}"

--- a/examples/playground/pocs/07-adapters/03-fivetran-discover/rocky.toml
+++ b/examples/playground/pocs/07-adapters/03-fivetran-discover/rocky.toml
@@ -1,5 +1,6 @@
 [adapter.fivetran_main]
 type = "fivetran"
+kind = "discovery"
 destination_id = "${FIVETRAN_DESTINATION_ID}"
 api_key = "${FIVETRAN_API_KEY}"
 api_secret = "${FIVETRAN_API_SECRET}"


### PR DESCRIPTION
## Summary

- New `AdapterKind` enum (`data` | `discovery`) on `[adapter.*]` blocks + canonical `rocky-core::adapter_capability` table. Discovery-only adapter types (fivetran / airbyte / iceberg / manual) **must** declare `kind = "discovery"` — a parse-time error with the one-line fix points readers at exactly what to add. DuckDB stays dual-role (absent `kind` = both traits registered).
- Parse-time validation in `load_rocky_config` catches `kind` inconsistencies and cross-adapter references (`source.adapter` → data-only, `source.discovery.adapter` → discovery-only). Scoped to not overlap with existing `rocky validate` V017/V022 diagnostics.
- Migrations: both fivetran POCs, `engine/rocky.toml`, the `rocky init` template, and the parse-test fixture. Hand-written `rocky-project.schema.json` gets the `kind` enum for VS Code autocomplete. `rocky-config` and `rocky-new-adapter` skills updated.

## Motivation

Reviewing a rocky.toml with `[adapter.fivetran]` and `[adapter.databricks]` side-by-side, a reader cannot tell which adapter moves data. Fivetran declares credentials that look identical to a warehouse adapter's, yet it has no data path — it only calls the Fivetran REST API to enumerate connectors. Requiring `kind = "discovery"` makes the role self-evident in the raw config, without forcing readers to learn the Rust trait surface of each adapter crate.

## Test plan

- [x] 12 new unit tests (4 in `adapter_capability::tests`, 8 in `config::tests`) cover every branch of the validation matrix, including the DuckDB-narrowing cross-reference case.
- [x] Regression: `bridge::tests::fivetran_is_discovery_only` still passes (no bridge.rs behaviour change in this PR).
- [x] Full workspace `cargo test --lib` green (869 rocky-core tests), `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean.
- [x] End-to-end smoke: a rocky.toml with `type = "fivetran"` but no `kind` now fails `rocky validate` with the suggested fix inline; adding `kind = "discovery"` makes it parse.

## Follow-ons (separate PRs)

- `engine/crates/rocky-core/src/bridge.rs:170` — collapse the `"fivetran" | "airbyte" | "iceberg" | "manual"` match into a `capability_for()` call now that the canonical table exists.
- Dedicated `rocky validate` V-codes (V030/V031) for kind errors — today they surface through the V001 catch-all, which is clear to humans but not structured for IDE integration.
- `just validate-config-schema` recipe to catch drift between `AdapterConfig` and the hand-written `rocky-project.schema.json`.