### PR TITLE
feat(engine): DQX parity phase 3 — row quarantine (split / tag / drop)

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -92,6 +92,10 @@ export interface RunOutput {
    * Pipeline type that was executed (e.g., "replication").
    */
   pipeline_type?: string | null;
+  /**
+   * Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.
+   */
+  quarantine: QuarantineOutput[];
   resumed_from?: string | null;
   /**
    * True when running in shadow mode (targets rewritten).
@@ -266,5 +270,45 @@ export interface PermissionSummary {
   grants_added: number;
   grants_revoked: number;
   schemas_created: number;
+  [k: string]: unknown;
+}
+/**
+ * Row-quarantine outcome for a single table processed by the quality pipeline. Emitted when `[pipeline.x.checks.quarantine]` is enabled and the table has at least one error-severity row-level assertion that lowers to a boolean predicate.
+ *
+ * Row counts are reported when the warehouse adapter supplies them. Adapters that cannot count rows written by a `CREATE OR REPLACE TABLE` leave the counts as `None`.
+ */
+export interface QuarantineOutput {
+  /**
+   * Dagster-style asset key path (`[catalog, schema, table]`) of the source table the quarantine acted on.
+   */
+  asset_key: string[];
+  /**
+   * Error message from the first failing statement, if any.
+   */
+  error?: string | null;
+  /**
+   * Quarantine mode that was applied. One of `"split"`, `"tag"`, `"drop"` (matches [`rocky_core::config::QuarantineMode`]).
+   */
+  mode: string;
+  /**
+   * `true` when every quarantine statement executed successfully. `false` means a partial failure — inspect `error` for details.
+   */
+  ok: boolean;
+  /**
+   * Fully-qualified name of the `__quarantine` output table. Empty for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
+   */
+  quarantine_table: string;
+  /**
+   * Number of rows in the `__quarantine` output, when the adapter can report it.
+   */
+  quarantined_rows?: number | null;
+  /**
+   * Number of rows in the `__valid` output, when the adapter can report it.
+   */
+  valid_rows?: number | null;
+  /**
+   * Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = "tag"` (source is rewritten in place).
+   */
+  valid_table: string;
   [k: string]: unknown;
 }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3122,6 +3122,7 @@ mod tests {
             shadow: false,
             materializations: vec![],
             check_results: vec![],
+            quarantine: vec![],
             anomalies: vec![],
             errors: vec![],
             execution: ExecutionSummary {

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -334,9 +334,47 @@ pub async fn run_quality(
                     }
                 }
 
-                output
-                    .check_results
-                    .push(TableCheckOutput { asset_key, checks });
+                output.check_results.push(TableCheckOutput {
+                    asset_key: asset_key.clone(),
+                    checks,
+                });
+
+                // Row quarantine — split/tag/drop rows that violate
+                // error-severity row-level assertions. Compiles from
+                // config (not from assertion query results) so a failed
+                // assertion query does not suppress quarantine.
+                if let Some(ref q_cfg) = pipeline.checks.quarantine
+                    && q_cfg.enabled
+                {
+                    let ir_ref = rocky_core::ir::TableRef {
+                        catalog: table_ref.catalog.clone(),
+                        schema: table_ref.schema.clone(),
+                        table: table_name.clone(),
+                    };
+                    match rocky_core::quarantine::compile_quarantine_sql(
+                        &pipeline.checks.assertions,
+                        table_name,
+                        &ir_ref,
+                        dialect,
+                        q_cfg,
+                    ) {
+                        Ok(Some(plan)) => {
+                            let q_output = execute_quarantine_plan(
+                                warehouse_adapter.as_ref(),
+                                asset_key,
+                                plan,
+                            )
+                            .await;
+                            output.quarantine.push(q_output);
+                        }
+                        Ok(None) => {} // no quarantinable assertions
+                        Err(e) => warn!(
+                            error = %e,
+                            table = %full_table,
+                            "failed to compile quarantine SQL — skipping"
+                        ),
+                    }
+                }
             }
         }
     }
@@ -353,8 +391,21 @@ pub async fn run_quality(
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
         let total_checks: usize = output.check_results.iter().map(|t| t.checks.len()).sum();
+        let quarantine_summary = if output.quarantine.is_empty() {
+            String::new()
+        } else {
+            let total_q: u64 = output
+                .quarantine
+                .iter()
+                .filter_map(|q| q.quarantined_rows)
+                .sum();
+            format!(
+                ", quarantined {total_q} row(s) across {} table(s)",
+                output.quarantine.len()
+            )
+        };
         println!(
-            "quality pipeline complete: {total_checks} check(s) across {} table(s), {error_failures} error / {warning_failures} warning failed, in {}ms",
+            "quality pipeline complete: {total_checks} check(s) across {} table(s), {error_failures} error / {warning_failures} warning failed{quarantine_summary}, in {}ms",
             output.check_results.len(),
             output.duration_ms
         );
@@ -419,6 +470,80 @@ fn classify_assertion(
             (within_min && within_max, n)
         }
     }
