### PR TITLE
feat: surface COPY INTO row counts from Databricks and Snowflake loaders

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Loader `rows_loaded` accuracy (Databricks + Snowflake)
+
+The Databricks and Snowflake loaders now report the actual number of rows
+written by their COPY INTO statements instead of always reporting `0` in
+`LoadFileOutput.rows_loaded`.
+
+- **Databricks** parses `num_affected_rows` from the COPY INTO response's
+  single-row result set. `DatabricksLoaderAdapter::load` switched from
+  `execute_statement` (returns only the statement id) to `execute_sql`
+  (returns the full `QueryResult`) for the COPY INTO call; the redundant
+  `SELECT COUNT(*)` follow-up was removed.
+- **Snowflake** parses `ROWS_LOADED` from the per-file result set that COPY
+  INTO returns and sums across files. The cloud-URI and local-file paths
+  both capture the count; the trailing `DROP STAGE` still runs via
+  `execute_statement`.
+
+Both implementations fall back to `0` rather than erroring when the column
+is missing from the response, so unexpected API shapes still produce a
+usable load result. Surfaces via `rocky run --output json` and the Dagster
+integration's `RockyLoadFile.rows_loaded`.
+
 ## [1.3.0] — 2026-04-16
 
 ### Added — Adapter `kind` field
@@ -142,9 +163,6 @@ prerequisite that makes Load nodes in DAG execution work.
   `commands/run.rs` retains its direct `rocky_databricks::throttle` /
   `::batch` / `::governance` imports for the replication path. Deeper
   decoupling behind the adapter trait boundary is deferred.
-- `rows_loaded` is currently 0 for the Databricks and Snowflake loaders
-  (their COPY INTO responses contain row counts that aren't surfaced by
-  `execute_statement` today). Will be addressed in a follow-up.
 
 ### Added — Dagster Pipes protocol emitter (T2)
 

--- a/engine/crates/rocky-databricks/src/loader.rs
+++ b/engine/crates/rocky-databricks/src/loader.rs
@@ -18,14 +18,14 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
 
-use crate::connector::DatabricksConnector;
+use crate::connector::{DatabricksConnector, QueryResult};
 
 /// Databricks loader adapter using COPY INTO.
 pub struct DatabricksLoaderAdapter {
@@ -94,6 +94,33 @@ fn format_options_clause(format: FileFormat, options: &LoadOptions) -> Option<St
     }
 }
 
