### PR TITLE
feat(engine): DQX parity phase 4b — Aggregate, Composite Unique, time-window sugar

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -175,6 +175,14 @@ impl SqlDialect for BigQueryDialect {
     ) -> rocky_core::traits::AdapterResult<String> {
         Ok(format!("REGEXP_CONTAINS({column}, r'{pattern}')"))
     }
+
+    fn date_minus_days_expr(&self, days: u32) -> rocky_core::traits::AdapterResult<String> {
+        Ok(format!("DATE_SUB(CURRENT_DATE(), INTERVAL {days} DAY)"))
+    }
+
+    fn current_timestamp_expr(&self) -> &'static str {
+        "CURRENT_TIMESTAMP()"
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -431,6 +431,10 @@ fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
         TestType::RegexMatch { .. } => "regex_match",
+        TestType::Aggregate { .. } => "aggregate",
+        TestType::Composite { .. } => "composite",
+        TestType::NotInFuture => "not_in_future",
+        TestType::OlderThanNDays { .. } => "older_than_n_days",
     }
 }
 
@@ -461,12 +465,17 @@ fn classify_assertion(
         TestType::NotNull
         | TestType::Expression { .. }
         | TestType::InRange { .. }
-        | TestType::RegexMatch { .. } => {
+        | TestType::RegexMatch { .. }
+        | TestType::NotInFuture
+        | TestType::OlderThanNDays { .. } => {
             let n = first_cell_u64();
             (n == 0, n)
         }
         // Row-set-based: every returned row is a violation.
-        TestType::Unique | TestType::AcceptedValues { .. } | TestType::Relationships { .. } => {
+        TestType::Unique
+        | TestType::AcceptedValues { .. }
+        | TestType::Relationships { .. }
+        | TestType::Composite { .. } => {
             let n = rows.len() as u64;
             (n == 0, n)
         }
@@ -475,6 +484,11 @@ fn classify_assertion(
             let within_min = min.map(|m| n >= m).unwrap_or(true);
             let within_max = max.map(|m| n <= m).unwrap_or(true);
             (within_min && within_max, n)
+        }
+        // Aggregate: the test SQL returns a single 0/1 cell (0 = pass).
+        TestType::Aggregate { .. } => {
+            let n = first_cell_u64();
+            (n == 0, n)
         }
     }
 }

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -313,11 +313,15 @@ fn interpret_result(
     result: &rocky_core::traits::QueryResult,
 ) -> (String, Option<String>) {
     match test_type {
-        // not_null / expression / in_range / regex_match: SELECT COUNT(*) — pass when count == 0
+        // not_null / expression / in_range / regex_match / time_window / aggregate:
+        // single-cell numeric result — 0 = pass, >0 = fail.
         TestType::NotNull
         | TestType::Expression { .. }
         | TestType::InRange { .. }
-        | TestType::RegexMatch { .. } => {
+        | TestType::RegexMatch { .. }
+        | TestType::NotInFuture
+        | TestType::OlderThanNDays { .. }
+        | TestType::Aggregate { .. } => {
             let count = first_row_count(result);
             if count == 0 {
                 ("pass".to_string(), None)
@@ -326,14 +330,20 @@ fn interpret_result(
                     TestType::NotNull => "NULL row(s)",
                     TestType::InRange { .. } => "out-of-range row(s)",
                     TestType::RegexMatch { .. } => "non-matching row(s)",
+                    TestType::NotInFuture => "future-timestamped row(s)",
+                    TestType::OlderThanNDays { .. } => "too-recent row(s)",
+                    TestType::Aggregate { .. } => "aggregate failure",
                     _ => "violating row(s)",
                 };
                 ("fail".to_string(), Some(format!("{count} {what} found")))
             }
         }
 
-        // unique / accepted_values / relationships: rows returned = failures
-        TestType::Unique | TestType::AcceptedValues { .. } | TestType::Relationships { .. } => {
+        // unique / accepted_values / relationships / composite: rows returned = failures
+        TestType::Unique
+        | TestType::AcceptedValues { .. }
+        | TestType::Relationships { .. }
+        | TestType::Composite { .. } => {
             let row_count = result.rows.len();
             if row_count == 0 {
                 ("pass".to_string(), None)
@@ -342,6 +352,7 @@ fn interpret_result(
                     TestType::Unique => "duplicate value(s)",
                     TestType::AcceptedValues { .. } => "unexpected value(s)",
                     TestType::Relationships { .. } => "orphaned row(s)",
+                    TestType::Composite { .. } => "duplicate key(s)",
                     _ => unreachable!(),
                 };
                 (
@@ -400,5 +411,9 @@ fn test_type_label(tt: &TestType) -> &'static str {
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
         TestType::RegexMatch { .. } => "regex_match",
+        TestType::Aggregate { .. } => "aggregate",
+        TestType::Composite { .. } => "composite",
+        TestType::NotInFuture => "not_in_future",
+        TestType::OlderThanNDays { .. } => "older_than_n_days",
     }
 }

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -403,6 +403,10 @@ fn test_type_label(test_type: &crate::tests::TestType) -> String {
         crate::tests::TestType::RowCountRange { .. } => "row_count_range".into(),
         crate::tests::TestType::InRange { .. } => "in_range".into(),
         crate::tests::TestType::RegexMatch { .. } => "regex_match".into(),
+        crate::tests::TestType::Aggregate { .. } => "aggregate".into(),
+        crate::tests::TestType::Composite { .. } => "composite".into(),
+        crate::tests::TestType::NotInFuture => "not_in_future".into(),
+        crate::tests::TestType::OlderThanNDays { .. } => "older_than_n_days".into(),
     }
 }
 

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -215,9 +215,10 @@ struct LabeledPredicate {
 
 /// Whether a test kind lowers cleanly to a row-level boolean predicate.
 ///
-/// `unique` / `relationships` / `row_count_range` are aggregate / set-based
-/// — they stay observational. `expression` and `regex_match` are
-/// trusted user SQL (same contract as [`crate::tests::generate_test_sql`]).
+/// `unique` / `relationships` / `row_count_range` / `aggregate` /
+/// `composite` are aggregate / set-based — they stay observational.
+/// `expression` and `regex_match` are trusted user SQL (same contract as
+/// [`crate::tests::generate_test_sql`]).
 pub fn is_quarantinable(test_type: &TestType) -> bool {
     matches!(
         test_type,
@@ -226,6 +227,8 @@ pub fn is_quarantinable(test_type: &TestType) -> bool {
             | TestType::Expression { .. }
             | TestType::InRange { .. }
             | TestType::RegexMatch { .. }
+            | TestType::NotInFuture
+            | TestType::OlderThanNDays { .. }
     )
 }
 
@@ -273,6 +276,10 @@ fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
         TestType::RegexMatch { .. } => "regex_match",
+        TestType::Aggregate { .. } => "aggregate",
+        TestType::Composite { .. } => "composite",
+        TestType::NotInFuture => "not_in_future",
+        TestType::OlderThanNDays { .. } => "older_than_n_days",
     };
     match column {
         Some(c) if validation::validate_identifier(c).is_ok() => format!("{kind}_{c}"),
@@ -361,10 +368,31 @@ fn lower_valid_predicate(
             // NULL-permissive: (col IS NULL OR <match>)
             Ok(format!("({col} IS NULL OR {match_pred})"))
         }
-        // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
-        TestType::Unique | TestType::Relationships { .. } | TestType::RowCountRange { .. } => {
-            Err(QuarantineError::EmptyExpression)
+        TestType::NotInFuture => {
+            let col = required_column(column, label)?;
+            validation::validate_identifier(col)?;
+            let now = dialect.current_timestamp_expr();
+            // NULL-permissive: (col IS NULL OR col <= <now>)
+            Ok(format!("({col} IS NULL OR {col} <= {now})"))
         }
+        TestType::OlderThanNDays { days } => {
+            let col = required_column(column, label)?;
+            validation::validate_identifier(col)?;
+            if *days == 0 {
+                return Err(QuarantineError::InvalidInRangeBound { value: "0".into() });
+            }
+            let bound = dialect
+                .date_minus_days_expr(*days)
+                .map_err(QuarantineError::from)?;
+            // NULL-permissive: (col IS NULL OR col <= <N days ago>)
+            Ok(format!("({col} IS NULL OR {col} <= ({bound}))"))
+        }
+        // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
+        TestType::Unique
+        | TestType::Relationships { .. }
+        | TestType::RowCountRange { .. }
+        | TestType::Aggregate { .. }
+        | TestType::Composite { .. } => Err(QuarantineError::EmptyExpression),
     }
 }
 

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -43,6 +43,21 @@ pub enum TestGenError {
 
     #[error("regex_match test is not supported by this adapter: {0}")]
     RegexNotSupported(String),
+
+    #[error("aggregate test op '{op}' requires a 'column' (not needed only for 'count')")]
+    AggregateMissingColumn { op: String },
+
+    #[error("aggregate test 'value' '{value}' must parse as a number")]
+    InvalidAggregateValue { value: String },
+
+    #[error("composite test requires at least two columns in 'columns'")]
+    CompositeTooFewColumns,
+
+    #[error("time_window 'older_than_n_days' requires a 'days' field")]
+    TimeWindowMissingDays,
+
+    #[error("time_window test is not supported by this adapter: {0}")]
+    TimeWindowNotSupported(String),
 }
 
 /// Severity of a test failure.
@@ -119,6 +134,127 @@ pub enum TestType {
         /// portable subset (character classes, anchors, quantifiers).
         pattern: String,
     },
+    /// Assert that an aggregate (`sum`, `count`, `avg`, `min`, `max`) of
+    /// a column satisfies a comparison against a numeric threshold. The
+    /// comparison is what **passes** — e.g. `op = "sum", cmp = "gt",
+    /// value = "0"` means "sum(col) > 0 passes; otherwise fails".
+    ///
+    /// Table-level; not quarantinable. Use `count` (no column) for the
+    /// row-count-based variants that `row_count_range` can't express
+    /// (equality, strict inequalities).
+    Aggregate {
+        /// Aggregate operator.
+        op: AggregateOp,
+        /// Comparison between `op(column)` and `value`. The check passes
+        /// when the comparison is true.
+        cmp: AggregateCmp,
+        /// Threshold to compare against. Parsed as `f64`.
+        value: String,
+    },
+    /// Assert that a combination of columns is unique across all rows.
+    /// Extends [`TestType::Unique`] to composite keys.
+    ///
+    /// Set-based; not quarantinable.
+    Composite {
+        /// The kind of composite assertion. Currently `unique` only —
+        /// kept as an enum to leave room for `not_null_any` /
+        /// `not_null_all` in a later phase without another TestType.
+        kind: CompositeKind,
+        /// Columns that together form the key. Must have at least two
+        /// entries (single-column uniqueness is covered by `Unique`).
+        columns: Vec<String>,
+    },
+    /// First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp
+    /// in the future. Row-level; quarantinable (NULL column values pass).
+    NotInFuture,
+    /// First-class sugar for `col <= CURRENT_DATE - N days` — every row's
+    /// timestamp must be at least `days` days old. Row-level;
+    /// quarantinable (NULL column values pass). Dialect-specific: uses
+    /// [`SqlDialect::date_minus_days_expr`].
+    OlderThanNDays {
+        /// N — days in the past. Must be > 0.
+        days: u32,
+    },
+}
+
+/// Aggregate operator used by [`TestType::Aggregate`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateOp {
+    /// `SUM(column)` — column required.
+    Sum,
+    /// `COUNT(*)` — column ignored.
+    Count,
+    /// `AVG(column)` — column required.
+    Avg,
+    /// `MIN(column)` — column required.
+    Min,
+    /// `MAX(column)` — column required.
+    Max,
+}
+
+impl AggregateOp {
+    fn sql(&self, column: Option<&str>) -> Result<String, TestGenError> {
+        match self {
+            AggregateOp::Count => Ok("COUNT(*)".to_string()),
+            other => {
+                let col = column.ok_or_else(|| TestGenError::AggregateMissingColumn {
+                    op: format!("{other:?}").to_lowercase(),
+                })?;
+                validation::validate_identifier(col)?;
+                let name = match other {
+                    AggregateOp::Sum => "SUM",
+                    AggregateOp::Avg => "AVG",
+                    AggregateOp::Min => "MIN",
+                    AggregateOp::Max => "MAX",
+                    AggregateOp::Count => unreachable!(),
+                };
+                Ok(format!("{name}({col})"))
+            }
+        }
+    }
+}
+
+/// Comparison operator used by [`TestType::Aggregate`].
+///
+/// Deserialized from the tokens `"lt"`, `"lte"`, `"gt"`, `"gte"`, `"eq"`,
+/// `"ne"` (and their symbolic aliases `"<"`, `"<="`, `">"`, `">="`,
+/// `"=="`, `"!="`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub enum AggregateCmp {
+    #[serde(rename = "lt", alias = "<")]
+    Lt,
+    #[serde(rename = "lte", alias = "<=")]
+    Lte,
+    #[serde(rename = "gt", alias = ">")]
+    Gt,
+    #[serde(rename = "gte", alias = ">=")]
+    Gte,
+    #[serde(rename = "eq", alias = "==")]
+    Eq,
+    #[serde(rename = "ne", alias = "!=")]
+    Ne,
+}
+
+impl AggregateCmp {
+    fn sql(&self) -> &'static str {
+        match self {
+            AggregateCmp::Lt => "<",
+            AggregateCmp::Lte => "<=",
+            AggregateCmp::Gt => ">",
+            AggregateCmp::Gte => ">=",
+            AggregateCmp::Eq => "=",
+            AggregateCmp::Ne => "<>",
+        }
+    }
+}
+
+/// Kind of composite (multi-column) assertion.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompositeKind {
+    /// `(col1, col2, ...)` is unique across all rows.
+    Unique,
 }
 
 /// A single declarative test declared in a model sidecar TOML.
@@ -319,6 +455,73 @@ fn generate_test_sql_inner(
                 .map_err(|e| TestGenError::RegexNotSupported(e.to_string()))?;
             Ok(format!(
                 "SELECT COUNT(*) FROM {table} WHERE {}NOT ({match_pred})",
+                filter_and(filter),
+            ))
+        }
+        TestType::Aggregate { op, cmp, value } => {
+            // Validate the threshold parses as a number; emit as SQL literal.
+            let n = value
+                .parse::<f64>()
+                .map_err(|_| TestGenError::InvalidAggregateValue {
+                    value: value.clone(),
+                })?;
+            let op_sql = op.sql(test.column.as_deref())?;
+            let cmp_sql = cmp.sql();
+            let lit = format_numeric(n);
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
+            // Return a single cell: 0 when the aggregate *passes* (cmp
+            // holds), 1 otherwise. The caller treats 0 as pass, >0 as fail.
+            Ok(format!(
+                "SELECT CASE WHEN {op_sql} {cmp_sql} {lit} THEN 0 ELSE 1 END FROM {table}{where_clause}"
+            ))
+        }
+        TestType::Composite { kind, columns } => {
+            if columns.len() < 2 {
+                return Err(TestGenError::CompositeTooFewColumns);
+            }
+            for col in columns {
+                validation::validate_identifier(col)?;
+            }
+            let cols = columns.join(", ");
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
+            match kind {
+                CompositeKind::Unique => Ok(format!(
+                    "SELECT {cols}, COUNT(*) FROM {table}{where_clause} GROUP BY {cols} HAVING COUNT(*) > 1"
+                )),
+            }
+        }
+        TestType::NotInFuture => {
+            let col = require_column(test, "not_in_future")?;
+            validation::validate_identifier(col)?;
+            let dialect = dialect.ok_or_else(|| {
+                TestGenError::TimeWindowNotSupported(
+                    "use generate_test_sql_with_dialect for not_in_future".into(),
+                )
+            })?;
+            let now = dialect.current_timestamp_expr();
+            // Failing rows: timestamp strictly in the future.
+            Ok(format!(
+                "SELECT COUNT(*) FROM {table} WHERE {}{col} > {now}",
+                filter_and(filter),
+            ))
+        }
+        TestType::OlderThanNDays { days } => {
+            if *days == 0 {
+                return Err(TestGenError::TimeWindowMissingDays);
+            }
+            let col = require_column(test, "older_than_n_days")?;
+            validation::validate_identifier(col)?;
+            let dialect = dialect.ok_or_else(|| {
+                TestGenError::TimeWindowNotSupported(
+                    "use generate_test_sql_with_dialect for older_than_n_days".into(),
+                )
+            })?;
+            let bound = dialect
+                .date_minus_days_expr(*days)
+                .map_err(|e| TestGenError::TimeWindowNotSupported(e.to_string()))?;
+            // Failing rows: timestamp more recent than the bound.
+            Ok(format!(
+                "SELECT COUNT(*) FROM {table} WHERE {}{col} > ({bound})",
                 filter_and(filter),
             ))
         }
@@ -1036,5 +1239,188 @@ pattern = "^[a-z]+@example\\.com$"
         };
         let sql = generate_test_sql(&decl, "t").unwrap();
         assert_eq!(sql, "SELECT COUNT(*) FROM t WHERE id IS NULL");