+}
+
+/// Execute a compiled [`rocky_core::quarantine::QuarantinePlan`] against
+/// the warehouse and return a [`QuarantineOutput`] summarizing the result.
+///
+/// Statements execute in plan order — quarantine-first for `split` mode
+/// so a partial failure leaves a stray quarantine table rather than a
+/// stale valid table downstream pipelines might read. Row counts are
+/// captured via `SELECT COUNT(*)` against the written tables; adapters
+/// that cannot count leave the fields as `None`.
+async fn execute_quarantine_plan(
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    asset_key: Vec<String>,
+    plan: rocky_core::quarantine::QuarantinePlan,
+) -> QuarantineOutput {
+    let mode_str = match plan.mode {
+        rocky_core::config::QuarantineMode::Split => "split",
+        rocky_core::config::QuarantineMode::Tag => "tag",
+        rocky_core::config::QuarantineMode::Drop => "drop",
+    };
+    let mut out = QuarantineOutput {
+        asset_key,
+        mode: mode_str.to_string(),
+        valid_table: plan.valid_table.clone(),
+        quarantine_table: plan.quarantine_table.clone(),
+        valid_rows: None,
+        quarantined_rows: None,
+        ok: true,
+        error: None,
+    };
+
+    for stmt in &plan.statements {
+        if let Err(e) = warehouse.execute_statement(&stmt.sql).await {
+            out.ok = false;
+            out.error = Some(format!("{}: {}", role_label(stmt.role), e));
+            warn!(
+                role = role_label(stmt.role),
+                target = stmt.target.as_str(),
+                error = %e,
+                "quarantine statement failed"
+            );
+            return out;
+        }
+    }
+
+    if !plan.valid_table.is_empty() {
+        out.valid_rows = count_rows(warehouse, &plan.valid_table).await;
+    }
+    if !plan.quarantine_table.is_empty() {
+        out.quarantined_rows = count_rows(warehouse, &plan.quarantine_table).await;
+    }
+
+    out
+}
+
+fn role_label(role: rocky_core::quarantine::StatementRole) -> &'static str {
+    use rocky_core::quarantine::StatementRole;
+    match role {
+        StatementRole::Quarantine => "quarantine",
+        StatementRole::Valid => "valid",
+        StatementRole::Tag => "tag",
+    }
+}
+
+async fn count_rows(
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    full_table: &str,
+) -> Option<u64> {
+    let sql = format!("SELECT COUNT(*) FROM {full_table}");
+    let result = warehouse.execute_query(&sql).await.ok()?;
+    result.rows.first().and_then(|r| r.first()).and_then(|v| {
+        v.as_u64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+    })
 }
 
 /// Count failed checks bucketed by severity across every table result.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -121,6 +121,11 @@ pub struct RunOutput {
     pub shadow: bool,
     pub materializations: Vec<MaterializationOutput>,
     pub check_results: Vec<TableCheckOutput>,
+    /// Row-quarantine outcomes — one entry per table the quality
+    /// pipeline quarantined. Empty for runs that did not use
+    /// `[pipeline.x.checks.quarantine]`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub quarantine: Vec<QuarantineOutput>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub anomalies: Vec<AnomalyOutput>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -280,6 +285,48 @@ pub struct PartitionSummary {
 pub struct TableCheckOutput {
     pub asset_key: Vec<String>,
     pub checks: Vec<CheckResult>,
+}
+
+/// Row-quarantine outcome for a single table processed by the quality
+/// pipeline. Emitted when `[pipeline.x.checks.quarantine]` is enabled
+/// and the table has at least one error-severity row-level assertion
+/// that lowers to a boolean predicate.
+///
+/// Row counts are reported when the warehouse adapter supplies them.
+/// Adapters that cannot count rows written by a `CREATE OR REPLACE
+/// TABLE` leave the counts as `None`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct QuarantineOutput {
+    /// Dagster-style asset key path
+    /// (`[catalog, schema, table]`) of the source table the quarantine
+    /// acted on.
+    pub asset_key: Vec<String>,
+    /// Quarantine mode that was applied. One of `"split"`, `"tag"`,
+    /// `"drop"` (matches [`rocky_core::config::QuarantineMode`]).
+    pub mode: String,
+    /// Fully-qualified `catalog.schema.table` name of the `__valid`
+    /// output table. Empty for `mode = "tag"` (source is rewritten in
+    /// place).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub valid_table: String,
+    /// Fully-qualified name of the `__quarantine` output table. Empty
+    /// for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub quarantine_table: String,
+    /// Number of rows in the `__valid` output, when the adapter can
+    /// report it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_rows: Option<u64>,
+    /// Number of rows in the `__quarantine` output, when the adapter
+    /// can report it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantined_rows: Option<u64>,
+    /// `true` when every quarantine statement executed successfully.
+    /// `false` means a partial failure — inspect `error` for details.
+    pub ok: bool,
+    /// Error message from the first failing statement, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1635,6 +1682,7 @@ impl RunOutput {
             shadow: false,
             materializations: vec![],
             check_results: vec![],
+            quarantine: vec![],
             anomalies: vec![],
             errors: vec![],
             execution: ExecutionSummary {

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -500,6 +500,10 @@ pub struct ChecksConfig {
     /// model tests.
     #[serde(default)]
     pub assertions: Vec<QualityAssertion>,
+    /// Row quarantine — split/tag/drop rows that violate error-severity
+    /// row-level assertions. Disabled when unset. See [`QuarantineConfig`].
+    #[serde(default)]
+    pub quarantine: Option<QuarantineConfig>,
     /// Row count anomaly detection threshold (percentage deviation from baseline).
     /// Default: 50.0 (50% deviation triggers anomaly). Set to 0 to disable.
     #[serde(default = "default_anomaly_threshold_pct")]
@@ -600,6 +604,77 @@ pub struct QualityAssertion {
     /// type-specific fields like `values` / `to_table`).
     #[serde(flatten)]
     pub test: crate::tests::TestDecl,
+}
+
+/// How to handle rows that fail error-severity row-level assertions.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QuarantineMode {
+    /// Write a `<table>__valid` table with passing rows and a
+    /// `<table>__quarantine` table with failing rows (plus per-assertion
+    /// `_error_<name>` label columns). Original table untouched. Default.
+    #[default]
+    Split,
+    /// Replace `<table>` in place with a copy that has per-assertion
+    /// `_error_<name>` label columns set for failing rows. Rewrites the
+    /// source — use with care; not recommended when the source is a raw
+    /// replication target.
+    Tag,
+    /// Write only the `<table>__valid` half. Failing rows are discarded.
+    /// Irreversible at run-time.
+    Drop,
+}
+
+/// Row quarantine configuration. When enabled, error-severity row-level
+/// assertions (`not_null`, `accepted_values`, `expression`) on a given
+/// table are compiled into a single boolean row predicate. Rows matching
+/// the predicate go to the `__valid` table; rows that don't go to the
+/// `__quarantine` table (or are dropped / tagged, per `mode`).
+///
+/// Aggregate / set-based assertions (`unique`, `relationships`,
+/// `row_count_range`) are **not** lowered — they stay observational and
+/// produce `CheckResult` entries as before.
+///
+/// ```toml
+/// [pipeline.nightly_dq.checks.quarantine]
+/// enabled = true
+/// mode    = "split"          # "split" (default) | "tag" | "drop"
+/// # suffix_valid       = "__valid"
+/// # suffix_quarantine  = "__quarantine"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuarantineConfig {
+    /// Enable quarantine. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// How to split rows — see [`QuarantineMode`].
+    #[serde(default)]
+    pub mode: QuarantineMode,
+    /// Table-name suffix for the passing-rows table. Default `"__valid"`.
+    #[serde(default = "default_suffix_valid")]
+    pub suffix_valid: String,
+    /// Table-name suffix for the failing-rows table. Default `"__quarantine"`.
+    #[serde(default = "default_suffix_quarantine")]
+    pub suffix_quarantine: String,
+}
+
+impl Default for QuarantineConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: QuarantineMode::default(),
+            suffix_valid: default_suffix_valid(),
+            suffix_quarantine: default_suffix_quarantine(),
+        }
+    }
+}
+
+fn default_suffix_valid() -> String {
+    "__valid".to_string()
+}
+
+fn default_suffix_quarantine() -> String {
+    "__quarantine".to_string()
 }
 
 /// Freshness check configuration with optional per-schema overrides.

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod object_store;
 pub mod optimize;
 pub mod plan_partition;
 pub mod preview;
