### PR TITLE
feat(engine/rocky-cli): surface adapter-kind errors as V032/V033 diagnostics

### DIFF
--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -30,11 +30,13 @@ pub fn validate(config_path: &Path, json: bool) -> Result<()> {
 fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
     let mut out = ValidateOutput::new();
 
-    // Parse config (with env var substitution).
-    // load_rocky_config returns ConfigError::FileNotFound for missing
+    // Parse config (with env var substitution) — use the lenient parser
+    // so every `kind`-field issue surfaces as its own V032 / V033
+    // diagnostic instead of the V001 catch-all bailing on the first one.
+    // parse_rocky_config returns ConfigError::FileNotFound for missing
     // files, which the CLI error reporter upgrades to a rich miette
     // diagnostic with `rocky init` / `rocky playground` hints.
-    let cfg = match rocky_core::config::load_rocky_config(config_path) {
+    let cfg = match rocky_core::config::parse_rocky_config(config_path) {
         Ok(cfg) => {
             out.push(ValidateMessage {
                 severity: "ok".into(),
@@ -56,6 +58,13 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
             return Ok(out);
         }
     };
+
+    // Emit a structured diagnostic for every adapter-kind / pipeline-role
+    // issue. V032 covers `[adapter.*]` `kind` invariants; V033 covers
+    // `source.adapter` / `source.discovery.adapter` role mismatches.
+    for err in rocky_core::config::validate_adapter_kinds(&cfg) {
+        out.push(kind_diagnostic(&err, config_path));
+    }
 
     // Validate adapters
     if cfg.adapters.is_empty() {
@@ -224,6 +233,36 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
     lint_config(&cfg, &loaded_models, &mut out);
 
     Ok(out)
+}
+
+/// Converts a `kind`-validation error into a `ValidateMessage` with a
+/// structured V-code and a `field` path that points an IDE at the
+/// offending key in `rocky.toml`.
+fn kind_diagnostic(err: &rocky_core::config::ConfigError, config_path: &Path) -> ValidateMessage {
+    use rocky_core::config::ConfigError;
+
+    let (code, field) = match err {
+        ConfigError::AdapterMissingDiscoveryKind { name, .. }
+        | ConfigError::AdapterKindUnsupported { name, .. } => {
+            ("V032", Some(format!("adapter.{name}.kind")))
+        }
+        ConfigError::PipelineSourceAdapterNotData { pipeline, .. } => {
+            ("V033", Some(format!("pipeline.{pipeline}.source.adapter")))
+        }
+        ConfigError::PipelineDiscoveryAdapterNotDiscovery { pipeline, .. } => (
+            "V033",
+            Some(format!("pipeline.{pipeline}.source.discovery.adapter")),
+        ),
+        _ => ("V001", None),
+    };
+
+    ValidateMessage {
+        severity: "error".into(),
+        code: code.into(),
+        message: err.to_string(),
+        file: Some(config_path.display().to_string()),
+        field,
+    }
 }
 
 fn validate_adapter(
@@ -903,6 +942,138 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(toml_str.as_bytes()).unwrap();
         validate_inner(f.path()).unwrap()
+    }
+
+    #[test]
+    fn test_missing_discovery_kind_emits_v032() {
+        let out = validate_toml(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+"#,
+        );
+        let errors: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.severity == "error" && m.code == "V032")
+            .collect();
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected one V032 diagnostic: {:?}",
+            out.messages
+        );
+        assert!(errors[0].message.contains("discovery-only"));
+        assert_eq!(
+            errors[0].field.as_deref(),
+            Some("adapter.fivetran_main.kind")
+        );
+    }
+
+    #[test]
+    fn test_adapter_kind_mismatch_emits_v032() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "databricks"
+kind = "discovery"
+host = "h"
+http_path = "p"
+token = "t"
+"#,
+        );
+        let errors: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.severity == "error" && m.code == "V032")
+            .collect();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("only supports data"));
+    }
+
+    #[test]
+    fn test_pipeline_discovery_to_data_only_emits_v033() {
+        let out = validate_toml(
+            r#"
+[adapter.db]
+type = "databricks"
+host = "h"
+http_path = "p"
+token = "t"
+
+[pipeline.poc]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.poc.source]
+adapter = "db"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.source.discovery]
+adapter = "db"
+
+[pipeline.poc.target]
+adapter = "db"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        let errors: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.severity == "error" && m.code == "V033")
+            .collect();
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected one V033 diagnostic: {:?}",
+            out.messages
+        );
+        assert_eq!(
+            errors[0].field.as_deref(),
+            Some("pipeline.poc.source.discovery.adapter")
+        );
+    }
+
+    #[test]
+    fn test_multiple_kind_issues_all_surface() {
+        // Two unrelated kind issues in the same file — both should
+        // surface as separate diagnostics instead of bailing on the
+        // first one at parse time.
+        let out = validate_toml(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+
+[adapter.db]
+type = "databricks"
+kind = "discovery"
+host = "h"
+http_path = "p"
+token = "t"
+"#,
+        );
+        let v032: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.code == "V032" && m.severity == "error")
+            .collect();
+        assert_eq!(
+            v032.len(),
+            2,
+            "both V032 issues should surface: {:?}",
+            out.messages
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1598,21 +1598,29 @@ pub struct PipelineTargetConfig {
     pub governance: GovernanceConfig,
 }
 
-/// Validates the `kind` field on every adapter block and every
-/// `source.adapter` / `source.discovery.adapter` reference.
+/// Collects every `kind`-field and pipeline-role issue in a parsed
+/// `RockyConfig`.
 ///
-/// Runs after deserialization so parse-time errors point readers at the
-/// exact config fix (e.g. "add `kind = \"discovery\"` to
+/// Runs after deserialization so errors point readers at the exact
+/// config fix (e.g. "add `kind = \"discovery\"` to
 /// [adapter.fivetran_main]") rather than failing deep inside the CLI
 /// adapter registry at runtime.
 ///
-/// Orthogonal to [`crate::config`]-level issues like unknown adapter types
-/// or missing pipeline adapter references — those are surfaced by the
-/// `rocky validate` command as rich diagnostics and by the CLI registry
-/// at instantiation time. This function narrows its focus to the `kind`
-/// invariants so the two error paths don't double-report.
-pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
+/// Returns all issues, not just the first, so `rocky validate` can
+/// surface each one as its own structured diagnostic. Production load
+/// paths use [`load_rocky_config`], which fails fast on the first
+/// returned error.
+///
+/// Orthogonal to [`crate::config`]-level issues like unknown adapter
+/// types or missing pipeline adapter references — those are surfaced
+/// by the `rocky validate` command as rich diagnostics (V017 / V022)
+/// and by the CLI registry at instantiation time. This function
+/// narrows its focus to the `kind` invariants so the two error paths
+/// don't double-report.
+pub fn validate_adapter_kinds(config: &RockyConfig) -> Vec<ConfigError> {
     use crate::adapter_capability::capability_for;
+
+    let mut errors = Vec::new();
 
     for (name, adapter) in &config.adapters {
         let Some(cap) = capability_for(&adapter.adapter_type) else {
@@ -1623,14 +1631,14 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
             // Discovery-only type — `kind = "discovery"` is required so
             // the role is self-evident in the raw config file.
             (None, false, true) => {
-                return Err(ConfigError::AdapterMissingDiscoveryKind {
+                errors.push(ConfigError::AdapterMissingDiscoveryKind {
                     name: name.clone(),
                     adapter_type: adapter.adapter_type.clone(),
                 });
             }
             // Declared `kind` must be a role the adapter actually supports.
             (Some(AdapterKind::Data), false, _) => {
-                return Err(ConfigError::AdapterKindUnsupported {
+                errors.push(ConfigError::AdapterKindUnsupported {
                     name: name.clone(),
                     adapter_type: adapter.adapter_type.clone(),
                     declared: "data".to_owned(),
@@ -1638,7 +1646,7 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
                 });
             }
             (Some(AdapterKind::Discovery), _, false) => {
-                return Err(ConfigError::AdapterKindUnsupported {
+                errors.push(ConfigError::AdapterKindUnsupported {
                     name: name.clone(),
                     adapter_type: adapter.adapter_type.clone(),
                     declared: "discovery".to_owned(),
@@ -1660,7 +1668,7 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
             if capability_for(&source_cfg.adapter_type).is_some()
                 && !adapter_role_active(source_cfg, AdapterKind::Data)
             {
-                return Err(ConfigError::PipelineSourceAdapterNotData {
+                errors.push(ConfigError::PipelineSourceAdapterNotData {
                     pipeline: pipeline_name.clone(),
                     adapter: replication.source.adapter.clone(),
                 });
@@ -1672,7 +1680,7 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
                 if capability_for(&disc_cfg.adapter_type).is_some()
                     && !adapter_role_active(disc_cfg, AdapterKind::Discovery)
                 {
-                    return Err(ConfigError::PipelineDiscoveryAdapterNotDiscovery {
+                    errors.push(ConfigError::PipelineDiscoveryAdapterNotDiscovery {
                         pipeline: pipeline_name.clone(),
                         adapter: discovery.adapter.clone(),
                     });
@@ -1681,7 +1689,7 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Result<(), ConfigError> {
         }
     }
 
-    Ok(())
+    errors
 }
 
 /// Does this adapter actively serve `role`?
@@ -1710,21 +1718,16 @@ fn adapter_role_active(adapter: &AdapterConfig, role: AdapterKind) -> bool {
     }
 }
 
-/// Loads and parses a Rocky configuration from a TOML file (v2 format only).
+/// Parses a Rocky configuration from a TOML file **without** running
+/// [`validate_adapter_kinds`].
 ///
-/// Environment variables are substituted before parsing. Supports both named
-/// adapter form (`[adapter.foo]`) and unnamed shorthand (`[adapter]` with a
-/// `type` key) for single-adapter projects. Same for `[pipeline]` vs
-/// `[pipeline.name]`.
-///
-/// Deprecated config keys are automatically remapped to their new names and
-/// a `tracing::warn!` is emitted for each one. Callers that need to surface
-/// deprecation warnings programmatically (e.g., `rocky doctor`, `rocky
-/// validate`) can use [`check_config_deprecations`] on the raw TOML string.
-///
-/// Also validates adapter `kind` fields and pipeline adapter references —
-/// see [`validate_adapter_kinds`].
-pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
+/// Env var substitution, deprecation remapping, and shorthand
+/// normalization still run — the only thing skipped is the `kind`-field
+/// invariant check. Intended for `rocky validate`, which wants to
+/// collect `kind` issues as structured diagnostics (V032 / V033)
+/// instead of bailing on the first one. Production code paths should
+/// use [`load_rocky_config`] so misuse fails fast.
+pub fn parse_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     let raw = std::fs::read_to_string(path).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             ConfigError::FileNotFound {
@@ -1739,7 +1742,30 @@ pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     apply_deprecations(&mut value);
     normalize_toml_shorthands(&mut value);
     let config: RockyConfig = value.try_into()?;
-    validate_adapter_kinds(&config)?;
+    Ok(config)
+}
+
+/// Loads, parses, and validates a Rocky configuration (v2 format only).
+///
+/// Environment variables are substituted before parsing. Supports both named
+/// adapter form (`[adapter.foo]`) and unnamed shorthand (`[adapter]` with a
+/// `type` key) for single-adapter projects. Same for `[pipeline]` vs
+/// `[pipeline.name]`.
+///
+/// Deprecated config keys are automatically remapped to their new names and
+/// a `tracing::warn!` is emitted for each one. Callers that need to surface
+/// deprecation warnings programmatically (e.g., `rocky doctor`, `rocky
+/// validate`) can use [`check_config_deprecations`] on the raw TOML string.
+///
+/// Also validates adapter `kind` fields and pipeline adapter references —
+/// see [`validate_adapter_kinds`]. Fails fast on the first such issue;
+/// `rocky validate` uses [`parse_rocky_config`] + [`validate_adapter_kinds`]
+/// directly so it can emit every issue as its own diagnostic.
+pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
+    let config = parse_rocky_config(path)?;
+    if let Some(first) = validate_adapter_kinds(&config).into_iter().next() {
+        return Err(first);
+    }
     Ok(config)
 }
 
@@ -1912,6 +1938,16 @@ mod tests {
         value.try_into().unwrap()
     }
 
+    fn expect_single_error(cfg: &RockyConfig) -> ConfigError {
+        let mut errors = validate_adapter_kinds(cfg);
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one kind error, got {errors:?}"
+        );
+        errors.remove(0)
+    }
+
     #[test]
     fn discovery_only_adapter_requires_kind_field() {
         let cfg = parse(
@@ -1923,8 +1959,7 @@ api_key = "k"
 api_secret = "s"
 "#,
         );
-        let err = validate_adapter_kinds(&cfg).unwrap_err();
-        match err {
+        match expect_single_error(&cfg) {
             ConfigError::AdapterMissingDiscoveryKind { name, adapter_type } => {
                 assert_eq!(name, "fivetran_main");
                 assert_eq!(adapter_type, "fivetran");
@@ -1945,7 +1980,7 @@ api_key = "k"
 api_secret = "s"
 "#,
         );
-        validate_adapter_kinds(&cfg).expect("config should validate");
+        assert!(validate_adapter_kinds(&cfg).is_empty());
     }
 
     #[test]
@@ -1960,7 +1995,7 @@ http_path = "p"
 token = "t"
 "#,
         );
-        let err = validate_adapter_kinds(&cfg).unwrap_err();
+        let err = expect_single_error(&cfg);
         assert!(matches!(
             err,
             ConfigError::AdapterKindUnsupported { ref declared, .. }
@@ -1979,7 +2014,7 @@ http_path = "p"
 token = "t"
 "#,
         );
-        validate_adapter_kinds(&cfg).expect("config should validate");
+        assert!(validate_adapter_kinds(&cfg).is_empty());
     }
 
     #[test]
@@ -2010,7 +2045,7 @@ catalog_template = "poc"
 schema_template = "demo"
 "#,
         );
-        validate_adapter_kinds(&cfg).expect("duckdb should serve both roles without kind");
+        assert!(validate_adapter_kinds(&cfg).is_empty());
     }
 
     #[test]
@@ -2044,9 +2079,8 @@ catalog_template = "poc"
 schema_template = "demo"
 "#,
         );
-        let err = validate_adapter_kinds(&cfg).unwrap_err();
         assert!(matches!(
-            err,
+            expect_single_error(&cfg),
             ConfigError::PipelineDiscoveryAdapterNotDiscovery { .. }
         ));
     }
@@ -2082,9 +2116,8 @@ catalog_template = "poc"
 schema_template = "demo"
 "#,
         );
-        let err = validate_adapter_kinds(&cfg).unwrap_err();
         assert!(matches!(
-            err,
+            expect_single_error(&cfg),
             ConfigError::PipelineSourceAdapterNotData { .. }
         ));
     }
@@ -2099,7 +2132,42 @@ schema_template = "demo"
 type = "postgres"
 "#,
         );
-        validate_adapter_kinds(&cfg).expect("unknown adapter type is someone else's problem");
+        assert!(validate_adapter_kinds(&cfg).is_empty());
+    }
+
+    #[test]
+    fn multiple_kind_issues_are_all_collected() {
+        // Two unrelated issues in the same config — both must surface
+        // so `rocky validate` can emit one diagnostic per issue.
+        let cfg = parse(
+            r#"
+[adapter.fivetran_main]
+type = "fivetran"
+# missing `kind = "discovery"` — issue 1
+destination_id = "d"
+api_key = "k"
+api_secret = "s"
+
+[adapter.db]
+type = "databricks"
+kind = "discovery"           # issue 2: databricks is data-only
+host = "h"
+http_path = "p"
+token = "t"
+"#,
+        );
+        let errors = validate_adapter_kinds(&cfg);
+        assert_eq!(errors.len(), 2, "both issues should surface: {errors:?}");
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::AdapterMissingDiscoveryKind { .. }))
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::AdapterKindUnsupported { .. }))
+        );
     }
 
     // --- v2 config tests ---


### PR DESCRIPTION
## Summary

- `rocky validate` now emits **V032** (adapter-block `kind` issues) and **V033** (pipeline `source.adapter` / `source.discovery.adapter` role mismatches) as separate structured diagnostics with `field` paths pointing at the offending key. Previously these all collapsed into a single V001 catch-all that bailed on the first issue.
- A config with multiple independent kind issues now surfaces every one of them in a single `rocky validate` run, so an IDE or CI report can display the full set instead of one-at-a-time.
- Internally: `validate_adapter_kinds` returns `Vec<ConfigError>` (all issues) rather than `Result<(), ConfigError>` (first). Production paths (`load_rocky_config`) still fail fast by taking the first from the vec — new `parse_rocky_config` is the lenient counterpart used only by `rocky validate`.

## Why

Follow-on from #97 (adapter `kind` field). Advisor flagged that V001 was structurally inadequate for IDE integration — users could see the error text but tools couldn't filter by code or jump to the offending line. This PR gives each kind issue its own code and field path. The underlying perceptibility goal is unchanged; this improves how the validation surfaces.

## V-code allocation

| Code | Fires for | `field` |
|---|---|---|
| V032 | `AdapterMissingDiscoveryKind`, `AdapterKindUnsupported` | `adapter.<name>.kind` |
| V033 | `PipelineSourceAdapterNotData`, `PipelineDiscoveryAdapterNotDiscovery` | `pipeline.<name>.source.adapter` or `pipeline.<name>.source.discovery.adapter` |

V030/V031 were already taken (models/DAG validation) so these start at V032.

## Test plan

- [x] rocky-core: 8 existing kind-validation tests ported to the new `Vec` signature. New `multiple_kind_issues_are_all_collected` proves the all-at-once collection.
- [x] rocky-cli: 4 new `validate_inner` tests cover V032 (missing kind + type mismatch), V033 (discovery → data-only cross-ref), and the multi-issue collection case.
- [x] Full workspace `cargo test --lib` — 870 rocky-core tests, 12 validate tests, all green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Rebased onto current main (post #98, #99).

## Remaining follow-on

`just validate-config-schema` drift check (catches `AdapterConfig` ↔ hand-written `rocky-project.schema.json` divergence). Separate small PR.