### PR TITLE
chore(dagster): refresh fixtures_generated for engine 1.8.0

### DIFF
--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "dag",
   "nodes": [
     {

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "command": "test",
   "total": 3,
   "passed": 3,


### PR DESCRIPTION
Captures the `version` field bump from 1.7.0 to 1.8.0 across all 35
fixtures under integrations/dagster/tests/fixtures_generated/ so the
codegen-drift CI check passes.