+/// Extract the `num_affected_rows` count from a COPY INTO response.
+///
+/// Databricks' COPY INTO returns a single-row result set whose schema
+/// exposes per-operation counters (`num_affected_rows`, `num_inserted_rows`,
+/// `num_skipped_corrupt_files`, …). We read `num_affected_rows` since it
+/// represents the rows written by this COPY INTO call (matches COPY INTO
+/// semantics for append-only + merge-schema loads).
+///
+/// Returns `None` when the column is missing, the result is empty, or the
+/// value isn't a non-negative integer — the caller should default to 0 in
+/// that case rather than fail the load.
+fn extract_num_affected_rows(result: &QueryResult) -> Option<u64> {
+    let idx = result
+        .columns
+        .iter()
+        .position(|c| c.name.eq_ignore_ascii_case("num_affected_rows"))?;
+    let first_row = result.rows.first()?;
+    let cell = first_row.get(idx)?;
+    match cell {
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .or_else(|| n.as_i64().and_then(|i| u64::try_from(i).ok())),
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
 /// Build the full `COPY INTO ... FROM '<uri>'` SQL statement.
 fn build_copy_into_sql(
     uri: &str,
@@ -153,28 +180,31 @@ impl LoaderAdapter for DatabricksLoaderAdapter {
 
         let sql = build_copy_into_sql(&uri, &target_ref, format, options);
         info!(sql = %sql, "databricks COPY INTO");
-        self.connector
-            .execute_statement(&sql)
+        let copy_result = self
+            .connector
+            .execute_sql(&sql)
             .await
             .map_err(|e| AdapterError::msg(e.to_string()))?;
 
-        // COPY INTO doesn't return an affected-row count in its REST response
-        // shape used here. We follow up with a SELECT COUNT(*) so the caller
-        // gets an accurate `rows_loaded` value.
-        let count_sql = format!("SELECT COUNT(*) FROM {target_ref}");
-        let count_result = self
-            .connector
-            .execute_statement(&count_sql)
-            .await
-            .map_err(|e| AdapterError::msg(e.to_string()))?;
-        // execute_statement returns a statement-id string; we'd need
-        // execute_query to read the count. Falling back to 0 here since
-        // Databricks' bulk-load path doesn't expose a cheap row count without
-        // another query round-trip — left as a follow-up.
-        let _ = count_result;
+        // Databricks' COPY INTO returns a single-row result set whose
+        // schema includes `num_affected_rows` (the count of rows written
+        // into the target table for this call). Parse it from the result;
+        // if the column isn't present we fall back to 0 rather than fail,
+        // so older/non-standard API shapes still return a usable load.
+        let rows_loaded = match extract_num_affected_rows(&copy_result) {
+            Some(n) => n,
+            None => {
+                warn!(
+                    statement_id = %copy_result.statement_id,
+                    "databricks COPY INTO response missing `num_affected_rows` \
+                     column; reporting 0 rows loaded"
+                );
+                0
+            }
+        };
 
         Ok(LoadResult {
-            rows_loaded: 0,
+            rows_loaded,
             bytes_read: 0, // Cloud-URI sources: no local byte count.
             duration_ms: start.elapsed().as_millis() as u64,
         })
@@ -294,5 +324,52 @@ mod tests {
             resolve_format(&src, &LoadOptions::default()).unwrap(),
             FileFormat::Parquet
         );
+    }
+
+    fn copy_into_result(column: &str, value: serde_json::Value) -> QueryResult {
+        use crate::connector::ColumnSchema;
+        QueryResult {
+            statement_id: "stmt-copy".into(),
+            columns: vec![ColumnSchema {
+                name: column.into(),
+                type_name: "LONG".into(),
+                position: 0,
+            }],
+            rows: vec![vec![value]],
+            total_row_count: Some(1),
+        }
+    }
+
+    #[test]
+    fn test_extract_num_affected_rows_number() {
+        let qr = copy_into_result("num_affected_rows", serde_json::json!(1234));
+        assert_eq!(extract_num_affected_rows(&qr), Some(1234));
+    }
+
+    #[test]
+    fn test_extract_num_affected_rows_string() {
+        // Databricks sometimes returns numeric columns as JSON strings in
+        // JSON_ARRAY disposition (SQL LONGs don't fit in JSON numbers).
+        let qr = copy_into_result("num_affected_rows", serde_json::json!("4242"));
+        assert_eq!(extract_num_affected_rows(&qr), Some(4242));
+    }
+
+    #[test]
+    fn test_extract_num_affected_rows_case_insensitive() {
+        let qr = copy_into_result("NUM_AFFECTED_ROWS", serde_json::json!(7));
+        assert_eq!(extract_num_affected_rows(&qr), Some(7));
+    }
+
+    #[test]
+    fn test_extract_num_affected_rows_missing_column() {
+        let qr = copy_into_result("num_inserted_rows", serde_json::json!(5));
+        assert_eq!(extract_num_affected_rows(&qr), None);
+    }
+
+    #[test]
+    fn test_extract_num_affected_rows_empty_rows() {
+        let mut qr = copy_into_result("num_affected_rows", serde_json::json!(9));
+        qr.rows.clear();
+        assert_eq!(extract_num_affected_rows(&qr), None);
     }
 }

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -4,12 +4,15 @@
 //! verifying correct behavior for happy paths, auth failures, retries,
 //! and malformed responses.
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter, TableRef};
 use rocky_core::config::RetryConfig;
 use rocky_databricks::auth::{Auth, AuthConfig};
 use rocky_databricks::connector::{ConnectorConfig, ConnectorError, DatabricksConnector};
-use wiremock::matchers::{header, method, path};
+use rocky_databricks::loader::DatabricksLoaderAdapter;
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Creates a PAT-authenticated connector pointing at the given wiremock server.
@@ -416,6 +419,97 @@ async fn test_empty_result_set() {
     assert_eq!(result.columns.len(), 1);
     assert!(result.rows.is_empty());
     assert_eq!(result.total_row_count, Some(0));
+}
+
+/// End-to-end: `DatabricksLoaderAdapter::load` parses `num_affected_rows`
+/// from the COPY INTO response and surfaces it as `LoadResult.rows_loaded`.
+#[tokio::test]
+async fn test_loader_surfaces_num_affected_rows() {
+    let server = MockServer::start().await;
+
+    // Mock COPY INTO response: a single-row result set whose first column is
+    // `num_affected_rows`. This matches Databricks' observed REST shape for
+    // DML statements (including COPY INTO).
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-copy-001",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "num_affected_rows", "type_name": "LONG", "position": 0},
+                        {"name": "num_inserted_rows", "type_name": "LONG", "position": 1}
+                    ]
+                },
+                "total_row_count": 1
+            },
+            "result": {
+                "data_array": [["1234", "1234"]]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector);
+
+    let source = LoadSource::CloudUri("s3://bucket/users.csv".into());
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "users".into(),
+    };
+
+    let result = loader
+        .load(&source, &target, &LoadOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.rows_loaded, 1234,
+        "loader should surface num_affected_rows from COPY INTO"
+    );
+}
+
+/// Loader degrades gracefully when `num_affected_rows` isn't in the response:
+/// the load still succeeds with `rows_loaded = 0` rather than erroring.
+#[tokio::test]
+async fn test_loader_missing_num_affected_rows() {
+    let server = MockServer::start().await;
+
+    // No manifest / no results — older API shapes or unexpected responses.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-copy-002",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": null,
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector);
+
+    let source = LoadSource::CloudUri("s3://bucket/users.csv".into());
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "users".into(),
+    };
+
+    let result = loader
+        .load(&source, &target, &LoadOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows_loaded, 0);
 }
 
 /// Bearer token is sent correctly in the Authorization header.

