### PR TITLE
perf(engine/rocky-compiler): incremental compile reuses previous typecheck (§P3.1)

### DIFF
--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -215,6 +215,191 @@ pub fn compile_project(
     })
 }
 
+/// §P3.1 — Incremental compile, narrow scope.
+///
+/// Given the previous `CompileResult` and the set of model files that
+/// changed on disk, rebuilds only the typecheck of models that can have
+/// changed (the changed file itself + transitive dependents + anything
+/// new or with a shifted upstream set).
+///
+/// Falls through to a full [`compile`] — with an explicit branch each
+/// time — when the incremental path would either (a) touch too much of
+/// the graph to be worth the bookkeeping, (b) hit a case we don't yet
+/// reason about safely, or (c) affect inputs that aren't per-model
+/// (source_schemas / source_column_info).
+///
+/// This is deliberately a hand-rolled optimization. §P5.1 (salsa) is
+/// the long-term answer; this function exists so the LSP's per-keystroke
+/// path can stop paying a full-project typecheck when a single model
+/// edits don't ripple.
+pub fn compile_incremental(
+    config: &CompilerConfig,
+    changed_files: &[PathBuf],
+    previous: &CompileResult,
+) -> Result<CompileResult, CompileError> {
+    use std::collections::HashSet;
+
+    let total_start = Instant::now();
+
+    // The caller is responsible for guaranteeing that `previous` was
+    // produced against the same `config.source_schemas` and
+    // `config.source_column_info` as the current call. Source-schema
+    // changes affect every downstream model, so if they shift the caller
+    // must invoke `compile` directly rather than this path.
+    // The LSP constructs `CompilerConfig` once per workspace-init
+    // (see `RockyLsp::config_for_compile`), so this invariant holds in
+    // practice.
+
+    // 1. Load the new project + rebuild the semantic graph. Both are cheap
+    //    relative to typecheck — the whole point of the optimization.
+    let load_start = Instant::now();
+    let project = Project::load(&config.models_dir)?;
+    let project_load_ms = load_start.elapsed().as_millis() as u64;
+
+    let sg_start = Instant::now();
+    let semantic_graph = semantic::build_semantic_graph(&project, &config.source_column_info)
+        .map_err(CompileError::SemanticGraph)?;
+    let semantic_graph_ms = sg_start.elapsed().as_millis() as u64;
+
+    // 2. Compute the affected set. The comparison must be with the NEW
+    //    graph so we catch upstream shifts and newly-added models.
+    let mut affected: HashSet<String> = HashSet::new();
+
+    let changed_paths: HashSet<PathBuf> = changed_files.iter().cloned().collect();
+    for m in &project.models {
+        let path = PathBuf::from(&m.file_path);
+        if changed_paths.contains(&path) {
+            affected.insert(m.config.name.clone());
+        }
+    }
+
+    // New-to-project: any model in the new graph that wasn't typed
+    // previously is affected (we have no cached result for it).
+    for name in semantic_graph.models.keys() {
+        if !previous.type_check.typed_models.contains_key(name) {
+            affected.insert(name.clone());
+        }
+    }
+
+    // Upstream shift: even with unchanged SQL, a model whose dependency
+    // set differs from the previous graph's must be re-typechecked —
+    // the scope it reads from has changed.
+    for (name, schema) in &semantic_graph.models {
+        if let Some(prev_schema) = previous.semantic_graph.models.get(name) {
+            if schema.upstream != prev_schema.upstream {
+                affected.insert(name.clone());
+            }
+        }
+    }
+
+    // Transitive dependents. Fixed-point over the NEW graph.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (name, schema) in &semantic_graph.models {
+            if !affected.contains(name) && schema.upstream.iter().any(|up| affected.contains(up)) {
+                affected.insert(name.clone());
+                changed = true;
+            }
+        }
+    }
+
+    // Guardrails: small projects and large blast radius aren't worth
+    // the merging cost — fall through.
+    let total = semantic_graph.models.len();
+    if total < 10 || affected.len() * 2 > total {
+        return compile(config);
+    }
+
+    // 3. Run the incremental typecheck against the reused `typed_models`
+    //    from `previous`, scoped to the affected subset.
+    let join_keys_acc = Arc::new(AtomicU64::new(0));
+    let tc_start = Instant::now();
+    let mut type_check = typecheck::typecheck_project_incremental(
+        &semantic_graph,
+        &config.source_schemas,
+        &project.models,
+        &affected,
+        &previous.type_check,
+        Some(&join_keys_acc),
+    );
+    let typecheck_ms = tc_start.elapsed().as_millis() as u64;
+    let typecheck_join_keys_ms = join_keys_acc.load(Ordering::Relaxed);
+
+    // 4. Re-validate contracts. Cheap, and the merged typed_models may
+    //    differ from previous so re-running is the safe default.
+    let contracts_start = Instant::now();
+    let contract_diagnostics = {
+        let mut contract_map = contracts::discover_contracts_from_models(&project.models)
+            .map_err(CompileError::ContractLoad)?;
+
+        if let Some(ref contracts_dir) = config.contracts_dir {
+            let explicit =
+                contracts::load_contracts(contracts_dir).map_err(CompileError::ContractLoad)?;
+            contract_map.extend(explicit);
+        }
+
+        if contract_map.is_empty() {
+            Vec::new()
+        } else {
+            validate_all_contracts(&contract_map, &type_check.typed_models)
+        }
+    };
+    let contracts_ms = contracts_start.elapsed().as_millis() as u64;
+
+    // 5. Extract per-model timings + merge diagnostics (same shape as
+    //    the full path).
+    let model_timings: HashMap<String, ModelCompileTimings> =
+        std::mem::take(&mut type_check.model_typecheck_ms)
+            .into_iter()
+            .map(|(name, ms)| {
+                (
+                    name,
+                    ModelCompileTimings {
+                        typecheck_ms: ms,
+                        total_ms: ms,
+                    },
+                )
+            })
+            .collect();
+
+    let mut diagnostics = type_check.diagnostics.clone();
+    diagnostics.extend(contract_diagnostics.iter().cloned());
+
+    let has_errors = diagnostics
+        .iter()
+        .any(super::diagnostic::Diagnostic::is_error);
+
+    let timings = PhaseTimings {
+        project_load_ms,
+        semantic_graph_ms,
+        typecheck_ms,
+        typecheck_join_keys_ms,
+        contracts_ms,
+        total_ms: total_start.elapsed().as_millis() as u64,
+    };
+
+    tracing::info!(
+        target: "rocky::compile::timings",
+        affected = affected.len(),
+        total_models = total,
+        typecheck_ms,
+        total_ms = timings.total_ms,
+        "incremental compile finished"
+    );
+
+    Ok(CompileResult {
+        project,
+        semantic_graph,
+        type_check,
+        contract_diagnostics,
+        diagnostics,
+        has_errors,
+        timings,
+        model_timings,
+    })
+}
+
 fn validate_all_contracts(
     contract_map: &HashMap<String, CompilerContract>,
     typed_models: &IndexMap<String, Vec<TypedColumn>>,

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -226,6 +226,187 @@ pub fn typecheck_project_with_models(
     }
 }
 
