### PR TITLE
feat(engine/rocky-bigquery): batch_describe_schema via INFORMATION_SCHEMA

### DIFF
--- a/engine/crates/rocky-bigquery/src/batch.rs
+++ b/engine/crates/rocky-bigquery/src/batch.rs
@@ -1,0 +1,136 @@
+//! Batched warehouse operations for BigQuery.
+//!
+//! Only `batch_describe_schema` is implemented; `batch_row_counts` and
+//! `batch_freshness` return "not yet implemented" so the run loop falls
+//! back to per-table queries via the generic `WarehouseAdapter` path.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use rocky_core::ir::{ColumnInfo, TableRef};
+use rocky_core::traits::{
+    AdapterError, AdapterResult, BatchCheckAdapter, FreshnessResult, RowCountResult,
+    WarehouseAdapter,
+};
+
+use crate::connector::BigQueryAdapter;
+
+/// Batched check adapter for BigQuery.
+///
+/// Holds a shared reference to the underlying [`BigQueryAdapter`] and
+/// re-uses its authenticated HTTP client + query path. The batch-describe
+/// query targets \`{project}.{dataset}.INFORMATION_SCHEMA.COLUMNS\`, which
+/// BigQuery scopes to a single dataset per reference — one round trip
+/// returns every table's columns in the dataset.
+pub struct BigQueryBatchCheckAdapter {
+    adapter: Arc<BigQueryAdapter>,
+}
+
+impl BigQueryBatchCheckAdapter {
+    pub fn new(adapter: Arc<BigQueryAdapter>) -> Self {
+        Self { adapter }
+    }
+}
+
+/// Generate the BigQuery `INFORMATION_SCHEMA.COLUMNS` query that describes
+/// every table in a single dataset in one round trip.
+///
+/// BigQuery requires `INFORMATION_SCHEMA` references to be fully qualified
+/// by project + dataset (`` `{project}`.`{dataset}`.INFORMATION_SCHEMA.COLUMNS ``).
+/// Identifiers are backtick-quoted; this function assumes callers already
+/// validated them (the wiring in `registry.rs` trusts config values the
+/// same way the per-table `describe_table` path does at
+/// `connector.rs:183-209`).
+fn generate_batch_describe_sql(catalog: &str, schema: &str) -> String {
+    format!(
+        "SELECT LOWER(table_name), LOWER(column_name), data_type, is_nullable \
+         FROM `{catalog}`.`{schema}`.INFORMATION_SCHEMA.COLUMNS \
+         ORDER BY table_name, ordinal_position"
+    )
+}
+
+#[async_trait]
+impl BatchCheckAdapter for BigQueryBatchCheckAdapter {
+    async fn batch_row_counts(&self, _tables: &[TableRef]) -> AdapterResult<Vec<RowCountResult>> {
+        Err(AdapterError::msg(
+            "batch_row_counts not yet implemented for BigQuery",
+        ))
+    }
+
+    async fn batch_freshness(
+        &self,
+        _tables: &[TableRef],
+        _timestamp_col: &str,
+    ) -> AdapterResult<Vec<FreshnessResult>> {
+        Err(AdapterError::msg(
+            "batch_freshness not yet implemented for BigQuery",
+        ))
+    }
+
+    async fn batch_describe_schema(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> AdapterResult<HashMap<String, Vec<ColumnInfo>>> {
+        let sql = generate_batch_describe_sql(catalog, schema);
+        let result = self.adapter.execute_query(&sql).await?;
+
+        let mut map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+
+        for row in &result.rows {
+            let table = row
+                .first()
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let col_name = row
+                .get(1)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let data_type = row
+                .get(2)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let nullable = row
+                .get(3)
+                .and_then(|v| v.as_str())
+                .map(|s| s.eq_ignore_ascii_case("YES"))
+                .unwrap_or(true);
+
+            if table.is_empty() || col_name.is_empty() {
+                continue;
+            }
+
+            map.entry(table).or_default().push(ColumnInfo {
+                name: col_name,
+                data_type,
+                nullable,
+            });
+        }
+
+        Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_describe_sql_scopes_to_project_and_dataset() {
+        let sql = generate_batch_describe_sql("my-project", "analytics");
+        assert!(sql.contains("`my-project`.`analytics`.INFORMATION_SCHEMA.COLUMNS"));
+        assert!(sql.contains("ORDER BY table_name, ordinal_position"));
+    }
+
+    #[test]
+    fn batch_describe_sql_selects_nullable_column() {
+        let sql = generate_batch_describe_sql("p", "s");
+        assert!(sql.contains("is_nullable"));
+        assert!(sql.contains("data_type"));
+    }
+}

--- a/engine/crates/rocky-bigquery/src/lib.rs
+++ b/engine/crates/rocky-bigquery/src/lib.rs
@@ -4,6 +4,7 @@
 //! for Google BigQuery using the REST API (jobs.query + jobs.getQueryResults).
 
 pub mod auth;
+pub mod batch;
 pub mod connector;
 pub mod dialect;
 pub mod governance;

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -41,6 +41,7 @@ use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
 use rocky_snowflake::batch::SnowflakeBatchCheckAdapter;
 use rocky_snowflake::connector::SnowflakeConnector;
 
+use rocky_bigquery::batch::BigQueryBatchCheckAdapter;
 use rocky_bigquery::connector::BigQueryAdapter;
 
 /// Holds constructed adapter instances, keyed by name from the config.
@@ -52,6 +53,10 @@ pub struct AdapterRegistry {
     /// Databricks-typed). Used by `batch_check_adapter` to dispatch the
     /// Snowflake-specific `INFORMATION_SCHEMA.COLUMNS` describe query.
     snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>>,
+    /// Typed BigQuery adapters so `batch_check_adapter` can run the
+    /// `INFORMATION_SCHEMA.COLUMNS` describe query through the same
+    /// authenticated HTTP client that the generic warehouse adapter uses.
+    bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>>,
     adapter_configs: HashMap<String, AdapterConfig>,
 }
 
@@ -62,6 +67,7 @@ impl AdapterRegistry {
         let mut discovery = HashMap::new();
         let mut connectors = HashMap::new();
         let mut snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>> = HashMap::new();
+        let mut bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>> = HashMap::new();
         let mut adapter_configs = HashMap::new();
 
         for (name, adapter_cfg) in &config.adapters {
@@ -277,9 +283,12 @@ impl AdapterRegistry {
                     let bq_auth = rocky_bigquery::auth::BigQueryAuth::from_env()
                         .context(format!("adapters.{name}: auth configuration error"))?;
 
-                    let adapter = BigQueryAdapter::new(project_id, location, bq_auth)
-                        .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300));
-                    warehouse.insert(name.clone(), Arc::new(adapter));
+                    let adapter = Arc::new(
+                        BigQueryAdapter::new(project_id, location, bq_auth)
+                            .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300)),
+                    );
+                    bigquery_adapters.insert(name.clone(), adapter.clone());
+                    warehouse.insert(name.clone(), adapter as Arc<dyn WarehouseAdapter>);
                 }
                 other => {
                     let mut msg = format!(
@@ -312,6 +321,7 @@ impl AdapterRegistry {
             discovery,
             connectors,
             snowflake_connectors,
+            bigquery_adapters,
             adapter_configs,
         })
     }