--- a/engine/crates/rocky-snowflake/src/loader.rs
+++ b/engine/crates/rocky-snowflake/src/loader.rs
@@ -21,7 +21,7 @@ use rocky_adapter_sdk::{
     TableRef,
 };
 
-use crate::connector::SnowflakeConnector;
+use crate::connector::{QueryResult, SnowflakeConnector};
 use crate::stage::{
     copy_into_sql, create_external_stage_sql, create_temporary_stage_sql, drop_stage_sql,
     generate_stage_name, put_file_sql,
@@ -39,12 +39,21 @@ impl SnowflakeLoaderAdapter {
     }
 
     /// Execute a statement, mapping connector errors into the adapter's
-    /// error type.
+    /// error type. Used when the caller doesn't need the result rows.
     async fn exec(&self, sql: &str) -> AdapterResult<()> {
         self.connector
             .execute_statement(sql)
             .await
             .map(|_| ())
+            .map_err(|e| AdapterError::msg(e.to_string()))
+    }
+
+    /// Execute a statement and return the full result set. Used by COPY INTO
+    /// so we can parse per-file `rows_loaded` from the response.
+    async fn exec_with_rows(&self, sql: &str) -> AdapterResult<QueryResult> {
+        self.connector
+            .execute_sql(sql)
+            .await
             .map_err(|e| AdapterError::msg(e.to_string()))
     }
 }
@@ -101,7 +110,7 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
         }
 
         // Build and run the appropriate sequence for the source type.
