### PR TITLE
feat(engine): Trust-system Arc 7 (first wave) — blast-radius SELECT * linter (P002)

### DIFF
--- a/engine/crates/rocky-compiler/src/blast_radius.rs
+++ b/engine/crates/rocky-compiler/src/blast_radius.rs
@@ -1,0 +1,324 @@
+//! Blast-radius linter for `SELECT *` (P002).
+//!
+//! Emits a warning when a model uses `SELECT *` AND at least one downstream
+//! model references specific columns of its output. The lint is
+//! *blast-radius-aware*: a leaf model with `SELECT *` is intentionally not
+//! flagged — the user inspected the result themselves. The diagnostic only
+//! fires when an upstream schema change at the star's source would silently
+//! propagate into a downstream that names columns of this model.
+//!
+//! Detection runs against the semantic graph rather than re-parsing SQL:
+//! `ModelSchema::has_star` is set during graph construction by
+//! `rocky_sql::lineage`, and `column_consumers(model, column)` enumerates
+//! the exact downstream edges that make the radius concrete. No new
+//! parser or type-inference machinery is required for this wave; the next
+//! wave (Arc 7 type inference over raw `.sql` models) will sharpen which
+//! upstream is treated as "typed."
+
+use indexmap::IndexMap;
+use std::collections::HashMap;
+
+use crate::diagnostic::{Diagnostic, P002, SourceSpan};
+use crate::semantic::SemanticGraph;
+
+/// Cap on listed columns per downstream entry in the diagnostic message,
+/// to keep miette output legible on wide schemas.
+const COLS_PREVIEW_LIMIT: usize = 3;
+
+/// Inspect the semantic graph for `SELECT *` blast-radius hazards and
+/// return one warning per offending model.
+///
+/// `file_paths` maps model name → source file path so the resulting
+/// diagnostics carry a [`SourceSpan`] pointing at the model file. Models
+/// without a file path entry get a span-less diagnostic — the LSP and
+/// CLI both render that gracefully.
+pub fn detect_select_star_blast_radius(
+    graph: &SemanticGraph,
+    file_paths: &HashMap<String, String>,
+) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+
+    for (name, schema) in &graph.models {
+        if !schema.has_star {
+            continue;
+        }
+
+        let mut by_downstream: IndexMap<&str, Vec<&str>> = IndexMap::new();
+        for col in &schema.columns {
+            for edge in graph.column_consumers(name, &col.name) {
+                let down: &str = &edge.target.model;
+                by_downstream
+                    .entry(down)
+                    .or_default()
+                    .push(col.name.as_str());
+            }
+        }
+
+        if by_downstream.is_empty() {
+            continue;
+        }
+
+        let summary = summarize_downstreams(&by_downstream);
+        let downstream_count = by_downstream.len();
+        let plural = if downstream_count == 1 {
+            "consumer"
+        } else {
+            "consumers"
+        };
+        let message = format!(
+            "SELECT * silently propagates upstream schema changes to {downstream_count} downstream {plural}: {summary}",
+        );
+
+        let mut diag = Diagnostic::warning(P002, name, message).with_suggestion(
+            "replace SELECT * with an explicit column list to make schema dependencies visible",
+        );
+
+        if let Some(file) = file_paths.get(name) {
+            diag = diag.with_span(SourceSpan {
+                file: file.clone(),
+                line: 1,
+                col: 1,
+            });
+        }
+
+        diags.push(diag);
+    }
+
+    diags
+}
+
+fn summarize_downstreams(by_downstream: &IndexMap<&str, Vec<&str>>) -> String {
+    by_downstream
+        .iter()
+        .map(|(d, cols)| {
+            let total = cols.len();
+            let preview = cols
+                .iter()
+                .take(COLS_PREVIEW_LIMIT)
+                .copied()
+                .collect::<Vec<_>>()
+                .join(", ");
+            if total > COLS_PREVIEW_LIMIT {
+                let extra = total - COLS_PREVIEW_LIMIT;
+                format!("`{d}` ({preview}, +{extra} more)")
+            } else {
+                format!("`{d}` ({preview})")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostic::Severity;
+    use crate::project::Project;
+    use crate::semantic::build_semantic_graph;
+    use rocky_core::ir::ColumnInfo;
+    use rocky_core::models::{Model, ModelConfig, StrategyConfig, TargetConfig};
+
+    fn make_model(name: &str, sql: &str) -> Model {
+        Model {
+            config: ModelConfig {
+                name: name.to_string(),
+                depends_on: vec![],
+                strategy: StrategyConfig::default(),
+                target: TargetConfig {
+                    catalog: "warehouse".to_string(),
+                    schema: "silver".to_string(),
+                    table: name.to_string(),
+                },
+                sources: vec![],
+                adapter: None,
+                intent: None,
+                freshness: None,
+                tests: vec![],
+                format: None,
+                format_options: None,
+            },
+            sql: sql.to_string(),
+            file_path: format!("models/{name}.sql"),
+            contract_path: None,
+        }
+    }
+
+    fn file_paths_for(models: &[Model]) -> HashMap<String, String> {
+        models
+            .iter()
+            .map(|m| (m.config.name.clone(), m.file_path.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn flags_select_star_with_explicit_downstream_consumer() {
+        // a is a typed upstream, b stars from a, c references specific
+        // columns from b → b's blast radius is real.
+        let models = vec![
+            make_model("a", "SELECT id, name FROM source.raw.users"),
+            make_model("b", "SELECT * FROM a"),
+            make_model("c", "SELECT id FROM b"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert_eq!(diags.len(), 1);
+        let d = &diags[0];
+        assert_eq!(&*d.code, "P002");
+        assert_eq!(d.severity, Severity::Warning);
+        assert_eq!(d.model, "b");
+        assert!(d.message.contains("`c`"), "message: {}", d.message);
+        assert!(d.message.contains("id"), "message: {}", d.message);
+        assert_eq!(
+            d.span.as_ref().map(|s| s.file.as_str()),
+            Some("models/b.sql"),
+        );
+    }
+
+    #[test]
+    fn no_warning_when_select_star_has_no_downstream() {
+        // Leaf model with SELECT * — user already inspected the result.
+        let models = vec![
+            make_model("a", "SELECT id, name FROM source.raw.users"),
+            make_model("b", "SELECT * FROM a"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert!(diags.is_empty(), "leaf SELECT * should not warn: {diags:?}",);
+    }
+
+    #[test]
+    fn no_warning_when_no_select_star() {
+        let models = vec![
+            make_model("a", "SELECT id, name FROM source.raw.users"),
+            make_model("b", "SELECT id, name FROM a"),
+            make_model("c", "SELECT id FROM b"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert!(diags.is_empty(), "no star → no warning: {diags:?}");
+    }
+
+    #[test]
+    fn flags_select_star_from_typed_external_source() {
+        // External source with known schema → star expansion is typed →
+        // downstream consumer makes blast radius real.
+        let models = vec![
+            make_model("a", "SELECT * FROM catalog.schema.users"),
+            make_model("b", "SELECT id FROM a"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let mut sources = HashMap::new();
+        sources.insert(
+            "catalog.schema.users".to_string(),
+            vec![
+                ColumnInfo {
+                    name: "id".to_string(),
+                    data_type: "BIGINT".to_string(),
+                    nullable: false,
+                },
+                ColumnInfo {
+                    name: "name".to_string(),
+                    data_type: "STRING".to_string(),
+                    nullable: true,
+                },
+            ],
+        );
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &sources).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert_eq!(diags.len(), 1, "diags: {diags:?}");
+        assert_eq!(diags[0].model, "a");
+        assert!(diags[0].message.contains("`b`"));
+    }
+
+    #[test]
+    fn no_warning_when_upstream_is_untyped_external_source() {
+        // Star expansion against an unknown source produces no columns,
+        // so no consumer edges exist — no blast radius to flag.
+        let models = vec![
+            make_model("a", "SELECT * FROM catalog.schema.unknown"),
+            make_model("b", "SELECT id FROM a"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert!(
+            diags.is_empty(),
+            "untyped upstream → no blast radius: {diags:?}",
+        );
+    }
+
+    #[test]
+    fn aggregates_columns_per_downstream() {
+        // Two downstreams reference different columns of b — diagnostic
+        // should list both with their referenced columns.
+        let models = vec![
+            make_model("a", "SELECT id, name, email FROM source.raw.users"),
+            make_model("b", "SELECT * FROM a"),
+            make_model("c", "SELECT id, name FROM b"),
+            make_model("d", "SELECT email FROM b"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert_eq!(diags.len(), 1);
+        let msg = diags[0].message.to_string();
+        assert!(msg.contains("2 downstream consumers"), "msg: {msg}");
+        assert!(msg.contains("`c`"), "msg: {msg}");
+        assert!(msg.contains("`d`"), "msg: {msg}");
+    }
+
+    #[test]
+    fn truncates_long_column_lists_in_message() {
+        let models = vec![
+            make_model("a", "SELECT c1, c2, c3, c4, c5, c6 FROM source.raw.wide"),
+            make_model("b", "SELECT * FROM a"),
+            make_model("c", "SELECT c1, c2, c3, c4, c5 FROM b"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert_eq!(diags.len(), 1);
+        let msg = diags[0].message.to_string();
+        assert!(msg.contains("+2 more"), "msg should truncate: {msg}");
+    }
+
+    #[test]
+    fn diagnostic_has_actionable_suggestion() {
+        let models = vec![
+            make_model("a", "SELECT id FROM source.raw.users"),
+            make_model("b", "SELECT * FROM a"),
+            make_model("c", "SELECT id FROM b"),
+        ];
+        let file_paths = file_paths_for(&models);
+        let project = Project::from_models(models).unwrap();
+        let graph = build_semantic_graph(&project, &HashMap::new()).unwrap();
+
+        let diags = detect_select_star_blast_radius(&graph, &file_paths);
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0]
+                .suggestion
+                .as_deref()
+                .is_some_and(|s| s.contains("explicit column list")),
+            "suggestion: {:?}",
+            diags[0].suggestion,
+        );
+    }
+}

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::blast_radius;
 use crate::contracts::{self, CompilerContract};
 use crate::diagnostic::{Diagnostic, W011};
 use crate::project::{Project, ProjectError};
@@ -195,9 +196,21 @@ pub fn compile_project(
             })
             .collect();
 
-    // 6. Merge all diagnostics.
+    // 6. Blast-radius lint (P002): warn on `SELECT *` in models that have
+    //    downstream consumers referencing specific columns. Always-on,
+    //    warning severity — non-blocking but visible in both CLI and LSP.
+    let file_paths: HashMap<String, String> = project
+        .models
+        .iter()
+        .map(|m| (m.config.name.clone(), m.file_path.clone()))
+        .collect();
+    let blast_radius_diagnostics =
+        blast_radius::detect_select_star_blast_radius(&semantic_graph, &file_paths);
+
+    // 7. Merge all diagnostics.
     let mut diagnostics = type_check.diagnostics.clone();
     diagnostics.extend(contract_diagnostics.iter().cloned());
+    diagnostics.extend(blast_radius_diagnostics);
 
     let has_errors = diagnostics
         .iter()
@@ -363,8 +376,20 @@ pub fn compile_incremental(
             })
             .collect();
 
+    // Blast-radius lint (P002), mirroring the full-path wiring. The graph
+    // already reflects the new state, so the lint sees post-edit consumer
+    // edges — exactly what the LSP needs to surface live.
+    let file_paths: HashMap<String, String> = project
+        .models
+        .iter()
+        .map(|m| (m.config.name.clone(), m.file_path.clone()))
+        .collect();
+    let blast_radius_diagnostics =
+        blast_radius::detect_select_star_blast_radius(&semantic_graph, &file_paths);
+
     let mut diagnostics = type_check.diagnostics.clone();
     diagnostics.extend(contract_diagnostics.iter().cloned());
+    diagnostics.extend(blast_radius_diagnostics);
 
     let has_errors = diagnostics
         .iter()

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -66,6 +66,15 @@ pub const I001: &str = "I001";
 /// Model compiled with SELECT *.
 pub const I002: &str = "I002";
 
+// Lints — portability + blast-radius
+/// Construct is not portable to the configured target dialect.
+/// Error severity, opt-in via `--target-dialect`. Emitted by the CLI.
+pub const P001: &str = "P001";
+/// `SELECT *` model has downstream consumers that reference specific
+/// columns of its output — a schema change in the star's source would
+/// silently propagate. Warning severity, always-on.
+pub const P002: &str = "P002";
+
 /// Severity level of a diagnostic.
 ///
 /// Serialized in PascalCase (`"Error"`, `"Warning"`, `"Info"`) to stay

--- a/engine/crates/rocky-compiler/src/lib.rs
+++ b/engine/crates/rocky-compiler/src/lib.rs
@@ -8,6 +8,7 @@
 //! 5. **Compilation** — top-level `compile()` entry point
 
 pub mod arena;
+pub mod blast_radius;
 pub mod cache;
 pub mod compile;
 pub mod contracts;

--- a/engine/crates/rocky-sql/src/portability.rs
+++ b/engine/crates/rocky-sql/src/portability.rs
@@ -80,7 +80,9 @@ impl Visitor for PortabilityVisitor {
                     construct: "ILIKE".to_string(),
                     supported_by: vec![Dialect::Snowflake, Dialect::DuckDB, Dialect::Databricks],
                     target: self.target,
-                    suggestion: "use LOWER(lhs) LIKE LOWER(pattern) for portable case-insensitive matching".to_string(),
+                    suggestion:
+                        "use LOWER(lhs) LIKE LOWER(pattern) for portable case-insensitive matching"
+                            .to_string(),
                 });
             }
             _ => {}

--- a/engine/crates/rocky-sql/src/portability.rs
+++ b/engine/crates/rocky-sql/src/portability.rs
@@ -75,15 +75,13 @@ impl Visitor for PortabilityVisitor {
                     self.issues.push(issue);
                 }
             }
-            Expr::ILike { .. } => {
-                if !supports_ilike(self.target) {
-                    self.issues.push(PortabilityIssue {
-                        construct: "ILIKE".to_string(),
-                        supported_by: vec![Dialect::Snowflake, Dialect::DuckDB, Dialect::Databricks],
-                        target: self.target,
-                        suggestion: "use LOWER(lhs) LIKE LOWER(pattern) for portable case-insensitive matching".to_string(),
-                    });
-                }
+            Expr::ILike { .. } if !supports_ilike(self.target) => {
+                self.issues.push(PortabilityIssue {
+                    construct: "ILIKE".to_string(),
+                    supported_by: vec![Dialect::Snowflake, Dialect::DuckDB, Dialect::Databricks],
+                    target: self.target,
+                    suggestion: "use LOWER(lhs) LIKE LOWER(pattern) for portable case-insensitive matching".to_string(),
+                });
             }
             _ => {}
         }

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -15,6 +15,18 @@
       },
       "model": "stg_orders",
       "suggestion": null
+    },
+    {
+      "severity": "Warning",
+      "code": "P002",
+      "message": "SELECT * may silently propagate upstream schema changes to 1 downstream consumer: `fct_revenue` (customer_id, amount)",
+      "span": {
+        "file": "models/stg_orders.rocky",
+        "line": 1,
+        "col": 1
+      },
+      "model": "stg_orders",
+      "suggestion": "replace SELECT * with an explicit column list to make schema dependencies visible"
     }
   ],
   "has_errors": false,

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -19,7 +19,7 @@
     {
       "severity": "Warning",
       "code": "P002",
-      "message": "SELECT * may silently propagate upstream schema changes to 1 downstream consumer: `fct_revenue` (customer_id, amount)",
+      "message": "SELECT * silently propagates upstream schema changes to 1 downstream consumer: `fct_revenue` (customer_id, amount)",
       "span": {
         "file": "models/stg_orders.rocky",
         "line": 1,


### PR DESCRIPTION
## Summary

- Adds always-on, warning-severity **P002** diagnostic emitted when a model uses `SELECT *` AND at least one downstream model references specific columns of its output. Leaf `SELECT *` is intentionally not flagged (the user inspected the result themselves).
- Reuses Arc 6's lint shape (P-prefixed code, `crate::diagnostic::P002` const) and the existing `SemanticGraph::column_consumers` index — no new parser or type-inference machinery for this wave.
- Wires into `rocky-compiler::compile_project` (and the incremental path) so both `rocky compile` and the LSP per-keystroke loop surface P002 without any opt-in flag.

## Trust outcome

Trust-system Arc 7 is "SQL as first-class with types." Wave 1 ships the **blast-radius-aware** linter the arc description promises: when a model M does `SELECT * FROM upstream` and a downstream model D references specific columns of M, an upstream schema change at `upstream` silently propagates through M's star into D's reference scope. The diagnostic names exactly which downstream consumers reference which of M's columns (capped at 3 per consumer for legibility), with an actionable suggestion to switch to an explicit column list.

## What's deferred to wave 2

Per the trust-direction plan, Arc 7 wave 2 unlocks the heavier work:

- **Type inference over raw `.sql` models** so they hold typed DAG membership equal to `.rocky` models. Sharpens P002's notion of "typed upstream" beyond the semantic-graph `has_star` heuristic.
- **DAG-aware SQL refactoring** (rename column across dependents).
- **`[lints]` block in `rocky.toml`** + per-model `-- rocky-allow: select-star` pragma, mirroring Arc 6's deferred portability config.
- Sharper source spans (per-construct byte offsets) — same wave-2 line item Arc 6 deferred.

## Test plan

- [x] 8 unit tests in `blast_radius::tests` cover the matrix: explicit downstream consumer, leaf, no star, typed external source, untyped external source, multi-downstream aggregation, column-list truncation, suggestion shape.
- [x] `cargo test --workspace` — full engine suite passes (no regressions from making P002 always-on).
- [x] `pytest` in `integrations/dagster/` — all 307 tests pass; fixtures unaffected (playground default POC has no `SELECT *`).
- [x] `cargo fmt --check` + `cargo clippy -p rocky-compiler -p rocky-cli --all-targets -- -D warnings`.
- [x] Eyeballed CLI text mode (`rocky compile --output table`) against a 3-model temp project — miette renders the P002 warning with source-span underline and `help:` line; final summary correctly reads `0 errors, 1 warnings`.
- [x] Eyeballed CLI JSON mode — P002 surfaces in the existing `diagnostics[]` array, no schema change.
- [x] Verified `just codegen` produces no schema or generated-binding drift (P002 is just another diagnostic code string in the existing wire shape).