### PR TITLE
docs: drop stale version tags from dagster narrative prose

### DIFF
--- a/docs/src/content/docs/dagster/automation.md
+++ b/docs/src/content/docs/dagster/automation.md
@@ -7,7 +7,7 @@ sidebar:
 
 Dagster 1.12+ uses
 [`AutomationCondition`](https://docs.dagster.io/api/dagster/declarative-automation#dagster.AutomationCondition)
-for asset-centric declarative automation. `dagster-rocky` 0.4 ships two
+for asset-centric declarative automation. `dagster-rocky` ships two
 helpers that name the canonical Rocky-side mappings so you don't have to dig
 through Dagster docs.
 

--- a/docs/src/content/docs/dagster/branch-deployments.md
+++ b/docs/src/content/docs/dagster/branch-deployments.md
@@ -12,7 +12,7 @@ Rocky-side response is to **shadow-run** every materialization against a
 sandboxed schema instead of production tables, so PR diffs are visible
 side-by-side without touching production data.
 
-`dagster-rocky` 0.4 ships three small primitives to make this trivial:
+`dagster-rocky` ships three small primitives to make this trivial:
 
 - **`is_branch_deployment()`** — boolean check for the standard Dagster+
   env vars.

--- a/docs/src/content/docs/dagster/contracts.md
+++ b/docs/src/content/docs/dagster/contracts.md
@@ -5,7 +5,7 @@ sidebar:
   order: 17
 ---
 
-`dagster-rocky` 0.4 surfaces Rocky's compile-time contract validation as
+`dagster-rocky` surfaces Rocky's compile-time contract validation as
 native Dagster [`AssetCheckSpec`](https://docs.dagster.io/api/dagster/asset-checks#dagster.AssetCheckSpec)
 and [`AssetCheckResult`](https://docs.dagster.io/api/dagster/asset-checks#dagster.AssetCheckResult)
 events. Each model with a `.contract.toml` file gets one or more contract

--- a/docs/src/content/docs/dagster/derived-models.md
+++ b/docs/src/content/docs/dagster/derived-models.md
@@ -5,7 +5,7 @@ sidebar:
   order: 18
 ---
 
-`dagster-rocky` 0.4 historically only surfaced source-replication tables
+`dagster-rocky` historically only surfaced source-replication tables
 (one `AssetSpec` per discovered Fivetran/connector table). Derived models
 — the `*.sql` / `*.rocky` files Rocky compiles from your `models/`
 directory — were invisible to the asset graph. The

--- a/docs/src/content/docs/dagster/freshness.md
+++ b/docs/src/content/docs/dagster/freshness.md
@@ -5,7 +5,7 @@ sidebar:
   order: 9
 ---
 
-`dagster-rocky` 0.4 maps Rocky's freshness configuration onto Dagster's
+`dagster-rocky` maps Rocky's freshness configuration onto Dagster's
 [`FreshnessPolicy`](https://docs.dagster.io/api/dagster/assets#dagster.FreshnessPolicy)
 so the Dagster UI surfaces stale-data badges and the declarative-automation
 freshness conditions trigger correctly.

--- a/docs/src/content/docs/dagster/health.md
+++ b/docs/src/content/docs/dagster/health.md
@@ -5,7 +5,7 @@ sidebar:
   order: 15
 ---
 
-`dagster-rocky` 0.4 ships `rocky_healthcheck()` — a wrapper around
+`dagster-rocky` ships `rocky_healthcheck()` — a wrapper around
 `rocky doctor` suitable for Dagster+ code-location startup probes, custom
 asset checks, and custom ops.
 

--- a/docs/src/content/docs/dagster/observability.md
+++ b/docs/src/content/docs/dagster/observability.md
@@ -5,7 +5,7 @@ sidebar:
   order: 12
 ---
 
-`dagster-rocky` 0.4 elevates Rocky's runtime observability signals from log
+`dagster-rocky` elevates Rocky's runtime observability signals from log
 warnings to first-class Dagster primitives:
 
 - **Schema drift** → `dg.AssetObservation` events on the asset timeline

--- a/docs/src/content/docs/dagster/partitions.md
+++ b/docs/src/content/docs/dagster/partitions.md
@@ -7,7 +7,7 @@ sidebar:
 
 Rocky's `time_interval` materialization strategy declares a model is
 partitioned by a time column with a fixed granularity (`hour`, `day`, `month`,
-or `year`). `dagster-rocky` 0.4 ships `partitions.py` — a translation layer
+or `year`). `dagster-rocky` ships `partitions.py` — a translation layer
 that converts these strategies into Dagster's
 [`PartitionsDefinition`](https://docs.dagster.io/api/dagster/partitions#dagster.PartitionsDefinition)
 variants.

--- a/docs/src/content/docs/dagster/pipes.md
+++ b/docs/src/content/docs/dagster/pipes.md
@@ -5,7 +5,7 @@ sidebar:
   order: 20
 ---
 
-`dagster-rocky` 0.4 ships **`RockyResource.run_streaming()`** — a
+`dagster-rocky` ships **`RockyResource.run_streaming()`** — a
 Pipes-style alternative to `RockyResource.run()` that spawns the binary
 via `subprocess.Popen`, forwards rocky's stderr (where the engine's
 Rust `tracing` layer writes `info!()` / `warn!()` macros) to

--- a/docs/src/content/docs/dagster/scaffold.md
+++ b/docs/src/content/docs/dagster/scaffold.md
@@ -5,7 +5,7 @@ sidebar:
   order: 16
 ---
 
-`dagster-rocky` 0.4 ships two ways to bootstrap a new project:
+`dagster-rocky` ships two ways to bootstrap a new project:
 
 1. **`dg scaffold defs dagster_rocky.RockyComponent <name>`** — uses Dagster's
    built-in scaffolder via the registered entry point. Writes a bare

--- a/docs/src/content/docs/dagster/schedules.md
+++ b/docs/src/content/docs/dagster/schedules.md
@@ -7,7 +7,7 @@ sidebar:
 
 Dagster's [`ScheduleDefinition`](https://docs.dagster.io/api/dagster/schedules-sensors#dagster.ScheduleDefinition)
 is fully sufficient for scheduled Rocky runs without any Rocky-specific glue.
-`dagster-rocky` 0.4 ships `build_rocky_schedule()` as a thin convenience that
+`dagster-rocky` ships `build_rocky_schedule()` as a thin convenience that
 bakes in sensible defaults and accepts the same `target=` shape as
 `rocky_source_sensor()` for symmetry.
 

--- a/docs/src/content/docs/dagster/sensors.md
+++ b/docs/src/content/docs/dagster/sensors.md
@@ -5,7 +5,7 @@ sidebar:
   order: 10
 ---
 
-`dagster-rocky` 0.4 ships `rocky_source_sensor()` — a factory that builds a
+`dagster-rocky` ships `rocky_source_sensor()` — a factory that builds a
 Dagster [`SensorDefinition`](https://docs.dagster.io/api/dagster/sensors#dagster.SensorDefinition)
 that polls `rocky discover` and emits a `RunRequest` for any source whose
 upstream connector has produced new data since the previous tick.

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/instal
 **Pin a specific version:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- 1.0.0
+curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- <version>
 ```
 
 ## Windows


### PR DESCRIPTION
## Summary

- Twelve `docs/dagster/*.md` pages opened with "\`dagster-rocky\` 0.4 ships X" framing. The current release is 1.6.0, so the version tag misleads without adding information — stripped from all twelve.
- Replaced the hard-coded `1.0.0` pin in the install-script example (`getting-started/installation.md`) with a `<version>` placeholder.
- Benchmarks table and JSON sample outputs (`"version": "1.6.0"`) left untouched — those are intentional version-progression data and real CLI output.

## Test plan

- [ ] `npm run build` / preview under `docs/` renders cleanly
- [ ] Spot-check one dagster page renders without the stray "0.4"