### PR TITLE
feat(engine/rocky-core): parallel within-layer DAG execution

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "criterion",
  "csv",
  "futures",
  "hmac",

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -423,7 +423,11 @@ pub async fn run(
     // Governance operations route through the GovernanceAdapter trait
     // (Plan 01: genericize run.rs). Catalog/schema creation uses
     // SqlDialect + WarehouseAdapter for SQL generation + execution.
-    let _governance_span = info_span!("governance_setup").entered();
+    // Span kept as a declaration only; `.entered()` would hold an
+    // `EnteredSpan` (!Send) across the awaits below and break the DAG
+    // executor's per-layer parallelism. Tracing events below remain at the
+    // subscriber's root context — acceptable for a setup block.
+    let _governance_span = info_span!("governance_setup");
     {
         let dialect = warehouse_adapter.dialect();
 
@@ -765,8 +769,6 @@ pub async fn run(
             }
         }
     }
-    drop(_governance_span);
-
     // --- Checkpoint / resume: filter already-completed tables ---
     let run_id = format!("run-{}", Utc::now().format("%Y%m%d-%H%M%S-%3f"));
 
@@ -1325,7 +1327,8 @@ pub async fn run(
         .map(tokio::sync::Mutex::into_inner);
 
     // --- Batched checks ---
-    let _checks_span = info_span!("batched_checks").entered();
+    // See the `_governance_span` note above — same reason.
+    let _checks_span = info_span!("batched_checks");
     let checks_start = Instant::now();
 
     let row_count_enabled = pipeline.checks.row_count.enabled() && !source_batch_refs.is_empty();
@@ -1589,8 +1592,6 @@ pub async fn run(
             "batched checks complete"
         );
     }
