### PR TITLE
docs: close coverage gaps for check hooks, ci-diff, Layer 0 dedup

### DIFF
--- a/docs/src/content/docs/concepts/hooks.md
+++ b/docs/src/content/docs/concepts/hooks.md
@@ -41,7 +41,9 @@ Events are organized into five phases:
 
 | Event | When | Use case |
 |-------|------|----------|
-| `check_result` | Quality check completes | Threshold alerting |
+| `before_checks` | Quality checks begin | Mute downstream alerts during expected check windows |
+| `check_result` | A quality check completes | Per-check threshold alerting |
+| `after_checks` | All checks finish | Aggregate summary to dashboards, gating on total pass rate |
 | `drift_detected` | Schema drift found | Schema change notification |
 | `anomaly_detected` | Row count anomaly | Data quality alert |
 

--- a/docs/src/content/docs/guides/ci-cd.md
+++ b/docs/src/content/docs/guides/ci-cd.md
@@ -33,6 +33,27 @@ Exit codes:
 
 The command detects both compile-time issues (type mismatches, missing dependencies, contract violations) and runtime issues (SQL syntax errors, division by zero, invalid casts).
 
+### Structural diff against a base ref
+
+For PR review, [`rocky ci-diff`](/reference/commands/modeling/#rocky-ci-diff) is a companion to `rocky ci`. It compares model files between a base git ref and `HEAD`, compiles both sides, and reports added / modified / removed columns per model. The output is both JSON (for pipelines) and Markdown (for PR comments):
+
+```bash
+rocky ci-diff                    # defaults to main
+rocky ci-diff release/2026-04 --models src/models
+```
+
+In GitHub Actions, post the pre-rendered Markdown block to the PR directly:
+
+```yaml
+- name: Post diff to PR
+  run: |
+    rocky ci-diff --output json | jq -r .markdown | \
+      gh pr comment "$PR_NUMBER" --body-file -
+  env:
+    PR_NUMBER: ${{ github.event.pull_request.number }}
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## 2. GitHub Actions
 
 ### Basic setup

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -8,7 +8,7 @@ sidebar:
 Rocky provides a single binary with subcommands for the full pipeline lifecycle. Commands are organized into categories:
 
 - **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `run`, `state`
-- **Modeling**: `compile`, `lineage`, `test`, `ci`
+- **Modeling**: `compile`, `lineage`, `test`, `ci`, `ci-diff`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
 - **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `hooks`, `validate-migration`, `test-adapter`

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -296,13 +296,14 @@ Generate `OPTIMIZE` and `VACUUM` SQL for storage compaction on Delta tables. Com
 
 ```bash
 rocky compact <model> [flags]
+rocky compact --measure-dedup [flags]   # experimental, project-wide scope
 ```
 
 ### Arguments
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `model` | `string` | **(required)** | Target table in `catalog.schema.table` format. |
+| `model` | `string` | **(required unless `--measure-dedup`)** | Target table in `catalog.schema.table` format. |
 
 ### Flags
 
@@ -310,6 +311,10 @@ rocky compact <model> [flags]
 |------|------|---------|-------------|
 | `--target-size <SIZE>` | `string` | | Target file size (e.g., `256MB`, `512MB`, `1GB`). |
 | `--dry-run` | `bool` | `false` | Show SQL without executing. |
+| `--measure-dedup` | `bool` | `false` | Experimental. Measure the cross-table dedup ratio across all Rocky-managed tables in the project (Layer 0 storage experiment). Project-wide; does not take a model argument. |
+| `--exclude-columns <COLS>` | `string` | Rocky-owned metadata cols | Comma-separated columns to exclude from the "semantic" dedup hash. Defaults to `_loaded_by,_loaded_at,_fivetran_synced,_synced_at`. Requires `--measure-dedup`. |
+| `--calibrate-bytes` | `bool` | `false` | Run byte-level calibration on a sampled subset of tables. Produces a sharper but more expensive second estimate alongside the cheap partition-level one. Requires `--measure-dedup`. |
+| `--all-tables` | `bool` | `false` | Scan all warehouse tables instead of only Rocky-managed ones. Requires `--measure-dedup`. |
 
 ### Examples
 
@@ -342,6 +347,26 @@ rocky compact acme_warehouse.staging__us_west__shopify.orders --target-size 256M
 ```
 
 The generated SQL uses the Delta `ZORDER` / file-size hints; `target_size_mb` echoes the parsed value (e.g. `256` for `256MB`).
+
+#### Layer 0 dedup measurement (experimental)
+
+`--measure-dedup` runs a project-wide analysis that hashes each row on its semantic columns and reports the fraction of duplicate content across Rocky-managed tables. It is a research tool for Rocky's Layer 0 storage work — the output is a measurement, not a plan, and no SQL is issued against the target tables.
+
+```bash
+# Cheap partition-level estimate across all Rocky-managed tables
+rocky compact --measure-dedup
+
+# Add a byte-level calibration pass on a sampled subset
+rocky compact --measure-dedup --calibrate-bytes
+
+# Include every warehouse table, not just Rocky-managed ones
+rocky compact --measure-dedup --all-tables
+
+# Customize which metadata columns are excluded from the dedup hash
+rocky compact --measure-dedup --exclude-columns "_loaded_at,_loaded_by,_synced_at"
+```
+
+The command emits a distinct `compact-dedup` JSON shape with per-table contributions and a project-wide summary. Use `--output json` in CI to track the ratio over time.
 
 ### Related Commands
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -331,4 +331,73 @@ rocky ci --models src/models --contracts src/contracts
 
 - [`rocky compile`](#rocky-compile) -- compile step only
 - [`rocky test`](#rocky-test) -- test step only
+- [`rocky ci-diff`](#rocky-ci-diff) -- structural diff of changed models vs a base git ref
 - [`rocky validate`](/reference/commands/core-pipeline/#rocky-validate) -- validate config (often run before CI)
+
+---
+
+## `rocky ci-diff`
+
+Detect which models changed between a base git ref and `HEAD`, compile both sides, and report added/modified/removed columns. Emits both JSON (for CI pipelines) and a pre-rendered Markdown block suitable for posting as a PR comment.
+
+```bash
+rocky ci-diff [base_ref] [flags]
+```
+
+### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `base_ref` | `string` | `main` | Git ref to compare against. Rocky shells out to `git diff --name-only <base_ref> HEAD` to find changed `.sql`, `.rocky`, and sidecar `.toml` files. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--models <PATH>` | `PathBuf` | `models` | Directory containing model files. |
+
+### Examples
+
+Diff the current branch against `main`:
+
+```bash
+rocky ci-diff
+```
+
+```json
+{
+  "version": "1.7.0",
+  "command": "ci-diff",
+  "base_ref": "main",
+  "head_ref": "HEAD",
+  "summary": {
+    "added": 1,
+    "modified": 2,
+    "removed": 0
+  },
+  "models": [
+    {
+      "model": "fct_orders",
+      "status": "modified",
+      "columns": [
+        { "name": "order_status", "change": "added" },
+        { "name": "amount_cents", "change": "type_changed", "from": "INT", "to": "BIGINT" }
+      ]
+    }
+  ],
+  "markdown": "### Model diff vs `main`\n\n| Model | Status | ... |"
+}
+```
+
+Diff against a feature-branch base and a non-default models directory:
+
+```bash
+rocky ci-diff release/2026-04 --models src/models
+```
+
+The `markdown` field holds a ready-to-post report; in a GitHub Actions workflow you can `jq -r .markdown` the JSON output and feed it into `gh pr comment`.
+
+### Related Commands
+
+- [`rocky ci`](#rocky-ci) -- full compile + test for CI
+- [`rocky compile`](#rocky-compile) -- compile a single branch without diffing


### PR DESCRIPTION
## Summary

Docs-only. Closes the real coverage gaps surfaced by a docs audit against the current CLI and hook surface.

- **`concepts/hooks.md`** — adds `before_checks` and `after_checks` to the Quality phase table. The doc previously covered 15 of the 17 events emitted by `HookEvent`; these two were the only omissions from recent check-lifecycle hook batches.
- **`reference/commands/modeling.md`** — adds a full `rocky ci-diff` reference section (arguments, flags, JSON output shape, Markdown PR-comment example). The command existed in the binary but had no dedicated reference page; only `llms.txt` mentioned it.
- **`guides/ci-cd.md`** — links `rocky ci-diff` from the CI/CD walkthrough with a GitHub Actions snippet that pipes the pre-rendered Markdown block into `gh pr comment`.
- **`reference/cli.md`** — adds `ci-diff` to the Modeling category index.
- **`reference/commands/administration.md`** — documents the `rocky compact --measure-dedup` flag family (Layer 0 dedup measurement): `--measure-dedup`, `--calibrate-bytes`, `--exclude-columns`, `--all-tables`. Called out as experimental.

## Non-gaps (verified already documented)

The initial audit mislabelled several items as undocumented because it grepped for Rust-side tokens (`DriftDetected`, `on_drift_detected`) instead of the bare event names that actually appear in docs. After re-verification, the following were confirmed as already covered and intentionally left alone:

- Hook events: `compile_complete`, `check_result`, `drift_detected`, `anomaly_detected`, `state_synced`
- CLI commands: `rocky hooks list/test`, `init-adapter`, `test-adapter`, `export-schemas`
- Dagster T2: `run_pipes`, `run_streaming`, `RockyComponent`, `branch_deploy_shadow_suffix`, `is_branch_deployment`
- `features/time-interval.md` already covers every time-interval flag
- `concepts/rocky-dsl.md` covers `!=` → `IS DISTINCT FROM`, `match`, window functions, `@date` literals
- `reference/configuration.md` covers all four `[state]` backends

## Test plan

- [x] `npm run build` in `docs/` — 68 pages, 3.89s, no errors
- [ ] Reviewer spot-check on the rendered pages (hooks, modeling, ci-cd, administration) via Netlify preview