### PR TITLE
docs: align READMEs, llms.txt, and agent files with trust-system positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Rocky monorepo
 
-Single repository for the Rocky data platform — a Rust-based SQL transformation engine that replaces dbt — and its first-party integrations.
+Single repository for the Rocky data platform — a Rust-based control plane for warehouse data pipelines, positioned as "the trust system for your data" — and its first-party integrations.
 
 ## Subprojects
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-A SQL transformation engine built in Rust. Type-safe compilation, column-level lineage, AI-powered intent, and a language server — for data pipelines that don't break.
+The **trust system for your data**. A Rust-based control plane for warehouse pipelines: branches, replay, column-level lineage, compile-time safety, per-model cost attribution. Keep Databricks or Snowflake. Bring Rocky for the DAG.
 
 ## Try it in 60 seconds
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,8 +1,16 @@
 # Rocky
 
-> A compiled SQL transformation engine written in Rust. Replaces dbt's DAG resolution, incremental logic, SQL generation, and schema management with a type-safe, config-driven approach. No Jinja. No manifest. No parse step.
+> The trust system for your data. A Rust-based control plane for warehouse-side data pipelines: branches, replay, provable reproducibility, column-level lineage, compile-time safety, per-model cost attribution. Keep Databricks or Snowflake. Bring Rocky for the DAG.
 
-Rocky follows the ELT pattern: it operates on data already in the warehouse, landed by ingestion tools like Fivetran or Airbyte. Rocky owns the T (warehouse-side transformation and replication).
+Rocky is not a warehouse. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, DuckDB); Rocky owns the graph — dependencies, compile-time types, drift, incremental logic, lineage, cost. No Jinja, no manifest, no parse step.
+
+Scope on the ELT spectrum:
+- Extract (SaaS sources) — not Rocky; use Fivetran, Airbyte, Stitch, or warehouse-native CDC
+- Extract (files) — `rocky load` handles CSV / Parquet / JSONL from a directory
+- Load (bronze replication) — config-driven pipelines via Fivetran metadata / DuckDB information_schema / manual declaration
+- Transform — compiled SQL models
+- Quality — inline assertions during `rocky run`
+- Orchestration — first-class Dagster integration; `rocky serve` for standalone teams
 
 ## Architecture at a glance
 

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -1,6 +1,6 @@
 # Rocky — Agent Instructions
 
-Rocky is a Rust SQL transformation engine. It replaces dbt's core responsibilities (SQL generation, incremental logic, schema management) with a config-driven approach.
+Rocky is a Rust-based control plane for warehouse-side data pipelines — the trust system for your data. It owns the DAG: compile-time types, branches + replay, column-level lineage, drift handling, incremental logic, and cost attribution. Storage and compute stay with the warehouse (Databricks, Snowflake, BigQuery, DuckDB).
 
 ## Key Concepts
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,12 +1,33 @@
 # Rocky
 
-A SQL transformation engine built in Rust. Type-safe compilation, column-level lineage, AI-powered intent, and a language server — for data pipelines that don't break.
+The **trust system for your data**. A Rust-based control plane for warehouse-side data pipelines: branches, replay, provable reproducibility, column-level lineage, compile-time safety, per-model cost attribution.
+
+Keep Databricks or Snowflake. Bring Rocky for the DAG.
+
+**Rocky is not a warehouse.** Storage and compute stay with your warehouse; Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost.
 
 No Jinja. No manifest. No parse step.
 
-## Why Rocky
+## Scope on the ELT spectrum
 
-Rocky replaces dbt's core responsibilities — DAG resolution, incremental logic, SQL generation, schema management — with a compiled, type-safe approach. Models are type-checked before execution, schema changes are detected automatically, and an AI intent layer keeps models synchronized when upstream schemas evolve. Rocky ships as a single binary with no runtime dependencies.
+| Stage | Rocky | Notes |
+|---|---|---|
+| Extract (SaaS sources) | — | Use Fivetran, Airbyte, Stitch, or warehouse-native CDC |
+| Extract (files) | ✅ | `rocky load` — CSV / Parquet / JSONL from a directory |
+| Load (bronze replication) | ✅ | Config-driven replication pipelines |
+| Transform | ✅ | Compiled SQL models |
+| Quality | ✅ | Inline assertions during `rocky run` |
+| Orchestration | Partial | First-class Dagster integration; `rocky serve` standalone |
+
+## The seven trust dimensions
+
+1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Git-grade workflow on a warehouse.
+2. **Cost attribution + budgets** — per-model cost on every run; `[budget]` block in `rocky.toml`; `budget_breach` hook event.
+3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
+4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).
+5. **Schema-grounded AI** — every AI feature gated through the compiler; generated SQL type-checks before it lands.
+6. **Polyglot correctness** — dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB.
+7. **SQL as first-class with types** — type inference over raw `.sql`, `SELECT *` blast-radius lint, DAG-aware refactoring.
 
 ## Quick start
 
@@ -26,6 +47,10 @@ The playground is self-contained: sample models, contracts, and a DuckDB backend
 | Category | Capabilities |
 |----------|-------------|
 | **Compiler** | Type checking, column-level lineage, data contracts, DAG resolution, diagnostics with suggestions |
+| **Branches** | `rocky branch create`/`delete`/`list`/`show`, `rocky run --branch`, `rocky replay <run_id>` |
+| **Cost** | Per-model cost attribution on every run, `[budget]` blocks, `budget_breach` hook event |
+| **Observability** | `rocky trace` Gantt output, OpenTelemetry OTLP export, structured JSON events |
+| **Portability** | Dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB |
 | **DSL** | Pipeline-oriented `.rocky` syntax — optional, models stay plain SQL by default |
 | **AI** | Intent metadata, schema-sync, intent extraction, test generation |
 | **IDE** | VS Code extension, full LSP (completion, hover, go-to-def, rename, code actions, inlay hints) |

--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "dag",
   "nodes": [
     {

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "history",
   "runs": [],
   "count": 0

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "optimize",
   "recommendations": [],
   "total_models_analyzed": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Follow-up to #193. Propagates the trust-system positioning from the intro page across the rest of the repo's high-visibility markdown.

- **`engine/README.md`** — lead with trust-system framing; add the ELT scope table, seven trust dimensions section, and Branches / Cost / Observability / Portability rows in the features table.
- **`README.md` (monorepo root)** — one-liner now reads *"The trust system for your data. … Keep Databricks or Snowflake. Bring Rocky for the DAG."* instead of the generic "SQL transformation engine" line.
- **`docs/public/llms.txt`** — replace the *"owns the T"* positioning and add explicit ELT scope bullets so LLM-crawlers pick up the accurate coverage (`rocky load`, bronze replication).
- **`CLAUDE.md` (root)** and **`engine/AGENTS.md`** — one-line wording fixes so future agent guidance doesn't carry the stale *"replaces dbt"* frame.

All changes are pure copy; no code or feature changes.

## Why now

Launch-prep: ensures the GitHub landing page, engine README, and LLM-visible positioning all align with the intro (#193). Avoids the "you say trust system in one place and 'replaces dbt' in another" credibility hit on launch day.

## Test plan

- [x] `npm run build` in `docs/` passes — 69 pages, 1.68s, no errors (llms.txt is a static asset so build is just a safety check)
- [ ] GitHub landing page preview shows the updated tagline
- [ ] Rendered `engine/README.md` on GitHub shows the ELT scope table + seven trust dimensions cleanly (no broken emoji / table glyphs)
- [ ] No factual drift vs #193's intro wording (ELT scope, seven dimensions bullets, `rocky load` coverage)