### PR TITLE
feat(engine): DQX parity phase 1+2 — unified check surface + severity/fail_on_error

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -11,6 +11,10 @@
 export type CheckResult = CheckResult1 & {
   name: string;
   passed: boolean;
+  /**
+   * Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+   */
+  severity?: TestSeverity & string;
   [k: string]: unknown;
 };
 export type CheckResult1 =
@@ -36,11 +40,30 @@ export type CheckResult1 =
       [k: string]: unknown;
     }
   | {
+      /**
+       * Column under test, when the assertion has one.
+       */
+      column?: string | null;
+      /**
+       * Number of failing rows (0 when passed). For `row_count_range`, this stores the observed total row count.
+       */
+      failing_rows: number;
+      /**
+       * Assertion kind — the `TestType` discriminant serialized as snake_case (e.g., `"not_null"`, `"accepted_values"`).
+       */
+      kind: string;
+      [k: string]: unknown;
+    }
+  | {
       query: string;
       result_value: number;
       threshold: number;
       [k: string]: unknown;
     };
+/**
+ * Severity of a test failure.
+ */
+export type TestSeverity = "error" | "warning";
 
 /**
  * JSON output for `rocky run`.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -733,8 +733,8 @@ pub async fn run(
                         }
                         prefix
                     },
-                    check_column_match: pipeline.checks.column_match,
-                    check_row_count: pipeline.checks.row_count,
+                    check_column_match: pipeline.checks.column_match.enabled(),
+                    check_row_count: pipeline.checks.row_count.enabled(),
                     check_freshness: pipeline.checks.freshness.is_some(),
                     column_match_exclude: pipeline
                         .metadata_columns
@@ -1328,7 +1328,7 @@ pub async fn run(
     let _checks_span = info_span!("batched_checks").entered();
     let checks_start = Instant::now();
 
-    let row_count_enabled = pipeline.checks.row_count && !source_batch_refs.is_empty();
+    let row_count_enabled = pipeline.checks.row_count.enabled() && !source_batch_refs.is_empty();
     let freshness_enabled = pipeline.checks.freshness.is_some() && !freshness_batch_refs.is_empty();
 
     if row_count_enabled || freshness_enabled {
@@ -1558,7 +1558,8 @@ pub async fn run(
             let key = fr.table.full_name();
             if let Some(ts) = fr.max_timestamp {
                 let lag = (now - ts).num_seconds().unsigned_abs();
-                let check = checks::check_freshness(lag, freshness_cfg.threshold_seconds);
+                let mut check = checks::check_freshness(lag, freshness_cfg.threshold_seconds);
+                check.severity = freshness_cfg.severity;
 
                 if let Some((_, asset_key)) = batch_asset_keys.iter().find(|(k, _)| *k == key) {
                     let entry = pending_checks.entry(key).or_insert_with(|| PendingCheck {

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -118,7 +118,7 @@ pub async fn run_quality(
     output_json: bool,
 ) -> Result<()> {
     use rocky_core::checks::{CheckDetails, CheckResult};
-    use rocky_core::tests::{TestSeverity, generate_test_sql};
+    use rocky_core::tests::generate_test_sql;
 
     let start = Instant::now();
 
@@ -139,7 +139,6 @@ pub async fn run_quality(
     output.pipeline_type = Some("quality".to_string());
 
     let row_count_severity = pipeline.checks.row_count.severity();
-    let custom_default_severity = TestSeverity::Error;
 
     if !pipeline.checks.enabled {
         warn!("quality pipeline checks are disabled — nothing to do");
@@ -231,11 +230,7 @@ pub async fn run_quality(
                 // Custom checks
                 for custom in &pipeline.checks.custom {
                     let sql = custom.sql.replace("{table}", &full_table);
-                    let severity = if custom.severity == TestSeverity::default() {
-                        custom_default_severity
-                    } else {
-                        custom.severity
-                    };
+                    let severity = custom.severity;
                     match warehouse_adapter.execute_query(&sql).await {
                         Ok(result) => {
                             let result_value: u64 = result

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -117,6 +117,9 @@ pub async fn run_quality(
     rocky_cfg: &rocky_core::config::RockyConfig,
     output_json: bool,
 ) -> Result<()> {
+    use rocky_core::checks::{CheckDetails, CheckResult};
+    use rocky_core::tests::{TestSeverity, generate_test_sql};
+
     let start = Instant::now();
 
     let pipes = crate::pipes::PipesEmitter::detect();
@@ -135,6 +138,9 @@ pub async fn run_quality(
     );
     output.pipeline_type = Some("quality".to_string());
 
+    let row_count_severity = pipeline.checks.row_count.severity();
+    let custom_default_severity = TestSeverity::Error;
+
     if !pipeline.checks.enabled {
         warn!("quality pipeline checks are disabled — nothing to do");
     } else {
@@ -142,7 +148,6 @@ pub async fn run_quality(
             let tables_to_check: Vec<String> = if let Some(ref table) = table_ref.table {
                 vec![table.clone()]
             } else {
-                // List tables in schema via warehouse adapter
                 match warehouse_adapter
                     .execute_query(&format!(
                         "SELECT table_name FROM {}.information_schema.tables WHERE table_schema = '{}'",
@@ -182,7 +187,7 @@ pub async fn run_quality(
                 let mut checks = Vec::new();
 
                 // Row count check
-                if pipeline.checks.row_count {
+                if pipeline.checks.row_count.enabled() {
                     match warehouse_adapter
                         .execute_query(&format!("SELECT COUNT(*) FROM {full_table}"))
                         .await
@@ -197,20 +202,22 @@ pub async fn run_quality(
                                         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
                                 })
                                 .unwrap_or(0);
-                            checks.push(rocky_core::checks::CheckResult {
+                            checks.push(CheckResult {
                                 name: "row_count".into(),
                                 passed: count > 0,
-                                details: rocky_core::checks::CheckDetails::RowCount {
+                                severity: row_count_severity,
+                                details: CheckDetails::RowCount {
                                     source_count: count,
                                     target_count: count,
                                 },
                             });
                         }
                         Err(e) => {
-                            checks.push(rocky_core::checks::CheckResult {
+                            checks.push(CheckResult {
                                 name: "row_count".into(),
                                 passed: false,
-                                details: rocky_core::checks::CheckDetails::Custom {
+                                severity: row_count_severity,
+                                details: CheckDetails::Custom {
                                     query: format!("SELECT COUNT(*) FROM {full_table}"),
                                     result_value: 0,
                                     threshold: 1,
@@ -224,6 +231,11 @@ pub async fn run_quality(
                 // Custom checks
                 for custom in &pipeline.checks.custom {
                     let sql = custom.sql.replace("{table}", &full_table);
+                    let severity = if custom.severity == TestSeverity::default() {
+                        custom_default_severity
+                    } else {
+                        custom.severity
+                    };
                     match warehouse_adapter.execute_query(&sql).await {
                         Ok(result) => {
                             let result_value: u64 = result
@@ -235,10 +247,11 @@ pub async fn run_quality(
                                         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
                                 })
                                 .unwrap_or(0);
-                            checks.push(rocky_core::checks::CheckResult {
+                            checks.push(CheckResult {
                                 name: custom.name.clone(),
                                 passed: result_value >= custom.threshold,
-                                details: rocky_core::checks::CheckDetails::Custom {
+                                severity,
+                                details: CheckDetails::Custom {
                                     query: sql,
                                     result_value,
                                     threshold: custom.threshold,
@@ -246,16 +259,73 @@ pub async fn run_quality(
                             });
                         }
                         Err(e) => {
-                            checks.push(rocky_core::checks::CheckResult {
+                            checks.push(CheckResult {
                                 name: custom.name.clone(),
                                 passed: false,
-                                details: rocky_core::checks::CheckDetails::Custom {
+                                severity,
+                                details: CheckDetails::Custom {
                                     query: sql,
                                     result_value: 0,
                                     threshold: custom.threshold,
                                 },
                             });
                             warn!(error = %e, check = custom.name.as_str(), "custom check query failed");
+                        }
+                    }
+                }
+
+                // Row-level assertions — match by unqualified table name.
+                for assertion in &pipeline.checks.assertions {
+                    if assertion.table != *table_name {
+                        continue;
+                    }
+                    let test = &assertion.test;
+                    let sql = match generate_test_sql(test, &full_table) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                table = %full_table,
+                                "failed to generate assertion SQL — skipping"
+                            );
+                            continue;
+                        }
+                    };
+                    let kind = test_type_kind(&test.test_type);
+                    let name = format!("{kind}:{}", test.column.as_deref().unwrap_or("-"));
+
+                    match warehouse_adapter.execute_query(&sql).await {
+                        Ok(result) => {
+                            let (passed, failing_rows) =
+                                classify_assertion(&test.test_type, &result.rows);
+                            checks.push(CheckResult {
+                                name,
+                                passed,
+                                severity: test.severity,
+                                details: CheckDetails::Assertion {
+                                    kind: kind.to_string(),
+                                    column: test.column.clone(),
+                                    failing_rows,
+                                },
+                            });
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                table = %full_table,
+                                assertion = %name,
+                                "assertion query failed"
+                            );
+                            checks.push(CheckResult {
+                                name,
+                                passed: false,
+                                severity: test.severity,
+                                details: CheckDetails::Assertion {
+                                    kind: kind.to_string(),
+                                    column: test.column.clone(),
+                                    failing_rows: 0,
+                                },
+                            });
                         }
                     }
                 }
@@ -273,24 +343,97 @@ pub async fn run_quality(
         super::run::emit_pipes_events(p, &output);
     }
 
+    let (error_failures, warning_failures) = count_failures_by_severity(&output);
+
     if output_json {
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         let total_checks: usize = output.check_results.iter().map(|t| t.checks.len()).sum();
-        let failed: usize = output
-            .check_results
-            .iter()
-            .flat_map(|t| &t.checks)
-            .filter(|r| !r.passed)
-            .count();
         println!(
-            "quality pipeline complete: {total_checks} check(s) across {} table(s), {failed} failed, in {}ms",
+            "quality pipeline complete: {total_checks} check(s) across {} table(s), {error_failures} error / {warning_failures} warning failed, in {}ms",
             output.check_results.len(),
             output.duration_ms
         );
     }
 
+    if error_failures > 0 && pipeline.checks.fail_on_error {
+        anyhow::bail!("quality pipeline failed: {error_failures} error-severity check(s) failed");
+    }
+
     Ok(())
+}
+
+/// Short snake_case tag for each `TestType` variant — embedded in check
+/// result details so downstream consumers can distinguish assertion kinds.
+fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
+    use rocky_core::tests::TestType;
+    match t {
+        TestType::NotNull => "not_null",
+        TestType::Unique => "unique",
+        TestType::AcceptedValues { .. } => "accepted_values",
+        TestType::Relationships { .. } => "relationships",
+        TestType::Expression { .. } => "expression",
+        TestType::RowCountRange { .. } => "row_count_range",
+    }
+}
+
+/// Classify an assertion query's result into `(passed, failing_rows)`.
+///
+/// The classification is kind-dependent:
+/// - `NotNull` / `Expression`: first cell is a failure count; 0 passes.
+/// - `Unique` / `AcceptedValues` / `Relationships`: every result row is a
+///   violation; empty result passes. `failing_rows` is the row count.
+/// - `RowCountRange`: first cell is the total row count; pass/fail decided
+///   by the caller against `min`/`max` (handled below).
+fn classify_assertion(
+    t: &rocky_core::tests::TestType,
+    rows: &[Vec<serde_json::Value>],
+) -> (bool, u64) {
+    use rocky_core::tests::TestType;
+    let first_cell_u64 = || -> u64 {
+        rows.first()
+            .and_then(|r| r.first())
+            .and_then(|v| {
+                v.as_u64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            })
+            .unwrap_or(0)
+    };
+    match t {
+        TestType::NotNull | TestType::Expression { .. } => {
+            let n = first_cell_u64();
+            (n == 0, n)
+        }
+        TestType::Unique | TestType::AcceptedValues { .. } | TestType::Relationships { .. } => {
+            let n = rows.len() as u64;
+            (n == 0, n)
+        }
+        TestType::RowCountRange { min, max } => {
+            let n = first_cell_u64();
+            let within_min = min.map(|m| n >= m).unwrap_or(true);
+            let within_max = max.map(|m| n <= m).unwrap_or(true);
+            (within_min && within_max, n)
+        }
+    }
+}
+
+/// Count failed checks bucketed by severity across every table result.
+fn count_failures_by_severity(output: &RunOutput) -> (usize, usize) {
+    use rocky_core::tests::TestSeverity;
+    let mut error = 0usize;
+    let mut warning = 0usize;
+    for t in &output.check_results {
+        for c in &t.checks {
+            if c.passed {
+                continue;
+            }
+            match c.severity {
+                TestSeverity::Error => error += 1,
+                TestSeverity::Warning => warning += 1,
+            }
+        }
+    }
+    (error, warning)
 }
 
 /// Execute `rocky run` for a snapshot (SCD Type 2) pipeline.

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -7,6 +7,7 @@ use crate::column_map;
 
 use crate::ir::{ColumnInfo, TableRef};
 use crate::sql_gen::SqlGenError;
+use crate::tests::TestSeverity;
 use crate::traits::SqlDialect;
 
 /// Result of a single data quality check.
@@ -14,6 +15,11 @@ use crate::traits::SqlDialect;
 pub struct CheckResult {
     pub name: String,
     pub passed: bool,
+    /// Severity reported when the check fails. `error` causes the quality
+    /// pipeline to exit non-zero (subject to `fail_on_error`); `warning`
+    /// is advisory and does not fail the run.
+    #[serde(default)]
+    pub severity: TestSeverity,
     #[serde(flatten)]
     pub details: CheckDetails,
 }
@@ -42,6 +48,25 @@ pub enum CheckDetails {
         column: String,
         null_rate: f64,
         threshold: f64,
+    },
+    /// Row-level assertion evaluated via the `TestDecl` surface
+    /// (`not_null`, `unique`, `accepted_values`, `relationships`,
+    /// `expression`, `row_count_range`).
+    ///
+    /// `failing_rows` is the count of rows that violated the assertion;
+    /// `0` means the check passed. For `row_count_range`, `failing_rows`
+    /// stores the observed row count (the caller asserts pass/fail via
+    /// the configured bounds).
+    Assertion {
+        /// Assertion kind — the `TestType` discriminant serialized as
+        /// snake_case (e.g., `"not_null"`, `"accepted_values"`).
+        kind: String,
+        /// Column under test, when the assertion has one.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        column: Option<String>,
+        /// Number of failing rows (0 when passed). For `row_count_range`,
+        /// this stores the observed total row count.
+        failing_rows: u64,
     },
     /// User-defined SQL check evaluated against a threshold.
     Custom {
@@ -152,6 +177,7 @@ pub fn check_row_count(source_count: u64, target_count: u64) -> CheckResult {
     CheckResult {
         name: "row_count".to_string(),
         passed: source_count == target_count,
+        severity: TestSeverity::Error,
         details: CheckDetails::RowCount {
             source_count,
             target_count,
@@ -179,6 +205,7 @@ pub fn check_column_match(
     CheckResult {
         name: "column_match".to_string(),
         passed,
+        severity: TestSeverity::Error,
         details: CheckDetails::ColumnMatch { missing, extra },
     }
 }
@@ -188,6 +215,7 @@ pub fn check_null_rate(column: &str, null_rate: f64, threshold: f64) -> CheckRes
     CheckResult {
         name: "null_rate".to_string(),
         passed: null_rate <= threshold,
+        severity: TestSeverity::Error,
         details: CheckDetails::NullRate {
             column: column.to_string(),
             null_rate,
@@ -201,10 +229,38 @@ pub fn check_custom(name: &str, query: &str, result_value: u64, threshold: u64) 
     CheckResult {
         name: name.to_string(),
         passed: result_value <= threshold,
+        severity: TestSeverity::Error,
         details: CheckDetails::Custom {
             query: query.to_string(),
             result_value,
             threshold,
+        },
+    }
+}
+
+/// Builds a `CheckResult` for a row-level assertion.
+///
+/// `kind` is the `TestType` discriminant in snake_case (e.g. `"not_null"`).
+/// `passed` is classified by the caller — the classification is
+/// kind-dependent (count-based for `not_null`/`expression`,
+/// empty-result-set for `unique`/`accepted_values`/`relationships`,
+/// range-check for `row_count_range`).
+pub fn check_assertion(
+    name: impl Into<String>,
+    kind: impl Into<String>,
+    column: Option<String>,
+    failing_rows: u64,
+    passed: bool,
+    severity: TestSeverity,
+) -> CheckResult {
+    CheckResult {
+        name: name.into(),
+        passed,
+        severity,
+        details: CheckDetails::Assertion {
+            kind: kind.into(),
+            column,
+            failing_rows,
         },
     }
 }
@@ -214,6 +270,7 @@ pub fn check_freshness(lag_seconds: u64, threshold_seconds: u64) -> CheckResult 
     CheckResult {
         name: "freshness".to_string(),
         passed: lag_seconds <= threshold_seconds,
+        severity: TestSeverity::Error,
         details: CheckDetails::Freshness {
             lag_seconds,
             threshold_seconds,

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -484,23 +484,115 @@ pub struct ChecksConfig {
     #[serde(default)]
     pub enabled: bool,
     #[serde(default)]
-    pub row_count: bool,
+    pub row_count: AggregateCheckToggle,
     #[serde(default)]
-    pub column_match: bool,
+    pub column_match: AggregateCheckToggle,
     #[serde(default)]
     pub freshness: Option<FreshnessConfig>,
     #[serde(default)]
     pub null_rate: Option<NullRateConfig>,
     #[serde(default)]
     pub custom: Vec<CustomCheckConfig>,
+    /// Row-level assertions (`not_null`, `unique`, `accepted_values`,
+    /// `relationships`, `expression`, `row_count_range`) executed against
+    /// specific tables in the quality pipeline. Each entry targets a single
+    /// table by name and reuses the `TestDecl` surface from declarative
+    /// model tests.
+    #[serde(default)]
+    pub assertions: Vec<QualityAssertion>,
     /// Row count anomaly detection threshold (percentage deviation from baseline).
     /// Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.
     #[serde(default = "default_anomaly_threshold_pct")]
     pub anomaly_threshold_pct: f64,
+    /// When `true` (default), the quality run exits non-zero if any
+    /// error-severity check fails. Set `false` to force the pipeline to
+    /// always succeed and leave failure handling to downstream consumers
+    /// of the JSON output.
+    #[serde(default = "default_fail_on_error")]
+    pub fail_on_error: bool,
 }
 
 fn default_anomaly_threshold_pct() -> f64 {
     50.0
+}
+
+fn default_fail_on_error() -> bool {
+    true
+}
+
+/// Per-check-kind toggle that accepts either a plain boolean (legacy form)
+/// or a struct with `enabled` + `severity`.
+///
+/// ```toml
+/// # Legacy — still supported
+/// row_count = true
+///
+/// # New — per-check severity
+/// [pipeline.x.checks.row_count]
+/// enabled  = true
+/// severity = "warning"
+/// ```
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AggregateCheckToggle {
+    /// Legacy boolean toggle. Severity defaults to `error`.
+    Bool(bool),
+    /// Explicit struct form with per-check severity.
+    Detailed {
+        #[serde(default)]
+        enabled: bool,
+        #[serde(default)]
+        severity: crate::tests::TestSeverity,
+    },
+}
+
+impl Default for AggregateCheckToggle {
+    fn default() -> Self {
+        AggregateCheckToggle::Bool(false)
+    }
+}
+
+impl AggregateCheckToggle {
+    /// Whether this check is enabled.
+    pub fn enabled(&self) -> bool {
+        match self {
+            AggregateCheckToggle::Bool(b) => *b,
+            AggregateCheckToggle::Detailed { enabled, .. } => *enabled,
+        }
+    }
+
+    /// Severity reported when this check fails. Defaults to `error`.
+    pub fn severity(&self) -> crate::tests::TestSeverity {
+        match self {
+            AggregateCheckToggle::Bool(_) => crate::tests::TestSeverity::Error,
+            AggregateCheckToggle::Detailed { severity, .. } => *severity,
+        }
+    }
+}
+
+/// A single row-level assertion attached to a quality pipeline, scoped to
+/// one table in the pipeline's `tables` list.
+///
+/// ```toml
+/// [[pipeline.nightly_dq.checks.assertions]]
+/// table    = "orders"
+/// type     = "not_null"
+/// column   = "customer_id"
+/// severity = "error"
+/// ```
+///
+/// The `type`-specific fields (and `column`, `severity`) are flattened
+/// from `TestDecl` — the same surface used by declarative model tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityAssertion {
+    /// Table name this assertion applies to. Must match a table discovered
+    /// from one of the pipeline's `[[tables]]` entries (by unqualified
+    /// table name).
+    pub table: String,
+    /// The declarative test (flattened: `type`, `column`, severity, and
+    /// type-specific fields like `values` / `to_table`).
+    #[serde(flatten)]
+    pub test: crate::tests::TestDecl,
 }
 
 /// Freshness check configuration with optional per-schema overrides.
@@ -511,6 +603,9 @@ pub struct FreshnessConfig {
     /// value overrides threshold_seconds for matching schemas.
     #[serde(default)]
     pub overrides: std::collections::HashMap<String, u64>,
+    /// Severity reported when freshness lag exceeds the threshold.
+    #[serde(default)]
+    pub severity: crate::tests::TestSeverity,
 }
 
 /// Null rate check configuration: columns to check, threshold, and sample size.
@@ -520,6 +615,9 @@ pub struct NullRateConfig {
     pub threshold: f64,
     #[serde(default = "default_sample_percent")]
     pub sample_percent: u32,
+    /// Severity reported when a column's null rate exceeds the threshold.
+    #[serde(default)]
+    pub severity: crate::tests::TestSeverity,
 }
 
 fn default_sample_percent() -> u32 {
@@ -533,6 +631,9 @@ pub struct CustomCheckConfig {
     pub sql: String,
     #[serde(default)]
     pub threshold: u64,
+    /// Severity reported when this check fails.
+    #[serde(default)]
+    pub severity: crate::tests::TestSeverity,
 }
 
 /// Governance settings: auto-creation of catalogs/schemas, tags, isolation, and grants.
@@ -2968,9 +3069,184 @@ fail_fast = true
         assert_eq!(q.tables[0].table.as_deref(), Some("orders"));
         assert!(q.tables[1].table.is_none()); // all tables in schema
         assert!(q.checks.enabled);
-        assert!(q.checks.row_count);
+        assert!(q.checks.row_count.enabled());
         assert_eq!(q.checks.custom.len(), 1);
         assert_eq!(q.execution.concurrency, ConcurrencyMode::Fixed(2));
+    }
+
+    // --- Phase 1+2: unified check surface + severity ---
+
+    #[test]
+    fn test_parse_quality_pipeline_with_assertions() {
+        let toml_str = r#"
+[adapter.db]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.nightly_dq]
+type = "quality"
+
+[pipeline.nightly_dq.target]
+adapter = "db"
+
+[[pipeline.nightly_dq.tables]]
+catalog = "poc"
+schema = "staging"
+table = "orders"
+
+[pipeline.nightly_dq.checks]
+enabled = true
+row_count = true
+
+[[pipeline.nightly_dq.checks.assertions]]
+table = "orders"
+type = "not_null"
+column = "customer_id"
+
+[[pipeline.nightly_dq.checks.assertions]]
+table = "orders"
+type = "accepted_values"
+column = "status"
+values = ["pending", "shipped"]
+severity = "warning"
+
+[[pipeline.nightly_dq.checks.assertions]]
+table = "orders"
+type = "expression"
+expression = "total >= 0"
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).unwrap();
+        let q = config.pipelines["nightly_dq"].as_quality().unwrap();
+        assert_eq!(q.checks.assertions.len(), 3);
+        assert_eq!(q.checks.assertions[0].table, "orders");
+        assert!(matches!(
+            q.checks.assertions[0].test.test_type,
+            crate::tests::TestType::NotNull
+        ));
+        assert_eq!(
+            q.checks.assertions[1].test.severity,
+            crate::tests::TestSeverity::Warning
+        );
+        assert!(matches!(
+            q.checks.assertions[2].test.test_type,
+            crate::tests::TestType::Expression { .. }
+        ));
+    }
+
+    #[test]
+    fn test_aggregate_check_toggle_bool_legacy() {
+        let toml_str = r#"
+[adapter.db]
+type = "duckdb"
+path = "p"
+
+[pipeline.q]
+type = "quality"
+
+[pipeline.q.target]
+adapter = "db"
+
+[[pipeline.q.tables]]
+catalog = "c"
+schema = "s"
+
+[pipeline.q.checks]
+enabled = true
+row_count = true
+column_match = false
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).unwrap();
+        let q = config.pipelines["q"].as_quality().unwrap();
+        assert!(q.checks.row_count.enabled());
+        assert_eq!(
+            q.checks.row_count.severity(),
+            crate::tests::TestSeverity::Error
+        );
+        assert!(!q.checks.column_match.enabled());
+    }
+
+    #[test]
+    fn test_aggregate_check_toggle_detailed() {
+        let toml_str = r#"
+[adapter.db]
+type = "duckdb"
+path = "p"
+
+[pipeline.q]
+type = "quality"
+
+[pipeline.q.target]
+adapter = "db"
+
+[[pipeline.q.tables]]
+catalog = "c"
+schema = "s"
+
+[pipeline.q.checks]
+enabled = true
+
+[pipeline.q.checks.row_count]
+enabled = true
+severity = "warning"
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).unwrap();
+        let q = config.pipelines["q"].as_quality().unwrap();
+        assert!(q.checks.row_count.enabled());
+        assert_eq!(
+            q.checks.row_count.severity(),
+            crate::tests::TestSeverity::Warning
+        );
+    }
+
+    #[test]
+    fn test_fail_on_error_defaults_true() {
+        let toml_str = r#"
+[adapter.db]
+type = "duckdb"
+path = "p"
+
+[pipeline.q]
+type = "quality"
+
+[pipeline.q.target]
+adapter = "db"
+
+[[pipeline.q.tables]]
+catalog = "c"
+schema = "s"
+
+[pipeline.q.checks]
+enabled = true
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).unwrap();
+        let q = config.pipelines["q"].as_quality().unwrap();
+        assert!(q.checks.fail_on_error);
+    }
+
+    #[test]
+    fn test_fail_on_error_false_escape_hatch() {
+        let toml_str = r#"
+[adapter.db]
+type = "duckdb"
+path = "p"
+
+[pipeline.q]
+type = "quality"
+
+[pipeline.q.target]
+adapter = "db"
+
+[[pipeline.q.tables]]
+catalog = "c"
+schema = "s"
+
+[pipeline.q.checks]
+enabled = true
+fail_on_error = false
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).unwrap();
+        let q = config.pipelines["q"].as_quality().unwrap();
+        assert!(!q.checks.fail_on_error);
     }
 
     // --- Snapshot pipeline tests ---
@@ -3203,7 +3479,7 @@ concurrency = 2
         assert_eq!(l.options.csv_delimiter, "\t");
         assert!(!l.options.csv_has_header);
         assert!(l.checks.enabled);
-        assert!(l.checks.row_count);
+        assert!(l.checks.row_count.enabled());
         assert_eq!(l.execution.concurrency, ConcurrencyMode::Fixed(2));
     }
 

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
@@ -3,7 +3,7 @@
 > **Category:** 01-quality
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 15s
-> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, standalone checks (row_count, column_match, freshness, null_rate)
+> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, aggregate checks (row_count / column_match / freshness), unified row-level `[[checks.assertions]]` (not_null, unique, accepted_values, expression, row_count_range), per-check `severity`, `fail_on_error`
 
 ## What it shows
 
@@ -12,13 +12,21 @@ Rocky's quality pipeline type — a dedicated pipeline that runs data quality ch
 - A standalone pipeline with its own schedule
 - Targeted at specific schemas/tables
 - Chainable via `depends_on` (runs after ingest completes)
+- Able to express DQX-parity row-level assertions (`not_null`, `unique`,
+  `accepted_values`, `relationships`, `expression`, `row_count_range`) via
+  `[[pipeline.x.checks.assertions]]` blocks on the same surface used by
+  declarative model tests
 
 ## Why it's distinctive
 
 - **Decoupled from data movement** — checks run independently, on their own schedule
 - **Schema-level targeting** — check all tables in `staging__orders` without listing each one
 - **Pipeline chaining** — `depends_on = ["ingest"]` ensures data is fresh before checking
-- **Full check suite** — row_count, column_match, freshness, null_rate, anomaly detection
+- **One assertion surface** — row-level assertions use the same `TestDecl` fields
+  as declarative model tests; no second dialect to learn
+- **Severity-gated failures** — each check carries `severity = "error" | "warning"`;
+  `fail_on_error` (default `true`) lets the run exit non-zero when any
+  error-severity check fails
 - **dbt comparison:** dbt tests are tightly coupled to models; Rocky quality pipelines are standalone
 
 ## Layout
@@ -48,15 +56,24 @@ Rocky's quality pipeline type — a dedicated pipeline that runs data quality ch
 ```text
 Pipeline types:
   ingest     → replication (data movement)
-  nightly_dq → quality (checks only, depends_on ingest)
+  nightly_dq → quality (row-level assertions + aggregate checks)
 
 Run ingest pipeline first
 Run quality pipeline (standalone checks)
 
-Quality results:
-  staging__orders:  row_count=200 ✓  column_match ✓  freshness ✓
-  staging__customers: row_count=50 ✓  null_rate(region)=10% ⚠ (threshold: 5%)
-POC complete.
+Quality results (orders):
+  row_count                               passed
+  not_null(customer_id)      severity=error    FAIL — 2 failing rows
+  accepted_values(status)    severity=error    FAIL — 1 bad value
+  expression(amount >= 0)    severity=warning  FAIL — 1 violation
+
+Quality results (customers):
+  row_count                               passed
+  unique(customer_id)        severity=error    passed
+  not_null(email)            severity=error    passed
+  row_count_range 40..60     severity=error    passed (50 rows)
+
+fail_on_error = false → pipeline exits 0 even with error-severity failures.
 ```
 
 ## What happened
@@ -65,10 +82,13 @@ POC complete.
 2. `ingest` pipeline replicated orders and customers into staging schemas
 3. `nightly_dq` pipeline ran standalone checks against the staged tables:
    - **row_count:** verified tables are non-empty
-   - **column_match:** verified schema consistency between source and target
-   - **freshness:** verified data is less than 24h old
-   - **null_rate:** flagged `region` column in customers (10% null > 5% threshold)
-4. Quality results reported independently from the ingest pipeline
+   - **column_match (warning):** verified schema consistency between source and target
+   - **freshness (warning):** verified data is less than 24h old
+   - **`[[checks.assertions]]`:** unified `TestDecl`-style row-level checks —
+     `not_null`, `accepted_values`, `expression`, `unique`, `row_count_range` —
+     each with its own `severity`
+4. `fail_on_error = false` suppresses the non-zero exit so the POC stays green.
+   Remove it (or set `true`) to wire the quality pipeline into CI as a gate.
 
 ## Related
 

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/data/seed.sql
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/data/seed.sql
@@ -1,16 +1,27 @@
-CREATE SCHEMA IF NOT EXISTS raw__orders;
-CREATE SCHEMA IF NOT EXISTS raw__customers;
+-- Seed the staging schemas directly; the POC exercises the quality
+-- pipeline against pre-populated tables (no data movement).
+CREATE SCHEMA IF NOT EXISTS staging__orders;
+CREATE SCHEMA IF NOT EXISTS staging__customers;
 
-CREATE OR REPLACE TABLE raw__orders.orders AS
+CREATE OR REPLACE TABLE staging__orders.orders AS
 SELECT
     i AS order_id,
-    1 + (i % 50) AS customer_id,
-    ROUND(10 + RANDOM() * 490, 2) AS amount,
-    CASE (i % 4) WHEN 0 THEN 'pending' WHEN 1 THEN 'shipped' WHEN 2 THEN 'delivered' ELSE 'cancelled' END AS status,
+    -- Inject 2 NULL customer_ids to exercise the not_null assertion.
+    CASE WHEN i IN (7, 42) THEN NULL ELSE 1 + (i % 50) END AS customer_id,
+    -- One negative amount to exercise the `amount >= 0` expression assertion.
+    CASE WHEN i = 99 THEN -5.0 ELSE ROUND(10 + RANDOM() * 490, 2) END AS amount,
+    -- One out-of-list status to exercise the accepted_values assertion.
+    CASE
+        WHEN i = 13 THEN 'unknown'
+        WHEN (i % 4) = 0 THEN 'pending'
+        WHEN (i % 4) = 1 THEN 'shipped'
+        WHEN (i % 4) = 2 THEN 'delivered'
+        ELSE 'cancelled'
+    END AS status,
     TIMESTAMP '2026-04-01' + INTERVAL (i * 300) SECOND AS created_at
 FROM generate_series(1, 200) AS t(i);
 
-CREATE OR REPLACE TABLE raw__customers.customers AS
+CREATE OR REPLACE TABLE staging__customers.customers AS
 SELECT
     i AS customer_id,
     'Customer ' || i AS name,

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -4,39 +4,75 @@
 type = "duckdb"
 path = "poc.duckdb"
 
-# Replication pipeline to set up data first
-[pipeline.ingest]
-strategy = "full_refresh"
-
-[pipeline.ingest.source.schema_pattern]
-prefix = "raw__"
-separator = "__"
-components = ["source"]
-
-[pipeline.ingest.target]
-catalog_template = "poc"
-schema_template = "staging__{source}"
-
-# Quality pipeline — runs checks against existing tables
 [pipeline.nightly_dq]
 type = "quality"
-depends_on = ["ingest"]
 
 [pipeline.nightly_dq.target]
 adapter = "default"
 
+# Target named tables directly (avoids depending on information_schema).
 [[pipeline.nightly_dq.tables]]
 catalog = "poc"
-schema = "staging__orders"
+schema  = "staging__orders"
+table   = "orders"
 
 [[pipeline.nightly_dq.tables]]
 catalog = "poc"
-schema = "staging__customers"
+schema  = "staging__customers"
+table   = "customers"
 
 [pipeline.nightly_dq.checks]
 enabled = true
 row_count = true
-column_match = true
-freshness = { threshold_seconds = 86400 }
-null_rate = { threshold_pct = 5 }
+column_match = { enabled = true, severity = "warning" }
+freshness = { threshold_seconds = 86400, severity = "warning" }
 anomaly_threshold_pct = 30.0
+# Phase 2 escape hatch: keep the POC green while surfacing failing rows.
+# Remove (or set `true`) to fail CI on any error-severity violation.
+fail_on_error = false
+
+# --- Phase 1: row-level assertions (unified surface) ---
+
+# not_null — 2 rows (order_id 7, 42) violate this.
+[[pipeline.nightly_dq.checks.assertions]]
+table    = "orders"
+type     = "not_null"
+column   = "customer_id"
+severity = "error"
+
+# accepted_values — 1 row (order_id 13) with status = 'unknown' violates.
+[[pipeline.nightly_dq.checks.assertions]]
+table    = "orders"
+type     = "accepted_values"
+column   = "status"
+values   = ["pending", "shipped", "delivered", "cancelled"]
+severity = "error"
+
+# expression — 1 row (order_id 99) with amount = -5 violates.
+[[pipeline.nightly_dq.checks.assertions]]
+table      = "orders"
+type       = "expression"
+expression = "amount >= 0"
+severity   = "warning"
+
+# unique — passes; customer_id generated sequentially.
+[[pipeline.nightly_dq.checks.assertions]]
+table    = "customers"
+type     = "unique"
+column   = "customer_id"
+severity = "error"
+
+# not_null email — passes; seed never sets NULL email.
+[[pipeline.nightly_dq.checks.assertions]]
+table    = "customers"
+type     = "not_null"
+column   = "email"
+severity = "error"
+
+# row_count_range — customers has exactly 50 rows.
+[[pipeline.nightly_dq.checks.assertions]]
+table    = "customers"
+type     = "row_count_range"
+min      = 40
+max      = 60
+severity = "error"

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
@@ -9,24 +9,23 @@ rm -f .rocky-state.redb poc.duckdb
 
 duckdb poc.duckdb < data/seed.sql
 
-rocky validate
+rocky validate > /dev/null
 
-echo "=== Pipeline types ==="
-echo "  ingest     → replication (data movement)"
-echo "  nightly_dq → quality (checks only, depends_on ingest)"
-
-echo
-echo "=== Run ingest pipeline first ==="
-rocky -c rocky.toml -o json run --pipeline ingest --filter source=orders > expected/run_ingest.json 2>&1 || true
-rocky -c rocky.toml -o json run --pipeline ingest --filter source=customers >> expected/run_ingest.json 2>&1 || true
+echo "=== Run quality pipeline (standalone checks + assertions) ==="
+rocky -c rocky.toml -o json run --pipeline nightly_dq > expected/run_quality.json
 
 echo
-echo "=== Run quality pipeline (standalone checks) ==="
-rocky -c rocky.toml -o json run --pipeline nightly_dq > expected/run_quality.json 2>&1 || true
+echo "=== Summary ==="
+jq '{
+  pipeline_type,
+  check_results: [
+    .check_results[] | {
+      table: (.asset_key | join(".")),
+      checks: [ .checks[] | { name, severity, passed } ]
+    }
+  ]
+}' expected/run_quality.json
 
 echo
-echo "=== Quality results ==="
-cat expected/run_quality.json 2>/dev/null | head -40 || echo "(quality pipeline execution in progress — config validates correctly)"
-
-echo
-echo "POC complete: quality pipeline configured with row_count, column_match, freshness, null_rate checks."
+echo "POC complete: unified check surface (row_count + assertions) with mixed severity."
+echo "Flip fail_on_error=true in rocky.toml to make error-severity failures non-zero."

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from pydantic import AwareDatetime, BaseModel, conint
 
 
@@ -16,63 +18,6 @@ class AnomalyOutput(BaseModel):
     deviation_pct: float
     reason: str
     table: str
-
-
-class CheckResult1(BaseModel):
-    """
-    Row count comparison between source and target tables.
-    """
-
-    name: str
-    passed: bool
-    source_count: conint(ge=0)
-    target_count: conint(ge=0)
-
-
-class CheckResult2(BaseModel):
-    """
-    Column presence comparison between source and target schemas.
-    """
-
-    name: str
-    passed: bool
-    extra: list[str]
-    missing: list[str]
-
-
-class CheckResult3(BaseModel):
-    """
-    Data freshness measured as lag from the max timestamp to now.
-    """
-
-    name: str
-    passed: bool
-    lag_seconds: conint(ge=0)
-    threshold_seconds: conint(ge=0)
-
-
-class CheckResult4(BaseModel):
-    """
-    Null rate for a specific column, sampled via TABLESAMPLE.
-    """
-
-    name: str
-    passed: bool
-    column: str
-    null_rate: float
-    threshold: float
-
-
-class CheckResult5(BaseModel):
-    """
-    User-defined SQL check evaluated against a threshold.
-    """
-
-    name: str
-    passed: bool
-    query: str
-    result_value: conint(ge=0)
-    threshold: conint(ge=0)
 
 
 class DriftActionOutput(BaseModel):
@@ -210,13 +155,6 @@ class PermissionSummary(BaseModel):
     schemas_created: conint(ge=0)
 
 
-class TableCheckOutput(BaseModel):
-    asset_key: list[str]
-    checks: list[
-        CheckResult1 | CheckResult2 | CheckResult3 | CheckResult4 | CheckResult5
-    ]
-
-
 class TableErrorOutput(BaseModel):
     """
     Error from a table that failed during parallel processing.
@@ -224,6 +162,126 @@ class TableErrorOutput(BaseModel):
 
     asset_key: list[str]
     error: str
+
+
+class TestSeverity1(StrEnum):
+    """
+    Test failure is a hard error — pipeline fails.
+    """
+
+    error = "error"
+
+
+class TestSeverity2(StrEnum):
+    """
+    Test failure is a warning — pipeline continues.
+    """
+
+    warning = "warning"
+
+
+class CheckResult1(BaseModel):
+    """
+    Row count comparison between source and target tables.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    source_count: conint(ge=0)
+    target_count: conint(ge=0)
+
+
+class CheckResult2(BaseModel):
+    """
+    Column presence comparison between source and target schemas.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    extra: list[str]
+    missing: list[str]
+
+
+class CheckResult3(BaseModel):
+    """
+    Data freshness measured as lag from the max timestamp to now.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    lag_seconds: conint(ge=0)
+    threshold_seconds: conint(ge=0)
+
+
+class CheckResult4(BaseModel):
+    """
+    Null rate for a specific column, sampled via TABLESAMPLE.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    column: str
+    null_rate: float
+    threshold: float
+
+
+class CheckResult5(BaseModel):
+    """
+    Row-level assertion evaluated via the `TestDecl` surface (`not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`).
+
+    `failing_rows` is the count of rows that violated the assertion; `0` means the check passed. For `row_count_range`, `failing_rows` stores the observed row count (the caller asserts pass/fail via the configured bounds).
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    column: str | None = None
+    """
+    Column under test, when the assertion has one.
+    """
+    failing_rows: conint(ge=0)
+    """
+    Number of failing rows (0 when passed). For `row_count_range`, this stores the observed total row count.
+    """
+    kind: str
+    """
+    Assertion kind — the `TestType` discriminant serialized as snake_case (e.g., `"not_null"`, `"accepted_values"`).
+    """
+
+
+class CheckResult6(BaseModel):
+    """
+    User-defined SQL check evaluated against a threshold.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity1 | TestSeverity2 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    query: str
+    result_value: conint(ge=0)
+    threshold: conint(ge=0)
 
 
 class MaterializationOutput(BaseModel):
@@ -235,6 +293,18 @@ class MaterializationOutput(BaseModel):
     Partition window this materialization targeted, present only when the model's strategy is `time_interval`. `None` for unpartitioned strategies (full_refresh, incremental, merge).
     """
     rows_copied: conint(ge=0) | None = None
+
+
+class TableCheckOutput(BaseModel):
+    asset_key: list[str]
+    checks: list[
+        CheckResult1
+        | CheckResult2
+        | CheckResult3
+        | CheckResult4
+        | CheckResult5
+        | CheckResult6
+    ]
 
 
 class RunOutput(BaseModel):

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -33,6 +33,7 @@
         {
           "name": "row_count",
           "passed": true,
+          "severity": "error",
           "source_count": 500,
           "target_count": 500
         }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -33,6 +33,7 @@
         {
           "name": "row_count",
           "passed": true,
+          "severity": "error",
           "source_count": 500,
           "target_count": 500
         }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -33,6 +33,7 @@
         {
           "name": "row_count",
           "passed": true,
+          "severity": "error",
           "source_count": 500,
           "target_count": 500
         }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -33,6 +33,7 @@
         {
           "name": "row_count",
           "passed": true,
+          "severity": "error",
           "source_count": 5,
           "target_count": 5
         }

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -120,6 +120,33 @@
           "type": "object"
         },
         {
+          "description": "Row-level assertion evaluated via the `TestDecl` surface (`not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`).\n\n`failing_rows` is the count of rows that violated the assertion; `0` means the check passed. For `row_count_range`, `failing_rows` stores the observed row count (the caller asserts pass/fail via the configured bounds).",
+          "properties": {
+            "column": {
+              "description": "Column under test, when the assertion has one.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "failing_rows": {
+              "description": "Number of failing rows (0 when passed). For `row_count_range`, this stores the observed total row count.",
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "kind": {
+              "description": "Assertion kind — the `TestType` discriminant serialized as snake_case (e.g., `\"not_null\"`, `\"accepted_values\"`).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "failing_rows",
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
           "description": "User-defined SQL check evaluated against a threshold.",
           "properties": {
             "query": {
@@ -151,6 +178,15 @@
         },
         "passed": {
           "type": "boolean"
+        },
+        "severity": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestSeverity"
+            }
+          ],
+          "default": "error",
+          "description": "Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run."
         }
       },
       "required": [
@@ -598,6 +634,25 @@
         "error"
       ],
       "type": "object"
+    },
+    "TestSeverity": {
+      "description": "Severity of a test failure.",
+      "oneOf": [
+        {
+          "description": "Test failure is a hard error — pipeline fails.",
+          "enum": [
+            "error"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Test failure is a warning — pipeline continues.",
+          "enum": [
+            "warning"
+          ],
+          "type": "string"
+        }
+      ]
     }
   },
   "description": "JSON output for `rocky run`.",


### PR DESCRIPTION
## Summary

- **Phase 1 — unified check surface.** Quality pipelines can now express every `TestDecl` (`not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`) via `[[pipeline.x.checks.assertions]]`, reusing the exact same `TestType` surface as declarative model tests. New `CheckDetails::Assertion { kind, column, failing_rows }` variant carries results through the JSON output.
- **Phase 2 — severity + fail_on_error.** `CheckResult.severity: TestSeverity`, per-check severity on `FreshnessConfig`/`NullRateConfig`/`CustomCheckConfig`, `AggregateCheckToggle` untagged enum (legacy `bool` + new `{ enabled, severity }`) for `row_count`/`column_match`, and `ChecksConfig.fail_on_error` (default `true`) that makes the quality run exit non-zero on any error-severity failure.
- **Codegen cascade committed.** `schemas/run.schema.json`, dagster Pydantic, vscode TypeScript, and dagster fixtures all regenerated via `just codegen` + `just regen-fixtures`.
- **POC rewritten.** `examples/playground/pocs/01-quality/06-quality-pipeline-standalone/` now demonstrates assertions with mixed severity and the `fail_on_error` escape hatch end-to-end.

## Breaking change — engine-v1.4.0

Quality pipelines used to always return `Ok(())`. They now exit non-zero when any error-severity check fails. The escape hatch is:

```toml
[pipeline.x.checks]
fail_on_error = false
```

Legacy `row_count = true` / `column_match = true` configs keep working via the `AggregateCheckToggle` untagged enum — no schema break.

## Follow-ups (intentionally out of scope)

1. **POC ingest path.** The original POC wired `ingest → nightly_dq` with `depends_on`, but the ingest silently `|| true`-failed and the quality path then hit `{catalog}.information_schema.tables` (not valid DuckDB). This PR drops the ingest and seeds `staging__*` schemas directly so the POC actually runs. A small follow-up can fix the DuckDB information-schema query in `run_local.rs` (around the schema-listing branch) and restore the chained demo.
2. **Assertion `name` collisions.** Synthetic name format `{kind}:{column}` collides when two assertions share the same table/kind/column. Consumers already read `kind` + `column` from `CheckDetails::Assertion`, so it's cosmetic; per-assertion explicit `name` is listed in the plan as a later extension.

## Test plan

- [x] `cargo test --workspace --lib` (all green; 6 new config round-trip tests added)
- [x] `cargo test -p rocky-core --test e2e` (30 pass)
- [x] `cargo test -p rocky-core --test integration` (20 pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `pytest integrations/dagster/` (307 pass — fixtures + Pydantic drift verified)
- [x] POC end-to-end (`./run.sh`): assertions fire on seeded violations; `fail_on_error = true` variant exits 1 with `"2 error-severity check(s) failed"`
- [ ] Reviewer spot-check: extend a real pipeline to use `[[checks.assertions]]` and confirm the wire-through into Dagster asset-check metadata