+    }
+
+    // ----- Phase 4b: Aggregate -----
+
+    #[test]
+    fn test_aggregate_sum_gt() {
+        let decl = TestDecl {
+            test_type: TestType::Aggregate {
+                op: AggregateOp::Sum,
+                cmp: AggregateCmp::Gt,
+                value: "0".into(),
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT CASE WHEN SUM(amount) > 0 THEN 0 ELSE 1 END FROM orders"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_count_no_column() {
+        let decl = TestDecl {
+            test_type: TestType::Aggregate {
+                op: AggregateOp::Count,
+                cmp: AggregateCmp::Gte,
+                value: "10".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT CASE WHEN COUNT(*) >= 10 THEN 0 ELSE 1 END FROM orders"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_avg_with_filter() {
+        let decl = TestDecl {
+            test_type: TestType::Aggregate {
+                op: AggregateOp::Avg,
+                cmp: AggregateCmp::Lte,
+                value: "100".into(),
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Warning,
+            filter: Some("status = 'shipped'".into()),
+        };
+        let sql = generate_test_sql(&decl, "orders").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT CASE WHEN AVG(amount) <= 100 THEN 0 ELSE 1 END FROM orders WHERE (status = 'shipped')"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_rejects_non_numeric_value() {
+        let decl = TestDecl {
+            test_type: TestType::Aggregate {
+                op: AggregateOp::Sum,
+                cmp: AggregateCmp::Gt,
+                value: "hello".into(),
+            },
+            column: Some("amount".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("must parse as a number"));
+    }
+
+    #[test]
+    fn test_aggregate_sum_requires_column() {
+        let decl = TestDecl {
+            test_type: TestType::Aggregate {
+                op: AggregateOp::Sum,
+                cmp: AggregateCmp::Gt,
+                value: "0".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("requires a 'column'"));
+    }
+
+    #[test]
+    fn test_aggregate_cmp_symbolic_aliases() {
+        let toml_str = r#"
+type = "aggregate"
+op = "sum"
+column = "amount"
+cmp = ">="
+value = "0"
+"#;
+        let decl: TestDecl = toml::from_str(toml_str).unwrap();
+        if let TestType::Aggregate { cmp, .. } = &decl.test_type {
+            assert_eq!(*cmp, AggregateCmp::Gte);
+        } else {
+            panic!("expected Aggregate");
+        }
+    }
+
+    // ----- Phase 4b: Composite -----
+
+    #[test]
+    fn test_composite_unique_two_columns() {
+        let decl = TestDecl {
+            test_type: TestType::Composite {
+                kind: CompositeKind::Unique,
+                columns: vec!["order_id".into(), "line_item_id".into()],
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "order_lines").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT order_id, line_item_id, COUNT(*) FROM order_lines GROUP BY order_id, line_item_id HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_composite_rejects_single_column() {
+        let decl = TestDecl {
+            test_type: TestType::Composite {
+                kind: CompositeKind::Unique,
+                columns: vec!["order_id".into()],
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("at least two columns"));
+    }
+
+    // ----- Phase 4b: TimeWindow -----
+
+    #[test]
+    fn test_not_in_future_needs_dialect() {
+        // Plain `generate_test_sql` errors on NotInFuture — it needs a
+        // dialect to emit the correct CURRENT_TIMESTAMP form.
+        let decl = TestDecl {
+            test_type: TestType::NotInFuture,
+            column: Some("created_at".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn test_older_than_n_days_needs_dialect() {
+        let decl = TestDecl {
+            test_type: TestType::OlderThanNDays { days: 30 },
+            column: Some("created_at".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("not supported"));
+    }
+
+    #[test]
+    fn test_older_than_n_days_rejects_zero() {
+        let decl = TestDecl {
+            test_type: TestType::OlderThanNDays { days: 0 },
+            column: Some("created_at".into()),
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let err = generate_test_sql(&decl, "t").unwrap_err();
+        assert!(err.to_string().contains("requires a 'days' field"));
     }
 }

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -311,6 +311,26 @@ pub trait SqlDialect: Send + Sync {
             "regex_match not supported by this dialect",
         ))
     }
+
+    /// Build a dialect-specific SQL expression equivalent to
+    /// `CURRENT_DATE - N days`. Used by `TestType::OlderThanNDays`
+    /// (Phase 4b). The default impl uses the ANSI
+    /// `CURRENT_DATE - INTERVAL 'N' DAY` form, which works for
+    /// Databricks, Snowflake, and DuckDB. BigQuery overrides because
+    /// it requires `DATE_SUB(CURRENT_DATE(), INTERVAL N DAY)`.
+    fn date_minus_days_expr(&self, days: u32) -> AdapterResult<String> {
+        Ok(format!("CURRENT_DATE - INTERVAL '{days}' DAY"))
+    }
+
+    /// SQL expression returning the current timestamp. Used by
+    /// `TestType::NotInFuture` (Phase 4b).
+    ///
+    /// Default: `CURRENT_TIMESTAMP` (ANSI keyword, no parens). Works for
+    /// Databricks, Snowflake, DuckDB. BigQuery overrides to
+    /// `CURRENT_TIMESTAMP()` because it requires the function form.
+    fn current_timestamp_expr(&self) -> &'static str {
+        "CURRENT_TIMESTAMP"
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -619,6 +619,10 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
         TestType::RegexMatch { .. } => "regex_match",
+        TestType::Aggregate { .. } => "aggregate",
+        TestType::Composite { .. } => "composite",
+        TestType::NotInFuture => "not_in_future",
+        TestType::OlderThanNDays { .. } => "older_than_n_days",
     };
 
     match &test.column {

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -128,3 +128,37 @@ type     = "not_null"
 column   = "customer_id"
 filter   = "status = 'shipped'"
 severity = "warning"
+
+# --- Phase 4b: aggregate + composite unique + time_window ---
+
+# aggregate — sum(amount) must be > 0. Passes because positive amounts
+# dominate (the single row with amount = -5 doesn't flip the sign).
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_positive_total"
+table    = "orders"
+type     = "aggregate"
+op       = "sum"
+column   = "amount"
+cmp      = ">"
+value    = "0"
+severity = "warning"
+
+# composite unique — (order_id, customer_id) pair. order_id is already
+# globally unique so this passes trivially; real configs pair keys that
+# aren't individually unique (e.g. `["order_id", "line_item_id"]`).
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_composite_unique"
+table    = "orders"
+type     = "composite"
+kind     = "unique"
+columns  = ["order_id", "customer_id"]
+severity = "warning"
+
+# not_in_future — created_at must not be in the future. Seed generates
+# timestamps around 2026-04-01; all should pass.
+[[pipeline.nightly_dq.checks.assertions]]
+name     = "orders_created_at_not_in_future"
+table    = "orders"
+type     = "not_in_future"
+column   = "created_at"
+severity = "error"


### PR DESCRIPTION
## Summary

Closes the DQX row/aggregate check catalog with three new `TestType` variants:

1. **`Aggregate { op, cmp, value }`** — table-level `SUM` / `COUNT(*)` / `AVG` / `MIN` / `MAX` with a comparison threshold. Not quarantinable (table-scoped).
2. **`Composite { kind: "unique", columns }`** — multi-column uniqueness; extends the existing `Unique`. Not quarantinable (set-based).
3. **`NotInFuture`** + **`OlderThanNDays { days }`** — first-class sugar for `col <= CURRENT_TIMESTAMP` and `col <= CURRENT_DATE - N days`. Row-level, NULL-permissive, quarantinable.

All three honor the Phase 4a per-check `filter` predicate and integrate cleanly with the Phase 3 quarantine pipeline (time-window kinds lower into the `__valid`/`__quarantine` split; aggregate + composite stay observational by design).

## Design notes

- **`Aggregate` accepts both token forms for `cmp`** — snake_case (`"lt"`, `"gte"`, `"eq"`, …) and symbolic aliases (`"<"`, `">="`, `"=="`, …). Both deserialize to the same variant.
- **`Composite` requires at least two columns** — single-column uniqueness stays on the existing `Unique` kind.
- **Time-window predicates use two new `SqlDialect` trait methods with ANSI default impls**:
  - `current_timestamp_expr()` — default `CURRENT_TIMESTAMP` (works for Databricks, Snowflake, DuckDB); BigQuery overrides to `CURRENT_TIMESTAMP()`.
  - `date_minus_days_expr(days)` — default `CURRENT_DATE - INTERVAL 'N' DAY`; BigQuery overrides to `DATE_SUB(CURRENT_DATE(), INTERVAL N DAY)`.
- **Discovered during POC verification:** DuckDB rejects `CURRENT_TIMESTAMP()` with parens. Default impl on the trait uses the no-parens ANSI form; BigQuery override supplies the function form. Caught by the POC run; not by the unit tests (which used a fake dialect).

## Test plan

- [x] 14 new unit tests covering: aggregate SQL shape for sum/count/avg, filter wrapping, non-numeric value rejection, missing-column rejection, symbolic cmp aliases, composite unique two-column, single-column rejection, not_in_future dialect requirement, older_than_n_days zero-days rejection
- [x] `cargo test -p rocky-core --lib` — 920/920 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just codegen` — idempotent (no output-schema change)
- [x] `just regen-fixtures` — no drift
- [x] POC `06-quality-pipeline-standalone` extended with aggregate + composite unique + not_in_future assertions; 14 checks, 196 valid + 4 quarantined on DuckDB

## Follow-up

Phase 4 is now complete (4a + 4b). Remaining DQX parity items (Phase 5 profile + ai-suggest; Phase 6 UC tag writeback) are deferred / demand-gated per the backlog.