### PR TITLE
fix(engine/rocky-sql): collapse nested if to unblock clippy 1.95 CI

### DIFF
--- a/engine/crates/rocky-sql/src/transpile.rs
+++ b/engine/crates/rocky-sql/src/transpile.rs
@@ -98,17 +98,15 @@ pub fn transpile(sql: &str, from: Dialect, to: Dialect) -> TranspileResult {
     // Dialect-specific transformations
     match (from, to) {
         // Snowflake QUALIFY → subquery wrapper
-        (Dialect::Snowflake, Dialect::DuckDB) => {
-            if result.to_uppercase().contains("QUALIFY") {
-                warnings.push(TranspileWarning {
-                    original: "QUALIFY clause".to_string(),
-                    reason: format!("{to} does not support QUALIFY — manual rewrite needed"),
-                    suggestion: Some(
-                        "Wrap the query in a subquery and move the QUALIFY condition to WHERE"
-                            .to_string(),
-                    ),
-                });
-            }
+        (Dialect::Snowflake, Dialect::DuckDB) if result.to_uppercase().contains("QUALIFY") => {
+            warnings.push(TranspileWarning {
+                original: "QUALIFY clause".to_string(),
+                reason: format!("{to} does not support QUALIFY — manual rewrite needed"),
+                suggestion: Some(
+                    "Wrap the query in a subquery and move the QUALIFY condition to WHERE"
+                        .to_string(),
+                ),
+            });
         }
         // BigQuery supports QUALIFY natively since 2023 — no change needed
         (_, Dialect::Snowflake) | (_, Dialect::Databricks) => {


### PR DESCRIPTION
## Summary

Clippy 1.95 enables `collapsible_match` by default, and the nested `if result.to_uppercase().contains("QUALIFY")` inside the `(Dialect::Snowflake, Dialect::DuckDB)` arm of the dialect-transformation match now trips `-D warnings`. CI (`engine-ci`) is currently red on `main` because of it.

This collapses the nested `if` into a match guard on the arm itself — identical behaviour, one less level of indentation, CI unblocked.

## Test plan

- [x] `cargo clippy -p rocky-sql --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (confirms no other drift from the clippy version bump)
- [x] `cargo test -p rocky-sql --lib` — 39/39 pass

Fast-track this one — it blocks every open PR from going green.