### PR TITLE
feat(engine/rocky-cli): per-table hook events in dispatch loop

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1132,6 +1132,21 @@ pub async fn run(
         let pipeline_ref = shared_pipeline.clone();
         let task = task.clone();
 
+        // §P2.6 per-table emit: before_materialize fires on the main
+        // task just before we spawn — the registry is shared via Arc
+        // so we don't need to move it into the spawned future.
+        let table_ref = format!(
+            "{}.{}.{}",
+            task.target_catalog, task.target_schema, task.table_name
+        );
+        let _ = hook_registry
+            .fire(&HookContext::before_materialize(
+                &run_id,
+                pipeline_name,
+                &table_ref,
+            ))
+            .await;
+
         join_set.spawn(async move {
             let _permit = permit;
             let result = process_table(warehouse.as_ref(), &state, &pipeline_ref, &task).await;
@@ -1178,6 +1193,16 @@ pub async fn run(
                     t.on_success();
                     adjust_semaphore(t, &semaphore, &mut semaphore_capacity);
                 }
+                // §P2.6 per-table emit: after_materialize on success.
+                let _ = hook_registry
+                    .fire(&HookContext::after_materialize(
+                        &run_id,
+                        pipeline_name,
+                        &tr.target_full_name,
+                        tr.materialization.duration_ms,
+                        tr.materialization.rows_copied,
+                    ))
+                    .await;
                 output.tables_copied += 1;
                 rocky_observe::metrics::METRICS.inc_tables_processed();
                 rocky_observe::metrics::METRICS
@@ -1275,6 +1300,16 @@ pub async fn run(
                             format!("{}.{}.{}", t.target_catalog, t.target_schema, t.table_name)
                         })
                         .unwrap_or_default();
+
+                    // §P2.6 per-table emit: materialize_error.
+                    let _ = hook_registry
+                        .fire(&HookContext::materialize_error(
+                            &run_id,
+                            pipeline_name,
+                            &table_key,
+                            &msg,
+                        ))
+                        .await;
                     let state = shared_state.lock().await;
                     if let Err(e) = state.record_table_progress(
                         &shared_run_id,


### PR DESCRIPTION
## Summary

Tenth batch. Direct follow-up to #156: the \`HookRegistry::fire\` wedge that wiring shipped covered only pipeline-level events (\`pipeline_start\` / \`pipeline_complete\` / \`pipeline_error\`). This PR adds the three per-table events the registry defines.

### Emit sites

- **\`before_materialize\`** — fires on the main task just before each table is dispatched to the parallel executor. Target is \`catalog.schema.table\`.
- **\`after_materialize\`** — fires when the spawned task returns \`Ok\`. Carries \`duration_ms\` + \`rows_copied\` from the materialization record.
- **\`materialize_error\`** — fires when \`process_table\` returns \`Err\`. Carries the fully-qualified table key + error message.

### Implementation notes

- No threading needed through \`process_table\` / spawned futures. The registry is \`Arc<HookRegistry>\` from #156; emits happen on the outer async task as tasks dispatch and their results come back.
- Panicked-task (\`JoinError\`) path remains silent — we've lost the table identity by then. Surfaced elsewhere via metrics + state store; not a typical user-visible error class.
- Hook failures are swallowed, consistent with the #156 pattern: a misconfigured webhook shouldn't block execution.

### What's left on the hook-wiring follow-ups

- Errors propagating via \`?\` in the main run body still skip the pipeline-level emits. A top-level CLI wrapper would close that.
- The other 12 hook events the registry defines (\`before/after_checks\`, \`drift_detected\`, \`anomaly_detected\`, \`state_synced\`, model-level, compile-level, etc.) each need their own callsite identification.

## Test plan

- [x] \`cargo test --workspace --all-features\` — 2193 passed / 0 failed
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`just codegen-rust\` — no drift
- [ ] CI

## Commits

1. \`49bbd7a\` feat(engine/rocky-cli): per-table hook events in parallel dispatch loop