### PR TITLE
docs: refresh getting-started and llms.txt

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,85 +1,144 @@
 # Rocky
 
-> Rust SQL transformation engine. Replaces dbt's core responsibilities (DAG resolution, incremental logic, SQL generation, schema management) with a compiled, type-safe approach. No Jinja. No manifest. No parse step.
+> A compiled SQL transformation engine written in Rust. Replaces dbt's DAG resolution, incremental logic, SQL generation, and schema management with a type-safe, config-driven approach. No Jinja. No manifest. No parse step.
 
-## Overview
+Rocky follows the ELT pattern: it operates on data already in the warehouse, landed by ingestion tools like Fivetran or Airbyte. Rocky owns the T (warehouse-side transformation and replication).
 
-Rocky is a monorepo containing a Rust CLI engine, a Dagster Python integration, a VS Code extension, and a curated catalog of 28 POCs.
+## Architecture at a glance
 
-Key concepts:
-- Bronze layer: Config-driven replication from sources (Fivetran, DuckDB, manual) into warehouses (Databricks, Snowflake, DuckDB) — no SQL files needed
-- Silver layer: Custom SQL models with TOML configuration (sidecar .sql + .toml files)
-- Rocky DSL: Pipeline-oriented syntax (.rocky files) as an alternative to SQL
-- Schema patterns: Parse source schema names into structured components for multi-tenant routing
-- Inline checks: Data quality checks (row count, column match, freshness, null rate, anomaly, custom) run during replication
-- Data contracts: Compile-time schema enforcement (required/protected columns, type checking)
-- AI intent: Generate models, explain logic, sync schema changes, generate tests with Claude
-- Embedded state: Watermarks stored in local redb database, with S3/Valkey/tiered sync
+- **Single binary** (`rocky`), starts in under 100ms.
+- **Adapter model** separates *source discovery* (Fivetran, DuckDB, manual) from *warehouse execution* (Databricks, Snowflake, BigQuery, DuckDB). The core is warehouse-agnostic.
+- **Bronze layer** (replication) is driven entirely by `rocky.toml` — zero SQL files for 1:1 copies.
+- **Silver layer** (transformation) is pure SQL with a sidecar `.toml` for config. No templating language.
+- **Rocky DSL** (`.rocky` files) is an optional pipeline-oriented syntax; raw SQL stays first-class.
+- **State** (watermarks, run history) lives in a local `redb` database with optional S3 / Valkey sync.
+- **JSON output** is versioned and schema-backed — designed for orchestrator consumption.
 
-## Commands
+## Monorepo
 
-### Core Pipeline
+| Path | Artifact | Purpose |
+|---|---|---|
+| `engine/` | `rocky` CLI | 20-crate Rust workspace |
+| `integrations/dagster/` | `dagster-rocky` PyPI wheel | Dagster resource + component |
+| `editors/vscode/` | Rocky VSIX | LSP client + AI commands |
+| `examples/playground/` | Config only | 47 POCs across 8 categories; DuckDB-backed, no credentials |
+
+## CLI commands
+
+### Core pipeline
 - `rocky init [path]` — Scaffold a new project
-- `rocky validate` — Check config without connecting to APIs
-- `rocky discover` — List available connectors and tables
-- `rocky plan --filter key=value` — Generate SQL without executing
-- `rocky run --filter key=value` — Execute the full pipeline
+- `rocky validate` — Check config without network calls
+- `rocky discover` — List connectors and tables
+- `rocky plan [--filter key=value]` — Generate SQL without executing
+- `rocky run [--filter key=value] [--resume-latest]` — Execute the pipeline
 - `rocky state` — Show stored watermarks
+- `rocky load` — Bulk load data from files into the warehouse
 
 ### Modeling
 - `rocky compile` — Type-check models, resolve DAG, validate contracts
-- `rocky lineage <model>` — Column-level lineage tracing
-- `rocky test` — Run model tests via DuckDB (no warehouse needed)
-- `rocky ci` — Compile + test in one step (for CI/CD)
+- `rocky lineage <model>` — Column-level lineage
+- `rocky test` — Run assertions locally via DuckDB
+- `rocky ci` — Compile + test in one step
+- `rocky ci-diff` — Diff current vs. base branch for PR feedback
+- `rocky dag` / `rocky dag-run` — Inspect / execute the DAG
+- `rocky drift` — Report schema drift between source and target
+- `rocky column-lineage <model>` — Column-level lineage JSON
+
+### Data quality
+- `rocky test` — Unit-style assertions (`not_null`, `unique`, `in_range`, `regex_match`, `aggregate`, custom SQL)
+- Inline pipeline checks: `row_count`, `column_match`, `freshness`, `null_rate`, `anomaly`, custom (configured in `rocky.toml`)
 
 ### AI
