### PR TITLE
feat(engine/rocky-core): advisory file lock on state store

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1301,6 +1301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3432,7 @@ dependencies = [
  "bytes",
  "chrono",
  "csv",
+ "fs4",
  "futures",
  "hmac",
  "indexmap",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -65,6 +65,8 @@ sqlparser = { version = "0.61", features = ["visitor"] }
 
 # State store
 redb = "2"
+# Advisory file lock for single-writer enforcement on state DB
+fs4 = "0.13"
 
 # Logging
 tracing = "0.1"

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -69,7 +69,7 @@ pub async fn doctor(
     // 2. State store
     if should_run("state", check_filter) {
         let start = Instant::now();
-        match rocky_core::state::StateStore::open(state_path) {
+        match rocky_core::state::StateStore::open_read_only(state_path) {
             Ok(store) => {
                 // Try reading watermarks to verify the DB is healthy
                 match store.list_watermarks() {

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -21,7 +21,7 @@ pub fn run_history(
     since: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
-    let store = StateStore::open(state_path)?;
+    let store = StateStore::open_read_only(state_path)?;
 
     let since_ts: Option<DateTime<Utc>> = since
         .map(|s| {

--- a/engine/crates/rocky-cli/src/commands/metrics.rs
+++ b/engine/crates/rocky-cli/src/commands/metrics.rs
@@ -22,7 +22,7 @@ pub fn run_metrics(
     alerts: bool,
     output_json: bool,
 ) -> Result<()> {
-    let store = StateStore::open(state_path)?;
+    let store = StateStore::open_read_only(state_path)?;
 
     let snapshots = store.get_quality_trend(model_name, if trend { 20 } else { 1 })?;
 

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -19,7 +19,7 @@ pub fn run_optimize(
     model_filter: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
-    let store = StateStore::open(state_path)?;
+    let store = StateStore::open_read_only(state_path)?;
     let config = CostConfig::default();
 
     // Get all runs to extract model names and compute stats

--- a/engine/crates/rocky-cli/src/commands/state.rs
+++ b/engine/crates/rocky-cli/src/commands/state.rs
@@ -8,7 +8,7 @@ use crate::output::*;
 
 /// Execute `rocky state show`.
 pub fn state_show(state_path: &Path, output_json: bool) -> Result<()> {
-    let store = StateStore::open(state_path).context(format!(
+    let store = StateStore::open_read_only(state_path).context(format!(
         "failed to open state store at {}",
         state_path.display()
     ))?;

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 redb = { workspace = true }
+fs4 = { workspace = true }
 redis = { workspace = true }
 regex = { workspace = true }
 csv = { workspace = true }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1,5 +1,7 @@
+use std::fs::File;
 use std::path::Path;
 
+use fs4::fs_std::FileExt;
 use redb::{Database, ReadableTable, TableDefinition};
 use thiserror::Error;
 
@@ -77,6 +79,19 @@ pub enum StateError {
 
     #[error("state schema version is corrupt: expected an integer, found {0:?}")]
     VersionParse(String),
+
+    #[error(
+        "state store at {path} is locked by another process; only one rocky writer \
+         can run at a time against the same state file"
+    )]
+    LockHeldByOther { path: String },
+
+    #[error("i/o error opening state lock file at {path}: {source}")]
+    LockIo {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 impl From<redb::TransactionError> for StateError {
@@ -88,10 +103,22 @@ impl From<redb::TransactionError> for StateError {
 /// Embedded state store backed by redb for tracking watermarks and run history.
 pub struct StateStore {
     db: Database,
+    // Held exclusive advisory lock on `<path>.lock`. `None` for read-only opens.
+    // Released automatically when the `File` is dropped.
+    _lock_file: Option<File>,
 }
 
 impl StateStore {
-    /// Opens or creates a state store at the given path.
+    /// Opens or creates a state store at the given path for **writing**.
+    ///
+    /// Takes an exclusive advisory lock on `<path>.lock`. If another process
+    /// already holds the lock the call fails with
+    /// [`StateError::LockHeldByOther`] — this guarantees only one writer can
+    /// mutate the state file at a time, which prevents the silent-corruption
+    /// race where two `rocky run` processes interleave writes.
+    ///
+    /// Use [`StateStore::open_read_only`] for inspection commands that must not
+    /// contend with a concurrent writer.
     ///
     /// On first open the schema version is written to the `metadata` table.
     /// On subsequent opens the stored version is compared to
@@ -99,6 +126,50 @@ impl StateStore {
     /// binary (stored > current) an error is returned immediately so that the
     /// caller can surface a clear message rather than silently misreading data.
     pub fn open(path: &Path) -> Result<Self, StateError> {
+        Self::open_inner(path, true)
+    }
+
+    /// Opens an existing state store for **read-only** access.
+    ///
+    /// Does NOT take the advisory write lock — multiple readers (and one
+    /// concurrent writer) can safely call this at the same time. Redb's own
+    /// MVCC guarantees consistent reads. Use this for inspection commands
+    /// (`rocky state`, `rocky history`, `rocky doctor`, `rocky metrics`,
+    /// `rocky optimize`, server APIs) so they don't block a live `rocky run`.
+    pub fn open_read_only(path: &Path) -> Result<Self, StateError> {
+        Self::open_inner(path, false)
+    }
+
+    fn open_inner(path: &Path, lock: bool) -> Result<Self, StateError> {
+        // Acquire the advisory lock BEFORE opening the database — otherwise two
+        // concurrent writers could both pass `Database::create` before either
+        // of them reaches the lock check.
+        let lock_file = if lock {
+            let lock_path = path.with_extension("redb.lock");
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(|e| StateError::LockIo {
+                    path: lock_path.display().to_string(),
+                    source: e,
+                })?;
+            FileExt::try_lock_exclusive(&file)
+                .map_err(|e| StateError::LockIo {
+                    path: lock_path.display().to_string(),
+                    source: e,
+                })?
+                .then_some(())
+                .ok_or_else(|| StateError::LockHeldByOther {
+                    path: path.display().to_string(),
+                })?;
+            Some(file)
+        } else {
+            None
+        };
+
         let db = Database::create(path)?;
 
         // Single write transaction: check/write schema version AND ensure all
@@ -151,7 +222,10 @@ impl StateStore {
         }
         txn.commit()?;
 
-        Ok(StateStore { db })
+        Ok(StateStore {
+            db,
+            _lock_file: lock_file,
+        })
     }
 
     /// Gets the watermark for a table (keyed by `catalog.schema.table`).

--- a/engine/crates/rocky-core/tests/state_lock.rs
+++ b/engine/crates/rocky-core/tests/state_lock.rs
@@ -1,0 +1,95 @@
+//! Advisory file-lock semantics on `StateStore`.
+//!
+//! Verifies the single-writer invariant introduced to prevent two concurrent
+//! `rocky run` processes from silently corrupting a shared state file.
+//!
+//! redb itself prevents two `Database` handles on the same file within a
+//! single process (`DatabaseAlreadyOpen`). The advisory `fs4` lock layered on
+//! top is what catches the cross-process race that matters in production.
+//! We simulate "another process" here by acquiring the fs4 lock directly on
+//! `<path>.redb.lock` — this is exactly what a second `rocky run` on a
+//! different machine-OS-process would do.
+
+use std::fs::OpenOptions;
+
+use fs4::fs_std::FileExt;
+use rocky_core::state::{StateError, StateStore};
+use tempfile::TempDir;
+
+#[test]
+fn second_writer_fails_when_lock_held_externally() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.redb");
+    let lock_path = path.with_extension("redb.lock");
+
+    // Simulate another process: hold the advisory lock on the .lock file
+    // directly, without opening the redb database at all.
+    let external_lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap();
+    let acquired = FileExt::try_lock_exclusive(&external_lock).unwrap();
+    assert!(acquired, "external lock should be acquired in a clean temp dir");
+
+    match StateStore::open(&path) {
+        Err(StateError::LockHeldByOther { .. }) => {}
+        Err(other) => panic!("expected LockHeldByOther, got {other:?}"),
+        Ok(_) => panic!("open should fail while external lock is held"),
+    }
+}
+
+#[test]
+fn lock_released_on_drop() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.redb");
+
+    let first = StateStore::open(&path).expect("first open should succeed");
+    drop(first);
+
+    // Acquiring the lock externally after drop must succeed, proving the
+    // write lock was released.
+    let lock_path = path.with_extension("redb.lock");
+    let external_lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap();
+    let acquired = FileExt::try_lock_exclusive(&external_lock).unwrap();
+    assert!(
+        acquired,
+        "advisory lock should be free after the StateStore was dropped"
+    );
+}
+
+#[test]
+fn open_read_only_ignores_write_lock() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.redb");
+
+    // Initialise the database once (writer), then drop so redb releases its
+    // in-process handle. The on-disk file and the .lock file both remain.
+    drop(StateStore::open(&path).expect("initial writer open"));
+
+    // Now simulate another process holding the write lock.
+    let lock_path = path.with_extension("redb.lock");
+    let external_lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap();
+    let acquired = FileExt::try_lock_exclusive(&external_lock).unwrap();
+    assert!(acquired);
+
+    // A read-only open must still succeed despite the external write lock:
+    // inspection commands (`rocky state`, `rocky history`, ...) should never
+    // be blocked by a live `rocky run`.
+    let _reader = StateStore::open_read_only(&path)
+        .expect("read-only open should not be blocked by the advisory lock");
+}

--- a/engine/crates/rocky-server/src/api.rs
+++ b/engine/crates/rocky-server/src/api.rs
@@ -232,7 +232,7 @@ async fn list_runs(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let state_path = state.models_dir.join(".rocky-state.redb");
-    let store = rocky_core::state::StateStore::open(&state_path)
+    let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let runs = store
         .list_runs(50)
@@ -263,7 +263,7 @@ async fn model_history(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let state_path = state.models_dir.join(".rocky-state.redb");
-    let store = rocky_core::state::StateStore::open(&state_path)
+    let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let history = store
         .get_model_history(&name, 50)
@@ -296,7 +296,7 @@ async fn model_metrics(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let state_path = state.models_dir.join(".rocky-state.redb");
-    let store = rocky_core::state::StateStore::open(&state_path)
+    let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let snapshots = store
         .get_quality_trend(&name, 20)

--- a/engine/crates/rocky-server/src/dashboard.rs
+++ b/engine/crates/rocky-server/src/dashboard.rs
@@ -115,7 +115,7 @@ async fn gather_project_info(state: &ServerState) -> ProjectInfo {
     let last_run = {
         let state_path = state.models_dir.join(".rocky-state.redb");
         if state_path.exists() {
-            rocky_core::state::StateStore::open(&state_path)
+            rocky_core::state::StateStore::open_read_only(&state_path)
                 .ok()
                 .and_then(|store| store.list_runs(1).ok())
                 .and_then(|runs| runs.into_iter().next())


### PR DESCRIPTION
## Summary

- Adds an exclusive cross-process advisory lock on `<state>.redb.lock` via `fs4` so two concurrent `rocky run` processes against the same state file can't silently interleave writes.
- New `StateStore::open_read_only` for inspection commands (`rocky state`, `history`, `metrics`, `optimize`, `doctor`, server APIs) — skips the lock so readers never block a live writer. redb's MVCC handles reader/writer correctness.
- Writers (`run`, `load`, `run_local`) keep `StateStore::open`.

## Behaviour

| Caller                              | Method                 | Lock |
|-------------------------------------|------------------------|:----:|
| `rocky run` / `rocky load` / etc.   | `open`                 | ✅   |
| `rocky state` / `history` / `metrics` / `optimize` / `doctor` | `open_read_only` | ❌ |
| server APIs (`api.rs`, `dashboard.rs`) | `open_read_only`    | ❌   |

A second writer against the same state path fails fast with a clear `StateError::LockHeldByOther { path }` instead of producing silent corruption or a cryptic redb storage error.

## Test plan

- [x] `cargo test -p rocky-core --test state_lock` — 3 new integration tests cover: second writer rejection, drop releases the lock, read-only ignores the write lock.
- [x] `cargo test -p rocky-core` — all pre-existing tests still pass (temp-dir fixtures use distinct lock paths).
- [x] `cargo test -p rocky-cli` — 141/141 pass.
- [x] `cargo check --workspace` clean.
- [x] `cargo clippy -p rocky-core -p rocky-cli -p rocky-server` clean.
- [ ] Manual: run two `rocky run` processes against the same state path — second fails fast with `LockHeldByOther`.
- [ ] Manual: `rocky state show` / `rocky history` works while a writer holds the lock.