### PR TITLE
chore(engine): DQX phase 1+2 follow-ups — list_tables_sql + per-assertion name

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -150,6 +150,23 @@ impl SqlDialect for BigQueryDialect {
             "COMMIT TRANSACTION".to_string(),
         ])
     }
+
+    fn list_tables_sql(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> rocky_core::traits::AdapterResult<String> {
+        // BigQuery's INFORMATION_SCHEMA.TABLES lives per-dataset, so the
+        // four-part `project.dataset.INFORMATION_SCHEMA.TABLES` form is
+        // required. Backtick-quote project + dataset per BQ conventions.
+        rocky_sql::validation::validate_identifier(catalog)
+            .map_err(rocky_core::traits::AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(schema)
+            .map_err(rocky_core::traits::AdapterError::new)?;
+        Ok(format!(
+            "SELECT table_name FROM `{catalog}`.`{schema}`.INFORMATION_SCHEMA.TABLES"
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -147,13 +147,20 @@ pub async fn run_quality(
             let tables_to_check: Vec<String> = if let Some(ref table) = table_ref.table {
                 vec![table.clone()]
             } else {
-                match warehouse_adapter
-                    .execute_query(&format!(
-                        "SELECT table_name FROM {}.information_schema.tables WHERE table_schema = '{}'",
-                        table_ref.catalog, table_ref.schema
-                    ))
-                    .await
+                let list_sql = match dialect.list_tables_sql(&table_ref.catalog, &table_ref.schema)
                 {
+                    Ok(sql) => sql,
+                    Err(e) => {
+                        warn!(
+                            catalog = table_ref.catalog.as_str(),
+                            schema = table_ref.schema.as_str(),
+                            error = %e,
+                            "failed to build list-tables SQL — skipping"
+                        );
+                        continue;
+                    }
+                };
+                match warehouse_adapter.execute_query(&list_sql).await {
                     Ok(result) => result
                         .rows
                         .into_iter()
@@ -287,7 +294,9 @@ pub async fn run_quality(
                         }
                     };
                     let kind = test_type_kind(&test.test_type);
-                    let name = format!("{kind}:{}", test.column.as_deref().unwrap_or("-"));
+                    let name = assertion.name.clone().unwrap_or_else(|| {
+                        format!("{kind}:{}", test.column.as_deref().unwrap_or("-"))
+                    });
 
                     match warehouse_adapter.execute_query(&sql).await {
                         Ok(result) => {

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -575,6 +575,7 @@ impl AggregateCheckToggle {
 ///
 /// ```toml
 /// [[pipeline.nightly_dq.checks.assertions]]
+/// name     = "orders_customer_id_not_null"  # optional
 /// table    = "orders"
 /// type     = "not_null"
 /// column   = "customer_id"
@@ -589,6 +590,12 @@ pub struct QualityAssertion {
     /// from one of the pipeline's `[[tables]]` entries (by unqualified
     /// table name).
     pub table: String,
+    /// Optional identifier used as the `CheckResult.name` in the JSON
+    /// output. When unset, a synthesized `"{kind}:{column}"` name is
+    /// used — which can collide if multiple assertions share the same
+    /// table, kind, and column. Set `name` explicitly to disambiguate.
+    #[serde(default)]
+    pub name: Option<String>,
     /// The declarative test (flattened: `type`, `column`, severity, and
     /// type-specific fields like `values` / `to_table`).
     #[serde(flatten)]
@@ -3104,6 +3111,7 @@ type = "not_null"
 column = "customer_id"
 
 [[pipeline.nightly_dq.checks.assertions]]
+name = "orders_status_allowed"
 table = "orders"
 type = "accepted_values"
 column = "status"
@@ -3119,10 +3127,15 @@ expression = "total >= 0"
         let q = config.pipelines["nightly_dq"].as_quality().unwrap();
         assert_eq!(q.checks.assertions.len(), 3);
         assert_eq!(q.checks.assertions[0].table, "orders");
+        assert!(q.checks.assertions[0].name.is_none());
         assert!(matches!(
             q.checks.assertions[0].test.test_type,
             crate::tests::TestType::NotNull
         ));
+        assert_eq!(
+            q.checks.assertions[1].name.as_deref(),
+            Some("orders_status_allowed")
+        );
         assert_eq!(
             q.checks.assertions[1].test.severity,
             crate::tests::TestSeverity::Warning

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -273,6 +273,29 @@ pub trait SqlDialect: Send + Sync {
     fn delete_where(&self, target: &str, where_clause: &str) -> String {
         format!("DELETE FROM {target} WHERE {where_clause}")
     }
+
+    /// SQL query that returns one row per user table in a catalog/schema,
+    /// with `table_name` as the first column.
+    ///
+    /// Used by the quality pipeline when a `[[tables]]` entry omits
+    /// `table` — every table in the schema is then checked.
+    ///
+    /// Default implementation uses the ANSI catalog-prefixed
+    /// `information_schema` form (`{catalog}.information_schema.tables`
+    /// filtered by `table_schema`), which works for Databricks Unity
+    /// Catalog, Snowflake, and BigQuery. Warehouses without a
+    /// catalog-prefixed information schema (e.g. DuckDB) must override.
+    ///
+    /// `catalog` and `schema` are validated as SQL identifiers before
+    /// interpolation; callers should pass the already-validated values.
+    fn list_tables_sql(&self, catalog: &str, schema: &str) -> AdapterResult<String> {
+        rocky_sql::validation::validate_identifier(catalog).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(schema).map_err(AdapterError::new)?;
+        Ok(format!(
+            "SELECT table_name FROM {catalog}.information_schema.tables \
+             WHERE table_schema = '{schema}'"
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -326,6 +326,21 @@ mod tests {
     }
 
     #[test]
+    fn test_list_tables_sql_uses_catalog_prefix() {
+        let d = dialect();
+        let sql = d.list_tables_sql("acme", "staging__orders").unwrap();
+        // Databricks Unity Catalog exposes per-catalog information_schema.
+        assert!(
+            sql.contains("FROM acme.information_schema.tables"),
+            "sql: {sql}"
+        );
+        assert!(
+            sql.contains("table_schema = 'staging__orders'"),
+            "sql: {sql}"
+        );
+    }
+
+    #[test]
     fn test_insert_overwrite_partition_single_replace_where() {
         // Databricks Delta: single REPLACE WHERE statement, atomic.
         let d = dialect();

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -174,6 +174,20 @@ impl SqlDialect for DuckDbSqlDialect {
             "COMMIT".into(),
         ])
     }
+
+    fn list_tables_sql(&self, catalog: &str, schema: &str) -> AdapterResult<String> {
+        // DuckDB's information_schema is a flat, un-prefixed catalog —
+        // the catalog name has to be pushed into a WHERE filter instead
+        // of the `FROM` expression.
+        rocky_sql::validation::validate_identifier(catalog)
+            .map_err(rocky_core::traits::AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(schema)
+            .map_err(rocky_core::traits::AdapterError::new)?;
+        Ok(format!(
+            "SELECT table_name FROM information_schema.tables \
+             WHERE table_catalog = '{catalog}' AND table_schema = '{schema}'"
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -235,6 +249,26 @@ mod tests {
             d.tablesample_clause(10).unwrap(),
             "USING SAMPLE 10 PERCENT (bernoulli)"
         );
+    }
+
+    #[test]
+    fn test_list_tables_sql_filters_catalog_and_schema() {
+        let d = dialect();
+        let sql = d.list_tables_sql("poc", "staging__orders").unwrap();
+        // DuckDB requires the un-prefixed information_schema + catalog filter.
+        assert!(sql.contains("FROM information_schema.tables"), "sql: {sql}");
+        assert!(sql.contains("table_catalog = 'poc'"), "sql: {sql}");
+        assert!(
+            sql.contains("table_schema = 'staging__orders'"),
+            "sql: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_list_tables_sql_rejects_injection() {
+        let d = dialect();
+        assert!(d.list_tables_sql("poc; DROP TABLE users; --", "s").is_err());
+        assert!(d.list_tables_sql("poc", "s'; --").is_err());
     }
 
     #[test]

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -10,7 +10,8 @@ type = "quality"
 [pipeline.nightly_dq.target]
 adapter = "default"
 
-# Target named tables directly (avoids depending on information_schema).
+# `orders` is targeted by name; `customers` uses schema-level targeting
+# (omit `table`) to exercise the dialect's `list_tables_sql` path.
 [[pipeline.nightly_dq.tables]]
 catalog = "poc"
 schema  = "staging__orders"
@@ -19,7 +20,6 @@ table   = "orders"
 [[pipeline.nightly_dq.tables]]
 catalog = "poc"
 schema  = "staging__customers"
-table   = "customers"
 
 [pipeline.nightly_dq.checks]
 enabled = true
@@ -35,6 +35,7 @@ fail_on_error = false
 
 # not_null — 2 rows (order_id 7, 42) violate this.
 [[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_customer_id_required"
 table    = "orders"
 type     = "not_null"
 column   = "customer_id"
@@ -42,6 +43,7 @@ severity = "error"
 
 # accepted_values — 1 row (order_id 13) with status = 'unknown' violates.
 [[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_status_allowed"
 table    = "orders"
 type     = "accepted_values"
 column   = "status"


### PR DESCRIPTION
## Summary

Two cleanup items flagged during [PR #110](https://github.com/rocky-data/rocky/pull/110) review.

1. **`SqlDialect::list_tables_sql(catalog, schema)`** — new trait method invoked by `run_local::run_quality` when a `[[tables]]` entry omits `table` (check every table in the schema). Default impl uses the catalog-prefixed `{catalog}.information_schema.tables` form shared by Databricks/Snowflake/BigQuery-style warehouses. DuckDB overrides to `information_schema.tables` with a `table_catalog = '...'` filter (its information_schema is flat, not per-catalog). BigQuery overrides to the per-dataset `<project>.<dataset>.INFORMATION_SCHEMA.TABLES` four-part form.
2. **`QualityAssertion.name: Option<String>`** — optional identifier used as the `CheckResult.name` in the JSON output. Replaces the synthesized `"{kind}:{column}"` fallback when set, killing name collisions when multiple assertions share the same table/kind/column.

The POC (`examples/playground/pocs/01-quality/06-quality-pipeline-standalone/`) now exercises both: `customers` is discovered via `list_tables_sql` (no explicit `table =`), and the two `orders` error-severity assertions use explicit `name = "..."`.

No schema change — `QualityAssertion` is config-side, not part of the CLI JSON output. No codegen cascade or fixture regen needed.

## Test plan

- [x] `cargo test -p rocky-core --lib` (875 pass; assertion round-trip test extended to cover `name`)
- [x] `cargo test -p rocky-duckdb --lib` (60 pass; new `list_tables_sql` shape + injection-rejection tests)
- [x] `cargo test -p rocky-databricks --lib` (90 pass; new catalog-prefix shape test)
- [x] `cargo test -p rocky-bigquery --lib` (40 pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `pytest integrations/dagster/` (307 pass)
- [x] POC `./run.sh` — schema-level discovery + named assertions both surface correctly in the JSON