-- `rocky ai "<intent>"` — Generate model from natural language
-- `rocky ai-sync` — Detect schema changes, propose model updates
+- `rocky ai "<intent>"` — Generate a model from natural language
+- `rocky ai-sync` — Detect upstream schema changes, propose updates
 - `rocky ai-explain` — Generate intent descriptions from SQL
 - `rocky ai-test` — Generate test assertions from intent
 
 ### Administration
-- `rocky doctor` — Aggregate health checks
-- `rocky compare` — Shadow vs production comparison
-- `rocky history` — Run history and model execution history
+- `rocky doctor` — Aggregate health check
+- `rocky compare` — Shadow-vs-production comparison
+- `rocky history` — Run + model execution history
 - `rocky metrics <model>` — Quality metrics and trends
+- `rocky estimate` — Cost / row-count estimation
 - `rocky optimize` — Materialization strategy recommendations
-- `rocky compact <model>` — Storage compaction (OPTIMIZE/VACUUM)
-- `rocky archive` — Archive old data partitions
+- `rocky compact <model>` / `rocky compact-dedup` — Storage compaction (OPTIMIZE / VACUUM / dedup)
+- `rocky archive` — Archive old partitions
 - `rocky profile-storage` — Storage layout analysis
+- `rocky seed` — Load seed data
+- `rocky model-history <model>` — History for a single model
 
 ### Development
-- `rocky playground [path]` — Create credential-free DuckDB project
-- `rocky import-dbt` — Convert dbt project to Rocky
+- `rocky playground [path]` — Create a credential-free DuckDB project
+- `rocky import-dbt` — Convert a dbt project to Rocky
 - `rocky serve` — HTTP API server
-- `rocky lsp` — Language Server Protocol for IDE integration
-- `rocky hooks list/test` — Manage lifecycle hooks
+- `rocky lsp` — Language Server Protocol (IDE integration)
+- `rocky hooks list` / `rocky hooks test` — Manage lifecycle hooks
+- `rocky init-adapter <name>` — Scaffold a new warehouse adapter crate
+- `rocky test-adapter --adapter <name>` — Run conformance tests
+- `rocky validate-migration` — Validate a migration plan
 
-## Materialization Strategies
+### Global flags
+- `-c, --config <PATH>` — config file (default `rocky.toml`)
+- `-o, --output <FORMAT>` — `json` (default) or `table`
+- `--state-path <PATH>` — state store path (default `.rocky-state.redb`)
 
-- `full_refresh` — CREATE OR REPLACE TABLE
-- `incremental` — INSERT INTO WHERE ts > watermark
-- `merge` — MERGE INTO USING ON key
+## Materialization strategies
+
+- `full_refresh` — `CREATE OR REPLACE TABLE`
+- `incremental` — `INSERT INTO ... WHERE ts > watermark`
+- `merge` — `MERGE INTO ... USING ON key`
 - `materialized_view` — Databricks materialized views
 - `dynamic_table` — Snowflake dynamic tables with target lag
-- `time_interval` — Partition-keyed processing with @start_date/@end_date
+- `time_interval` — Partition-keyed processing with `@start_date` / `@end_date`
 
-## Configuration
+## Configuration (`rocky.toml`)
 
-Rocky reads `rocky.toml` with named adapters (`[adapter.NAME]`) and named pipelines (`[pipeline.NAME]`).
-Sections: adapters, pipelines (source, target, governance, checks, execution), state, cache, cost, hooks.
+Top-level sections:
 
-## Dagster Integration
+- `[adapter.NAME]` — named adapter connections (one per warehouse / source)
+- `[pipeline.NAME]` — named pipelines (one of: `replication`, `transformation`, `quality`, `snapshot`)
+- `[pipeline.NAME.source]` / `[pipeline.NAME.target]` — pipeline endpoints
+- `[pipeline.NAME.source.schema_pattern]` — multi-tenant schema name parser
+- `[pipeline.NAME.checks]` — inline data quality checks
+- `[pipeline.NAME.governance]` — tags, permissions, workspace isolation
+- `[state]` — watermark backend (`local`, `s3`, `valkey`)
+- `[cache]` / `[cost]` / `[hooks]` — optional subsystems
 
-The `dagster-rocky` Python package provides:
-- `RockyResource` — Dagster resource wrapping the CLI (20+ methods)
-- `load_rocky_assets()` — Auto-discover assets from Rocky sources
-- `emit_check_results()` / `emit_materializations()` — Convert results to Dagster events
-- `RockyComponent` — State-backed component for scalable discovery
-- `run_streaming()` / `run_pipes()` — Streaming and Dagster Pipes integration
-- Autogenerated Pydantic models for all 28 JSON output schemas
+Select pipelines at runtime with `--pipeline NAME`.
 
