### PR TITLE
perf(engine): P4.2 — ir.rs Vec<Arc<str>> + merge_into trait coordination

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -29,7 +29,7 @@ impl SqlDialect for BigQueryDialect {
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String> {
         if keys.is_empty() {

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -620,7 +620,11 @@ pub async fn run_snapshot(
             schema: pipeline.target.schema.clone(),
             table: pipeline.target.table.clone(),
         },
-        unique_key: pipeline.unique_key.clone(),
+        unique_key: pipeline
+            .unique_key
+            .iter()
+            .map(|s| std::sync::Arc::from(s.as_str()))
+            .collect(),
         updated_at: pipeline.updated_at.clone(),
         invalidate_hard_deletes: pipeline.invalidate_hard_deletes,
         governance: rocky_core::ir::GovernanceConfig {

--- a/engine/crates/rocky-core/src/arrow_loader.rs
+++ b/engine/crates/rocky-core/src/arrow_loader.rs
@@ -486,7 +486,7 @@ mod tests {
             &self,
             _target: &str,
             _source_sql: &str,
-            _keys: &[String],
+            _keys: &[std::sync::Arc<str>],
             _update_cols: &crate::ir::ColumnSelection,
         ) -> crate::traits::AdapterResult<String> {
             Ok(String::new())

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -294,7 +294,7 @@ mod tests {
             &self,
             _target: &str,
             _source_sql: &str,
-            _keys: &[String],
+            _keys: &[std::sync::Arc<str>],
             _update_cols: &ColumnSelection,
         ) -> AdapterResult<String> {
             unimplemented!()

--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -346,7 +346,7 @@ mod tests {
             &self,
             _target: &str,
             _source_sql: &str,
-            _keys: &[String],
+            _keys: &[std::sync::Arc<str>],
             _update_cols: &ColumnSelection,
         ) -> AdapterResult<String> {
             unimplemented!()

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -1,3 +1,10 @@
+//! §P4.2: identifier-list fields on IR structs — `unique_key`,
+//! `partition_by`, `ColumnSelection::Explicit`, `columns_to_drop` — use
+//! `Vec<Arc<str>>` so cloning a plan / drift result is refcount-cheap.
+//! JSON wire format is preserved by serde's `rc` feature.
+
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use rocky_sql::validation::{self, ValidationError};
 use serde::{Deserialize, Serialize};
@@ -50,7 +57,7 @@ pub struct SnapshotPlan {
     pub source: SourceRef,
     pub target: TargetRef,
     /// Columns that uniquely identify a row.
-    pub unique_key: Vec<String>,
+    pub unique_key: Vec<Arc<str>>,
     /// Column used to detect changes.
     pub updated_at: String,
     /// When true, invalidate rows deleted from source.
@@ -71,7 +78,7 @@ pub enum MaterializationStrategy {
     },
     /// Upsert based on unique key columns.
     Merge {
-        unique_key: Vec<String>,
+        unique_key: Vec<Arc<str>>,
         update_columns: ColumnSelection,
     },
     /// Databricks Materialized View — warehouse manages refresh.
@@ -103,7 +110,7 @@ pub enum MaterializationStrategy {
     /// MERGE overhead is unnecessary.
     DeleteInsert {
         /// Column(s) used to identify the partition to delete before inserting.
-        partition_by: Vec<String>,
+        partition_by: Vec<Arc<str>>,
     },
     /// Alias for `TimeInterval` with sensible defaults. Processes data
     /// in micro-batches based on a timestamp column. dbt-compatible naming.
@@ -180,7 +187,7 @@ pub enum ColumnSelection {
     /// `SELECT *`
     All,
     /// `SELECT col1, col2, ...`
-    Explicit(Vec<String>),
+    Explicit(Vec<Arc<str>>),
 }
 
 /// Extra columns to add during replication (e.g., `CAST(NULL AS STRING) AS _loaded_by`).
@@ -260,7 +267,7 @@ pub struct DriftResult {
     pub grace_period_columns: Vec<GracePeriodColumn>,
     /// Columns whose grace period has expired and should be dropped from the target.
     #[serde(default)]
-    pub columns_to_drop: Vec<String>,
+    pub columns_to_drop: Vec<Arc<str>>,
 }
 
 /// A single column that has drifted between source and target.

--- a/engine/crates/rocky-core/src/lakehouse.rs
+++ b/engine/crates/rocky-core/src/lakehouse.rs
@@ -351,7 +351,7 @@ mod tests {
             &self,
             _target: &str,
             _source_sql: &str,
-            _keys: &[String],
+            _keys: &[std::sync::Arc<str>],
             _update_cols: &ColumnSelection,
         ) -> AdapterResult<String> {
             unimplemented!("not needed for lakehouse tests")

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -459,9 +459,16 @@ impl Model {
                 unique_key,
                 update_columns,
             } => MaterializationStrategy::Merge {
-                unique_key: unique_key.clone(),
+                unique_key: unique_key
+                    .iter()
+                    .map(|s| std::sync::Arc::from(s.as_str()))
+                    .collect(),
                 update_columns: match update_columns {
-                    Some(cols) => crate::ir::ColumnSelection::Explicit(cols.clone()),
+                    Some(cols) => crate::ir::ColumnSelection::Explicit(
+                        cols.iter()
+                            .map(|s| std::sync::Arc::from(s.as_str()))
+                            .collect(),
+                    ),
                     None => crate::ir::ColumnSelection::All,
                 },
             },
@@ -479,7 +486,10 @@ impl Model {
             StrategyConfig::Ephemeral => MaterializationStrategy::Ephemeral,
             StrategyConfig::DeleteInsert { partition_by } => {
                 MaterializationStrategy::DeleteInsert {
-                    partition_by: partition_by.clone(),
+                    partition_by: partition_by
+                        .iter()
+                        .map(|s| std::sync::Arc::from(s.as_str()))
+                        .collect(),
                 }
             }
             StrategyConfig::Microbatch {

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -519,7 +519,7 @@ mod unit_tests {
             &self,
             _: &str,
             _: &str,
-            _: &[String],
+            _: &[std::sync::Arc<str>],
             _: &ColumnSelection,
         ) -> AdapterResult<String> {
             unimplemented!()

--- a/engine/crates/rocky-core/src/seeds.rs
+++ b/engine/crates/rocky-core/src/seeds.rs
@@ -848,7 +848,7 @@ id = "INTEGER"
             &self,
             _target: &str,
             _source_sql: &str,
-            _keys: &[String],
+            _keys: &[std::sync::Arc<str>],
             _update_cols: &crate::ir::ColumnSelection,
         ) -> crate::traits::AdapterResult<String> {
             Ok(String::new())

--- a/engine/crates/rocky-core/src/snapshots.rs
+++ b/engine/crates/rocky-core/src/snapshots.rs
@@ -109,7 +109,11 @@ impl SnapshotConfig {
         SnapshotPlan {
             source: self.source.clone(),
             target: self.target.clone(),
-            unique_key: self.unique_key.clone(),
+            unique_key: self
+                .unique_key
+                .iter()
+                .map(|s| std::sync::Arc::from(s.as_str()))
+                .collect(),
             updated_at,
             invalidate_hard_deletes: self.invalidate_hard_deletes,
             governance: GovernanceConfig {
@@ -365,9 +369,16 @@ fn format_target(config: &SnapshotConfig, dialect: &dyn SqlDialect) -> Result<St
 }
 
 /// Build a `left.k1 = right.k1 AND left.k2 = right.k2` join condition.
-fn build_join_condition(keys: &[String], left: &str, right: &str) -> String {
+///
+/// Generic over the key slice element so both `Vec<String>`
+/// (SnapshotConfig) and `Vec<Arc<str>>` (IR) call sites can share it
+/// without per-call conversion (§P4.2).
+fn build_join_condition<S: AsRef<str>>(keys: &[S], left: &str, right: &str) -> String {
     keys.iter()
-        .map(|k| format!("{left}.{k} = {right}.{k}"))
+        .map(|k| {
+            let k = k.as_ref();
+            format!("{left}.{k} = {right}.{k}")
+        })
         .collect::<Vec<_>>()
         .join(" AND ")
 }
@@ -410,7 +421,7 @@ mod tests {
             &self,
             target: &str,
             source_sql: &str,
-            keys: &[String],
+            keys: &[std::sync::Arc<str>],
             update_cols: &ColumnSelection,
         ) -> AdapterResult<String> {
             if keys.is_empty() {

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -646,7 +646,7 @@ mod tests {
             &self,
             target: &str,
             source_sql: &str,
-            keys: &[String],
+            keys: &[std::sync::Arc<str>],
             update_cols: &ColumnSelection,
         ) -> AdapterResult<String> {
             if keys.is_empty() {

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -202,11 +202,16 @@ pub trait SqlDialect: Send + Sync {
     fn insert_into(&self, target: &str, select_sql: &str) -> String;
 
     /// MERGE INTO (upsert by key).
+    ///
+    /// Keys are `&[Arc<str>]` so the ir-level `Vec<Arc<str>>` on
+    /// `MaterializationStrategy::Merge::unique_key` threads through without
+    /// per-call allocation (§P4.2). Dialect implementations dereference
+    /// (`&**key`) to get a `&str` for validation / formatting.
     fn merge_into(
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String>;
 

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -38,7 +38,7 @@ impl SqlDialect for TestDialect {
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String> {
         if keys.is_empty() {

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -34,7 +34,7 @@ impl SqlDialect for DatabricksSqlDialect {
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String> {
         if keys.is_empty() {

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -41,7 +41,7 @@ impl SqlDialect for DuckDbSqlDialect {
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String> {
         if keys.is_empty() {

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -41,7 +41,7 @@ impl SqlDialect for SnowflakeSqlDialect {
         &self,
         target: &str,
         source_sql: &str,
-        keys: &[String],
+        keys: &[std::sync::Arc<str>],
         update_cols: &ColumnSelection,
     ) -> AdapterResult<String> {
         if keys.is_empty() {


### PR DESCRIPTION
## Summary

Sixth batch. Single focused change: §P4.2 — the four identifier-list fields on IR structs switch from \`Vec<String>\` to \`Vec<Arc<str>>\`, with a coordinated change to \`SqlDialect::merge_into\` so the new type threads through adapters without per-call conversion.

- \`SnapshotPlan.unique_key\`, \`MaterializationStrategy::Merge.unique_key\`, \`DeleteInsert.partition_by\`, \`ColumnSelection::Explicit\`, \`DriftResult.columns_to_drop\` → \`Vec<Arc<str>>\`.
- \`SqlDialect::merge_into\` signature: \`keys: &[String]\` → \`keys: &[Arc<str>]\`. Updated in all 5 dialect impls (databricks, snowflake, duckdb, bigquery) + 8 rocky-core mock impls (e2e.rs, arrow_loader, checks, drift, lakehouse, quarantine, seeds, snapshots, sql_gen).
- Call-site conversion at the **config→IR boundary only** (once per pipeline construction): \`models.rs\`, \`snapshots.rs::to_plan\`, \`run_local.rs\` map through \`Arc::from(s.as_str())\`. No per-clone, no per-statement conversion.
- \`snapshots::build_join_condition\` generalised to \`<S: AsRef<str>>\` so both \`Vec<String>\` (SnapshotConfig) and \`Vec<Arc<str>>\` (SnapshotPlan) call sites share it.

## Why trait coordination matters

Attempted this as a purely-IR change in #152 (batch 5) and reverted: \`merge_into(&self, keys: &[String], …)\` across 5+ dialects meant every call site would need \`.iter().map(|s| s.to_string()).collect::<Vec<_>>()\` to bridge, which defeats the whole point of removing the String alloc. This PR changes the trait in lockstep.

## JSON wire format preservation

serde's \`rc\` feature (already enabled workspace-wide) makes \`Arc<str>\` (de)serialize as a string. No schema drift; no codegen regen needed.

## Test plan

- [x] \`cargo test --workspace --all-features\` — 2193 passed / 0 failed
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`just codegen-rust\` — no drift
- [ ] CI: engine-ci + codegen-drift

## Commits

1. \`a7fddde\` perf(engine): ir.rs identifier lists → Vec<Arc<str>> + merge_into trait