+pub mod quarantine;
 pub mod redacted;
 pub mod schema;
 pub mod seeds;

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -1,0 +1,822 @@
+//! Row-quarantine SQL compilation for the quality pipeline.
+//!
+//! Phase 3 of the DQX parity plan. Lowers a subset of row-level
+//! [`crate::tests::TestType`] assertions into a single boolean predicate
+//! per target table, and emits CTAS statements that split the source into
+//! `<table>__valid` (passing rows) and `<table>__quarantine` (failing
+//! rows with per-assertion `_error_*` label columns), or one of the
+//! variants described by [`crate::config::QuarantineMode`].
+//!
+//! Only **error-severity** assertions of kind `not_null`,
+//! `accepted_values`, and `expression` are lowered. Aggregate / set-based
+//! kinds (`unique`, `relationships`, `row_count_range`) are non-quarantining
+//! by design — they still emit observational `CheckResult` entries from
+//! [`crate::checks`].
+
+use std::collections::HashSet;
+
+use thiserror::Error;
+
+use rocky_sql::validation::{self, ValidationError};
+
+use crate::config::{QualityAssertion, QuarantineConfig, QuarantineMode};
+use crate::ir::TableRef;
+use crate::tests::{TestSeverity, TestType};
+use crate::traits::{AdapterError, SqlDialect};
+
+/// Errors from quarantine SQL compilation.
+#[derive(Debug, Error)]
+pub enum QuarantineError {
+    #[error("validation error: {0}")]
+    Validation(#[from] ValidationError),
+
+    #[error("adapter error: {0}")]
+    Adapter(String),
+
+    #[error("assertion '{name}' requires a column but none was provided")]
+    MissingColumn { name: String },
+
+    #[error("accepted_values assertion '{name}' requires at least one value")]
+    EmptyAcceptedValues { name: String },
+
+    #[error("expression assertion has an empty expression")]
+    EmptyExpression,
+}
+
+impl From<AdapterError> for QuarantineError {
+    fn from(e: AdapterError) -> Self {
+        QuarantineError::Adapter(e.to_string())
+    }
+}
+
+/// A compiled quarantine plan for a single target table.
+#[derive(Debug, Clone)]
+pub struct QuarantinePlan {
+    /// Execution mode — mirrors the input [`QuarantineConfig::mode`].
+    pub mode: QuarantineMode,
+    /// Fully-qualified name of the source table (input to the split).
+    pub source_table: String,
+    /// Fully-qualified name of the `__valid` output table. Empty for
+    /// [`QuarantineMode::Tag`] (that mode rewrites the source in place).
+    pub valid_table: String,
+    /// Fully-qualified name of the `__quarantine` output table. Empty for
+    /// [`QuarantineMode::Drop`] (failing rows are discarded).
+    pub quarantine_table: String,
+    /// SQL statements to execute, in order. The runtime executes them
+    /// sequentially and counts row effects per statement. Quarantine
+    /// CTAS runs before the valid CTAS so a partial failure leaves a
+    /// stray quarantine table (cheap to inspect) rather than a stale
+    /// valid table downstream pipelines might read.
+    pub statements: Vec<QuarantineStatement>,
+}
+
+/// A single SQL statement produced by [`compile_quarantine_sql`].
+#[derive(Debug, Clone)]
+pub struct QuarantineStatement {
+    /// Human-readable role of this statement (`"quarantine"`, `"valid"`,
+    /// `"tag"`). Used for logging and row-effect attribution.
+    pub role: StatementRole,
+    /// Fully-qualified table name this statement writes to.
+    pub target: String,
+    /// The SQL text to execute.
+    pub sql: String,
+}
+
+/// Role of a statement inside a [`QuarantinePlan`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatementRole {
+    /// CTAS that writes the `__quarantine` table.
+    Quarantine,
+    /// CTAS that writes the `__valid` table.
+    Valid,
+    /// CTAS that rewrites the source table in-place with `_error_*` tags.
+    Tag,
+}
+
+/// Compile a quarantine plan for one table.
+///
+/// Returns `Ok(None)` when the table has no quarantinable assertions
+/// (nothing to split). Returns an error if SQL generation fails — a
+/// single bad assertion fails the whole plan so the caller doesn't
+/// silently ship partial quarantine SQL.
+///
+/// `assertions` should be the full list of assertions attached to the
+/// pipeline's [`crate::config::ChecksConfig`]. Filtering by target table
+/// happens here; filtering by severity and kind also happens here.
+pub fn compile_quarantine_sql(
+    assertions: &[QualityAssertion],
+    unqualified_table: &str,
+    table_ref: &TableRef,
+    dialect: &dyn SqlDialect,
+    config: &QuarantineConfig,
+) -> Result<Option<QuarantinePlan>, QuarantineError> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    let quarantinable: Vec<&QualityAssertion> = assertions
+        .iter()
+        .filter(|a| a.table == unqualified_table)
+        .filter(|a| a.test.severity == TestSeverity::Error)
+        .filter(|a| is_quarantinable(&a.test.test_type))
+        .collect();
+
+    if quarantinable.is_empty() {
+        return Ok(None);
+    }
+
+    let source_table =
+        dialect.format_table_ref(&table_ref.catalog, &table_ref.schema, &table_ref.table)?;
+
+    let valid_name = suffixed_table_name(&table_ref.table, &config.suffix_valid)?;
+    let quarantine_name = suffixed_table_name(&table_ref.table, &config.suffix_quarantine)?;
+    let valid_table =
+        dialect.format_table_ref(&table_ref.catalog, &table_ref.schema, &valid_name)?;
+    let quarantine_table =
+        dialect.format_table_ref(&table_ref.catalog, &table_ref.schema, &quarantine_name)?;
+
+    let mut names: HashSet<String> = HashSet::new();
+    let mut labeled: Vec<LabeledPredicate> = Vec::with_capacity(quarantinable.len());
+    for assertion in &quarantinable {
+        let label = safe_error_label(assertion, &mut names)?;
+        let valid_pred =
+            lower_valid_predicate(&assertion.test.test_type, &assertion.test.column, &label)?;
+        labeled.push(LabeledPredicate { label, valid_pred });
+    }
+
+    let valid_where = labeled
+        .iter()
+        .map(|p| p.valid_pred.clone())
+        .collect::<Vec<_>>()
+        .join(" AND ");
+
+    let mut statements = Vec::with_capacity(2);
+    match config.mode {
+        QuarantineMode::Split => {
+            statements.push(build_quarantine_ctas(
+                &quarantine_table,
+                &source_table,
+                &labeled,
+                &valid_where,
+                dialect,
+            ));
+            statements.push(build_valid_ctas(
+                &valid_table,
+                &source_table,
+                &valid_where,
+                dialect,
+            ));
+        }
+        QuarantineMode::Drop => {
+            statements.push(build_valid_ctas(
+                &valid_table,
+                &source_table,
+                &valid_where,
+                dialect,
+            ));
+        }
+        QuarantineMode::Tag => {
+            statements.push(build_tag_ctas(&source_table, &labeled, dialect));
+        }
+    }
+
+    Ok(Some(QuarantinePlan {
+        mode: config.mode,
+        source_table,
+        valid_table: if matches!(config.mode, QuarantineMode::Tag) {
+            String::new()
+        } else {
+            valid_table
+        },
+        quarantine_table: if matches!(config.mode, QuarantineMode::Split) {
+            quarantine_table
+        } else {
+            String::new()
+        },
+        statements,
+    }))
+}
+
+struct LabeledPredicate {
+    label: String,
+    valid_pred: String,
+}
+
+/// Whether a test kind lowers cleanly to a row-level boolean predicate.
+///
+/// `unique` / `relationships` / `row_count_range` are aggregate / set-based
+/// — they stay observational. `expression` is trusted user SQL (same
+/// contract as [`crate::tests::generate_test_sql`]).
+pub fn is_quarantinable(test_type: &TestType) -> bool {
+    matches!(
+        test_type,
+        TestType::NotNull | TestType::AcceptedValues { .. } | TestType::Expression { .. }
+    )
+}
+
+/// Build a SQL-identifier-safe `_error_<name>` label for one assertion.
+///
+/// The user's optional `name` can contain characters (colons, spaces) that
+/// are not valid identifiers. We synthesize a safe name from the kind +
+/// column (and the explicit `name` when it parses as an identifier),
+/// appending `_2`, `_3`, ... on collision so two assertions with the same
+/// kind + column still produce distinct error columns.
+fn safe_error_label(
+    assertion: &QualityAssertion,
+    taken: &mut HashSet<String>,
+) -> Result<String, QuarantineError> {
+    let base = if let Some(name) = assertion.name.as_deref() {
+        if validation::validate_identifier(name).is_ok() {
+            name.to_string()
+        } else {
+            synthesize_label(&assertion.test.test_type, assertion.test.column.as_deref())
+        }
+    } else {
+        synthesize_label(&assertion.test.test_type, assertion.test.column.as_deref())
+    };
+
+    let mut candidate = format!("_error_{base}");
+    validation::validate_identifier(&candidate)?;
+
+    let mut n = 2u32;
+    while taken.contains(&candidate) {
+        candidate = format!("_error_{base}_{n}");
+        validation::validate_identifier(&candidate)?;
+        n += 1;
+    }
+    taken.insert(candidate.clone());
+    Ok(candidate)
+}
+
+fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
+    let kind = match test_type {
+        TestType::NotNull => "not_null",
+        TestType::AcceptedValues { .. } => "accepted_values",
+        TestType::Expression { .. } => "expression",
+        TestType::Unique => "unique",
+        TestType::Relationships { .. } => "relationships",
+        TestType::RowCountRange { .. } => "row_count_range",
+    };
+    match column {
+        Some(c) if validation::validate_identifier(c).is_ok() => format!("{kind}_{c}"),
+        _ => kind.to_string(),
+    }
+}
+
+/// Lower a quarantinable assertion into a boolean "row is valid" predicate.
+///
+/// Semantics match the existing [`crate::tests::generate_test_sql`] output:
+/// - `NotNull`: NULL values are failures → `col IS NOT NULL`.
+/// - `AcceptedValues`: NULL passes (existing `col NOT IN (...)` treats NULL
+///   as excluded) → `(col IS NULL OR col IN (...))`.
+/// - `Expression`: NULL passes (existing `WHERE NOT (expr)` treats NULL
+///   as excluded) → `COALESCE((expr), TRUE)`.
+///
+/// The returned predicate is total — it evaluates to `TRUE` or `FALSE`,
+/// never NULL — so the top-level `AND` and `NOT` cannot propagate NULL.
+fn lower_valid_predicate(
+    test_type: &TestType,
+    column: &Option<String>,
+    label: &str,
+) -> Result<String, QuarantineError> {
+    match test_type {
+        TestType::NotNull => {
+            let col = column
+                .as_deref()
+                .ok_or_else(|| QuarantineError::MissingColumn {
+                    name: label.to_string(),
+                })?;
+            validation::validate_identifier(col)?;
+            Ok(format!("{col} IS NOT NULL"))
+        }
+        TestType::AcceptedValues { values } => {
+            let col = column
+                .as_deref()
+                .ok_or_else(|| QuarantineError::MissingColumn {
+                    name: label.to_string(),
+                })?;
+            validation::validate_identifier(col)?;
+            if values.is_empty() {
+                return Err(QuarantineError::EmptyAcceptedValues {
+                    name: label.to_string(),
+                });
+            }
+            let in_list = values
+                .iter()
+                .map(|v| format!("'{}'", v.replace('\'', "''")))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(format!("({col} IS NULL OR {col} IN ({in_list}))"))
+        }
+        TestType::Expression { expression } => {
+            if expression.trim().is_empty() {
+                return Err(QuarantineError::EmptyExpression);
+            }
+            // Expression is user-supplied SQL (same contract as
+            // `generate_test_sql`). Wrap in COALESCE so NULL expressions
+            // count as passing — matches the existing
+            // `WHERE NOT (expression)` semantic.
+            Ok(format!("COALESCE(({expression}), TRUE)"))
+        }
+        // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
+        TestType::Unique | TestType::Relationships { .. } | TestType::RowCountRange { .. } => {
+            Err(QuarantineError::EmptyExpression)
+        }
+    }
+}
+
+fn build_quarantine_ctas(
+    target: &str,
+    source: &str,
+    labeled: &[LabeledPredicate],
+    valid_where: &str,
+    dialect: &dyn SqlDialect,
+) -> QuarantineStatement {
+    let error_cols = labeled
+        .iter()
+        .map(|p| {
+            format!(
+                "CASE WHEN NOT ({}) THEN '{}' END AS {}",
+                p.valid_pred, p.label, p.label
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let select = format!("SELECT *, {error_cols} FROM {source} WHERE NOT ({valid_where})");
+    QuarantineStatement {
+        role: StatementRole::Quarantine,
+        target: target.to_string(),
+        sql: dialect.create_table_as(target, &select),
+    }
+}
+
+fn build_valid_ctas(
+    target: &str,
+    source: &str,
+    valid_where: &str,
+    dialect: &dyn SqlDialect,
+) -> QuarantineStatement {
+    let select = format!("SELECT * FROM {source} WHERE {valid_where}");
+    QuarantineStatement {
+        role: StatementRole::Valid,
+        target: target.to_string(),
+        sql: dialect.create_table_as(target, &select),
+    }
+}
+
+fn build_tag_ctas(
+    source: &str,
+    labeled: &[LabeledPredicate],
+    dialect: &dyn SqlDialect,
+) -> QuarantineStatement {
+    let error_cols = labeled
+        .iter()
+        .map(|p| {
+            format!(
+                "CASE WHEN NOT ({}) THEN '{}' END AS {}",
+                p.valid_pred, p.label, p.label
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let select = format!("SELECT *, {error_cols} FROM {source}");
+    QuarantineStatement {
+        role: StatementRole::Tag,
+        target: source.to_string(),
+        sql: dialect.create_table_as(source, &select),
+    }
+}
+
+fn suffixed_table_name(table: &str, suffix: &str) -> Result<String, QuarantineError> {
+    validation::validate_identifier(table)?;
+    let candidate = format!("{table}{suffix}");
+    validation::validate_identifier(&candidate)?;
+    Ok(candidate)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::ir::{ColumnSelection, MetadataColumn};
+    use crate::tests::TestDecl;
+    use crate::traits::{AdapterError, AdapterResult};
+
+    struct TestDialect;
+
+    impl SqlDialect for TestDialect {
+        fn format_table_ref(&self, c: &str, s: &str, t: &str) -> AdapterResult<String> {
+            rocky_sql::validation::format_table_ref(c, s, t).map_err(AdapterError::new)
+        }
+        fn create_table_as(&self, target: &str, select_sql: &str) -> String {
+            format!("CREATE OR REPLACE TABLE {target} AS\n{select_sql}")
+        }
+        fn insert_into(&self, _: &str, _: &str) -> String {
+            unimplemented!()
+        }
+        fn merge_into(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: &ColumnSelection,
+        ) -> AdapterResult<String> {
+            unimplemented!()
+        }
+        fn select_clause(
+            &self,
+            _: &ColumnSelection,
+            _: &[MetadataColumn],
+        ) -> AdapterResult<String> {
+            unimplemented!()
+        }
+        fn watermark_where(&self, _: &str, _: &str) -> AdapterResult<String> {
+            unimplemented!()
+        }
+        fn describe_table_sql(&self, t: &str) -> String {
+            format!("DESCRIBE TABLE {t}")
+        }
+        fn drop_table_sql(&self, t: &str) -> String {
+            format!("DROP TABLE IF EXISTS {t}")
+        }
+        fn create_catalog_sql(&self, _: &str) -> Option<AdapterResult<String>> {
+            None
+        }
+        fn create_schema_sql(&self, _: &str, _: &str) -> Option<AdapterResult<String>> {
+            None
+        }
+        fn tablesample_clause(&self, _: u32) -> Option<String> {
+            None
+        }
+        fn insert_overwrite_partition(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> AdapterResult<Vec<String>> {
+            unimplemented!()
+        }
+    }
+
+    fn table() -> TableRef {
+        TableRef {
+            catalog: "poc".into(),
+            schema: "staging__orders".into(),
+            table: "orders".into(),
+        }
+    }
+
+    fn assertion(
+        name: Option<&str>,
+        kind: TestType,
+        column: Option<&str>,
+        severity: TestSeverity,
+    ) -> QualityAssertion {
+        QualityAssertion {
+            table: "orders".into(),
+            name: name.map(str::to_string),
+            test: TestDecl {
+                test_type: kind,
+                column: column.map(str::to_string),
+                severity,
+            },
+        }
+    }
+
+    fn split_config() -> QuarantineConfig {
+        QuarantineConfig {
+            enabled: true,
+            mode: QuarantineMode::Split,
+            suffix_valid: "__valid".into(),
+            suffix_quarantine: "__quarantine".into(),
+        }
+    }
+
+    #[test]
+    fn disabled_returns_none() {
+        let cfg = QuarantineConfig {
+            enabled: false,
+            ..split_config()
+        };
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan =
+            compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg).unwrap();
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn no_quarantinable_assertions_returns_none() {
+        let cfg = split_config();
+        let assertions = vec![
+            // Unique is not quarantinable (set-based).
+            assertion(None, TestType::Unique, Some("id"), TestSeverity::Error),
+            // Warning-severity NotNull is filtered out.
+            assertion(
+                None,
+                TestType::NotNull,
+                Some("email"),
+                TestSeverity::Warning,
+            ),
+        ];
+        let plan =
+            compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg).unwrap();
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn split_mode_produces_two_statements() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        assert_eq!(plan.statements.len(), 2);
+        assert_eq!(plan.statements[0].role, StatementRole::Quarantine);
+        assert_eq!(plan.statements[1].role, StatementRole::Valid);
+        assert_eq!(plan.valid_table, "poc.staging__orders.orders__valid");
+        assert_eq!(
+            plan.quarantine_table,
+            "poc.staging__orders.orders__quarantine"
+        );
+    }
+
+    #[test]
+    fn not_null_predicate_shape() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Valid CTAS contains: WHERE customer_id IS NOT NULL
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("WHERE customer_id IS NOT NULL")
+        );
+        // Quarantine CTAS contains: WHERE NOT (customer_id IS NOT NULL)
+        assert!(
+            plan.statements[0]
+                .sql
+                .contains("WHERE NOT (customer_id IS NOT NULL)")
+        );
+        // Error label column is present.
+        assert!(
+            plan.statements[0]
+                .sql
+                .contains("_error_not_null_customer_id")
+        );
+    }
+
+    #[test]
+    fn accepted_values_predicate_is_null_permissive() {
+        // This is the advisor's flagged case: NULL must pass the
+        // AcceptedValues check to match existing Rocky `NOT IN` semantics.
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::AcceptedValues {
+                values: vec!["pending".into(), "shipped".into()],
+            },
+            Some("status"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Valid predicate: NULL or in list.
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("(status IS NULL OR status IN ('pending', 'shipped'))")
+        );
+    }
+
+    #[test]
+    fn accepted_values_escapes_quotes() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::AcceptedValues {
+                values: vec!["it's".into()],
+            },
+            Some("name"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        assert!(plan.statements[1].sql.contains("'it''s'"));
+    }
+
+    #[test]
+    fn expression_uses_coalesce_true() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::Expression {
+                expression: "amount >= 0".into(),
+            },
+            None,
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // COALESCE makes NULL `amount >= 0` resolve to TRUE (preserves
+        // existing `WHERE NOT (expr)` semantic that excludes NULL).
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("COALESCE((amount >= 0), TRUE)")
+        );
+    }
+
+    #[test]
+    fn multiple_assertions_anded() {
+        let cfg = split_config();
+        let assertions = vec![
+            assertion(
+                None,
+                TestType::NotNull,
+                Some("customer_id"),
+                TestSeverity::Error,
+            ),
+            assertion(
+                None,
+                TestType::AcceptedValues {
+                    values: vec!["pending".into()],
+                },
+                Some("status"),
+                TestSeverity::Error,
+            ),
+        ];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        let valid_sql = &plan.statements[1].sql;
+        assert!(valid_sql.contains("customer_id IS NOT NULL AND"));
+        assert!(valid_sql.contains("status IS NULL OR status IN ('pending')"));
+    }
+
+    #[test]
+    fn drop_mode_emits_only_valid_ctas() {
+        let cfg = QuarantineConfig {
+            mode: QuarantineMode::Drop,
+            ..split_config()
+        };
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        assert_eq!(plan.statements.len(), 1);
+        assert_eq!(plan.statements[0].role, StatementRole::Valid);
+        assert!(plan.quarantine_table.is_empty());
+    }
+
+    #[test]
+    fn tag_mode_rewrites_source_in_place() {
+        let cfg = QuarantineConfig {
+            mode: QuarantineMode::Tag,
+            ..split_config()
+        };
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        assert_eq!(plan.statements.len(), 1);
+        assert_eq!(plan.statements[0].role, StatementRole::Tag);
+        // Target of the tag CTAS is the source table (no suffix).
+        assert_eq!(plan.statements[0].target, "poc.staging__orders.orders");
+        // Tag CTAS has no WHERE filter — every row is kept.
+        assert!(!plan.statements[0].sql.contains("WHERE"));
+        // But it does add the `_error_*` case column.
+        assert!(
+            plan.statements[0]
+                .sql
+                .contains("_error_not_null_customer_id")
+        );
+    }
+
+    #[test]
+    fn colon_in_user_name_is_synthesized_to_identifier() {
+        // Matches the run_local.rs fallback `{kind}:{column}` — not a valid
+        // identifier. The quarantine compiler must not trust user names
+        // verbatim; it synthesizes a safe label instead.
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            Some("not_null:customer_id"),
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        assert!(
+            plan.statements[0]
+                .sql
+                .contains("_error_not_null_customer_id")
+        );
+    }
+
+    #[test]
+    fn duplicate_assertion_labels_deduped_with_suffix() {
+        let cfg = split_config();
+        let assertions = vec![
+            assertion(
+                None,
+                TestType::NotNull,
+                Some("customer_id"),
+                TestSeverity::Error,
+            ),
+            // Same kind + column — must not produce colliding _error columns.
+            assertion(
+                None,
+                TestType::NotNull,
+                Some("customer_id"),
+                TestSeverity::Error,
+            ),
+        ];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        let sql = &plan.statements[0].sql;
+        assert!(sql.contains("AS _error_not_null_customer_id,"));
+        assert!(sql.contains("AS _error_not_null_customer_id_2"));
+    }
+
+    #[test]
+    fn statement_order_is_quarantine_before_valid() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Quarantine runs first so a partial failure leaves a stray
+        // quarantine table rather than a stale valid table.
+        assert_eq!(plan.statements[0].role, StatementRole::Quarantine);
+        assert_eq!(plan.statements[1].role, StatementRole::Valid);
+    }
+
+    #[test]
+    fn rejects_bad_column_identifier() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("col; DROP TABLE"),
+            TestSeverity::Error,
+        )];
+        let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg).err();
+        assert!(err.is_some());
+    }
+
+    #[test]
+    fn rejects_bad_suffix() {
+        let cfg = QuarantineConfig {
+            suffix_valid: "; DROP".into(),
+            ..split_config()
+        };
+        let assertions = vec![assertion(
+            None,
+            TestType::NotNull,
+            Some("customer_id"),
+            TestSeverity::Error,
+        )];
+        let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg).err();
+        assert!(err.is_some());
+    }
+}

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
@@ -3,7 +3,7 @@
 > **Category:** 01-quality
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 15s
-> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, aggregate checks (row_count / column_match / freshness), unified row-level `[[checks.assertions]]` (not_null, unique, accepted_values, expression, row_count_range), per-check `severity`, `fail_on_error`
+> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, aggregate checks (row_count / column_match / freshness), unified row-level `[[checks.assertions]]` (not_null, unique, accepted_values, expression, row_count_range), per-check `severity`, `fail_on_error`, row `[checks.quarantine]` (split / tag / drop)
 
 ## What it shows
 
