### PR TITLE
refactor(engine/rocky-core): preserve error context in SQL generation

### DIFF
--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -72,8 +72,17 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       - name: Install duckdb (for fixture regen)
+        # Pin to a specific release rather than `curl | sh` the vendor
+        # installer — avoids running an unverified remote shell script in CI.
+        env:
+          DUCKDB_VERSION: "1.1.3"
         run: |
-          curl -fsSL https://install.duckdb.org | sh
+          tmp="$(mktemp -d)"
+          url="https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip"
+          curl -fsSL --retry 3 --retry-delay 2 -o "$tmp/duckdb.zip" "$url"
+          unzip -q -d "$tmp/duckdb" "$tmp/duckdb.zip"
+          install -d "$HOME/.duckdb/cli/latest"
+          install -m 0755 "$tmp/duckdb/duckdb" "$HOME/.duckdb/cli/latest/duckdb"
           echo "$HOME/.duckdb/cli/latest" >> "$GITHUB_PATH"
 
       - name: uv sync (dagster)

--- a/.github/workflows/dagster-release.yml
+++ b/.github/workflows/dagster-release.yml
@@ -63,6 +63,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" dist/* \
+          # Guard the glob so an empty dist/ (uv build silently produced no
+          # artifacts) doesn't send the literal string `dist/*` to the
+          # upload command.
+          shopt -s nullglob
+          artifacts=( dist/* )
+          shopt -u nullglob
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "ERROR: no artifacts found under dist/" >&2
+            ls -la dist/ || true
+            exit 1
+          fi
+          gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --clobber

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -150,7 +150,20 @@ jobs:
       - name: Generate checksums.txt
         run: |
           cd release-artifacts
-          sha256sum rocky-*.tar.gz rocky-*.zip > checksums.txt
+          # Require that at least one of each expected archive glob was
+          # actually downloaded — otherwise `sha256sum rocky-*.tar.gz` would
+          # happily write an empty checksums.txt (or a line for the literal
+          # glob string) and we'd publish unverifiable artifacts.
+          shopt -s nullglob
+          targz=( rocky-*.tar.gz )
+          zips=( rocky-*.zip )
+          shopt -u nullglob
+          if (( ${#targz[@]} == 0 || ${#zips[@]} == 0 )); then
+            echo "ERROR: expected at least one rocky-*.tar.gz and one rocky-*.zip in release-artifacts/" >&2
+            ls -la
+            exit 1
+          fi
+          sha256sum "${targz[@]}" "${zips[@]}" > checksums.txt
           cat checksums.txt
 
       - name: Upload checksums to release

--- a/.github/workflows/engine-wasm-release.yml
+++ b/.github/workflows/engine-wasm-release.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: engine
@@ -66,33 +71,41 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#engine-wasm-v}"
+          # Accept only SemVer-ish tokens so the value is safe to interpolate
+          # into package.json below.
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Refusing to publish: tag '${GITHUB_REF_NAME}' did not yield a SemVer version (got '${VERSION}')" >&2
+            exit 1
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Write package.json with tag version
         working-directory: engine/crates/rocky-wasm/pkg
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          cat > package.json <<PKGJSON
-          {
-            "name": "@rocky-data/compiler",
-            "version": "${{ steps.version.outputs.version }}",
-            "description": "WASM bindings for Rocky's Rust compiler pipeline — SQL lineage, Rocky DSL parsing, and identifier validation",
-            "main": "rocky_wasm.js",
-            "types": "rocky_wasm.d.ts",
-            "files": [
+          # Use `jq` rather than string interpolation so the version is quoted
+          # as a JSON value and never able to break out of the template.
+          jq -n --arg version "$PKG_VERSION" '{
+            name: "@rocky-data/compiler",
+            version: $version,
+            description: "WASM bindings for Rockys Rust compiler pipeline — SQL lineage, Rocky DSL parsing, and identifier validation",
+            main: "rocky_wasm.js",
+            types: "rocky_wasm.d.ts",
+            files: [
               "rocky_wasm_bg.wasm",
               "rocky_wasm.js",
               "rocky_wasm.d.ts",
               "rocky_wasm_bg.wasm.d.ts"
             ],
-            "repository": {
-              "type": "git",
-              "url": "https://github.com/rocky-data/rocky",
-              "directory": "engine/crates/rocky-wasm"
+            repository: {
+              type: "git",
+              url: "https://github.com/rocky-data/rocky",
+              directory: "engine/crates/rocky-wasm"
             },
-            "keywords": ["wasm", "sql", "lineage", "transformation", "rocky"],
-            "license": "Apache-2.0"
-          }
-          PKGJSON
+            keywords: ["wasm", "sql", "lineage", "transformation", "rocky"],
+            license: "Apache-2.0"
+          }' > package.json
 
       - name: Archive WASM package
         run: tar czf rocky-wasm.tar.gz -C crates/rocky-wasm/pkg .
@@ -107,10 +120,11 @@ jobs:
         working-directory: engine
 
       - name: Publish to npm
-        if: env.NODE_AUTH_TOKEN != ''
+        if: ${{ secrets.NPM_TOKEN != '' }}
         working-directory: engine/crates/rocky-wasm/pkg
         env:
+          # `actions/setup-node` already wrote a registry-scoped .npmrc that
+          # reads $NODE_AUTH_TOKEN from the environment at publish time, so
+          # the token never hits disk.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          npm publish --access public
+        run: npm publish --access public

--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -26,7 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # Pin to a specific version + --locked so a regression in a newer
+        # cargo-audit release can't silently change the weekly CI signal.
+        # Bump deliberately alongside any MSRV or advisory-db change.
+        run: cargo install cargo-audit --version 0.21.1 --locked
       - name: Run cargo audit
         run: cargo audit
 
@@ -45,7 +48,8 @@ jobs:
           sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
       - run: sudo apt-get update && sudo apt-get install -y cmake
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        # Pinned + --locked for the same reason as cargo-audit above.
+        run: cargo install cargo-tarpaulin --version 0.31.2 --locked
       - name: Run coverage
         run: cargo tarpaulin --all-targets --timeout 600 --out xml --output-dir coverage/
       - name: Upload coverage report

--- a/editors/vscode/src/codeLens.ts
+++ b/editors/vscode/src/codeLens.ts
@@ -85,11 +85,23 @@ function makeLens(
 }
 
 /**
+ * Single-quote an argument for POSIX shells; on Windows quote with `"` and
+ * double any embedded quotes. Callers route through `terminal.sendText`, which
+ * goes through the user's shell, so every interpolated token must be escaped.
+ */
+function shellQuote(arg: string): string {
+  if (process.platform === "win32") {
+    return `"${arg.replace(/"/g, '""')}"`;
+  }
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
  * Runs `rocky run --filter name=<model>` in the integrated terminal.
  */
 function runModelInTerminal(modelName: string): void {
   const cfg = getConfig();
-  const cmd = `${cfg.serverPath} run --filter name=${modelName} --output json`;
+  const cmd = `${shellQuote(cfg.serverPath)} run --filter name=${shellQuote(modelName)} --output json`;
   const terminal = vscode.window.createTerminal({
     name: `Rocky: run ${modelName}`,
     iconPath: new vscode.ThemeIcon("play"),
@@ -103,7 +115,7 @@ function runModelInTerminal(modelName: string): void {
  */
 function compileModelInTerminal(modelName: string): void {
   const cfg = getConfig();
-  const cmd = `${cfg.serverPath} compile --model ${modelName} --output json`;
+  const cmd = `${shellQuote(cfg.serverPath)} compile --model ${shellQuote(modelName)} --output json`;
   const terminal = vscode.window.createTerminal({
     name: `Rocky: compile ${modelName}`,
     iconPath: new vscode.ThemeIcon("file-code"),

--- a/editors/vscode/src/webviews/doctor.ts
+++ b/editors/vscode/src/webviews/doctor.ts
@@ -17,11 +17,18 @@ export function showDoctorResult(result: DoctorResult): void {
 
   panel.webview.html = renderDoctorHtml(panel.webview, result);
 
-  panel.webview.onDidReceiveMessage((msg: { command: string }) => {
-    if (msg.command === "rerun") {
+  const allowedCommands = new Set(["rerun", "openSettings"] as const);
+  panel.webview.onDidReceiveMessage((raw: unknown) => {
+    // Treat all webview messages as untrusted — the webview's script is
+    // ours today, but a future CSP gap or injected iframe could forge one.
+    if (typeof raw !== "object" || raw === null) return;
+    const cmd = (raw as { command?: unknown }).command;
+    if (typeof cmd !== "string" || !allowedCommands.has(cmd as never)) return;
+
+    if (cmd === "rerun") {
       panel.dispose();
       void vscode.commands.executeCommand("rocky.doctor");
-    } else if (msg.command === "openSettings") {
+    } else if (cmd === "openSettings") {
       void vscode.commands.executeCommand(
         "workbench.action.openSettings",
         "rocky",

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1180,7 +1180,7 @@ pub async fn run(
                 // Checkpoint: record successful table progress
                 {
                     let state = shared_state.lock().await;
-                    let _ = state.record_table_progress(
+                    if let Err(e) = state.record_table_progress(
                         &shared_run_id,
                         &rocky_core::state::TableProgress {
                             index: total_completed - 1,
@@ -1194,7 +1194,9 @@ pub async fn run(
                                 .map_or(0, |m| m.duration_ms),
                             completed_at: Utc::now(),
                         },
-                    );
+                    ) {
+                        tracing::warn!(error = %e, "failed to record table progress for run ");
+                    }
                 }
             }
             Ok((idx, Err(e))) => {
@@ -1230,7 +1232,7 @@ pub async fn run(
                         })
                         .unwrap_or_default();
                     let state = shared_state.lock().await;
-                    let _ = state.record_table_progress(
+                    if let Err(e) = state.record_table_progress(
                         &shared_run_id,
                         &rocky_core::state::TableProgress {
                             index: idx,
@@ -1241,7 +1243,9 @@ pub async fn run(
                             duration_ms: 0,
                             completed_at: Utc::now(),
                         },
-                    );
+                    ) {
+                        tracing::warn!(error = %e, "failed to record table progress for run ");
+                    }
                 }
 
                 table_errors.push(TableError {
@@ -1261,7 +1265,7 @@ pub async fn run(
                 // Checkpoint: record panicked task progress
                 {
                     let state = shared_state.lock().await;
-                    let _ = state.record_table_progress(
+                    if let Err(e) = state.record_table_progress(
                         &shared_run_id,
                         &rocky_core::state::TableProgress {
                             index: 0,
@@ -1272,7 +1276,9 @@ pub async fn run(
                             duration_ms: 0,
                             completed_at: Utc::now(),
                         },
-                    );
+                    ) {
+                        tracing::warn!(error = %e, "failed to record table progress for run ");
+                    }
                 }
 
                 table_errors.push(TableError {
@@ -1312,13 +1318,15 @@ pub async fn run(
         {
             let state = shared_state.lock().await;
             for wm in &deferred_watermarks {
-                let _ = state.set_watermark(
+                if let Err(e) = state.set_watermark(
                     &wm.state_key,
                     &WatermarkState {
                         last_value: wm.timestamp,
                         updated_at: wm.timestamp,
                     },
-                );
+                ) {
+                    tracing::warn!(error = %e, "failed to persist watermark for run ");
+                }
             }
         }
 
@@ -1356,7 +1364,7 @@ pub async fn run(
                 if !settled.contains(&key) {
                     let mut asset_key = task.asset_key_prefix.clone();
                     asset_key.push(task.table_name.clone());
-                    let _ = state.record_table_progress(
+                    if let Err(e) = state.record_table_progress(
                         &shared_run_id,
                         &rocky_core::state::TableProgress {
                             index: idx,
@@ -1367,7 +1375,9 @@ pub async fn run(
                             duration_ms: 0,
                             completed_at: Utc::now(),
                         },
-                    );
+                    ) {
+                        tracing::warn!(error = %e, "failed to record table progress for run ");
+                    }
                 }
             }
         }
@@ -1459,13 +1469,15 @@ pub async fn run(
     {
         let state = shared_state.lock().await;
         for wm in &deferred_watermarks {
-            let _ = state.set_watermark(
+            if let Err(e) = state.set_watermark(
                 &wm.state_key,
                 &WatermarkState {
                     last_value: wm.timestamp,
                     updated_at: wm.timestamp,
                 },
-            );
+            ) {
+                tracing::warn!(error = %e, "failed to persist watermark for run ");
+            }
         }
     }
 
@@ -2904,7 +2916,7 @@ async fn process_completed_result(
             // Checkpoint: record successful table progress
             {
                 let state = shared_state.lock().await;
-                let _ = state.record_table_progress(
+                if let Err(e) = state.record_table_progress(
                     shared_run_id,
                     &rocky_core::state::TableProgress {
                         index: *total_completed - 1,
@@ -2915,7 +2927,9 @@ async fn process_completed_result(
                         duration_ms: output.materializations.last().map_or(0, |m| m.duration_ms),
                         completed_at: Utc::now(),
                     },
-                );
+                ) {
+                    tracing::warn!(error = %e, "failed to record table progress for run ");
+                }
             }
         }
         Ok((idx, Err(e))) => {
@@ -2947,7 +2961,7 @@ async fn process_completed_result(
                     .map(|t| format!("{}.{}.{}", t.target_catalog, t.target_schema, t.table_name))
                     .unwrap_or_default();
                 let state = shared_state.lock().await;
-                let _ = state.record_table_progress(
+                if let Err(e) = state.record_table_progress(
                     shared_run_id,
                     &rocky_core::state::TableProgress {
                         index: idx,
@@ -2958,7 +2972,9 @@ async fn process_completed_result(
                         duration_ms: 0,
                         completed_at: Utc::now(),
                     },
-                );
+                ) {
+                    tracing::warn!(error = %e, "failed to record table progress for run ");
+                }
             }
 
             table_errors.push(TableError {
@@ -2974,7 +2990,7 @@ async fn process_completed_result(
             // Checkpoint: record panicked task progress
             {
                 let state = shared_state.lock().await;
-                let _ = state.record_table_progress(
+                if let Err(e) = state.record_table_progress(
                     shared_run_id,
                     &rocky_core::state::TableProgress {
                         index: 0,
@@ -2985,7 +3001,9 @@ async fn process_completed_result(
                         duration_ms: 0,
                         completed_at: Utc::now(),
                     },
-                );
+                ) {
+                    tracing::warn!(error = %e, "failed to record table progress for run ");
+                }
             }
 
             table_errors.push(TableError {

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -800,7 +800,11 @@ fn lint_config(
 
     // L007: single-adapter project repeats adapter name
     if cfg.adapters.len() == 1 {
-        let adapter_name = cfg.adapters.keys().next().unwrap();
+        let adapter_name = cfg
+            .adapters
+            .keys()
+            .next()
+            .expect("len == 1 guarantees one key");
         let mut ref_count = 0usize;
         for pc in cfg.pipelines.values() {
             // Count adapter references across all pipeline types

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -540,7 +540,11 @@ pub fn resolve_pipeline<'a>(
         }
         None => {
             if config.pipelines.len() == 1 {
-                let (name, pipeline) = config.pipelines.iter().next().unwrap();
+                let (name, pipeline) = config
+                    .pipelines
+                    .iter()
+                    .next()
+                    .expect("len == 1 guarantees one entry");
                 Ok((name.as_str(), pipeline))
             } else if config.pipelines.is_empty() {
                 bail!("no pipelines defined in config")

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -84,12 +84,7 @@ pub fn generate_null_rate_sql(
     sample_percent: u32,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
 
     let sample_clause = dialect
         .tablesample_clause(sample_percent)
@@ -129,12 +124,7 @@ pub fn generate_row_count_sql(
     table: &TableRef,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(format!("SELECT COUNT(*) AS cnt FROM {ref_str}"))
 }
 
@@ -145,12 +135,7 @@ pub fn generate_freshness_sql(
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
     rocky_sql::validation::validate_identifier(timestamp_column)?;
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(format!(
         "SELECT MAX({timestamp_column}) AS max_ts FROM {ref_str}"
     ))
@@ -163,12 +148,7 @@ pub fn generate_custom_check_sql(
     sql_template: &str,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(sql_template.replace("{target}", &ref_str))
 }
 

--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -58,12 +58,7 @@ pub fn generate_describe_table_sql(
     table: &TableRef,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(dialect.describe_table_sql(&ref_str))
 }
 
@@ -72,12 +67,7 @@ pub fn generate_drop_table_sql(
     table: &TableRef,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let ref_str = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(dialect.drop_table_sql(&ref_str))
 }
 
@@ -166,12 +156,7 @@ pub fn generate_alter_column_sql(
     drifted_columns: &[DriftedColumn],
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let table_ref = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
 
     let mut statements = Vec::new();
     for col in drifted_columns {
@@ -314,12 +299,7 @@ pub fn generate_drop_column_sql(
     columns: &[String],
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let table_ref = dialect
-        .format_table_ref(&table.catalog, &table.schema, &table.table)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
 
     let mut statements = Vec::new();
     for col_name in columns {

--- a/engine/crates/rocky-core/src/hooks/template.rs
+++ b/engine/crates/rocky-core/src/hooks/template.rs
@@ -104,45 +104,41 @@ fn resolve_conditionals(
     input: &str,
     lookup: &HashMap<String, String>,
 ) -> Result<String, TemplateError> {
+    const IF_OPEN: &str = "{{#if ";
+    const IF_CLOSE: &str = "{{/if}}";
+    const EXPR_CLOSE: &str = "}}";
+
     let mut result = String::with_capacity(input.len());
     let mut remaining = input;
 
     loop {
-        // Find next {{#if ...}}
-        let Some(if_start) = remaining.find("{{#if ") else {
+        // Split on the next `{{#if ` marker. `split_once` returns &str slices
+        // on char boundaries, so malformed UTF-8 in the surrounding template
+        // body can't panic us the way raw byte offsets would.
+        let Some((before, after_if_open)) = remaining.split_once(IF_OPEN) else {
             result.push_str(remaining);
             break;
         };
+        result.push_str(before);
 
-        // Copy everything before the conditional
-        result.push_str(&remaining[..if_start]);
-
-        // Parse the field name
-        let after_if = &remaining[if_start + 6..]; // skip "{{#if "
-        let Some(close_brace) = after_if.find("}}") else {
-            // Malformed — treat as literal
-            result.push_str(&remaining[if_start..if_start + 6]);
-            remaining = after_if;
+        // Find the end of the `{{#if <field>}}` tag.
+        let Some((field_raw, after_open_tag)) = after_if_open.split_once(EXPR_CLOSE) else {
+            // Malformed — treat `{{#if ` as a literal and keep scanning.
+            result.push_str(IF_OPEN);
+            remaining = after_if_open;
             continue;
         };
+        let field = field_raw.trim();
 
-        let field = after_if[..close_brace].trim();
-        let after_open_tag = &after_if[close_brace + 2..];
-
-        // Find the matching {{/if}}
-        let Some(endif_pos) = after_open_tag.find("{{/if}}") else {
+        // Find the matching `{{/if}}`.
+        let Some((inner, after_endif)) = after_open_tag.split_once(IF_CLOSE) else {
             return Err(TemplateError::UnclosedConditional {
                 field: field.to_string(),
             });
         };
 
-        let inner = &after_open_tag[..endif_pos];
-        let after_endif = &after_open_tag[endif_pos + 7..]; // skip "{{/if}}"
-
-        // Include inner content only if field is present and non-empty
-        let field_present = lookup.get(field).is_some_and(|v| !v.is_empty());
-
-        if field_present {
+        // Include inner content only if field is present and non-empty.
+        if lookup.get(field).is_some_and(|v| !v.is_empty()) {
             result.push_str(inner);
         }
 
@@ -157,34 +153,33 @@ fn resolve_conditionals(
 // ---------------------------------------------------------------------------
 
 fn substitute_fields(input: &str, lookup: &HashMap<String, String>) -> String {
+    const OPEN: &str = "{{";
+    const CLOSE: &str = "}}";
+
     let mut result = String::with_capacity(input.len());
     let mut remaining = input;
 
     loop {
-        let Some(open) = remaining.find("{{") else {
+        let Some((before, after_open)) = remaining.split_once(OPEN) else {
             result.push_str(remaining);
             break;
         };
+        result.push_str(before);
 
-        result.push_str(&remaining[..open]);
-
-        let after_open = &remaining[open + 2..];
-        let Some(close) = after_open.find("}}") else {
-            // Unclosed — treat as literal
-            result.push_str("{{");
+        let Some((field_raw, after_close)) = after_open.split_once(CLOSE) else {
+            // Unclosed — emit the `{{` literally and keep scanning.
+            result.push_str(OPEN);
             remaining = after_open;
             continue;
         };
 
-        let field = after_open[..close].trim();
-
-        // Look up value; unknown fields resolve to empty string
+        let field = field_raw.trim();
         if let Some(value) = lookup.get(field) {
             result.push_str(value);
         }
-        // else: empty string (intentionally no output for unknown fields)
+        // else: empty string (intentionally no output for unknown fields).
 
-        remaining = &after_open[close + 2..];
+        remaining = after_close;
     }
 
     result

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -679,16 +679,13 @@ pub fn load_models_from_dir(dir: &Path) -> Result<Vec<Model>, ModelError> {
 fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
     let content = content.trim_start();
 
-    if !content.starts_with("---toml") {
-        return None;
-    }
+    // `strip_prefix` / `split_once` return &str slices on char boundaries, so
+    // malformed input (including non-UTF-8-boundary markers in the SQL body)
+    // can't panic the way raw `content[7..]` byte slicing could.
+    let after_start = content.strip_prefix("---toml")?;
+    let (frontmatter, sql) = after_start.split_once("\n---")?;
 
-    let after_start = &content[7..]; // skip "---toml"
-    let end_pos = after_start.find("\n---")?;
-    let frontmatter = after_start[..end_pos].trim();
-    let sql = after_start[end_pos + 4..].trim(); // skip "\n---"
-
-    Some((frontmatter, sql))
+    Some((frontmatter.trim(), sql.trim()))
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-core/src/snapshots.rs
+++ b/engine/crates/rocky-core/src/snapshots.rs
@@ -220,10 +220,9 @@ pub fn generate_snapshot_sql(
         }
         SnapshotStrategy::Check { check_columns } => {
             if check_columns.is_empty() {
-                return Err(SqlGenError::UnsafeFragment {
-                    value: String::new(),
-                    reason: "check strategy requires at least one check_column".to_string(),
-                });
+                return Err(SqlGenError::InvalidRequest(
+                    "check strategy requires at least one check_column".to_string(),
+                ));
             }
             for col in check_columns {
                 validation::validate_identifier(col)?;
@@ -349,30 +348,20 @@ fn generate_snapshot_id(target: &TargetRef) -> String {
 
 /// Format and validate the source table reference.
 fn format_source(config: &SnapshotConfig, dialect: &dyn SqlDialect) -> Result<String, SqlGenError> {
-    dialect
-        .format_table_ref(
-            &config.source.catalog,
-            &config.source.schema,
-            &config.source.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })
+    Ok(dialect.format_table_ref(
+        &config.source.catalog,
+        &config.source.schema,
+        &config.source.table,
+    )?)
 }
 
 /// Format and validate the target table reference.
 fn format_target(config: &SnapshotConfig, dialect: &dyn SqlDialect) -> Result<String, SqlGenError> {
-    dialect
-        .format_table_ref(
-            &config.target.catalog,
-            &config.target.schema,
-            &config.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })
+    Ok(dialect.format_table_ref(
+        &config.target.catalog,
+        &config.target.schema,
+        &config.target.table,
+    )?)
 }
 
 /// Build a `left.k1 = right.k1 AND left.k2 = right.k2` join condition.

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -5,7 +5,7 @@ use crate::ir::{
     MaterializationStrategy, PartitionWindow, ReplicationPlan, SnapshotPlan, TransformationPlan,
 };
 use crate::lakehouse::{self, LakehouseError};
-use crate::traits::SqlDialect;
+use crate::traits::{AdapterError, SqlDialect};
 
 /// Errors from SQL generation, including identifier validation and unsafe fragment detection.
 #[derive(Debug, Error)]
@@ -26,6 +26,20 @@ pub enum SqlGenError {
 
     #[error("lakehouse DDL error: {0}")]
     Lakehouse(#[from] LakehouseError),
+
+    /// An adapter-level error surfaced while composing SQL (e.g. identifier
+    /// rejection from `SqlDialect::format_table_ref`). Keeping the source
+    /// error in the chain preserves the offending identifier rather than
+    /// stringifying it into an empty-`value` `UnsafeFragment`.
+    #[error("dialect error: {0}")]
+    Dialect(#[from] AdapterError),
+
+    /// SQL generation was invoked with an incompatible plan or arguments —
+    /// e.g. `MaterializationStrategy::DynamicTable` without a warehouse, or
+    /// a `check`-strategy snapshot without any `check_column`s. Distinct
+    /// from `UnsafeFragment`, which reports bad SQL content.
+    #[error("invalid SQL generation request: {0}")]
+    InvalidRequest(String),
 }
 
 /// Generates the SELECT SQL for a replication plan using the given dialect.
@@ -33,23 +47,13 @@ pub fn generate_select_sql(
     plan: &ReplicationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let select = dialect
-        .select_clause(&plan.columns, &plan.metadata_columns)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let select = dialect.select_clause(&plan.columns, &plan.metadata_columns)?;
 
-    let source = dialect
-        .format_table_ref(
-            &plan.source.catalog,
-            &plan.source.schema,
-            &plan.source.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let source = dialect.format_table_ref(
+        &plan.source.catalog,
+        &plan.source.schema,
+        &plan.source.table,
+    )?;
 
     let mut sql = format!("{select}\nFROM {source}");
 
@@ -57,23 +61,13 @@ pub fn generate_select_sql(
         timestamp_column, ..
     } = &plan.strategy
     {
-        let target = dialect
-            .format_table_ref(
-                &plan.target.catalog,
-                &plan.target.schema,
-                &plan.target.table,
-            )
-            .map_err(|e| SqlGenError::UnsafeFragment {
-                value: String::new(),
-                reason: e.to_string(),
-            })?;
+        let target = dialect.format_table_ref(
+            &plan.target.catalog,
+            &plan.target.schema,
+            &plan.target.table,
+        )?;
 
-        let where_clause = dialect
-            .watermark_where(timestamp_column, &target)
-            .map_err(|e| SqlGenError::UnsafeFragment {
-                value: String::new(),
-                reason: e.to_string(),
-            })?;
+        let where_clause = dialect.watermark_where(timestamp_column, &target)?;
 
         let _ = write!(sql, "\n{where_clause}");
     }
@@ -89,23 +83,13 @@ fn generate_select_sql_no_watermark(
     plan: &ReplicationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let select = dialect
-        .select_clause(&plan.columns, &plan.metadata_columns)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let select = dialect.select_clause(&plan.columns, &plan.metadata_columns)?;
 
-    let source = dialect
-        .format_table_ref(
-            &plan.source.catalog,
-            &plan.source.schema,
-            &plan.source.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let source = dialect.format_table_ref(
+        &plan.source.catalog,
+        &plan.source.schema,
+        &plan.source.table,
+    )?;
 
     Ok(format!("{select}\nFROM {source}"))
 }
@@ -115,16 +99,11 @@ pub fn generate_insert_sql(
     plan: &ReplicationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
     let select = generate_select_sql(plan, dialect)?;
     Ok(dialect.insert_into(&target, &select))
 }
@@ -134,16 +113,11 @@ pub fn generate_create_table_as_sql(
     plan: &ReplicationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     let select = generate_select_sql_no_watermark(plan, dialect)?;
 
@@ -155,16 +129,11 @@ pub fn generate_merge_sql(
     plan: &ReplicationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     let (unique_key, update_columns) = match &plan.strategy {
         MaterializationStrategy::Merge {
@@ -178,12 +147,7 @@ pub fn generate_merge_sql(
 
     let select = generate_select_sql_no_watermark(plan, dialect)?;
 
-    dialect
-        .merge_into(&target, &select, unique_key, update_columns)
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })
+    Ok(dialect.merge_into(&target, &select, unique_key, update_columns)?)
 }
 
 /// Generates transformation SQL using the given dialect.
@@ -198,25 +162,15 @@ pub fn generate_transformation_sql(
     plan: &TransformationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     // Validate all source references
     for source in &plan.sources {
-        dialect
-            .format_table_ref(&source.catalog, &source.schema, &source.table)
-            .map_err(|e| SqlGenError::UnsafeFragment {
-                value: String::new(),
-                reason: e.to_string(),
-            })?;
+        dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
     }
 
     // If a lakehouse format is specified, use format-specific DDL generation
@@ -244,12 +198,7 @@ pub fn generate_transformation_sql(
             unique_key,
             update_columns,
         } => {
-            let stmt = dialect
-                .merge_into(&target, &plan.sql, unique_key, update_columns)
-                .map_err(|e| SqlGenError::UnsafeFragment {
-                    value: String::new(),
-                    reason: e.to_string(),
-                })?;
+            let stmt = dialect.merge_into(&target, &plan.sql, unique_key, update_columns)?;
             Ok(vec![stmt])
         }
         MaterializationStrategy::MaterializedView => {
@@ -258,10 +207,9 @@ pub fn generate_transformation_sql(
         MaterializationStrategy::DynamicTable { .. } => {
             // Dynamic tables require a warehouse parameter not available in the plan.
             // Use generate_dynamic_table_sql directly when warehouse is known.
-            Err(SqlGenError::UnsafeFragment {
-                value: String::new(),
-                reason: "DynamicTable strategy requires calling generate_dynamic_table_sql with warehouse parameter".to_string(),
-            })
+            Err(SqlGenError::InvalidRequest(
+                "DynamicTable strategy requires calling generate_dynamic_table_sql with warehouse parameter".to_string(),
+            ))
         }
         MaterializationStrategy::TimeInterval {
             time_column,
@@ -297,12 +245,7 @@ pub fn generate_transformation_sql(
 
             let substituted = substitute_partition_placeholders(&plan.sql, window);
 
-            dialect
-                .insert_overwrite_partition(&target, &filter, &substituted)
-                .map_err(|e| SqlGenError::UnsafeFragment {
-                    value: String::new(),
-                    reason: e.to_string(),
-                })
+            Ok(dialect.insert_overwrite_partition(&target, &filter, &substituted)?)
         }
         MaterializationStrategy::Ephemeral => {
             // Ephemeral models are not materialized — the compiler inlines
@@ -362,16 +305,11 @@ pub fn generate_time_interval_bootstrap_sql(
     plan: &TransformationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     // Sentinel window: start == end → half-open [start, end) is empty.
     // The chosen timestamp is well before any real partition boundary so
@@ -424,16 +362,11 @@ pub fn generate_transformation_initial_ddl(
     plan: &TransformationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     if let Some(ref format) = plan.format {
         let opts = plan.format_options.as_ref().cloned().unwrap_or_default();
@@ -469,16 +402,11 @@ pub fn generate_materialized_view_sql(
     plan: &TransformationPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     Ok(format!(
         "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{sql}",
@@ -493,16 +421,11 @@ pub fn generate_dynamic_table_sql(
     warehouse: &str,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     // Validate target_lag and warehouse to prevent injection
     validate_sql_type(target_lag)?;
@@ -573,26 +496,16 @@ pub fn generate_snapshot_sql(
     plan: &SnapshotPlan,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let source = dialect
-        .format_table_ref(
-            &plan.source.catalog,
-            &plan.source.schema,
-            &plan.source.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
-    let target = dialect
-        .format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
-        )
-        .map_err(|e| SqlGenError::UnsafeFragment {
-            value: String::new(),
-            reason: e.to_string(),
-        })?;
+    let source = dialect.format_table_ref(
+        &plan.source.catalog,
+        &plan.source.schema,
+        &plan.source.table,
+    )?;
+    let target = dialect.format_table_ref(
+        &plan.target.catalog,
+        &plan.target.schema,
+        &plan.target.table,
+    )?;
 
     if plan.unique_key.is_empty() {
         return Err(SqlGenError::MergeNoKey);

--- a/engine/crates/rocky-observe/src/events.rs
+++ b/engine/crates/rocky-observe/src/events.rs
@@ -12,7 +12,7 @@ use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
-use tracing::debug;
+use tracing::{debug, trace};
 
 // ---------------------------------------------------------------------------
 // PipelineEvent
@@ -118,11 +118,15 @@ impl EventBus {
 
     /// Emit an event to all subscribers.
     ///
-    /// If no subscribers exist, the event is silently dropped.
+    /// If no subscribers exist, the event is dropped — `tokio::sync::broadcast::Sender::send`
+    /// only errors when there are zero active receivers, which is expected
+    /// for an event bus with no current listeners. The `debug!` above gives
+    /// operators visibility when that happens.
     pub fn emit(&self, event: PipelineEvent) {
         debug!(event_type = %event.event_type, target = ?event.target, "event emitted");
-        // Ignore send error (no receivers) — fire-and-forget observability
-        let _ = self.sender.send(event);
+        if self.sender.send(event).is_err() {
+            trace!("no subscribers; event dropped");
+        }
     }
 
     /// Subscribe to events. Returns a receiver that yields events.

--- a/engine/crates/rocky-sql/src/parser.rs
+++ b/engine/crates/rocky-sql/src/parser.rs
@@ -150,11 +150,13 @@ pub fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParseError> {
 
 /// Parses a SQL string expecting exactly one statement.
 pub fn parse_single_statement(sql: &str) -> Result<Statement, ParseError> {
-    let statements = parse_sql(sql)?;
+    let mut statements = parse_sql(sql)?;
     if statements.len() != 1 {
         return Err(ParseError::MultipleStatements(statements.len()));
     }
-    Ok(statements.into_iter().next().unwrap())
+    // Length is guaranteed to be 1 by the check above; `swap_remove(0)` gives
+    // us the Statement without an `unwrap()` on the iterator.
+    Ok(statements.swap_remove(0))
 }
 
 #[cfg(test)]

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -145,17 +145,31 @@ fi
 
 if [[ -n "${ACTUAL_HASH}" ]]; then
     echo "  SHA256: ${ACTUAL_HASH}"
-    if download_file "${CHECKSUMS_URL}" "${TMP}/checksums.txt" 2>/dev/null; then
-        EXPECTED_HASH="$(grep "${ARCHIVE}" "${TMP}/checksums.txt" | cut -d' ' -f1 || true)"
-        if [[ -n "${EXPECTED_HASH}" ]]; then
-            if [[ "${ACTUAL_HASH}" != "${EXPECTED_HASH}" ]]; then
-                echo "Error: Checksum mismatch!" >&2
-                echo "  Expected: ${EXPECTED_HASH}" >&2
-                echo "  Actual:   ${ACTUAL_HASH}" >&2
-                exit 1
-            fi
-            echo "  Checksum verified."
+    # checksums.txt is published alongside every engine release. If the
+    # download fails we must not silently skip verification — an attacker
+    # who can strip the file would otherwise downgrade us to no integrity
+    # check. Only skip when the host lacks any sha256 tooling (handled by
+    # the outer `if -n ACTUAL_HASH`).
+    if ! download_file "${CHECKSUMS_URL}" "${TMP}/checksums.txt"; then
+        echo "Error: Failed to download ${CHECKSUMS_URL}." >&2
+        echo "  Refusing to install an unverified binary. Retry, or set" >&2
+        echo "  ROCKY_SKIP_CHECKSUM=1 if you intentionally want to skip." >&2
+        if [[ "${ROCKY_SKIP_CHECKSUM:-}" != "1" ]]; then
+            exit 1
         fi
+    else
+        EXPECTED_HASH="$(grep "${ARCHIVE}" "${TMP}/checksums.txt" | cut -d' ' -f1 || true)"
+        if [[ -z "${EXPECTED_HASH}" ]]; then
+            echo "Error: checksums.txt did not contain an entry for ${ARCHIVE}." >&2
+            exit 1
+        fi
+        if [[ "${ACTUAL_HASH}" != "${EXPECTED_HASH}" ]]; then
+            echo "Error: Checksum mismatch!" >&2
+            echo "  Expected: ${EXPECTED_HASH}" >&2
+            echo "  Actual:   ${ACTUAL_HASH}" >&2
+            exit 1
+        fi
+        echo "  Checksum verified."
     fi
 fi
 

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1007,7 +1007,7 @@ def _emit_contract_check_results(
 
 
 def _log_compile_diagnostics(
-    context,
+    context: dg.AssetExecutionContext,
     compile_state: _CompileState,
 ) -> None:
     for diag in compile_state.diagnostics:
@@ -1023,7 +1023,7 @@ def _log_compile_diagnostics(
 def _select_filters(
     group: _GroupBuild,
     selected_keys: set[dg.AssetKey],
-    context,
+    context: dg.AssetExecutionContext,
 ) -> list[str]:
     """Pick group-level filter or per-source filters depending on subset."""
     needed_source_ids = {
@@ -1041,7 +1041,7 @@ def _select_filters(
 
 
 def _run_filters(
-    context,
+    context: dg.AssetExecutionContext,
     rocky: RockyResource,
     filters: list[str],
     *,
@@ -1070,7 +1070,7 @@ def _run_filters(
 
 
 def _log_run_diagnostics(
-    context,
+    context: dg.AssetExecutionContext,
     result: RunResult,
 ) -> None:
     """Log run-level errors and contract violations.

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -121,9 +121,7 @@ def discover_contract_rules(contracts_dir: Path) -> dict[str, ContractRules]:
         if not stem:
             # Degenerate filename (just `.contract.toml`). Skip but surface
             # it — otherwise a misnamed file silently contributes nothing.
-            _log.warning(
-                "Ignoring contract file with empty model name: %s", path
-            )
+            _log.warning("Ignoring contract file with empty model name: %s", path)
             continue
         rules = _parse_contract_rules(path)
         if not rules.is_empty:

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -34,12 +34,15 @@ auto-wires them when ``contracts_dir`` is configured.
 
 from __future__ import annotations
 
+import logging
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import dagster as dg
+
+_log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -116,6 +119,11 @@ def discover_contract_rules(contracts_dir: Path) -> dict[str, ContractRules]:
         # Filename: foo.contract.toml → model name "foo"
         stem = path.name.removesuffix(".contract.toml")
         if not stem:
+            # Degenerate filename (just `.contract.toml`). Skip but surface
+            # it — otherwise a misnamed file silently contributes nothing.
+            _log.warning(
+                "Ignoring contract file with empty model name: %s", path
+            )
             continue
         rules = _parse_contract_rules(path)
         if not rules.is_empty:

--- a/integrations/dagster/src/dagster_rocky/dag_assets.py
+++ b/integrations/dagster/src/dagster_rocky/dag_assets.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 import dagster as dg
 
+from . import partitions
 from .freshness import freshness_policy_from_model
 
 if TYPE_CHECKING:
@@ -70,18 +71,22 @@ class DagAssetGroup:
 def _partitions_def_for_node(
     node: DagNodeOutput,
 ) -> dg.PartitionsDefinition | None:
-    """Create a Dagster PartitionsDefinition from a node's partition shape."""
+    """Create a Dagster PartitionsDefinition from a node's partition shape.
+
+    Delegates to :func:`partitions.partitions_def_for_time_interval` after
+    normalizing the dag-schema grain aliases (``daily`` / ``hourly`` / …) to
+    the canonical :data:`partitions.TimeGrain` enum so the two code paths
+    stay in lockstep.
+    """
     if node.partition_shape is None:
         return None
-    grain = node.partition_shape.granularity
-    start = node.partition_shape.first_partition or "2024-01-01"
-    if grain == "daily":
-        return dg.DailyPartitionsDefinition(start_date=start)
-    if grain == "hourly":
-        return dg.HourlyPartitionsDefinition(start_date=start)
-    if grain == "monthly":
-        return dg.MonthlyPartitionsDefinition(start_date=start)
-    return None
+    grain = partitions.normalize_grain(node.partition_shape.granularity)
+    if grain is None:
+        return None
+    return partitions.partitions_def_for_time_interval(
+        granularity=grain,
+        first_partition=node.partition_shape.first_partition,
+    )
 
 
 def _shape_key_for_node(node: DagNodeOutput) -> str:

--- a/integrations/dagster/src/dagster_rocky/derived_models.py
+++ b/integrations/dagster/src/dagster_rocky/derived_models.py
@@ -116,7 +116,9 @@ def build_model_specs(
         A list of ``dg.AssetSpec``, one per derived model. Empty when
         ``compile_result.models_detail`` is empty.
     """
-    del contract_rules_by_model  # noqa: F841 — reserved for future use
+    # Accepted for forward compatibility (see docstring); contract check
+    # specs are still emitted from the component layer.
+    _ = contract_rules_by_model
 
     # Build a name → asset_key map up front so depends_on can be resolved.
     model_to_key: dict[str, dg.AssetKey] = {}

--- a/integrations/dagster/src/dagster_rocky/partitions.py
+++ b/integrations/dagster/src/dagster_rocky/partitions.py
@@ -54,6 +54,31 @@ if TYPE_CHECKING:
 TimeGrain = Literal["hour", "day", "month", "year"]
 
 
+#: Alternate grain vocabulary emitted by ``rocky dag --output json`` (see
+#: ``integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py``).
+#: Kept as a lookup table rather than a second source of truth so the two
+#: code paths can't drift over time.
+_DAG_GRAIN_ALIASES: dict[str, TimeGrain] = {
+    "hourly": "hour",
+    "daily": "day",
+    "monthly": "month",
+    "yearly": "year",
+}
+
+
+def normalize_grain(grain: str) -> TimeGrain | None:
+    """Normalize any supported grain string to the canonical :data:`TimeGrain`.
+
+    Accepts both the ``rocky compile`` enum values (``hour`` / ``day`` / …)
+    and the ``rocky dag`` alias strings (``hourly`` / ``daily`` / …). Returns
+    ``None`` for unknown values so callers can fall back to "unpartitioned"
+    without having to catch an exception.
+    """
+    if grain in ("hour", "day", "month", "year"):
+        return grain  # type: ignore[return-value]
+    return _DAG_GRAIN_ALIASES.get(grain)
+
+
 def partitions_def_for_time_interval(
     *,
     granularity: TimeGrain | str,

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import shutil
 import subprocess
 import threading
@@ -56,6 +57,8 @@ from .types import (
     ValidateMigrationResult,
 )
 
+_log = logging.getLogger(__name__)
+
 # Default subprocess timeout for any single Rocky CLI invocation. One hour is
 # generous enough for full pipeline runs but still bounds runaway processes.
 DEFAULT_TIMEOUT_SECONDS = 3600
@@ -87,25 +90,29 @@ def _forward_stderr_to_context(
        stderr (see ``engine/crates/rocky-observe/src/tracing_setup.rs``)
        so this captures every ``info!()`` / ``warn!()`` macro emission.
 
-    Silently swallows any exceptions reading the pipe so a crashed
-    reader thread doesn't take down the parent. The trade-off is that
-    on a corrupt pipe we lose live streaming but the subprocess still
-    completes and the final stdout parsing still runs.
+    On unexpected read errors the reader thread logs the error at WARN
+    via the module logger and exits cleanly so it doesn't take down the
+    parent. We still lose live streaming for the rest of the run, but
+    the subprocess completes and the final stdout parsing still runs.
     """
     if stderr is None:
         return
-    with contextlib.suppress(Exception):
-        # Outer suppress catches a broken pipe or any other read error so
-        # the reader thread exits cleanly without taking down the parent.
+    try:
         for raw in stderr:
             line = raw.rstrip("\n")
             if not line:
                 continue
             sink.append(line)
+            # `context.log` can raise mid-line if the run is being torn
+            # down — suppress and keep reading so `sink` stays populated
+            # for failure metadata.
             with contextlib.suppress(Exception):
-                # context.log can raise if the run is being torn down;
-                # don't crash the reader thread on shutdown races.
                 context.log.info(f"rocky: {line}")
+    except (OSError, ValueError) as exc:
+        # OSError covers broken-pipe / EBADF / closed-file on the subprocess
+        # stderr handle. ValueError covers "I/O operation on closed file"
+        # from CPython. Anything else escapes so we notice the real bug.
+        _log.warning("rocky stderr reader terminated: %s", exc)
 
 
 class RockyResource(dg.ConfigurableResource):

--- a/scripts/_normalize_fixture.py
+++ b/scripts/_normalize_fixture.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Zero out timing fields and replace wall-clock timestamps in a fixture JSON.
+
+Invoked by scripts/regen_fixtures.sh after each `rocky` capture so the
+corpus is byte-stable across regen runs. A future engine change that makes
+`last_value` / `watermark` data-derived rather than wall-clock would need to
+drop them from ``WALL_CLOCK_FIELDS``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+# Numeric timing fields (durations) — zeroed for determinism.
+TIMING_SUFFIXES: tuple[str, ...] = ("_ms", "_seconds", "_secs")
+
+# Wall-clock ISO-8601 timestamp fields the engine stamps with the current
+# time when it writes state / history / metrics / run-metadata rows.
+WALL_CLOCK_FIELDS: frozenset[str] = frozenset(
+    {
+        "updated_at",
+        "started_at",
+        "finished_at",
+        "timestamp",
+        "captured_at",
+        "last_value",
+        "watermark",
+    }
+)
+SENTINEL_TS = "2000-01-01T00:00:00Z"
+
+
+def normalize(node: object) -> None:
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if isinstance(v, (int, float)) and any(
+                k.endswith(s) for s in TIMING_SUFFIXES
+            ):
+                node[k] = 0
+            elif isinstance(v, str) and k in WALL_CLOCK_FIELDS:
+                node[k] = SENTINEL_TS
+            else:
+                normalize(v)
+    elif isinstance(node, list):
+        for item in node:
+            normalize(item)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: _normalize_fixture.py <path>", file=sys.stderr)
+        sys.exit(2)
+    path = sys.argv[1]
+    with open(path) as f:
+        data = json.load(f)
+    normalize(data)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -30,6 +30,7 @@ readonly WORKSPACE_ROOT="$(dirname "$SCRIPT_DIR")"
 readonly ROCKY="$WORKSPACE_ROOT/engine/target/release/rocky"
 readonly POC="$WORKSPACE_ROOT/examples/playground/pocs/00-foundations/00-playground-default"
 readonly PARTITION_POC="$WORKSPACE_ROOT/examples/playground/pocs/02-performance/03-partition-checksum"
+readonly NORMALIZER="$SCRIPT_DIR/_normalize_fixture.py"
 
 # Output directory: fixtures_generated/ by default, fixtures/ if --in-place.
 DEST="$WORKSPACE_ROOT/integrations/dagster/tests/fixtures_generated"
@@ -85,48 +86,7 @@ capture() {
     # out so the fixtures are stable across regen runs. Without this,
     # doctor's `duration_ms` and compile's `total_ms`/etc. drift by a few
     # milliseconds on every machine and break the codegen-drift CI check.
-    python3 - "$out_file" <<'PY'
-import json, sys
-path = sys.argv[1]
-# Numeric timing fields (durations) — zeroed for determinism.
-TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
-# Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics / run-metadata rows.
-# Replaced with a fixed sentinel so the corpus is byte-stable across regen
-# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
-# materialization metadata) are both wall-clock under the current engine
-# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
-# than a data-derived value. A future change that makes these data-derived
-# would need to drop them from this set.
-WALL_CLOCK_FIELDS = {
-    "updated_at",
-    "started_at",
-    "finished_at",
-    "timestamp",
-    "captured_at",
-    "last_value",
-    "watermark",
-}
-SENTINEL_TS = "2000-01-01T00:00:00Z"
-def normalize(node):
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if isinstance(v, (int, float)) and any(k.endswith(s) for s in TIMING_SUFFIXES):
-                node[k] = 0
-            elif isinstance(v, str) and k in WALL_CLOCK_FIELDS:
-                node[k] = SENTINEL_TS
-            else:
-                normalize(v)
-    elif isinstance(node, list):
-        for item in node:
-            normalize(item)
-with open(path) as f:
-    data = json.load(f)
-normalize(data)
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-PY
+    python3 "$NORMALIZER" "$out_file"
 }
 
 capture discover discover
@@ -178,48 +138,7 @@ capture_partition() {
     local out_file="$PARTITION_DEST/${name}.json"
     echo "==> partition/$name"
     "$ROCKY" "$@" 2>/dev/null > "$out_file" || true
-    python3 - "$out_file" <<'PY'
-import json, sys
-path = sys.argv[1]
-# Numeric timing fields (durations) — zeroed for determinism.
-TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
-# Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics / run-metadata rows.
-# Replaced with a fixed sentinel so the corpus is byte-stable across regen
-# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
-# materialization metadata) are both wall-clock under the current engine
-# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
-# than a data-derived value. A future change that makes these data-derived
-# would need to drop them from this set.
-WALL_CLOCK_FIELDS = {
-    "updated_at",
-    "started_at",
-    "finished_at",
-    "timestamp",
-    "captured_at",
-    "last_value",
-    "watermark",
-}
-SENTINEL_TS = "2000-01-01T00:00:00Z"
-def normalize(node):
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if isinstance(v, (int, float)) and any(k.endswith(s) for s in TIMING_SUFFIXES):
-                node[k] = 0
-            elif isinstance(v, str) and k in WALL_CLOCK_FIELDS:
-                node[k] = SENTINEL_TS
-            else:
-                normalize(v)
-    elif isinstance(node, list):
-        for item in node:
-            normalize(item)
-with open(path) as f:
-    data = json.load(f)
-normalize(data)
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-PY
+    python3 "$NORMALIZER" "$out_file"
 }
 
 if [[ -d "$PARTITION_POC" ]]; then
@@ -283,48 +202,7 @@ capture_into() {
     local out_file="$DEST/${subdir}/${name}.json"
     echo "==> ${subdir}/${name}"
     "$ROCKY" "$@" 2>/dev/null > "$out_file" || true
-    python3 - "$out_file" <<'PY'
-import json, sys
-path = sys.argv[1]
-# Numeric timing fields (durations) — zeroed for determinism.
-TIMING_SUFFIXES = ("_ms", "_seconds", "_secs")
-# Wall-clock ISO-8601 timestamp fields that the engine stamps with the
-# current time when it writes state / history / metrics / run-metadata rows.
-# Replaced with a fixed sentinel so the corpus is byte-stable across regen
-# runs. ``last_value`` (state watermark) and ``watermark`` (run-output
-# materialization metadata) are both wall-clock under the current engine
-# behavior — full_refresh runs stamp NOW() as the "as-of" watermark rather
-# than a data-derived value. A future change that makes these data-derived
-# would need to drop them from this set.
-WALL_CLOCK_FIELDS = {
-    "updated_at",
-    "started_at",
-    "finished_at",
-    "timestamp",
-    "captured_at",
-    "last_value",
-    "watermark",
-}
-SENTINEL_TS = "2000-01-01T00:00:00Z"
-def normalize(node):
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if isinstance(v, (int, float)) and any(k.endswith(s) for s in TIMING_SUFFIXES):
-                node[k] = 0
-            elif isinstance(v, str) and k in WALL_CLOCK_FIELDS:
-                node[k] = SENTINEL_TS
-            else:
-                normalize(v)
-    elif isinstance(node, list):
-        for item in node:
-            normalize(item)
-with open(path) as f:
-    data = json.load(f)
-normalize(data)
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-PY
+    python3 "$NORMALIZER" "$out_file"
 }
 
 POCS_ROOT="$WORKSPACE_ROOT/examples/playground/pocs"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,8 +36,18 @@ require_cmd() {
 
 confirm_tag() {
     local tag="$1"
-    if git -C "$WORKSPACE_ROOT" rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+    # `rev-parse --verify --quiet` returns non-zero only when the ref is
+    # missing or ambiguous; any other git failure (permission denied,
+    # corrupt repo) still bubbles up as an error rather than being
+    # papered over the way `rev-parse >/dev/null 2>&1` would.
+    if git -C "$WORKSPACE_ROOT" rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
         die "Tag $tag already exists. Bump the version or delete the tag first."
+    fi
+    # Also refuse to create a tag that already exists on the remote —
+    # otherwise `git push origin <tag>` succeeds silently if the local tag
+    # happens to match the remote exactly.
+    if git -C "$WORKSPACE_ROOT" ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
+        die "Tag $tag already exists on origin. Bump the version or delete the remote tag first."
     fi
 }
 
@@ -84,10 +94,14 @@ release_engine() {
     tar czf "$linux_archive" -C "$(dirname "$linux_bin")" --transform 's/rocky-linux-amd64/rocky/' rocky-linux-amd64
     info "Packaged $linux_archive ($(du -h "$linux_archive" | cut -f1))"
 
-    # 3. Tag and push
+    # 3. Tag and push. Each step is guarded so a tag-creation failure (e.g.
+    # unsigned config, protected ref) never proceeds to `push` on a missing
+    # or stale tag.
     info "Creating and pushing tag $tag"
-    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag"
-    git -C "$WORKSPACE_ROOT" push origin "$tag"
+    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag" \
+        || die "git tag -a $tag failed — aborting before push"
+    git -C "$WORKSPACE_ROOT" push origin "$tag" \
+        || die "git push origin $tag failed"
 
     # 4. Create GitHub Release with macOS + Linux
     # The tag push also triggers engine-release.yml which builds all 5 targets.
@@ -129,10 +143,14 @@ release_dagster() {
         (cd "$WORKSPACE_ROOT/integrations/dagster" && uv publish)
     fi
 
-    # 3. Tag and push
+    # 3. Tag and push. Each step is guarded so a tag-creation failure (e.g.
+    # unsigned config, protected ref) never proceeds to `push` on a missing
+    # or stale tag.
     info "Creating and pushing tag $tag"
-    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag"
-    git -C "$WORKSPACE_ROOT" push origin "$tag"
+    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag" \
+        || die "git tag -a $tag failed — aborting before push"
+    git -C "$WORKSPACE_ROOT" push origin "$tag" \
+        || die "git push origin $tag failed"
 
     # 4. Create GitHub Release
     create_release "$tag" \
@@ -176,10 +194,14 @@ release_vscode() {
         (cd "$WORKSPACE_ROOT/editors/vscode" && npx @vscode/vsce publish --pat "$VSCE_PAT")
     fi
 
-    # 3. Tag and push
+    # 3. Tag and push. Each step is guarded so a tag-creation failure (e.g.
+    # unsigned config, protected ref) never proceeds to `push` on a missing
+    # or stale tag.
     info "Creating and pushing tag $tag"
-    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag"
-    git -C "$WORKSPACE_ROOT" push origin "$tag"
+    git -C "$WORKSPACE_ROOT" tag -a "$tag" -m "Release $tag" \
+        || die "git tag -a $tag failed — aborting before push"
+    git -C "$WORKSPACE_ROOT" push origin "$tag" \
+        || die "git push origin $tag failed"
 
     # 4. Create GitHub Release
     create_release "$tag" \

--- a/scripts/vendor_rocky.sh
+++ b/scripts/vendor_rocky.sh
@@ -109,13 +109,20 @@ download_asset() {
             --dir /tmp \
             --clobber
     elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        if ! command -v jq >/dev/null 2>&1; then
+            echo "Error: jq is required when using GITHUB_TOKEN fallback (gh CLI is preferred)" >&2
+            exit 1
+        fi
+        # Parse the release JSON via jq rather than a grep/cut regex — `$asset`
+        # would otherwise be interpreted as a regex, so `.` / `+` / `?` in the
+        # filename silently match broader patterns than intended.
         local asset_url
         asset_url=$(curl -fsSL \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$REPO/releases/tags/${TAG_PREFIX}${VERSION}" \
-            | grep -o "\"browser_download_url\": \"[^\"]*$asset\"" \
-            | cut -d'"' -f4)
+            | jq -r --arg name "$asset" \
+                '.assets[] | select(.name == $name) | .browser_download_url')
         if [[ -z "$asset_url" ]]; then
             echo "Error: could not find $asset in release ${TAG_PREFIX}${VERSION}" >&2
             return 1


### PR DESCRIPTION
Replace 30 `.map_err(|e| SqlGenError::UnsafeFragment { value: String::new(),
reason: e.to_string() })` sites across sql_gen / checks / drift / snapshots
with a `Dialect(#[from] AdapterError)` variant that keeps the adapter error
in the source chain. The old pattern discarded the offending identifier into
an always-empty `value` field; the new variant lets callers walk `Error::source`
for the full context.

Two self-constructed `UnsafeFragment` sites (DynamicTable-missing-warehouse,
Check-strategy-empty-columns) move to a new `InvalidRequest(String)` variant
since they report a bad call shape rather than bad SQL content.

Also replace hand-rolled byte-offset slicing in `models.rs` frontmatter
parsing and `hooks/template.rs` conditional/field substitution with
`split_once` / `strip_prefix` so the parsers can't panic on malformed
UTF-8 in the SQL body, and turn `statements.into_iter().next().unwrap()`
in `rocky-sql::parser::parse_single_statement` into an invariant-checked
`swap_remove(0)`.

All 920 rocky-core unit tests and 39 rocky-sql tests still pass.