### PR TITLE
feat(engine/rocky-cli): fire pipeline_error on execute_models failure (§P2.6 follow-up)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2017,19 +2017,41 @@ pub async fn run(
     if run_all || models_dir.is_some() {
         let mdir = models_dir.unwrap_or_else(|| std::path::Path::new("models"));
         if mdir.exists() {
-            let warehouse = adapter_registry.warehouse_adapter(&pipeline.target.adapter)?;
-            execute_models(
-                mdir,
-                warehouse.as_ref(),
-                state_store.as_ref(),
-                partition_opts,
-                &run_id,
-                None, // no model filter in replication path
-                &mut output,
-                Some(&hook_registry),
-                Some(pipeline_name),
-            )
-            .await?;
+            // §P2.6 follow-up — execute_models + warehouse adapter
+            // construction were the remaining `?`-propagation sites
+            // where a pipeline error could surface without firing
+            // `pipeline_error`. Other early-return sites — Ctrl-C at
+            // line 1520 and partial-failure bail! below — already
+            // fire. Wrap both calls so subscribers see
+            // `pipeline_error` before the error reaches the caller.
+            let exec_result: Result<()> = async {
+                let warehouse = adapter_registry.warehouse_adapter(&pipeline.target.adapter)?;
+                execute_models(
+                    mdir,
+                    warehouse.as_ref(),
+                    state_store.as_ref(),
+                    partition_opts,
+                    &run_id,
+                    None, // no model filter in replication path
+                    &mut output,
+                    Some(&hook_registry),
+                    Some(pipeline_name),
+                )
+                .await?;
+                Ok(())
+            }
+            .await;
+            if let Err(e) = exec_result {
+                let _ = hook_registry
+                    .fire(&HookContext::pipeline_error(
+                        &run_id,
+                        pipeline_name,
+                        &format!("{e:#}"),
+                    ))
+                    .await;
+                let _ = hook_registry.wait_async_webhooks().await;
+                return Err(e);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the last remaining gap where a `rocky run` error could surface to the caller without firing `pipeline_error` + draining async webhooks.

## Before this change

Three early-return sites in `rocky run`:
1. **Ctrl-C**: `return Err(Interrupted)` at ~L1520 — already fires `pipeline_error` + drains.
2. **Partial failure**: `anyhow::bail!` at ~L2118 — already fires + drains.
3. **`execute_models` failure**: bare `?`-propagation at ~L2032 — **silent**: hook subscribers saw `pipeline_start` but never a terminal `pipeline_error` / `pipeline_complete`.

## After this change

The compiled-model path (`execute_models` + warehouse adapter construction) is now wrapped in an `async` block whose `Err` result is caught, fires `pipeline_error`, drains webhooks, then propagates.

With this PR, **every** error path in `rocky run` after `pipeline_start` has fired is guaranteed to emit either a terminal `pipeline_error` or `pipeline_complete`. Hook subscribers no longer need a timeout heuristic to detect "pipeline never finished."

## Roadmap

Closes the final hook-wiring follow-up from batch 9 (PR #156). The §P2.6 lifecycle hook work is now complete.

## Test plan

- [x] `cargo build -p rocky-cli`
- [x] `cargo clippy -p rocky-cli --all-features --all-targets -- -D warnings`
- [x] `cargo test -p rocky-cli --all-features`
- [x] `cargo fmt --check`