### PR TITLE
fix(vscode): lower engines.vscode to ^1.105.0 to unblock CI tests

### DIFF
--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -77,7 +77,7 @@ icons/
 ### TypeScript
 - Target: ES2022, Module: CommonJS
 - Strict mode enabled
-- VS Code API minimum: 1.110.0
+- VS Code API minimum: 1.105.0 (must match the version pinned in `src/test/runTest.ts`; test runner activates against that exact build)
 - Use `cp.execFile()` for subprocess calls (not `cp.exec()` — no shell injection)
 - Use `vscode.window.withProgress()` for long-running commands
 - Escape HTML in webview content via `escapeHtml()`

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.6.0",
-        "@types/vscode": "^1.115.0",
+        "@types/vscode": "^1.105.0",
         "@viz-js/viz": "^3.26.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.8.0",
@@ -27,7 +27,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "vscode": "^1.115.0"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
     "directory": "editors/vscode"
   },
   "engines": {
-    "vscode": "^1.115.0"
+    "vscode": "^1.105.0"
   },
   "icon": "icons/rocky-icon-128.png",
   "galleryBanner": {
@@ -407,7 +407,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
-    "@types/vscode": "^1.115.0",
+    "@types/vscode": "^1.105.0",
     "@viz-js/viz": "^3.26.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.8.0",


### PR DESCRIPTION
## Summary
- `engines.vscode` was at `^1.115.0` (bumped in #25 to follow a Dependabot `@types/vscode` bump), but `src/test/runTest.ts` pins the test runner to `1.105.0` — which is the latest publicly released VS Code stable. The extension host then refused to activate the extension (`Extension is not compatible with Code 1.105.0. Extension requires: ^1.115.0.`), so every "commands are registered" / "task type is registered" assertion failed.
- Drop both `engines.vscode` and `@types/vscode` to `^1.105.0` so the manifest matches the version the test runner actually exercises. No code uses 1.106+ APIs.
- Update `editors/vscode/CLAUDE.md` so the stated API minimum reflects reality and flags the runTest.ts pin as the source of truth.

## Test plan
- [x] `npm run compile` — TypeScript still compiles clean.
- [x] `npm run test:unit` — 20/20 vitest unit tests pass.
- [x] `npm test` — all 8 integration tests pass locally against VS Code 1.105.0 (previously 6 were failing in CI).
- [ ] `vscode-ci` workflow goes green on this PR.

## Follow-up
When VS Code 1.115 actually ships, bump `VSCODE_TEST_VERSION` / the pin in `src/test/runTest.ts` in the same PR as any future `engines.vscode` bump so the manifest and the test target never diverge again.