### PR TITLE
feat(engine): DQX parity phase 4a — filter + InRange + RegexMatch

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -167,6 +167,14 @@ impl SqlDialect for BigQueryDialect {
             "SELECT table_name FROM `{catalog}`.`{schema}`.INFORMATION_SCHEMA.TABLES"
         ))
     }
+
+    fn regex_match_predicate(
+        &self,
+        column: &str,
+        pattern: &str,
+    ) -> rocky_core::traits::AdapterResult<String> {
+        Ok(format!("REGEXP_CONTAINS({column}, r'{pattern}')"))
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -118,7 +118,7 @@ pub async fn run_quality(
     output_json: bool,
 ) -> Result<()> {
     use rocky_core::checks::{CheckDetails, CheckResult};
-    use rocky_core::tests::generate_test_sql;
+    use rocky_core::tests::generate_test_sql_with_dialect;
 
     let start = Instant::now();
 
@@ -282,7 +282,7 @@ pub async fn run_quality(
                         continue;
                     }
                     let test = &assertion.test;
-                    let sql = match generate_test_sql(test, &full_table) {
+                    let sql = match generate_test_sql_with_dialect(test, &full_table, dialect) {
                         Ok(s) => s,
                         Err(e) => {
                             warn!(
@@ -429,6 +429,8 @@ fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",
         TestType::RowCountRange { .. } => "row_count_range",
+        TestType::InRange { .. } => "in_range",
+        TestType::RegexMatch { .. } => "regex_match",
     }
 }
 
@@ -455,10 +457,15 @@ fn classify_assertion(
             .unwrap_or(0)
     };
     match t {
-        TestType::NotNull | TestType::Expression { .. } => {
+        // Count-based: first cell is the count of failing rows.
+        TestType::NotNull
+        | TestType::Expression { .. }
+        | TestType::InRange { .. }
+        | TestType::RegexMatch { .. } => {
             let n = first_cell_u64();
             (n == 0, n)
         }
+        // Row-set-based: every returned row is a violation.
         TestType::Unique | TestType::AcceptedValues { .. } | TestType::Relationships { .. } => {
             let n = rows.len() as u64;
             (n == 0, n)

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
 use rocky_core::models;
-use rocky_core::tests::{TestSeverity, TestType, generate_test_sql};
+use rocky_core::tests::{TestSeverity, TestType, generate_test_sql_with_dialect};
 use rocky_core::traits::WarehouseAdapter;
 
 use crate::output::{
@@ -252,7 +252,7 @@ async fn execute_one_test(
     };
 
     // Generate SQL.
-    let sql = match generate_test_sql(test_decl, fq_table) {
+    let sql = match generate_test_sql_with_dialect(test_decl, fq_table, adapter.dialect()) {
         Ok(sql) => sql,
         Err(e) => {
             return DeclarativeTestResult {
@@ -313,14 +313,19 @@ fn interpret_result(
     result: &rocky_core::traits::QueryResult,
 ) -> (String, Option<String>) {
     match test_type {
-        // not_null / expression: SELECT COUNT(*) — pass when count == 0
-        TestType::NotNull | TestType::Expression { .. } => {
+        // not_null / expression / in_range / regex_match: SELECT COUNT(*) — pass when count == 0
+        TestType::NotNull
+        | TestType::Expression { .. }
+        | TestType::InRange { .. }
+        | TestType::RegexMatch { .. } => {
             let count = first_row_count(result);
             if count == 0 {
                 ("pass".to_string(), None)
             } else {
                 let what = match test_type {
                     TestType::NotNull => "NULL row(s)",
+                    TestType::InRange { .. } => "out-of-range row(s)",
+                    TestType::RegexMatch { .. } => "non-matching row(s)",
                     _ => "violating row(s)",
                 };
                 ("fail".to_string(), Some(format!("{count} {what} found")))
@@ -393,5 +398,7 @@ fn test_type_label(tt: &TestType) -> &'static str {
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",
         TestType::RowCountRange { .. } => "row_count_range",
+        TestType::InRange { .. } => "in_range",
+        TestType::RegexMatch { .. } => "regex_match",
     }
 }

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -401,6 +401,8 @@ fn test_type_label(test_type: &crate::tests::TestType) -> String {
         crate::tests::TestType::Relationships { .. } => "relationships".into(),
         crate::tests::TestType::Expression { .. } => "expression".into(),
         crate::tests::TestType::RowCountRange { .. } => "row_count_range".into(),
+        crate::tests::TestType::InRange { .. } => "in_range".into(),
+        crate::tests::TestType::RegexMatch { .. } => "regex_match".into(),
     }
 }
 
@@ -444,11 +446,13 @@ mod tests {
                             test_type: TestType::NotNull,
                             column: Some("order_id".into()),
                             severity: TestSeverity::Error,
+                            filter: None,
                         },
                         TestDecl {
                             test_type: TestType::Unique,
                             column: Some("order_id".into()),
                             severity: TestSeverity::Error,
+                            filter: None,
                         },
                         TestDecl {
                             test_type: TestType::AcceptedValues {
@@ -460,6 +464,7 @@ mod tests {
                             },
                             column: Some("status".into()),
                             severity: TestSeverity::Warning,
+                            filter: None,
                         },
                     ],
                 },
@@ -477,6 +482,7 @@ mod tests {
                         },
                         column: None,
                         severity: TestSeverity::Error,
+                        filter: None,
                     }],
                 },
             ],

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -41,6 +41,12 @@ pub enum QuarantineError {
 
     #[error("expression assertion has an empty expression")]
     EmptyExpression,
+
+    #[error("in_range bound '{value}' must parse as a number")]
+    InvalidInRangeBound { value: String },
+
+    #[error("regex_match assertion '{name}' contains an unsafe pattern")]
+    UnsafeRegexPattern { name: String },
 }
 
 impl From<AdapterError> for QuarantineError {
@@ -139,8 +145,13 @@ pub fn compile_quarantine_sql(
     let mut labeled: Vec<LabeledPredicate> = Vec::with_capacity(quarantinable.len());
     for assertion in &quarantinable {
         let label = safe_error_label(assertion, &mut names)?;
-        let valid_pred =
-            lower_valid_predicate(&assertion.test.test_type, &assertion.test.column, &label)?;
+        let base_pred = lower_valid_predicate(
+            &assertion.test.test_type,
+            &assertion.test.column,
+            &label,
+            dialect,
+        )?;
+        let valid_pred = wrap_filter(&assertion.test.filter, &base_pred);
         labeled.push(LabeledPredicate { label, valid_pred });
     }
 
@@ -205,12 +216,16 @@ struct LabeledPredicate {
 /// Whether a test kind lowers cleanly to a row-level boolean predicate.
 ///
 /// `unique` / `relationships` / `row_count_range` are aggregate / set-based
-/// — they stay observational. `expression` is trusted user SQL (same
-/// contract as [`crate::tests::generate_test_sql`]).
+/// — they stay observational. `expression` and `regex_match` are
+/// trusted user SQL (same contract as [`crate::tests::generate_test_sql`]).
 pub fn is_quarantinable(test_type: &TestType) -> bool {
     matches!(
         test_type,
-        TestType::NotNull | TestType::AcceptedValues { .. } | TestType::Expression { .. }
+        TestType::NotNull
+            | TestType::AcceptedValues { .. }
+            | TestType::Expression { .. }
+            | TestType::InRange { .. }
+            | TestType::RegexMatch { .. }
     )
 }
 
@@ -256,6 +271,8 @@ fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
         TestType::Unique => "unique",
         TestType::Relationships { .. } => "relationships",
         TestType::RowCountRange { .. } => "row_count_range",
+        TestType::InRange { .. } => "in_range",
+        TestType::RegexMatch { .. } => "regex_match",
     };
     match column {
         Some(c) if validation::validate_identifier(c).is_ok() => format!("{kind}_{c}"),
@@ -271,6 +288,8 @@ fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
 ///   as excluded) → `(col IS NULL OR col IN (...))`.
 /// - `Expression`: NULL passes (existing `WHERE NOT (expr)` treats NULL
 ///   as excluded) → `COALESCE((expr), TRUE)`.
+/// - `InRange`: NULL passes → `(col IS NULL OR NOT (col < min OR col > max))`.
+/// - `RegexMatch`: NULL passes → `(col IS NULL OR <dialect regex match>)`.
 ///
 /// The returned predicate is total — it evaluates to `TRUE` or `FALSE`,
 /// never NULL — so the top-level `AND` and `NOT` cannot propagate NULL.
@@ -278,23 +297,16 @@ fn lower_valid_predicate(
     test_type: &TestType,
     column: &Option<String>,
     label: &str,
+    dialect: &dyn SqlDialect,
 ) -> Result<String, QuarantineError> {
     match test_type {
         TestType::NotNull => {
-            let col = column
-                .as_deref()
-                .ok_or_else(|| QuarantineError::MissingColumn {
-                    name: label.to_string(),
-                })?;
+            let col = required_column(column, label)?;
             validation::validate_identifier(col)?;
             Ok(format!("{col} IS NOT NULL"))
         }
         TestType::AcceptedValues { values } => {
-            let col = column
-                .as_deref()
-                .ok_or_else(|| QuarantineError::MissingColumn {
-                    name: label.to_string(),
-                })?;
+            let col = required_column(column, label)?;
             validation::validate_identifier(col)?;
             if values.is_empty() {
                 return Err(QuarantineError::EmptyAcceptedValues {
@@ -318,10 +330,68 @@ fn lower_valid_predicate(
             // `WHERE NOT (expression)` semantic.
             Ok(format!("COALESCE(({expression}), TRUE)"))
         }
+        TestType::InRange { min, max } => {
+            let col = required_column(column, label)?;
+            validation::validate_identifier(col)?;
+            let fail_pred =
+                crate::tests::in_range_fail_predicate_public(col, min.as_deref(), max.as_deref())
+                    .map_err(|e| match e {
+                    crate::tests::TestGenError::MissingInRangeBound => {
+                        QuarantineError::EmptyExpression
+                    }
+                    crate::tests::TestGenError::InvalidInRangeBound { value } => {
+                        QuarantineError::InvalidInRangeBound { value }
+                    }
+                    _ => QuarantineError::EmptyExpression,
+                })?;
+            // NULL-permissive: (col IS NULL OR NOT (col < min OR col > max))
+            Ok(format!("({col} IS NULL OR NOT ({fail_pred}))"))
+        }
+        TestType::RegexMatch { pattern } => {
+            let col = required_column(column, label)?;
+            validation::validate_identifier(col)?;
+            crate::tests::validate_regex_pattern(pattern).map_err(|_| {
+                QuarantineError::UnsafeRegexPattern {
+                    name: label.to_string(),
+                }
+            })?;
+            let match_pred = dialect
+                .regex_match_predicate(col, pattern)
+                .map_err(QuarantineError::from)?;
+            // NULL-permissive: (col IS NULL OR <match>)
+            Ok(format!("({col} IS NULL OR {match_pred})"))
+        }
         // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
         TestType::Unique | TestType::Relationships { .. } | TestType::RowCountRange { .. } => {
             Err(QuarantineError::EmptyExpression)
         }
+    }
+}
+
+fn required_column<'a>(
+    column: &'a Option<String>,
+    label: &str,
+) -> Result<&'a str, QuarantineError> {
+    column
+        .as_deref()
+        .ok_or_else(|| QuarantineError::MissingColumn {
+            name: label.to_string(),
+        })
+}
+
+/// Apply a per-check `filter` to a base valid predicate.
+///
+/// Model: if the filter is FALSE or NULL, the row is "out of scope" for
+/// this assertion and passes unconditionally. If the filter is TRUE, the
+/// base predicate decides.
+///
+/// Implemented as `CASE WHEN (filter) THEN base ELSE TRUE END` — a total
+/// boolean across all rows, so the top-level `AND` / `NOT` can't
+/// propagate NULL.
+fn wrap_filter(filter: &Option<String>, base_pred: &str) -> String {
+    match filter.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(f) => format!("(CASE WHEN ({f}) THEN ({base_pred}) ELSE TRUE END)"),
+        None => base_pred.to_string(),
     }
 }
 
@@ -459,6 +529,9 @@ mod unit_tests {
         ) -> AdapterResult<Vec<String>> {
             unimplemented!()
         }
+        fn regex_match_predicate(&self, column: &str, pattern: &str) -> AdapterResult<String> {
+            Ok(format!("regexp_matches({column}, '{pattern}')"))
+        }
     }
 
     fn table() -> TableRef {
@@ -482,6 +555,7 @@ mod unit_tests {
                 test_type: kind,
                 column: column.map(str::to_string),
                 severity,
+                filter: None,
             },
         }
     }
@@ -818,5 +892,151 @@ mod unit_tests {
         )];
         let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg).err();
         assert!(err.is_some());
+    }
+
+    // ----- Phase 4a -----
+
+    fn assertion_with_filter(
+        kind: TestType,
+        column: Option<&str>,
+        filter: Option<&str>,
+    ) -> QualityAssertion {
+        QualityAssertion {
+            table: "orders".into(),
+            name: None,
+            test: TestDecl {
+                test_type: kind,
+                column: column.map(str::to_string),
+                severity: TestSeverity::Error,
+                filter: filter.map(str::to_string),
+            },
+        }
+    }
+
+    #[test]
+    fn in_range_lowers_to_null_permissive_valid_predicate() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::InRange {
+                min: Some("0".into()),
+                max: Some("1000".into()),
+            },
+            Some("amount"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Valid CTAS: (amount IS NULL OR NOT (amount < 0 OR amount > 1000))
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("(amount IS NULL OR NOT (amount < 0 OR amount > 1000))")
+        );
+    }
+
+    #[test]
+    fn regex_match_lowers_to_null_permissive_valid_predicate() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::RegexMatch {
+                pattern: "^[a-z]+$".into(),
+            },
+            Some("email"),
+            TestSeverity::Error,
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Valid CTAS: (email IS NULL OR regexp_matches(email, '^[a-z]+$'))
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("(email IS NULL OR regexp_matches(email, '^[a-z]+$'))")
+        );
+    }
+
+    #[test]
+    fn filter_wraps_valid_predicate_with_case() {
+        let cfg = split_config();
+        let assertions = vec![assertion_with_filter(
+            TestType::NotNull,
+            Some("customer_id"),
+            Some("region = 'US'"),
+        )];
+        let plan = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .unwrap()
+            .unwrap();
+        // Out-of-scope rows (filter false/null) pass unconditionally:
+        // (CASE WHEN (region = 'US') THEN (customer_id IS NOT NULL) ELSE TRUE END)
+        assert!(
+            plan.statements[1]
+                .sql
+                .contains("CASE WHEN (region = 'US') THEN (customer_id IS NOT NULL) ELSE TRUE END")
+        );
+    }
+
+    #[test]
+    fn in_range_rejects_non_numeric_bounds() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::InRange {
+                min: Some("yesterday".into()),
+                max: None,
+            },
+            Some("amount"),
+            TestSeverity::Error,
+        )];
+        let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .err()
+            .unwrap();
+        assert!(matches!(err, QuarantineError::InvalidInRangeBound { .. }));
+    }
+
+    #[test]
+    fn regex_match_rejects_unsafe_pattern() {
+        let cfg = split_config();
+        let assertions = vec![assertion(
+            None,
+            TestType::RegexMatch {
+                pattern: "foo'; DROP TABLE".into(),
+            },
+            Some("email"),
+            TestSeverity::Error,
+        )];
+        let err = compile_quarantine_sql(&assertions, "orders", &table(), &TestDialect, &cfg)
+            .err()
+            .unwrap();
+        assert!(matches!(err, QuarantineError::UnsafeRegexPattern { .. }));
+    }
+
+    #[test]
+    fn all_phase4a_kinds_covered_by_is_quarantinable() {
+        assert!(is_quarantinable(&TestType::NotNull));
+        assert!(is_quarantinable(&TestType::AcceptedValues {
+            values: vec!["a".into()]
+        }));
+        assert!(is_quarantinable(&TestType::Expression {
+            expression: "x > 0".into()
+        }));
+        assert!(is_quarantinable(&TestType::InRange {
+            min: Some("0".into()),
+            max: Some("1".into()),
+        }));
+        assert!(is_quarantinable(&TestType::RegexMatch {
+            pattern: "x".into()
+        }));
+        assert!(!is_quarantinable(&TestType::Unique));
+        assert!(!is_quarantinable(&TestType::Relationships {
+            to_table: "t".into(),
+            to_column: "c".into(),
+        }));
+        assert!(!is_quarantinable(&TestType::RowCountRange {
+            min: None,
+            max: Some(10),
+        }));
     }
 }

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -24,6 +24,25 @@ pub enum TestGenError {
 
     #[error("row_count_range test requires at least one of 'min' or 'max'")]
     MissingRange,
+
+    #[error("in_range test requires at least one of 'min' or 'max'")]
+    MissingInRangeBound,
+
+    #[error(
+        "in_range bound '{value}' must parse as a number (Phase 4a supports numeric ranges only; use `time_window` or `expression` for temporal bounds)"
+    )]
+    InvalidInRangeBound { value: String },
+
+    #[error("regex_match test requires a non-empty 'pattern'")]
+    EmptyRegexPattern,
+
+    #[error(
+        "regex_match pattern contains unsafe character '{found}'; patterns may not contain single quotes, backticks, or semicolons"
+    )]
+    UnsafeRegexPattern { found: char },
+
+    #[error("regex_match test is not supported by this adapter: {0}")]
+    RegexNotSupported(String),
 }
 
 /// Severity of a test failure.
