### PR TITLE
feat(engine+vscode): split rocky-lsp binary + VS Code integration (§P3.11)

### DIFF
--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -35,22 +35,26 @@ jobs:
           - runner: macos-14
             target: aarch64-apple-darwin
             archive: rocky-aarch64-apple-darwin.tar.gz
+            lsp_archive: rocky-lsp-aarch64-apple-darwin.tar.gz
             ext: tar.gz
 
           - runner: macos-14
             target: x86_64-apple-darwin
             archive: rocky-x86_64-apple-darwin.tar.gz
+            lsp_archive: rocky-lsp-x86_64-apple-darwin.tar.gz
             ext: tar.gz
 
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             archive: rocky-x86_64-unknown-linux-gnu.tar.gz
+            lsp_archive: rocky-lsp-x86_64-unknown-linux-gnu.tar.gz
             ext: tar.gz
             zigbuild: true
 
           - runner: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             archive: rocky-aarch64-unknown-linux-gnu.tar.gz
+            lsp_archive: rocky-lsp-aarch64-unknown-linux-gnu.tar.gz
             ext: tar.gz
             zigbuild: true
             cross: true
@@ -58,6 +62,7 @@ jobs:
           - runner: windows-2022
             target: x86_64-pc-windows-msvc
             archive: rocky-x86_64-pc-windows-msvc.zip
+            lsp_archive: rocky-lsp-x86_64-pc-windows-msvc.zip
             ext: zip
 
     steps:
@@ -97,31 +102,40 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
-      # Linux: build with cargo-zigbuild (portable glibc)
-      - name: Build release binary (zigbuild)
+      # Linux: build with cargo-zigbuild (portable glibc). Build both
+      # binaries in the same invocation so the workspace compile cache
+      # is shared and we don't pay rocky-core / rocky-compiler twice.
+      - name: Build release binaries (zigbuild)
         if: matrix.zigbuild
-        run: cargo zigbuild --release --bin rocky --target ${{ matrix.target }}
+        run: cargo zigbuild --release --bin rocky --bin rocky-lsp --target ${{ matrix.target }}
 
       # macOS / Windows: build with plain cargo
-      - name: Build release binary (cargo)
+      - name: Build release binaries (cargo)
         if: ${{ !matrix.zigbuild }}
-        run: cargo build --release --bin rocky --target ${{ matrix.target }}
+        run: cargo build --release --bin rocky --bin rocky-lsp --target ${{ matrix.target }}
 
-      # Unix: package as .tar.gz
-      - name: Package binary (tar.gz)
+      # Unix: package each binary as its own .tar.gz. Split archives so
+      # consumers who only need the LSP don't download the full CLI.
+      - name: Package binaries (tar.gz)
         if: matrix.ext == 'tar.gz'
-        run: tar czf ${{ matrix.archive }} -C target/${{ matrix.target }}/release rocky
+        run: |
+          tar czf ${{ matrix.archive }} -C target/${{ matrix.target }}/release rocky
+          tar czf ${{ matrix.lsp_archive }} -C target/${{ matrix.target }}/release rocky-lsp
 
-      # Windows: package as .zip
-      - name: Package binary (zip)
+      # Windows: same split, as .zip
+      - name: Package binaries (zip)
         if: matrix.ext == 'zip'
         shell: pwsh
-        run: Compress-Archive -Path target/${{ matrix.target }}/release/rocky.exe -DestinationPath ${{ matrix.archive }}
+        run: |
+          Compress-Archive -Path target/${{ matrix.target }}/release/rocky.exe -DestinationPath ${{ matrix.archive }}
+          Compress-Archive -Path target/${{ matrix.target }}/release/rocky-lsp.exe -DestinationPath ${{ matrix.lsp_archive }}
 
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
-          files: engine/${{ matrix.archive }}
+          files: |
+            engine/${{ matrix.archive }}
+            engine/${{ matrix.lsp_archive }}
 
   # Generate checksums.txt from all platform archives and attach to the release.
   # Runs after all build jobs so every archive is present before hashing.

