### PR TITLE
perf(engine/rocky-lang): Expr sub-expressions → Arc<Expr> (P3.7)

### DIFF
--- a/engine/crates/rocky-lang/src/ast.rs
+++ b/engine/crates/rocky-lang/src/ast.rs
@@ -1,4 +1,14 @@
 //! DSL Abstract Syntax Tree types.
+//!
+//! §P3.7: sub-expression fields on `Expr` use `Arc<Expr>` instead of
+//! `Box<Expr>`. Cloning an `Expr` (common during lowering and
+//! typechecking of DSL pipelines) becomes a refcount bump on the
+//! sub-tree instead of a deep allocation. `Arc` (not `Rc`) because
+//! `CompileResult` — which transitively holds the AST — is now
+//! moved across a `tokio::task::spawn_blocking` boundary (§P3.3),
+//! and `Rc` isn't `Send`.
+
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -126,29 +136,29 @@ pub enum Expr {
     Null,
     /// Binary operation.
     BinaryOp {
-        left: Box<Expr>,
+        left: Arc<Expr>,
         op: BinOp,
-        right: Box<Expr>,
+        right: Arc<Expr>,
     },
     /// Unary operation.
-    UnaryOp { op: UnaryOp, expr: Box<Expr> },
+    UnaryOp { op: UnaryOp, expr: Arc<Expr> },
     /// Function call.
     FunctionCall { name: String, args: Vec<Expr> },
     /// IS NULL / IS NOT NULL.
-    IsNull { expr: Box<Expr>, negated: bool },
+    IsNull { expr: Arc<Expr>, negated: bool },
     /// IN [list].
     ///
     /// TODO(plan-15): The parser does not yet support `in [...]` / `not in [...]`
     /// syntax. This node can only be constructed programmatically. Add parser
     /// support for `expr in [val1, val2]` and `expr not in [val1, val2]`.
     InList {
-        expr: Box<Expr>,
+        expr: Arc<Expr>,
         list: Vec<Expr>,
         negated: bool,
     },
     /// match expression (compiles to CASE WHEN).
     Match {
-        expr: Box<Expr>,
+        expr: Arc<Expr>,
         arms: Vec<MatchArm>,
     },
     /// Function call with window spec.

--- a/engine/crates/rocky-lang/src/lower.rs
+++ b/engine/crates/rocky-lang/src/lower.rs
@@ -3,6 +3,9 @@
 //! Compiles the DSL AST into standard SQL. The key semantic improvement:
 //! `!=` compiles to `IS DISTINCT FROM` (NULL-safe), not SQL's `!=`.
 
+#[cfg(test)]
+use std::sync::Arc;
+
 use crate::ast::*;
 
 /// Lower a Rocky DSL file to a SQL string.
@@ -1746,13 +1749,13 @@ derive {
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::BinaryOp {
-                    left: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Column("a".into())),
+                    left: Arc::new(Expr::BinaryOp {
+                        left: Arc::new(Expr::Column("a".into())),
                         op: BinOp::Or,
-                        right: Box::new(Expr::Column("b".into())),
+                        right: Arc::new(Expr::Column("b".into())),
                     }),
                     op: BinOp::And,
-                    right: Box::new(Expr::Column("c".into())),
+                    right: Arc::new(Expr::Column("c".into())),
                 }),
             ],
         };
@@ -1774,13 +1777,13 @@ derive {
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::BinaryOp {
-                    left: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Column("a".into())),
+                    left: Arc::new(Expr::BinaryOp {
+                        left: Arc::new(Expr::Column("a".into())),
                         op: BinOp::And,
-                        right: Box::new(Expr::Column("b".into())),
+                        right: Arc::new(Expr::Column("b".into())),
                     }),
                     op: BinOp::Or,
-                    right: Box::new(Expr::Column("c".into())),
+                    right: Arc::new(Expr::Column("c".into())),
                 }),
             ],
         };