@@ -27,6 +27,12 @@ Rocky's quality pipeline type — a dedicated pipeline that runs data quality ch
 - **Severity-gated failures** — each check carries `severity = "error" | "warning"`;
   `fail_on_error` (default `true`) lets the run exit non-zero when any
   error-severity check fails
+- **Row quarantine** — `[checks.quarantine]` compiles error-severity row-level
+  assertions into a single boolean predicate per table and splits rows into
+  `<table>__valid` / `<table>__quarantine` CTASes. Each quarantined row carries
+  an `_error_<assertion>` label column identifying which assertion it
+  violated. Warning-severity assertions stay observational and do not drive
+  the split.
 - **dbt comparison:** dbt tests are tightly coupled to models; Rocky quality pipelines are standalone
 
 ## Layout
@@ -89,6 +95,13 @@ fail_on_error = false → pipeline exits 0 even with error-severity failures.
      each with its own `severity`
 4. `fail_on_error = false` suppresses the non-zero exit so the POC stays green.
    Remove it (or set `true`) to wire the quality pipeline into CI as a gate.
+5. **Row quarantine on `orders`:** `[checks.quarantine] mode = "split"` writes
+   `orders__valid` (197 rows) and `orders__quarantine` (3 rows). The
+   quarantine table carries `_error_orders_customer_id_required` /
+   `_error_orders_status_allowed` label columns — only the assertion that
+   each row violated is non-NULL. The warning-severity `amount >= 0`
+   assertion (row 99) is **not** lowered into the predicate and stays in
+   `orders__valid`.
 
 ## Related
 

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -31,6 +31,17 @@ anomaly_threshold_pct = 30.0
 # Remove (or set `true`) to fail CI on any error-severity violation.
 fail_on_error = false
 
