### PR TITLE
feat: Trust-system Arc 2 (first wave) — per-run cost attribution + [budget]

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -335,6 +335,49 @@
       ],
       "type": "string"
     },
+    "BudgetBreachAction": {
+      "description": "What to do when a [`BudgetConfig`] limit is exceeded by an actual run.\n\n`Warn` always fires the `budget_breach` event; `Error` additionally causes `rocky run` to exit with a non-zero status so orchestrators can gate downstream work on the breach.",
+      "enum": [
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
+    "BudgetConfig": {
+      "additionalProperties": false,
+      "description": "Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.",
+      "properties": {
+        "max_duration_ms": {
+          "default": null,
+          "description": "Maximum allowed run wall-clock duration in milliseconds.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "max_usd": {
+          "default": null,
+          "description": "Maximum allowed run cost in USD. When set and exceeded, emits `budget_breach` on the event bus; when paired with `on_breach = \"error\"`, also fails the run.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "on_breach": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/BudgetBreachAction"
+            }
+          ],
+          "default": "warn",
+          "description": "What to do when a limit is breached. Defaults to `warn` — fire the event, keep the run successful. Set to `error` to fail the run."
+        }
+      },
+      "type": "object"
+    },
     "ChecksConfig": {
       "additionalProperties": false,
       "description": "Data quality checks configuration (row count, column match, freshness, null rate, custom).",
@@ -2422,6 +2465,19 @@
       ],
       "default": {},
       "description": "Named adapter configurations (keyed by adapter name)."