-## Docs
+## Supported adapters
+
+| Role | Adapter | Status |
+|---|---|---|
+| Source | Fivetran | Stable |
+| Source | DuckDB | Stable |
+| Source | Manual (TOML) | Stable |
+| Warehouse | Databricks | Stable — SQL Statement API, Unity Catalog, adaptive concurrency (AIMD) |
+| Warehouse | Snowflake | Beta — OAuth, key-pair JWT, password |
+| Warehouse | BigQuery | Beta — service account, ADC |
+| Warehouse | DuckDB | Stable — local in-process, used by playground and `rocky test` |
+
+A single DuckDB instance can act as both source and warehouse — that is how the playground runs end-to-end without credentials.
+
+## Dagster integration (`dagster-rocky`)
+
+- `RockyResource` — Configurable resource wrapping the CLI (20+ typed methods)
+- `load_rocky_assets()` — Auto-discover Dagster assets from Rocky sources
+- `emit_check_results()` / `emit_materializations()` — Convert JSON output to Dagster events
+- `RockyComponent` — State-backed `dg` component for scalable discovery
+- `run_streaming()` / `run_pipes()` — Streaming + Dagster Pipes
+- Autogenerated Pydantic v2 models for every CLI output schema
+
+## AI intent layer
+
+Intent is stored as model metadata in the `.toml` sidecar. Rocky's AI commands operate on that intent:
+
+- Generate a model from a prompt (`rocky ai`)
+- Keep models in sync when upstream schemas change (`rocky ai-sync`)
+- Backfill intent descriptions from existing SQL (`rocky ai-explain`)
+- Derive test assertions from intent (`rocky ai-test`)
+
+## Docs index
 
 - [Introduction](getting-started/introduction/)
 - [Installation](getting-started/installation/)
@@ -100,4 +159,5 @@ The `dagster-rocky` Python package provides:
 - [Data Governance](guides/governance/)
 - [CI/CD Integration](guides/ci-cd/)
 - [IDE Setup](guides/ide-setup/)
+- [Migrate from dbt](guides/migrate-from-dbt/)
 - [Contributing](advanced/contributing/)

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -1,34 +1,33 @@
 ---
 title: Installation
-description: How to install Rocky on macOS, Linux, and Windows
+description: Install the Rocky CLI on macOS, Linux, or Windows
 sidebar:
   order: 2
 ---
 
-## Quick Install (macOS / Linux)
+## macOS / Linux
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
 ```
 
-This downloads the latest release binary to `~/.local/bin/rocky`. The script automatically verifies checksums and detects your platform.
-
-To install to a custom directory:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | ROCKY_INSTALL_DIR=/usr/local/bin bash
-```
-
-To install a specific version:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- 1.0.0
-```
-
-Make sure `~/.local/bin` is in your `PATH`. Add this to your shell profile if needed:
+Installs to `~/.local/bin/rocky` and verifies checksums. Make sure `~/.local/bin` is on your `PATH`:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
+```
+
+**Custom install directory:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh \
+  | ROCKY_INSTALL_DIR=/usr/local/bin bash
+```
+
+**Pin a specific version:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- 1.0.0
 ```
 
 ## Windows
@@ -37,30 +36,30 @@ export PATH="$HOME/.local/bin:$PATH"
 irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
 ```
 
-## GitHub Releases
+## Pre-built binaries
 
-Download pre-built binaries from the [releases page](https://github.com/rocky-data/rocky/releases):
+Direct downloads from the [releases page](https://github.com/rocky-data/rocky/releases):
 
-| Platform | Architecture | Archive |
-|----------|-------------|---------|
-| macOS | Apple Silicon (M1+) | `rocky-aarch64-apple-darwin.tar.gz` |
-| macOS | Intel | `rocky-x86_64-apple-darwin.tar.gz` |
-| Linux | x86_64 | `rocky-x86_64-unknown-linux-gnu.tar.gz` |
-| Linux | ARM64 | `rocky-aarch64-unknown-linux-gnu.tar.gz` |
-| Windows | x86_64 | `rocky-x86_64-pc-windows-msvc.zip` |
+| Platform | Archive |
+|---|---|
+| macOS (Apple Silicon) | `rocky-aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `rocky-x86_64-apple-darwin.tar.gz` |
+| Linux x86_64 | `rocky-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `rocky-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `rocky-x86_64-pc-windows-msvc.zip` |
 
-## Build from Source
+## Build from source
 
-Requires Rust 1.85+ (edition 2024):
+Requires Rust 1.85+ (edition 2024).
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git
 cd rocky/engine
 cargo build --release