+# --- Phase 3: row quarantine (split mode) ---
+# Splits `orders` into `orders__valid` (passing rows) and
+# `orders__quarantine` (failing rows with `_error_*` label columns).
+# Only error-severity row-level assertions on `orders` drive the split:
+# the `not_null` on customer_id and `accepted_values` on status.
+# The `expression` on `amount >= 0` is warning-severity — it stays
+# observational and does not send order_id=99 to the quarantine table.
+[pipeline.nightly_dq.checks.quarantine]
+enabled = true
+mode    = "split"
+
 # --- Phase 1: row-level assertions (unified surface) ---
 
 # not_null — 2 rows (order_id 7, 42) violate this.

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
@@ -23,9 +23,21 @@ jq '{
       table: (.asset_key | join(".")),
       checks: [ .checks[] | { name, severity, passed } ]
     }
-  ]
+  ],
+  quarantine: (.quarantine // [])
 }' expected/run_quality.json
 
 echo
-echo "POC complete: unified check surface (row_count + assertions) with mixed severity."
+echo "=== Quarantine split (orders) ==="
+echo "orders__valid row count:"
+duckdb poc.duckdb -c "SELECT COUNT(*) AS valid_rows FROM staging__orders.orders__valid;"
+echo "orders__quarantine row count + _error_* label columns:"
+duckdb poc.duckdb -c "SELECT order_id, customer_id, status,
+    _error_orders_customer_id_required,
+    _error_orders_status_allowed
+  FROM staging__orders.orders__quarantine
+  ORDER BY order_id;"
+
+echo
+echo "POC complete: unified check surface + mixed severity + Phase 3 row quarantine (split)."
 echo "Flip fail_on_error=true in rocky.toml to make error-severity failures non-zero."

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -155,6 +155,47 @@ class PermissionSummary(BaseModel):
     schemas_created: conint(ge=0)
 
 