+    },
+    "budget": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BudgetConfig"
+        }
+      ],
+      "default": {
+        "max_duration_ms": null,
+        "max_usd": null,
+        "on_breach": "warn"
+      },
+      "description": "Declarative run-level budget. See [`BudgetConfig`] for the semantics of each limit and the breach action."
     },
     "cost": {
       "allOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -25,6 +25,12 @@ export type RedactedString = string;
  */
 export type AdapterKind = "data" | "discovery";
 /**
+ * What to do when a [`BudgetConfig`] limit is exceeded by an actual run.
+ *
+ * `Warn` always fires the `budget_breach` event; `Error` additionally causes `rocky run` to exit with a non-zero status so orchestrators can gate downstream work on the breach.
+ */
+export type BudgetBreachAction = "warn" | "error";
+/**
  * Supports both single-webhook and multi-webhook syntax per event.
  *
  * Single: `[hook.webhooks.on_pipeline_start]` Multiple: `[[hook.webhooks.on_pipeline_start]]`
@@ -274,6 +280,10 @@ export interface RockyConfig {
    */
   adapter?: AdaptersFieldSchema;
   /**
+   * Declarative run-level budget. See [`BudgetConfig`] for the semantics of each limit and the breach action.
+   */
+  budget?: BudgetConfig;
+  /**
    * Cost estimation configuration.
    */
   cost?: CostSection;
@@ -412,6 +422,25 @@ export interface RetryConfig {
    * `None` (default) keeps legacy behaviour — per-statement [`RetryConfig::max_retries`] is the only bound. `Some(0)` means no retries are allowed for the whole run.
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.
+ *
+ * A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.
+ */
+export interface BudgetConfig {
+  /**
+   * Maximum allowed run wall-clock duration in milliseconds.
+   */
+  max_duration_ms?: number | null;
+  /**
+   * Maximum allowed run cost in USD. When set and exceeded, emits `budget_breach` on the event bus; when paired with `on_breach = "error"`, also fails the run.
+   */
+  max_usd?: number | null;
+  /**
+   * What to do when a limit is breached. Defaults to `warn` — fire the event, keep the run successful. Set to `error` to fail the run.
+   */
+  on_breach?: BudgetBreachAction & string;
 }
 /**
  * Cost estimation configuration.

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -70,8 +70,16 @@ export type TestSeverity = "error" | "warning";
  */
 export interface RunOutput {
   anomalies: AnomalyOutput[];
+  /**
+   * Budget breaches detected at end of run. Empty when no `[budget]` block is configured or all configured limits were respected. Each breach is also emitted as a `budget_breach` [`rocky_observe::events::PipelineEvent`] and fires the `on_budget_breach` hook so subscribers see them live.
+   */
+  budget_breaches?: BudgetBreachOutput[];
   check_results: TableCheckOutput[];
   command: string;
+  /**
+   * Aggregate cost attribution across every materialization in this run (per-model entries + run totals). `None` for DuckDB-only pipelines or when no materializations produced a cost number.
+   */
+  cost_summary?: RunCostSummary | null;
   drift: DriftSummary;
   duration_ms: number;
   errors: TableErrorOutput[];
@@ -122,9 +130,62 @@ export interface AnomalyOutput {
   table: string;
   [k: string]: unknown;
 }
+/**
+ * One budget breach surfaced on [`RunOutput::budget_breaches`].
+ *
+ * Kept as a CLI-side struct (rather than re-using [`rocky_core::config::BudgetBreach`]) so the JSON schema lives alongside the other `rocky run` output types. The fields mirror `BudgetBreach` one-to-one.
+ */
+export interface BudgetBreachOutput {
+  actual: number;
+  limit: number;
+  /**
+   * Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+   */
+  limit_type: string;
+  [k: string]: unknown;
+}
 export interface TableCheckOutput {
   asset_key: string[];
   checks: CheckResult[];
+  [k: string]: unknown;
+}
+/**
+ * Aggregate cost attribution for a `rocky run` invocation.
+ *
+ * The run finalizer walks every [`MaterializationOutput`] in [`RunOutput::materializations`], computes a per-model dollar cost using [`rocky_core::cost::compute_observed_cost_usd`], and stuffs the totals here. Consumers (Dagster, custom dashboards) can then read either the per-model breakdown or the run total without re-deriving the cost model themselves.
+ */
+export interface RunCostSummary {
+  /**
+   * Adapter type the cost formula was parameterised against, for audit. Values mirror `AdapterConfig.type`: "databricks", "snowflake", "bigquery", "duckdb".
+   */
+  adapter_type: string;
+  /**
+   * Per-model cost attribution, ordered as in [`RunOutput::materializations`].
+   */
+  per_model: ModelCostEntry[];
+  /**
+   * Sum of every per-model `cost_usd` that produced a number. `None` when no materialization produced a cost.
+   */
+  total_cost_usd?: number | null;
+  /**
+   * Wall-clock time summed across every materialization. Separate from [`RunOutput::duration_ms`] (which includes setup / governance overhead) so budget enforcement can target model-compute time specifically.
+   */
+  total_duration_ms: number;
+  [k: string]: unknown;
+}
+/**
+ * Per-model cost attribution entry inside [`RunCostSummary`].
+ */
+export interface ModelCostEntry {
+  /**
+   * Asset key path for the model this entry covers.
+   */
+  asset_key: string[];
+  /**
+   * Observed cost for this materialization. `None` when the adapter type isn't billed or the formula couldn't be computed.
+   */
+  cost_usd?: number | null;
+  duration_ms: number;
   [k: string]: unknown;
 }
 export interface DriftSummary {
@@ -192,6 +253,10 @@ export interface ExecutionSummary {
 }
 export interface MaterializationOutput {
   asset_key: string[];
+  /**
+   * Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.
+   */
+  cost_usd?: number | null;
   duration_ms: number;
   metadata: MaterializationMetadata;
   /**

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -319,9 +319,19 @@ pub async fn run(
         .await?;
 
         output.duration_ms = start.elapsed().as_millis() as u64;
+
+        let adapter_type = rocky_cfg
+            .adapters
+            .get(&target_adapter_name)
+            .map(|a| a.adapter_type.clone())
+            .unwrap_or_default();
+        output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
+        let budget_result = output.check_and_record_budget(&rocky_cfg.budget, Some(&run_id));
+
         if output_json {
             print_json(&output)?;
         }
+        budget_result?;
         return Ok(());
     }
 
@@ -1506,6 +1516,17 @@ pub async fn run(
         }
 
         output.duration_ms = start.elapsed().as_millis() as u64;
+
+        // Populate cost summary on the interrupted output so orchestrators
+        // can see what the partial run cost. Skip the budget check — we
+        // don't want to fire `budget_breach` on partial work.
+        let adapter_type = rocky_cfg
+            .adapters
+            .get(&pipeline.target.adapter)
+            .map(|a| a.adapter_type.clone())
+            .unwrap_or_default();
+        output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
+
         if output_json {
             print_json(&output)?;
         } else {
@@ -2089,6 +2110,32 @@ pub async fn run(
         })
         .collect();
 
+    // Populate per-model / per-run cost attribution and run the
+    // configured `[budget]` check. Populate always; propagate the
+    // budget error (if any) after the output has been printed so
+    // orchestrators still see the final JSON.
+    let adapter_type = rocky_cfg
+        .adapters
+        .get(&pipeline.target.adapter)
+        .map(|a| a.adapter_type.clone())
+        .unwrap_or_default();
+    output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
+    let budget_result = output.check_and_record_budget(&rocky_cfg.budget, Some(&run_id));
+    // Fire the `on_budget_breach` hook for each recorded breach so
+    // shell hooks / webhooks configured via `[hook.on_budget_breach]`
+    // see the breach alongside the bus event.
+    for breach in &output.budget_breaches {
+        let _ = hook_registry
+            .fire(&HookContext::budget_breach(
+                &run_id,
+                pipeline_name,
+                &breach.limit_type,
+                breach.limit,
+                breach.actual,
+            ))
+            .await;
+    }
+
     // Dagster Pipes message emission. We emit at the END of the run
     // (not per-event during) so the streaming is batch-at-the-end
     // rather than truly live — that's a simplification of the full
@@ -2159,6 +2206,11 @@ pub async fn run(
         ))
         .await;
     let _ = hook_registry.wait_async_webhooks().await;
+
+    // Propagate budget breach error (if any) after the hooks have
+    // drained, so subscribers see the breach event before the CLI
+    // exits non-zero.
+    budget_result?;
 
     Ok(())
 }
@@ -2854,6 +2906,7 @@ async fn run_one_partition(
                 end: partition_plan.window.end,
                 batched_with: partition_plan.batch_with.clone(),
             }),
+            cost_usd: None,
         }),
     }
 }
@@ -3122,6 +3175,7 @@ async fn process_table(
             },
             // Replication tables are never time_interval; no partition info.
             partition: None,
+            cost_usd: None,
         },
         drift_checked: true,
         drift_detected: drift_action,
@@ -3706,6 +3760,8 @@ mod tests {
             },
             partition_summaries: vec![],
             interrupted: false,
+            cost_summary: None,
+            budget_breaches: vec![],
         };
 
         emit_pipes_events(&emitter, &output);

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -671,6 +671,7 @@ pub async fn run_snapshot(
                 compile_time_ms: None,
             },
             partition: None,
+            cost_usd: None,
         });
     } else {
         output.tables_failed = 1;

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -162,6 +162,72 @@ pub struct RunOutput {
     /// Always serialised (even when `false`) so consumers don't have to
     /// treat its absence specially.
     pub interrupted: bool,
+    /// Aggregate cost attribution across every materialization in this
+    /// run (per-model entries + run totals). `None` for DuckDB-only
+    /// pipelines or when no materializations produced a cost number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_summary: Option<RunCostSummary>,
+    /// Budget breaches detected at end of run. Empty when no
+    /// `[budget]` block is configured or all configured limits were
+    /// respected. Each breach is also emitted as a `budget_breach`
+    /// [`rocky_observe::events::PipelineEvent`] and fires the
+    /// `on_budget_breach` hook so subscribers see them live.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub budget_breaches: Vec<BudgetBreachOutput>,
+}
+
+/// Per-model cost attribution entry inside [`RunCostSummary`].
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ModelCostEntry {
+    /// Asset key path for the model this entry covers.
+    pub asset_key: Vec<String>,
+    pub duration_ms: u64,
+    /// Observed cost for this materialization. `None` when the adapter
+    /// type isn't billed or the formula couldn't be computed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+}
+
+/// Aggregate cost attribution for a `rocky run` invocation.
+///
+/// The run finalizer walks every [`MaterializationOutput`] in
+/// [`RunOutput::materializations`], computes a per-model dollar cost
+/// using [`rocky_core::cost::compute_observed_cost_usd`], and stuffs the
+/// totals here. Consumers (Dagster, custom dashboards) can then read
+/// either the per-model breakdown or the run total without re-deriving
+/// the cost model themselves.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RunCostSummary {
+    /// Sum of every per-model `cost_usd` that produced a number.
+    /// `None` when no materialization produced a cost.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cost_usd: Option<f64>,
+    /// Wall-clock time summed across every materialization. Separate
+    /// from [`RunOutput::duration_ms`] (which includes setup /
+    /// governance overhead) so budget enforcement can target
+    /// model-compute time specifically.
+    pub total_duration_ms: u64,
+    /// Per-model cost attribution, ordered as in
+    /// [`RunOutput::materializations`].
+    pub per_model: Vec<ModelCostEntry>,
+    /// Adapter type the cost formula was parameterised against, for
+    /// audit. Values mirror `AdapterConfig.type`: "databricks",
+    /// "snowflake", "bigquery", "duckdb".
+    pub adapter_type: String,
+}
+
+/// One budget breach surfaced on [`RunOutput::budget_breaches`].
+///
+/// Kept as a CLI-side struct (rather than re-using
+/// [`rocky_core::config::BudgetBreach`]) so the JSON schema lives
+/// alongside the other `rocky run` output types. The fields mirror
+/// `BudgetBreach` one-to-one.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BudgetBreachOutput {
+    /// Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+    pub limit_type: String,
+    pub limit: f64,
+    pub actual: f64,
 }
 
 fn is_zero(v: &usize) -> bool {
@@ -236,6 +302,15 @@ pub struct MaterializationOutput {
     /// strategies (full_refresh, incremental, merge).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<PartitionInfo>,
+    /// Observed dollar cost of this materialization, computed post-hoc
+    /// from the adapter-appropriate formula (duration × DBU rate for
+    /// Databricks/Snowflake, bytes × $/TB for BigQuery, zero for
+    /// DuckDB). `None` when the warehouse type isn't billed or the
+    /// adapter didn't report the inputs the formula needs. Populated by
+    /// the run finalizer via
+    /// `rocky_core::cost::compute_observed_cost_usd`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1734,6 +1809,148 @@ impl RunOutput {
             },
             partition_summaries: vec![],
             interrupted: false,
+            cost_summary: None,
+            budget_breaches: vec![],
+        }
+    }
+
+    /// Walk every [`MaterializationOutput`] already pushed onto this
+    /// run, populate per-model `cost_usd` via the adapter-specific
+    /// formula, and aggregate the totals into [`RunCostSummary`].
+    ///
+    /// Always safe to call — no-op for unbilled adapters (fivetran,
+    /// airbyte), zero-cost for DuckDB, etc. Split from
+    /// [`RunOutput::check_and_record_budget`] so the interrupt path
+    /// can surface per-model cost without firing budget breach events
+    /// on partial work.
+    pub fn populate_cost_summary(
+        &mut self,
+        adapter_type: &str,
+        cost_cfg: &rocky_core::config::CostSection,
+    ) {
+        let Some(wh) = rocky_core::cost::WarehouseType::from_adapter_type(adapter_type) else {
+            return;
+        };
+
+        let dbu_per_hour =
+            rocky_core::cost::warehouse_size_to_dbu_per_hour(&cost_cfg.warehouse_size);
+        let cost_per_dbu = cost_cfg.compute_cost_per_dbu;
+
+        let mut per_model = Vec::with_capacity(self.materializations.len());
+        let mut any_cost_computed = false;
+        let mut total_cost = 0.0;
+        let mut total_duration_ms: u64 = 0;
+
+        for mat in &mut self.materializations {
+            // `bytes_scanned` is not yet plumbed into `MaterializationOutput`
+            // from the adapter layer — a later wave will wire
+            // Databricks's `result.manifest.total_byte_count` /
+            // Snowflake's `statistics.queryLoad` / BigQuery's
+            // `totalBytesProcessed` through. Until then BigQuery cost
+            // stays `None`; Databricks/Snowflake/DuckDB compute from
+            // `duration_ms` alone.
+            let cost = rocky_core::cost::compute_observed_cost_usd(
+                wh,
+                None,
+                mat.duration_ms,
+                dbu_per_hour,
+                cost_per_dbu,
+            );
+            mat.cost_usd = cost;
+            if let Some(c) = cost {
+                any_cost_computed = true;
+                total_cost += c;
+            }
+            total_duration_ms = total_duration_ms.saturating_add(mat.duration_ms);
+            per_model.push(ModelCostEntry {
+                asset_key: mat.asset_key.clone(),
+                duration_ms: mat.duration_ms,
+                cost_usd: cost,
+            });
+        }
+
+        let total_cost_usd = if any_cost_computed {
+            Some(total_cost)
+        } else {
+            None
+        };
+
+        self.cost_summary = Some(RunCostSummary {
+            total_cost_usd,
+            total_duration_ms,
+            per_model,
+            adapter_type: adapter_type.to_string(),
+        });
+    }
+
+    /// Run the [`rocky_core::config::BudgetConfig`] check against the
+    /// already-populated [`RunCostSummary`] and [`Self::duration_ms`].
+    ///
+    /// For each breached dimension, emits a `budget_breach`
+    /// [`rocky_observe::events::PipelineEvent`] on the global event bus
+    /// (so hook subscribers and Dagster see breaches live) and records
+    /// the breach on [`Self::budget_breaches`] (so JSON consumers can
+    /// read it synchronously).
+    ///
+    /// Returns `Err` when `budget_cfg.on_breach = "error"` and any
+    /// configured limit was exceeded. In every other case — including
+    /// `on_breach = "warn"` with a breach — returns `Ok(())` so the
+    /// event fires but the run still succeeds.
+    ///
+    /// No-op when [`rocky_core::config::BudgetConfig::is_unset`].
+    pub fn check_and_record_budget(
+        &mut self,
+        budget_cfg: &rocky_core::config::BudgetConfig,
+        run_id: Option<&str>,
+    ) -> anyhow::Result<()> {
+        if budget_cfg.is_unset() {
+            return Ok(());
+        }
+
+        let observed_cost = self.cost_summary.as_ref().and_then(|s| s.total_cost_usd);
+        let breaches = budget_cfg.check_breaches(observed_cost, self.duration_ms);
+        if breaches.is_empty() {
+            return Ok(());
+        }
+
+        let bus = rocky_observe::events::global_event_bus();
+        for b in &breaches {
+            let mut evt = rocky_observe::events::PipelineEvent::new("budget_breach")
+                .with_metadata("limit_type", serde_json::json!(b.limit_type.as_str()))
+                .with_metadata("limit", serde_json::json!(b.limit))
+                .with_metadata("actual", serde_json::json!(b.actual));
+            if let Some(rid) = run_id {
+                evt = evt.with_run_id(rid);
+            }
+            bus.emit(evt);
+        }
+
+        self.budget_breaches = breaches
+            .iter()
+            .map(|b| BudgetBreachOutput {
+                limit_type: b.limit_type.as_str().to_string(),
+                limit: b.limit,
+                actual: b.actual,
+            })
+            .collect();
+
+        match budget_cfg.on_breach {
+            rocky_core::config::BudgetBreachAction::Warn => Ok(()),
+            rocky_core::config::BudgetBreachAction::Error => {
+                let joined = breaches
+                    .iter()
+                    .map(|b| {
+                        format!(
+                            "{}: actual {} > limit {}",
+                            b.limit_type.as_str(),
+                            b.actual,
+                            b.limit
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                Err(anyhow::anyhow!("budget exceeded — {joined}"))
+            }
         }
     }
 }
@@ -1908,6 +2125,119 @@ pub fn print_json<T: Serialize>(output: &T) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(output)?;
     println!("{json}");
     Ok(())
+}
+
+#[cfg(test)]
+mod cost_finalize_tests {
+    use super::*;
+    use rocky_core::config::{BudgetBreachAction, BudgetConfig, CostSection};
+
+    fn mat(asset_key: &[&str], duration_ms: u64) -> MaterializationOutput {
+        MaterializationOutput {
+            asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
+            rows_copied: None,
+            duration_ms,
+            metadata: MaterializationMetadata {
+                strategy: "full_refresh".to_string(),
+                watermark: None,
+                target_table_full_name: None,
+                sql_hash: None,
+                column_count: None,
+                compile_time_ms: None,
+            },
+            partition: None,
+            cost_usd: None,
+        }
+    }
+
+    #[test]
+    fn populate_cost_summary_no_op_on_unbilled_adapter() {
+        let mut out = RunOutput::new(String::new(), 1000, 1);
+        out.materializations.push(mat(&["a", "b", "c"], 1000));
+        out.populate_cost_summary("fivetran", &CostSection::default());
+        assert!(out.cost_summary.is_none(), "unbilled adapters skip cost");
+        assert!(out.materializations[0].cost_usd.is_none());
+    }
+
+    #[test]
+    fn populate_cost_summary_duckdb_is_zero() {
+        let mut out = RunOutput::new(String::new(), 1000, 1);
+        out.materializations.push(mat(&["a", "b"], 2000));
+        out.populate_cost_summary("duckdb", &CostSection::default());
+        let summary = out.cost_summary.as_ref().unwrap();
+        assert_eq!(summary.adapter_type, "duckdb");
+        assert_eq!(summary.total_duration_ms, 2000);
+        assert_eq!(summary.total_cost_usd, Some(0.0));
+        assert_eq!(summary.per_model.len(), 1);
+        assert_eq!(summary.per_model[0].cost_usd, Some(0.0));
+        assert_eq!(out.materializations[0].cost_usd, Some(0.0));
+    }
+
+    #[test]
+    fn populate_cost_summary_databricks_uses_duration() {
+        let mut out = RunOutput::new(String::new(), 3_600_000, 1);
+        out.materializations.push(mat(&["orders"], 1_800_000));
+        out.materializations.push(mat(&["customers"], 1_800_000));
+        let cost_cfg = CostSection {
+            storage_cost_per_gb_month: 0.023,
+            compute_cost_per_dbu: 0.40,
+            warehouse_size: "Medium".to_string(),
+            min_history_runs: 5,
+        };
+        out.populate_cost_summary("databricks", &cost_cfg);
+
+        let summary = out.cost_summary.as_ref().unwrap();
+        // 1 hr total on Medium (24 DBU/hr) at $0.40/DBU = $9.60.
+        let total = summary.total_cost_usd.unwrap();
+        assert!((total - 9.60).abs() < 1.0e-6, "total cost = {total}");
+        assert_eq!(summary.per_model.len(), 2);
+    }
+
+    #[test]
+    fn check_and_record_budget_noop_when_unset() {
+        let mut out = RunOutput::new(String::new(), 0, 1);
+        let budget = BudgetConfig::default();
+        assert!(out.check_and_record_budget(&budget, None).is_ok());
+        assert!(out.budget_breaches.is_empty());
+    }
+
+    #[test]
+    fn check_and_record_budget_warn_flags_but_succeeds() {
+        let mut out = RunOutput::new(String::new(), 7_200_000, 1);
+        out.materializations.push(mat(&["huge"], 7_200_000));
+        out.populate_cost_summary(
+            "databricks",
+            &CostSection {
+                storage_cost_per_gb_month: 0.023,
+                compute_cost_per_dbu: 0.40,
+                warehouse_size: "Medium".to_string(),
+                min_history_runs: 5,
+            },
+        );
+        let budget = BudgetConfig {
+            max_usd: Some(5.0),
+            max_duration_ms: Some(60_000),
+            on_breach: BudgetBreachAction::Warn,
+        };
+        assert!(out.check_and_record_budget(&budget, Some("run-1")).is_ok());
+        assert_eq!(out.budget_breaches.len(), 2);
+    }
+
+    #[test]
+    fn check_and_record_budget_error_returns_err() {
+        let mut out = RunOutput::new(String::new(), 120_000, 1);
+        out.materializations.push(mat(&["over"], 120_000));
+        out.populate_cost_summary("duckdb", &CostSection::default());
+        let budget = BudgetConfig {
+            max_usd: None,
+            max_duration_ms: Some(60_000),
+            on_breach: BudgetBreachAction::Error,
+        };
+        let result = out.check_and_record_budget(&budget, None);
+        assert!(result.is_err(), "error mode must return Err on breach");
+        assert_eq!(out.budget_breaches.len(), 1);
+        assert_eq!(out.budget_breaches[0].limit_type, "max_duration_ms");
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -302,6 +302,7 @@ mod tests {
             pipelines: Default::default(),
             hooks: Default::default(),
             cost: Default::default(),
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -987,6 +987,126 @@ impl Default for CostSection {
     }
 }
 
+/// What to do when a [`BudgetConfig`] limit is exceeded by an actual run.
+///
+/// `Warn` always fires the `budget_breach` event; `Error` additionally
+/// causes `rocky run` to exit with a non-zero status so orchestrators
+/// can gate downstream work on the breach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetBreachAction {
+    #[default]
+    Warn,
+    Error,
+}
+
+/// Declarative run-level budget for cost, duration, and (future) data
+/// volume. All limits are optional; when unset the dimension is not
+/// enforced.
+///
+/// A breach is detected at end of run by comparing [`BudgetConfig`]
+/// against the observed [`crate::cost::compute_observed_cost_usd`] total
+/// and the run wall clock. Per-model budgets are deferred to a later
+/// wave — the first iteration enforces run-level totals only.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BudgetConfig {
+    /// Maximum allowed run cost in USD. When set and exceeded, emits
+    /// `budget_breach` on the event bus; when paired with
+    /// `on_breach = "error"`, also fails the run.
+    #[serde(default)]
+    pub max_usd: Option<f64>,
+
+    /// Maximum allowed run wall-clock duration in milliseconds.
+    #[serde(default)]
+    pub max_duration_ms: Option<u64>,
+
+    /// What to do when a limit is breached. Defaults to `warn` — fire the
+    /// event, keep the run successful. Set to `error` to fail the run.
+    #[serde(default)]
+    pub on_breach: BudgetBreachAction,
+}
+
+impl BudgetConfig {
+    /// True when no limit is configured — skip budget checking entirely.
+    #[must_use]
+    pub fn is_unset(&self) -> bool {
+        self.max_usd.is_none() && self.max_duration_ms.is_none()
+    }
+
+    /// Compare observed totals against each configured limit.
+    ///
+    /// Returns one [`BudgetBreach`] per breached dimension; an empty
+    /// vector when within budget or when no limits are configured.
+    /// `observed_cost_usd` is `None` when the adapters didn't produce
+    /// enough data to compute a cost (e.g. BigQuery with no bytes
+    /// reported); in that case the cost dimension is skipped rather
+    /// than treated as zero.
+    #[must_use]
+    pub fn check_breaches(
+        &self,
+        observed_cost_usd: Option<f64>,
+        observed_duration_ms: u64,
+    ) -> Vec<BudgetBreach> {
+        let mut breaches = Vec::new();
+
+        if let (Some(limit), Some(actual)) = (self.max_usd, observed_cost_usd)
+            && actual > limit
+        {
+            breaches.push(BudgetBreach {
+                limit_type: BudgetLimitType::MaxUsd,
+                limit,
+                actual,
+            });
+        }
+
+        if let Some(limit) = self.max_duration_ms
+            && observed_duration_ms > limit
+        {
+            breaches.push(BudgetBreach {
+                limit_type: BudgetLimitType::MaxDurationMs,
+                limit: limit as f64,
+                actual: observed_duration_ms as f64,
+            });
+        }
+
+        breaches
+    }
+}
+
+/// Which budget limit was breached. Surfaced on [`BudgetBreach`] so
+/// subscribers can filter on a stable tag rather than string-match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetLimitType {
+    MaxUsd,
+    MaxDurationMs,
+}
+
+impl BudgetLimitType {
+    /// String tag used in `budget_breach` [`crate::hooks`] / event
+    /// payload `limit_type` fields.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BudgetLimitType::MaxUsd => "max_usd",
+            BudgetLimitType::MaxDurationMs => "max_duration_ms",
+        }
+    }
+}
+
+/// One breached budget dimension from [`BudgetConfig::check_breaches`].
+///
+/// `limit` and `actual` are stored as `f64` so a single struct carries
+/// both the USD dimension (naturally `f64`) and the duration dimension
+/// (originally `u64` milliseconds, widened without loss up to 2^53).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BudgetBreach {
+    pub limit_type: BudgetLimitType,
+    pub limit: f64,
+    pub actual: f64,
+}
+
 /// Valkey/Redis cache configuration for distributed caching.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheConfig {
@@ -1164,6 +1284,11 @@ pub struct RockyConfig {
     /// Cost estimation configuration.
     #[serde(default)]
     pub cost: CostSection,
+
+    /// Declarative run-level budget. See [`BudgetConfig`] for the
+    /// semantics of each limit and the breach action.
+    #[serde(default)]
+    pub budget: BudgetConfig,
 
     /// Schema evolution configuration (grace-period column drops).
     #[serde(default)]
@@ -4734,5 +4859,96 @@ concurrency = "turbo"
         let fixed = ConcurrencyMode::Fixed(16);
         let json = serde_json::to_string(&fixed).unwrap();
         assert_eq!(json, "16");
+    }
+
+    // -- Budget ------------------------------------------------------------
+
+    #[test]
+    fn budget_defaults_are_unset() {
+        let cfg = BudgetConfig::default();
+        assert!(cfg.is_unset());
+        assert_eq!(cfg.on_breach, BudgetBreachAction::Warn);
+    }
+
+    #[test]
+    fn budget_parses_from_toml() {
+        let toml_str = r#"
+max_usd = 25.0
+max_duration_ms = 900000
+on_breach = "error"
+"#;
+        let cfg: BudgetConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.max_usd, Some(25.0));
+        assert_eq!(cfg.max_duration_ms, Some(900_000));
+        assert_eq!(cfg.on_breach, BudgetBreachAction::Error);
+    }
+
+    #[test]
+    fn budget_rejects_unknown_fields() {
+        let toml_str = r#"
+max_usd = 10.0
+max_rows = 1000000
+"#;
+        let result: Result<BudgetConfig, _> = toml::from_str(toml_str);
+        assert!(result.is_err(), "unknown fields must be rejected");
+    }
+
+    #[test]
+    fn budget_check_breaches_empty_when_under_limits() {
+        let cfg = BudgetConfig {
+            max_usd: Some(10.0),
+            max_duration_ms: Some(60_000),
+            on_breach: BudgetBreachAction::Warn,
+        };
+        assert!(cfg.check_breaches(Some(9.0), 30_000).is_empty());
+    }
+
+    #[test]
+    fn budget_check_breaches_flags_usd_over() {
+        let cfg = BudgetConfig {
+            max_usd: Some(10.0),
+            max_duration_ms: None,
+            on_breach: BudgetBreachAction::Error,
+        };
+        let breaches = cfg.check_breaches(Some(15.0), 0);
+        assert_eq!(breaches.len(), 1);
+        assert_eq!(breaches[0].limit_type, BudgetLimitType::MaxUsd);
+        assert_eq!(breaches[0].limit, 10.0);
+        assert_eq!(breaches[0].actual, 15.0);
+    }
+
+    #[test]
+    fn budget_check_breaches_flags_duration_over() {
+        let cfg = BudgetConfig {
+            max_usd: None,
+            max_duration_ms: Some(60_000),
+            on_breach: BudgetBreachAction::Warn,
+        };
+        let breaches = cfg.check_breaches(None, 120_000);
+        assert_eq!(breaches.len(), 1);
+        assert_eq!(breaches[0].limit_type, BudgetLimitType::MaxDurationMs);
+    }
+
+    #[test]
+    fn budget_check_breaches_skips_usd_when_unknown() {
+        // When the adapters didn't produce enough data to compute cost,
+        // the USD dimension is skipped rather than treated as zero.
+        let cfg = BudgetConfig {
+            max_usd: Some(10.0),
+            max_duration_ms: None,
+            on_breach: BudgetBreachAction::Warn,
+        };
+        assert!(cfg.check_breaches(None, 0).is_empty());
+    }
+
+    #[test]
+    fn budget_check_breaches_handles_both_limits() {
+        let cfg = BudgetConfig {
+            max_usd: Some(5.0),
+            max_duration_ms: Some(60_000),
+            on_breach: BudgetBreachAction::Warn,
+        };
+        let breaches = cfg.check_breaches(Some(12.0), 90_000);
+        assert_eq!(breaches.len(), 2);
     }
 }

--- a/engine/crates/rocky-core/src/cost.rs
+++ b/engine/crates/rocky-core/src/cost.rs
@@ -100,6 +100,22 @@ impl WarehouseType {
             Self::DuckDb => WarehouseCostModel::duckdb(),
         }
     }
+
+    /// Parse a Rocky adapter `type` string into a [`WarehouseType`].
+    ///
+    /// Returns `None` for adapters that don't represent a billed warehouse
+    /// (e.g. `fivetran`, `airbyte` — source adapters that move data but
+    /// don't charge compute to us).
+    #[must_use]
+    pub fn from_adapter_type(s: &str) -> Option<Self> {
+        match s {
+            "databricks" => Some(Self::Databricks),
+            "snowflake" => Some(Self::Snowflake),
+            "bigquery" => Some(Self::BigQuery),
+            "duckdb" => Some(Self::DuckDb),
+            _ => None,
+        }
+    }
 }
 
 /// Per-operation pricing constants for a warehouse.
@@ -516,6 +532,77 @@ pub fn aggregate_project_cost(estimates: &HashMap<String, CostEstimate>) -> Cost
 }
 
 // ---------------------------------------------------------------------------
+// Observed cost (post-execution, per-adapter)
+// ---------------------------------------------------------------------------
+
+/// BigQuery on-demand pricing in USD per TB scanned. Hard-coded default
+/// (`$6.25/TB`) — matches the public price list; we expose this as a
+/// constant rather than a config knob until someone asks for per-region
+/// overrides.
+pub const BIGQUERY_USD_PER_TB_SCANNED: f64 = 6.25;
+
+/// DBU throughput per hour for a named warehouse size.
+///
+/// Numbers mirror Databricks SQL Warehouse sizing. Snowflake users can
+/// treat these as credits/hr with their own `cost_per_dbu` interpretation:
+/// the scaling curve differs (Snowflake doubles exactly, Databricks
+/// doesn't) but the order of magnitude holds for a wave-1 approximation.
+/// Unknown sizes fall back to `Medium` rather than failing — the trust
+/// outcome degrades gracefully to "directional cost estimate" instead of
+/// "no cost at all".
+#[must_use]
+pub fn warehouse_size_to_dbu_per_hour(size: &str) -> f64 {
+    match size.to_ascii_lowercase().as_str() {
+        "2x-small" | "2xsmall" => 4.0,
+        "x-small" | "xsmall" => 6.0,
+        "small" => 12.0,
+        "medium" => 24.0,
+        "large" => 40.0,
+        "x-large" | "xlarge" => 80.0,
+        "2x-large" | "2xlarge" => 144.0,
+        "3x-large" | "3xlarge" => 272.0,
+        "4x-large" | "4xlarge" => 528.0,
+        _ => 24.0,
+    }
+}
+
+/// Observed dollar cost of a single completed execution, computed from
+/// the measurements the adapter returned.
+///
+/// Unlike [`CostEstimate`] (which powers `rocky estimate` / `rocky
+/// optimize` before execution), this is a post-hoc number intended for
+/// `rocky run` cost attribution: given actual `duration_ms` and
+/// `bytes_scanned`, pick the right billing formula per warehouse.
+///
+/// - **Databricks / Snowflake**: duration-based. `cost = duration_hours *
+///   dbu_per_hour * cost_per_dbu`. DBU/credit throughput comes from
+///   [`warehouse_size_to_dbu_per_hour`]; the per-DBU rate comes from
+///   `[cost].compute_cost_per_dbu` in `rocky.toml`.
+/// - **BigQuery**: bytes-based. `cost = bytes_scanned / 1e12 *
+///   BIGQUERY_USD_PER_TB_SCANNED`. Returns `None` when `bytes_scanned`
+///   wasn't reported.
+/// - **DuckDB**: always `0.0` (local execution).
+#[must_use]
+pub fn compute_observed_cost_usd(
+    warehouse_type: WarehouseType,
+    bytes_scanned: Option<u64>,
+    duration_ms: u64,
+    dbu_per_hour: f64,
+    cost_per_dbu: f64,
+) -> Option<f64> {
+    match warehouse_type {
+        WarehouseType::Databricks | WarehouseType::Snowflake => {
+            let hours = duration_ms as f64 / 3_600_000.0;
+            Some(hours * dbu_per_hour * cost_per_dbu)
+        }
+        WarehouseType::BigQuery => {
+            bytes_scanned.map(|b| (b as f64 / 1.0e12) * BIGQUERY_USD_PER_TB_SCANNED)
+        }
+        WarehouseType::DuckDb => Some(0.0),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -800,6 +887,122 @@ mod tests {
         assert_eq!(json, "\"medium\"");
         let json = serde_json::to_string(&Confidence::Low).unwrap();
         assert_eq!(json, "\"low\"");
+    }
+
+    // -- Observed cost --------------------------------------------------------
+
+    #[test]
+    fn from_adapter_type_known_warehouses() {
+        assert_eq!(
+            WarehouseType::from_adapter_type("databricks"),
+            Some(WarehouseType::Databricks)
+        );
+        assert_eq!(
+            WarehouseType::from_adapter_type("snowflake"),
+            Some(WarehouseType::Snowflake)
+        );
+        assert_eq!(
+            WarehouseType::from_adapter_type("bigquery"),
+            Some(WarehouseType::BigQuery)
+        );
+        assert_eq!(
+            WarehouseType::from_adapter_type("duckdb"),
+            Some(WarehouseType::DuckDb)
+        );
+    }
+
+    #[test]
+    fn from_adapter_type_ignores_sources() {
+        // Source adapters don't represent a billed warehouse.
+        assert_eq!(WarehouseType::from_adapter_type("fivetran"), None);
+        assert_eq!(WarehouseType::from_adapter_type("airbyte"), None);
+        assert_eq!(WarehouseType::from_adapter_type(""), None);
+    }
+
+    #[test]
+    fn warehouse_size_mapping_is_monotone() {
+        let small = warehouse_size_to_dbu_per_hour("small");
+        let medium = warehouse_size_to_dbu_per_hour("medium");
+        let large = warehouse_size_to_dbu_per_hour("large");
+        assert!(small < medium);
+        assert!(medium < large);
+    }
+
+    #[test]
+    fn warehouse_size_is_case_insensitive_and_alias_tolerant() {
+        assert_eq!(warehouse_size_to_dbu_per_hour("Medium"), 24.0);
+        assert_eq!(warehouse_size_to_dbu_per_hour("MEDIUM"), 24.0);
+        assert_eq!(warehouse_size_to_dbu_per_hour("x-small"), 6.0);
+        assert_eq!(warehouse_size_to_dbu_per_hour("xsmall"), 6.0);
+    }
+
+    #[test]
+    fn warehouse_size_unknown_falls_back_to_medium() {
+        assert_eq!(warehouse_size_to_dbu_per_hour("nonsense"), 24.0);
+        assert_eq!(warehouse_size_to_dbu_per_hour(""), 24.0);
+    }
+
+    #[test]
+    fn observed_cost_duckdb_is_free() {
+        let cost =
+            compute_observed_cost_usd(WarehouseType::DuckDb, Some(1_000_000), 5_000, 24.0, 0.40);
+        assert_eq!(cost, Some(0.0));
+    }
+
+    #[test]
+    fn observed_cost_databricks_uses_duration() {
+        // 1 hour on a Medium (24 DBU/hr) at $0.40/DBU = $9.60.
+        let cost =
+            compute_observed_cost_usd(WarehouseType::Databricks, None, 3_600_000, 24.0, 0.40)
+                .unwrap();
+        assert!((cost - 9.60).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn observed_cost_databricks_ignores_bytes() {
+        // Whether bytes_scanned is set or not, Databricks cost depends only
+        // on duration.
+        let with_bytes = compute_observed_cost_usd(
+            WarehouseType::Databricks,
+            Some(10_000_000),
+            1_800_000, // 30 min
+            24.0,
+            0.40,
+        );
+        let without_bytes =
+            compute_observed_cost_usd(WarehouseType::Databricks, None, 1_800_000, 24.0, 0.40);
+        assert_eq!(with_bytes, without_bytes);
+    }
+
+    #[test]
+    fn observed_cost_bigquery_uses_bytes() {
+        // 1 TB scanned at $6.25/TB = $6.25.
+        let cost = compute_observed_cost_usd(
+            WarehouseType::BigQuery,
+            Some(1_000_000_000_000),
+            60_000,
+            24.0,
+            0.40,
+        )
+        .unwrap();
+        assert!((cost - 6.25).abs() < 1.0e-9);
+    }
+
+    #[test]
+    fn observed_cost_bigquery_none_without_bytes() {
+        let cost = compute_observed_cost_usd(WarehouseType::BigQuery, None, 60_000, 24.0, 0.40);
+        assert_eq!(cost, None);
+    }
+
+    #[test]
+    fn observed_cost_snowflake_scales_linearly_with_duration() {
+        let thirty_min =
+            compute_observed_cost_usd(WarehouseType::Snowflake, None, 1_800_000, 4.0, 2.00)
+                .unwrap();
+        let one_hour =
+            compute_observed_cost_usd(WarehouseType::Snowflake, None, 3_600_000, 4.0, 2.00)
+                .unwrap();
+        assert!((one_hour - 2.0 * thirty_min).abs() < 1.0e-9);
     }
 
     // -- DAG propagation -------------------------------------------------------

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -570,6 +570,7 @@ mod tests {
             pipelines: pipeline_map,
             hooks: Default::default(),
             cost: Default::default(),
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         }

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -706,6 +706,7 @@ mod tests {
             pipelines: IndexMap::new(),
             hooks: Default::default(),
             cost: Default::default(),
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         };
@@ -775,6 +776,7 @@ mod tests {
             pipelines: IndexMap::new(),
             hooks: Default::default(),
             cost: Default::default(),
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         };
@@ -840,6 +842,7 @@ mod tests {
             pipelines: IndexMap::new(),
             hooks: Default::default(),
             cost: Default::default(),
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         };

--- a/engine/crates/rocky-core/src/hooks/mod.rs
+++ b/engine/crates/rocky-core/src/hooks/mod.rs
@@ -76,6 +76,9 @@ pub enum HookEvent {
     DriftDetected,
     AnomalyDetected,
     StateSynced,
+
+    // Budget lifecycle (Arc 2)
+    BudgetBreach,
 }
 
 impl HookEvent {
@@ -99,6 +102,7 @@ impl HookEvent {
             Self::DriftDetected => "on_drift_detected",
             Self::AnomalyDetected => "on_anomaly_detected",
             Self::StateSynced => "on_state_synced",
+            Self::BudgetBreach => "on_budget_breach",
         }
     }
 
@@ -122,6 +126,7 @@ impl HookEvent {
             "on_drift_detected" => Some(Self::DriftDetected),
             "on_anomaly_detected" => Some(Self::AnomalyDetected),
             "on_state_synced" => Some(Self::StateSynced),
+            "on_budget_breach" => Some(Self::BudgetBreach),
             _ => None,
         }
     }
@@ -146,6 +151,7 @@ impl HookEvent {
             Self::DriftDetected,
             Self::AnomalyDetected,
             Self::StateSynced,
+            Self::BudgetBreach,
         ]
     }
 }
@@ -409,6 +415,39 @@ impl HookContext {
 
     pub fn state_synced(run_id: &str, pipeline: &str) -> Self {
         Self::new(HookEvent::StateSynced, run_id, pipeline)
+    }
+
+    // -- Budget lifecycle builders (Arc 2) --
+
+    /// Build a [`HookContext`] for a run-level budget breach.
+    ///
+    /// `limit_type` is the stable tag string (e.g. `"max_usd"`,
+    /// `"max_duration_ms"`) that
+    /// [`crate::config::BudgetLimitType::as_str`] emits. `limit` is the
+    /// configured cap; `actual` is what the run observed. Both ride on
+    /// `metadata` so the existing shell-hook template engine can
+    /// interpolate them (`{{metadata.limit}}`, `{{metadata.actual}}`).
+    pub fn budget_breach(
+        run_id: &str,
+        pipeline: &str,
+        limit_type: &str,
+        limit: f64,
+        actual: f64,
+    ) -> Self {
+        let mut ctx = Self::new(HookEvent::BudgetBreach, run_id, pipeline);
+        ctx.metadata.insert(
+            "limit_type".to_string(),
+            serde_json::Value::String(limit_type.to_string()),
+        );
+        if let Some(limit_val) = serde_json::Number::from_f64(limit) {
+            ctx.metadata
+                .insert("limit".to_string(), serde_json::Value::Number(limit_val));
+        }
+        if let Some(actual_val) = serde_json::Number::from_f64(actual) {
+            ctx.metadata
+                .insert("actual".to_string(), serde_json::Value::Number(actual_val));
+        }
+        ctx
     }
 
     /// Creates a synthetic test context for `rocky hooks test`.

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -922,6 +922,7 @@ mod tests {
                 warehouse_size: "Medium".to_string(),
                 min_history_runs: 5,
             },
+            budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
         }

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -92,6 +92,41 @@ class BindingType(StrEnum):
     READ_ONLY = "READ_ONLY"
 
 
+class BudgetBreachAction(StrEnum):
+    """
+    What to do when a [`BudgetConfig`] limit is exceeded by an actual run.
+
+    `Warn` always fires the `budget_breach` event; `Error` additionally causes `rocky run` to exit with a non-zero status so orchestrators can gate downstream work on the breach.
+    """
+
+    warn = "warn"
+    error = "error"
+
+
+class BudgetConfig(BaseModel):
+    """
+    Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.
+
+    A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    max_duration_ms: conint(ge=0) | None = None
+    """
+    Maximum allowed run wall-clock duration in milliseconds.
+    """
+    max_usd: float | None = None
+    """
+    Maximum allowed run cost in USD. When set and exceeded, emits `budget_breach` on the event bus; when paired with `on_breach = "error"`, also fails the run.
+    """
+    on_breach: BudgetBreachAction | None = "warn"
+    """
+    What to do when a limit is breached. Defaults to `warn` — fire the event, keep the run successful. Set to `error` to fail the run.
+    """
+
+
 class CompositeKind1(StrEnum):
     """
     `(col1, col2, ...)` is unique across all rows.
@@ -2015,6 +2050,13 @@ class RockyConfig(BaseModel):
     )
     """
     Named adapter configurations (keyed by adapter name).
+    """
+    budget: BudgetConfig | None = Field(
+        {"max_duration_ms": None, "max_usd": None, "on_breach": "warn"},
+        validate_default=True,
+    )
+    """
+    Declarative run-level budget. See [`BudgetConfig`] for the semantics of each limit and the breach action.
     """
     cost: CostSection | None = Field(
         {

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -20,6 +20,21 @@ class AnomalyOutput(BaseModel):
     table: str
 
 
+class BudgetBreachOutput(BaseModel):
+    """
+    One budget breach surfaced on [`RunOutput::budget_breaches`].
+
+    Kept as a CLI-side struct (rather than re-using [`rocky_core::config::BudgetBreach`]) so the JSON schema lives alongside the other `rocky run` output types. The fields mirror `BudgetBreach` one-to-one.
+    """
+
+    actual: float
+    limit: float
+    limit_type: str
+    """
+    Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+    """
+
+
 class DriftActionOutput(BaseModel):
     action: str
     reason: str
@@ -118,6 +133,22 @@ class MetricsSnapshot(BaseModel):
     tables_processed: conint(ge=0)
 
 
+class ModelCostEntry(BaseModel):
+    """
+    Per-model cost attribution entry inside [`RunCostSummary`].
+    """
+
+    asset_key: list[str]
+    """
+    Asset key path for the model this entry covers.
+    """
+    cost_usd: float | None = None
+    """
+    Observed cost for this materialization. `None` when the adapter type isn't billed or the formula couldn't be computed.
+    """
+    duration_ms: conint(ge=0)
+
+
 class PartitionInfo(BaseModel):
     """
     Partition window information for a single `time_interval` materialization.
@@ -193,6 +224,31 @@ class QuarantineOutput(BaseModel):
     valid_table: str
     """
     Fully-qualified `catalog.schema.table` name of the `__valid` output table. Empty for `mode = "tag"` (source is rewritten in place).
+    """
+
+
+class RunCostSummary(BaseModel):
+    """
+    Aggregate cost attribution for a `rocky run` invocation.
+
+    The run finalizer walks every [`MaterializationOutput`] in [`RunOutput::materializations`], computes a per-model dollar cost using [`rocky_core::cost::compute_observed_cost_usd`], and stuffs the totals here. Consumers (Dagster, custom dashboards) can then read either the per-model breakdown or the run total without re-deriving the cost model themselves.
+    """
+
+    adapter_type: str
+    """
+    Adapter type the cost formula was parameterised against, for audit. Values mirror `AdapterConfig.type`: "databricks", "snowflake", "bigquery", "duckdb".
+    """
+    per_model: list[ModelCostEntry]
+    """
+    Per-model cost attribution, ordered as in [`RunOutput::materializations`].
+    """
+    total_cost_usd: float | None = None
+    """
+    Sum of every per-model `cost_usd` that produced a number. `None` when no materialization produced a cost.
+    """
+    total_duration_ms: conint(ge=0)
+    """
+    Wall-clock time summed across every materialization. Separate from [`RunOutput::duration_ms`] (which includes setup / governance overhead) so budget enforcement can target model-compute time specifically.
     """
 
 
@@ -327,6 +383,10 @@ class CheckResult6(BaseModel):
 
 class MaterializationOutput(BaseModel):
     asset_key: list[str]
+    cost_usd: float | None = None
+    """
+    Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.
+    """
     duration_ms: conint(ge=0)
     metadata: MaterializationMetadata
     partition: PartitionInfo | None = None
@@ -354,8 +414,16 @@ class RunOutput(BaseModel):
     """
 
     anomalies: list[AnomalyOutput]
+    budget_breaches: list[BudgetBreachOutput] | None = None
+    """
+    Budget breaches detected at end of run. Empty when no `[budget]` block is configured or all configured limits were respected. Each breach is also emitted as a `budget_breach` [`rocky_observe::events::PipelineEvent`] and fires the `on_budget_breach` hook so subscribers see them live.
+    """
     check_results: list[TableCheckOutput]
     command: str
+    cost_summary: RunCostSummary | None = None
+    """
+    Aggregate cost attribution across every materialization in this run (per-model entries + run totals). `None` for DuckDB-only pipelines or when no materializations produced a cost number.
+    """
     drift: DriftSummary
     duration_ms: conint(ge=0)
     errors: list[TableErrorOutput]

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [
@@ -74,5 +75,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [
@@ -74,5 +75,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [
@@ -74,5 +75,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [
@@ -83,5 +84,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -63,5 +64,21 @@
       }
     ]
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -57,5 +58,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -57,5 +58,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -19,7 +19,8 @@
         "strategy": "incremental",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -57,5 +58,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__events.events"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -57,5 +58,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "events",
+          "events"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -40,7 +41,8 @@
         "key": "2026-04-04",
         "start": "2026-04-04T00:00:00Z",
         "end": "2026-04-05T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -61,7 +63,8 @@
         "key": "2026-04-05",
         "start": "2026-04-05T00:00:00Z",
         "end": "2026-04-06T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -82,7 +85,8 @@
         "key": "2026-04-06",
         "start": "2026-04-06T00:00:00Z",
         "end": "2026-04-07T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -103,7 +107,8 @@
         "key": "2026-04-07",
         "start": "2026-04-07T00:00:00Z",
         "end": "2026-04-08T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -124,7 +129,8 @@
         "key": "2026-04-08",
         "start": "2026-04-08T00:00:00Z",
         "end": "2026-04-09T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -170,5 +176,66 @@
       "partitions_failed": 0
     }
   ],
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -40,7 +41,8 @@
         "key": "2026-04-07",
         "start": "2026-04-07T00:00:00Z",
         "end": "2026-04-08T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -86,5 +88,30 @@
       "partitions_failed": 0
     }
   ],
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "poc.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     },
     {
       "asset_key": [
@@ -40,7 +41,8 @@
         "key": "2026-04-07",
         "start": "2026-04-07T00:00:00Z",
         "end": "2026-04-08T00:00:00Z"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -86,5 +88,30 @@
       "partitions_failed": 0
     }
   ],
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      },
+      {
+        "asset_key": [
+          "",
+          "marts",
+          "fct_daily_orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -19,7 +19,8 @@
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
         "target_table_full_name": "playground.staging__orders.orders"
-      }
+      },
+      "cost_usd": 0.0
     }
   ],
   "check_results": [],
@@ -54,5 +55,21 @@
     "tables_drifted": 0,
     "actions_taken": []
   },
-  "interrupted": false
+  "interrupted": false,
+  "cost_summary": {
+    "total_cost_usd": 0.0,
+    "total_duration_ms": 0,
+    "per_model": [
+      {
+        "asset_key": [
+          "duckdb",
+          "orders",
+          "orders"
+        ],
+        "duration_ms": 0,
+        "cost_usd": 0.0
+      }
+    ],
+    "adapter_type": "duckdb"
+  }
 }

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -334,6 +334,49 @@
       ],
       "type": "string"
     },
+    "BudgetBreachAction": {
+      "description": "What to do when a [`BudgetConfig`] limit is exceeded by an actual run.\n\n`Warn` always fires the `budget_breach` event; `Error` additionally causes `rocky run` to exit with a non-zero status so orchestrators can gate downstream work on the breach.",
+      "enum": [
+        "warn",
+        "error"
+      ],
+      "type": "string"
+    },
+    "BudgetConfig": {
+      "additionalProperties": false,
+      "description": "Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.",
+      "properties": {
+        "max_duration_ms": {
+          "default": null,
+          "description": "Maximum allowed run wall-clock duration in milliseconds.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "max_usd": {
+          "default": null,
+          "description": "Maximum allowed run cost in USD. When set and exceeded, emits `budget_breach` on the event bus; when paired with `on_breach = \"error\"`, also fails the run.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "on_breach": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/BudgetBreachAction"
+            }
+          ],
+          "default": "warn",
+          "description": "What to do when a limit is breached. Defaults to `warn` — fire the event, keep the run successful. Set to `error` to fail the run."
+        }
+      },
+      "type": "object"
+    },
     "ChecksConfig": {
       "additionalProperties": false,
       "description": "Data quality checks configuration (row count, column match, freshness, null rate, custom).",
@@ -2421,6 +2464,19 @@
       ],
       "default": {},
       "description": "Named adapter configurations (keyed by adapter name)."
+    },
+    "budget": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/BudgetConfig"
+        }
+      ],
+      "default": {
+        "max_duration_ms": null,
+        "max_usd": null,
+        "on_breach": "warn"
+      },
+      "description": "Declarative run-level budget. See [`BudgetConfig`] for the semantics of each limit and the breach action."
     },
     "cost": {
       "allOf": [

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -33,6 +33,29 @@
       ],
       "type": "object"
     },
+    "BudgetBreachOutput": {
+      "description": "One budget breach surfaced on [`RunOutput::budget_breaches`].\n\nKept as a CLI-side struct (rather than re-using [`rocky_core::config::BudgetBreach`]) so the JSON schema lives alongside the other `rocky run` output types. The fields mirror `BudgetBreach` one-to-one.",
+      "properties": {
+        "actual": {
+          "format": "double",
+          "type": "number"
+        },
+        "limit": {
+          "format": "double",
+          "type": "number"
+        },
+        "limit_type": {
+          "description": "Which limit was breached: `\"max_usd\"` or `\"max_duration_ms\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "actual",
+        "limit",
+        "limit_type"
+      ],
+      "type": "object"
+    },
     "CheckResult": {
       "anyOf": [
         {
@@ -378,6 +401,14 @@
           },
           "type": "array"
         },
+        "cost_usd": {
+          "description": "Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
         "duration_ms": {
           "format": "uint64",
           "minimum": 0.0,
@@ -495,6 +526,36 @@
         "table_duration_p95_ms",
         "tables_failed",
         "tables_processed"
+      ],
+      "type": "object"
+    },
+    "ModelCostEntry": {
+      "description": "Per-model cost attribution entry inside [`RunCostSummary`].",
+      "properties": {
+        "asset_key": {
+          "description": "Asset key path for the model this entry covers.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cost_usd": {
+          "description": "Observed cost for this materialization. `None` when the adapter type isn't billed or the formula couldn't be computed.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "duration_ms": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "asset_key",
+        "duration_ms"
       ],
       "type": "object"
     },
@@ -656,6 +717,42 @@
       ],
       "type": "object"
     },
+    "RunCostSummary": {
+      "description": "Aggregate cost attribution for a `rocky run` invocation.\n\nThe run finalizer walks every [`MaterializationOutput`] in [`RunOutput::materializations`], computes a per-model dollar cost using [`rocky_core::cost::compute_observed_cost_usd`], and stuffs the totals here. Consumers (Dagster, custom dashboards) can then read either the per-model breakdown or the run total without re-deriving the cost model themselves.",
+      "properties": {
+        "adapter_type": {
+          "description": "Adapter type the cost formula was parameterised against, for audit. Values mirror `AdapterConfig.type`: \"databricks\", \"snowflake\", \"bigquery\", \"duckdb\".",
+          "type": "string"
+        },
+        "per_model": {
+          "description": "Per-model cost attribution, ordered as in [`RunOutput::materializations`].",
+          "items": {
+            "$ref": "#/definitions/ModelCostEntry"
+          },
+          "type": "array"
+        },
+        "total_cost_usd": {
+          "description": "Sum of every per-model `cost_usd` that produced a number. `None` when no materialization produced a cost.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "total_duration_ms": {
+          "description": "Wall-clock time summed across every materialization. Separate from [`RunOutput::duration_ms`] (which includes setup / governance overhead) so budget enforcement can target model-compute time specifically.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "adapter_type",
+        "per_model",
+        "total_duration_ms"
+      ],
+      "type": "object"
+    },
     "TableCheckOutput": {
       "properties": {
         "asset_key": {
@@ -724,6 +821,13 @@
       },
       "type": "array"
     },
+    "budget_breaches": {
+      "description": "Budget breaches detected at end of run. Empty when no `[budget]` block is configured or all configured limits were respected. Each breach is also emitted as a `budget_breach` [`rocky_observe::events::PipelineEvent`] and fires the `on_budget_breach` hook so subscribers see them live.",
+      "items": {
+        "$ref": "#/definitions/BudgetBreachOutput"
+      },
+      "type": "array"
+    },
     "check_results": {
       "items": {
         "$ref": "#/definitions/TableCheckOutput"
@@ -732,6 +836,17 @@
     },
     "command": {
       "type": "string"
+    },
+    "cost_summary": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RunCostSummary"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Aggregate cost attribution across every materialization in this run (per-model entries + run totals). `None` for DuckDB-only pipelines or when no materializations produced a cost number."
     },
     "drift": {
       "$ref": "#/definitions/DriftSummary"


### PR DESCRIPTION
## Summary

First wave of Arc 2 from the [trust-system direction](https://github.com/rocky-data/rocky/tree/main) — cost attribution + budgets + breach events. Mirrors Arc 1's shape: one bundled PR, run-level only (per-model + per-column deferred).

- **Per-adapter cost helper** in `rocky-core::cost` — `compute_observed_cost_usd(warehouse, bytes_scanned, duration_ms, dbu_per_hour, cost_per_dbu)` picks the right billing formula: Databricks/Snowflake duration × DBU × \$/DBU, BigQuery bytes × \$6.25/TB, DuckDB zero. `WarehouseType::from_adapter_type` maps adapter `type` strings; unbilled sources (fivetran, airbyte) are skipped cleanly.
- **`RunOutput.cost_summary`** — per-model + run totals (`total_cost_usd`, `total_duration_ms`, `per_model`, `adapter_type`). `MaterializationOutput.cost_usd` is populated inline so per-asset consumers don't need to re-derive. Populated on every exit path (happy, interrupted, model-only), only enforced on happy + model-only.
- **`[budget]` block in `rocky.toml`** — `max_usd`, `max_duration_ms`, `on_breach = "warn"|"error"`. Breaches surface on `RunOutput.budget_breaches`, emit a `budget_breach` `PipelineEvent` on the event bus, and fire `HookEvent::BudgetBreach` so `[hook.on_budget_breach]` shell hooks / webhooks see it live. `on_breach = "error"` makes `rocky run` exit non-zero after printing the final JSON.
- **Pre-execution `rocky estimate` cost unchanged** — this PR covers *observed* cost only; the existing `EstimateOutput.estimated_cost_usd` path is untouched.

Deferred to later Arc 2 waves: per-model budgets (need model-sidecar UX decision), adapter-reported `bytes_scanned` plumbing (Databricks manifest / Snowflake statistics / BigQuery totalBytesProcessed), PR cost-projection GitHub Action, `rocky cost` historical command.

## Test plan

- [x] `cargo test -p rocky-core` — 967 tests pass (9 new `cost::` + 7 new `config::tests::budget*` + 17 hook presets unaffected)
- [x] `cargo test -p rocky-cli` — 161 tests pass (6 new `output::cost_finalize_tests` covering populate + check + error-mode)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just codegen` — schemas / Pydantic / TypeScript regenerated and committed
- [x] `just regen-fixtures` — all 37 fixtures pick up the new `cost_summary` field
- [x] `uv run pytest` in `integrations/dagster/` — 307 tests pass
- [x] `npx tsc --noEmit` in `editors/vscode/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)