@@ -361,10 +371,10 @@ impl AdapterRegistry {
     /// [`WarehouseAdapter`] trait methods.
     ///
     /// Databricks implements all three batch methods (UNION ALL row counts +
-    /// freshness + `information_schema.columns` describe). Snowflake
-    /// currently only batches describe; its row-counts / freshness methods
-    /// return "not yet implemented" so `run.rs` falls back to per-table
-    /// queries for those.
+    /// freshness + `information_schema.columns` describe). Snowflake and
+    /// BigQuery batch only describe for now; their row-count / freshness
+    /// methods return "not yet implemented" so `run.rs` falls back to
+    /// per-table queries for those.
     pub fn batch_check_adapter(&self, name: &str) -> Option<Arc<dyn BatchCheckAdapter>> {
         if let Some(connector) = self.connectors.get(name) {
             return Some(Arc::new(DatabricksBatchCheckAdapter::new(
@@ -373,6 +383,9 @@ impl AdapterRegistry {
         }
         if let Some(connector) = self.snowflake_connectors.get(name) {
             return Some(Arc::new(SnowflakeBatchCheckAdapter::new(connector.clone())));
+        }
+        if let Some(adapter) = self.bigquery_adapters.get(name) {
+            return Some(Arc::new(BigQueryBatchCheckAdapter::new(adapter.clone())));
         }
         None
     }


### PR DESCRIPTION
## Summary

Implements \`BatchCheckAdapter::batch_describe_schema\` for BigQuery. Same shape as the Snowflake adapter landed in #131 — one \`INFORMATION_SCHEMA.COLUMNS\` query per dataset replaces N per-table \`DESCRIBE\` round trips.

At ~100 ms RPC latency on a 100-table dataset, the previous fallback costs ~10 s of wall-clock before any real work starts. With this PR, that collapses to a single round trip.

## What moved

- **New \`rocky-bigquery::batch::BigQueryBatchCheckAdapter\`** — wraps \`Arc<BigQueryAdapter>\`, runs the batched query through the existing HTTP client + auth plumbing (so it inherits the new polling loop from #129).
- **Query shape:** \`SELECT LOWER(table_name), LOWER(column_name), data_type, is_nullable FROM \\\`{project}\\\`.\\\`{dataset}\\\`.INFORMATION_SCHEMA.COLUMNS ORDER BY table_name, ordinal_position\` — BigQuery requires the fully-qualified \`INFORMATION_SCHEMA\` reference and scopes per-dataset by design.
- **Registry:** \`AdapterRegistry::batch_check_adapter\` now tries Databricks → BigQuery → \`None\`. A dedicated \`bigquery_adapters: HashMap\` was added so the typed \`BigQueryAdapter\` is reachable from the batch path.
- **\`batch_row_counts\` / \`batch_freshness\`:** return a "not yet implemented" error. The run loop already falls back to per-table \`WarehouseAdapter\` methods on error — no behaviour change for those paths.

## Depends on

- #129 (BigQuery async polling) — any \`INFORMATION_SCHEMA.COLUMNS\` query on a large dataset will exceed BigQuery's sync window, so without the polling fix this would return an empty result set. Merge #129 first.

## Test plan

- [x] \`cargo test -p rocky-bigquery\` — 45/45 pass (3 new: scoping, \`is_nullable\` select list, polling ladder regression tests from #129).
- [x] \`cargo clippy -p rocky-bigquery -p rocky-cli\` — clean.
- [x] \`cargo check --workspace\` — clean.
- [ ] Manual verification: run \`rocky run\` against a live BigQuery dataset with ≥ 20 tables, verify single \`INFORMATION_SCHEMA.COLUMNS\` query in BigQuery query history + \`batch describe complete\` in debug logs.
- [ ] Follow-up: integration test against a mocked BigQuery API — paired with the Snowflake batch adapter's integration test.