+/// §P3.1 — Incremental typecheck. Reuses `previous.typed_models` entries for
+/// models that are **not** in `affected`, and re-typechecks only the models
+/// that are.
+///
+/// The caller is responsible for computing a correct `affected` set — any
+/// model whose typecheck inputs may have shifted (own SQL changed, upstream
+/// changed, config changed, new to the project). Members of `affected` that
+/// don't exist in `graph.models` are ignored.
+///
+/// The `reference_map` is always rebuilt in full (SQL scanning is cheap),
+/// and diagnostics / timings are stitched so the result is observationally
+/// identical to a full `typecheck_project_with_models` in shape.
+pub fn typecheck_project_incremental(
+    graph: &SemanticGraph,
+    source_schemas: &HashMap<String, Vec<TypedColumn>>,
+    models: &[rocky_core::models::Model],
+    affected: &HashSet<String>,
+    previous: &TypeCheckResult,
+    join_keys_acc: Option<&Arc<AtomicU64>>,
+) -> TypeCheckResult {
+    let mut typed_models: IndexMap<String, Vec<TypedColumn>> = IndexMap::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut model_typecheck_ms: HashMap<String, u64> = HashMap::with_capacity(graph.models.len());
+
+    let mut model_names: HashSet<String> = HashSet::with_capacity(graph.models.len());
+    model_names.extend(graph.models.keys().cloned());
+
+    let model_by_name: HashMap<&str, &rocky_core::models::Model> =
+        models.iter().map(|m| (m.config.name.as_str(), m)).collect();
+
+    // Files that belong to affected models — any reference_map entry
+    // whose RefLocation.file is in this set came FROM an affected file and
+    // is therefore stale.
+    let affected_files: HashSet<PathBuf> = models
+        .iter()
+        .filter(|m| affected.contains(&m.config.name))
+        .map(|m| PathBuf::from(&m.file_path))
+        .collect();
+
+    // Seed reference_map from `previous`, dropping stale entries (anything
+    // recorded FROM an affected file — those refs were rebuilt below).
+    // Avoids the SQL-reparse cost of running `collect_references` over the
+    // non-affected models, which is the dominant overhead on wide DAGs.
+    let mut reference_map = ReferenceMap {
+        model_refs: previous
+            .reference_map
+            .model_refs
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    v.iter()
+                        .filter(|loc| !affected_files.contains(&loc.file))
+                        .cloned()
+                        .collect(),
+                )
+            })
+            .filter(|(_, v): &(String, Vec<RefLocation>)| !v.is_empty())
+            .collect(),
+        column_refs: previous
+            .reference_map
+            .column_refs
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.clone(),
+                    v.iter()
+                        .filter(|loc| !affected_files.contains(&loc.file))
+                        .cloned()
+                        .collect(),
+                )
+            })
+            .filter(|(_, v): &((String, String), Vec<RefLocation>)| !v.is_empty())
+            .collect(),
+        model_defs: HashMap::new(),
+    };
+
+    // Register fresh model definition locations for every model in the
+    // current graph (overwrites stale defs from removed models).
+    for m in models {
+        reference_map.model_defs.insert(
+            m.config.name.clone(),
+            RefLocation {
+                file: PathBuf::from(&m.file_path),
+                line: 1,
+                col: 0,
+                end_col: 0,
+            },
+        );
+    }
+
+    // Inject source schemas.
+    for (source_name, cols) in source_schemas {
+        typed_models.insert(source_name.clone(), cols.clone());
+    }
+
+    // Seed typed_models with non-affected entries from the previous result.
+    // Source schemas overlap is fine — we inserted them first, and re-inserting
+    // the same entry from previous.typed_models is idempotent.
+    for (name, cols) in &previous.typed_models {
+        if !affected.contains(name) && graph.models.contains_key(name) {
+            typed_models.insert(name.clone(), cols.clone());
+            // Carry over timing so model_typecheck_ms stays complete.
+            if let Some(&ms) = previous.model_typecheck_ms.get(name) {
+                model_typecheck_ms.insert(name.clone(), ms);
+            }
+        }
+    }
+
+    let layers = derive_execution_layers(graph);
+
+    let mut col_index: HashMap<String, HashMap<String, usize>> =
+        HashMap::with_capacity(typed_models.len());
+    for (name, cols) in typed_models.iter() {
+        let idx: HashMap<String, usize> = cols
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.name.clone(), i))
+            .collect();
+        col_index.insert(name.clone(), idx);
+    }
+
+    for layer in &layers {
+        let typed_snapshot = &typed_models;
+        let col_index_snapshot = &col_index;
+
+        let mut layer_outputs: Vec<ModelTypecheckOutput> = layer
+            .par_iter()
+            .with_min_len(32)
+            .filter_map(|model_name| {
+                if !affected.contains(model_name.as_str()) {
+                    return None;
+                }
+                let model_schema = graph.model_schema(model_name)?;
+                Some(compute_model_typecheck(
+                    model_name,
+                    model_schema,
+                    graph,
+                    typed_snapshot,
+                    col_index_snapshot,
+                    &model_by_name,
+                    &model_names,
+                    join_keys_acc,
+                ))
+            })
+            .collect();
+
+        layer_outputs.sort_by(|a, b| a.model_name.cmp(&b.model_name));
+
+        for out in layer_outputs {
+            model_typecheck_ms.insert(out.model_name.clone(), out.typecheck_ms);
+            let idx: HashMap<String, usize> = out
+                .typed_cols
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (c.name.clone(), i))
+                .collect();
+            col_index.insert(out.model_name.clone(), idx);
+            typed_models.insert(out.model_name, out.typed_cols);
+            diagnostics.extend(out.diagnostics);
+            merge_reference_map(&mut reference_map, out.ref_map);
+        }
+    }
+
+    // Carry over non-affected models' diagnostics so the full diagnostic set
+    // reflects the whole project. The affected models produced fresh
+    // diagnostics above; here we stitch in the untouched remainder.
+    for d in &previous.diagnostics {
+        if !affected.contains(&d.model) && graph.models.contains_key(&d.model) {
+            diagnostics.push(d.clone());
+        }
+    }
+
+    TypeCheckResult {
+        typed_models,
+        diagnostics,
+        reference_map,
+        model_typecheck_ms,
+    }
+}
+
 /// Pure per-model output from a single typecheck pass.
 struct ModelTypecheckOutput {
     model_name: String,

--- a/engine/crates/rocky-compiler/tests/integration.rs
+++ b/engine/crates/rocky-compiler/tests/integration.rs
@@ -251,3 +251,212 @@ fn test_contract_project_with_no_contracts_dir() {
     // Without contracts dir, no contract diagnostics
     assert!(result.contract_diagnostics.is_empty());
 }
+
+// ---- Incremental compile (§P3.1) ----
+
+/// Generate a synthetic 20-model linear-chain project into `dir`.
+/// Layout: `m00` → `m01` → … → `m19`. Big enough to exceed the
+/// `total < 10` guardrail in `compile_incremental` so the incremental
+/// path actually runs.
+fn generate_linear_project(dir: &std::path::Path) {
+    use std::fs;
+    let models_dir = dir.join("models");
+    fs::create_dir_all(&models_dir).unwrap();
+    for i in 0..20 {
+        let name = format!("m{i:02}");
+        let sql = if i == 0 {
+            "SELECT 1 AS id, 'a' AS label".to_string()
+        } else {
+            let upstream = format!("m{:02}", i - 1);
+            format!("SELECT id, label FROM {upstream}")
+        };
+        let toml = if i == 0 {
+            format!(
+                r#"name = "{name}"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "warehouse"
+schema = "s"
+table = "{name}"
+"#
+            )
+        } else {
+            let upstream = format!("m{:02}", i - 1);
+            format!(
+                r#"name = "{name}"
+depends_on = ["{upstream}"]
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "warehouse"
+schema = "s"
+table = "{name}"
+"#
+            )
+        };
+        fs::write(models_dir.join(format!("{name}.sql")), &sql).unwrap();
+        fs::write(models_dir.join(format!("{name}.toml")), &toml).unwrap();
+    }
+}
+
+/// Equivalence test: editing one leaf and running incremental produces a
+/// typecheck result observationally identical to a fresh full compile on
+/// the same post-edit state. Guards the "affected set completeness" claim
+/// — if we ever miss a case (new model, upstream shift), typed_models or
+/// diagnostics will diverge between the two runs and this test fails.
+#[test]
+fn incremental_matches_full_after_leaf_edit() {
+    use rocky_compiler::compile::compile_incremental;
+    use std::fs;
+
+    let dir = tempfile::tempdir().unwrap();
+    generate_linear_project(dir.path());
+
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        contracts_dir: None,
+        source_schemas: HashMap::new(),
+        source_column_info: HashMap::new(),
+    };
+
+    let seed = compile(&config).unwrap();
+    assert_eq!(seed.project.model_count(), 20);
+    assert!(!seed.has_errors);
+
+    // Edit a leaf — m19 has no dependents, so affected = {m19} only.
+    let target_sql = dir.path().join("models/m19.sql");
+    let edited = fs::read_to_string(&target_sql).unwrap() + " -- edited\n";
+    fs::write(&target_sql, edited).unwrap();
+
+    let incr = compile_incremental(&config, std::slice::from_ref(&target_sql), &seed).unwrap();
+    let full = compile(&config).unwrap();
+
+    assert_eq!(incr.project.model_count(), full.project.model_count());
+    assert_eq!(
+        incr.type_check.typed_models.len(),
+        full.type_check.typed_models.len(),
+        "typed_models count must match full compile"
+    );
+    for (name, cols) in &full.type_check.typed_models {
+        let incr_cols = incr
+            .type_check
+            .typed_models
+            .get(name)
+            .unwrap_or_else(|| panic!("missing typed_models entry for {name}"));
+        let incr_names: Vec<&str> = incr_cols.iter().map(|c| c.name.as_str()).collect();
+        let full_names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(incr_names, full_names, "columns differ for {name}");
+    }
+
+    let sort_diags = |ds: Vec<rocky_compiler::diagnostic::Diagnostic>| {
+        let mut v: Vec<(String, String, String)> = ds
+            .into_iter()
+            .map(|d| (d.model, d.code.to_string(), d.message.to_string()))
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(
+        sort_diags(incr.diagnostics.clone()),
+        sort_diags(full.diagnostics.clone()),
+        "diagnostics must match full compile"
+    );
+    assert_eq!(incr.has_errors, full.has_errors);
+}
+
+/// Old `compile_incremental` in `lsp.rs` returned `ReferenceMap::default()`
+/// after any incremental compile, which broke Find References / Rename
+/// between edits. This test guards the new path: after a leaf edit, the
+/// incremental result must carry a non-empty `reference_map`.
+#[test]
+fn incremental_preserves_reference_map() {
+    use rocky_compiler::compile::compile_incremental;
+    use std::fs;
+
+    let dir = tempfile::tempdir().unwrap();
+    generate_linear_project(dir.path());
+
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        contracts_dir: None,
+        source_schemas: HashMap::new(),
+        source_column_info: HashMap::new(),
+    };
+
+    let seed = compile(&config).unwrap();
+    assert!(
+        !seed.type_check.reference_map.model_defs.is_empty(),
+        "seed compile should have populated model_defs"
+    );
+
+    let target_sql = dir.path().join("models/m19.sql");
+    let edited = fs::read_to_string(&target_sql).unwrap() + " -- edited\n";
+    fs::write(&target_sql, edited).unwrap();
+
+    let incr = compile_incremental(&config, &[target_sql], &seed).unwrap();
+    assert!(
+        !incr.type_check.reference_map.model_defs.is_empty(),
+        "incremental compile must not zero out reference_map"
+    );
+    assert!(
+        !incr.type_check.reference_map.model_refs.is_empty(),
+        "incremental compile must preserve model_refs entries"
+    );
+}
+
+/// Adding a brand-new model file must land in the affected set even
+/// though it's not in `previous.project.models`. Without this, the
+/// incremental path would silently skip typechecking the new model.
+#[test]
+fn incremental_handles_new_model_file() {
+    use rocky_compiler::compile::compile_incremental;
+    use std::fs;
+
+    let dir = tempfile::tempdir().unwrap();
+    generate_linear_project(dir.path());
+
+    let config = CompilerConfig {
+        models_dir: dir.path().join("models"),
+        contracts_dir: None,
+        source_schemas: HashMap::new(),
+        source_column_info: HashMap::new(),
+    };
+
+    let seed = compile(&config).unwrap();
+
+    // Add a new leaf model that reads from m19.
+    let new_sql = dir.path().join("models/m20.sql");
+    fs::write(&new_sql, "SELECT id, label FROM m19").unwrap();
+    fs::write(
+        dir.path().join("models/m20.toml"),
+        r#"name = "m20"
+depends_on = ["m19"]
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "warehouse"
+schema = "s"
+table = "m20"
+"#,
+    )
+    .unwrap();
+
+    let incr = compile_incremental(&config, &[new_sql], &seed).unwrap();
+    let full = compile(&config).unwrap();
+
+    assert_eq!(
+        incr.type_check.typed_models.len(),
+        full.type_check.typed_models.len()
+    );
+    assert!(
+        incr.type_check.typed_models.contains_key("m20"),
+        "new model m20 must be typechecked by incremental path"
+    );
+}

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -2619,70 +2619,16 @@ fn find_last_nonblank_before(lines: &[&str], before_idx: usize) -> usize {
 // ── Incremental compilation (Phase 3H) ──────────────────────────────────────
 
 /// Incremental compilation: recompile only changed models + dependents.
+///
+/// §P3.1 — delegates to `rocky_compiler::compile::compile_incremental`,
+/// which reuses `previous.type_check.typed_models` for non-affected
+/// models instead of re-typechecking the whole project.
 pub fn compile_incremental(
     changed_files: &[std::path::PathBuf],
     previous: &CompileResult,
     config: &CompilerConfig,
 ) -> std::result::Result<CompileResult, rocky_compiler::compile::CompileError> {
-    // Identify which models changed
-    let changed_models: Vec<&str> = previous
-        .project
-        .models
-        .iter()
-        .filter(|m| {
-            let path = std::path::Path::new(&m.file_path);
-            changed_files.iter().any(|cf| cf == path)
-        })
-        .map(|m| m.config.name.as_str())
-        .collect();
-
-    if changed_models.is_empty() {
-        // No model files changed — return previous result as-is
-        return Ok(CompileResult {
-            project: rocky_compiler::project::Project::load(&config.models_dir)?,
-            semantic_graph: previous.semantic_graph.clone(),
-            type_check: rocky_compiler::typecheck::TypeCheckResult {
-                typed_models: previous.type_check.typed_models.clone(),
-                diagnostics: previous.type_check.diagnostics.clone(),
-                reference_map: rocky_compiler::typecheck::ReferenceMap::default(),
-                model_typecheck_ms: previous.type_check.model_typecheck_ms.clone(),
-            },
-            contract_diagnostics: previous.contract_diagnostics.clone(),
-            diagnostics: previous.diagnostics.clone(),
-            has_errors: previous.has_errors,
-            timings: previous.timings.clone(),
-            model_timings: previous.model_timings.clone(),
-        });
-    }
-
-    // Find transitive dependents
-    let mut affected: std::collections::HashSet<String> = changed_models
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect();
-
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (model_name, schema) in &previous.semantic_graph.models {
-            if !affected.contains(model_name)
-                && schema.upstream.iter().any(|up| affected.contains(up))
-            {
-                affected.insert(model_name.clone());
-                changed = true;
-            }
-        }
-    }
-
-    // If most models are affected, just do a full recompile
-    let total = previous.project.models.len();
-    if affected.len() > total / 2 || total < 10 {
-        return rocky_compiler::compile::compile(config);
-    }
-
-    // Otherwise, still do full compile (incremental merging is complex)
-    // but this framework allows future optimization
-    rocky_compiler::compile::compile(config)
+    rocky_compiler::compile::compile_incremental(config, changed_files, previous)
 }
 
 // ── Server entry point ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