-# Binary at: target/release/rocky
+# binary at target/release/rocky
 ```
 
-## Verify Installation
+## Verify
 
 ```bash
 rocky --version

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -1,119 +1,78 @@
 ---
 title: Introduction
-description: What is Rocky and how it compares to dbt
+description: What Rocky is and how it compares to dbt
 sidebar:
   order: 1
 ---
 
-Rocky is a **compiled SQL transformation engine** written in Rust. It replaces dbt's core responsibilities — DAG resolution, incremental logic, SQL generation, and schema management — with a type-safe, config-driven approach.
+Rocky is a **compiled SQL transformation engine** written in Rust. It replaces dbt's core responsibilities — DAG resolution, incremental logic, SQL generation, schema management — with a type-safe, config-driven approach.
 
 No Jinja. No manifest. No parse step.
 
-Rocky follows the **ELT pattern** — it operates on data already in your warehouse, landed by ingestion tools like Fivetran or Airbyte. Rocky handles the **T** (transformation and replication within the warehouse), not the **E** or **L**.
+Rocky follows the **ELT pattern**: it operates on data already in the warehouse, landed by ingestion tools like Fivetran or Airbyte. Rocky owns the **T** (warehouse-side transformation and replication), not the E or L.
 
-## Why Rocky?
+## Why Rocky
 
-Traditional tools like dbt work well at small scale, but introduce significant overhead as pipelines grow:
+- **Fast.** Single binary, starts in under 100ms. Compiles 500 models in seconds, not minutes.
+- **Type-safe.** Column-level type inference catches schema errors at compile time.
+- **Pure SQL.** No Jinja templating; business logic stays in SQL.
+- **Config-first bronze.** Source replication is driven by `rocky.toml` — zero SQL files for 1:1 copies.
+- **Embedded state.** Watermarks live in a local `redb` database, with optional S3 / Valkey sync.
 
-- **Slow startup**: dbt takes 30-60 seconds just to start, then 2-3 minutes to parse 500 models
-- **Memory-hungry**: A mid-size dbt project consumes 500MB-2GB of RAM
-- **Jinja complexity**: Business logic buried in template macros is hard to test and debug
-- **Repetitive staging**: Writing `SELECT * FROM {{ source(...) }}` for every source table
+## Design principles
 
-Rocky eliminates these problems by compiling to a single binary that starts in under 100ms, parses instantly, and uses pure SQL instead of Jinja templates.
+1. **Adapter-based.** Source adapters (Fivetran, DuckDB, manual) handle discovery. Warehouse adapters (Databricks, Snowflake, BigQuery, DuckDB) handle execution. The core engine is warehouse-agnostic.
+2. **Config over code.** Bronze layer replication needs no SQL — just TOML.
+3. **Pure SQL models.** Silver-layer transformations use standard SQL plus a `.toml` sidecar.
+4. **Inline quality checks.** Data checks run during replication, not as a separate step.
+5. **Structured output.** Every command emits versioned JSON for orchestrator consumption.
 
-## Key Design Principles
+## How Rocky compares to dbt
 
-1. **Adapter-based architecture**: Source adapters (Fivetran, DuckDB, manual) handle discovery; warehouse adapters (Databricks, Snowflake, DuckDB) handle execution. The core engine is warehouse-agnostic.
-2. **Config over code**: The bronze layer (source replication) is driven entirely by `rocky.toml` — no SQL files needed for 1:1 copies
-3. **Pure SQL**: Transformation models use standard SQL with TOML configuration — no templating language
-4. **Inline quality checks**: Data checks run during replication, not as a separate step
-5. **Structured output**: All CLI output is versioned JSON, designed for orchestrator integration
-6. **Embedded state**: Watermarks stored in a local `redb` database, with optional remote sync to S3 or Valkey
-
-## How Rocky Compares to dbt
-
-| Concept | dbt | Rocky |
-|---------|-----|-------|
-| Project config | `dbt_project.yml` + `profiles.yml` | `rocky.toml` |
-| Connection config | `profiles.yml` | `[adapter.NAME]` blocks in `rocky.toml` |
-| Sources | `schema.yml` with `source()` macro | Auto-discovered (Fivetran, DuckDB, manual) |
-| Staging models | One `.sql` file per source table | Config-driven bronze layer (zero SQL) |
-| Transformation models | SQL + Jinja `{{ ref() }}` | SQL + TOML config |
-| Materialization config | `{{ config(materialized='...') }}` | `[strategy]` in TOML |
+| | dbt | Rocky |
+|---|---|---|
+| Templating | Jinja | None — pure SQL |
+| Staging models | One `.sql` per source table | Config-driven bronze (zero SQL) |
 | Dependencies | `{{ ref('model') }}` | `depends_on = ["model"]` |
