### PR TITLE
feat(engine): Trust-system Arc 6 (wave 2) — [portability] config + per-model pragma

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -556,6 +556,16 @@
       ],
       "type": "object"
     },
+    "Dialect": {
+      "description": "Target dialect for transpilation.\n\nSerializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.",
+      "enum": [
+        "databricks",
+        "snowflake",
+        "bigquery",
+        "duckdb"
+      ],
+      "type": "string"
+    },
     "DiscoveryConfig": {
       "additionalProperties": false,
       "description": "Discovery configuration within a pipeline source.",
@@ -1281,6 +1291,33 @@
         }
       ],
       "description": "Schema-only helper mirroring [`AdaptersFieldSchema`] for `[pipeline.*]`.\n\nThe flat-pipeline shorthand exists in [`normalize_toml_shorthands`] but is unused across all committed POCs; including it in the schema is defensive — a user typing `[pipeline] source = ...` shouldn't see a false IDE error. The pipeline payload references [`PipelineConfig`] directly, whose hand-written `JsonSchema` impl emits an `anyOf` of the five pipeline variants."
+    },
+    "PortabilityConfig": {
+      "additionalProperties": false,
+      "description": "Project-wide dialect portability configuration.\n\nLives at the top level because a Rocky project targets one warehouse; per-pipeline overrides aren't supported yet (no demand signal). The `allow` list applies to every model — a per-model override is the `-- rocky-allow: <constructs>` pragma in the model SQL itself, parsed by [`rocky_sql::pragma`].",
+      "properties": {
+        "allow": {
+          "default": [],
+          "description": "Project-wide allow-list of construct labels (case-insensitive, matched against `PortabilityIssue::construct`). Useful for blanket exemptions like `allow = [\"QUALIFY\"]` when a project standardizes on a specific extension. For per-model exemptions prefer the `-- rocky-allow: <construct>` pragma over expanding this list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "target_dialect": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dialect"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target dialect for the portability lint. When unset, no lint runs (matches the wave-1 \"flag opt-in\" behavior). The CLI flag overrides this if both are present."
+        }
+      },
+      "type": "object"
     },
     "QualityAssertion": {
       "description": "A single row-level assertion attached to a quality pipeline, scoped to one table in the pipeline's `tables` list.\n\n```toml [[pipeline.nightly_dq.checks.assertions]] name     = \"orders_customer_id_not_null\"  # optional table    = \"orders\" type     = \"not_null\" column   = \"customer_id\" severity = \"error\" ```\n\nThe `type`-specific fields (and `column`, `severity`) are flattened from `TestDecl` — the same surface used by declarative model tests.",
@@ -2523,6 +2560,18 @@
       ],
       "default": {},
       "description": "Named pipeline configurations (keyed by pipeline name)."
+    },
+    "portability": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PortabilityConfig"
+        }
+      ],
+      "default": {
+        "allow": [],
+        "target_dialect": null
+      },
+      "description": "Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`]."
     },
     "retry": {
       "anyOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -263,6 +263,12 @@ export type BindingType = "READ_WRITE" | "READ_ONLY";
  */
 export type LoadFileFormat = "csv" | "parquet" | "json_lines";
 /**
+ * Target dialect for transpilation.
+ *
+ * Serializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.
+ */
+export type Dialect = "databricks" | "snowflake" | "bigquery" | "duckdb";
+/**
  * State storage backend variants.
  */
 export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
@@ -295,6 +301,10 @@ export interface RockyConfig {
    * Named pipeline configurations (keyed by pipeline name).
    */
   pipeline?: PipelinesFieldSchema;
+  /**
+   * Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`].
+   */
+  portability?: PortabilityConfig;
   /**
    * Run-level retry budget shared across every adapter for this run.
    *
@@ -1091,6 +1101,21 @@ export interface LoadTargetConfig {
    * Optional explicit table name. When omitted, derives from the file name (e.g., `orders.csv` -> table `orders`).
    */
   table?: string | null;
+}
+/**
+ * Project-wide dialect portability configuration.
+ *
+ * Lives at the top level because a Rocky project targets one warehouse; per-pipeline overrides aren't supported yet (no demand signal). The `allow` list applies to every model — a per-model override is the `-- rocky-allow: <constructs>` pragma in the model SQL itself, parsed by [`rocky_sql::pragma`].
+ */
+export interface PortabilityConfig {
+  /**
+   * Project-wide allow-list of construct labels (case-insensitive, matched against `PortabilityIssue::construct`). Useful for blanket exemptions like `allow = ["QUALIFY"]` when a project standardizes on a specific extension. For per-model exemptions prefer the `-- rocky-allow: <construct>` pragma over expanding this list.
+   */
+  allow?: string[];
+  /**
+   * Target dialect for the portability lint. When unset, no lint runs (matches the wave-1 "flag opt-in" behavior). The CLI flag overrides this if both are present.
+   */
+  target_dialect?: Dialect | null;
 }
 /**
  * Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3632,6 +3632,7 @@ version = "1.10.0"
 dependencies = [
  "miette",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "sqlparser",

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -8,14 +8,17 @@ use anyhow::Result;
 use rocky_compiler::compile::{self, CompilerConfig};
 use rocky_compiler::diagnostic::{self, Diagnostic, Severity};
 use rocky_compiler::incrementality;
+use rocky_core::config as rocky_config;
 use rocky_core::macros::{expand_macros, load_macros_from_dir};
 use rocky_sql::portability::{self, PortabilityIssue};
+use rocky_sql::pragma;
 use rocky_sql::transpile::Dialect;
 
 use crate::output::{CompileOutput, CostHint, ModelDetail, print_json};
 
 /// Execute `rocky compile`.
 pub fn run_compile(
+    config_path: Option<&Path>,
     models_dir: &Path,
     contracts_dir: Option<&Path>,
     model_filter: Option<&str>,
@@ -32,13 +35,36 @@ pub fn run_compile(
 
     let mut result = compile::compile(&config)?;
 
-    // Portability lint. Opt-in via `--target-dialect`. Emits error-severity
-    // P001 diagnostics for constructs that don't run on the chosen target;
-    // the catalog mirrors what `rocky_sql::transpile` already knows about.
-    if let Some(dialect) = target_dialect {
+    // Portability lint. Effective target_dialect = CLI flag > [portability]
+    // config > unset. Project-wide allow list and per-model `-- rocky-allow:`
+    // pragmas suppress matching constructs before they become diagnostics.
+    let portability_cfg = match config_path {
+        Some(path) => rocky_config::load_rocky_config(path)
+            .ok()
+            .map(|c| c.portability),
+        None => None,
+    };
+    let effective_dialect =
+        target_dialect.or_else(|| portability_cfg.as_ref().and_then(|p| p.target_dialect));
+    let project_allow: std::collections::HashSet<String> = portability_cfg
+        .as_ref()
+        .map(|p| {
+            p.allow
+                .iter()
+                .map(|c| c.trim().to_ascii_uppercase())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let Some(dialect) = effective_dialect {
         let mut portability_errors = false;
         for model in &result.project.models {
+            let model_pragmas = pragma::parse_pragmas(&model.sql);
             for issue in portability::detect_portability_issues(&model.sql, dialect) {
+                let upper = issue.construct.to_ascii_uppercase();
+                if project_allow.contains(&upper) || model_pragmas.allows(&upper) {
+                    continue;
+                }
                 result.diagnostics.push(build_p001_diagnostic(
                     &model.config.name,
                     &model.file_path,
@@ -282,6 +308,39 @@ mod tests {
         .unwrap();
     }
 
+    /// Write a minimal `rocky.toml` next to a models dir, with optional
+    /// `[portability]` section content. Returns the path so tests can pass
+    /// it as the new `config_path` argument. Uses the shape committed in
+    /// `examples/playground/pocs/00-foundations/00-playground-default/rocky.toml`.
+    fn write_rocky_toml(dir: &Path, portability_block: &str) -> std::path::PathBuf {
+        let path = dir.join("rocky.toml");
+        let body = format!(
+            r#"[adapter]
+type = "duckdb"
+path = ":memory:"
+
+[pipeline.p]
+strategy = "full_refresh"
+
+[pipeline.p.source.discovery]
+adapter = "default"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "c"
+schema_template = "s"
+
+{portability_block}
+"#
+        );
+        fs::write(&path, body).unwrap();
+        path
+    }
+
     #[test]
     fn build_p001_has_error_severity_and_code() {
         let issue = PortabilityIssue {
@@ -309,6 +368,7 @@ mod tests {
         // With target_dialect = BigQuery, NVL should trigger P001 and the
         // compile should bail with the generic "compilation failed" error.
         let err = run_compile(
+            None,
             &models_dir,
             None,
             None,
@@ -331,7 +391,7 @@ mod tests {
         write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
 
         // No target_dialect → no P001, compile succeeds.
-        run_compile(&models_dir, None, None, true, false, None)
+        run_compile(None, &models_dir, None, None, true, false, None)
             .expect("compile should succeed without lint");
     }
 
@@ -344,6 +404,7 @@ mod tests {
 
         // NVL is native to Snowflake, so the lint should produce no issues.
         run_compile(
+            None,
             &models_dir,
             None,
             None,
@@ -352,5 +413,126 @@ mod tests {
             Some(Dialect::Snowflake),
         )
         .expect("snowflake target should accept NVL");
+    }
+
+    // ---- Wave 2: [portability] block + pragma ----
+
+    #[test]
+    fn config_target_dialect_drives_lint_when_no_flag() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
+        let config = write_rocky_toml(dir.path(), "[portability]\ntarget_dialect = \"bigquery\"\n");
+
+        let err =
+            run_compile(Some(&config), &models_dir, None, None, true, false, None).unwrap_err();
+        assert!(
+            err.to_string().contains("compilation failed"),
+            "config target_dialect should fire P001: {err}",
+        );
+    }
+
+    #[test]
+    fn flag_overrides_config_target_dialect() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
+        // Config says snowflake (NVL native), flag overrides to bigquery
+        // (NVL not portable). The flag must win and the lint must fire.
+        let config = write_rocky_toml(
+            dir.path(),
+            "[portability]\ntarget_dialect = \"snowflake\"\n",
+        );
+
+        let err = run_compile(
+            Some(&config),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            Some(Dialect::BigQuery),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("compilation failed"));
+    }
+
+    #[test]
+    fn config_allow_list_suppresses_p001() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
+        let config = write_rocky_toml(
+            dir.path(),
+            "[portability]\ntarget_dialect = \"bigquery\"\nallow = [\"NVL\"]\n",
+        );
+
+        // Project-wide allow-list of NVL → no P001 → compile succeeds.
+        run_compile(Some(&config), &models_dir, None, None, true, false, None)
+            .expect("allow-listed NVL should not trip the lint");
+    }
+
+    #[test]
+    fn per_model_pragma_suppresses_p001() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(
+            &models_dir,
+            "m1",
+            "-- rocky-allow: NVL\nSELECT NVL(a, b) AS c FROM t",
+        );
+        let config = write_rocky_toml(dir.path(), "[portability]\ntarget_dialect = \"bigquery\"\n");
+
+        // Pragma exempts this model, so the lint should not fire.
+        run_compile(Some(&config), &models_dir, None, None, true, false, None)
+            .expect("pragma-exempted model should not trip the lint");
+    }
+
+    #[test]
+    fn pragma_is_per_model_not_project_wide() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        // m1 has the pragma; m2 does not. m2 should still trip the lint.
+        write_model(
+            &models_dir,
+            "m1",
+            "-- rocky-allow: NVL\nSELECT NVL(a, b) AS c FROM t",
+        );
+        write_model(&models_dir, "m2", "SELECT NVL(d, e) AS f FROM t");
+        let config = write_rocky_toml(dir.path(), "[portability]\ntarget_dialect = \"bigquery\"\n");
+
+        let err =
+            run_compile(Some(&config), &models_dir, None, None, true, false, None).unwrap_err();
+        assert!(
+            err.to_string().contains("compilation failed"),
+            "m2 should still trip the lint: {err}",
+        );
+    }
+
+    #[test]
+    fn missing_config_file_falls_through_to_flag_only() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
+        let nonexistent = dir.path().join("nope.toml");
+
+        // Config file doesn't exist → portability config silently None →
+        // flag-only behavior remains. With no flag, no lint fires.
+        run_compile(
+            Some(&nonexistent),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+        )
+        .expect("missing config should fall through, not error");
     }
 }

--- a/engine/crates/rocky-cli/src/commands/watch.rs
+++ b/engine/crates/rocky-cli/src/commands/watch.rs
@@ -100,7 +100,15 @@ pub async fn run_watch(
 /// Run compile and print the result. Errors are printed, not propagated,
 /// so the watch loop continues after a failed compilation.
 fn print_compile_result(models_dir: &Path, contracts_dir: Option<&Path>, output_json: bool) {
-    match run_compile(models_dir, contracts_dir, None, output_json, false, None) {
+    match run_compile(
+        None,
+        models_dir,
+        contracts_dir,
+        None,
+        output_json,
+        false,
+        None,
+    ) {
         Ok(()) => {
             if !output_json {
                 println!("[watch] compilation succeeded");

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -305,6 +305,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1336,6 +1336,38 @@ pub struct RockyConfig {
     /// when adapters have wildly different rate limits.
     #[serde(default)]
     pub retry: Option<RunRetryConfig>,
+
+    /// Dialect-portability lint configuration. Consumed by `rocky compile`
+    /// to drive P001 (and, when wired, future) diagnostics. The CLI's
+    /// `--target-dialect` flag, when set, takes precedence over
+    /// [`PortabilityConfig::target_dialect`].
+    #[serde(default)]
+    pub portability: PortabilityConfig,
+}
+
+/// Project-wide dialect portability configuration.
+///
+/// Lives at the top level because a Rocky project targets one warehouse;
+/// per-pipeline overrides aren't supported yet (no demand signal). The
+/// `allow` list applies to every model — a per-model override is the
+/// `-- rocky-allow: <constructs>` pragma in the model SQL itself, parsed
+/// by [`rocky_sql::pragma`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PortabilityConfig {
+    /// Target dialect for the portability lint. When unset, no lint runs
+    /// (matches the wave-1 "flag opt-in" behavior). The CLI flag overrides
+    /// this if both are present.
+    #[serde(default)]
+    pub target_dialect: Option<rocky_sql::transpile::Dialect>,
+
+    /// Project-wide allow-list of construct labels (case-insensitive,
+    /// matched against `PortabilityIssue::construct`). Useful for blanket
+    /// exemptions like `allow = ["QUALIFY"]` when a project standardizes on
+    /// a specific extension. For per-model exemptions prefer the
+    /// `-- rocky-allow: <construct>` pragma over expanding this list.
+    #[serde(default)]
+    pub allow: Vec<String>,
 }
 
 /// Top-level retry configuration applied across every adapter for this

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -573,6 +573,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -709,6 +709,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         };
 
         let models = vec![
@@ -779,6 +780,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         };
 
         let models = vec![Model {
@@ -845,6 +847,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None);

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -925,6 +925,7 @@ mod tests {
             budget: Default::default(),
             schema_evolution: Default::default(),
             retry: None,
+            portability: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 regex = { workspace = true }
 
 [lints]

--- a/engine/crates/rocky-sql/src/lib.rs
+++ b/engine/crates/rocky-sql/src/lib.rs
@@ -2,5 +2,6 @@ pub mod dialect;
 pub mod lineage;
 pub mod parser;
 pub mod portability;
+pub mod pragma;
 pub mod transpile;
 pub mod validation;

--- a/engine/crates/rocky-sql/src/pragma.rs
+++ b/engine/crates/rocky-sql/src/pragma.rs
@@ -1,0 +1,186 @@
+//! Per-model linting pragmas embedded in SQL line comments.
+//!
+//! Models can opt out of specific lint constructs by adding a `rocky-allow`
+//! pragma to their SQL body, anywhere on a line that begins with `--`:
+//!
+//! ```sql
+//! -- rocky-allow: NVL, QUALIFY
+//! SELECT NVL(a, b) FROM t QUALIFY ROW_NUMBER() OVER (...) = 1
+//! ```
+//!
+//! Construct names are case-insensitive identifiers matched against the
+//! lint emitter's own labels (e.g. `PortabilityIssue::construct`). The
+//! parser is dialect-independent and intentionally permissive: any pragma
+//! it doesn't recognize is silently ignored, so future lint codes can
+//! introduce new pragma names without breaking existing models.
+//!
+//! Wave 1 ships only `rocky-allow` (used to suppress P001 portability
+//! diagnostics). The same parser will back a future `[lints]`-block driven
+//! per-model toggle for P002 — see `project_rocky_active_priority` Arc 7
+//! wave 2 backlog.
+
+use std::collections::HashSet;
+
+/// Set of lint construct labels a single model has opted out of.
+///
+/// Labels are upper-cased on insert so callers can compare against the
+/// canonical construct names emitted by the lint side
+/// (`PortabilityIssue::construct` is uppercase).
+#[derive(Debug, Clone, Default)]
+pub struct ModelPragmas {
+    allowed_constructs: HashSet<String>,
+}
+
+impl ModelPragmas {
+    /// Build an empty pragma set (no opt-outs).
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// True if `construct` (case-insensitive) was listed in any
+    /// `-- rocky-allow:` pragma in the model's SQL.
+    pub fn allows(&self, construct: &str) -> bool {
+        self.allowed_constructs
+            .contains(&construct.to_ascii_uppercase())
+    }
+
+    /// Borrow the underlying allow set (already upper-cased).
+    pub fn allowed_constructs(&self) -> &HashSet<String> {
+        &self.allowed_constructs
+    }
+
+    /// Insert a construct label into the allow set. Internal use; tests
+    /// and the project-level allow merge use this directly to avoid
+    /// rebuilding through the SQL scanner.
+    pub fn insert(&mut self, construct: impl AsRef<str>) {
+        self.allowed_constructs
+            .insert(construct.as_ref().trim().to_ascii_uppercase());
+    }
+}
+
+/// Scan a SQL body for all `-- rocky-allow:` pragmas and collect the
+/// allowed constructs into a [`ModelPragmas`] set.
+///
+/// The scanner is line-based and only inspects line comments (`--`); block
+/// comments and string literals are not parsed because the pragma syntax
+/// is conventionally placed on its own header line above the SQL body.
+/// Multiple pragmas in the same model accumulate.
+pub fn parse_pragmas(sql: &str) -> ModelPragmas {
+    let mut pragmas = ModelPragmas::empty();
+    for line in sql.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("--") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(payload) = rest
+            .strip_prefix("rocky-allow:")
+            .or_else(|| rest.strip_prefix("rocky-allow :"))
+            .or_else(|| {
+                rest.strip_prefix("ROCKY-ALLOW:")
+                    .or_else(|| rest.strip_prefix("ROCKY-ALLOW :"))
+            })
+        else {
+            continue;
+        };
+        for token in payload.split(',') {
+            let cleaned = token.trim();
+            if !cleaned.is_empty() {
+                pragmas.insert(cleaned);
+            }
+        }
+    }
+    pragmas
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_sql_has_no_pragmas() {
+        let p = parse_pragmas("SELECT 1");
+        assert!(p.allowed_constructs().is_empty());
+    }
+
+    #[test]
+    fn parses_single_construct() {
+        let p = parse_pragmas("-- rocky-allow: NVL\nSELECT NVL(a, b) FROM t");
+        assert!(p.allows("NVL"));
+        assert!(!p.allows("QUALIFY"));
+    }
+
+    #[test]
+    fn parses_comma_separated_list() {
+        let p = parse_pragmas("-- rocky-allow: NVL, QUALIFY, ILIKE\nSELECT 1");
+        assert!(p.allows("NVL"));
+        assert!(p.allows("QUALIFY"));
+        assert!(p.allows("ILIKE"));
+        assert!(!p.allows("DATE_ADD"));
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        let p = parse_pragmas("-- rocky-allow: nvl, Qualify\nSELECT 1");
+        assert!(p.allows("NVL"));
+        assert!(p.allows("nvl"));
+        assert!(p.allows("QUALIFY"));
+        assert!(p.allows("qualify"));
+    }
+
+    #[test]
+    fn multiple_pragmas_accumulate() {
+        let p =
+            parse_pragmas("-- rocky-allow: NVL\n-- rocky-allow: QUALIFY\nSELECT NVL(a, b) FROM t");
+        assert!(p.allows("NVL"));
+        assert!(p.allows("QUALIFY"));
+    }
+
+    #[test]
+    fn ignores_unrelated_comments() {
+        let p = parse_pragmas("-- this is just a comment\n-- TODO: refactor\nSELECT 1");
+        assert!(p.allowed_constructs().is_empty());
+    }
+
+    #[test]
+    fn allows_indentation_before_dashes() {
+        let p = parse_pragmas("    -- rocky-allow: NVL\n  SELECT 1");
+        assert!(p.allows("NVL"));
+    }
+
+    #[test]
+    fn handles_uppercase_pragma_keyword() {
+        let p = parse_pragmas("-- ROCKY-ALLOW: NVL\nSELECT 1");
+        assert!(p.allows("NVL"));
+    }
+
+    #[test]
+    fn skips_empty_tokens_in_list() {
+        let p = parse_pragmas("-- rocky-allow: NVL,, QUALIFY,\nSELECT 1");
+        assert!(p.allows("NVL"));
+        assert!(p.allows("QUALIFY"));
+        assert_eq!(p.allowed_constructs().len(), 2);
+    }
+
+    #[test]
+    fn ignores_pragma_without_colon() {
+        // The colon is the discriminator — without it, this is an ordinary
+        // comment that happens to mention the keyword, not a directive.
+        let p = parse_pragmas("-- rocky-allow NVL\nSELECT 1");
+        assert!(!p.allows("NVL"));
+    }
+
+    #[test]
+    fn ignores_pragma_inside_string_literal() {
+        // Pragma scanning is line-comment-only, so a string literal that
+        // happens to contain the pragma syntax is correctly ignored.
+        let p = parse_pragmas("SELECT '-- rocky-allow: NVL' AS msg FROM t");
+        assert!(!p.allows("NVL"));
+    }
+
+    #[test]
+    fn empty_pragma_with_no_constructs_is_noop() {
+        let p = parse_pragmas("-- rocky-allow:\nSELECT 1");
+        assert!(p.allowed_constructs().is_empty());
+    }
+}

--- a/engine/crates/rocky-sql/src/transpile.rs
+++ b/engine/crates/rocky-sql/src/transpile.rs
@@ -15,7 +15,24 @@
 //! be written natively.
 
 /// Target dialect for transpilation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so
+/// the long-form names can sit in `rocky.toml` under the `[portability]`
+/// block without translation. The CLI's short-form flag values
+/// (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the
+/// `TargetDialect` clap enum and convert to this type at the boundary.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
 pub enum Dialect {
     Databricks,
     Snowflake,

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1089,6 +1089,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             expand_macros,
             target_dialect,
         } => rocky_cli::commands::run_compile(
+            Some(cli.config.as_path()),
             &models,
             contracts.as_deref(),
             model.as_deref(),

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -178,6 +178,19 @@ class CostSection(BaseModel):
     """
 
 
+class Dialect(StrEnum):
+    """
+    Target dialect for transpilation.
+
+    Serializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.
+    """
+
+    databricks = "databricks"
+    snowflake = "snowflake"
+    bigquery = "bigquery"
+    duckdb = "duckdb"
+
+
 class DiscoveryConfig(BaseModel):
     """
     Discovery configuration within a pipeline source.
@@ -362,6 +375,26 @@ class Type17(StrEnum):
 
 class Type18(StrEnum):
     load = "load"
+
+
+class PortabilityConfig(BaseModel):
+    """
+    Project-wide dialect portability configuration.
+
+    Lives at the top level because a Rocky project targets one warehouse; per-pipeline overrides aren't supported yet (no demand signal). The `allow` list applies to every model — a per-model override is the `-- rocky-allow: <constructs>` pragma in the model SQL itself, parsed by [`rocky_sql::pragma`].
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    allow: list[str] | None = []
+    """
+    Project-wide allow-list of construct labels (case-insensitive, matched against `PortabilityIssue::construct`). Useful for blanket exemptions like `allow = ["QUALIFY"]` when a project standardizes on a specific extension. For per-model exemptions prefer the `-- rocky-allow: <construct>` pragma over expanding this list.
+    """
+    target_dialect: Dialect | None = None
+    """
+    Target dialect for the portability lint. When unset, no lint runs (matches the wave-1 "flag opt-in" behavior). The CLI flag overrides this if both are present.
+    """
 
 
 class Type19(StrEnum):
@@ -2097,6 +2130,12 @@ class RockyConfig(BaseModel):
     ) = Field({}, validate_default=True)
     """
     Named pipeline configurations (keyed by pipeline name).
+    """
+    portability: PortabilityConfig | None = Field(
+        {"allow": [], "target_dialect": None}, validate_default=True
+    )
+    """
+    Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`].
     """
     retry: RunRetryConfig | None = None
     """

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -555,6 +555,16 @@
       ],
       "type": "object"
     },
+    "Dialect": {
+      "description": "Target dialect for transpilation.\n\nSerializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.",
+      "enum": [
+        "databricks",
+        "snowflake",
+        "bigquery",
+        "duckdb"
+      ],
+      "type": "string"
+    },
     "DiscoveryConfig": {
       "additionalProperties": false,
       "description": "Discovery configuration within a pipeline source.",
@@ -1280,6 +1290,33 @@
         }
       ],
       "description": "Schema-only helper mirroring [`AdaptersFieldSchema`] for `[pipeline.*]`.\n\nThe flat-pipeline shorthand exists in [`normalize_toml_shorthands`] but is unused across all committed POCs; including it in the schema is defensive — a user typing `[pipeline] source = ...` shouldn't see a false IDE error. The pipeline payload references [`PipelineConfig`] directly, whose hand-written `JsonSchema` impl emits an `anyOf` of the five pipeline variants."
+    },
+    "PortabilityConfig": {
+      "additionalProperties": false,
+      "description": "Project-wide dialect portability configuration.\n\nLives at the top level because a Rocky project targets one warehouse; per-pipeline overrides aren't supported yet (no demand signal). The `allow` list applies to every model — a per-model override is the `-- rocky-allow: <constructs>` pragma in the model SQL itself, parsed by [`rocky_sql::pragma`].",
+      "properties": {
+        "allow": {
+          "default": [],
+          "description": "Project-wide allow-list of construct labels (case-insensitive, matched against `PortabilityIssue::construct`). Useful for blanket exemptions like `allow = [\"QUALIFY\"]` when a project standardizes on a specific extension. For per-model exemptions prefer the `-- rocky-allow: <construct>` pragma over expanding this list.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "target_dialect": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Dialect"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Target dialect for the portability lint. When unset, no lint runs (matches the wave-1 \"flag opt-in\" behavior). The CLI flag overrides this if both are present."
+        }
+      },
+      "type": "object"
     },
     "QualityAssertion": {
       "description": "A single row-level assertion attached to a quality pipeline, scoped to one table in the pipeline's `tables` list.\n\n```toml [[pipeline.nightly_dq.checks.assertions]] name     = \"orders_customer_id_not_null\"  # optional table    = \"orders\" type     = \"not_null\" column   = \"customer_id\" severity = \"error\" ```\n\nThe `type`-specific fields (and `column`, `severity`) are flattened from `TestDecl` — the same surface used by declarative model tests.",
@@ -2522,6 +2559,18 @@
       ],
       "default": {},
       "description": "Named pipeline configurations (keyed by pipeline name)."
+    },
+    "portability": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PortabilityConfig"
+        }
+      ],
+      "default": {
+        "allow": [],
+        "target_dialect": null
+      },
+      "description": "Dialect-portability lint configuration. Consumed by `rocky compile` to drive P001 (and, when wired, future) diagnostics. The CLI's `--target-dialect` flag, when set, takes precedence over [`PortabilityConfig::target_dialect`]."
     },
     "retry": {
       "anyOf": [


### PR DESCRIPTION
## Summary

- New `[portability]` block in `rocky.toml` with `target_dialect` + `allow` list, replacing the wave-1 flag-only UX with project-level configuration.
- Per-model SQL pragma `-- rocky-allow: NVL, QUALIFY` (case-insensitive, comma-separated) for targeted exemptions.
- Generic pragma parser in new `rocky-sql/src/pragma.rs` so a future `[lints]` block for P002 reuses it.
- `Dialect` enum now `Serialize/Deserialize/JsonSchema` (lowercase variants) so `target_dialect = "bigquery"` parses naturally from TOML.

## Precedence

1. CLI `--target-dialect` flag (highest — useful for CI matrix runs / debugging)
2. `[portability] target_dialect` in `rocky.toml`
3. Unset → no lint runs (matches wave-1 default)

Allow-listing composes additively: project-wide `[portability] allow = [...]` ∪ per-model `-- rocky-allow:` pragma. Either suppresses the matching construct's P001 diagnostic before it hits the diagnostics vec.

## What's deferred to wave 3

- Sharper source spans (per-construct byte offsets) — same wave-3 line item Arc 6 wave 1 deferred.
- Lint on expanded SQL when `--expand-macros` is set.
- `[lints]` block driving per-model P002 toggles (lives in Arc 7's roadmap because it pairs with type-inference work).

## Test plan

- [x] `cargo test --workspace` — full engine suite, all crates, 0 failures.
- [x] 12 unit tests in `pragma::tests` covering single/multi/case/indent/uppercase/string-literal/edge cases.
- [x] 6 new integration tests in `commands::compile::tests`: config-only, flag-overrides-config, project allow-list suppresses, per-model pragma suppresses, pragma-is-per-model-not-project-wide, missing-config falls through. Plus the 4 wave-1 tests still pass with the new signature.
- [x] `pytest` in `integrations/dagster/` — 307/307 pass; fixtures unchanged because the playground default doesn't opt into portability config.
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `just codegen` — rocky-project.schema.json, dagster Pydantic, vscode TS all regenerated and committed (`portability` block now in the schema).
- [x] End-to-end CLI smoke test: 2-model project where m1's NVL fires P001 (project allow has QUALIFY but not NVL) and m2's NVL is suppressed by `-- rocky-allow: NVL` pragma. Compile bails with exactly 1 error on m1.