### PR TITLE
fix(engine): make rocky compact --measure-dedup work on Databricks Unity Catalog

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Databricks OAuth 403 "Invalid Token" → token refresh
+
+`rocky-databricks/src/connector.rs::is_transient` previously classified only 401 as transient-and-refreshable. Databricks's SQL Statement Execution API returns **HTTP 403 "Invalid Token"** where 401 would be more idiomatic, which meant long-running operations that crossed the 1-hour OAuth M2M TTL boundary mid-execution died on the first post-expiry call with no retry and no token refresh.
+
+- `is_transient` now treats both 401 and 403 as transient.
+- The retry loop's `invalidate_cache` branch matches both 401 and 403, so the next attempt triggers a fresh `client_credentials` exchange.
+- Bad credentials still re-fail every attempt and exhaust the retry budget — no new attack surface.
+- Surfaced by a multi-hour `rocky compact --measure-dedup` sweep against a production Databricks workspace.
+
+### Fixed — `rocky compact --measure-dedup` on Databricks Unity Catalog
+
+The Layer 0 dedup-measurement command had three defects that made it unusable against Unity Catalog. All three land together since any real Databricks sweep hits each one in sequence:
+
+- **Unqualified `information_schema.tables` query.** Unity Catalog has no workspace-wide `information_schema`; every query must be `<catalog>.information_schema.tables`. `enumerate_tables` now accepts an explicit catalog list (derived from the managed-table set via the new `managed_catalog_set` helper) and fans out per-catalog with catalog-qualified queries. The unqualified form is kept as the `None` fall-through for DuckDB (single-DB scope). Catalogs that fail enumeration (missing, no `USE CATALOG` grant, etc.) are skipped with a warning rather than aborting the sweep.
+- **ANSI-only `table_type` filter.** `WHERE table_type IN ('BASE TABLE', 'TABLE')` excluded every Delta table on Databricks (which uses `MANAGED`, `EXTERNAL`, `STREAMING_TABLE`, `FOREIGN`). Flipped to `NOT IN ('VIEW', 'MATERIALIZED_VIEW', 'MATERIALIZED VIEW')` — broadly portable across warehouses.
+- **No tolerance for empty tables or single-table failures.** An empty table's `HASH` aggregate returns NULL, which aborted the entire sweep. Similarly, one `describe_table` or `hash_table` failure killed all prior + future work. Now all three degrade gracefully: NULL-checksum rows are skipped, per-table failures warn and continue, and the summary log reports skipped catalogs + skipped tables so results can be interpreted as partial coverage rather than silently incomplete.
+
+Known gap (not fixed here): `--all-tables` on Databricks still hits the unqualified `information_schema` query and errors out. The fix is to add `SHOW CATALOGS` discovery for the `None` catalog path, deferred as it needs adapter-level plumbing.
+
 ## [1.9.0] — 2026-04-19
 
 Perf-resilience batch 2. Four items off the roadmap's near-term bucket — two perf foundations, two 1.0 auth-resilience closeouts — plus a refactor pass consolidating the auth-cache pattern across adapters.

