### PR TITLE
docs: reframe intro around trust-system positioning + ELT scope fix

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -5,27 +5,44 @@ sidebar:
   order: 1
 ---
 
-Rocky is a **compiled SQL transformation engine** written in Rust. It replaces dbt's core responsibilities — DAG resolution, incremental logic, SQL generation, schema management — with a type-safe, config-driven approach.
+Rocky is the **trust system for your data**. Branches, replay, provable reproducibility, complete column-level lineage, compile-time safety, per-model cost attribution — things your current stack can't offer because it doesn't own the DAG.
 
-No Jinja. No manifest. No parse step.
+Keep Databricks or Snowflake. Bring Rocky for the DAG.
 
-Rocky follows the **ELT pattern**: it operates on data already in the warehouse, landed by ingestion tools like Fivetran or Airbyte. Rocky owns the **T** (warehouse-side transformation and replication), not the E or L.
+## What Rocky is
 
-## Why Rocky
+A Rust-based control plane for warehouse-side data work. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, or DuckDB). Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost.
 
-- **Fast.** Single binary, starts in under 100ms. Compiles 500 models in seconds, not minutes.
+**Rocky is not a warehouse.** It's what sits on top of one.
+
+## Scope on the ELT spectrum
+
+| Stage | Rocky | Notes |
+|---|---|---|
+| Extract (SaaS sources) | — | Use Fivetran, Airbyte, Stitch, or warehouse-native CDC |
+| Extract (files) | ✅ | `rocky load` — CSV, Parquet, JSONL from a directory into the warehouse |
+| Load (bronze replication) | ✅ | Config-driven replication pipelines. Discovery via Fivetran metadata, DuckDB `information_schema`, or manual declaration |
+| Transform | ✅ | Compiled SQL models — no Jinja, no manifest, no parse step |
+| Quality | ✅ | Inline assertions during `rocky run`; no separate test step |
+| Orchestration | Partial | First-class Dagster integration; `rocky serve` for small standalone teams |
+
+## The seven trust dimensions
+
+1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Git-grade workflow on a warehouse.
+2. **Cost attribution + budgets** — per-model cost on every run. `[budget]` block in `rocky.toml`; `budget_breach` hook event on exceed.
+3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
+4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).
+5. **Schema-grounded AI** — every AI feature gated through the compiler; generated SQL type-checks before it lands.
+6. **Polyglot correctness** — dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB (12 constructs today).
+7. **SQL as first-class with types** — type inference over raw `.sql`, `SELECT *` blast-radius lint, DAG-aware refactoring.
+
+## Practical differentiators
+
+- **Fast.** Single binary, starts in under 100ms. Compiles 500 models in seconds.
 - **Type-safe.** Column-level type inference catches schema errors at compile time.
-- **Pure SQL.** No Jinja templating; business logic stays in SQL.
+- **Pure SQL.** No Jinja; business logic stays in SQL.
 - **Config-first bronze.** Source replication is driven by `rocky.toml` — zero SQL files for 1:1 copies.
 - **Embedded state.** Watermarks live in a local `redb` database, with optional S3 / Valkey sync.
-
-## Design principles
-
-1. **Adapter-based.** Source adapters (Fivetran, DuckDB, manual) handle discovery. Warehouse adapters (Databricks, Snowflake, BigQuery, DuckDB) handle execution. The core engine is warehouse-agnostic.
-2. **Config over code.** Bronze layer replication needs no SQL — just TOML.
-3. **Pure SQL models.** Silver-layer transformations use standard SQL plus a `.toml` sidecar.
-4. **Inline quality checks.** Data checks run during replication, not as a separate step.
-5. **Structured output.** Every command emits versioned JSON for orchestrator consumption.
 
 ## How Rocky compares to dbt
 
@@ -34,10 +51,21 @@ Rocky follows the **ELT pattern**: it operates on data already in the warehouse,
 | Templating | Jinja | None — pure SQL |
 | Staging models | One `.sql` per source table | Config-driven bronze (zero SQL) |
 | Dependencies | `{{ ref('model') }}` | `depends_on = ["model"]` |