+class QuarantineOutput(BaseModel):
+    """
+    Row-quarantine outcome for a single table processed by the quality pipeline. Emitted when `[pipeline.x.checks.quarantine]` is enabled and the table has at least one error-severity row-level assertion that lowers to a boolean predicate.
+
+    Row counts are reported when the warehouse adapter supplies them. Adapters that cannot count rows written by a `CREATE OR REPLACE TABLE` leave the counts as `None`.
+    """
+
+    asset_key: list[str]
+    """
+    Dagster-style asset key path (`[catalog, schema, table]`) of the source table the quarantine acted on.
+    """
+    error: str | None = None
+    """
+    Error message from the first failing statement, if any.
+    """
+    mode: str
+    """
+    Quarantine mode that was applied. One of `"split"`, `"tag"`, `"drop"` (matches [`rocky_core::config::QuarantineMode`]).
+    """
+    ok: bool
+    """
+    `true` when every quarantine statement executed successfully. `false` means a partial failure — inspect `error` for details.
+    """
+    quarantine_table: str
+    """
+    Fully-qualified name of the `__quarantine` output table. Empty for `mode = "drop"` (failing rows discarded) and `mode = "tag"`.
+    """
+    quarantined_rows: conint(ge=0) | None = None
+    """
+    Number of rows in the `__quarantine` output, when the adapter can report it.
+    """
+    valid_rows: conint(ge=0) | None = None
+    """
+    Number of rows in the `__valid` output, when the adapter can report it.
+    """
+    valid_table: str
+    """
+    Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = "tag"` (source is rewritten in place).
+    """
+
+
 class TableErrorOutput(BaseModel):
     """
     Error from a table that failed during parallel processing.
@@ -334,6 +375,10 @@ class RunOutput(BaseModel):
     pipeline_type: str | None = None
     """
     Pipeline type that was executed (e.g., "replication").
