### PR TITLE
feat(engine/rocky-snowflake): batch_describe_schema via INFORMATION_SCHEMA

### DIFF
--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -38,6 +38,7 @@ use rocky_iceberg::adapter::IcebergDiscoveryAdapter;
 use rocky_iceberg::client::IcebergCatalogClient;
 
 use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::batch::SnowflakeBatchCheckAdapter;
 use rocky_snowflake::connector::SnowflakeConnector;
 
 use rocky_bigquery::connector::BigQueryAdapter;
@@ -47,6 +48,10 @@ pub struct AdapterRegistry {
     warehouse: HashMap<String, Arc<dyn WarehouseAdapter>>,
     discovery: HashMap<String, Arc<dyn DiscoveryAdapter>>,
     connectors: HashMap<String, Arc<DatabricksConnector>>,
+    /// Snowflake connectors tracked separately from `connectors` (which is
+    /// Databricks-typed). Used by `batch_check_adapter` to dispatch the
+    /// Snowflake-specific `INFORMATION_SCHEMA.COLUMNS` describe query.
+    snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>>,
     adapter_configs: HashMap<String, AdapterConfig>,
 }
 
@@ -56,6 +61,7 @@ impl AdapterRegistry {
         let mut warehouse = HashMap::new();
         let mut discovery = HashMap::new();
         let mut connectors = HashMap::new();
+        let mut snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>> = HashMap::new();
         let mut adapter_configs = HashMap::new();
 
         for (name, adapter_cfg) in &config.adapters {
@@ -236,20 +242,29 @@ impl AdapterRegistry {
                     )
                     .context(format!("adapters.{name}: auth configuration error"))?;
 
-                    let sf_connector = SnowflakeConnector::new(
-                        rocky_snowflake::connector::ConnectorConfig {
-                            account: account.to_string(),
-                            warehouse: sf_warehouse.to_string(),
-                            database: adapter_cfg.database.clone(),
-                            schema: None,
-                            role: adapter_cfg.role.clone(),
-                            timeout: Duration::from_secs(adapter_cfg.timeout_secs.unwrap_or(120)),
-                            retry: adapter_cfg.retry.clone(),
-                        },
-                        sf_auth,
-                    );
+                    let sf_connector_config = rocky_snowflake::connector::ConnectorConfig {
+                        account: account.to_string(),
+                        warehouse: sf_warehouse.to_string(),
+                        database: adapter_cfg.database.clone(),
+                        schema: None,
+                        role: adapter_cfg.role.clone(),
+                        timeout: Duration::from_secs(adapter_cfg.timeout_secs.unwrap_or(120)),
+                        retry: adapter_cfg.retry.clone(),
+                    };
 
-                    let adapter = SnowflakeWarehouseAdapter::new(sf_connector);
+                    // The warehouse adapter wraps its own connector; a second
+                    // connector with the same config drives the batch-check
+                    // path. Keeping it separate means the batch describe
+                    // query won't contend with in-flight `execute_statement`
+                    // calls on the warehouse adapter's connector.
+                    let sf_connector_for_batch = Arc::new(SnowflakeConnector::new(
+                        sf_connector_config.clone(),
+                        sf_auth.clone(),
+                    ));
+                    snowflake_connectors.insert(name.clone(), sf_connector_for_batch);
+
+                    let warehouse_connector = SnowflakeConnector::new(sf_connector_config, sf_auth);
+                    let adapter = SnowflakeWarehouseAdapter::new(warehouse_connector);
                     warehouse.insert(name.clone(), Arc::new(adapter));
                 }
                 "bigquery" => {
@@ -296,6 +311,7 @@ impl AdapterRegistry {
             warehouse,
             discovery,
             connectors,
+            snowflake_connectors,
             adapter_configs,
         })
     }