-| Macros | Jinja macros | Not needed — pure SQL |
-| Seeds | CSV files loaded as tables | Not supported (out of scope) |
-| Snapshots | SCD Type 2 via snapshots | `merge` strategy with unique key |
-| Tests | `schema.yml` tests | Inline checks in `rocky.toml` |
-| Compile | `dbt compile` | `rocky plan` |
-| Run | `dbt run` | `rocky run` |
-| Test separately | `dbt test` | Built into `rocky run` |
+| Tests | `schema.yml` + `dbt test` | Inline checks + assertions built into `rocky run` |
 | State | `manifest.json` + `target/` | Embedded `redb` database |
 
-## Supported Adapters
+Full side-by-side comparison: [features/comparison](/features/comparison/).
 
-Rocky's adapter model separates *where data is discovered* from *where data is processed*:
+## Supported adapters
 
-| Role | Adapter | Description |
-|------|---------|-------------|
-| Source | Fivetran | Calls Fivetran REST API to discover connectors and enabled tables |
-| Source | DuckDB | Lists schemas and tables from a local DuckDB database via `information_schema` |
-| Source | Manual | Reads schema/table definitions from `rocky.toml` config |
-| Warehouse | Databricks | Executes SQL via SQL Statement API, manages Unity Catalog governance |
-| Warehouse | Snowflake | Executes SQL via Snowflake REST API; OAuth, key-pair JWT, and password auth |
-| Warehouse | BigQuery | Executes SQL via BigQuery API; service account and application default auth (Beta) |
-| Warehouse | DuckDB | Local in-process execution — runs `rocky validate/discover/plan/run` end-to-end with no credentials |
-
-Source adapters are metadata-only — they identify what schemas and tables exist, they do not extract or move data. The actual data must already be in the warehouse, landed by an ingestion tool.
-
-A single DuckDB adapter instance can act as both source and warehouse, which is how the playground and credential-free examples run end-to-end.
-
-Rocky is designed for extensibility — new source and warehouse adapters can be added through the [Adapter SDK](/concepts/adapters/) without modifying the core engine.
-
-## Monorepo
-
-Rocky lives in a single monorepo with four subprojects:
-
-| Path | Language | What it is |
+| Role | Adapter | Notes |
 |---|---|---|
-| `engine/` | Rust | Core CLI + engine (20-crate Cargo workspace) |
-| `integrations/dagster/` | Python | Dagster integration (`dagster-rocky` package) |
-| `editors/vscode/` | TypeScript | VS Code extension (LSP client + syntax highlighting) |
-| `examples/playground/` | Config only | Self-contained POC catalog (28 POCs) + benchmark suite |
+| Source | Fivetran | REST API discovery; metadata only |
+| Source | DuckDB | `information_schema` discovery |
+| Source | Manual | Tables declared in `rocky.toml` |
+| Warehouse | Databricks | SQL Statement API, Unity Catalog, adaptive concurrency |
+| Warehouse | Snowflake | REST API; OAuth / JWT / password (Beta) |
+| Warehouse | BigQuery | REST API; service account / ADC (Beta) |
+| Warehouse | DuckDB | In-process; powers the playground and `rocky test` |
 
-## Architecture
+Source adapters are metadata-only — they identify what exists. Actual data must already be in the warehouse. A single DuckDB instance can serve as both source and warehouse, which is how the credential-free playground works end-to-end.
 
-Rocky's engine is a Cargo workspace with 20 crates:
+New adapters plug in via the [Adapter SDK](/concepts/adapters/) without modifying the core engine.
 
-- **rocky-core** — Warehouse-agnostic transformation engine: IR, schema patterns, SQL generation, checks, state, hooks
-- **rocky-sql** — SQL parsing and validation (built on `sqlparser-rs`)
-- **rocky-lang** — Rocky DSL lexer and parser (`.rocky` files)
-- **rocky-compiler** — Type checking, semantic analysis, contract validation, diagnostics
-- **rocky-adapter-sdk** — Traits and conformance tests for building custom warehouse adapters
-- **rocky-databricks** — Databricks warehouse adapter: SQL Statement API, Unity Catalog governance, adaptive concurrency (AIMD)
-- **rocky-snowflake** — Snowflake warehouse adapter: REST API, OAuth + key-pair JWT + password auth
-- **rocky-duckdb** — DuckDB warehouse + discovery adapter, also used by `rocky test` and the bundled E2E suite
-- **rocky-fivetran** — Fivetran source adapter: REST API discovery (metadata only), schema config, sync detection
-- **rocky-engine** — Local query engine (DataFusion + Arrow) used for type inference and `rocky test`
-- **rocky-server** — HTTP API and LSP server (`rocky serve` / `rocky lsp`)
-- **rocky-cache** — Three-tier caching (memory, Valkey, API)
-- **rocky-ai** — AI intent layer (`explain`, `sync`, `test`, `generate`)
-- **rocky-observe** — Metrics, event bus, and structured JSON logging
-- **rocky-bigquery** — BigQuery warehouse adapter (connector, auth, dialect) (Beta)
-- **rocky-airbyte** — Airbyte source adapter (protocol integration)
-- **rocky-iceberg** — Apache Iceberg table format adapter (metadata + snapshot management)
-- **rocky-cli** — CLI commands, output formatting, Dagster Pipes protocol
-- **rocky-wasm** — WebAssembly exports for browser/edge execution
-- **rocky** — The binary crate
+## Monorepo layout
 