+    """
+    quarantine: list[QuarantineOutput]
+    """
+    Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.
     """
     resumed_from: str | None = None
     shadow: bool

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -595,6 +595,67 @@
       ],
       "type": "object"
     },
+    "QuarantineOutput": {
+      "description": "Row-quarantine outcome for a single table processed by the quality pipeline. Emitted when `[pipeline.x.checks.quarantine]` is enabled and the table has at least one error-severity row-level assertion that lowers to a boolean predicate.\n\nRow counts are reported when the warehouse adapter supplies them. Adapters that cannot count rows written by a `CREATE OR REPLACE TABLE` leave the counts as `None`.",
+      "properties": {
+        "asset_key": {
+          "description": "Dagster-style asset key path (`[catalog, schema, table]`) of the source table the quarantine acted on.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "error": {
+          "description": "Error message from the first failing statement, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mode": {
+          "description": "Quarantine mode that was applied. One of `\"split\"`, `\"tag\"`, `\"drop\"` (matches [`rocky_core::config::QuarantineMode`]).",
+          "type": "string"
+        },
+        "ok": {
+          "description": "`true` when every quarantine statement executed successfully. `false` means a partial failure — inspect `error` for details.",
+          "type": "boolean"
+        },
+        "quarantine_table": {
+          "description": "Fully-qualified name of the `__quarantine` output table. Empty for `mode = \"drop\"` (failing rows discarded) and `mode = \"tag\"`.",
+          "type": "string"
+        },
+        "quarantined_rows": {
+          "description": "Number of rows in the `__quarantine` output, when the adapter can report it.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valid_rows": {
+          "description": "Number of rows in the `__valid` output, when the adapter can report it.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valid_table": {
+          "description": "Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = \"tag\"` (source is rewritten in place).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "asset_key",
+        "mode",
+        "ok",
+        "quarantine_table",
+        "valid_table"
+      ],
+      "type": "object"
+    },
     "TableCheckOutput": {
       "properties": {
         "asset_key": {
@@ -732,6 +793,13 @@
         "null"
       ]
     },
+    "quarantine": {
+      "description": "Row-quarantine outcomes — one entry per table the quality pipeline quarantined. Empty for runs that did not use `[pipeline.x.checks.quarantine]`.",
+      "items": {
+        "$ref": "#/definitions/QuarantineOutput"
+      },
+      "type": "array"
+    },
     "resumed_from": {
       "type": [
         "string",
@@ -774,6 +842,7 @@
     "materializations",
     "partition_summaries",
     "permissions",
+    "quarantine",
     "shadow",
     "tables_copied",
     "tables_failed",


### PR DESCRIPTION
## Summary

- Adds row quarantine to the quality pipeline: error-severity row-level assertions (`not_null`, `accepted_values`, `expression`) compile into a boolean predicate per table and drive CTAS statements that split `<table>` into `<table>__valid` / `<table>__quarantine` (or the `tag` / `drop` variants).
- Each quarantined row gets a `_error_<assertion>` label column identifying which assertion flagged it. Warning-severity assertions stay observational — they do not drive the split.
- Aggregate / set-based kinds (`unique`, `relationships`, `row_count_range`) are intentionally non-quarantining; they continue to emit `CheckResult` entries as before.

## Config surface

```toml
[pipeline.nightly_dq.checks.quarantine]
enabled = true
mode    = "split"   # "split" (default) | "tag" | "drop"
# suffix_valid      = "__valid"
# suffix_quarantine = "__quarantine"
```

## Design notes

- **Quarantine-before-valid** statement order — a partial failure leaves a stray quarantine table rather than a stale valid table downstream pipelines might read.
- **NULL-permissive predicates** match existing `generate_test_sql` semantics: `AcceptedValues` uses `(col IS NULL OR col IN (…))`; `Expression` wraps in `COALESCE((expr), TRUE)` so null predicates don't accidentally quarantine rows.
- **Identifier-safe `_error_<label>`** synthesizer with collision dedup (`_2`, `_3`, …). The user's optional `name` field is used only when it validates as a SQL identifier; otherwise a `<kind>_<column>` fallback is used.

## Test plan

- [x] 15 unit tests in `rocky-core::quarantine` — NULL semantics, dedup, all three modes, bad-identifier rejection
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rocky-core -p rocky-cli` — new + existing pass
- [x] `uv run pytest` in `integrations/dagster` — 307/307 (additive Pydantic field, back-compat)
- [x] POC `06-quality-pipeline-standalone`: 200 orders → 197 valid + 3 quarantined; warning-severity `amount >= 0` row correctly stays in valid
- [x] `mode = "tag"` empirically verified on DuckDB (200 rows preserved with `_error_*` tags populated)

## Scope

Part of the DQX parity plan. Phase 1+2 (unified check surface + severity / `fail_on_error`) shipped in #110, #111. Phase 4 (per-check `filter`, `RegexMatch`, `InRange`, composite `unique`, aggregate sugar) follows.