@@ -1803,10 +1806,10 @@ derive {
                 }),
                 PipelineStep::Where(Expr::UnaryOp {
                     op: UnaryOp::Not,
-                    expr: Box::new(Expr::BinaryOp {
-                        left: Box::new(Expr::Column("a".into())),
+                    expr: Arc::new(Expr::BinaryOp {
+                        left: Arc::new(Expr::Column("a".into())),
                         op: BinOp::And,
-                        right: Box::new(Expr::Column("b".into())),
+                        right: Arc::new(Expr::Column("b".into())),
                     }),
                 }),
             ],
@@ -1841,12 +1844,12 @@ derive {
                 PipelineStep::Derive(vec![(
                     "val".to_string(),
                     Expr::BinaryOp {
-                        left: Box::new(Expr::Column("a".into())),
+                        left: Arc::new(Expr::Column("a".into())),
                         op: BinOp::Sub,
-                        right: Box::new(Expr::BinaryOp {
-                            left: Box::new(Expr::Column("b".into())),
+                        right: Arc::new(Expr::BinaryOp {
+                            left: Arc::new(Expr::Column("b".into())),
                             op: BinOp::Sub,
-                            right: Box::new(Expr::Column("c".into())),
+                            right: Arc::new(Expr::Column("c".into())),
                         }),
                     },
                 )]),
@@ -1872,12 +1875,12 @@ derive {
                 PipelineStep::Derive(vec![(
                     "val".to_string(),
                     Expr::BinaryOp {
-                        left: Box::new(Expr::Column("a".into())),
+                        left: Arc::new(Expr::Column("a".into())),
                         op: BinOp::Div,
-                        right: Box::new(Expr::BinaryOp {
-                            left: Box::new(Expr::Column("b".into())),
+                        right: Arc::new(Expr::BinaryOp {
+                            left: Arc::new(Expr::Column("b".into())),
                             op: BinOp::Div,
-                            right: Box::new(Expr::Column("c".into())),
+                            right: Arc::new(Expr::Column("c".into())),
                         }),
                     },
                 )]),
@@ -1903,13 +1906,13 @@ derive {
                 PipelineStep::Derive(vec![(
                     "val".to_string(),
                     Expr::BinaryOp {
-                        left: Box::new(Expr::BinaryOp {
-                            left: Box::new(Expr::Column("a".into())),
+                        left: Arc::new(Expr::BinaryOp {
+                            left: Arc::new(Expr::Column("a".into())),
                             op: BinOp::Add,
-                            right: Box::new(Expr::Column("b".into())),
+                            right: Arc::new(Expr::Column("b".into())),
                         }),
                         op: BinOp::Mul,
-                        right: Box::new(Expr::Column("c".into())),
+                        right: Arc::new(Expr::Column("c".into())),
                     },
                 )]),
             ],
@@ -1996,7 +1999,7 @@ where amount > 100"#,
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::InList {
-                    expr: Box::new(Expr::Column("status".into())),
+                    expr: Arc::new(Expr::Column("status".into())),
                     list: vec![
                         Expr::StringLit("active".into()),
                         Expr::StringLit("pending".into()),
@@ -2023,7 +2026,7 @@ where amount > 100"#,
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::InList {
-                    expr: Box::new(Expr::Column("status".into())),
+                    expr: Arc::new(Expr::Column("status".into())),
                     list: vec![
                         Expr::StringLit("cancelled".into()),
                         Expr::StringLit("refunded".into()),
@@ -2049,7 +2052,7 @@ where amount > 100"#,
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::InList {
-                    expr: Box::new(Expr::Column("priority".into())),
+                    expr: Arc::new(Expr::Column("priority".into())),
                     list: vec![
                         Expr::NumberLit("1".into()),
                         Expr::NumberLit("2".into()),
@@ -2343,10 +2346,10 @@ derive {
                     "val".to_string(),
                     Expr::UnaryOp {
                         op: UnaryOp::Neg,
-                        expr: Box::new(Expr::BinaryOp {
-                            left: Box::new(Expr::Column("a".into())),
+                        expr: Arc::new(Expr::BinaryOp {
+                            left: Arc::new(Expr::Column("a".into())),
                             op: BinOp::Add,
-                            right: Box::new(Expr::Column("b".into())),
+                            right: Arc::new(Expr::Column("b".into())),
                         }),
                     },
                 )]),
@@ -2586,7 +2589,7 @@ derive {
                     alias: None,
                 }),
                 PipelineStep::Where(Expr::InList {
-                    expr: Box::new(Expr::Column("status".into())),
+                    expr: Arc::new(Expr::Column("status".into())),
                     list: vec![Expr::StringLit("active".into())],
                     negated: false,
                 }),

--- a/engine/crates/rocky-lang/src/parser.rs
+++ b/engine/crates/rocky-lang/src/parser.rs
@@ -1,5 +1,7 @@
 //! Recursive descent parser for the Rocky DSL.
 
+use std::sync::Arc;
+
 use logos::Logos;
 
 use crate::ast::*;
@@ -646,7 +648,7 @@ impl Parser {
         self.expect(&Token::RBrace)?;
 
         Ok(Expr::Match {
-            expr: Box::new(expr),
+            expr: Arc::new(expr),
             arms,
         })
     }
@@ -703,9 +705,9 @@ impl Parser {
             self.advance();
             let right = self.parse_and_expr()?;
             left = Expr::BinaryOp {
-                left: Box::new(left),
+                left: Arc::new(left),
                 op: BinOp::Or,
-                right: Box::new(right),
+                right: Arc::new(right),
             };
         }
         Ok(left)
@@ -717,9 +719,9 @@ impl Parser {
             self.advance();
             let right = self.parse_comparison()?;
             left = Expr::BinaryOp {
-                left: Box::new(left),
+                left: Arc::new(left),
                 op: BinOp::And,
-                right: Box::new(right),
+                right: Arc::new(right),
             };
         }
         Ok(left)
@@ -739,7 +741,7 @@ impl Parser {
             };
             self.expect(&Token::Null)?;
             return Ok(Expr::IsNull {
-                expr: Box::new(left),
+                expr: Arc::new(left),
                 negated,
             });
         }
@@ -759,9 +761,9 @@ impl Parser {
             self.advance();
             let right = self.parse_additive()?;
             left = Expr::BinaryOp {
-                left: Box::new(left),
+                left: Arc::new(left),
                 op,
-                right: Box::new(right),
+                right: Arc::new(right),
             };
         }
 
@@ -779,9 +781,9 @@ impl Parser {
             self.advance();
             let right = self.parse_multiplicative()?;
             left = Expr::BinaryOp {
-                left: Box::new(left),
+                left: Arc::new(left),
                 op,
-                right: Box::new(right),
+                right: Arc::new(right),
             };
         }
         Ok(left)
@@ -799,9 +801,9 @@ impl Parser {
             self.advance();
             let right = self.parse_unary()?;
             left = Expr::BinaryOp {
-                left: Box::new(left),
+                left: Arc::new(left),
                 op,
-                right: Box::new(right),
+                right: Arc::new(right),
             };
         }
         Ok(left)
@@ -814,7 +816,7 @@ impl Parser {
                 let expr = self.parse_unary()?;
                 Ok(Expr::UnaryOp {
                     op: UnaryOp::Not,
-                    expr: Box::new(expr),
+                    expr: Arc::new(expr),
                 })
             }
             Some(Token::Minus) => {
@@ -822,7 +824,7 @@ impl Parser {
                 let expr = self.parse_unary()?;
                 Ok(Expr::UnaryOp {
                     op: UnaryOp::Neg,
-                    expr: Box::new(expr),
+                    expr: Arc::new(expr),
                 })
             }
             _ => self.parse_primary(),


### PR DESCRIPTION
## Summary

Fifth batch from \`~/Developer/rocky-plans/plans/rocky-perf-resilience-roadmap.md\`. Single focused change: §P3.7 — \`Expr\` sub-expression fields switch from \`Box<Expr>\` to \`Arc<Expr>\`.

- Cloning a Rocky DSL \`Expr\` used to deep-copy its entire sub-tree (BinaryOp / UnaryOp / IsNull / InList / Match each held \`Box<Expr>\`, so every clone walked the AST and allocated fresh boxes all the way down).
- \`Arc<Expr>\` makes clones a refcount bump per branch; the sub-tree itself is shared structurally.
- \`Arc\` rather than \`Rc\` because \`CompileResult\` — which transitively holds the AST — is moved across \`tokio::task::spawn_blocking\` on the LSP recompile path since §P3.3 (#145), and \`Rc\` isn't \`Send\`.
- Depends on §P3.6 (#151): Token payloads already carry \`Arc<str>\`, so AST construction is literal-already-Arc-friendly.

## Consumer ripple

Zero outside \`rocky-lang\`. Downstream code (\`lower.rs\`, \`typecheck.rs\`, \`sql_gen.rs\`, visitors) uses deref / pattern-match / \`as_ref()\` — all of which work identically for \`Box\` and \`Arc\`. Only two edits outside \`ast.rs\`:

- \`parser.rs\` uses \`Arc::new(...)\` instead of \`Box::new(...)\` at ~20 construction sites (plus \`use std::sync::Arc\`).
- \`lower.rs\` test module gains \`#[cfg(test)] use std::sync::Arc\` for one test site.

## Deferred

- **P4.2** \`ir.rs\` \`Vec<String>\` → \`Vec<Arc<str>>\` — attempted this session, reverted. The trait-level \`merge_into(&self, …, keys: &[String], …)\` signature ripples through 5+ dialect impls (\`databricks\`, \`snowflake\`, \`duckdb\`, \`bigquery\`) and the \`ColumnSelection::Explicit(Vec<String>)\` consumer chain. Doing it piecemeal produces hot-path allocations that defeat the win. Needs its own focused PR with a coordinated trait-signature change.
- **P3.4 range-protocol variant** — the other half of §P3.4 (range-aware semantic tokens); needs matching vscode-extension client config.
- **P3.1 / P3.8 / P3.11 / P1.7** — larger surfaces.
- **Cross-adapter \`RetryBudget\`** — still needs top-level \`[retry]\` config design call.
- **\`HookRegistry::fire\` lifecycle wiring** — still owed.

## Test plan

- [x] \`cargo test --workspace --all-features\` — 2193 passed / 0 failed
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`just codegen-rust\` — no drift (ast isn't part of the codegen surface)
- [ ] CI: engine-ci + codegen-drift

## Commits

1. \`7b4a827\` perf(engine/rocky-lang): Expr sub-expressions → Arc<Expr>