### PR TITLE
fix(engine/rocky-compiler): sort_by_key in dbt_macros (clippy 1.95)

### DIFF
--- a/engine/crates/rocky-compiler/src/import/dbt_macros.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_macros.rs
@@ -191,7 +191,7 @@ pub fn resolve_macros(
     // Process macros from end to start so byte offsets remain valid
     let mut result = sql.to_string();
     let mut sorted_macros: Vec<&MacroUsage> = macros.iter().collect();
-    sorted_macros.sort_by(|a, b| b.span.0.cmp(&a.span.0));
+    sorted_macros.sort_by_key(|m| std::cmp::Reverse(m.span.0));
 
     for m in sorted_macros {
         let full_name = match &m.package {


### PR DESCRIPTION
## Summary

Third clippy 1.95 `unnecessary_sort_by` hit on `main` — same flavour as #99 and #101. This one in `rocky-compiler/src/import/dbt_macros.rs:194` where macro usages are sorted by descending span offset so SQL byte replacements happen end-to-start without invalidating earlier offsets.

Replaced with `sort_by_key(|m| std::cmp::Reverse(m.span.0))` — identical ordering.

I grep'd the whole workspace this time: `.sort_by(|a, b| b.` returns three hits. This PR fixes the only one clippy flags. The other two (rocky-server/lsp.rs and rocky-cli/metrics.rs) use `partial_cmp` on f64 values — clippy doesn't lint those because NaN handling can't be collapsed into `Reverse`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean across the whole workspace
- [x] `cargo test -p rocky-compiler --lib dbt_macros` — 14/14 pass
- [x] Ordering preserved (same descending-by-offset semantic the block depends on)

Unrelated to `engine-v1.3.0` release — that tag is building in `engine-release.yml` independently of `engine-ci`.