### PR TITLE
style(engine): cargo fmt across merged perf-resilience PRs

### DIFF
--- a/engine/crates/rocky-core/benches/dag_execute.rs
+++ b/engine/crates/rocky-core/benches/dag_execute.rs
@@ -76,17 +76,21 @@ fn bench_dag(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(10));
 
     for (label, concurrency) in [("sequential", Some(1)), ("parallel", None)] {
-        group.bench_with_input(BenchmarkId::from_parameter(label), &concurrency, |b, &cap| {
-            b.iter(|| {
-                rt.block_on(async {
-                    let mut executor = DagExecutor::new(SleepDispatcher);
-                    if let Some(n) = cap {
-                        executor = executor.with_max_concurrency(n);
-                    }
-                    executor.execute(&dag).await.unwrap()
-                })
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::from_parameter(label),
+            &concurrency,
+            |b, &cap| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut executor = DagExecutor::new(SleepDispatcher);
+                        if let Some(n) = cap {
+                            executor = executor.with_max_concurrency(n);
+                        }
+                        executor.execute(&dag).await.unwrap()
+                    })
+                });
+            },
+        );
     }
 
     group.finish();

--- a/engine/crates/rocky-core/src/dag_executor.rs
+++ b/engine/crates/rocky-core/src/dag_executor.rs
@@ -36,9 +36,9 @@ use crate::unified_dag::{NodeId, NodeKind, UnifiedDag, UnifiedDagError, executio
 /// concurrent children).
 type NodeTaskOutput = (
     NodeId,
-    String,         // id string
-    String,         // kind string
-    String,         // label
+    String, // id string
+    String, // kind string
+    String, // label
     NodeStatus,
     u64,            // duration_ms
     Option<String>, // error
@@ -186,7 +186,10 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
                 let label = node.label.clone();
 
                 let ancestors_for_node = ancestors.get(&id).cloned().unwrap_or_default();
-                if ancestors_for_node.iter().any(|a| failed_snapshot.contains(a)) {
+                if ancestors_for_node
+                    .iter()
+                    .any(|a| failed_snapshot.contains(a))
+                {
                     warn!(node = %id, "skipping node — upstream failure");
                     results.push(NodeResult {
                         id: id.0.clone(),
@@ -241,7 +244,15 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
                             }
                         };
                         let duration_ms = node_start.elapsed().as_millis() as u64;
-                        (id, id_str, kind_str, label_for_task, status, duration_ms, error)
+                        (
+                            id,
+                            id_str,
+                            kind_str,
+                            label_for_task,
+                            status,
+                            duration_ms,
+                            error,
+                        )
                     }
                     .instrument(span),
                 );

--- a/engine/crates/rocky-core/tests/state_lock.rs
+++ b/engine/crates/rocky-core/tests/state_lock.rs
@@ -32,7 +32,10 @@ fn second_writer_fails_when_lock_held_externally() {
         .open(&lock_path)
         .unwrap();
     let acquired = FileExt::try_lock_exclusive(&external_lock).unwrap();
-    assert!(acquired, "external lock should be acquired in a clean temp dir");
+    assert!(
+        acquired,
+        "external lock should be acquired in a clean temp dir"
+    );
 
     match StateStore::open(&path) {
         Err(StateError::LockHeldByOther { .. }) => {}


### PR DESCRIPTION
## Summary

Pure \`cargo fmt\` fix. The three perf-resilience PRs (#126, #127, #128) landed before CI flagged a fmt drift — the drift is confined to line-wrapping choices in:

- \`engine/crates/rocky-core/benches/dag_execute.rs:76\` — \`bench_with_input\` call
- \`engine/crates/rocky-core/src/dag_executor.rs\` — \`NodeTaskOutput\` type alias comments, \`any(|a|\` chain, 7-tuple construction
- \`engine/crates/rocky-core/tests/state_lock.rs\` — \`assert!\` with a long message

Zero logic changes; this PR is produced by \`cargo fmt\` on main.

## Test plan

- [x] \`cargo fmt -- --check\` — clean.
- [x] \`cargo check --workspace\` — clean.
- [ ] CI \`engine-ci\` fmt step passes.