--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -518,14 +518,15 @@ fn bench_single_file_change(c: &mut Criterion) {
     // Seed the incremental cache with a full cold compile.
     let previous = compile(&config).expect("seed compile must succeed");
 
-    // Pick a mart model (leaf of the DAG) — `fct_0500` is the first one
-    // `generate_layered_project` produces after 50+150+200 = 400 upstream
-    // models. Editing a leaf minimises downstream reflow so we're really
-    // measuring the incremental path's per-change overhead.
+    // Pick a mart model (leaf of the DAG) — `fct_0400` is the first one
+    // `generate_layered_project` produces, since layers 0..2 contribute
+    // 50+150+200 = 400 upstream models before marts begin. Editing a leaf
+    // minimises downstream reflow so we're really measuring the
+    // incremental path's per-change overhead.
     let models_dir = dir.path().join("models");
-    let target_sql = models_dir.join("fct_0500.sql");
+    let target_sql = models_dir.join("fct_0400.sql");
     let baseline =
-        fs::read_to_string(&target_sql).expect("layered project must contain fct_0500.sql");
+        fs::read_to_string(&target_sql).expect("layered project must contain fct_0400.sql");
 
     group.bench_function("500_models_edit_one_mart", |b| {
         let mut counter: u32 = 0;

--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -205,46 +205,77 @@ pub(crate) async fn compute_measure_dedup(
 
     // 5. Enumerate tables to measure, scoping to managed tables unless
     //    --all-tables was passed.
-    let all_warehouse_tables = enumerate_tables(adapter.as_ref()).await?;
-
-    let (tables, scope) = if all_tables {
-        (all_warehouse_tables, "all".to_string())
+    //
+    //    Order matters: resolve managed tables *first* so we can scope
+    //    the `information_schema.tables` query to the specific catalogs
+    //    Rocky manages. On Unity Catalog there is no workspace-wide
+    //    `information_schema` — every `FROM information_schema.tables`
+    //    needs a catalog prefix (`<cat>.information_schema.tables`).
+    //    Fanning out per catalog is the only form that works across
+    //    Databricks, Snowflake, and DuckDB.
+    let managed = if all_tables {
+        None
     } else {
-        let managed =
-            resolve_managed_tables(&rocky_cfg, pipeline_name, pipeline, &registry, config_path)
-                .await;
-        match managed {
-            Ok(Some(managed_set)) => {
-                let filtered: Vec<TableRef> = all_warehouse_tables
-                    .into_iter()
-                    .filter(|t| {
-                        t.validated_full_name()
-                            .map(|name| managed_set.contains(&name.to_lowercase()))
-                            .unwrap_or(false)
-                    })
-                    .collect();
-                tracing::info!(
-                    managed_tables = managed_set.len(),
-                    matched = filtered.len(),
-                    "scoped to Rocky-managed tables"
-                );
-                (filtered, "managed".to_string())
-            }
+        match resolve_managed_tables(&rocky_cfg, pipeline_name, pipeline, &registry, config_path)
+            .await
+        {
+            Ok(Some(managed_set)) => Some(managed_set),
             Ok(None) => {
                 tracing::warn!(
                     "could not resolve managed tables for this pipeline type; \
                      falling back to all warehouse tables"
                 );
-                (all_warehouse_tables, "all".to_string())
+                None
             }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     "failed to resolve managed tables; falling back to all warehouse tables"
                 );
-                (all_warehouse_tables, "all".to_string())
+                None
             }
         }
+    };
+
+    let catalog_scope = managed.as_ref().map(managed_catalog_set);
+    let all_warehouse_tables =
+        enumerate_tables(adapter.as_ref(), catalog_scope.as_deref()).await?;
+
+    let (tables, scope) = match managed.as_ref() {
+        Some(managed_set) => {
+            let filtered: Vec<TableRef> = all_warehouse_tables
+                .iter()
+                .cloned()
+                .filter(|t| {
+                    t.validated_full_name()
+                        .map(|name| managed_set.contains(&name.to_lowercase()))
+                        .unwrap_or(false)
+                })
+                .collect();
+            tracing::info!(
+                managed_tables = managed_set.len(),
+                warehouse_tables = all_warehouse_tables.len(),
+                matched = filtered.len(),
+                "scoped to Rocky-managed tables"
+            );
+            if filtered.is_empty() && !managed_set.is_empty() && !all_warehouse_tables.is_empty()
+            {
+                let managed_sample: Vec<&String> = managed_set.iter().take(5).collect();
+                let warehouse_sample: Vec<String> = all_warehouse_tables
+                    .iter()
+                    .take(5)
+                    .filter_map(|t| t.validated_full_name().ok().map(|s| s.to_lowercase()))
+                    .collect();
+                tracing::warn!(
+                    ?managed_sample,
+                    ?warehouse_sample,
+                    "managed ∩ warehouse is empty — naming mismatch between \
+                     pipeline-resolved target names and warehouse table names"
+                );
+            }
+            (filtered, "managed".to_string())
+        }
+        None => (all_warehouse_tables, "all".to_string()),
     };
 
     let tables_scanned = tables.len();
@@ -265,6 +296,13 @@ pub(crate) async fn compute_measure_dedup(
     let mut semantic_per_table: Vec<(String, Vec<PartitionChecksum>)> =
         Vec::with_capacity(tables_scanned);
 
+    // Counters for the graceful-degradation summary emitted after the
+    // sweep. `describe_table` and `hash_table` failures on individual
+    // tables are treated as skippable — a measurement sweep over
+    // thousands of warehouse tables must not abort on one bad row.
+    let mut describe_failures: usize = 0;
+    let mut hash_failures: usize = 0;
+
     for table in &tables {
         let table_ref_str = table
             .validated_full_name()
@@ -275,10 +313,18 @@ pub(crate) async fn compute_measure_dedup(
         // (DuckDB's `hash()` is variadic but the `*` doesn't expand
         // inside function arguments) — by always passing explicit
         // column lists.
-        let column_info = adapter
-            .describe_table(table)
-            .await
-            .map_err(|e| anyhow!("failed to describe {table_ref_str}: {e}"))?;
+        let column_info = match adapter.describe_table(table).await {
+            Ok(info) => info,
+            Err(e) => {
+                tracing::warn!(
+                    table = %table_ref_str,
+                    error = %e,
+                    "describe_table failed — skipping"
+                );
+                describe_failures += 1;
+                continue;
+            }
+        };
 
         let all_columns: Vec<String> = column_info.iter().map(|c| c.name.clone()).collect();
         let semantic_columns: Vec<String> = column_info
@@ -299,7 +345,18 @@ pub(crate) async fn compute_measure_dedup(
             );
             Vec::new()
         } else {
-            hash_table(adapter.as_ref(), table, &all_columns).await?
+            match hash_table(adapter.as_ref(), table, &all_columns).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        table = %table_ref_str,
+                        error = %e,
+                        "raw hash failed — skipping table"
+                    );
+                    hash_failures += 1;
+                    continue;
+                }
+            }
         };
         raw_per_table.push((table_ref_str.clone(), raw));
 
@@ -311,9 +368,33 @@ pub(crate) async fn compute_measure_dedup(
             );
             Vec::new()
         } else {
-            hash_table(adapter.as_ref(), table, &semantic_columns).await?
+            match hash_table(adapter.as_ref(), table, &semantic_columns).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        table = %table_ref_str,
+                        error = %e,
+                        "semantic hash failed — skipping table"
+                    );
+                    hash_failures += 1;
+                    // Roll back the raw push we just made so the two
+                    // per_table vecs stay aligned for downstream stats.
+                    raw_per_table.pop();
+                    continue;
+                }
+            }
         };
         semantic_per_table.push((table_ref_str, semantic));
