### PR TITLE
fix(engine/rocky-core): replace sort_by+cmp with sort_by_key+Reverse

### DIFF
--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -554,7 +554,7 @@ impl StateStore {
             runs.push(run);
         }
         // Sort by started_at descending
-        runs.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        runs.sort_by_key(|run| std::cmp::Reverse(run.started_at));
         runs.truncate(limit);
         Ok(runs)
     }
@@ -622,7 +622,7 @@ impl StateStore {
                 snapshots.push(snapshot);
             }
         }
-        snapshots.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        snapshots.sort_by_key(|snapshot| std::cmp::Reverse(snapshot.timestamp));
         snapshots.truncate(limit);
         Ok(snapshots)
     }


### PR DESCRIPTION
## Summary

Clippy 1.95 flipped `unnecessary_sort_by` on by default and `engine-ci` is red on `main` again (same flavour as #99). Two descending-sort helpers in `rocky-core/src/state.rs` tripped it:

- `get_run_history` sorted runs by `started_at` DESC
- `get_quality_history` sorted snapshots by `timestamp` DESC

Both now use `sort_by_key(|x| std::cmp::Reverse(x.field))` — identical ordering, one less closure, clippy happy.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p rocky-core --lib state` — 54/54 pass
- [x] No behaviour change; ordering preserved

Fast-track so the engine-v1.3.0 release PR can go green.