-| Tests | `schema.yml` + `dbt test` | Inline checks + assertions built into `rocky run` |
+| Tests | `schema.yml` + `dbt test` | Inline checks + assertions in `rocky run` |
 | State | `manifest.json` + `target/` | Embedded `redb` database |
+| Branches | — | `rocky branch create`, `rocky run --branch` |
+| Column-level lineage | Post-hoc (`dbt docs`) | Compile-time output |
+| Cost attribution | — | Per-model, every run |
 
 Full side-by-side comparison: [features/comparison](/features/comparison/).
+
+## Design principles
+
+1. **Adapter-based.** Source adapters (Fivetran, DuckDB, manual) handle discovery. Warehouse adapters (Databricks, Snowflake, BigQuery, DuckDB) handle execution. The core engine is warehouse-agnostic.
+2. **Config over code.** Bronze layer replication needs no SQL — just TOML.
+3. **Pure SQL models.** Silver-layer transformations use standard SQL plus a `.toml` sidecar.
+4. **Inline quality checks.** Data checks run during replication, not as a separate step.
+5. **Structured output.** Every command emits versioned JSON for orchestrator consumption.
 
 ## Supported adapters
 
@@ -51,7 +79,7 @@ Full side-by-side comparison: [features/comparison](/features/comparison/).
 | Warehouse | BigQuery | REST API; service account / ADC (Beta) |
 | Warehouse | DuckDB | In-process; powers the playground and `rocky test` |
 
-Source adapters are metadata-only — they identify what exists. Actual data must already be in the warehouse. A single DuckDB instance can serve as both source and warehouse, which is how the credential-free playground works end-to-end.
+Source adapters are metadata-only — they identify what exists. Actual data already lives in the warehouse, or is loaded via `rocky load` for files. A single DuckDB instance can serve as both source and warehouse, which is how the credential-free playground works end-to-end.
 
 New adapters plug in via the [Adapter SDK](/concepts/adapters/) without modifying the core engine.
 
@@ -62,7 +90,7 @@ New adapters plug in via the [Adapter SDK](/concepts/adapters/) without modifyin
 | `engine/` | `rocky` CLI | Rust (20-crate workspace) |
 | `integrations/dagster/` | `dagster-rocky` wheel | Python |
 | `editors/vscode/` | Rocky VSIX | TypeScript |
-| `examples/playground/` | POC catalog (47 POCs) | TOML / SQL |
+| `examples/playground/` | POC catalog | TOML / SQL |
 
 Crate-level breakdown: [Architecture](/concepts/architecture/).
 


### PR DESCRIPTION
## Summary

- Lead with the approved trust-system positioning ("Rocky is the trust system for your data; keep Databricks or Snowflake, bring Rocky for the DAG") instead of "compiled SQL transformation engine / replaces dbt."
- Replace the inaccurate *"Rocky owns the T, not the E or L"* line with an explicit ELT scope table showing `rocky load` (files) and warehouse-side bronze replication as shipped capabilities, alongside T.
- Add a **seven trust dimensions** section summarising the arcs shipped through engine-v1.11.0 (branches/replay/lineage, cost attribution, circuit breakers, observability, schema-grounded AI, polyglot correctness, SQL-first-class types).
- Extend the dbt comparison table with branches, compile-time column-level lineage, and per-model cost attribution rows.

## Why now

This prepares the public-facing intro for the upcoming HN / Reddit announcement. The `owns the T, not E or L` line was the most loaded first-reply bait for skeptical readers (rocky load ships; replication pipelines cover bronze) — that's now corrected. The broader positioning rewrite lands with it so the whole intro reads consistently.

## Test plan

- [ ] \`npm run build\` in \`docs/\` passes (Astro / Starlight)
- [ ] Internal links resolve: \`/features/comparison/\`, \`/concepts/adapters/\`, \`/concepts/architecture/\`
- [ ] Local dev server renders the page cleanly (table widths, emoji glyphs, code-span rendering)
- [ ] No factual drift vs current engine behavior (Snowflake/BigQuery marked Beta, \`rocky load\` supports CSV/Parquet/JSONL, branch/replay wording matches CHANGELOG 1.11.0)