### PR TITLE
docs: cover trust-system arcs 1–7 (engine v1.11.0)

### DIFF
--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -135,6 +135,7 @@ Observability infrastructure.
 - **metrics.rs** — In-process metrics collection: counters (tables processed/failed, statements executed, retries, anomalies) and duration histograms (p50/p95/max for tables and queries). Thread-safe via atomics, serialized to JSON in run output.
 - **tracing.rs** — Structured JSON logging via the `tracing` crate
 - **events.rs** — Event broadcasting over Valkey Pub/Sub for real-time monitoring
+- **otel.rs** — Feature-gated OpenTelemetry exporter. When the engine is built with `--features otel`, `rocky run` exports in-process metrics as OTLP via an `OtelGuard` RAII handle. Send metrics to any OTLP-compatible collector (Honeycomb, Datadog, Grafana Tempo, Prometheus via the OTel collector) without bespoke integration code.
 
 ### rocky-lang
 

--- a/docs/src/content/docs/concepts/hooks.md
+++ b/docs/src/content/docs/concepts/hooks.md
@@ -53,6 +53,21 @@ Events are organized into five phases:
 |-------|------|----------|
 | `state_synced` | State store synced | Backup confirmation |
 
+### Budget phase
+
+| Event | When | Use case |
+|-------|------|----------|
+| `budget_breach` | Observed run cost or duration exceeds a limit declared in [`[budget]`](/reference/configuration/#budget) | Page oncall on overspend; gate downstream runs on `on_breach = "error"` |
+
+### Adapter resilience phase
+
+| Event | When | Use case |
+|-------|------|----------|
+| `circuit_breaker_tripped` | Adapter circuit breaker moves `Closed → Open` after consecutive transient failures | Mute retries; notify oncall that a warehouse endpoint is unhealthy |
+| `circuit_breaker_recovered` | Half-open trial request succeeds and the breaker closes | Clear the alert; record recovery latency |
+
+Circuit-breaker behaviour is configured per-adapter via [`[adapter.NAME.retry]`](/reference/configuration/#adapternameretry) — `circuit_breaker_threshold` sets the failure count that trips it, and `circuit_breaker_recovery_timeout_secs` enables timed auto-recovery through the half-open state.
+
 ## Shell hooks
 
 Shell hooks execute a command and pipe the event context as JSON to stdin:

--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -52,6 +52,16 @@ Partition-keyed materialization with:
 - **SELECT * expansion** with deduplication
 - **Parallel type checking** via rayon across DAG execution layers
 - **Data contracts** with required columns, protected columns (prevent removal), allowed type changes (widening whitelist), and nullability constraints
+- **Seeded type inference**: `rocky compile --with-seed` runs `data/seed.sql` through an in-memory DuckDB so leaf `.sql` models pick up real source types instead of `Unknown`
+
+## Linters
+
+- **P001 dialect portability** — opt-in lint rejecting SQL that won't run on the chosen target (`databricks` / `snowflake` / `bigquery` / `duckdb`). Catches `NVL`, `DATEADD`, `QUALIFY`, `ILIKE`, `FLATTEN`, and friends.
+- **P002 blast-radius `SELECT *`** — always-on warning when a model uses `SELECT *` AND a downstream model references specific columns of its output. Leaf-model `SELECT *` is intentionally not flagged.
+- **Project-wide allow list** (`[portability] allow = [...]`) for blanket exemptions.
+- **Per-model `-- rocky-allow: CONSTRUCT, OTHER` pragma** for targeted opt-outs.
+
+Full reference: [Linters](/features/linters/).
 
 ## Column-Level Lineage
 
@@ -128,10 +138,10 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 ## CLI Commands (38+)
 
 ### Core Pipeline
-`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state`
+`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch`
 
 ### Modeling & Compilation
-`compile` · `lineage` · `test` · `ci` · `export-schemas`
+`compile` · `lineage` · `test` · `ci` · `ci-diff` · `export-schemas`
 
 ### AI
 `ai` (generate) · `ai-sync` · `ai-explain` · `ai-test`
@@ -140,7 +150,17 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 `playground` · `serve` · `lsp` · `init-adapter` · `test-adapter` · `import-dbt` · `validate-migration`
 
 ### Administration
-`doctor` · `history` · `metrics` · `optimize` · `compact` · `profile-storage` · `archive` · `bench` · `hooks list` · `hooks test`
+`doctor` · `history` · `replay` · `trace` · `metrics` · `optimize` · `compact` · `profile-storage` · `archive` · `bench` · `hooks list` · `hooks test`
+
+## Observability
+
+- **15-event hook lifecycle** — pipeline / discover / compile / per-model / per-table / checks / drift / anomaly / state-sync events fire through the hook registry. See [Hooks](/concepts/hooks/).
+- **`rocky trace <run_id|latest>`** — Gantt-style timeline of a completed run with concurrency lanes, rendered from the state-store `RunRecord`.
+- **`rocky replay <run_id|latest>`** — flat per-model dump of SQL hashes, row counts, bytes, and timings captured at execution time.
+- **Timed half-open circuit breaker** — three-state (`Closed` / `Open` / `HalfOpen`) breaker shared across Databricks + Snowflake adapters. Fires `circuit_breaker_tripped` / `circuit_breaker_recovered` events.
+- **OTLP metrics export** (feature-gated via `--features otel`) — `rocky run` exports in-process counters and histograms to any OTLP-compatible collector.
+- **Run-level budgets** — `[budget] max_usd` + `max_duration_ms` with `on_breach = "warn" | "error"`; fires `budget_breach` events. See [`[budget]`](/reference/configuration/#budget).
+- **Per-run cost attribution** — `RunOutput.cost_summary` carries per-run total cost; per-materialization `cost_usd` flows through `MaterializationMetadata`.
 
 ## IDE / Language Server (11 capabilities)
 

--- a/docs/src/content/docs/features/linters.md
+++ b/docs/src/content/docs/features/linters.md
@@ -1,0 +1,166 @@
+---
+title: Linters
+description: P001 dialect-portability lint and P002 blast-radius SELECT * lint, plus the -- rocky-allow pragma for targeted exemptions.
+sidebar:
+  order: 7
+---
+
+Rocky ships two built-in lints that catch the two most common silent-breakage classes in SQL projects: SQL that only runs on one warehouse dialect, and `SELECT *` expressions whose schema is actually consumed downstream. Both lints run as part of `rocky compile` (and surface as LSP diagnostics in the VS Code extension).
+
+| Code | Severity | What it catches | Enabled |
+|---|---|---|---|
+| **P001** | `error` | SQL constructs that don't run on the configured target dialect | Opt-in via `--target-dialect` or `[portability]` |
+| **P002** | `warning` | `SELECT *` where a downstream model references specific columns | Always on |
+
+---
+
+## P001 — dialect portability
+
+Rejects SQL constructs that don't exist on the chosen warehouse dialect. Detection is AST-based (sqlparser visitor over each model's SQL), using the same catalog that backs Rocky's SQL transpiler.
+
+### Covered constructs
+
+| Construct | Supported by |
+|---|---|
+| `NVL`, `IFNULL` | Snowflake, Databricks |
+| `DATEADD` | Snowflake, Databricks |
+| `DATE_ADD` | BigQuery |
+| `TO_VARCHAR` | Snowflake |
+| `LEN`, `CHARINDEX` | Snowflake |
+| `ARRAY_SIZE` | Snowflake |
+| `DATE_FORMAT` | BigQuery, Databricks |
+| `QUALIFY` | Snowflake, Databricks, DuckDB |
+| `ILIKE` | Snowflake, Databricks, DuckDB, BigQuery |
+| `FLATTEN` | Snowflake |
+
+The catalog is conservative — anything not in it is assumed portable. False negatives (non-portable SQL that slips through) are expected; false positives (portable SQL flagged as non-portable) are not.
+
+### How to enable
+
+Either pass `--target-dialect <dbx|sf|bq|duckdb>` on the command line:
+
+```bash
+rocky compile --target-dialect bq
+```
+
+Or declare the target once in `rocky.toml`:
+
+```toml
+[portability]
+target_dialect = "bigquery"
+```
+
+When both are set, the CLI flag wins. See [`[portability]`](/reference/configuration/#portability) for the full config.
+
+### Example diagnostic
+
+```json
+{
+  "severity": "error",
+  "code": "P001",
+  "model": "fct_revenue",
+  "message": "NVL is not portable to BigQuery (supported by: Snowflake, Databricks)",
+  "span": { "file": "models/fct_revenue.sql", "line": 1, "col": 1 },
+  "suggestion": "use COALESCE"
+}
+```
+
+Every P001 diagnostic names the construct, the supported dialects, and a one-line suggestion of the portable replacement.
+
+---
+
+## P002 — blast-radius `SELECT *`
+
+Warns when a model uses `SELECT *` **and** at least one downstream model references specific columns of its output. The lint is blast-radius-aware: a leaf model with `SELECT *` is intentionally **not** flagged — a leaf projection's columns are never consumed by a named reference, so an upstream schema change can't silently leak past the `SELECT *`.
+
+### What it protects against
+
+```sql
+-- models/stg_orders.sql
+SELECT * FROM raw__orders.orders
+```
+
+```sql
+-- models/fct_revenue.sql
+SELECT order_id, total_amount  -- explicit column reference
+FROM stg_orders
+```
+
+If `raw__orders.orders` drops `total_amount`, `stg_orders` keeps compiling (it's just `SELECT *`), but `fct_revenue` breaks at run time. P002 fires on `stg_orders` and names `fct_revenue` as the consumer that made the radius concrete.
+
+### Example diagnostic
+
+```json
+{
+  "severity": "warning",
+  "code": "P002",
+  "model": "stg_orders",
+  "message": "SELECT * silently propagates upstream schema changes to 2 downstream consumers: fct_revenue (order_id, total_amount, status), mart_ltv (customer_id)",
+  "span": { "file": "models/stg_orders.sql", "line": 1, "col": 1 },
+  "suggestion": "replace SELECT * with an explicit column list to make schema dependencies visible"
+}
+```
+
+The diagnostic caps each consumer's listed columns at 3 for legibility on wide schemas.
+
+### Always on
+
+P002 runs on every `rocky compile` and `rocky ci` invocation without any flag or config. Detection uses the semantic graph (`ModelSchema::has_star` + `column_consumers`), not a re-parse — the cost is a single pass over the already-compiled graph, so it's cheap enough to run by default.
+
+---
+
+## Exempting constructs
+
+### Project-wide allow list
+
+`[portability] allow` exempts a construct for every model in the project. Useful when a project standardizes on a non-portable extension:
+
+```toml
+[portability]
+target_dialect = "bigquery"
+allow = ["QUALIFY"]
+```
+
+Labels are case-insensitive and match `PortabilityIssue::construct` (e.g. `QUALIFY`, `NVL`, `DATEADD`).
+
+### Per-model `-- rocky-allow:` pragma
+
+For one-off exemptions, drop a pragma anywhere a line comment is legal in the model's SQL:
+
+```sql
+-- rocky-allow: NVL, QUALIFY
+SELECT NVL(a, b) AS c
+FROM t
+QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) = 1
+```
+
+Pragmas:
+
+- Accept a comma-separated list of construct labels.
+- Are case-insensitive (`nvl`, `NVL`, `Nvl` all work).
+- Apply only to the model whose SQL contains them — they are not hoisted to the project.
+- Are silently ignored if the label doesn't match any known construct, so adding a new lint later doesn't require removing stale pragmas.
+
+Prefer the pragma for targeted exemptions over expanding `[portability] allow`. The pragma lives next to the offending expression, which makes the decision reviewable in code.
+
+### P002 has no exemption knob today
+
+P002 warnings cannot yet be silenced per-model; the shared `pragma` parser is in place for a future `[lints]`-block driven toggle.
+
+---
+
+## Reading diagnostics
+
+Both lints emit the same diagnostic envelope as every other compiler check, so everything that reads `CompileOutput.diagnostics` handles them uniformly:
+
+- The CLI's text-mode output renders them with miette spans pointing at `models/<name>.sql`.
+- `rocky compile --output json` includes them in the `diagnostics` array.
+- The VS Code extension surfaces them as inline squiggles via the LSP.
+
+P001 diagnostics are errors — they fail `rocky compile` and `rocky ci`. P002 diagnostics are warnings — they show up in the output but do not fail the run.
+
+## Related
+
+- [`rocky compile`](/reference/commands/modeling/#rocky-compile) — where the lints run
+- [`[portability]` config](/reference/configuration/#portability) — project-level target-dialect + allow list
+- [SQL generation](/features/sql-generation/) — the transpiler that feeds the P001 catalog

--- a/docs/src/content/docs/guides/ai-features.md
+++ b/docs/src/content/docs/guides/ai-features.md
@@ -101,7 +101,21 @@ rocky ai "monthly revenue by category" -o json
 }
 ```
 
-## 3. The Compile-Verify Loop
+## 3. Schema-Grounded Prompts
+
+Before sending your intent to the LLM, `rocky ai` compiles the project and injects the resulting typed schemas into the prompt. The LLM sees the real column names, types, and model graph — so generated code references columns that actually exist, with the types they actually have.
+
+```bash
+rocky ai "monthly revenue by category" --models models
+```
+
+`--models <PATH>` points at the directory to compile for grounding (default `models`). If the directory doesn't exist or fails to compile, `rocky ai` degrades gracefully to unschema'd generation rather than failing outright — the compile-verify loop (next section) still guards the output.
+
+A second mechanism runs after generation: `rocky ai`'s `ValidationContext` typechecks the candidate SQL against the live project graph. If the LLM references a model or column that doesn't exist, the diagnostic flows back into the compile-verify loop as retry feedback instead of reaching your files.
+
+Rocky's typechecker is lenient on unresolved columns today, so schema grounding in the prompt is the primary mechanism preventing hallucinated columns; project-aware validation catches hallucinated *model* references in the project graph.
+
+## 4. The Compile-Verify Loop
 
 This is Rocky's key safety mechanism for AI-generated code. Every generated model is compiled before it is shown to you:
 
@@ -137,7 +151,7 @@ If all attempts fail, Rocky reports the best attempt and the remaining errors. N
 
 LLMs occasionally generate plausible-looking SQL that is semantically wrong -- a column name that does not exist, a JOIN on mismatched types, or an aggregation without a GROUP BY. The compile-verify loop catches these errors before you see the output.
 
-## 4. Add Intent to Existing Models
+## 5. Add Intent to Existing Models
 
 Intent is a natural language description stored in the model's TOML config. It serves two purposes:
 1. **Documentation**: Explains what the model does in business terms
@@ -207,7 +221,7 @@ stg_orders: Stage raw Shopify orders selecting order_id, customer, date, amount.
 
 Review and refine the descriptions before saving. The AI-generated intent is a starting point -- you know your business domain better than the LLM.
 
-## 5. Schema Change Sync
+## 6. Schema Change Sync
 
 When upstream schemas change (columns renamed, types changed, new columns added), `rocky ai-sync` proposes updates to downstream models based on their stored intent.
 
@@ -283,7 +297,7 @@ Suppose an upstream model `stg_orders` renames `unit_price` to `unit_price_local
 3. Review the diff and apply with `--apply`
 4. `rocky compile` passes again
 
-## 6. Generate Test Assertions
+## 7. Generate Test Assertions
 
 `rocky ai-test` generates test assertions based on each model's SQL logic and intent:
 
@@ -341,7 +355,7 @@ Testing 12 models...
   Result: 12 passed, 0 failed
 ```
 
-## 7. Intent in the IDE
+## 8. Intent in the IDE
 
 When using the [VS Code extension](/guides/ide-setup/), models with intent get enhanced IDE features:
 
@@ -349,7 +363,7 @@ When using the [VS Code extension](/guides/ide-setup/), models with intent get e
 - **Document Symbols**: Intent appears as the first child of the model in the Outline panel
 - **Diagnostics**: The compiler warns when intent mentions columns that do not exist in the model's output schema
 
-## 8. Best Practices for Intent Descriptions
+## 9. Best Practices for Intent Descriptions
 
 Good intent descriptions make `ai-sync` and `ai-test` significantly more effective. Here are guidelines:
 
@@ -412,7 +426,7 @@ intent = "Revenue model."
 
 This is too vague for `ai-sync` to make intelligent update proposals or for `ai-test` to generate meaningful assertions.
 
-## 9. AI Commands Reference
+## 10. AI Commands Reference
 
 | Command | Description |
 |---|---|

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -7,12 +7,12 @@ sidebar:
 
 Rocky provides a single binary with subcommands for the full pipeline lifecycle. Commands are organized into categories:
 
-- **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `run`, `state`
+- **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `run`, `state`, `branch`
 - **Modeling**: `compile`, `lineage`, `test`, `ci`, `ci-diff`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
 - **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `hooks`, `validate-migration`, `test-adapter`
-- **Administration**: `history`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`
+- **Administration**: `history`, `replay`, `trace`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`
 - **Diagnostics**: `doctor`, `compare`
 
 See the dedicated command reference pages for detailed documentation of each category.
@@ -208,6 +208,7 @@ rocky run --filter <key=value> [flags]
 | `--shadow` | | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | | Suffix appended to table names in shadow mode (default `_rocky_shadow`). |
 | `--shadow-schema <NAME>` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |
+| `--branch <NAME>` | | Execute against a named branch created with `rocky branch create`. Mutually exclusive with `--shadow` / `--shadow-schema`. See [`rocky branch`](/reference/commands/core-pipeline/#rocky-branch). |
 
 **Pipeline stages (in order):**
 

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -492,3 +492,183 @@ Same output shape — `model` is set when `--model` filters the run. `older_than
 - [`rocky compact`](#rocky-compact) -- compact remaining data after archival
 - [`rocky profile-storage`](#rocky-profile-storage) -- analyze storage to identify archival candidates
 - [`rocky history`](#rocky-history) -- review when data was last accessed
+
+---
+
+## `rocky replay`
+
+Inspect a recorded run from the state store. Surfaces the per-model SQL hashes, row counts, bytes, and timings captured by `RunRecord` at execution time — the concrete artefact behind the reproducibility claim. Inspection-only today; re-execution with pinned inputs is an Arc 1 follow-up.
+
+```bash
+rocky replay <target> [flags]
+```
+
+### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `target` | `string` | **(required)** | A specific `run_id`, or the literal `latest` for the most recent run. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--model <NAME>` | `string` | | Filter to a single model within the run. Errors if the model wasn't executed. |
+
+### Examples
+
+Replay the most recent run:
+
+```bash
+rocky replay latest
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "replay",
+  "run_id": "run_20260420_143022",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2026-04-20T14:30:22Z",
+  "finished_at": "2026-04-20T14:31:07Z",
+  "config_hash": "cfg_a3f2b1c4",
+  "models": [
+    {
+      "model_name": "stg_orders",
+      "status": "success",
+      "started_at": "2026-04-20T14:30:22Z",
+      "finished_at": "2026-04-20T14:30:23Z",
+      "duration_ms": 1200,
+      "sql_hash": "hash_a3f2b1c4",
+      "rows_affected": 150000,
+      "bytes_scanned": 41943040,
+      "bytes_written": 20971520
+    },
+    {
+      "model_name": "fct_revenue",
+      "status": "success",
+      "started_at": "2026-04-20T14:30:24Z",
+      "finished_at": "2026-04-20T14:31:07Z",
+      "duration_ms": 43000,
+      "sql_hash": "hash_b4e3c2d5",
+      "rows_affected": 8900,
+      "bytes_scanned": 20971520,
+      "bytes_written": 4194304
+    }
+  ]
+}
+```
+
+Filter to a single model within a specific run:
+
+```bash
+rocky replay run_20260420_143022 --model fct_revenue
+```
+
+`sql_hash` is stable across runs where the compiled SQL is identical, so diffing two replays is a fast way to detect whether a re-run would execute the same statements.
+
+### Related Commands
+
+- [`rocky trace`](#rocky-trace) -- same data rendered as a Gantt timeline
+- [`rocky history`](#rocky-history) -- list past runs
+- [`rocky run`](/reference/commands/core-pipeline/#rocky-run) -- record a new run
+
+---
+
+## `rocky trace`
+
+Render a completed run as a Gantt-style timeline. Sibling to `rocky replay` — reads the same `RunRecord`, but lays out models by start offset and assigns them to concurrency lanes so overlapping models show up on separate rows.
+
+```bash
+rocky trace <target> [flags]
+```
+
+### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `target` | `string` | **(required)** | A specific `run_id`, or the literal `latest`. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--model <NAME>` | `string` | | Filter to a single model within the run. |
+
+### Examples
+
+Trace the most recent run:
+
+```bash
+rocky trace latest
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "trace",
+  "run_id": "run_20260420_143022",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2026-04-20T14:30:22Z",
+  "finished_at": "2026-04-20T14:31:07Z",
+  "run_duration_ms": 45000,
+  "lane_count": 2,
+  "models": [
+    {
+      "model_name": "stg_orders",
+      "status": "success",
+      "start_offset_ms": 0,
+      "duration_ms": 1200,
+      "sql_hash": "hash_a3f2b1c4",
+      "lane": 0,
+      "rows_affected": 150000,
+      "bytes_scanned": 41943040,
+      "bytes_written": 20971520
+    },
+    {
+      "model_name": "stg_customers",
+      "status": "success",
+      "start_offset_ms": 100,
+      "duration_ms": 900,
+      "sql_hash": "hash_x9y8z7w6",
+      "lane": 1,
+      "rows_affected": 8000,
+      "bytes_scanned": 2097152,
+      "bytes_written": 1048576
+    },
+    {
+      "model_name": "fct_revenue",
+      "status": "success",
+      "start_offset_ms": 2000,
+      "duration_ms": 43000,
+      "sql_hash": "hash_b4e3c2d5",
+      "lane": 0,
+      "rows_affected": 8900,
+      "bytes_scanned": 20971520,
+      "bytes_written": 4194304
+    }
+  ]
+}
+```
+
+Lane assignment is greedy first-fit over sorted start offsets, so `lane_count` is the observed maximum concurrency. The table-mode output prints a bar chart:
+
+```
+$ rocky -o table trace latest
+run: run_20260420_143022
+status: success   trigger: manual   duration: 45.00s
+parallelism: 2 lanes
+
+  model                         timeline                                    duration  status
+  stg_orders                    [###.....................................]     1.20s  success
+  stg_customers                 [##......................................]     0.90s  success
+  fct_revenue                   [....####################################]    43.00s  success
+```
+
+### Related Commands
+
+- [`rocky replay`](#rocky-replay) -- flat per-model dump of the same run
+- [`rocky history`](#rocky-history) -- list recent runs
+- [`rocky metrics`](#rocky-metrics) -- quality metrics captured during runs

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -304,6 +304,7 @@ rocky run --filter <key=value> [flags]
 | `--shadow` | `bool` | `false` | Run in shadow mode: write to shadow targets instead of production. |
 | `--shadow-suffix <SUFFIX>` | `string` | `_rocky_shadow` | Suffix appended to table names in shadow mode. |
 | `--shadow-schema <NAME>` | `string` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |
+| `--branch <NAME>` | `string` | | Execute against a named branch previously registered with `rocky branch create`. Applies the branch's `schema_prefix` to every target (internally equivalent to `--shadow --shadow-schema <branch.schema_prefix>`). Mutually exclusive with `--shadow` / `--shadow-schema`. |
 
 ### Pipeline Stages
 
@@ -376,10 +377,18 @@ rocky run --filter client=acme --shadow
 rocky compare --filter client=acme
 ```
 
+Or run against a named branch — the persistent, named analogue of `--shadow`:
+
+```bash
+rocky branch create fix-price --description "testing reprice migration"
+rocky run --filter client=acme --branch fix-price
+```
+
 ### Related Commands
 
 - [`rocky plan`](#rocky-plan) -- preview SQL before execution
 - [`rocky state`](#rocky-state) -- inspect watermarks after a run
+- [`rocky branch`](#rocky-branch) -- manage named branches
 - [`rocky history`](/reference/commands/administration/#rocky-history) -- view past runs
 
 ---
@@ -441,3 +450,66 @@ acme_warehouse.staging__eu_central__stripe.charges    | 2026-03-29T22:15:00Z    
 
 - [`rocky run`](#rocky-run) -- update watermarks by executing the pipeline
 - [`rocky history`](/reference/commands/administration/#rocky-history) -- view run history
+
+---
+
+## `rocky branch`
+
+Manage named virtual branches. A branch is the persistent, named analogue of `--shadow` mode: it records a `schema_prefix` in the state store and, when `rocky run --branch <name>` is invoked, every model target has the prefix applied. Schema-prefix branches work uniformly across every adapter today; warehouse-native clones (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`) are a follow-up.
+
+```bash
+rocky branch create <name> [--description <text>]
+rocky branch delete <name>
+rocky branch list
+rocky branch show <name>
+```
+
+Branch names accept `[A-Za-z0-9_.\-]` up to 64 characters. The default schema prefix is `branch__<name>`. Deleting a branch removes the state-store entry but does **not** drop warehouse tables that were materialized under it.
+
+### Examples
+
+Create, list, run against, and delete a branch:
+
+```bash
+rocky branch create fix-price --description "testing reprice migration"
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "branch create",
+  "branch": {
+    "name": "fix-price",
+    "schema_prefix": "branch__fix-price",
+    "created_by": "hugo",
+    "created_at": "2026-04-20T14:22:11+00:00",
+    "description": "testing reprice migration"
+  }
+}
+```
+
+```bash
+rocky branch list
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "branch list",
+  "total": 2,
+  "branches": [
+    { "name": "fix-price", "schema_prefix": "branch__fix-price", "created_by": "hugo", "created_at": "2026-04-20T14:22:11+00:00", "description": "testing reprice migration" },
+    { "name": "ingest-v2", "schema_prefix": "branch__ingest-v2", "created_by": "ci",   "created_at": "2026-04-18T09:05:00+00:00", "description": null }
+  ]
+}
+```
+
+```bash
+rocky run --filter client=acme --branch fix-price
+rocky branch delete fix-price
+```
+
+### Related Commands
+
+- [`rocky run`](#rocky-run) -- execute a pipeline against a branch via `--run --branch`
+- [`rocky compare`](/reference/cli/#rocky-compare) -- diff branch output against production

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -24,6 +24,9 @@ rocky compile [flags]
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing `.sql` and `.toml` model files. |
 | `--contracts <PATH>` | `PathBuf` | | Directory containing data contract definitions. |
 | `--model <NAME>` | `string` | | Filter compilation to a single model by name. |
+| `--expand-macros` | `bool` | `false` | Expand macros from `macros/` and include the expanded SQL in the output. |
+| `--target-dialect <DIALECT>` | `dbx` \| `sf` \| `bq` \| `duckdb` | | Run the **P001 dialect-portability lint** against the chosen target. Non-portable constructs emit `error`-severity diagnostics. Precedence: flag > `[portability] target_dialect` in `rocky.toml` > unset. See [Portability linting](/features/linters/). |
+| `--with-seed` | `bool` | `false` | Execute `data/seed.sql` against an in-memory DuckDB and use its `information_schema` as the source-of-truth for raw source schemas. Turns leaf `.sql` models from `Unknown` columns into concrete types. Requires the `duckdb` feature (enabled by default in the shipped binary). |
 
 ### Examples
 
@@ -35,7 +38,7 @@ rocky compile
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.11.0",
   "command": "compile",
   "models": 14,
   "execution_layers": 4,
@@ -81,6 +84,40 @@ Compile models from a non-default directory:
 rocky compile --models src/transformations/
 ```
 
+Reject SQL that won't run on BigQuery (P001 dialect-portability lint):
+
+```bash
+rocky compile --target-dialect bq
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "compile",
+  "has_errors": true,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "code": "P001",
+      "model": "fct_revenue",
+      "message": "NVL is not portable to BigQuery (supported by: Snowflake, Databricks)",
+      "span": { "file": "models/fct_revenue.sql", "line": 1, "col": 1 },
+      "suggestion": "use COALESCE"
+    }
+  ]
+}
+```
+
+Both the `--target-dialect` flag and the `[portability]` config block (see [Configuration](/reference/configuration/)) drive the same check; the flag wins when both are set. Project-wide allow-lists and per-model `-- rocky-allow: …` pragmas exempt specific constructs — see [Portability linting](/features/linters/#p001--dialect-portability).
+
+Compile with seeded source schemas so leaf `.sql` models pick up real types:
+
+```bash
+rocky compile --with-seed
+```
+
+`--with-seed` looks for `data/seed.sql` relative to the project root (one level up from `--models`). It opens an in-memory DuckDB, runs the seed, and feeds the resulting `information_schema.columns` back into the compiler so downstream incrementality and type-inference get concrete types instead of `RockyType::Unknown`. Bails if `data/seed.sql` is missing or fails to execute.
+
 ### Related Commands
 
 - [`rocky lineage`](#rocky-lineage) -- trace column-level dependencies
@@ -111,6 +148,8 @@ rocky lineage <target> [flags]
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing model files. |
 | `--column <NAME>` | `string` | | Specific column to trace (alternative to `model.column` syntax). |
 | `--format <FORMAT>` | `string` | | Output format. Use `dot` for Graphviz DOT output. |
+| `--downstream` | `bool` | `false` | Walk the column-level graph forward (consumers) instead of backward (sources). Mutually exclusive with `--upstream`. |
+| `--upstream` | `bool` | `true` | Walk the column-level graph backward (sources). Default; the flag exists for explicitness in scripted callers. |
 
 ### Examples
 
@@ -186,6 +225,36 @@ Use the dot syntax shorthand:
 ```bash
 rocky lineage fct_revenue.revenue_amount --format dot | dot -Tpng -o lineage.png
 ```
+
+Walk downstream to see every consumer of a column — the answer to "what breaks if I change this?":
+
+```bash
+rocky lineage stg_orders.customer_id --downstream
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "lineage",
+  "model": "stg_orders",
+  "column": "customer_id",
+  "direction": "downstream",
+  "trace": [
+    {
+      "source": { "model": "stg_orders", "column": "customer_id" },
+      "target": { "model": "fct_revenue", "column": "customer_id" },
+      "transform": "direct"
+    },
+    {
+      "source": { "model": "fct_revenue", "column": "customer_id" },
+      "target": { "model": "mart_ltv",    "column": "customer_id" },
+      "transform": "direct"
+    }
+  ]
+}
+```
+
+Upstream output has `"direction": "upstream"` (the default shape, unchanged). The transitive walker is backed by an `edges_by_source_model` index so cost scales with fan-out rather than total edges.
 
 ### Related Commands
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -226,13 +226,18 @@ Retry policy for transient errors (HTTP 429/503, rate limits, timeouts). Uses ex
 | `backoff_multiplier` | float | `2.0` | Multiplier applied after each retry. |
 | `jitter` | bool | `true` | Add random jitter to prevent thundering herd. |
 | `circuit_breaker_threshold` | integer | `5` | Trip after this many consecutive failures. Set to 0 to disable. |
+| `circuit_breaker_recovery_timeout_secs` | integer | `null` | When set, the breaker auto-recovers after this many seconds: it enters half-open, admits a single trial request, and either closes on success or re-opens on failure. When unset, a tripped breaker stays tripped for the rest of the run (manual-reset behaviour). |
+| `max_retries_per_run` | integer | `null` | Per-adapter cross-statement retry budget for a single run. Use the top-level [`[retry]`](#retry) block when you want one shared budget across every adapter instead. |
 
 ```toml
 [adapter.prod.retry]
 max_retries = 5
 initial_backoff_ms = 500
 max_backoff_ms = 60000
+circuit_breaker_recovery_timeout_secs = 30
 ```
+
+When the breaker trips, Rocky emits a `circuit_breaker_tripped` pipeline event; on auto-recovery it emits `circuit_breaker_recovered`. Hook subscribers can observe both without polling the adapter. See [Hooks](/concepts/hooks/).
 
 ---
 
@@ -594,6 +599,67 @@ Cost assumptions used by `rocky optimize` when recommending materialization stra
 storage_cost_per_gb_month = 0.023
 compute_cost_per_dbu = 0.40
 warehouse_size = "Medium"
+```
+
+---
+
+## `[budget]`
+
+Declarative run-level cost and duration limits. When a run exceeds a configured limit, Rocky emits a `budget_breach` pipeline event and fires the `HookEvent::BudgetBreach` hook. With `on_breach = "error"` the run also exits non-zero. Unknown fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_usd` | float | | Maximum allowed run cost in USD. Cost is computed from per-materialization `cost_usd` values on `RunOutput.cost_summary`. `None` on runs where no adapter produced cost data (e.g. a BigQuery job with no bytes billed). |
+| `max_duration_ms` | integer | | Maximum allowed run wall time in milliseconds. |
+| `on_breach` | string | `"warn"` | Either `"warn"` (fire the event, keep the run successful) or `"error"` (also fail the run). |
+
+```toml
+[budget]
+max_usd = 25.0
+max_duration_ms = 900000   # 15 minutes
+on_breach = "error"
+```
+
+The limits are evaluated once per run against observed totals; per-model budgets are a follow-up. Subscribe to `on_budget_breach` under `[hook.*]` to route breaches into a notification system.
+
+---
+
+## `[portability]`
+
+Project-wide configuration for Rocky's dialect-portability lint (**P001**). When `target_dialect` is set, every `rocky compile` (and LSP-driven in-editor check) runs the lint against that target. The CLI flag `rocky compile --target-dialect <DIALECT>` overrides this block when both are present. Unknown fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `target_dialect` | string | | `"databricks"`, `"snowflake"`, `"bigquery"`, or `"duckdb"`. When unset, no lint runs (wave-1 "flag opt-in" behavior). |
+| `allow` | list of string | `[]` | Project-wide allow-list of construct labels (case-insensitive). Useful when a project standardizes on a non-portable extension like `QUALIFY`. Prefer per-model `-- rocky-allow: …` pragmas for targeted exemptions. |
+
+```toml
+[portability]
+target_dialect = "bigquery"
+allow = ["QUALIFY"]
+```
+
+Precedence for the effective target dialect:
+
+1. `rocky compile --target-dialect <DIALECT>` flag (wins if set).
+2. `[portability] target_dialect`.
+3. Unset — no lint.
+
+See [Linters](/features/linters/) for the full list of covered constructs and the per-model pragma syntax.
+
+---
+
+## `[retry]`
+
+Optional top-level cross-adapter retry budget. When set, `AdapterRegistry` builds one shared `Arc<AtomicI64>` budget and wires it through every adapter for this run — once exhausted, no adapter retries further. Prevents one failing endpoint from burning the whole budget pool that other adapters could have used.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_retries_per_run` | integer | | Total retries allowed across every adapter for this run. Omit the block to keep per-adapter budgets (each `[adapter.NAME.retry]` remains in isolation). |
+
+```toml
+[retry]
+max_retries_per_run = 50
 ```
 
 ---

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -196,6 +196,8 @@ Returns a complete summary of the pipeline execution.
 | `metrics` | object or null | Counters and percentile histograms for the run. |
 | `anomalies` | array | Row count anomalies detected by historical baseline comparison. |
 | `partition_summaries` | array | Per-model partition execution summaries (present for `time_interval` models). |
+| `cost_summary` | object or absent | Per-run cost rollup: `total_usd` (float or null), `by_adapter` (map of adapter → USD). Present when at least one adapter reports cost data. See [`[budget]`](/reference/configuration/#budget) for how cost limits are enforced. |
+| `budget_breaches` | array | Populated when `[budget]` limits tripped. Each entry has `limit_type` (`"max_usd"` / `"max_duration_ms"`), `limit`, and `actual` (both floats). Empty array when within budget or no limits configured. |
 
 **`materializations[]`:**
 
@@ -210,6 +212,7 @@ Returns a complete summary of the pipeline execution.
 | `metadata.sql_hash` | string or absent | 16-char hex hash of the generated SQL. |
 | `metadata.column_count` | integer or absent | Number of columns in the materialized table. |
 | `metadata.compile_time_ms` | integer or absent | Compile time in milliseconds for derived models. |
+| `metadata.cost_usd` | float or absent | Estimated cost for this materialization in USD. Rolls up into `cost_summary.total_usd` at the run level. |
 | `partition` | object or absent | Partition window info for `time_interval` materializations. |
 
 **`check_results[]`:**
@@ -514,14 +517,15 @@ Show model-level lineage with columns, upstream/downstream models, and column-le
 
 ### `rocky lineage <model> --column <col>`
 
-Trace a single column back through its upstream lineage chain.
+Trace a single column through its lineage chain. Default direction is **upstream** (sources). Pass `--downstream` to walk consumers instead.
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.11.0",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "net_revenue",
+  "direction": "upstream",
   "trace": [
     {
       "source": { "model": "stg_orders", "column": "total_amount" },
@@ -543,6 +547,7 @@ Trace a single column back through its upstream lineage chain.
 |-------|------|-------------|
 | `model` | string | The model containing the traced column. |
 | `column` | string | The column being traced. |
+| `direction` | string | `"upstream"` (default) or `"downstream"`. Set by the `--downstream` flag. |
 | `trace[].source` | object | Source column (`model` + `column`). |
 | `trace[].target` | object | Target column (`model` + `column`). |
 | `trace[].transform` | string | Transform kind: `"direct"`, `"cast"`, `"expression"`, etc. |
@@ -696,6 +701,131 @@ Show execution history for a specific model.
 | `executions[].status` | string | Execution status. |
 | `executions[].sql_hash` | string | Hash of the SQL that was executed. |
 | `count` | integer | Total number of executions returned. |
+
+---
+
+### `rocky replay <run_id|latest>`
+
+Per-model dump of a recorded run — SQL hash, row counts, bytes, and timings captured at execution time.
+
+```json
+{
+  "version": "1.11.0",
+  "command": "replay",
+  "run_id": "run_20260420_143022",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2026-04-20T14:30:22Z",
+  "finished_at": "2026-04-20T14:31:07Z",
+  "config_hash": "cfg_a3f2b1c4",
+  "models": [
+    {
+      "model_name": "fct_revenue",
+      "status": "success",
+      "started_at": "2026-04-20T14:30:24Z",
+      "finished_at": "2026-04-20T14:31:07Z",
+      "duration_ms": 43000,
+      "sql_hash": "hash_b4e3c2d5",
+      "rows_affected": 8900,
+      "bytes_scanned": 20971520,
+      "bytes_written": 4194304
+    }
+  ]
+}
+```
+
+**Field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `run_id` | string | Run identifier from the state store. |
+| `status` | string | `"success"`, `"partial_failure"`, or `"failure"`. |
+| `trigger` | string | What triggered the run: `"manual"`, `"sensor"`, `"schedule"`, `"ci"`. |
+| `config_hash` | string | Hash of the `rocky.toml` effective at run time. |
+| `models[].sql_hash` | string | Stable across runs where the compiled SQL is identical. |
+| `models[].bytes_scanned` / `bytes_written` | integer or null | Per-model byte counts, when the adapter reports them. |
+
+---
+
+### `rocky trace <run_id|latest>`
+
+Same run, laid out as a Gantt timeline — per-model start offsets + concurrency-lane assignments.
+
+```json
+{
+  "version": "1.11.0",
+  "command": "trace",
+  "run_id": "run_20260420_143022",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2026-04-20T14:30:22Z",
+  "finished_at": "2026-04-20T14:31:07Z",
+  "run_duration_ms": 45000,
+  "lane_count": 2,
+  "models": [
+    {
+      "model_name": "stg_orders",
+      "status": "success",
+      "start_offset_ms": 0,
+      "duration_ms": 1200,
+      "sql_hash": "hash_a3f2b1c4",
+      "lane": 0,
+      "rows_affected": 150000,
+      "bytes_scanned": 41943040,
+      "bytes_written": 20971520
+    }
+  ]
+}
+```
+
+**Field reference:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `run_duration_ms` | integer | Wall time from `started_at` to `finished_at`. |
+| `lane_count` | integer | Observed maximum concurrency (greedy first-fit over start offsets). |
+| `models[].start_offset_ms` | integer | Milliseconds between the run start and this model's start. |
+| `models[].lane` | integer | Concurrency lane index; models sharing a lane do not overlap in time. |
+
+---
+
+### `rocky branch create` / `branch show` / `branch list` / `branch delete`
+
+Branches use three distinct output shapes — see [`rocky branch`](/reference/commands/core-pipeline/#rocky-branch) for command-level usage.
+
+```json
+{
+  "version": "1.11.0",
+  "command": "branch create",
+  "branch": {
+    "name": "fix-price",
+    "schema_prefix": "branch__fix-price",
+    "created_by": "hugo",
+    "created_at": "2026-04-20T14:22:11+00:00",
+    "description": "testing reprice migration"
+  }
+}
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "branch list",
+  "total": 2,
+  "branches": [ { "name": "fix-price", "schema_prefix": "branch__fix-price", "created_by": "hugo", "created_at": "2026-04-20T14:22:11+00:00", "description": "testing reprice migration" } ]
+}
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "branch delete",
+  "name": "fix-price",
+  "removed": true
+}
+```
+
+`removed` is `false` when the branch didn't exist. Deletion does not drop warehouse tables — that's a separate cleanup step.
 
 ---
 


### PR DESCRIPTION
## Summary

Engine v1.11.0 shipped the first wave of every trust-system arc (plus two wave-2 follow-ups) — but the docs lagged. Grep across `docs/src/content/docs/` found **zero hits** for `rocky branch`, `rocky replay`, `rocky trace`, `--with-seed`, `--target-dialect`, `P001`, `P002`, `[budget]`, `[portability]`, `budget_breach`, or the half-open circuit breaker. This PR closes that gap.

## Changes by arc

| Arc | What shipped | Docs landing here |
|---|---|---|
| 1 | `rocky branch`, `rocky replay`, `lineage --downstream` | `commands/core-pipeline` (`rocky branch`, `--branch` on run), `commands/administration` (`rocky replay`), `commands/modeling` (`--downstream`), json-output `direction` field |
| 2 | `[budget]`, `cost_summary`, `budget_breach` | `reference/configuration` `[budget]`, json-output `cost_summary` / `budget_breaches` / `cost_usd`, hooks `budget_breach` event |
| 3 | Timed half-open circuit breaker | `reference/configuration` `circuit_breaker_recovery_timeout_secs`, hooks `circuit_breaker_tripped` / `_recovered` events |
| 4 | `rocky trace`, OTLP metrics export | `commands/administration` (`rocky trace`), `concepts/architecture` rocky-observe note, json-output shape |
| 5 | Schema-grounded AI prompt + project-aware validator | `guides/ai-features` new §3 (sections 3→4 renumbered) |
| 6 | P001 dialect-portability linter + `[portability]` + `-- rocky-allow:` pragma | new `features/linters`, `[portability]` in configuration, `--target-dialect` on `rocky compile` |
| 7 | P002 blast-radius `SELECT *` linter + `--with-seed` | `features/linters`, `--with-seed` on `rocky compile` |

Also: top-level `[retry]` block added to configuration (shipped earlier but also undocumented), `features/all-features` and `reference/cli` cross-links refreshed.

One content correction: the engine v1.11.0 changelog described `rocky ai --models <a,b,c>` as scoping prompt context to a subset of models, but the shipped CLI takes a path (the directory to compile for grounding). Docs describe what the binary actually does.

## Test plan

- [x] `npm run build` — docs build clean (69 pages)
- [x] All new anchors resolve in the rendered HTML (`#budget`, `#portability`, `#retry`, `#rocky-branch`, `#rocky-replay`, `#rocky-trace`, `#p001--dialect-portability`, `#adapternameretry`)
- [x] Pre-existing anchor links still resolve
- [ ] Manual spot-check of rendered pages on the Pages deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)