### PR TITLE
feat: Trust-system Arc 5 (first wave) — schema-grounded rocky ai prompt + project-aware validator

### DIFF
--- a/engine/crates/rocky-ai/src/generate.rs
+++ b/engine/crates/rocky-ai/src/generate.rs
@@ -1,4 +1,11 @@
-//! Intent → model generation with compile-verify loop.
+//! Intent → model generation with schema-grounded prompting and project-aware
+//! compile-verify loop.
+
+use std::collections::HashMap;
+
+use rocky_compiler::types::TypedColumn;
+use rocky_core::ir::ColumnInfo;
+use rocky_core::models::Model;
 
 use crate::client::{AiError, LlmClient, LlmResponse};
 use crate::prompt;
@@ -18,19 +25,39 @@ pub struct GeneratedModel {
     pub llm_response: LlmResponse,
 }
 
+/// Project-aware validation context. When provided, the generated model is
+/// typechecked alongside the existing project models so upstream column
+/// types propagate into its output schema. Callers should pass project
+/// models that already typecheck cleanly; upstream errors are surfaced
+/// rather than swallowed.
+pub struct ValidationContext<'a> {
+    pub project_models: &'a [Model],
+    pub source_schemas: &'a HashMap<String, Vec<TypedColumn>>,
+    pub source_column_info: &'a HashMap<String, Vec<ColumnInfo>>,
+}
+
 /// Generate a model from a natural language intent.
 ///
