### PR TITLE
chore(examples/playground): gitignore .jsonl + .log under pocs/**/expected

### DIFF
--- a/examples/playground/.gitignore
+++ b/examples/playground/.gitignore
@@ -8,6 +8,8 @@
 pocs/**/expected/*.json
 pocs/**/expected/*.dot
 pocs/**/expected/*.txt
+pocs/**/expected/*.jsonl
+pocs/**/expected/*.log
 !pocs/**/expected/.gitkeep
 
 # Python (benchmarks, dbt-migration POC)


### PR DESCRIPTION
## Summary

POCs' \`run.sh\` scripts write transient artifacts under \`expected/\` that should never be committed. The existing gitignore covered \`.json\`/\`.dot\`/\`.txt\`; this adds:

- \`.jsonl\` — \`07-adapters/04-custom-process-adapter\` \`tee\`s its JSON-RPC transcript there
- \`.log\` — \`03-ai/*\` POCs \`tee\` generation logs there

Found while running \`./scripts/run-all-duckdb.sh\` as smoke test for PR #196 — the transcript landed as an untracked file afterwards.

## Test plan

- [x] \`git status\` is clean after running \`./scripts/run-all-duckdb.sh\`