### PR TITLE
fix(engine): install scripts pick latest engine version by semver

### DIFF
--- a/engine/install.ps1
+++ b/engine/install.ps1
@@ -43,9 +43,15 @@ $ResolvedVersion = if ($env:ROCKY_VERSION) {
 if (-not $ResolvedVersion) {
     try {
         # Filter by tag prefix — /releases/latest may return a non-engine tag
-        # in the monorepo (dagster-v*, vscode-v*, etc.)
+        # in the monorepo (dagster-v*, vscode-v*, etc.). GitHub's /releases
+        # endpoint does not sort strictly by published_at across tag prefixes,
+        # and lexical sort places v1.10.0 before v1.9.0 — cast the stripped
+        # version to [version] and sort descending so 1.10.0 wins.
         $Releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -ErrorAction Stop
-        $ResolvedVersion = ($Releases | Where-Object { $_.tag_name -like "$TagPrefix*" } | Select-Object -First 1).tag_name
+        $ResolvedVersion = ($Releases
+            | Where-Object { $_.tag_name -match "^$TagPrefix\d+\.\d+\.\d+$" }
+            | Sort-Object -Property @{Expression = { [version]($_.tag_name -replace "^$TagPrefix", "") }} -Descending
+            | Select-Object -First 1).tag_name
         if (-not $ResolvedVersion) {
             Write-Error "Failed to find an engine release (tag prefix '$TagPrefix'). Set ROCKY_VERSION manually."
             exit 1

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -99,6 +99,11 @@ ARCHIVE="rocky-${TARGET}.tar.gz"
 # The monorepo releases multiple artifacts (engine-v*, dagster-v*, vscode-v*),
 # so /releases/latest can return a non-engine tag. Filter by TAG_PREFIX instead.
 #
+# GitHub's /releases endpoint does NOT sort strictly by published_at in a
+# monorepo with multiple tag prefixes, and lexical sort would put v1.10.0
+# before v1.9.0 — so we version-sort (sort -V) the engine-prefixed tags
+# and take the highest.
+#
 # Capture the full API response before piping through grep — piping directly
 # from curl/wget into grep causes set -o pipefail to abort the script when
 # grep exits 1 (no match found on old/pre-release tags).
@@ -106,9 +111,10 @@ if [[ -z "${ROCKY_VERSION:-}" ]]; then
     API_RESPONSE="$(download_file "https://api.github.com/repos/${REPO}/releases?per_page=30")"
     ROCKY_VERSION="$(echo "${API_RESPONSE}" \
         | grep '"tag_name"' \
-        | grep "\"${TAG_PREFIX}" \
-        | head -1 \
         | sed 's/.*"tag_name": "//;s/".*//' \
+        | grep -E "^${TAG_PREFIX}[0-9]+\.[0-9]+\.[0-9]+$" \
+        | sort -V -r \
+        | head -1 \
         || true)"
     if [[ -z "${ROCKY_VERSION}" ]]; then
         echo "Error: Failed to determine latest engine version (tag prefix '${TAG_PREFIX}'). Set ROCKY_VERSION manually." >&2

--- a/scripts/vendor_rocky.sh
+++ b/scripts/vendor_rocky.sh
@@ -145,8 +145,16 @@ if [[ -z "$VERSION" ]]; then
         echo "Error: --release without an explicit version requires gh CLI to look up the latest engine release" >&2
         exit 1
     fi
+    # `gh release list` orders by published_at DESC, but a hotfix on an
+    # older minor (e.g. 1.9.1 after 1.10.0) would then win over the true
+    # latest. Version-sort the engine-prefixed stable tags and take the
+    # highest. The stable-only regex excludes pre-releases, which `sort -V`
+    # would otherwise rank above the corresponding stable tag.
     VERSION=$(gh release list --repo "$REPO" --limit 30 \
-        | awk -v p="$TAG_PREFIX" '$0 ~ p {print $1; exit}' \
+        | grep -E "^${TAG_PREFIX}[0-9]+\.[0-9]+\.[0-9]+\b" \
+        | awk '{print $1}' \
+        | sort -V -r \
+        | head -1 \
         | sed "s/^${TAG_PREFIX}//")
     if [[ -z "$VERSION" ]]; then
         echo "Error: no engine releases found in $REPO" >&2


### PR DESCRIPTION
## Summary
- `engine/install.sh`, `engine/install.ps1`, and `scripts/vendor_rocky.sh` all picked the first `engine-v*` tag returned by the GitHub releases API. In a monorepo with multiple tag prefixes the API does not sort strictly by `published_at`, so `engine-v1.9.0` was winning over `engine-v1.10.0`. Lexical sort would have the same bug (`v1.10.0` < `v1.9.0`).
- Version-sort the engine-prefixed tags and take the highest (`sort -V -r | head -1` in bash, `[version]` cast + `Sort-Object -Descending` in PowerShell).
- Tighten the tag filter to `^engine-v\d+\.\d+\.\d+$` (stable only). `sort -V` and `[version]` both rank `-rc.1` above the corresponding stable — filtering now prevents a future pre-release from silently becoming "latest".

## Verification
- `curl … /releases?per_page=30 | grep … | sort -V -r | head -1` → `engine-v1.10.0` ✓
- `gh release list … | grep … | sort -V -r | head -1` → `engine-v1.10.0` ✓
- `bash -n` clean on both shell scripts.

## Test plan
- [ ] `curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash` resolves to `engine-v1.10.0` after merge
- [ ] `irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex` resolves to `engine-v1.10.0` (Windows)
- [ ] `scripts/vendor_rocky.sh --release` vendors the 1.10.0 binary
- [ ] Explicit `ROCKY_VERSION=engine-v1.9.0` / `bash -s -- 1.9.0` still installs the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)