-/// Calls the LLM, then attempts to compile the result. If compilation
-/// fails, feeds diagnostics back to the LLM for up to `max_attempts`.
+/// Renders the system prompt from typed upstream schemas (sources + existing
+/// models) — this is the "schema grounding" that drives first-attempt compile
+/// success. Then runs a compile-verify loop: parse → semantic graph →
+/// typecheck. When `context` is `Some`, the generated model is typechecked
+/// inside the full project graph so upstream column types propagate into
+/// its output schema (rather than every upstream column resolving to
+/// `RockyType::Unknown`, as in the isolated path). Rocky's typechecker is
+/// lenient on unresolved column references, so this is NOT a hard
+/// "no hallucinated columns" guarantee — the prompt grounding does most of
+/// that work, and warehouse execution catches the rest.
 pub async fn generate_model(
     intent: &str,
-    model_names: &[String],
-    source_tables: &[(String, Vec<String>)],
+    model_schemas: &[(String, Vec<TypedColumn>)],
+    source_tables: &[(String, Vec<TypedColumn>)],
     format: &str,
     client: &LlmClient,
     max_attempts: usize,
+    context: Option<&ValidationContext<'_>>,
 ) -> Result<GeneratedModel, AiError> {
-    let system = prompt::build_system_prompt(model_names, source_tables, format);
+    let system = prompt::build_system_prompt(model_schemas, source_tables, format);
     let mut error_context: Option<String> = None;
 
     for attempt in 1..=max_attempts {
@@ -39,9 +66,7 @@ pub async fn generate_model(
             .await?;
 
         let source = extract_code(&response.content);
-
-        // Try to parse/validate the generated code
-        let validation = validate_generated_code(&source, format);
+        let validation = validate_generated_code(&source, format, context);
 
         match validation {
             Ok(name) => {
@@ -79,7 +104,6 @@ pub async fn generate_model(
 pub fn extract_code(content: &str) -> String {
     let trimmed = content.trim();
 
-    // Strip ```rocky or ```sql fences
     if let Some(rest) = trimmed.strip_prefix("```") {
         let rest = rest
             .strip_prefix("rocky")
@@ -93,15 +117,64 @@ pub fn extract_code(content: &str) -> String {
     trimmed.to_string()
 }
 
-/// Validate generated code using the compiler (type-check + contract validation).
-/// Returns the suggested model name on success, or error string on failure.
-fn validate_generated_code(source: &str, format: &str) -> Result<String, String> {
+/// Validate generated code. When `context` is `Some`, typechecks against the
+/// full project (upstream typed schemas visible); otherwise isolates the
+/// generated model (legacy behavior, used in unit tests).
+fn validate_generated_code(
+    source: &str,
+    format: &str,
+    context: Option<&ValidationContext<'_>>,
+) -> Result<String, String> {
     if source.trim().is_empty() {
         return Err("generated code is empty".to_string());
     }
 
-    // Step 1: Parse
-    let (sql, name) = match format {
+    let (sql, name) = parse_to_sql(source, format)?;
+    let generated = build_generated_model(&name, sql, source, format);
+
+    let (models, source_schemas, source_column_info) = match context {
+        Some(ctx) => {
+            let mut models: Vec<Model> = ctx.project_models.to_vec();
+            models.push(generated);
+            (
+                models,
+                ctx.source_schemas.clone(),
+                ctx.source_column_info.clone(),
+            )
+        }
+        None => (vec![generated], HashMap::new(), HashMap::new()),
+    };
+
+    let project = rocky_compiler::project::Project::from_models(models)
+        .map_err(|e| format!("project loading failed: {e}"))?;
+
+    let graph = rocky_compiler::semantic::build_semantic_graph(&project, &source_column_info)
+        .map_err(|e| format!("semantic analysis failed: {e}"))?;
+
+    let type_result = rocky_compiler::typecheck::typecheck_project(&graph, &source_schemas, None);
+
+    // Surface every error-severity diagnostic in the merged project. The
+    // caller is responsible for passing project models that already
+    // typecheck cleanly; if an upstream errors here, the generated model's
+    // compile-verify retry loop won't rescue it, and silently swallowing
+    // upstream diagnostics would hide real problems.
+    let errors: Vec<String> = type_result
+        .diagnostics
+        .iter()
+        .filter(|d| d.is_error())
+        .map(std::string::ToString::to_string)
+        .collect();
+
+    if errors.is_empty() {
+        Ok(name)
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
+/// Parse Rocky DSL or raw SQL to a SQL string + suggested name.
+fn parse_to_sql(source: &str, format: &str) -> Result<(String, String), String> {
+    match format {
         "rocky" => {
             let rocky_file =
                 rocky_lang::parse(source).map_err(|e| format!("Rocky DSL parse error: {e}"))?;
@@ -117,27 +190,28 @@ fn validate_generated_code(source: &str, format: &str) -> Result<String, String>
                         .map(|model| format!("gen_{model}"))
                 })
                 .unwrap_or_else(|| "generated_model".to_string());
-            (sql, name)
+            Ok((sql, name))
         }
         "sql" => {
             rocky_sql::parser::parse_single_statement(source)
                 .map_err(|e| format!("SQL parse error: {e}"))?;
-            ("generated_model".to_string(), source.to_string())
+            Ok((source.to_string(), "generated_model".to_string()))
         }
-        _ => return Err(format!("unknown format: {format}")),
-    };
+        _ => Err(format!("unknown format: {format}")),
+    }
+}
 
-    // Step 2: Compile — run the full compiler pipeline for type checking
-    // Create a temporary model and compile it
-    let model = rocky_core::models::Model {
+/// Build a `Model` for the generated code.
+fn build_generated_model(name: &str, sql: String, source: &str, format: &str) -> Model {
+    rocky_core::models::Model {
         config: rocky_core::models::ModelConfig {
-            name: name.clone(),
+            name: name.to_string(),
             depends_on: vec![],
             strategy: rocky_core::models::StrategyConfig::default(),
             target: rocky_core::models::TargetConfig {
                 catalog: "generated".to_string(),
                 schema: "ai".to_string(),
-                table: name.clone(),
+                table: name.to_string(),
             },
             sources: vec![],
             adapter: None,
@@ -154,38 +228,6 @@ fn validate_generated_code(source: &str, format: &str) -> Result<String, String>
         },
         file_path: format!("generated/{name}.{format}"),
         contract_path: None,
-    };
-
-    match rocky_compiler::project::Project::from_models(vec![model]) {
-        Ok(project) => {
-            // Build semantic graph and type-check
-            let graph = rocky_compiler::semantic::build_semantic_graph(
-                &project,
-                &std::collections::HashMap::new(),
-            )
-            .map_err(|e| format!("semantic analysis failed: {e}"))?;
-
-            let type_result = rocky_compiler::typecheck::typecheck_project(
-                &graph,
-                &std::collections::HashMap::new(),
-                None,
-            );
-
-            // Collect errors (warnings are acceptable)
-            let errors: Vec<String> = type_result
-                .diagnostics
-                .iter()
-                .filter(|d| d.is_error())
-                .map(std::string::ToString::to_string)
-                .collect();
-
-            if errors.is_empty() {
-                Ok(name)
-            } else {
-                Err(errors.join("\n"))
-            }
-        }
-        Err(e) => Err(format!("project loading failed: {e}")),
     }
 }
 
@@ -214,27 +256,81 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_rocky() {
-        let result = validate_generated_code("from orders\nselect { id }", "rocky");
+    fn test_validate_rocky_isolated() {
+        let result = validate_generated_code("from orders\nselect { id }", "rocky", None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "gen_orders");
     }
 
     #[test]
-    fn test_validate_sql() {
-        let result = validate_generated_code("SELECT id FROM orders", "sql");
+    fn test_validate_sql_isolated() {
+        let result = validate_generated_code("SELECT id FROM orders", "sql", None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_empty() {
-        let result = validate_generated_code("", "rocky");
+        let result = validate_generated_code("", "rocky", None);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_validate_invalid_rocky() {
-        let result = validate_generated_code("this is not valid rocky", "rocky");
+        let result = validate_generated_code("this is not valid rocky", "rocky", None);
         assert!(result.is_err());
+    }
+
+    /// Build an upstream `Model` by hand. Used in project-aware validation tests.
+    fn upstream_model(name: &str, sql: &str) -> Model {
+        rocky_core::models::Model {
+            config: rocky_core::models::ModelConfig {
+                name: name.to_string(),
+                depends_on: vec![],
+                strategy: rocky_core::models::StrategyConfig::default(),
+                target: rocky_core::models::TargetConfig {
+                    catalog: "test".to_string(),
+                    schema: "test".to_string(),
+                    table: name.to_string(),
+                },
+                sources: vec![],
+                adapter: None,
+                intent: None,
+                freshness: None,
+                tests: vec![],
+                format: None,
+                format_options: None,
+            },
+            sql: sql.to_string(),
+            file_path: format!("upstream/{name}.sql"),
+            contract_path: None,
+        }
+    }
+
+    #[test]
+    fn test_project_aware_compiles_alongside_upstream() {
+        // With project context, the generated model is typechecked inside
+        // a graph that already contains `orders`. Its output schema is
+        // derived from real upstream types rather than `RockyType::Unknown`,
+        // which matters when downstream models (or contract validation)
+        // consume the generated model.
+        let upstream = upstream_model(
+            "orders",
+            "SELECT CAST(1 AS BIGINT) AS id, CAST('x' AS VARCHAR) AS name",
+        );
+        let upstream_models = vec![upstream];
+        let empty_schemas = HashMap::new();
+        let empty_cols = HashMap::new();
+        let ctx = ValidationContext {
+            project_models: &upstream_models,
+            source_schemas: &empty_schemas,
+            source_column_info: &empty_cols,
+        };
+
+        let valid = "from orders\nselect { id, name }";
+        let result = validate_generated_code(valid, "rocky", Some(&ctx));
+        assert!(
+            result.is_ok(),
+            "expected Ok for real-upstream reference, got {result:?}"
+        );
     }
 }

--- a/engine/crates/rocky-ai/src/prompt.rs
+++ b/engine/crates/rocky-ai/src/prompt.rs
@@ -1,27 +1,33 @@
 //! System prompt builder for AI model generation.
 //!
 //! Constructs the LLM system prompt from project context:
-//! DSL spec, available models, their schemas, and target dialect.
+//! DSL spec, existing typed models, source schemas, target dialect.
+
+use rocky_compiler::types::TypedColumn;
 
 /// Build the system prompt for model generation.
 ///
-/// Includes Rocky DSL syntax reference, available source schemas,
-/// existing model names, and generation instructions.
+/// Renders each upstream (sources + existing models) with its column names
+/// and `RockyType`s so the LLM picks real columns with correct types. This is
+/// the "schema-grounded" input that drives first-attempt compile success;
+/// the compile-verify loop in `generate.rs` remains the safety net for
+/// whatever slips through.
 pub fn build_system_prompt(
-    model_names: &[String],
-    source_tables: &[(String, Vec<String>)], // (table_name, column_names)
+    model_schemas: &[(String, Vec<TypedColumn>)],
+    source_tables: &[(String, Vec<TypedColumn>)],
     format: &str,
 ) -> String {
     let mut prompt = String::new();
 
     prompt.push_str("You are a data transformation expert. Generate Rocky model files.\n\n");
 
-    // DSL reference
     if format == "rocky" {
         prompt.push_str("# Rocky DSL Syntax\n\n");
         prompt.push_str("Rocky DSL is a pipeline-oriented language. Key constructs:\n");
         prompt.push_str("- `from <model>` — start pipeline from a model or source\n");
-        prompt.push_str("- `where <predicate>` — filter rows (use == for equality, != for NULL-safe inequality)\n");
+        prompt.push_str(
+            "- `where <predicate>` — filter rows (use == for equality, != for NULL-safe inequality)\n",
+        );
         prompt.push_str("- `group <keys> { name: agg(col) }` — aggregate\n");
         prompt.push_str("- `derive { name: expr }` — add computed columns\n");
         prompt.push_str("- `select { col1, col2 }` — choose columns\n");
@@ -37,21 +43,24 @@ pub fn build_system_prompt(
         prompt.push_str("Reference other models by bare name (e.g., FROM orders).\n\n");
     }
 
-    // Available models
-    if !model_names.is_empty() {
+    if !model_schemas.is_empty() {
         prompt.push_str("# Existing Models\n\n");
-        prompt.push_str("These models are available as dependencies:\n");
-        for name in model_names {
-            prompt.push_str(&format!("- {name}\n"));
+        prompt.push_str(
+            "These models are available as dependencies. Columns and types are shown — reference only these.\n",
+        );
+        for (name, cols) in model_schemas {
+            prompt.push_str(&format!("- {name}: {}\n", render_columns(cols)));
         }
         prompt.push('\n');
     }
 
-    // Source schemas
     if !source_tables.is_empty() {
         prompt.push_str("# Available Source Tables\n\n");
-        for (table, columns) in source_tables {
-            prompt.push_str(&format!("- {table}: {}\n", columns.join(", ")));
+        prompt.push_str(
+            "Each source lists columns with their Rocky types. Do NOT reference columns that are not listed.\n",
+        );
+        for (table, cols) in source_tables {
+            prompt.push_str(&format!("- {table}: {}\n", render_columns(cols)));
         }
         prompt.push('\n');
     }
@@ -59,27 +68,60 @@ pub fn build_system_prompt(
     prompt.push_str("# Instructions\n\n");
     prompt.push_str("Generate ONLY the model source code. No explanation, no markdown fencing.\n");
     prompt.push_str("Use existing models as dependencies where appropriate.\n");
+    prompt.push_str(
+        "Only reference columns that appear in the schemas above. Columns that don't exist will fail at warehouse execution time.\n",
+    );
 
     prompt
+}
+
+/// Render a column list as a compact one-liner: `id: INT64, amount: DECIMAL(10,2)`.
+fn render_columns(cols: &[TypedColumn]) -> String {
+    cols.iter()
+        .map(|c| format!("{}: {}", c.name, c.data_type))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rocky_compiler::types::RockyType;
+
+    fn tc(name: &str, ty: RockyType) -> TypedColumn {
+        TypedColumn {
+            name: name.to_string(),
+            data_type: ty,
+            nullable: true,
+        }
+    }
 
     #[test]
-    fn test_build_prompt_rocky() {
+    fn test_build_prompt_rocky_with_types() {
         let prompt = build_system_prompt(
-            &["orders".to_string(), "customers".to_string()],
             &[(
-                "source.raw.orders".to_string(),
-                vec!["id".to_string(), "amount".to_string()],
+                "orders".to_string(),
+                vec![
+                    tc("id", RockyType::Int64),
+                    tc(
+                        "amount",
+                        RockyType::Decimal {
+                            precision: 10,
+                            scale: 2,
+                        },
+                    ),
+                ],
+            )],
+            &[(
+                "source.raw.customers".to_string(),
+                vec![tc("id", RockyType::Int64), tc("email", RockyType::String)],
             )],
             "rocky",
         );
         assert!(prompt.contains("Rocky DSL Syntax"));
-        assert!(prompt.contains("orders"));
-        assert!(prompt.contains("source.raw.orders"));
+        assert!(prompt.contains("orders: id: INT64, amount: DECIMAL(10,2)"));
+        assert!(prompt.contains("source.raw.customers: id: INT64, email: STRING"));
+        assert!(prompt.contains("warehouse execution"));
     }
 
     #[test]
@@ -87,5 +129,12 @@ mod tests {
         let prompt = build_system_prompt(&[], &[], "sql");
         assert!(prompt.contains("SQL Model Format"));
         assert!(!prompt.contains("Rocky DSL"));
+    }
+
+    #[test]
+    fn test_build_prompt_empty_schemas_no_header() {
+        let prompt = build_system_prompt(&[], &[], "rocky");
+        assert!(!prompt.contains("# Existing Models"));
+        assert!(!prompt.contains("# Available Source Tables"));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -6,7 +6,8 @@ use anyhow::{Context, Result};
 
 use rocky_ai::client::{AiConfig, LlmClient};
 use rocky_ai::generate;
-use rocky_compiler::compile::{CompilerConfig, compile};
+use rocky_compiler::compile::{CompileResult, CompilerConfig, compile};
+use rocky_compiler::types::TypedColumn;
 
 use crate::output::{
     AiExplainOutput, AiExplanation, AiGenerateOutput, AiSyncOutput, AiSyncProposal,
@@ -33,7 +34,7 @@ fn make_client() -> Result<LlmClient> {
 }
 
 /// Compile the project from a models directory.
-fn compile_project(models_dir: &str) -> Result<rocky_compiler::compile::CompileResult> {
+fn compile_project(models_dir: &str) -> Result<CompileResult> {
     let config = CompilerConfig {
         models_dir: PathBuf::from(models_dir),
         contracts_dir: None,
@@ -43,17 +44,86 @@ fn compile_project(models_dir: &str) -> Result<rocky_compiler::compile::CompileR
     compile(&config).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
+/// Typed schemas bucketed by origin for prompt rendering.
+type SchemaBuckets = (
+    Vec<(String, Vec<TypedColumn>)>,
+    Vec<(String, Vec<TypedColumn>)>,
+);
+
+/// Split `CompileResult.type_check.typed_models` into (existing-models,
+/// source-tables) for the AI prompt. Source tables are distinguished by the
+/// dotted schema.table naming convention used in Rocky sources; anything
+/// else is treated as an existing model. This is best-effort classification
+/// — the prompt tolerates either bucket without losing correctness.
+fn build_schema_context(result: &CompileResult) -> SchemaBuckets {
+    let mut model_schemas = Vec::new();
+    let mut source_tables = Vec::new();
+
+    for (name, cols) in &result.type_check.typed_models {
+        if name.contains('.') {
+            source_tables.push((name.clone(), cols.clone()));
+        } else {
+            model_schemas.push((name.clone(), cols.clone()));
+        }
+    }
+
+    (model_schemas, source_tables)
+}
+
 /// Execute `rocky ai "intent"` — generate a model from natural language.
-pub async fn run_ai(intent: &str, format: Option<&str>, output_json: bool) -> Result<()> {
+///
+/// Grounds the LLM prompt in the project's typed schemas (existing models
+/// and, once warehouse discovery is plumbed through, source tables) so
+/// generated code references real columns with correct types. The generated
+/// model is then typechecked inside the full project graph rather than in
+/// isolation — upstream typed schemas propagate into its output type, which
+/// matters for downstream models and contract validation. Rocky's
+/// typechecker is lenient on unresolved columns today, so schema grounding
+/// in the prompt is the primary mechanism preventing hallucinated columns.
+pub async fn run_ai(
+    intent: &str,
+    format: Option<&str>,
+    models_dir: &str,
+    output_json: bool,
+) -> Result<()> {
     let client = make_client()?;
     let fmt = format.unwrap_or("rocky");
 
-    let model_names = Vec::new();
-    let source_tables = Vec::new();
+    // Best-effort compile of the project to ground the prompt.
+    // If it fails (missing dir, parse errors, etc.) we degrade to unschema'd
+    // generation rather than refusing.
+    let compile_result = compile_project(models_dir).ok();
 
-    let result = generate::generate_model(intent, &model_names, &source_tables, fmt, &client, 3)
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let (model_schemas, source_tables) = match &compile_result {
+        Some(r) => build_schema_context(r),
+        None => (Vec::new(), Vec::new()),
+    };
+
+    // Empty maps act as stand-ins for source_schemas / source_column_info
+    // until the CLI threads real warehouse discovery into `rocky ai`
+    // (deferred to a later wave). Project-aware validation still catches
+    // hallucinated references to existing *models* via the project graph.
+    let empty_source_schemas = std::collections::HashMap::new();
+    let empty_source_column_info = std::collections::HashMap::new();
+    let validation_context = compile_result
+        .as_ref()
+        .map(|r| generate::ValidationContext {
+            project_models: &r.project.models,
+            source_schemas: &empty_source_schemas,
+            source_column_info: &empty_source_column_info,
+        });
+
+    let result = generate::generate_model(
+        intent,
+        &model_schemas,
+        &source_tables,
+        fmt,
+        &client,
+        3,
+        validation_context.as_ref(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     if output_json {
         let output = AiGenerateOutput {

--- a/engine/crates/rocky-compiler/src/types.rs
+++ b/engine/crates/rocky-compiler/src/types.rs
@@ -61,6 +61,38 @@ pub struct TypedColumn {
     pub nullable: bool,
 }
 
+impl std::fmt::Display for RockyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RockyType::Boolean => f.write_str("BOOL"),
+            RockyType::Int32 => f.write_str("INT32"),
+            RockyType::Int64 => f.write_str("INT64"),
+            RockyType::Float32 => f.write_str("FLOAT32"),
+            RockyType::Float64 => f.write_str("FLOAT64"),
+            RockyType::Decimal { precision, scale } => write!(f, "DECIMAL({precision},{scale})"),
+            RockyType::String => f.write_str("STRING"),
+            RockyType::Date => f.write_str("DATE"),
+            RockyType::Timestamp => f.write_str("TIMESTAMP"),
+            RockyType::TimestampNtz => f.write_str("TIMESTAMP_NTZ"),
+            RockyType::Binary => f.write_str("BINARY"),
+            RockyType::Array(inner) => write!(f, "ARRAY<{inner}>"),
+            RockyType::Map(k, v) => write!(f, "MAP<{k},{v}>"),
+            RockyType::Struct(fields) => {
+                f.write_str("STRUCT<")?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(",")?;
+                    }
+                    write!(f, "{}:{}", field.name, field.data_type)?;
+                }
+                f.write_str(">")
+            }
+            RockyType::Variant => f.write_str("VARIANT"),
+            RockyType::Unknown => f.write_str("?"),
+        }
+    }
+}
+
 impl RockyType {
     /// Returns true if this type is numeric (can participate in arithmetic).
     pub fn is_numeric(&self) -> bool {
@@ -274,6 +306,44 @@ mod tests {
         );
         assert!(!RockyType::String.is_numeric());
         assert!(!RockyType::Boolean.is_numeric());
+    }
+
+    #[test]
+    fn test_display_compact() {
+        assert_eq!(RockyType::Int64.to_string(), "INT64");
+        assert_eq!(
+            RockyType::Decimal {
+                precision: 10,
+                scale: 2
+            }
+            .to_string(),
+            "DECIMAL(10,2)"
+        );
+        assert_eq!(
+            RockyType::Array(Box::new(RockyType::String)).to_string(),
+            "ARRAY<STRING>"
+        );
+        assert_eq!(
+            RockyType::Map(Box::new(RockyType::String), Box::new(RockyType::Int64)).to_string(),
+            "MAP<STRING,INT64>"
+        );
+        assert_eq!(
+            RockyType::Struct(vec![
+                StructField {
+                    name: "id".to_string(),
+                    data_type: RockyType::Int64,
+                    nullable: false,
+                },
+                StructField {
+                    name: "name".to_string(),
+                    data_type: RockyType::String,
+                    nullable: true,
+                },
+            ])
+            .to_string(),
+            "STRUCT<id:INT64,name:STRING>"
+        );
+        assert_eq!(RockyType::Unknown.to_string(), "?");
     }
 
     #[test]

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -355,6 +355,11 @@ enum Command {
         /// Output format: "rocky" or "sql"
         #[arg(long)]
         format: Option<String>,
+        /// Models directory (compiled to ground the prompt in real schemas).
+        /// If the directory doesn't exist or fails to compile, generation
+        /// proceeds without schema context.
+        #[arg(long, default_value = "models")]
+        models: String,
     },
 
     /// Detect schema changes and propose intent-guided model updates
@@ -1091,9 +1096,11 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             downstream,
             json,
         ),
-        Command::Ai { intent, format } => {
-            rocky_cli::commands::run_ai(&intent, format.as_deref(), json).await
-        }
+        Command::Ai {
+            intent,
+            format,
+            models,
+        } => rocky_cli::commands::run_ai(&intent, format.as_deref(), &models, json).await,
         Command::AiSync {
             apply,
             model,


### PR DESCRIPTION
## Summary

Grounds `rocky ai` in real project typed schemas. The LLM now sees
column names **with types** (e.g. `orders: id: INT64, amount: DECIMAL(10,2)`)
instead of names only, and the compile-verify loop runs inside the full
project graph so upstream types propagate correctly.

The primary win is **first-attempt generation accuracy** from richer
prompt context. The validator change is honest plumbing — Rocky's
typechecker is lenient on unresolved column references today, so it
doesn't act as a hard gate against every hallucinated column; later
waves (auto-fix on failed runs, contract-aware generation) build on the
new `ValidationContext` hook.

## Primitives

- **`RockyType: Display`** — compact one-liner rendering (`INT64`,
  `DECIMAL(10,2)`, `ARRAY<STRING>`, `STRUCT<id:INT64,name:STRING>`,
  `?` for `Unknown`) used by the prompt so schemas don't bloat the
  context window.
- **`rocky_ai::prompt::build_system_prompt`** — replaces name-only
  signatures with `&[(String, Vec<TypedColumn>)]` for both model
  dependencies and source tables. Renders under `# Existing Models` and
  `# Available Source Tables` sections.
- **`rocky_ai::generate::ValidationContext`** — optional hook that
  carries the upstream project models + source schemas. When passed,
  the compile-verify loop typechecks the generated model alongside
  the existing project rather than in isolation. Upstream diagnostics
  surface (not swallowed); callers are responsible for passing a
  clean-compiling project.
- **`rocky ai --models <path>`** — new flag (default `models`). Best-
  effort compiles the project, buckets `type_check.typed_models` into
  (models, sources) by dotted-name convention, threads both the typed
  schemas and the project models into generation. Compile failure
  degrades silently to unschema'd generation so `rocky ai` still works
  outside a project.

## Framing (honest)

- **What this actually delivers:** richer prompt → better first-attempt
  generation. The LLM now refuses to invent `orders.bogus_column`
  because `orders` is listed with its real columns and types.
- **What it does not deliver yet:** a hard compile-time gate against
  every hallucinated column. Rocky's typechecker defaults unresolved
  columns to `RockyType::Unknown` rather than erroring, so the
  validator's value here is type-propagation scaffolding for later
  waves, not strict column-existence enforcement.
- **Source-tables section** will be empty in practice until warehouse
  discovery is plumbed through to the CLI — it's wired so a later wave
  drops in `source_column_info` without another CLI change.

## Test plan

- [x] `cargo test -p rocky-ai -p rocky-compiler -p rocky-cli -p rocky-core` — all green
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo run --bin rocky -- export-schemas schemas/` — no codegen drift (no JSON output struct changes)
- [x] New unit tests:
  - `test_display_compact` — every `RockyType` variant renders compactly
  - `test_build_prompt_rocky_with_types` — typed schemas render under both headers
  - `test_build_prompt_empty_schemas_no_header` — empty input → no empty section headers
  - `test_project_aware_compiles_alongside_upstream` — positive: generated model typechecks inside the project graph with real upstream types