+    }
+
+    if describe_failures > 0 || hash_failures > 0 {
+        tracing::warn!(
+            describe_failures,
+            hash_failures,
+            total_matched = tables.len(),
+            hashed = semantic_per_table.len(),
+            "some tables were skipped during hashing; dedup numbers reflect only the hashed set"
+        );
     }
 
     // 7. Compute cross-table dedup stats for both passes.
@@ -511,28 +592,88 @@ fn resolve_transformation_managed_tables(
 /// Enumerate non-system tables visible to the warehouse adapter via
 /// `information_schema.tables`.
 ///
-/// Uses the **unqualified** form (no catalog prefix), which works on
-/// DuckDB (single-DB scope) and on Databricks/Snowflake when the
-/// session already has a default catalog/database bound — which is the
-/// case for every Rocky config that runs through `AdapterRegistry`.
+/// When `catalogs` is `Some(list)`, issues one catalog-prefixed query
+/// per catalog (`FROM <cat>.information_schema.tables`) and merges the
+/// results. This is required on Unity Catalog (Databricks) which has
+/// no workspace-wide `information_schema`, and also on Snowflake
+/// where the session's current database bounds the unqualified form.
+///
+/// When `catalogs` is `None`, issues a single unqualified query. This
+/// works on DuckDB (single-DB scope) and is the fall-through used when
+/// no managed-table resolution is available (e.g. `--all-tables`).
 ///
 /// System schemas (`information_schema`, `pg_catalog`, `system`) are
 /// filtered so the measurement doesn't include the warehouse's own
 /// metadata tables.
-async fn enumerate_tables(adapter: &dyn WarehouseAdapter) -> Result<Vec<TableRef>> {
+async fn enumerate_tables(
+    adapter: &dyn WarehouseAdapter,
+    catalogs: Option<&[String]>,
+) -> Result<Vec<TableRef>> {
     const SYSTEM_SCHEMAS: &[&str] = &["information_schema", "pg_catalog", "system"];
 
-    let sql = "SELECT table_catalog, table_schema, table_name \
-               FROM information_schema.tables \
-               WHERE table_type IN ('BASE TABLE', 'TABLE')";
+    let mut tables: Vec<TableRef> = Vec::new();
+    match catalogs {
+        Some(catalog_list) => {
+            let mut skipped: Vec<(String, String)> = Vec::new();
+            for catalog in catalog_list {
+                rocky_sql::validation::validate_identifier(catalog).map_err(|e| {
+                    anyhow!("invalid catalog identifier {catalog:?} in managed set: {e}")
+                })?;
+                let sql = format!(
+                    "SELECT table_catalog, table_schema, table_name \
+                     FROM {catalog}.information_schema.tables \
+                     WHERE table_type NOT IN ('VIEW', 'MATERIALIZED_VIEW', 'MATERIALIZED VIEW')"
+                );
+                match adapter.execute_query(&sql).await {
+                    Ok(result) => {
+                        collect_table_rows(&result.rows, SYSTEM_SCHEMAS, &mut tables)?;
+                    }
+                    Err(e) => {
+                        // Catalog may not exist yet (auto-created on first
+                        // write) or the session may lack USE CATALOG. A
+                        // measurement tool should degrade gracefully and
+                        // surface the skipped catalogs in a single summary
+                        // rather than aborting.
+                        tracing::warn!(
+                            catalog = %catalog,
+                            error = %e,
+                            "skipping catalog — enumeration failed (catalog missing or not accessible)"
+                        );
+                        skipped.push((catalog.clone(), e.to_string()));
+                    }
+                }
+            }
+            if !skipped.is_empty() {
+                tracing::warn!(
+                    skipped_catalogs = skipped.len(),
+                    total_catalogs = catalog_list.len(),
+                    "some catalogs were skipped during enumeration; dedup numbers \
+                     below reflect only the catalogs that were readable"
+                );
+            }
+        }
+        None => {
+            let sql = "SELECT table_catalog, table_schema, table_name \
+                       FROM information_schema.tables \
+                       WHERE table_type NOT IN ('VIEW', 'MATERIALIZED_VIEW', 'MATERIALIZED VIEW')";
+            let result = adapter
+                .execute_query(sql)
+                .await
+                .map_err(|e| anyhow!("failed to enumerate tables via information_schema: {e}"))?;
+            collect_table_rows(&result.rows, SYSTEM_SCHEMAS, &mut tables)?;
+        }
+    }
+    Ok(tables)
+}
 
-    let result = adapter
-        .execute_query(sql)
-        .await
-        .map_err(|e| anyhow!("failed to enumerate tables via information_schema: {e}"))?;
-
-    let mut tables = Vec::with_capacity(result.rows.len());
-    for row in &result.rows {
+/// Parse `SELECT table_catalog, table_schema, table_name` rows into
+/// [`TableRef`]s, dropping any that fall inside a system schema.
+fn collect_table_rows(
+    rows: &[Vec<serde_json::Value>],
+    system_schemas: &[&str],
+    tables: &mut Vec<TableRef>,
+) -> Result<()> {
+    for row in rows {
         let catalog = row
             .first()
             .and_then(|v| v.as_str())
@@ -543,7 +684,7 @@ async fn enumerate_tables(adapter: &dyn WarehouseAdapter) -> Result<Vec<TableRef
             .and_then(|v| v.as_str())
             .context("enumerate_tables: row missing table_schema column")?
             .to_string();
-        if SYSTEM_SCHEMAS
+        if system_schemas
             .iter()
             .any(|s| schema.eq_ignore_ascii_case(s))
         {
@@ -560,7 +701,28 @@ async fn enumerate_tables(adapter: &dyn WarehouseAdapter) -> Result<Vec<TableRef
             table: name,
         });
     }
-    Ok(tables)
+    Ok(())
+}
+
+/// Extract the distinct set of catalog identifiers from a managed-table
+/// set built by `resolve_managed_tables`.
+///
+/// The set is keyed on fully-qualified lowercase names (`catalog.schema.table`)
+/// assembled via `format!("{}.{}.{}", ...)` in the resolver, so splitting
+/// on the first `.` yields the catalog component. Names without a dot
+/// are skipped (defensive — the resolver always emits three components).
+fn managed_catalog_set(managed: &HashSet<String>) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for full in managed {
+        if let Some((catalog, _rest)) = full.split_once('.') {
+            if seen.insert(catalog.to_string()) {
+                out.push(catalog.to_string());
+            }
+        }
+    }
+    out.sort();
+    out
 }
 
 /// Execute one whole-table checksum SQL against the warehouse and parse
@@ -601,8 +763,15 @@ fn parse_checksum_rows(result: &QueryResult) -> Result<Vec<PartitionChecksum>> {
             .and_then(|v| v.as_str())
             .unwrap_or("__whole_table__")
             .to_string();
+        // Empty tables: the HASH aggregate returns NULL (Databricks) or
+        // the query returns zero rows (DuckDB). Either way there's no
+        // content to dedupe — skip silently instead of failing the sweep.
+        let checksum_cell = row.get(1);
+        if checksum_cell.map(|v| v.is_null()).unwrap_or(true) {
+            continue;
+        }
         let checksum =
-            json_number_to_u64(row.get(1)).context("checksum column is missing or not a number")?;
+            json_number_to_u64(checksum_cell).context("checksum column is missing or not a number")?;
         let row_count = json_number_to_u64(row.get(2))
             .context("row_count column is missing or not a number")?;
         checksums.push(PartitionChecksum {
@@ -1060,6 +1229,28 @@ mod tests {
     fn test_generate_compact_sql_custom_size() {
         let stmts = generate_compact_sql("my_table", 512);
         assert!(stmts[0].1.contains("512MB"));
+    }
+
+    #[test]
+    fn managed_catalog_set_extracts_distinct_catalogs() {
+        let mut managed = HashSet::new();
+        managed.insert("acme.raw__shopify.orders".to_string());
+        managed.insert("acme.raw__shopify.events".to_string());
+        managed.insert("beta.raw__stripe.charges".to_string());
+        managed.insert("acme.raw__stripe.customers".to_string());
+
+        let catalogs = managed_catalog_set(&managed);
+        assert_eq!(catalogs, vec!["acme".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn managed_catalog_set_skips_names_without_catalog_prefix() {
+        let mut managed = HashSet::new();
+        managed.insert("acme.schema.table".to_string());
+        managed.insert("schema_only".to_string()); // defensive: no `.`
+
+        let catalogs = managed_catalog_set(&managed);
+        assert_eq!(catalogs, vec!["acme".to_string()]);
     }
 
     /// E2E test for `compute_measure_dedup` against an ephemeral DuckDB.

--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -238,19 +238,18 @@ pub(crate) async fn compute_measure_dedup(
     };
 
     let catalog_scope = managed.as_ref().map(managed_catalog_set);
-    let all_warehouse_tables =
-        enumerate_tables(adapter.as_ref(), catalog_scope.as_deref()).await?;
+    let all_warehouse_tables = enumerate_tables(adapter.as_ref(), catalog_scope.as_deref()).await?;
 
     let (tables, scope) = match managed.as_ref() {
         Some(managed_set) => {
             let filtered: Vec<TableRef> = all_warehouse_tables
                 .iter()
-                .cloned()
                 .filter(|t| {
                     t.validated_full_name()
                         .map(|name| managed_set.contains(&name.to_lowercase()))
                         .unwrap_or(false)
                 })
+                .cloned()
                 .collect();
             tracing::info!(
                 managed_tables = managed_set.len(),
@@ -258,8 +257,7 @@ pub(crate) async fn compute_measure_dedup(
                 matched = filtered.len(),
                 "scoped to Rocky-managed tables"
             );
-            if filtered.is_empty() && !managed_set.is_empty() && !all_warehouse_tables.is_empty()
-            {
+            if filtered.is_empty() && !managed_set.is_empty() && !all_warehouse_tables.is_empty() {
                 let managed_sample: Vec<&String> = managed_set.iter().take(5).collect();
                 let warehouse_sample: Vec<String> = all_warehouse_tables
                     .iter()
@@ -767,11 +765,14 @@ fn parse_checksum_rows(result: &QueryResult) -> Result<Vec<PartitionChecksum>> {
         // the query returns zero rows (DuckDB). Either way there's no
         // content to dedupe — skip silently instead of failing the sweep.
         let checksum_cell = row.get(1);
-        if checksum_cell.map(|v| v.is_null()).unwrap_or(true) {
+        if checksum_cell
+            .map(serde_json::Value::is_null)
+            .unwrap_or(true)
+        {
             continue;
         }
-        let checksum =
-            json_number_to_u64(checksum_cell).context("checksum column is missing or not a number")?;
+        let checksum = json_number_to_u64(checksum_cell)
+            .context("checksum column is missing or not a number")?;
         let row_count = json_number_to_u64(row.get(2))
             .context("row_count column is missing or not a number")?;
         checksums.push(PartitionChecksum {

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -289,11 +289,17 @@ impl DatabricksConnector {
                                 .with_error_class(classify_error(&err)),
                         );
                         rocky_observe::metrics::METRICS.inc_retries_attempted();
-                        // 401 typically means the OAuth token expired between
-                        // cache-mint and server-use. Drop the cache so the
-                        // next attempt triggers a fresh token exchange;
-                        // genuine bad credentials re-fail and exhaust retries.
-                        if matches!(&err, ConnectorError::ApiError { status: 401, .. }) {
+                        // 401/403 typically mean the OAuth token expired
+                        // between cache-mint and server-use. Databricks
+                        // returns 403 "Invalid Token" from some SQL
+                        // endpoints where 401 would be more idiomatic.
+                        // Drop the cache so the next attempt triggers a
+                        // fresh token exchange; genuine bad credentials
+                        // re-fail and exhaust retries.
+                        if matches!(
+                            &err,
+                            ConnectorError::ApiError { status: 401 | 403, .. }
+                        ) {
                             self.auth.invalidate_cache().await;
                         }
                         let backoff_ms = compute_backoff(retry, attempt);
@@ -463,10 +469,16 @@ fn check_terminal_state(response: StatementResponse) -> Result<StatementResponse
 /// - Statement execution timeouts (may succeed on retry with a warmed-up warehouse)
 fn is_transient(err: &ConnectorError) -> bool {
     match err {
-        // 401 is transient-on-first-retry — the connector drops the OAuth
-        // cache before retrying, so a server-expired token is replaced with
-        // a fresh exchange. Bad credentials re-fail on every attempt.
-        ConnectorError::ApiError { status, .. } => matches!(status, 401 | 429 | 502 | 503 | 504),
+        // 401 and 403 are transient-on-first-retry — the connector drops
+        // the OAuth cache before retrying, so a server-expired token is
+        // replaced with a fresh exchange. Bad credentials re-fail on
+        // every attempt. Databricks's SQL Statement Execution API
+        // returns 403 "Invalid Token" where 401 would be more idiomatic;
+        // both paths must flow through the token-refresh branch or
+        // long-running operations die at the 1-hour OAuth TTL boundary.
+        ConnectorError::ApiError { status, .. } => {
+            matches!(status, 401 | 403 | 429 | 502 | 503 | 504)
+        }
         ConnectorError::Http(e) => e.is_connect() || e.is_timeout(),
         ConnectorError::StatementFailed { message, .. } => {
             let msg = message.to_uppercase();
@@ -673,6 +685,21 @@ mod tests {
         let err = ConnectorError::ApiError {
             status: 401,
             body: "unauthorized".into(),
+        };
+        assert!(is_transient(&err));
+    }
+
+    #[test]
+    fn test_transient_http_403_invalid_token() {
+        // Databricks's SQL Statement Execution API returns 403 "Invalid
+        // Token" where 401 would be more idiomatic. Without this in the
+        // transient set, the connector never drops the expired OAuth
+        // token and every subsequent call fails for the rest of the run
+        // (seen on a dedup sweep that crossed the 1-hour OAuth TTL
+        // boundary mid-execution).
+        let err = ConnectorError::ApiError {
+            status: 403,
+            body: "Invalid Token".into(),
         };
         assert!(is_transient(&err));
     }

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -298,7 +298,10 @@ impl DatabricksConnector {
                         // re-fail and exhaust retries.
                         if matches!(
                             &err,
-                            ConnectorError::ApiError { status: 401 | 403, .. }
+                            ConnectorError::ApiError {
+                                status: 401 | 403,
+                                ..
+                            }
                         ) {
                             self.auth.invalidate_cache().await;
                         }


### PR DESCRIPTION
## Summary

Four defects prevented ``rocky compact --measure-dedup`` from running
against a real Databricks workspace. All four land together because any
real sweep surfaces them in sequence. Surfaced by a production dedup
measurement that previously died at each step:

- **\`rocky-databricks\`** (commit \`8f2eef6\`): Databricks's SQL Statement
  Execution API returns HTTP 403 ``Invalid Token`` on expired OAuth M2M
  tokens (not 401). The connector retry loop only matched 401 for token
  refresh, so any long-running op died at the 1-hour TTL boundary. Patched
  ``is_transient`` and the ``invalidate_cache`` matcher to cover 401 and 403.

- **\`rocky-cli\`** (commit \`79d4b15\`): Three defects in ``compact --measure-dedup``:
  1. Unqualified ``information_schema.tables`` query — Unity Catalog has
     no workspace-wide info schema, queries must be catalog-prefixed.
     ``enumerate_tables`` now accepts a catalog list derived from the
     managed-table set and fans out per-catalog. Catalogs that fail
     enumeration (missing, no \`USE CATALOG\`) are skipped with a warning.
  2. ANSI-only \`table_type IN ('BASE TABLE', 'TABLE')\` filter excluded
     every Delta table on Databricks (\`MANAGED\`, \`EXTERNAL\`, etc.).
     Flipped to \`NOT IN ('VIEW', 'MATERIALIZED_VIEW', 'MATERIALIZED VIEW')\`.
  3. No tolerance for empty tables or single-table failures. An empty
     table's \`HASH\` returns NULL which aborted the sweep; one
     \`describe_table\` or \`hash_table\` failure killed all prior +
     future work. All three now skip-with-warning and the run summary
     surfaces skipped counts.

Known gap, not fixed here: ``--all-tables`` on Databricks still errors
out on the unqualified \`information_schema\` query. Fix needs
adapter-level \`SHOW CATALOGS\` plumbing — deferred to a separate PR.

## Test plan

- [x] ``cargo test -p rocky-cli --features duckdb -- compact`` — 13 tests pass (11 existing + 2 new for \`managed_catalog_set\`)
- [x] ``cargo test -p rocky-databricks -- connector::tests::test_transient`` — 7 tests pass (6 existing + 1 new for 403)
- [x] End-to-end against a production Databricks workspace (16-catalog sweep, 1528 managed tables, 377M rows, 83 min, completes cleanly including cross-hour OAuth refresh)
- [x] ``cargo clippy`` clean on both crates
- [x] CHANGELOG [Unreleased] entries added

## Follow-ups (tracked, not in this PR)

- \`--all-tables\` path needs \`SHOW CATALOGS\` fallback for Databricks
  (currently only works on DuckDB).
- The calibration loop inside \`calibrate_byte_dedup\` doesn't yet share
  the per-table skip-on-error tolerance added to the main hash loop —
  it still bails on first 403. Worked around today by the OAuth refresh
  fix (retries auto-refresh before the calibration step is reached), but
  worth defensive hardening in a follow-up.