@@ -72,6 +91,34 @@ pub enum TestType {
         #[serde(default)]
         max: Option<u64>,
     },
+    /// Assert that a column's values fall within a numeric range
+    /// (inclusive, half-open either side). Phase 4a supports numeric
+    /// bounds only — use `time_window` (Phase 4b) or `expression` for
+    /// temporal comparisons.
+    ///
+    /// NULL column values pass (consistent with existing `NOT IN` /
+    /// `NOT (expr)` semantics).
+    InRange {
+        /// Minimum value (inclusive). `None` means no lower bound.
+        #[serde(default)]
+        min: Option<String>,
+        /// Maximum value (inclusive). `None` means no upper bound.
+        #[serde(default)]
+        max: Option<String>,
+    },
+    /// Assert that a column's values match a regular expression.
+    ///
+    /// Dialect-specific operator (`REGEXP` / `RLIKE` / `REGEXP_LIKE` /
+    /// `REGEXP_CONTAINS`) is produced by [`SqlDialect::regex_match_predicate`].
+    /// Patterns are validated against a strict allowlist that rejects
+    /// single quotes, backticks, and semicolons.
+    ///
+    /// NULL column values pass.
+    RegexMatch {
+        /// The regex pattern. Dialect-specific syntax — stick to the
+        /// portable subset (character classes, anchors, quantifiers).
+        pattern: String,
+    },
 }
 
 /// A single declarative test declared in a model sidecar TOML.
