### PR TITLE
fix(engine/rocky-core): bound HTTP timeouts on object store access

### DIFF
--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -17,12 +17,29 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use object_store::{ObjectStore, path::Path as ObjectPath};
+use object_store::{ClientOptions, ObjectStore, path::Path as ObjectPath};
 use thiserror::Error;
 use tracing::debug;
+
+/// Per-request HTTP timeout for the underlying cloud client. Without this the
+/// default is unbounded, so a stuck TCP connection can hang forever (see Gold
+/// run f107d533, 2026-04-18, where S3 state upload hung for ~7h before the
+/// run was externally canceled).
+const CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Connect-phase timeout. Shorter than the request timeout so unreachable
+/// endpoints fail fast rather than chewing through the retry budget.
+const CLIENT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn default_client_options() -> ClientOptions {
+    ClientOptions::new()
+        .with_timeout(CLIENT_REQUEST_TIMEOUT)
+        .with_connect_timeout(CLIENT_CONNECT_TIMEOUT)
+}
 
 /// Errors returned by [`ObjectStoreProvider`] operations.
 #[derive(Debug, Error)]
@@ -96,18 +113,21 @@ impl ObjectStoreProvider {
 
         let store: Arc<dyn ObjectStore> = match scheme.as_str() {
             "s3" | "s3a" => {
-                let builder =
-                    object_store::aws::AmazonS3Builder::from_env().with_bucket_name(&bucket);
+                let builder = object_store::aws::AmazonS3Builder::from_env()
+                    .with_bucket_name(&bucket)
+                    .with_client_options(default_client_options());
                 Arc::new(builder.build()?)
             }
             "gs" | "gcs" => {
                 let builder = object_store::gcp::GoogleCloudStorageBuilder::from_env()
-                    .with_bucket_name(&bucket);
+                    .with_bucket_name(&bucket)
+                    .with_client_options(default_client_options());
                 Arc::new(builder.build()?)
             }
             "az" | "abfs" | "abfss" => {
                 let builder = object_store::azure::MicrosoftAzureBuilder::from_env()
-                    .with_container_name(&bucket);
+                    .with_container_name(&bucket)
+                    .with_client_options(default_client_options());
                 Arc::new(builder.build()?)
             }
             "file" => {

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -8,12 +8,19 @@
 //! so credential resolution follows the standard AWS SDK / GCP ADC chains.
 
 use std::path::Path;
+use std::time::Duration;
 
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use crate::config::{StateBackend, StateConfig};
 use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
+
+/// Hard upper bound on any single remote state transfer. Belt-and-suspenders
+/// complement to the per-request timeout configured on the cloud client in
+/// [`crate::object_store`]: the client timeout handles stuck TCP; this outer
+/// bound catches unforeseen await paths (SDK retry loops, DNS, TLS).
+const STATE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Debug, Error)]
 pub enum StateSyncError {
@@ -40,6 +47,9 @@ pub enum StateSyncError {
 
     #[error("object store error: {0}")]
     ObjectStore(#[from] ObjectStoreError),
+
+    #[error("state transfer timed out after {0:?}")]
+    Timeout(Duration),
 }
 
 /// State file name within the configured prefix.
@@ -178,24 +188,27 @@ async fn download_from_object_store(
         "downloading state from object store"
     );
 
-    match provider.exists(STATE_FILE).await {
-        Ok(true) => {
-            provider.download_file(STATE_FILE, local_path).await?;
-            info!(
-                size = local_path.metadata().map(|m| m.len()).unwrap_or(0),
-                "state restored from object store"
-            );
-            Ok(())
+    with_transfer_timeout(async {
+        match provider.exists(STATE_FILE).await {
+            Ok(true) => {
+                provider.download_file(STATE_FILE, local_path).await?;
+                info!(
+                    size = local_path.metadata().map(|m| m.len()).unwrap_or(0),
+                    "state restored from object store"
+                );
+                Ok(())
+            }
+            Ok(false) => {
+                info!("No existing state in object store — starting fresh");
+                Ok(())
+            }
+            Err(e) => {
+                warn!(error = %e, "state existence check failed (non-fatal, starting fresh)");
+                Ok(())
+            }
         }
-        Ok(false) => {
-            info!("No existing state in object store — starting fresh");
-            Ok(())
-        }
-        Err(e) => {
-            warn!(error = %e, "state existence check failed (non-fatal, starting fresh)");
-            Ok(())
-        }
-    }
+    })
+    .await
 }
 
 /// Upload `STATE_FILE` to an object store rooted at `<scheme>://<bucket>/<prefix>`.
@@ -210,8 +223,25 @@ async fn upload_to_object_store(
         uri = format!("{scheme}://{bucket}/{prefix}{STATE_FILE}"),
         "uploading state to object store"
     );
-    provider.upload_file(local_path, STATE_FILE).await?;
+    with_transfer_timeout(async {
+        provider.upload_file(local_path, STATE_FILE).await?;
+        Ok::<(), StateSyncError>(())
+    })
+    .await?;
     Ok(())
+}
+
+/// Wrap a state-transfer future with [`STATE_TRANSFER_TIMEOUT`]. On elapse
+/// the returned error is `StateSyncError::Timeout` — distinct from the
+/// per-request timeout the client raises, so callers can tell the two apart.
+async fn with_transfer_timeout<F, T>(fut: F) -> Result<T, StateSyncError>
+where
+    F: std::future::Future<Output = Result<T, StateSyncError>>,
+{
+    match tokio::time::timeout(STATE_TRANSFER_TIMEOUT, fut).await {
+        Ok(result) => result,
+        Err(_) => Err(StateSyncError::Timeout(STATE_TRANSFER_TIMEOUT)),
+    }
 }
 
 /// Download state from Valkey/Redis.


### PR DESCRIPTION
## Summary

- `AmazonS3Builder`/`GoogleCloudStorageBuilder`/`MicrosoftAzureBuilder` now get a `ClientOptions` with a 60s request timeout and 10s connect timeout — previously unbounded, so a stuck TCP connection would hang the await indefinitely and `object_store`'s own `RetryConfig` (180s budget) never triggered because no single request ever returned.
- `state_sync::{upload,download}_to_object_store` are additionally wrapped in `tokio::time::timeout(300s, …)` as a belt-and-suspenders bound on the total operation, with a new `StateSyncError::Timeout` variant so operators can distinguish the outer expiry from per-request client timeouts.

## Motivation

Gold run [`f107d533`](https://publicisgroupe.dagster.cloud/gold-dev/runs/f107d533-2c28-44af-b7f9-056488095160) (2026-04-18) hung for ~7 h: last log line `uploading state to object store`, then complete silence until external cancellation. Diagnosed as `upload_to_object_store` → `provider.upload_file` → blocked HTTP PUT with no client-side timeout.

## Test plan

- [x] `cargo build -p rocky-core` — clean
- [x] `cargo test -p rocky-core --lib state_sync::` — 6/6 pass
- [x] `cargo test -p rocky-core --lib object_store::` — 7/7 pass
- [ ] Full CI

## Release

Patch-bump worthy (engine 1.8.0 → 1.8.1). Happy to fold into the next `chore(engine): release` PR.