### PR TITLE
feat(engine/rocky-cli): wire compile_complete + per-model hook events

### DIFF
--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -518,14 +518,15 @@ fn bench_single_file_change(c: &mut Criterion) {
     // Seed the incremental cache with a full cold compile.
     let previous = compile(&config).expect("seed compile must succeed");
 
-    // Pick a mart model (leaf of the DAG) — `fct_0500` is the first one
-    // `generate_layered_project` produces after 50+150+200 = 400 upstream
-    // models. Editing a leaf minimises downstream reflow so we're really
-    // measuring the incremental path's per-change overhead.
+    // Pick a mart model (leaf of the DAG) — `fct_0400` is the first one
+    // `generate_layered_project` produces, since layers 0..2 contribute
+    // 50+150+200 = 400 upstream models before marts begin. Editing a leaf
+    // minimises downstream reflow so we're really measuring the
+    // incremental path's per-change overhead.
     let models_dir = dir.path().join("models");
-    let target_sql = models_dir.join("fct_0500.sql");
+    let target_sql = models_dir.join("fct_0400.sql");
     let baseline =
-        fs::read_to_string(&target_sql).expect("layered project must contain fct_0500.sql");
+        fs::read_to_string(&target_sql).expect("layered project must contain fct_0400.sql");
 
     group.bench_function("500_models_edit_one_mart", |b| {
         let mut counter: u32 = 0;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -313,6 +313,8 @@ pub async fn run(
             &run_id,
             Some(target_model),
             &mut output,
+            None, // model-only run has no pipeline hooks
+            None,
         )
         .await?;
 
@@ -1988,6 +1990,8 @@ pub async fn run(
                 &run_id,
                 None, // no model filter in replication path
                 &mut output,
+                Some(&hook_registry),
+                Some(pipeline_name),
             )
             .await?;
         }
@@ -2215,6 +2219,7 @@ pub(super) fn emit_pipes_events(pipes: &crate::pipes::PipesEmitter, output: &Run
 /// everything else (full_refresh / incremental / merge / materialized_view)
 /// uses the single-statement path via `generate_transformation_sql`.
 #[tracing::instrument(skip_all, name = "execute_models")]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_models(
     models_dir: &Path,
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
@@ -2223,6 +2228,11 @@ pub(crate) async fn execute_models(
     run_id: &str,
     model_name_filter: Option<&str>,
     output: &mut RunOutput,
+    // §P2.6 hook plumbing — optional so `rocky run --model <X>`
+    // (which skips the full pipeline context) can pass `None` without
+    // the caller having to synthesise a fake pipeline name.
+    hook_registry: Option<&HookRegistry>,
+    pipeline_name: Option<&str>,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
@@ -2256,6 +2266,20 @@ pub(crate) async fn execute_models(
         return Ok(());
     }
 
+    // §P2.6 emit: compile_complete — fires once after a successful
+    // compile pass, with the model count from the compiled project.
+    // Gated on both hook_registry + pipeline_name being supplied so
+    // `rocky run --model <X>` stays silent.
+    if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+        let _ = reg
+            .fire(&HookContext::compile_complete(
+                run_id,
+                pipe,
+                compile_result.project.models.len(),
+            ))
+            .await;
+    }
+
     let dialect = warehouse.dialect();
     let mut models_executed = 0usize;
 
@@ -2282,6 +2306,16 @@ pub(crate) async fn execute_models(
                 continue;
             };
 
+            // §P2.6 per-model emit: before_model_run. Duration is
+            // reserved for after_model_run — here we just announce
+            // the model is about to execute.
+            if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                let _ = reg
+                    .fire(&HookContext::before_model_run(run_id, pipe, model_name))
+                    .await;
+            }
+            let model_start = Instant::now();
+
             // Dispatch on the materialization strategy. time_interval models
             // take the per-partition path so the runtime can iterate
             // partitions, populate the window per partition, and record
@@ -2291,7 +2325,7 @@ pub(crate) async fn execute_models(
                 model.config.strategy,
                 rocky_core::models::StrategyConfig::TimeInterval { .. }
             ) {
-                execute_time_interval_model(
+                let time_interval_res = execute_time_interval_model(
                     model,
                     warehouse,
                     dialect,
@@ -2302,7 +2336,30 @@ pub(crate) async fn execute_models(
                     &exec_ctx,
                 )
                 .await
-                .with_context(|| format!("model '{model_name}' failed"))?;
+                .with_context(|| format!("model '{model_name}' failed"));
+                if let Err(ref e) = time_interval_res {
+                    if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                        let _ = reg
+                            .fire(&HookContext::model_error(
+                                run_id,
+                                pipe,
+                                model_name,
+                                &format!("{e:#}"),
+                            ))
+                            .await;
+                    }
+                }
+                time_interval_res?;
+                if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                    let _ = reg
+                        .fire(&HookContext::after_model_run(
+                            run_id,
+                            pipe,
+                            model_name,
+                            model_start.elapsed().as_millis() as u64,
+                        ))
+                        .await;
+                }
                 models_executed += 1;
                 continue;
             }
@@ -2324,11 +2381,35 @@ pub(crate) async fn execute_models(
                 statements = exec_stmts.len(),
                 "executing model"
             );
+            let mut exec_error: Option<anyhow::Error> = None;
             for exec_sql in &exec_stmts {
-                warehouse
-                    .execute_statement(exec_sql)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("model '{model_name}' failed: {e}"))?;
+                if let Err(e) = warehouse.execute_statement(exec_sql).await {
+                    exec_error = Some(anyhow::anyhow!("model '{model_name}' failed: {e}"));
+                    break;
+                }
+            }
+            if let Some(e) = exec_error {
+                if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                    let _ = reg
+                        .fire(&HookContext::model_error(
+                            run_id,
+                            pipe,
+                            model_name,
+                            &format!("{e:#}"),
+                        ))
+                        .await;
+                }
+                return Err(e);
+            }
+            if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                let _ = reg
+                    .fire(&HookContext::after_model_run(
+                        run_id,
+                        pipe,
+                        model_name,
+                        model_start.elapsed().as_millis() as u64,
+                    ))
+                    .await;
             }
             models_executed += 1;
         }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -831,6 +831,18 @@ pub async fn run(
         .fire(&HookContext::pipeline_start(&run_id, pipeline_name))
         .await;
 
+    // §P2.6 emit: discover_complete. Fired once, right after
+    // pipeline_start, with the source-discovery count captured above
+    // (discovery runs before run_id is established, so this is the
+    // earliest emit point with a stable run_id).
+    let _ = hook_registry
+        .fire(&HookContext::discover_complete(
+            &run_id,
+            pipeline_name,
+            connectors.len(),
+        ))
+        .await;
+
     let completed_keys: std::collections::HashSet<String> = if resume_latest {
         if let Ok(Some(prev)) = state_store.get_latest_run_progress() {
             let keys: std::collections::HashSet<String> = prev
@@ -1898,6 +1910,17 @@ pub async fn run(
                             "row count anomaly detected"
                         );
                         rocky_observe::metrics::METRICS.inc_anomalies_detected();
+                        // §P2.6 emit: anomaly_detected. Fires before
+                        // pushing to output.anomalies so we can pass
+                        // references without cloning.
+                        let _ = hook_registry
+                            .fire(&HookContext::anomaly_detected(
+                                &run_id,
+                                pipeline_name,
+                                &anomaly.table,
+                                &anomaly.reason,
+                            ))
+                            .await;
                         output.anomalies.push(AnomalyOutput {
                             table: anomaly.table,
                             current_count: anomaly.current_count,
@@ -1935,6 +1958,19 @@ pub async fn run(
     // Assemble check results
     for (_table_key, pending) in pending_checks {
         if !pending.checks.is_empty() {
+            // §P2.6 emit: check_result. Fires per-check inside the
+            // assembled bag so subscribers see every pass/fail
+            // (after_checks is the summary roll-up).
+            for check in &pending.checks {
+                let _ = hook_registry
+                    .fire(&HookContext::check_result(
+                        &run_id,
+                        pipeline_name,
+                        &check.name,
+                        check.passed,
+                    ))
+                    .await;
+            }
             output.check_results.push(TableCheckOutput {
                 asset_key: pending.asset_key,
                 checks: pending.checks,

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -68,6 +68,8 @@ pub async fn run_transformation(
             &run_id,
             None, // no model filter in local execution path
             &mut output,
+            None, // run_local doesn't build a HookRegistry
+            None,
         )
         .await?;
     } else {


### PR DESCRIPTION
## Summary

Completes the §P2.6 lifecycle hook wiring in `rocky run` by adding the final batch of event emits. Together with #156 / #157 / #158, the 15-event hook surface is now fully wired:

**Pipeline lifecycle** (#156): `pipeline_start`, `pipeline_complete`, `pipeline_error`, `wait_async_webhooks`
**Per-table** (#157): `before_materialize`, `after_materialize`, `materialize_error`
**State/checks** (#158): `drift_detected`, `before_checks`, `after_checks`, `state_synced`
**This PR**: `compile_complete`, `before_model_run`, `after_model_run`, `model_error`, `discover_complete`, `anomaly_detected`, `check_result`

## Changes

- `compile_complete` — once after successful project compile; includes compiled `model_count`.
- `before_model_run` / `after_model_run` / `model_error` — per-model in `execute_models`, with `duration_ms` measured from model start.
- `discover_complete` — once after source discovery, with `connector_count`. Emitted right after `pipeline_start` since discovery runs before `run_id` is established.
- `anomaly_detected` — inside the anomaly-detection block, before output push so references borrow without cloning.
- `check_result` — per-individual-check inside the assembled pending_checks bag.

`execute_models` gained two optional params — `hook_registry` and `pipeline_name`. The `rocky run --model <X>` direct path and `run_local` pass `None/None` so single-model runs stay silent about pipeline-scoped hooks. `#[allow(clippy::too_many_arguments)]` added — the arg list is now 9, and every arg is meaningful.

### Drive-by bench fix

Also bundles `fix(engine/rocky-cli): bench reads fct_0400, not fct_0500` — the `500_models_edit_one_mart` bench in `benches/compile.rs` was reading a path the fixture generator never produces (`fct_*` marts run 0400..0499, not 0500). Only surfaces in CI since local `cargo test` without `--all-targets` skips benches, which is why batches 3–11 didn't catch it.

## Roadmap context

Completes §P2.6 (Lifecycle Hook Events) from `rocky-perf-resilience-roadmap.md`.

## Test plan

- [x] `cargo build -p rocky-cli`
- [x] `cargo clippy -p rocky-cli --all-features --all-targets -- -D warnings`
- [x] `cargo test -p rocky-cli --all-features --all-targets` (147 unit tests + all benches, locally)
- [x] `cargo fmt --check`