### PR TITLE
feat(engine): cross-adapter RetryBudget via top-level [retry] config

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -1847,6 +1847,23 @@
       },
       "type": "object"
     },
+    "RunRetryConfig": {
+      "additionalProperties": false,
+      "description": "Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.",
+      "properties": {
+        "max_retries_per_run": {
+          "default": null,
+          "description": "Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "SchemaEvolutionConfig": {
       "additionalProperties": false,
       "description": "Schema evolution configuration.\n\nControls how Rocky handles columns that disappear from the source but still exist in the target table. Instead of immediately dropping them, Rocky can keep them for a grace period (filling with NULL) so downstream consumers have time to adapt.",
@@ -2439,6 +2456,18 @@
       ],
       "default": {},
       "description": "Named pipeline configurations (keyed by pipeline name)."
+    },
+    "retry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RunRetryConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
     },
     "schema_evolution": {
       "allOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -286,6 +286,14 @@ export interface RockyConfig {
    */
   pipeline?: PipelinesFieldSchema;
   /**
+   * Run-level retry budget shared across every adapter for this run.
+   *
+   * When set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.
+   *
+   * Unset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits.
+   */
+  retry?: RunRetryConfig | null;
+  /**
    * Schema evolution configuration (grace-period column drops).
    */
   schema_evolution?: SchemaEvolutionConfig;
@@ -1050,6 +1058,15 @@ export interface LoadTargetConfig {
    * Optional explicit table name. When omitted, derives from the file name (e.g., `orders.csv` -> table `orders`).
    */
   table?: string | null;
+}
+/**
+ * Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.
+ */
+export interface RunRetryConfig {
+  /**
+   * Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).
+   */
+  max_retries_per_run?: number | null;
 }
 /**
  * Schema evolution configuration.

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -70,6 +70,18 @@ impl AdapterRegistry {
         let mut bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>> = HashMap::new();
         let mut adapter_configs = HashMap::new();
 
+        // Cross-adapter run-level retry budget (follow-up to §P2.7). When
+        // the top-level `[retry]` section is set, every adapter in this
+        // registry receives the *same* budget instance — retries across
+        // adapters share the quota, so a runaway statement on Databricks
+        // can't later starve Snowflake. When unset, each adapter stays on
+        // its own per-adapter `retry.max_retries_per_run` (unchanged).
+        let shared_retry_budget = config
+            .retry
+            .as_ref()
+            .and_then(|r| r.max_retries_per_run)
+            .map(rocky_core::retry_budget::RetryBudget::new);
+
         for (name, adapter_cfg) in &config.adapters {
             adapter_configs.insert(name.clone(), adapter_cfg.clone());
 
@@ -106,31 +118,36 @@ impl AdapterRegistry {
                         retry: adapter_cfg.retry.clone(),
                     };
 
-                    let connector = Arc::new(DatabricksConnector::new(connector_config, auth));
-                    let adapter =
-                        Arc::new(DatabricksWarehouseAdapter::new(DatabricksConnector::new(
-                            ConnectorConfig {
-                                host: host.to_string(),
-                                warehouse_id: ConnectorConfig::warehouse_id_from_http_path(
-                                    http_path,
-                                )
-                                .context("failed to extract warehouse_id from http_path")?,
-                                timeout: Duration::from_secs(
-                                    adapter_cfg.timeout_secs.unwrap_or(120),
-                                ),
-                                retry: adapter_cfg.retry.clone(),
-                            },
-                            Auth::from_config(AuthConfig {
-                                host: host.to_string(),
-                                token: adapter_cfg.token.as_ref().map(|s| s.expose().to_string()),
-                                client_id: adapter_cfg.client_id.clone(),
-                                client_secret: adapter_cfg
-                                    .client_secret
-                                    .as_ref()
-                                    .map(|s| s.expose().to_string()),
-                            })
-                            .context("failed to resolve Databricks auth from adapter config")?,
-                        )));
+                    let mut connector = DatabricksConnector::new(connector_config, auth);
+                    if let Some(ref budget) = shared_retry_budget {
+                        connector = connector.with_retry_budget(budget.clone());
+                    }
+                    let connector = Arc::new(connector);
+                    let mut warehouse_conn = DatabricksConnector::new(
+                        ConnectorConfig {
+                            host: host.to_string(),
+                            warehouse_id: ConnectorConfig::warehouse_id_from_http_path(http_path)
+                                .context(
+                                "failed to extract warehouse_id from http_path",
+                            )?,
+                            timeout: Duration::from_secs(adapter_cfg.timeout_secs.unwrap_or(120)),
+                            retry: adapter_cfg.retry.clone(),
+                        },
+                        Auth::from_config(AuthConfig {
+                            host: host.to_string(),
+                            token: adapter_cfg.token.as_ref().map(|s| s.expose().to_string()),
+                            client_id: adapter_cfg.client_id.clone(),
+                            client_secret: adapter_cfg
+                                .client_secret
+                                .as_ref()
+                                .map(|s| s.expose().to_string()),
+                        })
+                        .context("failed to resolve Databricks auth from adapter config")?,
+                    );
+                    if let Some(ref budget) = shared_retry_budget {
+                        warehouse_conn = warehouse_conn.with_retry_budget(budget.clone());
+                    }
+                    let adapter = Arc::new(DatabricksWarehouseAdapter::new(warehouse_conn));
 
                     connectors.insert(name.clone(), connector);
                     warehouse.insert(name.clone(), adapter as Arc<dyn WarehouseAdapter>);
@@ -178,11 +195,14 @@ impl AdapterRegistry {
                         "adapters.{name}: destination_id required for fivetran"
                     ))?;
 
-                    let client = FivetranClient::with_retry(
+                    let mut client = FivetranClient::with_retry(
                         api_key.to_string(),
                         api_secret.to_string(),
                         adapter_cfg.retry.clone(),
                     );
+                    if let Some(ref budget) = shared_retry_budget {
+                        client = client.with_retry_budget(budget.clone());
+                    }
 
                     let adapter = Arc::new(FivetranDiscoveryAdapter::new(
                         client,
@@ -263,13 +283,19 @@ impl AdapterRegistry {
                     // path. Keeping it separate means the batch describe
                     // query won't contend with in-flight `execute_statement`
                     // calls on the warehouse adapter's connector.
-                    let sf_connector_for_batch = Arc::new(SnowflakeConnector::new(
-                        sf_connector_config.clone(),
-                        sf_auth.clone(),
-                    ));
-                    snowflake_connectors.insert(name.clone(), sf_connector_for_batch);
+                    let mut sf_connector_for_batch =
+                        SnowflakeConnector::new(sf_connector_config.clone(), sf_auth.clone());
+                    if let Some(ref budget) = shared_retry_budget {
+                        sf_connector_for_batch =
+                            sf_connector_for_batch.with_retry_budget(budget.clone());
+                    }
+                    snowflake_connectors.insert(name.clone(), Arc::new(sf_connector_for_batch));
 
-                    let warehouse_connector = SnowflakeConnector::new(sf_connector_config, sf_auth);
+                    let mut warehouse_connector =
+                        SnowflakeConnector::new(sf_connector_config, sf_auth);
+                    if let Some(ref budget) = shared_retry_budget {
+                        warehouse_connector = warehouse_connector.with_retry_budget(budget.clone());
+                    }
                     let adapter = SnowflakeWarehouseAdapter::new(warehouse_connector);
                     warehouse.insert(name.clone(), Arc::new(adapter));
                 }

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -303,6 +303,7 @@ mod tests {
             hooks: Default::default(),
             cost: Default::default(),
             schema_evolution: Default::default(),
+            retry: None,
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1168,6 +1168,36 @@ pub struct RockyConfig {
     /// Schema evolution configuration (grace-period column drops).
     #[serde(default)]
     pub schema_evolution: SchemaEvolutionConfig,
+
+    /// Run-level retry budget shared across every adapter for this run.
+    ///
+    /// When set, `rocky run` builds a single
+    /// [`crate::retry_budget::RetryBudget`] from
+    /// [`RunRetryConfig::max_retries_per_run`] and passes it to every
+    /// connector via `with_retry_budget(...)`. One bad table that burns
+    /// through retries on adapter A then has less budget available for
+    /// adapter B's retries — the protection §P2.7 added within a single
+    /// adapter now extends across the whole run.
+    ///
+    /// Unset (the default) preserves per-adapter semantics: each adapter
+    /// still honours its own `retry.max_retries_per_run` independently.
+    /// That's the backward-compatible path and stays the right choice
+    /// when adapters have wildly different rate limits.
+    #[serde(default)]
+    pub retry: Option<RunRetryConfig>,
+}
+
+/// Top-level retry configuration applied across every adapter for this
+/// run. See [`RockyConfig::retry`] for the cross-adapter semantics this
+/// unlocks.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RunRetryConfig {
+    /// Total number of retries allowed across every adapter for this run.
+    /// `None` means no cross-adapter cap (each adapter's own
+    /// `retry.max_retries_per_run` still applies in isolation).
+    #[serde(default)]
+    pub max_retries_per_run: Option<u32>,
 }
 
 /// Schema-only helper that mirrors the deserializer's acceptance of both

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -571,6 +571,7 @@ mod tests {
             hooks: Default::default(),
             cost: Default::default(),
             schema_evolution: Default::default(),
+            retry: None,
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -707,6 +707,7 @@ mod tests {
             hooks: Default::default(),
             cost: Default::default(),
             schema_evolution: Default::default(),
+            retry: None,
         };
 
         let models = vec![
@@ -775,6 +776,7 @@ mod tests {
             hooks: Default::default(),
             cost: Default::default(),
             schema_evolution: Default::default(),
+            retry: None,
         };
 
         let models = vec![Model {
@@ -839,6 +841,7 @@ mod tests {
             hooks: Default::default(),
             cost: Default::default(),
             schema_evolution: Default::default(),
+            retry: None,
         };
 
         let index = build_doc_index(&[], &config, None);

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -923,6 +923,7 @@ mod tests {
                 min_history_runs: 5,
             },
             schema_evolution: Default::default(),
+            retry: None,
         }
     }
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -457,6 +457,20 @@ class RetryConfig(BaseModel):
     """
 
 
+class RunRetryConfig(BaseModel):
+    """
+    Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    max_retries_per_run: conint(ge=0) | None = None
+    """
+    Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).
+    """
+
+
 class SchemaEvolutionConfig(BaseModel):
     """
     Schema evolution configuration.
@@ -2036,6 +2050,14 @@ class RockyConfig(BaseModel):
     ) = Field({}, validate_default=True)
     """
     Named pipeline configurations (keyed by pipeline name).
+    """
+    retry: RunRetryConfig | None = None
+    """
+    Run-level retry budget shared across every adapter for this run.
+
+    When set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.
+
+    Unset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits.
     """
     schema_evolution: SchemaEvolutionConfig | None = Field(
         {"grace_period_days": 7}, validate_default=True

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -1846,6 +1846,23 @@
       },
       "type": "object"
     },
+    "RunRetryConfig": {
+      "additionalProperties": false,
+      "description": "Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.",
+      "properties": {
+        "max_retries_per_run": {
+          "default": null,
+          "description": "Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "SchemaEvolutionConfig": {
       "additionalProperties": false,
       "description": "Schema evolution configuration.\n\nControls how Rocky handles columns that disappear from the source but still exist in the target table. Instead of immediately dropping them, Rocky can keep them for a grace period (filling with NULL) so downstream consumers have time to adapt.",
@@ -2438,6 +2455,18 @@
       ],
       "default": {},
       "description": "Named pipeline configurations (keyed by pipeline name)."
+    },
+    "retry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RunRetryConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
     },
     "schema_evolution": {
       "allOf": [


### PR DESCRIPTION
## Summary

Eighth batch. Single focused change: the follow-up from §P2.7 (#145) that shipped per-adapter \`max_retries_per_run\`. Users can now opt into sharing ONE retry budget across every adapter for a single run.

### New config

\`\`\`toml
[retry]
max_retries_per_run = 50
\`\`\`

When set, \`AdapterRegistry::from_config\` constructs a single \`RetryBudget\` Arc and wires it into every connector via \`with_retry_budget(...)\`. Databricks + Snowflake + Fivetran share the exact same atomic counter — one bad statement burning through retries on Databricks reduces headroom Snowflake has later. That's the cross-adapter protection §P2.7 deliberately left to follow-up.

Unset (default) = backward-compatible. Each adapter still honours its own per-adapter \`retry.max_retries_per_run\` in isolation. Remains the right choice when adapters have wildly-different rate limits.

### Code changes

- \`rocky-core/src/config.rs\`: new \`RockyConfig.retry: Option<RunRetryConfig>\`; \`RunRetryConfig { max_retries_per_run: Option<u32> }\`.
- \`rocky-cli/src/registry.rs\`: build \`shared_retry_budget\` once; apply via \`with_retry_budget\` to Databricks (×2 sites: adapter + connector), Snowflake (×2: batch-check + warehouse), and Fivetran (×1).
- Tests / mock call sites that build \`RockyConfig\` directly get the new \`retry: None\` field initialised.

### Schema cascade

schemars picks up the new field on \`RockyConfig\`, so \`rocky_project.schema.json\` + dagster Pydantic + vscode TypeScript regenerate with the optional \`retry\` section.

## Test plan

- [x] \`cargo test --workspace --all-features\` — 2193 passed / 0 failed
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`just codegen\` — schema / pydantic / TS regenerated
- [ ] CI: engine-ci + codegen-drift + dagster-ci

## Commits

1. \`a8ef984\` feat(engine): cross-adapter RetryBudget via top-level [retry] config