### PR TITLE
refactor(engine/rocky-core): drive bridge capabilities from canonical table

### DIFF
--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -142,42 +142,19 @@ pub struct BridgeCapability {
 
 /// Returns the bridge capabilities for a known adapter type.
 ///
-/// Adapter types that are discovery-only (fivetran, airbyte, iceberg) cannot
-/// participate in bridges — they have no warehouse execution capabilities.
+/// Data-plane capabilities (`can_export` / `can_import`) are derived from
+/// the canonical [`adapter_capability::capability_for`] table — any
+/// adapter without a `supports_data` role cannot participate in bridges.
+/// `cloud_storage` is orthogonal (it's about COPY INTO / UNLOAD support,
+/// not trait impls) and kept as a small local enumeration.
 pub fn adapter_capabilities(adapter_type: &str) -> BridgeCapability {
-    match adapter_type {
-        "databricks" => BridgeCapability {
-            can_export: true,
-            can_import: true,
-            cloud_storage: true,
-        },
-        "snowflake" => BridgeCapability {
-            can_export: true,
-            can_import: true,
-            cloud_storage: true,
-        },
-        "bigquery" => BridgeCapability {
-            can_export: true,
-            can_import: true,
-            cloud_storage: true,
-        },
-        "duckdb" => BridgeCapability {
-            can_export: true,
-            can_import: true,
-            cloud_storage: false,
-        },
-        // Discovery-only adapters cannot export or import.
-        "fivetran" | "airbyte" | "iceberg" | "manual" => BridgeCapability {
-            can_export: false,
-            can_import: false,
-            cloud_storage: false,
-        },
-        // Unknown adapter types — assume no capabilities.
-        _ => BridgeCapability {
-            can_export: false,
-            can_import: false,
-            cloud_storage: false,
-        },
+    let supports_data = crate::adapter_capability::capability_for(adapter_type)
+        .is_some_and(|cap| cap.supports_data);
+    let cloud_storage = matches!(adapter_type, "databricks" | "snowflake" | "bigquery");
+    BridgeCapability {
+        can_export: supports_data,
+        can_import: supports_data,
+        cloud_storage,
     }
 }
 


### PR DESCRIPTION
## Summary

- Collapses `bridge::adapter_capabilities` from a hard-coded `match` over adapter type strings into a `capability_for()` lookup against the canonical `adapter_capability` table introduced in #97.
- `can_export` / `can_import` now derive from `supports_data`. The `"fivetran" | "airbyte" | "iceberg" | "manual"` enumeration disappears — if an adapter is discovery-only in the capability table, it automatically cannot bridge.
- `cloud_storage` stays as a small local `matches!`. That flag is about COPY INTO / UNLOAD support (bridge-specific), not about trait impls; collapsing it into the shared table would conflate concerns at different abstraction levels.

## Why

The old match duplicated the discovery-only list that also lives in `adapter_capability::capability_for`. Two sources of truth for the same fact is a bug waiting to happen — add a new discovery adapter and bridge silently misbehaves until someone remembers to update both. This PR leaves exactly one canonical table.

Net change: `-35 / +12` lines in `bridge.rs`.

## Test plan

- [x] All 23 existing bridge tests pass unchanged, including:
  - `fivetran_is_discovery_only` (regression guard)
  - `unknown_adapter_has_no_capabilities` (default fallthrough)
  - `duckdb_has_no_cloud_storage` (proves `cloud_storage` remains orthogonal)
- [x] Full workspace `cargo test --lib` — 1963 tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Related

Part of the Tier 3 follow-on trail from #97. Remaining: dedicated V-codes for `rocky validate` kind errors, and a `just validate-config-schema` recipe to catch `AdapterConfig` ↔ `rocky-project.schema.json` drift.