-## Community & Support
+| Path | Artifact | Language |
+|---|---|---|
+| `engine/` | `rocky` CLI | Rust (20-crate workspace) |
+| `integrations/dagster/` | `dagster-rocky` wheel | Python |
+| `editors/vscode/` | Rocky VSIX | TypeScript |
+| `examples/playground/` | POC catalog (47 POCs) | TOML / SQL |
 
-- **GitHub Discussions** — Questions, ideas, and show-and-tell: [rocky-data/rocky/discussions](https://github.com/rocky-data/rocky/discussions)
-- **Issues** — Bug reports and feature requests: [rocky-data/rocky/issues](https://github.com/rocky-data/rocky/issues)
-- **Email** — General inquiries: [hello@rocky-data.dev](mailto:hello@rocky-data.dev)
-- **Security** — Vulnerability reports: [security@rocky-data.dev](mailto:security@rocky-data.dev) (see [SECURITY.md](https://github.com/rocky-data/rocky/blob/main/SECURITY.md))
+Crate-level breakdown: [Architecture](/concepts/architecture/).
+
+## Community
+
+- **Discussions** — [github.com/rocky-data/rocky/discussions](https://github.com/rocky-data/rocky/discussions)
+- **Issues** — [github.com/rocky-data/rocky/issues](https://github.com/rocky-data/rocky/issues)
+- **Email** — [hello@rocky-data.dev](mailto:hello@rocky-data.dev)
+- **Security** — [security@rocky-data.dev](mailto:security@rocky-data.dev) ([SECURITY.md](https://github.com/rocky-data/rocky/blob/main/SECURITY.md))
 
 ## License
 
-Rocky is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -5,26 +5,20 @@ sidebar:
   order: 3
 ---
 
-This guide walks you through setting up a Rocky pipeline that replicates Fivetran-landed sources into Databricks. If you do not have warehouse credentials handy, the [Playground guide](/guides/playground/) does the same thing end-to-end against a local DuckDB file with no setup.
+This walks through a Rocky pipeline that replicates Fivetran-landed sources into Databricks. No credentials? The [Playground guide](/guides/playground/) runs the same flow against a local DuckDB file.
 
-## 1. Initialize a Project
+## 1. Scaffold
 
 ```bash
 rocky init my-pipeline
 cd my-pipeline
 ```
 
-This creates:
+Creates `rocky.toml` and an empty `models/` directory.
 
-```
-my-pipeline/
-├── rocky.toml      # Pipeline configuration (named adapters + named pipelines)
-└── models/         # Transformation models (SQL + TOML)
-```
+## 2. Configure
 
-## 2. Configure Your Pipeline
-
-Edit `rocky.toml` to declare a Fivetran source adapter, a Databricks warehouse adapter, and a pipeline that wires them together:
+Edit `rocky.toml` to declare a Fivetran source, a Databricks target, and a pipeline that wires them together.
 
 ```toml
 [adapter.fivetran]
@@ -43,9 +37,6 @@ token = "${DATABRICKS_TOKEN}"
 type = "replication"
 strategy = "incremental"
 timestamp_column = "_fivetran_synced"
-metadata_columns = [
-    { name = "_loaded_by", type = "STRING", value = "NULL" },
-]
 
 [pipeline.bronze.source]
 adapter = "fivetran"
@@ -74,52 +65,25 @@ freshness = { threshold_seconds = 86400 }
 backend = "local"
 ```
 
-The `[adapter.NAME]` blocks define connections; the `[pipeline.NAME]` block ties them together. You can declare additional adapters and pipelines in the same file and select between them with `--pipeline NAME`.
+`[adapter.*]` blocks define connections. `[pipeline.*]` blocks tie them together. Select between pipelines with `--pipeline NAME`.
 
-Set the environment variables:
+Export the referenced environment variables before running Rocky (`DATABRICKS_HOST`, `FIVETRAN_API_KEY`, etc.).
 
-```bash
-export DATABRICKS_HOST="your-workspace.cloud.databricks.com"
-export DATABRICKS_HTTP_PATH="/sql/1.0/warehouses/abc123"
-export DATABRICKS_TOKEN="dapi..."
-export FIVETRAN_DESTINATION_ID="your_destination_id"
-export FIVETRAN_API_KEY="your_api_key"
-export FIVETRAN_API_SECRET="your_api_secret"
-```
-
-## 3. Validate Your Config
+## 3. Validate
 
 ```bash
 rocky validate
 ```
 
-Expected output:
+Checks config syntax and adapter wiring. Does not call external APIs.
 
-```
-  ok  Config syntax valid (v2 format)
-  ok  adapter.fivetran: fivetran
-  ok  adapter.prod: databricks (auth configured)
-  ok  pipeline.bronze: schema pattern parseable
-  ok  pipeline.bronze: replication / incremental -> warehouse / stage__{source}
-
-Validation complete.
-```
-
-`rocky validate` only checks the config — it does not call the Fivetran or Databricks APIs.
-
-## 4. Discover Sources
+## 4. Discover
 
 ```bash
 rocky -o table discover
 ```
 
-This calls the Fivetran API and lists all connectors that match the schema pattern:
-
-```
-connector_abc | tenant=acme regions=[us_west] source=shopify | 12 tables
-connector_def | tenant=acme regions=[us_west] source=stripe  | 8 tables
-connector_ghi | tenant=globex regions=[emea] source=hubspot  | 15 tables
-```
+Calls the Fivetran API and lists connectors matching the schema pattern.
 
 ## 5. Preview the SQL
 
@@ -127,79 +91,34 @@ connector_ghi | tenant=globex regions=[emea] source=hubspot  | 15 tables
 rocky plan --filter tenant=acme
 ```
 
-This shows the SQL Rocky will generate without executing it:
+Shows the SQL Rocky will generate, without executing it.
 
-```sql
--- create_catalog (acme_warehouse)
-CREATE CATALOG IF NOT EXISTS acme_warehouse;
-
--- create_schema (acme_warehouse.staging__us_west__shopify)
-CREATE SCHEMA IF NOT EXISTS acme_warehouse.staging__us_west__shopify;
-
--- incremental_copy (acme_warehouse.staging__us_west__shopify.orders)
-INSERT INTO acme_warehouse.staging__us_west__shopify.orders
-SELECT *, CAST(NULL AS STRING) AS _loaded_by
-FROM source_catalog.src__acme__us_west__shopify.orders
-WHERE _fivetran_synced > (
-    SELECT COALESCE(MAX(_fivetran_synced), TIMESTAMP '1970-01-01')
-    FROM acme_warehouse.staging__us_west__shopify.orders
-);
-```
-
-## 6. Run the Pipeline
+## 6. Run
 
 ```bash
 rocky run --filter tenant=acme
 ```
 
-This executes the full pipeline:
+Executes the full pipeline: discover → create catalogs/schemas → detect drift → copy data → run checks. Outputs a versioned JSON result with materializations, check results, drift actions, and permissions.
 
-1. Discovers sources from Fivetran
-2. Creates catalogs and schemas as needed and applies governance
-3. Detects schema drift between source and target
-4. Copies data incrementally (or full refresh if drift forces it)
-5. Runs data quality checks (row count, column match, freshness)
-
-The JSON output includes materializations, check results, drift actions, and permissions:
-
-```json
-{
-  "version": "1.6.0",
-  "command": "run",
-  "filter": "tenant=acme",
-  "duration_ms": 45200,
-  "tables_copied": 20,
-  "materializations": [...],
-  "check_results": [...],
-  "permissions": { "catalogs_created": 1, "schemas_created": 2 },
-  "drift": { "tables_checked": 20, "tables_drifted": 0 }
-}
-```
-
-If a run fails partway through, you can resume from the last checkpoint instead of rerunning everything:
+Resume from the last checkpoint after a failure:
 
 ```bash
 rocky run --filter tenant=acme --resume-latest
 ```
 
-## 7. Check State
+## 7. Inspect state
 
 ```bash
 rocky state
 ```
 
-Shows stored watermarks for each table:
+Shows stored watermarks for every table.
 
-```
-acme_warehouse.staging__us_west__shopify.orders | 2026-03-30T10:00:00Z | 2026-03-30T10:01:32Z
-acme_warehouse.staging__us_west__shopify.customers | 2026-03-30T10:00:00Z | 2026-03-30T10:01:35Z
-```
+## Next steps
 
-## Next Steps
-
-- Try the [playground](/guides/playground/) for a credential-free DuckDB version of this flow
-- Learn about [schema patterns](/concepts/schema-patterns/) to customize source-to-target mapping
-- Add [transformation models](/concepts/silver-layer/) for custom SQL
-- Configure [data quality checks](/features/data-quality-checks/)
-- Set up [permissions](/features/permissions/) for RBAC
-- Integrate with [Dagster](/dagster/introduction/) for orchestration
+- [Playground](/guides/playground/) — credential-free DuckDB version
+- [Schema patterns](/concepts/schema-patterns/) — customize source-to-target mapping
+- [Silver layer](/concepts/silver-layer/) — add transformation models
+- [Data quality checks](/features/data-quality-checks/)
+- [Dagster integration](/dagster/introduction/)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Rocky
 description: A SQL transformation engine built in Rust. Type-safe compilation, column-level lineage, AI-powered intent.
 template: splash
 hero:
-  tagline: A compiled SQL transformation engine built in Rust. Type-safe compilation, column-level lineage, AI-powered intent, and a language server — for data pipelines that don't break.
+  tagline: A compiled SQL transformation engine in Rust. Type-safe compilation, column-level lineage, and an AI intent layer — for data pipelines that don't break.
   actions:
     - text: Get Started in 60 Seconds
       link: /guides/playground/
@@ -18,22 +18,22 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 <CardGrid>
   <Card title="Type-Safe Compiler" icon="approve-check">
-    Column-level type inference, data contracts, and diagnostics with suggestions — errors caught before execution, not after.
+    Column-level type inference and data contracts catch errors before execution.
   </Card>
-  <Card title="Rocky DSL" icon="document">
-    Pipeline-oriented syntax with NULL-safe operators, window functions, and pattern matching. Or use standard SQL — your choice.
+  <Card title="Pure SQL or DSL" icon="document">
+    Write standard SQL with TOML config, or use the Rocky DSL for NULL-safe operators, windows, and pattern matching.
   </Card>
   <Card title="AI Intent Layer" icon="star">
-    Store intent as metadata. AI explains models, syncs them when upstream schemas change, and generates test assertions.
+    Store intent as metadata. AI explains models, syncs them when upstream schemas change, and generates tests.
   </Card>
   <Card title="VS Code Extension" icon="laptop">
-    Full language server: completion, hover, go-to-definition, find references, rename, code actions, inlay hints, and lineage visualization.
+    Full language server: completion, hover, go-to-definition, rename, code actions, and lineage visualization.
   </Card>
   <Card title="Quality Checks" icon="warning">
-    Pipeline-level row count / freshness / null rate / anomaly detection, plus declarative model-level assertions (`not_null`, `unique`, `in_range`, `regex_match`, `aggregate`, …) with per-check severity, filter, and row quarantine.
+    Inline pipeline checks (row count, freshness, null rate, anomaly) plus model-level assertions with severity and quarantine.
   </Card>
   <Card title="Dagster Integration" icon="puzzle">
-    First-class integration via dagster-rocky. Auto-discover assets, emit materializations, and translate check results.
+    Auto-discover assets, emit materializations, and translate check results — all via `dagster-rocky`.
   </Card>
 </CardGrid>
 
@@ -43,14 +43,14 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
 rocky playground my-first-project
 cd my-first-project
-rocky compile    # Type-check all models
-rocky test       # Run assertions locally
-rocky run        # Execute the pipeline
+rocky compile    # type-check
+rocky test       # run assertions locally
+rocky run        # execute the pipeline
 ```
 
-No credentials needed — the playground uses DuckDB locally.
+No credentials needed — the playground is DuckDB-backed.
 
 <CardGrid>
-  <LinkCard title="Coming from dbt?" href="/guides/migrate-from-dbt/" description="Step-by-step migration guide: import your dbt project, convert tests to contracts, and adopt incrementally." />
-  <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="dagster-rocky provides auto-discovery, rich metadata, and check result integration." />
+  <LinkCard title="Coming from dbt?" href="/guides/migrate-from-dbt/" description="Import your dbt project, convert tests to contracts, and adopt Rocky incrementally." />
+  <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="Auto-discovery, rich metadata, and check-result integration via dagster-rocky." />
 </CardGrid>


### PR DESCRIPTION
## Summary
- Tighten the getting-started flow: introduction, installation, quickstart, and the landing `index.mdx`.
- Expand `llms.txt` with an architecture overview, adapter matrix, and the full current CLI surface (commands, global flags, materialization strategies, Dagster + AI sections).
- Net −63 lines across 5 files — mostly consolidation and alignment with the 1.8.x engine state.

## Test plan
- [ ] `cd docs && npm run build` succeeds with no broken links
- [ ] Spot-check the rendered pages on the preview deploy:
  - [ ] `/getting-started/introduction/`
  - [ ] `/getting-started/installation/`
  - [ ] `/getting-started/quickstart/`
  - [ ] `/` (landing)
- [ ] `docs/public/llms.txt` reads cleanly end-to-end