### PR TITLE
fix(engine): codegen-drift fixture determinism

### DIFF
--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -8,7 +8,7 @@
 //! Consumers (dagster-rocky) can build a complete, connected Dagster asset
 //! graph from a single `rocky dag --output json` call.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -175,7 +175,7 @@ fn build_dag_output(
         .collect();
 
     // Summary.
-    let mut counts_by_kind: HashMap<String, usize> = HashMap::new();
+    let mut counts_by_kind: BTreeMap<String, usize> = BTreeMap::new();
     for node in &dag.nodes {
         *counts_by_kind.entry(node.kind.to_string()).or_default() += 1;
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use chrono::{DateTime, Utc};
@@ -1780,7 +1780,7 @@ pub struct DagSummaryOutput {
     pub total_nodes: usize,
     pub total_edges: usize,
     pub execution_layers: usize,
-    pub counts_by_kind: HashMap<String, usize>,
+    pub counts_by_kind: BTreeMap<String, usize>,
 }
 
 /// Output of `rocky run --dag`: per-node execution results plus aggregate counts.

--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:54.173571Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:54.287753Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:54.397239Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:54.506389Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "dag",
   "nodes": [
     {
@@ -38,8 +38,8 @@
     "total_edges": 1,
     "execution_layers": 2,
     "counts_by_kind": {
-      "source": 1,
-      "load": 1
+      "load": 1,
+      "source": 1
     }
   }
 }

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:53.217839Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:53.112771Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:53.378556Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "incremental",
-        "watermark": "2026-04-16T00:24:53.545139Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "state",
   "watermarks": [
     {
       "table": "poc.staging__events.events",
-      "last_value": "2026-04-16T00:24:53.378556Z",
+      "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "state",
   "watermarks": [
     {
       "table": "poc.staging__events.events",
-      "last_value": "2026-04-16T00:24:53.545139Z",
+      "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:53.727366Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:52.818544Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:52.974832Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:52.719353Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
       }
     },

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",
@@ -17,7 +17,7 @@
       "duration_ms": 0,
       "metadata": {
         "strategy": "full_refresh",
-        "watermark": "2026-04-16T00:24:51.995399Z",
+        "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "playground.staging__orders.orders"
       }
     }

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,10 +1,10 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "state",
   "watermarks": [
     {
       "table": "playground.staging__orders.orders",
-      "last_value": "2026-04-16T00:24:51.995399Z",
+      "last_value": "2000-01-01T00:00:00Z",
       "updated_at": "2000-01-01T00:00:00Z"
     }
   ]

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.3.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -91,17 +91,21 @@ path = sys.argv[1]
 # Numeric timing fields (durations) — zeroed for determinism.
 TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
 # Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics rows. Replaced with
-# a fixed sentinel so the corpus is byte-stable across regen runs. NOTE we
-# do NOT touch ``last_value`` (the watermark itself, which is a logical
-# value derived from the seeded data and IS deterministic) or anything in
-# the `data` payload — only fields whose name matches the wall-clock set.
+# current time when it writes state / history / metrics / run-metadata rows.
+# Replaced with a fixed sentinel so the corpus is byte-stable across regen
+# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
+# materialization metadata) are both wall-clock under the current engine
+# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
+# than a data-derived value. A future change that makes these data-derived
+# would need to drop them from this set.
 WALL_CLOCK_FIELDS = {
     "updated_at",
     "started_at",
     "finished_at",
     "timestamp",
     "captured_at",
+    "last_value",
+    "watermark",
 }
 SENTINEL_TS = "2000-01-01T00:00:00Z"
 def normalize(node):
@@ -180,17 +184,21 @@ path = sys.argv[1]
 # Numeric timing fields (durations) — zeroed for determinism.
 TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
 # Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics rows. Replaced with
-# a fixed sentinel so the corpus is byte-stable across regen runs. NOTE we
-# do NOT touch ``last_value`` (the watermark itself, which is a logical
-# value derived from the seeded data and IS deterministic) or anything in
-# the `data` payload — only fields whose name matches the wall-clock set.
+# current time when it writes state / history / metrics / run-metadata rows.
+# Replaced with a fixed sentinel so the corpus is byte-stable across regen
+# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
+# materialization metadata) are both wall-clock under the current engine
+# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
+# than a data-derived value. A future change that makes these data-derived
+# would need to drop them from this set.
 WALL_CLOCK_FIELDS = {
     "updated_at",
     "started_at",
     "finished_at",
     "timestamp",
     "captured_at",
+    "last_value",
+    "watermark",
 }
 SENTINEL_TS = "2000-01-01T00:00:00Z"
 def normalize(node):
@@ -281,17 +289,21 @@ path = sys.argv[1]
 # Numeric timing fields (durations) — zeroed for determinism.
 TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
 # Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics rows. Replaced with
-# a fixed sentinel so the corpus is byte-stable across regen runs. NOTE we
-# do NOT touch ``last_value`` (the watermark itself, which is a logical
-# value derived from the seeded data and IS deterministic) or anything in
-# the `data` payload — only fields whose name matches the wall-clock set.
+# current time when it writes state / history / metrics / run-metadata rows.
+# Replaced with a fixed sentinel so the corpus is byte-stable across regen
+# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
+# materialization metadata) are both wall-clock under the current engine
+# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
+# than a data-derived value. A future change that makes these data-derived
+# would need to drop them from this set.
 WALL_CLOCK_FIELDS = {
     "updated_at",
     "started_at",
     "finished_at",
     "timestamp",
     "captured_at",
+    "last_value",
+    "watermark",
 }
 SENTINEL_TS = "2000-01-01T00:00:00Z"
 def normalize(node):


### PR DESCRIPTION
## Summary

Finishes the codegen-drift cleanup started in PR #105. The fixture corpus had three determinism gaps that kept codegen-drift CI red:

1. **Stale version** — fixtures were captured at engine v1.0.3 and never regenerated through v1.1 → v1.3. Re-captured against the current engine.
2. **`watermark` / `last_value` drift** — the regen script's comment claimed these are data-derived and deterministic. They aren't: under current engine behavior, full_refresh runs stamp NOW() as the \`watermark\` in run-output materialization metadata, and the state-output \`last_value\` mirrors it. The anomaly POC runs full_refresh; the incremental POC falls back to full_refresh too (its \`strategy = \"incremental\"\` + \`timestamp_column = \"occurred_at\"\` doesn't fully engage for replication pipelines). Added both fields to \`WALL_CLOCK_FIELDS\` with a comment explaining the invariant and the future-proofing note.
3. **\`counts_by_kind\` HashMap iteration order** — \`DagSummaryOutput.counts_by_kind: HashMap<String, usize>\` serialized in random order, flipping \`{source, load}\` vs \`{load, source}\` per regen. Swapped to \`BTreeMap\` for sorted-by-key iteration. JSON schema unchanged (both serialize as \`object\` with additionalProperties).

## Verification

- [x] \`just codegen\` idempotent (second run produces no diff)
- [x] \`just regen-fixtures\` idempotent (second run produces no diff)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test -p rocky-cli\` passes
- [ ] codegen-drift CI green on this PR (expected)

## Future work

If a future engine change makes \`watermark\` / \`last_value\` data-derived (e.g. real incremental watermark from \`timestamp_column\`), drop them from \`WALL_CLOCK_FIELDS\` so the fixture corpus captures the real values. The comment in \`scripts/regen_fixtures.sh\` flags this.