--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Prefer the standalone `rocky-lsp` binary when available
+
+The LSP client now probes PATH (or the directory of an explicit `rocky.server.path`) for a `rocky-lsp` binary and uses it directly when present, falling back to `rocky lsp` otherwise. `rocky-lsp` is a purpose-built ~6 MB binary that skips the full adapter graph, so language-server spawn is faster and the on-disk footprint for IDE-only installs drops. Users without the split binary installed see no behaviour change — resolution is transparent.
+
 ## [1.4.2] — 2026-04-19
 
 ### Changed — Bundle extension with esbuild

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/lspClient.ts
+++ b/editors/vscode/src/lspClient.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import {
   LanguageClient,
@@ -63,11 +65,27 @@ export function startLspClient(context: vscode.ExtensionContext): void {
 async function launchClient(): Promise<void> {
   const cfg = getConfig();
 
-  const serverOptions: ServerOptions = {
-    command: cfg.serverPath,
-    args: ["lsp", ...cfg.extraArgs],
-    transport: TransportKind.stdio,
-  };
+  // §P3.11 — prefer the standalone `rocky-lsp` binary when it's
+  // installed next to `rocky`. It's ~6 MB instead of ~47 MB and skips
+  // loading the whole adapter graph, so fork+exec is faster.
+  // Resolution rules:
+  //   • if the user set an explicit `rocky.server.path` to a full path,
+  //     look for `rocky-lsp` in the same directory and use it if present.
+  //   • if serverPath is just "rocky" (the default), leave PATH-based
+  //     resolution to the OS by using the literal "rocky-lsp" command.
+  //     The OS returns ENOENT if absent; we fall back to `rocky lsp`.
+  const lspBin = resolveLspBinary(cfg.serverPath);
+  const serverOptions: ServerOptions = lspBin
+    ? {
+        command: lspBin,
+        args: cfg.extraArgs,
+        transport: TransportKind.stdio,
+      }
+    : {
+        command: cfg.serverPath,
+        args: ["lsp", ...cfg.extraArgs],
+        transport: TransportKind.stdio,
+      };
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
@@ -99,6 +117,61 @@ async function launchClient(): Promise<void> {
     statusBarItem.backgroundColor = undefined;
   } catch (err) {
     handleStartupFailure(err as Error);
+  }
+}
+
+/**
+ * Resolve the standalone `rocky-lsp` binary when the user hasn't forced a
+ * specific path. Returns `undefined` if we can't confirm its presence —
+ * the caller falls back to `rocky lsp` in that case.
+ *
+ * Only returns a path we've verified exists on disk, so startup never
+ * falls into a "command not found" failure purely because of this
+ * optimisation. Users without rocky-lsp installed see no behaviour
+ * change.
+ */
+function resolveLspBinary(serverPath: string): string | undefined {
+  const candidateNames =
+    process.platform === "win32"
+      ? ["rocky-lsp.exe", "rocky-lsp"]
+      : ["rocky-lsp"];
+
+  // Case 1: user set an explicit path like `/opt/rocky/bin/rocky` —
+  // look for a sibling `rocky-lsp` in the same directory.
+  if (serverPath !== "rocky" && serverPath.includes(path.sep)) {
+    const dir = path.dirname(serverPath);
+    for (const name of candidateNames) {
+      const full = path.join(dir, name);
+      if (isExecutableFile(full)) {
+        return full;
+      }
+    }
+    return undefined;
+  }
+
+  // Case 2: default "rocky" (or a bare name) — walk PATH and return
+  // the first rocky-lsp we find. Keeps startup synchronous and avoids
+  // the "spawn ENOENT" trap that would hit users without the split
+  // binary installed.
+  const pathEnv = process.env.PATH ?? "";
+  const pathSep = process.platform === "win32" ? ";" : ":";
+  for (const dir of pathEnv.split(pathSep)) {
+    if (!dir) continue;
+    for (const name of candidateNames) {
+      const full = path.join(dir, name);
+      if (isExecutableFile(full)) {
+        return full;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isExecutableFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
   }
 }
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3556,6 +3556,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocky-lsp"
+version = "1.9.0"
+dependencies = [
+ "rocky-server",
+ "tokio",
+]
+
+[[package]]
 name = "rocky-observe"
 version = "1.9.0"
 dependencies = [

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/rocky-cli",
     "crates/rocky-wasm",
     "rocky",
+    "rocky-lsp",
 ]
 resolver = "3"
 

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rocky-lsp"
+version = "1.9.0"
+description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+# §P3.11 — this is a purpose-built binary for IDE / editor integration.
+# It links only `rocky-server` (compiler + LSP surface) and the tokio
+# runtime, deliberately avoiding the adapter graph pulled in by the
+# main `rocky` CLI. Result: a ~5–8 MB binary instead of ~35–50 MB, so
+# VS Code's language-server client spawns faster and on-disk footprint
+# stays small. The main `rocky lsp` subcommand is kept as a fallback —
+# editors can prefer `rocky-lsp` when present.
+
+[dependencies]
+rocky-server = { path = "../crates/rocky-server" }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/engine/rocky-lsp/src/main.rs
+++ b/engine/rocky-lsp/src/main.rs
@@ -1,0 +1,17 @@
+//! §P3.11 — `rocky-lsp` standalone binary.
+//!
+//! A minimal entry point that starts the Rocky language server on
+//! stdin/stdout. Unlike the full `rocky` CLI (which links every
+//! adapter), this binary only pulls in `rocky-server` — compiler +
+//! LSP surface. Editors that install Rocky solely for IDE support
+//! avoid paying for the adapter graph.
+//!
+//! Transport is stdio, matching tower-lsp conventions. Arguments are
+//! ignored; editors typically launch this with no flags or a
+//! `--stdio` token for compatibility with language-server clients
+//! that always pass one.
+
+#[tokio::main]
+async fn main() {
+    rocky_server::lsp::run_lsp().await;
+}


### PR DESCRIPTION
## Summary

§P3.11 from the perf-resilience roadmap — the last [L] item. Ships a standalone `rocky-lsp` binary purpose-built for IDE integration, and teaches the VS Code extension to prefer it when present.

## What's in this PR

**1. New `rocky-lsp` binary crate** (`engine/rocky-lsp/`). Links only `rocky-server` (compiler + LSP surface) + tokio — deliberately no adapter graph.

| Binary | Size | Contents |
|---|---|---|
| `rocky` | **47 MB** | CLI + all adapters (Databricks, Snowflake, BigQuery, DuckDB, Fivetran, Airbyte, Iceberg) |
| `rocky-lsp` | **6.1 MB** | LSP only |

~87% reduction, matching the roadmap's predicted 35–50 MB → 5–8 MB. Smoke tested: piped an `initialize` request on stdin, got back a valid JSON-RPC response.

**2. Release workflow update** (`.github/workflows/engine-release.yml`). Each platform now produces two archives:
- `rocky-<target>.{tar.gz|zip}`
- `rocky-lsp-<target>.{tar.gz|zip}`

Both binaries build in a single `cargo build / zigbuild` invocation per matrix entry so the workspace compile cache is shared. The checksums job's `rocky-*` glob already matches both.

**3. VS Code extension preference** (`editors/vscode/src/lspClient.ts`). The LSP client probes for `rocky-lsp` (PATH walk, or sibling of explicit `rocky.server.path`) and launches it directly when present, falling back to `rocky lsp` otherwise. Users without the split binary installed see no behaviour change.

## What's deliberately NOT in this PR

- Engine version bump + release tag — the new binary ships whenever the next `engine-v*` tag is cut.
- VS Code extension release — can ship v1.5.0 whenever; the extension currently works fine against engine-v1.9.0 (rocky-lsp absent → falls back to `rocky lsp`).
- `engine/install.sh` updates — still installs just `rocky`. A follow-up could add an opt-in `--lsp-only` mode.

## Test plan

- [x] `cargo build --release --bin rocky --bin rocky-lsp` (both binaries build)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo fmt --check`
- [x] LSP smoke test: `initialize` request → valid JSON-RPC response
- [x] `npm run compile` in `editors/vscode/`
- [x] `npm run lint` in `editors/vscode/`
- [x] `npm test` in `editors/vscode/` (8 passing)