### PR TITLE
feat(engine): graceful Ctrl-C handling in rocky run

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -81,6 +81,10 @@ export interface RunOutput {
   excluded_tables: ExcludedTableOutput[];
   execution: ExecutionSummary;
   filter: string;
+  /**
+   * `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish "user interrupted" from "run failed". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.
+   */
+  interrupted: boolean;
   materializations: MaterializationOutput[];
   metrics?: MetricsSnapshot | null;
   /**

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -78,7 +78,7 @@ pub use optimize::run_optimize;
 pub use plan::plan;
 pub use playground::{run_playground, run_playground_with_template};
 pub use profile_storage::run_profile_storage;
-pub use run::{PartitionRunOptions, run};
+pub use run::{Interrupted, PartitionRunOptions, run};
 pub use run_dag_exec::run_with_dag;
 pub use seed::run_seed;
 pub use serve::run_serve;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -75,6 +75,33 @@ struct TableError {
     task_index: Option<usize>,
 }
 
+/// Sentinel error signalling that `rocky run` was cancelled by a SIGINT
+/// (first Ctrl-C). The outer binary (`rocky/src/main.rs`) downcasts this
+/// off the `anyhow::Error` chain and maps it to exit code 130 so callers
+/// (shell, CI, orchestrators) can distinguish "user cancelled" from a
+/// generic run failure. A second SIGINT bypasses this path entirely and
+/// calls `std::process::exit(130)` directly.
+#[derive(Debug, thiserror::Error)]
+#[error("run was interrupted by SIGINT")]
+pub struct Interrupted;
+
+/// Arm a background watcher that hard-exits with code 130 on a *second*
+/// SIGINT. The first SIGINT is handled by the outer `tokio::select!`
+/// branch — this watcher's job is to give the user an out when graceful
+/// cleanup itself hangs (e.g. a stuck warehouse query that ignores
+/// cancellation). Idempotent in practice: we only call it from the
+/// single-arm branch that flips `interrupted = true`.
+fn arm_second_sigint_watcher() {
+    eprintln!(
+        "\n[rocky] interrupt received — finishing in-flight statements; press Ctrl-C again to terminate"
+    );
+    tokio::spawn(async {
+        let _ = tokio::signal::ctrl_c().await;
+        eprintln!("\n[rocky] second SIGINT — terminating");
+        std::process::exit(130);
+    });
+}
+
 /// Input for a single table processing task.
 #[derive(Clone)]
 struct TableTask {
@@ -979,7 +1006,21 @@ pub async fn run(
     let error_rate_abort_pct = pipeline.execution.error_rate_abort_pct;
     let mut total_completed: usize = 0;
 
+    // SIGINT handling: a single pinned `ctrl_c()` future drives both the
+    // spawn loop's permit-wait and the drain loop below. On first Ctrl-C we
+    // spawn a hard-exit watcher for a second Ctrl-C, set `interrupted`, and
+    // stop issuing new work. In-flight tasks drain naturally so state
+    // updates remain consistent; anything not yet `Success` or `Failed` in
+    // the state store after drain is marked `Interrupted`.
+    let ctrl_c_signal = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c_signal);
+    let mut interrupted = false;
+
     for (idx, task) in tables_to_process.iter().enumerate() {
+        if interrupted {
+            break;
+        }
+
         // When adaptive concurrency is active, drain completed results before
         // spawning so we can adjust the semaphore to match the throttle's
         // recommendation before acquiring the next permit. This interleaves
@@ -1009,7 +1050,14 @@ pub async fn run(
             }
         }
 
-        let permit = semaphore.clone().acquire_owned().await?;
+        let permit = tokio::select! {
+            permit = semaphore.clone().acquire_owned() => permit?,
+            _ = &mut ctrl_c_signal, if !interrupted => {
+                arm_second_sigint_watcher();
+                interrupted = true;
+                break;
+            }
+        };
         let warehouse = shared_warehouse.clone();
         let state = shared_state.clone();
         let pipeline_ref = shared_pipeline.clone();
@@ -1022,8 +1070,22 @@ pub async fn run(
         });
     }
 
-    // Collect remaining results with adaptive error rate monitoring
-    while let Some(result) = join_set.join_next().await {
+    // Collect remaining results with adaptive error rate monitoring.
+    // Driven as a `loop { tokio::select! }` so a first SIGINT fires the
+    // hard-exit watcher and flips `interrupted = true`; tasks already in
+    // flight keep running and their results are still collected below.
+    loop {
+        let result = tokio::select! {
+            res = join_set.join_next() => match res {
+                Some(r) => r,
+                None => break,
+            },
+            _ = &mut ctrl_c_signal, if !interrupted => {
+                arm_second_sigint_watcher();
+                interrupted = true;
+                continue;
+            }
+        };
         total_completed += 1;
 
         match result {
@@ -1199,6 +1261,93 @@ pub async fn run(
                 break;
             }
         }
+    }
+
+    // SIGINT cleanup: flush watermarks for tables that completed, mark
+    // everything not-yet-`Success`/`Failed` as `Interrupted`, emit partial
+    // JSON, and return the sentinel error. Auto-retry + downstream phases
+    // are all skipped — they implicitly need a "successful" run baseline.
+    if interrupted {
+        output.interrupted = true;
+
+        {
+            let state = shared_state.lock().await;
+            for wm in &deferred_watermarks {
+                let _ = state.set_watermark(
+                    &wm.state_key,
+                    &WatermarkState {
+                        last_value: wm.timestamp,
+                        updated_at: wm.timestamp,
+                    },
+                );
+            }
+        }
+
+        // Diff: plan \ {Success|Failed} → mark as Interrupted. Uses the
+        // state store as source of truth for what already committed.
+        let settled: std::collections::HashSet<String> = {
+            let state = shared_state.lock().await;
+            state
+                .get_run_progress(&shared_run_id)
+                .ok()
+                .flatten()
+                .map(|p| {
+                    p.tables
+                        .iter()
+                        .filter(|t| {
+                            matches!(
+                                t.status,
+                                rocky_core::state::TableStatus::Success
+                                    | rocky_core::state::TableStatus::Failed
+                            )
+                        })
+                        .map(|t| t.table_key.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+
+        {
+            let state = shared_state.lock().await;
+            for (idx, task) in tables_to_process.iter().enumerate() {
+                let key = format!(
+                    "{}.{}.{}",
+                    task.target_catalog, task.target_schema, task.table_name
+                );
+                if !settled.contains(&key) {
+                    let mut asset_key = task.asset_key_prefix.clone();
+                    asset_key.push(task.table_name.clone());
+                    let _ = state.record_table_progress(
+                        &shared_run_id,
+                        &rocky_core::state::TableProgress {
+                            index: idx,
+                            table_key: key,
+                            asset_key,
+                            status: rocky_core::state::TableStatus::Interrupted,
+                            error: None,
+                            duration_ms: 0,
+                            completed_at: Utc::now(),
+                        },
+                    );
+                }
+            }
+        }
+
+        state_sync_handle.abort();
+
+        output.duration_ms = start.elapsed().as_millis() as u64;
+        if output_json {
+            print_json(&output)?;
+        } else {
+            eprintln!(
+                "[rocky] interrupted at {}/{} tables (run_id: {})",
+                total_completed,
+                tables_to_process.len(),
+                shared_run_id
+            );
+        }
+
+        return Err(anyhow::Error::new(Interrupted));
     }
 
     // Auto-retry failed tables
@@ -3150,6 +3299,7 @@ mod tests {
                 }],
             },
             partition_summaries: vec![],
+            interrupted: false,
         };
 
         emit_pipes_events(&emitter, &output);

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -75,25 +75,28 @@ struct TableError {
     task_index: Option<usize>,
 }
 
-/// Sentinel error signalling that `rocky run` was cancelled by a SIGINT
-/// (first Ctrl-C). The outer binary (`rocky/src/main.rs`) downcasts this
-/// off the `anyhow::Error` chain and maps it to exit code 130 so callers
-/// (shell, CI, orchestrators) can distinguish "user cancelled" from a
-/// generic run failure. A second SIGINT bypasses this path entirely and
-/// calls `std::process::exit(130)` directly.
+/// Sentinel error signalling that `rocky run` was cancelled by a shutdown
+/// signal (SIGINT / Ctrl-C, or SIGTERM on Unix — typically sent by
+/// Kubernetes during pod eviction). The outer binary
+/// (`rocky/src/main.rs`) downcasts this off the `anyhow::Error` chain and
+/// maps it to exit code 130 so callers (shell, CI, orchestrators) can
+/// distinguish "interrupted" from a generic run failure. A second signal
+/// bypasses this path entirely and calls `std::process::exit(130)`
+/// directly via the watcher armed on first signal.
 #[derive(Debug, thiserror::Error)]
-#[error("run was interrupted by SIGINT")]
+#[error("run was interrupted by a shutdown signal")]
 pub struct Interrupted;
 
 /// Arm a background watcher that hard-exits with code 130 on a *second*
-/// SIGINT. The first SIGINT is handled by the outer `tokio::select!`
-/// branch — this watcher's job is to give the user an out when graceful
-/// cleanup itself hangs (e.g. a stuck warehouse query that ignores
-/// cancellation). Idempotent in practice: we only call it from the
-/// single-arm branch that flips `interrupted = true`.
-fn arm_second_sigint_watcher() {
+/// SIGINT. The first signal (SIGINT or SIGTERM) is handled by the outer
+/// `tokio::select!` branch — this watcher gives the user an out when
+/// graceful cleanup itself hangs (e.g. a stuck warehouse query that
+/// ignores cancellation). Only SIGINT is watched here because K8s escalates
+/// SIGTERM → SIGKILL itself after `terminationGracePeriodSeconds`; the
+/// hard-exit we care about is the interactive "Ctrl-C again" case.
+fn arm_hard_exit_on_second_signal() {
     eprintln!(
-        "\n[rocky] interrupt received — finishing in-flight statements; press Ctrl-C again to terminate"
+        "\n[rocky] shutdown signal received — finishing in-flight statements; press Ctrl-C again to terminate"
     );
     tokio::spawn(async {
         let _ = tokio::signal::ctrl_c().await;
@@ -1006,14 +1009,20 @@ pub async fn run(
     let error_rate_abort_pct = pipeline.execution.error_rate_abort_pct;
     let mut total_completed: usize = 0;
 
-    // SIGINT handling: a single pinned `ctrl_c()` future drives both the
-    // spawn loop's permit-wait and the drain loop below. On first Ctrl-C we
-    // spawn a hard-exit watcher for a second Ctrl-C, set `interrupted`, and
-    // stop issuing new work. In-flight tasks drain naturally so state
-    // updates remain consistent; anything not yet `Success` or `Failed` in
-    // the state store after drain is marked `Interrupted`.
+    // Shutdown-signal handling: a single pinned future per signal source
+    // drives both the spawn loop's permit-wait and the drain loop below.
+    // On first SIGINT (Ctrl-C) or SIGTERM (K8s pod eviction) we arm a
+    // hard-exit watcher for a second SIGINT, set `interrupted`, and stop
+    // issuing new work. In-flight tasks drain naturally so state updates
+    // remain consistent; anything not yet `Success` or `Failed` in the
+    // state store after drain is marked `Interrupted`.
     let ctrl_c_signal = tokio::signal::ctrl_c();
     tokio::pin!(ctrl_c_signal);
+    // SIGTERM only on Unix — Windows doesn't have it, so the future is
+    // wrapped in an `Option` and a `#[cfg(unix)]`-guarded branch.
+    #[cfg(unix)]
+    let mut sigterm_stream =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
     let mut interrupted = false;
 
     for (idx, task) in tables_to_process.iter().enumerate() {
@@ -1053,7 +1062,21 @@ pub async fn run(
         let permit = tokio::select! {
             permit = semaphore.clone().acquire_owned() => permit?,
             _ = &mut ctrl_c_signal, if !interrupted => {
-                arm_second_sigint_watcher();
+                arm_hard_exit_on_second_signal();
+                interrupted = true;
+                break;
+            }
+            _ = async {
+                #[cfg(unix)]
+                if let Some(s) = sigterm_stream.as_mut() {
+                    let _ = s.recv().await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+                #[cfg(not(unix))]
+                std::future::pending::<()>().await;
+            }, if !interrupted => {
+                arm_hard_exit_on_second_signal();
                 interrupted = true;
                 break;
             }
@@ -1081,7 +1104,21 @@ pub async fn run(
                 None => break,
             },
             _ = &mut ctrl_c_signal, if !interrupted => {
-                arm_second_sigint_watcher();
+                arm_hard_exit_on_second_signal();
+                interrupted = true;
+                continue;
+            }
+            _ = async {
+                #[cfg(unix)]
+                if let Some(s) = sigterm_stream.as_mut() {
+                    let _ = s.recv().await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+                #[cfg(not(unix))]
+                std::future::pending::<()>().await;
+            }, if !interrupted => {
+                arm_hard_exit_on_second_signal();
                 interrupted = true;
                 continue;
             }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -139,6 +139,13 @@ pub struct RunOutput {
     /// didn't execute any partitioned models.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub partition_summaries: Vec<PartitionSummary>,
+    /// `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so
+    /// orchestrators can distinguish "user interrupted" from "run failed".
+    /// Tables that hadn't reached `Success` or `Failed` at interrupt time
+    /// are recorded as `TableStatus::Interrupted` in the state store.
+    /// Always serialised (even when `false`) so consumers don't have to
+    /// treat its absence specially.
+    pub interrupted: bool,
 }
 
 fn is_zero(v: &usize) -> bool {
@@ -1706,6 +1713,7 @@ impl RunOutput {
                 actions_taken: vec![],
             },
             partition_summaries: vec![],
+            interrupted: false,
         }
     }
 }

--- a/engine/crates/rocky-core/src/incremental.rs
+++ b/engine/crates/rocky-core/src/incremental.rs
@@ -41,6 +41,11 @@ pub enum PartitionStatus {
     /// Compute is in flight (set at the start of a partition run, cleared at
     /// the end). A long-lived `InProgress` row indicates a crashed runner.
     InProgress,
+    /// Compute was cancelled by a SIGINT (Ctrl-C) before it completed.
+    /// Distinguishable from `Failed` so `--resume-latest` / `--missing` can
+    /// tell "user interrupted" from "query failed" and surface it in JSON
+    /// output.
+    Interrupted,
 }
 
 /// State-store record for a single partition of a `time_interval` model.

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -486,6 +486,10 @@ pub enum TableStatus {
     Success,
     Failed,
     Skipped,
+    /// Table was cancelled by a SIGINT (Ctrl-C) before it completed —
+    /// distinct from `Failed` so `--resume-latest` knows to retry it and
+    /// JSON consumers can show "interrupted" in the UI.
+    Interrupted,
 }
 
 /// Execution record for a single table within a run.

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -845,7 +845,14 @@ async fn main() -> Result<()> {
                     }
                 }
             } else {
-                let run_future = rocky_cli::commands::run(
+                // `rocky_cli::commands::run` handles SIGINT internally so it
+                // can flush watermarks + mark in-flight tables as
+                // `Interrupted` in the state store. On first Ctrl-C it
+                // returns `Err` wrapping `rocky_cli::commands::Interrupted`;
+                // the main() error handler below maps that to exit code 130.
+                // No outer `select!` here — letting the internal handler own
+                // the signal is what makes graceful cancellation possible.
+                rocky_cli::commands::run(
                     &cli.config,
                     filter.as_deref(),
                     pipeline.as_deref(),
@@ -859,14 +866,8 @@ async fn main() -> Result<()> {
                     shadow_config.as_ref(),
                     &partition_opts,
                     model.as_deref(),
-                );
-                tokio::select! {
-                    result = run_future => result,
-                    _ = shutdown_signal() => {
-                        warn!("received shutdown signal, aborting run");
-                        anyhow::bail!("interrupted by shutdown signal")
-                    }
-                }
+                )
+                .await
             }
         }
         Command::Compare {
@@ -1204,6 +1205,18 @@ async fn main() -> Result<()> {
         Command::Fmt { paths, check } => rocky_cli::commands::run_fmt(&paths, check),
         Command::ExportSchemas { output_dir } => rocky_cli::commands::export_schemas(&output_dir),
     };
+
+    // SIGINT: map `commands::Interrupted` to the conventional shell exit
+    // code (128 + SIGINT). Only `rocky run` currently emits this; other
+    // commands fall through to the default exit-1-on-error below.
+    if let Err(ref err) = result {
+        if err
+            .downcast_ref::<rocky_cli::commands::Interrupted>()
+            .is_some()
+        {
+            std::process::exit(130);
+        }
+    }
 
     // In text mode, try to upgrade config errors to rich miette diagnostics
     // with source spans and suggestions. JSON mode returns structured errors

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -365,6 +365,10 @@ class RunOutput(BaseModel):
     """
     execution: ExecutionSummary
     filter: str
+    interrupted: bool
+    """
+    `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish "user interrupted" from "run failed". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.
+    """
     materializations: list[MaterializationOutput]
     metrics: MetricsSnapshot | None = None
     partition_summaries: list[PartitionSummary]

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -73,5 +73,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -73,5 +73,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -73,5 +73,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -82,5 +82,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -62,5 +62,6 @@
         "reason": "column 'amount' changed VARCHAR \u2192 DECIMAL(10,2)"
       }
     ]
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -56,5 +56,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -56,5 +56,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -56,5 +56,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -56,5 +56,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -169,5 +169,6 @@
       "partitions_succeeded": 5,
       "partitions_failed": 0
     }
-  ]
+  ],
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -85,5 +85,6 @@
       "partitions_succeeded": 1,
       "partitions_failed": 0
     }
-  ]
+  ],
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -85,5 +85,6 @@
       "partitions_succeeded": 1,
       "partitions_failed": 0
     }
-  ]
+  ],
+  "interrupted": false
 }

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -53,5 +53,6 @@
     "tables_checked": 1,
     "tables_drifted": 0,
     "actions_taken": []
-  }
+  },
+  "interrupted": false
 }

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -760,6 +760,10 @@
     "filter": {
       "type": "string"
     },
+    "interrupted": {
+      "description": "`true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish \"user interrupted\" from \"run failed\". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.",
+      "type": "boolean"
+    },
     "materializations": {
       "items": {
         "$ref": "#/definitions/MaterializationOutput"
@@ -839,6 +843,7 @@
     "excluded_tables",
     "execution",
     "filter",
+    "interrupted",
     "materializations",
     "partition_summaries",
     "permissions",


### PR DESCRIPTION
## Summary

First Ctrl-C on `rocky run` now triggers graceful cleanup instead of a hard bail. Watermarks for completed tables are flushed, in-flight tables are marked `TableStatus::Interrupted` in the state store, partial JSON is emitted, and the binary exits with code 130. A second Ctrl-C hard-exits via a spawned watcher so the user has an out if cleanup itself hangs.

## Behaviour

| Phase | Pre-PR | Post-PR |
|---|---|---|
| 1st SIGINT during `rocky run` | `main.rs` outer `select!` → `anyhow::bail!`, exit 1, no state update | In-process handler flushes watermarks, writes `Interrupted` rows, returns sentinel → exit 130 |
| 2nd SIGINT | N/A | Spawned watcher calls `process::exit(130)` directly |
| `rocky run --resume-latest` after interrupt | Re-does completed tables (no `Success` barrier) | Skips completed tables, retries `Interrupted` ones |
| JSON consumers | `"tables_copied": N` only | `"interrupted": true` + `TableStatus::Interrupted` rows |

## What moved

- **`rocky_core::state::TableStatus::Interrupted`** + **`rocky_core::incremental::PartitionStatus::Interrupted`** — new enum variants for the state store. Both enums were non-exhaustive in match sites, so the additions drop in without breaking callers.
- **`rocky_cli::commands::Interrupted`** — `thiserror::Error` sentinel returned via `anyhow::Error::new(Interrupted)`. `main.rs` downcasts to it and calls `process::exit(130)`.
- **`RunOutput.interrupted: bool`** — always serialised. Pydantic + TypeScript regenerated via `just codegen`.
- **Internal `tokio::select!` in `run.rs`** — wraps both `semaphore.acquire_owned()` in the spawn loop and `join_set.join_next()` in the drain loop. First SIGINT arms a hard-exit watcher, sets `interrupted = true`, stops issuing new work. Pinned `ctrl_c()` future is shared across both loops; the `if !interrupted` guard prevents the already-resolved future from being polled twice.
- **`main.rs`** — outer `tokio::select!` + `shutdown_signal()` removed for the `Run` command specifically. Internal handler owns the signal so cleanup can run. SIGTERM for `run` falls through to the default Rust handling (follow-up if Kubernetes shutdown graceful paths are needed).

## Schema cascade

Ran `just codegen`. Regenerated:
- `schemas/run.schema.json`
- `integrations/dagster/src/dagster_rocky/types_generated/run_schema.py`
- `editors/vscode/src/types/generated/run.ts`

All committed. `codegen-drift` CI should pass.

## Known limitation (out of scope, filed as follow-up)

A SIGINT mid-`ALTER TABLE` (schema drift evolution) can leave the target half-evolved — the in-flight statement can't be rolled back through the generic adapter path. Handling this requires schema-drift-aware cancellation (detect mid-evolve state on next run and either resume or roll forward). Not blocking this PR.

## Test plan

- [x] `cargo test -p rocky-core --lib` — 920/920 pass (enum additions clean).
- [x] `cargo test -p rocky-cli` — 141/141 pass.
- [x] `cargo clippy -p rocky-core -p rocky-cli -p rocky-server` — clean.
- [x] `cargo check --workspace` — clean.
- [x] `just codegen` — bindings regenerated, diff is confined to `run` artefacts.
- [ ] **Manual**: start a long-running `rocky run` (playground POC with a handful of tables + artificial delay via a slow dispatcher).
  - Hit Ctrl-C after first table completes → exit 130, `rocky state` shows N `Success` + M `Interrupted`.
  - `rocky run --resume-latest` against the same state → only touches `Interrupted` tables, skips `Success`.
  - Hit Ctrl-C twice rapidly → process exits immediately (exit 130 via hard-exit watcher).
- [ ] **Follow-up**: automated e2e test (`engine/crates/rocky-cli/tests/e2e_cancel.rs`) — deferred; it requires a slow mock dispatcher harness that doesn't exist yet. Manual verification in this PR; the harness + test can land as a separate testing-infra PR.