-    drop(_checks_span);
-
     // --- Compiled model execution (--all or --models) ---
     if run_all || models_dir.is_some() {
         let mdir = models_dir.unwrap_or_else(|| std::path::Path::new("models"));

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -41,6 +41,11 @@ tokio = { workspace = true }
 # committed `rocky.toml` under `examples/playground/pocs/` passes the
 # schemars-generated AdapterConfig schema.
 jsonschema = { version = "0.30", default-features = false }
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "dag_execute"
+harness = false
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-core/benches/dag_execute.rs
+++ b/engine/crates/rocky-core/benches/dag_execute.rs
@@ -1,0 +1,96 @@
+//! Benchmark within-layer parallelism of `DagExecutor`.
+//!
+//! Builds a wide DAG (1 source → 50 independent transformations → 1 quality
+//! sink). Each transformation sleeps for 10 ms, simulating a real warehouse
+//! round-trip. With `max_concurrency = Some(1)` the layer runs sequentially
+//! (~500 ms); with the default (`Some(usize::MAX)`-ish) it should finish in
+//! ~10–20 ms — the point of this bench.
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use rocky_core::dag_executor::{DagExecutor, NodeDispatcher, NodeFuture};
+use rocky_core::unified_dag::{EdgeType, NodeId, NodeKind, UnifiedDag, UnifiedEdge, UnifiedNode};
+use tokio::runtime::Runtime;
+
+const WIDTH: usize = 50;
+const NODE_SLEEP_MS: u64 = 10;
+
+struct SleepDispatcher;
+
+impl NodeDispatcher for SleepDispatcher {
+    fn dispatch(&self, _id: &NodeId, _kind: NodeKind, _label: &str) -> Option<NodeFuture> {
+        Some(Box::pin(async move {
+            tokio::time::sleep(Duration::from_millis(NODE_SLEEP_MS)).await;
+            Ok(())
+        }))
+    }
+}
+
+fn wide_dag() -> UnifiedDag {
+    let mut nodes = Vec::with_capacity(WIDTH + 2);
+    let mut edges = Vec::with_capacity(WIDTH * 2);
+
+    nodes.push(UnifiedNode {
+        id: NodeId("source".into()),
+        kind: NodeKind::Source,
+        label: "source".into(),
+        pipeline: None,
+    });
+
+    for i in 0..WIDTH {
+        let id = format!("t{i}");
+        nodes.push(UnifiedNode {
+            id: NodeId(id.clone()),
+            kind: NodeKind::Transformation,
+            label: id.clone(),
+            pipeline: None,
+        });
+        edges.push(UnifiedEdge {
+            from: NodeId("source".into()),
+            to: NodeId(id.clone()),
+            edge_type: EdgeType::DataDependency,
+        });
+        edges.push(UnifiedEdge {
+            from: NodeId(id),
+            to: NodeId("sink".into()),
+            edge_type: EdgeType::DataDependency,
+        });
+    }
+
+    nodes.push(UnifiedNode {
+        id: NodeId("sink".into()),
+        kind: NodeKind::Quality,
+        label: "sink".into(),
+        pipeline: None,
+    });
+
+    UnifiedDag { nodes, edges }
+}
+
+fn bench_dag(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let dag = wide_dag();
+
+    let mut group = c.benchmark_group("dag_execute_wide_50");
+    group.measurement_time(Duration::from_secs(10));
+
+    for (label, concurrency) in [("sequential", Some(1)), ("parallel", None)] {
+        group.bench_with_input(BenchmarkId::from_parameter(label), &concurrency, |b, &cap| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let mut executor = DagExecutor::new(SleepDispatcher);
+                    if let Some(n) = cap {
+                        executor = executor.with_max_concurrency(n);
+                    }
+                    executor.execute(&dag).await.unwrap()
+                })
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_dag);
+criterion_main!(benches);

--- a/engine/crates/rocky-core/src/dag_executor.rs
+++ b/engine/crates/rocky-core/src/dag_executor.rs
@@ -24,17 +24,33 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+use tracing::{Instrument, info, info_span, warn};
 
 use crate::unified_dag::{NodeId, NodeKind, UnifiedDag, UnifiedDagError, execution_phases};
 
-/// A boxed future returning the outcome of a single node execution.
+/// Task output carried across the `JoinSet` boundary: everything the
+/// aggregation loop needs to build a [`NodeResult`] plus the node's `NodeId`
+/// so we can update `failed_nodes` in the parent task (not inside the
+/// concurrent children).
+type NodeTaskOutput = (
+    NodeId,
+    String,         // id string
+    String,         // kind string
+    String,         // label
+    NodeStatus,
+    u64,            // duration_ms
+    Option<String>, // error
+);
+
+/// A boxed, `Send`-safe future returning the outcome of a single node execution.
 ///
-/// Not required to be `Send` — within a layer, nodes are awaited sequentially
-/// on the current task. This lets node implementations use `!Send` types (such
-/// as `tracing`'s `EnteredSpan`) without having to refactor for cross-thread
-/// safety. Layer-level dependency ordering is preserved.
-pub type NodeFuture = Pin<Box<dyn Future<Output = Result<(), String>>>>;
+/// Must be `Send` so the DAG executor can drive nodes concurrently within a
+/// layer via [`tokio::task::JoinSet`]. Node implementations therefore must
+/// not hold `!Send` types (e.g. `tracing::span::EnteredSpan`) across an
+/// await — use `.instrument(span)` on the future instead.
+pub type NodeFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
 
 /// Dispatcher that maps a [`NodeKind`] + node identity to an executor future.
 ///
@@ -127,9 +143,11 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
     /// Execute the entire DAG, layer by layer.
     ///
     /// Layers respect topological dependencies (Kahn's algorithm). Nodes
-    /// within a layer run sequentially on the current task — within-layer
-    /// parallelism is a future enhancement (blocked on making per-node
-    /// executors `Send`-safe; tracing spans currently aren't).
+    /// within a single layer are dispatched concurrently via
+    /// [`tokio::task::JoinSet`], bounded by `max_concurrency`
+    /// (`usize::MAX` if unset). Kahn's layering guarantees no intra-layer
+    /// dependencies, so the `failed_nodes` snapshot captured on layer entry
+    /// is correct for the whole layer's skip decisions.
     pub async fn execute(&self, dag: &UnifiedDag) -> Result<DagExecutionResult, DagExecutorError> {
         let start = Instant::now();
         let layers = execution_phases(dag)?;
@@ -139,6 +157,15 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
         let mut results: Vec<NodeResult> = Vec::new();
         let ancestors = build_ancestor_map(dag);
 
+        // `tokio::sync::Semaphore::new` rejects more permits than
+        // `Semaphore::MAX_PERMITS` (~2^61), so saturate at that cap when the
+        // caller hasn't pinned a concurrency ceiling.
+        let permits = self
+            .max_concurrency
+            .unwrap_or(Semaphore::MAX_PERMITS)
+            .min(Semaphore::MAX_PERMITS);
+        let semaphore = Arc::new(Semaphore::new(permits));
+
         for (layer_idx, layer_nodes) in layers.iter().enumerate() {
             info!(
                 layer = layer_idx,
@@ -146,15 +173,20 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
                 "executing DAG layer"
             );
 
+            // Snapshot failed set at layer entry so every node in this layer
+            // makes the same skip decision — Kahn's layering guarantees there
+            // are no dependencies between nodes within a single layer.
+            let failed_snapshot = failed_nodes.clone();
+
+            let mut join_set: JoinSet<NodeTaskOutput> = JoinSet::new();
+
             for node in layer_nodes {
                 let id = node.id.clone();
                 let kind = node.kind;
                 let label = node.label.clone();
 
-                // Skip if any ancestor has failed.
                 let ancestors_for_node = ancestors.get(&id).cloned().unwrap_or_default();
-                let should_skip = ancestors_for_node.iter().any(|a| failed_nodes.contains(a));
-                if should_skip {
+                if ancestors_for_node.iter().any(|a| failed_snapshot.contains(a)) {
                     warn!(node = %id, "skipping node — upstream failure");
                     results.push(NodeResult {
                         id: id.0.clone(),
@@ -168,27 +200,68 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
                     continue;
                 }
 
-                let node_start = Instant::now();
                 let dispatched = self.dispatcher.dispatch(&id, kind, &label);
-                let (status, error) = match dispatched {
-                    None => (NodeStatus::Skipped, None),
-                    Some(fut) => match fut.await {
-                        Ok(()) => (NodeStatus::Completed, None),
-                        Err(e) => {
-                            warn!(node = %id, error = %e, "node failed");
-                            failed_nodes.insert(id.clone());
-                            (NodeStatus::Failed, Some(e))
-                        }
-                    },
+                let Some(fut) = dispatched else {
+                    // Dispatcher opted out (e.g. Test nodes handled inside
+                    // their parent transformation). Mark skipped without
+                    // consuming a concurrency permit.
+                    results.push(NodeResult {
+                        id: id.0.clone(),
+                        kind: kind.to_string(),
+                        label,
+                        status: NodeStatus::Skipped,
+                        layer: layer_idx,
+                        duration_ms: 0,
+                        error: None,
+                    });
+                    continue;
                 };
 
+                let semaphore = Arc::clone(&semaphore);
+                let kind_str = kind.to_string();
+                let id_str = id.0.clone();
+                let label_for_task = label.clone();
+                let span = info_span!("dag_node", id = %id, kind = %kind);
+
+                join_set.spawn(
+                    async move {
+                        // Held for the lifetime of the node's execution;
+                        // permit is released on drop regardless of how the
+                        // future resolves.
+                        let _permit = semaphore
+                            .acquire_owned()
+                            .await
+                            .expect("dag_executor semaphore closed unexpectedly");
+                        let node_start = Instant::now();
+                        let (status, error) = match fut.await {
+                            Ok(()) => (NodeStatus::Completed, None),
+                            Err(e) => {
+                                warn!(node = %id, error = %e, "node failed");
+                                (NodeStatus::Failed, Some(e))
+                            }
+                        };
+                        let duration_ms = node_start.elapsed().as_millis() as u64;
+                        (id, id_str, kind_str, label_for_task, status, duration_ms, error)
+                    }
+                    .instrument(span),
+                );
+            }
+
+            while let Some(join_res) = join_set.join_next().await {
+                let (node_id, id_str, kind_str, label, status, duration_ms, error) = join_res
+                    .expect("dag_executor task panicked — this indicates a bug in a dispatcher");
+
+                if status == NodeStatus::Failed {
+                    failed_nodes.insert(node_id);
+                }
+
                 results.push(NodeResult {
-                    id: id.0.clone(),
-                    kind: kind.to_string(),
+                    id: id_str,
+                    kind: kind_str,
                     label,
                     status,
                     layer: layer_idx,
-                    duration_ms: node_start.elapsed().as_millis() as u64,
+                    duration_ms,
                     error,
                 });
             }


### PR DESCRIPTION
## Summary

- Replace the sequential per-node await loop in `DagExecutor::execute` with a `tokio::task::JoinSet` bounded by a `Semaphore`. Independent nodes in the same Kahn layer now run concurrently.
- **~17× speedup** on the 50-wide benchmark (615 ms → 35 ms with a 10 ms per-node sleep). Plan target was 2×.

## What moved

- `NodeFuture` gains a `+ Send` bound. The only `Send`-breaking sites inside the engine were two `.entered()` tracing spans in `rocky-cli/src/commands/run.rs` (`governance_setup`, `batched_checks`) held across awaits. Converted them to plain `Span` declarations — events inside still route through the subscriber, they just no longer parent to these spans. Minor observability regression, no behaviour change.
- Skip decisions use a `failed_nodes` snapshot captured once at layer entry. Kahn's layering guarantees no intra-layer dependencies, so the snapshot is sound.
- Per-node future is wrapped with `.instrument(info_span!("dag_node", ...))` to keep tracing `Send`-safe.
- `None`-returning dispatcher calls (e.g. `Test` nodes) skip without consuming a permit.
- Final `sort_by(layer, id)` keeps output order stable regardless of completion order.

## New files

- `engine/crates/rocky-core/benches/dag_execute.rs` — criterion bench for sequential vs parallel. Tagged `perf` so `engine-bench.yml` runs it.

## Test plan

- [x] `cargo test -p rocky-core --lib dag_executor::tests` — all 5 existing tests pass (plus ancestor-map).
- [x] `cargo test -p rocky-core` — 920/920 pass.
- [x] `cargo test -p rocky-cli` — 141/141 pass.
- [x] `cargo clippy -p rocky-core -p rocky-cli` — clean.
- [x] `cargo bench -p rocky-core --bench dag_execute -- --quick` — sequential 615 ms, parallel 35 ms (17× speedup on 50-wide).
- [ ] CI `engine-bench.yml` runs when the `perf` label fires.
- [ ] Manual: run playground POC end-to-end — same results, faster wall-clock on wider DAGs.