-        let file_size = match source {
+        let (rows_loaded, file_size) = match source {
             LoadSource::CloudUri(uri) => {
                 // External stage path: one CREATE, one COPY, one DROP.
                 let create_sql = create_external_stage_sql(&stage, uri, format, options);
@@ -110,7 +119,7 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
 
                 let copy_sql = copy_into_sql(&target_ref, &stage);
                 info!(sql = %copy_sql, "snowflake COPY INTO (external stage)");
-                let copy_result = self.exec(&copy_sql).await;
+                let copy_result = self.exec_with_rows(&copy_sql).await;
 
                 // Drop stage regardless of COPY result to tidy up.
                 let drop_sql = drop_stage_sql(&stage);
@@ -118,8 +127,8 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
                     warn!(error = %e, stage = %stage, "failed to drop stage (non-fatal)");
                 }
 
-                copy_result?;
-                0u64 // No local byte count for cloud sources.
+                let rows = rows_from_copy_result(&copy_result?);
+                (rows, 0u64) // No local byte count for cloud sources.
             }
             LoadSource::LocalFile(local_path) => {
                 // Internal stage path: CREATE, PUT, COPY, DROP.
@@ -143,26 +152,23 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
 
                 let copy_sql = copy_into_sql(&target_ref, &stage);
                 info!(sql = %copy_sql, "snowflake COPY INTO (internal stage)");
-                let copy_result = self.exec(&copy_sql).await;
+                let copy_result = self.exec_with_rows(&copy_sql).await;
 
                 let drop_sql = drop_stage_sql(&stage);
                 if let Err(e) = self.exec(&drop_sql).await {
                     warn!(error = %e, stage = %stage, "failed to drop stage (non-fatal)");
                 }
 
-                copy_result?;
-
-                std::fs::metadata(local_path)
+                let rows = rows_from_copy_result(&copy_result?);
+                let bytes = std::fs::metadata(local_path)
                     .map(|m| m.len())
-                    .unwrap_or_default()
+                    .unwrap_or_default();
+                (rows, bytes)
             }
         };
 
         Ok(LoadResult {
-            // Snowflake's COPY INTO returns row counts in the response payload,
-            // but `execute_statement` here surfaces only success/failure. A
-            // follow-up could parse counts from the connector's result row.
-            rows_loaded: 0,
+            rows_loaded,
             bytes_read: file_size,
             duration_ms: start.elapsed().as_millis() as u64,
         })
@@ -171,6 +177,58 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
     fn supported_formats(&self) -> Vec<FileFormat> {
         vec![FileFormat::Csv, FileFormat::Parquet, FileFormat::JsonLines]
     }
+}
+
+/// Extract the total `rows_loaded` from a COPY INTO response, warning when
+/// the column is missing so unexpected API shapes are visible in logs.
+///
+/// Returns `0` (rather than failing the load) when the column isn't present.
+fn rows_from_copy_result(result: &QueryResult) -> u64 {
+    match sum_rows_loaded(result) {
+        Some(n) => n,
+        None => {
+            warn!(
+                statement_handle = %result.statement_handle,
+                "snowflake COPY INTO response missing `rows_loaded` column; \
+                 reporting 0 rows loaded"
+            );
+            0
+        }
+    }
+}
+
+/// Sum the `rows_loaded` column across every row of a COPY INTO result.
+///
+/// Snowflake's COPY INTO returns one row per source file loaded with
+/// columns including `FILE`, `STATUS`, `ROWS_PARSED`, `ROWS_LOADED`,
+/// `ERRORS_SEEN`, etc. Summing `rows_loaded` across files gives the total
+/// rows appended to the target table for this COPY INTO call.
+///
+/// Returns `None` when the column is missing from the response schema —
+/// callers should default to 0 so unexpected API shapes don't fail the
+/// load.
+fn sum_rows_loaded(result: &QueryResult) -> Option<u64> {
+    let idx = result
+        .columns
+        .iter()
+        .position(|c| c.name.eq_ignore_ascii_case("rows_loaded"))?;
+    let mut total: u64 = 0;
+    for row in &result.rows {
+        let Some(cell) = row.get(idx) else {
+            continue;
+        };
+        let parsed = match cell {
+            serde_json::Value::Number(n) => n
+                .as_u64()
+                .or_else(|| n.as_i64().and_then(|i| u64::try_from(i).ok())),
+            serde_json::Value::String(s) => s.parse().ok(),
+            _ => None,
+        };
+        if let Some(v) = parsed {
+            total = total.saturating_add(v);
+        }
+    }
+    Some(total)
 }
 
 /// Convert a local path to a string for SQL interpolation, rejecting paths