§P3.1 from the perf-resilience roadmap — the last remaining **[M]** item. Two wins wrapped in one change:

**1. Correctness fix.** The old `compile_incremental` in `rocky-server/src/lsp.rs` had a latent bug: its \"no model files changed\" short-circuit wrote back `ReferenceMap::default()` (i.e. empty). This meant Find References / Rename silently returned no results after the first incremental compile. Every other branch fell through to a full `compile()`, so the rest of the \"incremental\" scaffolding was inert.

**2. Real incremental typecheck.** Pushed the logic down into `rocky-compiler::compile::compile_incremental` and made it actually skip work:
- Reuses `previous.typed_models` entries for models outside the affected subgraph
- Seeds `reference_map` from `previous`, dropping entries recorded FROM affected files and merging fresh refs — avoids SQL reparse over the non-affected remainder
- Stitches diagnostics (drops affected models' stale entries, keeps the rest, appends fresh)
- Computes the affected set against the *new* graph so new-to-project models and upstream-shift cases don't silently slip through

## Results

`single_file_change/500_models_edit_one_mart` bench: **~24 ms → ~18 ms** (~25 % faster). Modest because typecheck is only ~25 % of the compile pipeline on simple SELECTs — project load and semantic-graph rebuild dominate. Real LSP workloads with complex SQL (CTEs, joins, CASE expressions) should see a larger relative win.

Fall-through guardrails: projects with `<10` models or >50 % affected blast radius still go through the full path — bookkeeping isn't worth it past that point.

## Framework for §P5.1

With affected-set computation and non-affected reuse living in the compiler crate, swapping the hand-rolled cache for a salsa-style pull-based query graph becomes mechanical.

## Tests

- `incremental_matches_full_after_leaf_edit` — equivalence: incremental and full produce identical `typed_models` + sorted diagnostics after a leaf edit
- `incremental_handles_new_model_file` — guards the \"new-to-project\" branch of affected-set computation
- `incremental_preserves_reference_map` — guards the reference_map regression that motivated the change

## Test plan

- [x] `cargo build -p rocky-compiler -p rocky-server`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo fmt --check`
- [x] `cargo bench -p rocky-cli --bench compile -- single_file_change`