@@ -344,11 +360,21 @@ impl AdapterRegistry {
     /// check implementation — callers fall back to the per-table
     /// [`WarehouseAdapter`] trait methods.
     ///
-    /// Currently only Databricks implements [`BatchCheckAdapter`] (UNION ALL
-    /// row counts + freshness + `information_schema.columns` describe).
+    /// Databricks implements all three batch methods (UNION ALL row counts +
+    /// freshness + `information_schema.columns` describe). Snowflake
+    /// currently only batches describe; its row-counts / freshness methods
+    /// return "not yet implemented" so `run.rs` falls back to per-table
+    /// queries for those.
     pub fn batch_check_adapter(&self, name: &str) -> Option<Arc<dyn BatchCheckAdapter>> {
-        let connector = self.connectors.get(name)?.clone();
-        Some(Arc::new(DatabricksBatchCheckAdapter::new(connector)))
+        if let Some(connector) = self.connectors.get(name) {
+            return Some(Arc::new(DatabricksBatchCheckAdapter::new(
+                connector.clone(),
+            )));
+        }
+        if let Some(connector) = self.snowflake_connectors.get(name) {
+            return Some(Arc::new(SnowflakeBatchCheckAdapter::new(connector.clone())));
+        }
+        None
     }
 
     /// Build a governance adapter for the named warehouse.

--- a/engine/crates/rocky-snowflake/src/batch.rs
+++ b/engine/crates/rocky-snowflake/src/batch.rs
@@ -1,0 +1,151 @@
+//! Batched warehouse operations for Snowflake.
+//!
+//! The only operation currently implemented is `batch_describe_schema`,
+//! which replaces N `DESCRIBE TABLE` calls with one
+//! `INFORMATION_SCHEMA.COLUMNS` query per schema. `batch_row_counts` and
+//! `batch_freshness` remain unimplemented — callers fall back to the
+//! per-table [`WarehouseAdapter`] path for those.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use rocky_core::ir::{ColumnInfo, TableRef};
+use rocky_core::traits::{
+    AdapterError, AdapterResult, BatchCheckAdapter, FreshnessResult, RowCountResult,
+};
+use rocky_sql::validation::{self, ValidationError};
+
+use crate::connector::{ConnectorError, SnowflakeConnector};
+
+#[derive(Debug, Error)]
+pub enum BatchError {
+    #[error("validation error: {0}")]
+    Validation(#[from] ValidationError),
+
+    #[error("connector error: {0}")]
+    Connector(#[from] ConnectorError),
+}
+
+/// Batched check adapter for Snowflake.
+pub struct SnowflakeBatchCheckAdapter {
+    connector: Arc<SnowflakeConnector>,
+}
+
+impl SnowflakeBatchCheckAdapter {
+    pub fn new(connector: Arc<SnowflakeConnector>) -> Self {
+        Self { connector }
+    }
+}
+
+/// Generates the Snowflake `INFORMATION_SCHEMA.COLUMNS` query that describes
+/// every table in a single schema in one round trip.
+///
+/// Snowflake exposes `INFORMATION_SCHEMA.COLUMNS` per database; the query
+/// scopes to `<database>.information_schema.columns`. `table_schema` values
+/// are stored uppercase in Snowflake, so we use case-insensitive match.
+fn generate_batch_describe_sql(catalog: &str, schema: &str) -> Result<String, BatchError> {
+    validation::validate_identifier(catalog)?;
+    validation::validate_identifier(schema)?;
+
+    Ok(format!(
+        "SELECT LOWER(table_name), LOWER(column_name), data_type, is_nullable\n\
+         FROM {catalog}.information_schema.columns\n\
+         WHERE UPPER(table_schema) = UPPER('{schema}')\n\
+         ORDER BY table_name, ordinal_position"
+    ))
+}
+
+#[async_trait]
+impl BatchCheckAdapter for SnowflakeBatchCheckAdapter {
+    async fn batch_row_counts(&self, _tables: &[TableRef]) -> AdapterResult<Vec<RowCountResult>> {
+        // Snowflake could batch these with a UNION ALL over the supplied
+        // tables, but it's not wired yet. Return an error so `run.rs` falls
+        // back to per-table row-count queries via `WarehouseAdapter`.
+        Err(AdapterError::msg(
+            "batch_row_counts not yet implemented for Snowflake",
+        ))
+    }
+
+    async fn batch_freshness(
+        &self,
+        _tables: &[TableRef],
+        _timestamp_col: &str,
+    ) -> AdapterResult<Vec<FreshnessResult>> {
+        Err(AdapterError::msg(
+            "batch_freshness not yet implemented for Snowflake",
+        ))
+    }
+
+    async fn batch_describe_schema(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> AdapterResult<HashMap<String, Vec<ColumnInfo>>> {
+        let sql = generate_batch_describe_sql(catalog, schema).map_err(AdapterError::new)?;
+        let result = self
+            .connector
+            .execute_sql(&sql)
+            .await
+            .map_err(AdapterError::new)?;
+
+        let mut map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+
+        for row in &result.rows {
+            let table = row
+                .first()
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let col_name = row
+                .get(1)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let data_type = row
+                .get(2)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            // Snowflake's `is_nullable` is "YES" / "NO".
+            let nullable = row
+                .get(3)
+                .and_then(|v| v.as_str())
+                .map(|s| s.eq_ignore_ascii_case("YES"))
+                .unwrap_or(true);
+
+            if table.is_empty() || col_name.is_empty() {
+                continue;
+            }
+
+            map.entry(table).or_default().push(ColumnInfo {
+                name: col_name,
+                data_type,
+                nullable,
+            });
+        }
+
+        Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_describe_sql_scopes_to_database_and_schema() {
+        let sql = generate_batch_describe_sql("MY_DB", "analytics").unwrap();
+        assert!(sql.contains("MY_DB.information_schema.columns"));
+        assert!(sql.contains("UPPER('analytics')"));
+        assert!(sql.contains("ORDER BY table_name, ordinal_position"));
+    }
+
+    #[test]
+    fn batch_describe_sql_rejects_invalid_identifiers() {
+        assert!(generate_batch_describe_sql("bad; drop table users", "s").is_err());
+        assert!(generate_batch_describe_sql("c", "bad'; select *").is_err());
+    }
+}

--- a/engine/crates/rocky-snowflake/src/lib.rs
+++ b/engine/crates/rocky-snowflake/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod adapter;
 pub mod auth;
+pub mod batch;
 pub mod connector;
 pub mod dialect;
 pub mod governance;


### PR DESCRIPTION
## Summary

Implements \`BatchCheckAdapter::batch_describe_schema\` for Snowflake so the run loop's describe pre-flight no longer pays one RPC per table.

At ~100 ms RPC latency on a 100-table schema, the previous fallback (per-table \`DESCRIBE TABLE\`) costs ~10 s of wall-clock before any real work starts. One \`INFORMATION_SCHEMA.COLUMNS\` query brings that to a single round trip.

## What moved

- **New \`rocky-snowflake::batch::SnowflakeBatchCheckAdapter\`** — wraps a \`SnowflakeConnector\`, runs \`SELECT LOWER(table_name), LOWER(column_name), data_type, is_nullable FROM {db}.information_schema.columns WHERE UPPER(table_schema) = UPPER('{schema}')\`, returns the same \`HashMap<table, Vec<ColumnInfo>>\` shape as Databricks.
- **Snowflake-specific parsing:** \`is_nullable\` is \`"YES"/"NO"\` (vs Databricks' \`true\` default); schema names are uppercase in Snowflake metadata so the predicate uses case-insensitive match.
- **\`batch_row_counts\` / \`batch_freshness\`:** return a "not yet implemented" error. The run loop already falls back to per-table \`WarehouseAdapter\` methods on error so there's no behaviour change for those.
- **Registry:** \`AdapterRegistry::batch_check_adapter\` tries the Databricks connector first, then the Snowflake connector, returns \`None\` only when neither matches. A dedicated \`snowflake_connectors\` map was added alongside the existing \`connectors\` (Databricks-typed) so the typed \`SnowflakeConnector\` stays accessible to the batch path.

## Test plan

- [x] \`cargo test -p rocky-snowflake\` — 94/94 pass (2 new: \`batch_describe_sql_scopes_to_database_and_schema\`, \`batch_describe_sql_rejects_invalid_identifiers\`).
- [x] \`cargo clippy -p rocky-snowflake -p rocky-cli\` — clean.
- [x] \`cargo check --workspace\` — clean.
- [ ] Manual verification against live Snowflake: run \`rocky run\` on a pipeline with ≥ 20 tables, observe single describe query in the Snowflake query history and \`batch describe complete\` in debug logs.
- [ ] Follow-up: integration test against a mocked Snowflake statements API (pair with BigQuery batch in a testing-infra PR).

## Follow-ups (out of scope)

- \`batch_row_counts\` via \`UNION ALL\` of \`SELECT COUNT(*) FROM ...\` per table (same shape Databricks uses).
- \`batch_freshness\` via \`UNION ALL\` of \`SELECT MAX(<ts>) FROM ...\`.
- Likely best landed together since they share query-shape and error-parsing patterns.