@@ -99,14 +146,27 @@ pub struct TestDecl {
     pub test_type: TestType,
 
     /// Column under test. Required for `not_null`, `unique`,
-    /// `accepted_values`, and `relationships`. Ignored for `expression`
-    /// and `row_count_range`.
+    /// `accepted_values`, `relationships`, `in_range`, `regex_match`.
+    /// Ignored for `expression` and `row_count_range`.
     #[serde(default)]
     pub column: Option<String>,
 
     /// Severity of failure. Defaults to `error`.
     #[serde(default)]
     pub severity: TestSeverity,
+
+    /// Optional SQL boolean predicate that scopes the assertion to a
+    /// subset of rows. When set, only rows where `(filter)` evaluates
+    /// to `TRUE` are subject to the assertion — rows where the filter
+    /// is `FALSE` or `NULL` pass unconditionally.
+    ///
+    /// Filter is user-supplied SQL; the caller is responsible for
+    /// sandboxing execution (same contract as `expression`).
+    ///
+    /// Example: `filter = "created_at > current_date - interval 30 day"`
+    /// restricts a `not_null` check to rows created in the last 30 days.
+    #[serde(default)]
+    pub filter: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +174,10 @@ pub struct TestDecl {
 // ---------------------------------------------------------------------------
 
 /// Generates the assertion SQL for a declarative test.
+///
+/// Dialect-agnostic subset — for `RegexMatch` use
+/// [`generate_test_sql_with_dialect`] instead. This wrapper returns
+/// [`TestGenError::RegexNotSupported`] if the test is a `RegexMatch`.
 ///
 /// The returned SQL is designed to be evaluated against the model's target
 /// table. The caller checks the result:
@@ -125,7 +189,27 @@ pub struct TestDecl {
 /// - **`expression`**: returns the count of violating rows. Pass if 0.
 /// - **`row_count_range`**: returns the total row count. Caller asserts
 ///   the value falls within `[min, max]`.
+/// - **`in_range`**: returns the count of rows outside `[min, max]`. Pass if 0.
 pub fn generate_test_sql(test: &TestDecl, table: &str) -> Result<String, TestGenError> {
+    generate_test_sql_inner(test, table, None)
+}
+
+/// Dialect-aware variant of [`generate_test_sql`]. Required for
+/// `RegexMatch` (which needs a dialect-specific operator) and accepted
+/// for any other kind.
+pub fn generate_test_sql_with_dialect(
+    test: &TestDecl,
+    table: &str,
+    dialect: &dyn crate::traits::SqlDialect,
+) -> Result<String, TestGenError> {
+    generate_test_sql_inner(test, table, Some(dialect))
+}
+
+fn generate_test_sql_inner(
+    test: &TestDecl,
+    table: &str,
+    dialect: Option<&dyn crate::traits::SqlDialect>,
+) -> Result<String, TestGenError> {
     // Table may be fully-qualified (catalog.schema.table), so validate each
     // dot-separated component individually — same approach as the
     // `Relationships` variant uses for `to_table`.
@@ -133,17 +217,30 @@ pub fn generate_test_sql(test: &TestDecl, table: &str) -> Result<String, TestGen
         validation::validate_identifier(part)?;
     }
 
+    // Optional per-check `filter` applies to every kind by prefixing the
+    // row-level WHERE clause. Unique / Relationships / RowCountRange
+    // weave it in differently (see each arm).
+    let filter = test
+        .filter
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
     match &test.test_type {
         TestType::NotNull => {
             let col = require_column(test, "not_null")?;
             validation::validate_identifier(col)?;
-            Ok(format!("SELECT COUNT(*) FROM {table} WHERE {col} IS NULL"))
+            Ok(format!(
+                "SELECT COUNT(*) FROM {table} WHERE {}{col} IS NULL",
+                filter_and(filter),
+            ))
         }
         TestType::Unique => {
             let col = require_column(test, "unique")?;
             validation::validate_identifier(col)?;
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
             Ok(format!(
-                "SELECT {col}, COUNT(*) FROM {table} GROUP BY {col} HAVING COUNT(*) > 1"
+                "SELECT {col}, COUNT(*) FROM {table}{where_clause} GROUP BY {col} HAVING COUNT(*) > 1"
             ))
         }
         TestType::AcceptedValues { values } => {
@@ -158,7 +255,8 @@ pub fn generate_test_sql(test: &TestDecl, table: &str) -> Result<String, TestGen
                 .collect::<Vec<_>>()
                 .join(", ");
             Ok(format!(
-                "SELECT DISTINCT {col} FROM {table} WHERE {col} NOT IN ({in_list})"
+                "SELECT DISTINCT {col} FROM {table} WHERE {}{col} NOT IN ({in_list})",
+                filter_and(filter),
             ))
         }
         TestType::Relationships {
@@ -173,10 +271,11 @@ pub fn generate_test_sql(test: &TestDecl, table: &str) -> Result<String, TestGen
                 validation::validate_identifier(part)?;
             }
             validation::validate_identifier(to_column)?;
+            let filter_clause = filter.map(|f| format!("({f}) AND ")).unwrap_or_default();
             Ok(format!(
                 "SELECT t.{col} FROM {table} t \
                  LEFT JOIN {to_table} r ON t.{col} = r.{to_column} \
-                 WHERE r.{to_column} IS NULL AND t.{col} IS NOT NULL"
+                 WHERE {filter_clause}r.{to_column} IS NULL AND t.{col} IS NOT NULL"
             ))
         }
         TestType::Expression { expression } => {
@@ -186,16 +285,118 @@ pub fn generate_test_sql(test: &TestDecl, table: &str) -> Result<String, TestGen
             // Expression is user-supplied SQL — we cannot validate it as an
             // identifier. The caller is responsible for sandboxing execution.
             Ok(format!(
-                "SELECT COUNT(*) FROM {table} WHERE NOT ({expression})"
+                "SELECT COUNT(*) FROM {table} WHERE {}NOT ({expression})",
+                filter_and(filter),
             ))
         }
         TestType::RowCountRange { min, max } => {
             if min.is_none() && max.is_none() {
                 return Err(TestGenError::MissingRange);
             }
-            Ok(format!("SELECT COUNT(*) FROM {table}"))
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
+            Ok(format!("SELECT COUNT(*) FROM {table}{where_clause}"))
+        }
+        TestType::InRange { min, max } => {
+            let col = require_column(test, "in_range")?;
+            validation::validate_identifier(col)?;
+            let predicate = in_range_fail_predicate(col, min.as_deref(), max.as_deref())?;
+            Ok(format!(
+                "SELECT COUNT(*) FROM {table} WHERE {}({predicate})",
+                filter_and(filter),
+            ))
+        }
+        TestType::RegexMatch { pattern } => {
+            let col = require_column(test, "regex_match")?;
+            validation::validate_identifier(col)?;
+            validate_regex_pattern(pattern)?;
+            let dialect = dialect.ok_or_else(|| {
+                TestGenError::RegexNotSupported(
+                    "use generate_test_sql_with_dialect for regex_match".into(),
+                )
+            })?;
+            let match_pred = dialect
+                .regex_match_predicate(col, pattern)
+                .map_err(|e| TestGenError::RegexNotSupported(e.to_string()))?;
+            Ok(format!(
+                "SELECT COUNT(*) FROM {table} WHERE {}NOT ({match_pred})",
+                filter_and(filter),
+            ))
         }
     }
+}
+
+/// Returns `"(filter) AND "` or `""` for embedding into a WHERE clause
+/// that already has a trailing predicate.
+fn filter_and(filter: Option<&str>) -> String {
+    filter.map(|f| format!("({f}) AND ")).unwrap_or_default()
+}
+
+/// Public re-export of [`in_range_fail_predicate`] for
+/// [`crate::quarantine`], which needs the same numeric-range lowering
+/// when building the NULL-permissive valid predicate.
+pub fn in_range_fail_predicate_public(
+    col: &str,
+    min: Option<&str>,
+    max: Option<&str>,
+) -> Result<String, TestGenError> {
+    in_range_fail_predicate(col, min, max)
+}
+
+/// Build the "failing" predicate for `in_range`: `col < min OR col > max`,
+/// collapsing to one side when only one bound is set. Bounds are
+/// parsed as `f64` and re-emitted as SQL numeric literals — no string
+/// interpolation of user-supplied SQL text.
+fn in_range_fail_predicate(
+    col: &str,
+    min: Option<&str>,
+    max: Option<&str>,
+) -> Result<String, TestGenError> {
+    if min.is_none() && max.is_none() {
+        return Err(TestGenError::MissingInRangeBound);
+    }
+    let min_n = min.map(parse_numeric_bound).transpose()?;
+    let max_n = max.map(parse_numeric_bound).transpose()?;
+    let parts: Vec<String> = [
+        min_n.map(|n| format!("{col} < {}", format_numeric(n))),
+        max_n.map(|n| format!("{col} > {}", format_numeric(n))),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    Ok(parts.join(" OR "))
+}
+
+fn parse_numeric_bound(s: &str) -> Result<f64, TestGenError> {
+    s.parse::<f64>()
+        .map_err(|_| TestGenError::InvalidInRangeBound {
+            value: s.to_string(),
+        })
+}
+
+/// Format a parsed numeric bound as SQL. Prefers integer form when the
+/// value is integral to avoid `42.0` where `42` is natural.
+fn format_numeric(n: f64) -> String {
+    if n.fract() == 0.0 && n.is_finite() && n.abs() < 1e18 {
+        format!("{}", n as i64)
+    } else {
+        format!("{n}")
+    }
+}
+
+/// Strict allowlist for regex patterns. Rejects characters that could
+/// escape the single-quoted SQL literal context. No other regex-syntax
+/// validation is performed — the dialect's regex engine decides at query
+/// time whether the pattern is well-formed.
+pub fn validate_regex_pattern(pattern: &str) -> Result<(), TestGenError> {
+    if pattern.is_empty() {
+        return Err(TestGenError::EmptyRegexPattern);
+    }
+    for ch in pattern.chars() {
+        if matches!(ch, '\'' | '`' | ';') {
+            return Err(TestGenError::UnsafeRegexPattern { found: ch });
+        }
+    }
+    Ok(())
 }
 
 /// Extracts the required column from a test declaration, returning an error
@@ -402,6 +603,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::NotNull,
             column: Some("order_id".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "fct_orders").unwrap();
         assert_eq!(
@@ -416,6 +618,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::Unique,
             column: Some("email".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "fct_orders").unwrap();
         assert_eq!(
@@ -432,6 +635,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: Some("status".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "orders").unwrap();
         assert_eq!(
@@ -448,6 +652,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: Some("name".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "t").unwrap();
         assert!(sql.contains("'it''s'"), "single quotes should be escaped");
@@ -462,6 +667,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: Some("customer_id".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "fct_orders").unwrap();
         assert_eq!(
@@ -480,6 +686,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "orders").unwrap();
         assert_eq!(sql, "SELECT COUNT(*) FROM orders WHERE NOT (amount > 0)");
@@ -494,6 +701,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let sql = generate_test_sql(&decl, "orders").unwrap();
         assert_eq!(sql, "SELECT COUNT(*) FROM orders");
@@ -507,6 +715,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::NotNull,
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -520,6 +729,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::Unique,
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -531,6 +741,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::AcceptedValues { values: vec![] },
             column: Some("status".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -546,6 +757,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -560,6 +772,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -573,6 +786,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -589,6 +803,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
@@ -602,6 +817,7 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::NotNull,
             column: Some("col".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "drop table; --");
         assert!(result.is_err());
@@ -613,8 +829,212 @@ target = { catalog = "c", schema = "s", table = "t" }
             test_type: TestType::NotNull,
             column: Some("col; DROP TABLE".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let result = generate_test_sql(&decl, "t");
         assert!(result.is_err());
+    }
+
+    // ----- Phase 4a: InRange -----
+
+    #[test]
+    fn test_in_range_deser_both_bounds() {
+        let toml_str = r#"
+type = "in_range"
+column = "amount"
+min = "0"
+max = "1000"
+"#;
+        let decl: TestDecl = toml::from_str(toml_str).unwrap();
+        if let TestType::InRange { min, max } = &decl.test_type {
+            assert_eq!(min.as_deref(), Some("0"));
+            assert_eq!(max.as_deref(), Some("1000"));
+        } else {
+            panic!("expected InRange");
+        }
+    }
+
+    #[test]
+    fn test_sql_in_range_numeric_both() {
+        let decl = TestDecl {
+            test_type: TestType::InRange {
+                min: Some("0".into()),
+                max: Some("1000".into()),
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT COUNT(*) FROM orders WHERE (amount < 0 OR amount > 1000)"
+        );
+    }
+
+    #[test]
+    fn test_sql_in_range_min_only() {
+        let decl = TestDecl {
+            test_type: TestType::InRange {
+                min: Some("1".into()),
+                max: None,
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(sql, "SELECT COUNT(*) FROM orders WHERE (amount < 1)");
+    }
+
+    #[test]
+    fn test_sql_in_range_formats_decimal_bounds() {
+        let decl = TestDecl {
+            test_type: TestType::InRange {
+                min: Some("0.5".into()),
+                max: Some("99.95".into()),
+            },
+            column: Some("ratio".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "t").unwrap();
+        assert!(sql.contains("ratio < 0.5"));
+        assert!(sql.contains("ratio > 99.95"));
+    }
+
+    #[test]
+    fn test_in_range_rejects_non_numeric() {
+        let decl = TestDecl {
+            test_type: TestType::InRange {
+                min: Some("2026-01-01".into()),
+                max: None,
+            },
+            column: Some("created_at".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let result = generate_test_sql(&decl, "t");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("numeric ranges only")
+        );
+    }
+
+    #[test]
+    fn test_in_range_requires_at_least_one_bound() {
+        let decl = TestDecl {
+            test_type: TestType::InRange {
+                min: None,
+                max: None,
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let result = generate_test_sql(&decl, "t");
+        assert!(result.is_err());
+    }
+
+    // ----- Phase 4a: RegexMatch -----
+
+    #[test]
+    fn test_regex_match_deser() {
+        let toml_str = r#"
+type = "regex_match"
+column = "email"
+pattern = "^[a-z]+@example\\.com$"
+"#;
+        let decl: TestDecl = toml::from_str(toml_str).unwrap();
+        if let TestType::RegexMatch { pattern } = &decl.test_type {
+            assert_eq!(pattern, r"^[a-z]+@example\.com$");
+        } else {
+            panic!("expected RegexMatch");
+        }
+    }
+
+    #[test]
+    fn test_regex_match_needs_dialect() {
+        // Non-dialect helper errors on RegexMatch (matches SQL needs dialect).
+        let decl = TestDecl {
+            test_type: TestType::RegexMatch {
+                pattern: "^[a-z]+$".into(),
+            },
+            column: Some("email".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let result = generate_test_sql(&decl, "t");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_regex_pattern_allowlist() {
+        assert!(validate_regex_pattern("^[a-z]+@example\\.com$").is_ok());
+        assert!(validate_regex_pattern("").is_err());
+        assert!(validate_regex_pattern("foo'bar").is_err()); // single quote
+        assert!(validate_regex_pattern("foo;bar").is_err()); // semicolon
+        assert!(validate_regex_pattern("foo`bar").is_err()); // backtick
+    }
+
+    // ----- Phase 4a: filter -----
+
+    #[test]
+    fn test_filter_wraps_not_null() {
+        let decl = TestDecl {
+            test_type: TestType::NotNull,
+            column: Some("customer_id".into()),
+            severity: TestSeverity::Error,
+            filter: Some("created_at > '2026-01-01'".into()),
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT COUNT(*) FROM orders WHERE (created_at > '2026-01-01') AND customer_id IS NULL"
+        );
+    }
+
+    #[test]
+    fn test_filter_wraps_unique() {
+        let decl = TestDecl {
+            test_type: TestType::Unique,
+            column: Some("email".into()),
+            severity: TestSeverity::Error,
+            filter: Some("active = true".into()),
+        };
+        let sql = generate_test_sql(&decl, "customers").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT email, COUNT(*) FROM customers WHERE (active = true) GROUP BY email HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_filter_wraps_accepted_values() {
+        let decl = TestDecl {
+            test_type: TestType::AcceptedValues {
+                values: vec!["pending".into(), "shipped".into()],
+            },
+            column: Some("status".into()),
+            severity: TestSeverity::Error,
+            filter: Some("region = 'US'".into()),
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert!(sql.contains("WHERE (region = 'US') AND status NOT IN"));
+    }
+
+    #[test]
+    fn test_filter_blank_is_ignored() {
+        let decl = TestDecl {
+            test_type: TestType::NotNull,
+            column: Some("id".into()),
+            severity: TestSeverity::Error,
+            filter: Some("   ".into()),
+        };
+        let sql = generate_test_sql(&decl, "t").unwrap();
+        assert_eq!(sql, "SELECT COUNT(*) FROM t WHERE id IS NULL");
     }
 }

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -296,6 +296,21 @@ pub trait SqlDialect: Send + Sync {
              WHERE table_schema = '{schema}'"
         ))
     }
+
+    /// Build a dialect-specific boolean SQL predicate that matches when
+    /// `column` matches `pattern` (`REGEXP` / `RLIKE` / `REGEXP_LIKE` /
+    /// `REGEXP_CONTAINS`, depending on the warehouse).
+    ///
+    /// Used by `TestType::RegexMatch` (Phase 4a). The default impl
+    /// returns an error — adapters that support regex must override.
+    /// `column` is already validated as a SQL identifier; `pattern` is
+    /// already validated against the strict allowlist
+    /// ([`crate::tests::validate_regex_pattern`]).
+    fn regex_match_predicate(&self, _column: &str, _pattern: &str) -> AdapterResult<String> {
+        Err(AdapterError::msg(
+            "regex_match not supported by this dialect",
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -617,6 +617,8 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",
         TestType::RowCountRange { .. } => "row_count_range",
+        TestType::InRange { .. } => "in_range",
+        TestType::RegexMatch { .. } => "regex_match",
     };
 
     match &test.column {
@@ -1117,11 +1119,13 @@ mod tests {
                 test_type: TestType::NotNull,
                 column: Some("order_id".into()),
                 severity: TestSeverity::Error,
+                filter: None,
             },
             TestDecl {
                 test_type: TestType::Unique,
                 column: Some("order_id".into()),
                 severity: TestSeverity::Error,
+                filter: None,
             },
         ];
 
@@ -1375,6 +1379,7 @@ mod tests {
             test_type: TestType::NotNull,
             column: Some("id".into()),
             severity: TestSeverity::Error,
+            filter: None,
         }];
 
         let models = vec![model("stg_orders", vec![], test_decls)];
@@ -1482,6 +1487,7 @@ mod tests {
             test_type: TestType::NotNull,
             column: Some("order_id".into()),
             severity: TestSeverity::Error,
+            filter: None,
         };
         let label = format_test_label("stg_orders", &test, 0);
         assert_eq!(label, "stg_orders::not_null_order_id");
@@ -1496,6 +1502,7 @@ mod tests {
             },
             column: None,
             severity: TestSeverity::Error,
+            filter: None,
         };
         let label = format_test_label("stg_orders", &test, 2);
         assert_eq!(label, "stg_orders::row_count_range_2");

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -163,6 +163,14 @@ impl SqlDialect for DatabricksSqlDialect {
     fn tablesample_clause(&self, percent: u32) -> Option<String> {
         Some(format!("TABLESAMPLE ({percent} PERCENT)"))
     }
+
+    fn regex_match_predicate(
+        &self,
+        column: &str,
+        pattern: &str,
+    ) -> rocky_core::traits::AdapterResult<String> {
+        Ok(format!("{column} RLIKE '{pattern}'"))
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -188,6 +188,10 @@ impl SqlDialect for DuckDbSqlDialect {
              WHERE table_catalog = '{catalog}' AND table_schema = '{schema}'"
         ))
     }
+
+    fn regex_match_predicate(&self, column: &str, pattern: &str) -> AdapterResult<String> {
+        Ok(format!("regexp_matches({column}, '{pattern}')"))
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -182,6 +182,14 @@ impl SqlDialect for SnowflakeSqlDialect {
             "COMMIT".into(),
         ])
     }
+
+    fn regex_match_predicate(
+        &self,
+        column: &str,
+        pattern: &str,
+    ) -> rocky_core::traits::AdapterResult<String> {
+        Ok(format!("REGEXP_LIKE({column}, '{pattern}')"))
+    }
 }
 
 #[cfg(test)]

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/README.md
@@ -3,7 +3,7 @@
 > **Category:** 01-quality
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 15s
-> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, aggregate checks (row_count / column_match / freshness), unified row-level `[[checks.assertions]]` (not_null, unique, accepted_values, expression, row_count_range), per-check `severity`, `fail_on_error`, row `[checks.quarantine]` (split / tag / drop)
+> **Rocky features:** `type = "quality"`, `depends_on`, `tables`, aggregate checks (row_count / column_match / freshness), unified row-level `[[checks.assertions]]` (not_null, unique, accepted_values, expression, row_count_range, in_range, regex_match), per-check `filter`, per-check `severity`, `fail_on_error`, row `[checks.quarantine]` (split / tag / drop)
 
 ## What it shows
 
@@ -13,9 +13,11 @@ Rocky's quality pipeline type — a dedicated pipeline that runs data quality ch
 - Targeted at specific schemas/tables
 - Chainable via `depends_on` (runs after ingest completes)
 - Able to express DQX-parity row-level assertions (`not_null`, `unique`,
-  `accepted_values`, `relationships`, `expression`, `row_count_range`) via
-  `[[pipeline.x.checks.assertions]]` blocks on the same surface used by
-  declarative model tests
+  `accepted_values`, `relationships`, `expression`, `row_count_range`,
+  `in_range`, `regex_match`) via `[[pipeline.x.checks.assertions]]` blocks
+  on the same surface used by declarative model tests
+- Each assertion can carry a `filter` SQL predicate to scope it to a
+  subset of rows (e.g. only the last 30 days, only shipped orders)
 
 ## Why it's distinctive
 

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -89,3 +89,42 @@ type     = "row_count_range"
 min      = 40
 max      = 60
 severity = "error"
+
+# --- Phase 4a: in_range + regex_match + per-check filter ---
+
+# in_range — amount should be within [0, 10000]. Row 99 has amount = -5
+# (failing) but the `expression` assertion above already catches it at
+# warning severity. This error-severity `in_range` will both count the
+# failure AND quarantine the row (predicate lowers into the split).
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_amount_in_range"
+table    = "orders"
+type     = "in_range"
+column   = "amount"
+min      = "0"
+max      = "10000"
+severity = "error"
+
+# regex_match — the `email` column in `customers` should match an email
+# pattern. Seed data uses `customer{i}@example.com`; this should pass.
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "customers_email_format"
+table    = "customers"
+type     = "regex_match"
+column   = "email"
+pattern  = "^[a-z0-9_]+@[a-z0-9.]+$"
+severity = "warning"
+
+# filter — scope a check to a subset of rows. This `not_null` on
+# `customer_id` only applies to rows where status = 'shipped'; the
+# quarantine wraps the base predicate in `CASE WHEN (filter) THEN base
+# ELSE TRUE END` so out-of-scope rows (e.g. pending) stay valid even if
+# customer_id is NULL. Note: the broader error-severity `not_null` on
+# customer_id above still applies to all rows.
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_shipped_customer_id_present"
+table    = "orders"
+type     = "not_null"
+column   = "customer_id"
+filter   = "status = 'shipped'"
+severity = "warning"


### PR DESCRIPTION
## Summary

Adds three complementary extensions to the declarative test surface:

1. **Per-check `filter`** — scope an assertion to a subset of rows via a SQL boolean predicate.
2. **`TestType::InRange { min, max }`** — numeric range check (Phase 4b will add temporal via `TimeWindow`).
3. **`TestType::RegexMatch { pattern }`** — dialect-specific regex match via a new `SqlDialect::regex_match_predicate` trait method.

All three lower cleanly into the Phase 3 quarantine pipeline — they're now in `is_quarantinable`, and the `CASE WHEN (filter) THEN base ELSE TRUE END` form keeps out-of-scope rows in the `__valid` output.

## Design notes

- **`InRange` is numeric-only.** Temporal bounds stay on `TimeWindow` (Phase 4b) or `expression`. Bounds parse as `f64` and are re-emitted as SQL numeric literals — no user-SQL interpolation on the value path.
- **`RegexMatch` uses a `SqlDialect` trait method with a default impl that returns an error.** All four production dialects override: DuckDB `regexp_matches`, Databricks `RLIKE`, Snowflake `REGEXP_LIKE`, BigQuery `REGEXP_CONTAINS`. Adapters without regex support fail cleanly at runtime.
- **Regex patterns go through a strict allowlist** — rejects single quotes, backticks, and semicolons (preserves single-quoted-literal context).
- **`filter` + quarantine:** wrapped as `CASE WHEN (filter) THEN base_valid_pred ELSE TRUE END` so rows where `filter` is FALSE *or NULL* pass unconditionally.

## Test plan

- [x] 19 new unit tests in `tests` + `quarantine` modules cover: `in_range` SQL shape (numeric both/min-only/decimal), non-numeric bound rejection, `regex_match` dialect errors without dialect, allowlist validation, `filter` wrapping of every test kind, `filter` blank handling, `CASE WHEN` quarantine lowering, unsafe-pattern rejection
- [x] `cargo test -p rocky-core --lib` — 909/909 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just codegen` — idempotent (new `TestType` variants don't change output schemas)
- [x] `just regen-fixtures` — no change
- [x] POC `06-quality-pipeline-standalone` extended with `in_range`, `regex_match`, filtered `not_null`; 11 checks, 4 quarantined rows on DuckDB

## Follow-up

Phase 4b (aggregate sugar, composite `Unique`, `TimeWindow`) lands as a separate PR.