### PR TITLE
fix(engine): handle SIGPIPE gracefully on CLI stdout

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3272,6 +3272,7 @@ version = "1.11.0"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "miette",
  "rocky-cli",
  "rocky-core",

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -23,5 +23,11 @@ clap = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+# Used only to restore the kernel-default SIGPIPE handler on startup so the
+# CLI exits cleanly when its stdout is piped into `head`, `less`, `jq | head`,
+# etc. Scoped to Unix targets; Windows has no SIGPIPE.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [lints]
 workspace = true

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -855,6 +855,34 @@ enum ListAction {
     },
 }
 
+/// Restore the kernel-default SIGPIPE disposition so that piping the CLI
+/// into `head`, `less`, `jq | head`, etc. terminates the process cleanly
+/// (exit 141) instead of aborting on an `EPIPE` panic from `println!`.
+///
+/// Rust's standard library installs `SIG_IGN` for SIGPIPE at startup, which
+/// makes every subsequent `write(2)` return `EPIPE`; `println!` / `writeln!`
+/// then panic, and a panic in the main thread with `panic = "abort"`
+/// surfaces as SIGABRT (exit 134). Restoring `SIG_DFL` gives us the POSIX
+/// convention instead.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: `signal(2)` is async-signal-safe, and we call it as the very
+    // first statement of `main()` — before `Cli::parse()`, before the tokio
+    // runtime is built, and therefore before any threads exist. Restoring
+    // `SIG_DFL` only changes process-wide disposition to the kernel default;
+    // the worst case if the invariant (single-threaded, pre-runtime) were
+    // violated would be a transient race on the signal table, not UB.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {
+    // Windows has no SIGPIPE; `WriteFile` on a closed pipe returns an error
+    // that Rust surfaces as `ErrorKind::BrokenPipe` without aborting.
+}
+
 /// Synchronous entry point. Parses the CLI first so clap can handle
 /// `--version` / `--help` / `--completions` via its own short-circuit
 /// (it calls `process::exit(0)` before we ever reach here) without
@@ -868,6 +896,10 @@ enum ListAction {
 /// fast-exit flags, which matters for shell prompt integrations and
 /// editor-extension startup checks.
 fn main() -> Result<()> {
+    // Must run before `Cli::parse()`: clap emits `--help` / `--version`
+    // through `println!`, which panics on EPIPE if SIGPIPE is ignored.
+    reset_sigpipe();
+
     let cli = Cli::parse();
     let json = matches!(cli.output, OutputFormat::Json);
 


### PR DESCRIPTION
## Summary

`rocky compile --output json | head -N` (and every similar pipe that closes stdout early — `jq | head`, `| less`, `| head -c 1`, etc.) used to abort with SIGABRT (exit 134) on the child. Root cause: Rust's stdlib installs `SIG_IGN` for SIGPIPE at startup, so after the downstream pipe closes, the next `write(2)` returns `EPIPE`, `println!` panics, and under `panic = "abort"` that panic becomes SIGABRT.

Fix: restore the kernel-default SIGPIPE disposition (`SIG_DFL`) as the very first statement of `main()` — before `Cli::parse()`, before the tokio runtime is built, before any threads exist. The process now terminates cleanly with SIGPIPE (exit 141) instead, which is the POSIX convention for broken-pipe exits. Windows gets a no-op stub via `#[cfg(unix)]` since it has no SIGPIPE.

`libc` is added as a target-scoped dep under `[target.'cfg(unix)'.dependencies]` so the Windows build remains untouched.

Ref: rocky backlog TODO.md §3 (2026-04-20).

## Manual smoke test

```
$ ./engine/target/release/rocky --help | head -1
Command groups (Plan 22 design)
exit=0

$ ./engine/target/release/rocky --version | head -1
rocky 1.11.0
exit=0

$ ./engine/target/release/rocky --help | head -c 1 > /dev/null
exit=0

$ ./engine/target/release/rocky plan --help | head -c 1 > /dev/null
exit=0

$ cd examples/playground/pocs/01-quality/01-data-contracts-strict
$ ../../../../engine/target/release/rocky compile --output json | head -5
{ ... tracing lines on stderr + first 5 JSON lines on stdout ... }
exit=0

$ ../../../../engine/target/release/rocky compile --output json | head -1
exit=0
```

All exit codes are `0` (or, had the pipe closed mid-write rather than between writes, would be `141`). Never `134` (SIGABRT).

## Test plan

- [x] `cargo build -p rocky --release` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p rocky` — passes (0 tests; rocky is a thin binary crate)
- [x] Manual smoke tests above — all exit 0
- [x] SAFETY comment on the `libc::signal` unsafe block follows the `rust-unsafe` skill convention (async-signal-safety, single-threaded pre-runtime invariant, fallback worst case)
- [x] No schema cascade touched — runtime-only fix, no changes to `schemas/`, `types_generated/`, or any `*Output` struct