@@ -239,5 +297,92 @@ mod tests {
     fn test_local_path_str_accepts_normal() {
         let p = PathBuf::from("/tmp/data.csv");
         assert_eq!(local_path_str(&p).unwrap(), "/tmp/data.csv");
+    }
+
+    fn copy_into_result(columns: &[&str], rows: Vec<Vec<serde_json::Value>>) -> QueryResult {
+        use crate::connector::ColumnMetaData;
+        let columns = columns
+            .iter()
+            .map(|n| ColumnMetaData {
+                name: (*n).to_string(),
+                type_name: Some("FIXED".into()),
+                nullable: Some(true),
+            })
+            .collect();
+        let row_count = rows.len() as u64;
+        QueryResult {
+            statement_handle: "sf-copy".into(),
+            columns,
+            rows,
+            total_row_count: Some(row_count),
+        }
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_single_file() {
+        let qr = copy_into_result(
+            &[
+                "file",
+                "status",
+                "rows_parsed",
+                "rows_loaded",
+                "errors_seen",
+            ],
+            vec![vec![
+                serde_json::json!("users_1.csv"),
+                serde_json::json!("LOADED"),
+                serde_json::json!(100),
+                serde_json::json!(100),
+                serde_json::json!(0),
+            ]],
+        );
+        assert_eq!(sum_rows_loaded(&qr), Some(100));
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_multiple_files() {
+        let qr = copy_into_result(
+            &["file", "rows_loaded"],
+            vec![
+                vec![serde_json::json!("a.csv"), serde_json::json!(10)],
+                vec![serde_json::json!("b.csv"), serde_json::json!(20)],
+                vec![serde_json::json!("c.csv"), serde_json::json!(30)],
+            ],
+        );
+        assert_eq!(sum_rows_loaded(&qr), Some(60));
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_string_values() {
+        // Snowflake's REST API returns numeric columns as JSON strings.
+        let qr = copy_into_result(
+            &["rows_loaded"],
+            vec![vec![serde_json::json!("50")], vec![serde_json::json!("75")]],
+        );
+        assert_eq!(sum_rows_loaded(&qr), Some(125));
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_case_insensitive() {
+        let qr = copy_into_result(&["ROWS_LOADED"], vec![vec![serde_json::json!(42)]]);
+        assert_eq!(sum_rows_loaded(&qr), Some(42));
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_missing_column() {
+        let qr = copy_into_result(
+            &["file", "status"],
+            vec![vec![
+                serde_json::json!("users.csv"),
+                serde_json::json!("LOADED"),
+            ]],
+        );
+        assert_eq!(sum_rows_loaded(&qr), None);
+    }
+
+    #[test]
+    fn test_sum_rows_loaded_empty_result() {
+        let qr = copy_into_result(&["rows_loaded"], vec![]);
+        assert_eq!(sum_rows_loaded(&qr), Some(0));
     }
 }

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -4,12 +4,15 @@
 //! verifying correct behavior for happy paths, auth failures, retries,
 //! and malformed responses.
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter, TableRef};
 use rocky_core::config::RetryConfig;
 use rocky_snowflake::auth::{Auth, AuthConfig};
 use rocky_snowflake::connector::{ConnectorConfig, ConnectorError, SnowflakeConnector};
-use wiremock::matchers::{header, method, path};
+use rocky_snowflake::loader::SnowflakeLoaderAdapter;
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Creates an OAuth-authenticated connector pointing at the given wiremock server.
@@ -393,6 +396,158 @@ async fn test_empty_result_set() {
     assert_eq!(result.columns.len(), 1);
     assert!(result.rows.is_empty());
     assert_eq!(result.total_row_count, Some(0));
+}
+
+/// End-to-end: `SnowflakeLoaderAdapter::load` parses per-file `rows_loaded`
+/// from the COPY INTO response and surfaces the sum as `LoadResult.rows_loaded`.
+#[tokio::test]
+async fn test_loader_surfaces_rows_loaded() {
+    let server = MockServer::start().await;
+
+    // CREATE TEMPORARY STAGE — result set not inspected.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("CREATE TEMPORARY STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-create-stage",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    // COPY INTO — Snowflake returns one row per source file, with
+    // `rows_loaded` as one of the columns. Mocks two files summing to 300.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-copy-001",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": {
+                "numRows": 2,
+                "rowType": [
+                    {"name": "file", "type": "TEXT", "nullable": false},
+                    {"name": "status", "type": "TEXT", "nullable": false},
+                    {"name": "rows_parsed", "type": "FIXED", "nullable": false},
+                    {"name": "rows_loaded", "type": "FIXED", "nullable": false},
+                    {"name": "errors_seen", "type": "FIXED", "nullable": false}
+                ]
+            },
+            "data": [
+                ["s3://bucket/users_1.csv", "LOADED", "100", "100", "0"],
+                ["s3://bucket/users_2.csv", "LOADED", "200", "200", "0"]
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // DROP STAGE IF EXISTS — fires after COPY INTO, result ignored.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("DROP STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-drop-stage",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = SnowflakeLoaderAdapter::new(connector);
+
+    let source = LoadSource::CloudUri("s3://bucket/users/".into());
+    let target = TableRef {
+        catalog: "DB".into(),
+        schema: "RAW".into(),
+        table: "USERS".into(),
+    };
+
+    let options = LoadOptions {
+        format: Some(rocky_adapter_sdk::FileFormat::Csv),
+        ..Default::default()
+    };
+    let result = loader.load(&source, &target, &options).await.unwrap();
+
+    assert_eq!(
+        result.rows_loaded, 300,
+        "loader should sum per-file rows_loaded from COPY INTO response"
+    );
+}
+
+/// Loader degrades gracefully when the COPY INTO response doesn't carry a
+/// `rows_loaded` column: the load still succeeds with `rows_loaded = 0`.
+#[tokio::test]
+async fn test_loader_missing_rows_loaded_column() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("CREATE TEMPORARY STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-create",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-copy",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("DROP STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-drop",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = SnowflakeLoaderAdapter::new(connector);
+    let source = LoadSource::CloudUri("s3://bucket/data.csv".into());
+    let target = TableRef {
+        catalog: "DB".into(),
+        schema: "RAW".into(),
+        table: "USERS".into(),
+    };
+    let result = loader
+        .load(&source, &target, &LoadOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.rows_loaded, 0);
 }
 
 /// Bearer token is sent correctly in the Authorization header.


### PR DESCRIPTION
## Summary

- Databricks and Snowflake loaders previously reported `rows_loaded = 0` in `LoadFileOutput` even though their COPY INTO responses carry the information — user-visible via `rocky run --output json` and the Dagster integration.
- Databricks now parses `num_affected_rows` from the COPY INTO response's single-row result set; the loader switched from `execute_statement` to `execute_sql` for that call, and the dead `SELECT COUNT(*)` follow-up was removed.
- Snowflake now parses the per-file `ROWS_LOADED` column from the COPY INTO result set and sums across files; both the cloud-URI and local-file paths capture the count. `CREATE/DROP STAGE` still go through `execute_statement`.

Both adapters fall back to `0` with a `warn!` log when the expected column is missing, so unexpected API shapes still produce a usable load rather than failing the pipeline. No trait signature changes (`LoadResult.rows_loaded` already existed on the adapter SDK), and no new dependencies.

## Test plan

- [x] `cargo test -p rocky-databricks -p rocky-snowflake --features rocky-databricks/test-support,rocky-snowflake/test-support` — passes (unit + wiremock).
- [x] `cargo clippy --all-targets --features rocky-databricks/test-support,rocky-snowflake/test-support -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] New wiremock tests assert non-zero `rows_loaded` propagates end-to-end for both adapters, and that the missing-column fallback still succeeds.
- [ ] CI (engine-ci.yml) passes on the PR.