### PR TITLE
feat(engine): Trust-system Arc 1 — rocky branch compare

### DIFF
--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use rocky_core::compare::ComparisonThresholds;
+use rocky_core::shadow::ShadowConfig;
 use rocky_core::state::{BranchRecord, StateStore};
 
 use crate::output::{BranchDeleteOutput, BranchEntry, BranchListOutput, BranchOutput};
@@ -148,6 +150,41 @@ pub fn run_branch_list(state_path: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
+/// `rocky branch compare <name>` — diff a branch's table set against the
+/// main (production) targets.
+///
+/// Looks up the branch's `schema_prefix` in the state store and reuses the
+/// existing `rocky compare` machinery by constructing a [`ShadowConfig`]
+/// whose `schema_override` points at the branch's schema. Mirrors how
+/// `rocky run --branch <name>` wires the same prefix into the write path.
+///
+/// Branches with no materialized tables yet surface as missing rows/columns
+/// on the production side of the diff rather than crashing — the underlying
+/// compare path uses `unwrap_or_default` for describe/count failures.
+pub async fn run_branch_compare(
+    state_path: &Path,
+    config_path: &Path,
+    branch_name: &str,
+    filter: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let store = StateStore::open_read_only(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+
+    let record = store
+        .get_branch(branch_name)?
+        .with_context(|| format!("branch '{branch_name}' not found — see 'rocky branch list'"))?;
+
+    let shadow_config = ShadowConfig {
+        suffix: "_rocky_shadow".to_string(),
+        schema_override: Some(record.schema_prefix),
+        cleanup_after: false,
+    };
+    let thresholds = ComparisonThresholds::default();
+
+    super::compare::compare(config_path, filter, None, &shadow_config, &thresholds, json).await
+}
+
 /// `rocky branch show <name>` — inspect a single branch.
 pub fn run_branch_show(state_path: &Path, name: &str, json: bool) -> Result<()> {
     let store = StateStore::open_read_only(state_path)
@@ -179,6 +216,7 @@ pub fn run_branch_show(state_path: &Path, name: &str, json: bool) -> Result<()> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn validate_accepts_common_names() {
@@ -195,5 +233,65 @@ mod tests {
         assert!(validate_branch_name("has/slash").is_err());
         assert!(validate_branch_name("has;semi").is_err());
         assert!(validate_branch_name(&"x".repeat(65)).is_err());
+    }
+
+    /// `rocky branch compare` resolves the branch's `schema_prefix` from
+    /// the state store and wires it into a `ShadowConfig.schema_override` —
+    /// the same mapping used by `rocky run --branch`.
+    #[test]
+    fn branch_compare_maps_schema_prefix_to_shadow_override() {
+        let tmp = TempDir::new().unwrap();
+        let state_path = tmp.path().join("state.redb");
+
+        // Register a branch via the create path (populates the default
+        // `branch__<name>` schema_prefix).
+        run_branch_create(&state_path, "fix-price", None, false).unwrap();
+
+        // Fetch it directly the way `run_branch_compare` does and build
+        // the ShadowConfig — asserting the wiring is exact.
+        let store = StateStore::open_read_only(&state_path).unwrap();
+        let record = store.get_branch("fix-price").unwrap().unwrap();
+
+        let shadow_config = ShadowConfig {
+            suffix: "_rocky_shadow".to_string(),
+            schema_override: Some(record.schema_prefix.clone()),
+            cleanup_after: false,
+        };
+
+        assert_eq!(record.schema_prefix, "branch__fix-price");
+        assert_eq!(
+            shadow_config.schema_override.as_deref(),
+            Some("branch__fix-price")
+        );
+        assert!(!shadow_config.cleanup_after);
+    }
+
+    /// A missing branch must surface a crisp error that steers the user
+    /// toward `rocky branch list`.
+    #[tokio::test]
+    async fn branch_compare_missing_branch_crisp_error() {
+        let tmp = TempDir::new().unwrap();
+        let state_path = tmp.path().join("state.redb");
+
+        // Touch the state store so it exists but has no branches.
+        StateStore::open(&state_path).unwrap();
+
+        // config_path doesn't need to exist — resolution of the missing
+        // branch fails before the config is loaded.
+        let config_path = tmp.path().join("rocky.toml");
+
+        let err = run_branch_compare(&state_path, &config_path, "ghost", None, false)
+            .await
+            .expect_err("missing branch must be an error");
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("branch 'ghost' not found"),
+            "error must name the missing branch: {msg}"
+        );
+        assert!(
+            msg.contains("rocky branch list"),
+            "error must steer user to 'rocky branch list': {msg}"
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -52,7 +52,9 @@ pub use ai::{run_ai, run_ai_explain, run_ai_sync, run_ai_test};
 pub use archive::run_archive;
 #[cfg(feature = "duckdb")]
 pub use bench::run_bench;
-pub use branch::{run_branch_create, run_branch_delete, run_branch_list, run_branch_show};
+pub use branch::{
+    run_branch_compare, run_branch_create, run_branch_delete, run_branch_list, run_branch_show,
+};
 #[cfg(feature = "duckdb")]
 pub use ci::run_ci;
 pub use ci_diff::run_ci_diff;

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -821,6 +821,19 @@ enum BranchAction {
         /// Branch name
         name: String,
     },
+    /// Diff a branch's table set against production targets.
+    ///
+    /// Reuses the `rocky compare` machinery — looks up the branch's
+    /// `schema_prefix` in the state store and compares the branch
+    /// schema (e.g. `branch__myfeature`) against the pipeline's
+    /// production target schemas.
+    Compare {
+        /// Branch name
+        name: String,
+        /// Filter sources by component value (e.g., --filter client=acme)
+        #[arg(long)]
+        filter: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1338,6 +1351,16 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             BranchAction::List => rocky_cli::commands::run_branch_list(&cli.state_path, json),
             BranchAction::Show { name } => {
                 rocky_cli::commands::run_branch_show(&cli.state_path, &name, json)
+            }
+            BranchAction::Compare { name, filter } => {
+                rocky_cli::commands::run_branch_compare(
+                    &cli.state_path,
+                    &cli.config,
+                    &name,
+                    filter.as_deref(),
+                    json,
+                )
+                .await
             }
         },
         Command::Replay { target, model } => {


### PR DESCRIPTION
## Summary

- Adds `rocky branch compare <name> [--filter <k=v>]` — diffs a branch's materialized table set against the pipeline's main (production) targets.
- Reuses the existing `rocky compare` engine: resolves the branch's `schema_prefix` from the state store and constructs a `ShadowConfig` whose `schema_override` points at the branch schema (same wiring `rocky run --branch` already uses for writes, so the diff is consistent end-to-end).
- Zero JSON-schema change — reuses `CompareOutput` + `TableCompareResult` as-is. Codegen is a verified no-op.

Implements the follow-up bullet **"rocky branch compare — diff branch targets against main targets; reuses existing compare machinery"** from [`~/Developer/rocky-plans/TODO.md` §2 Trust-system Arc 1 follow-ups](https://github.com/rocky-data/rocky/tree/main) and [`plans/rocky-trust-system-direction.md` §"Arc 1"](https://github.com/rocky-data/rocky/tree/main).

## Design

**Option A (direct delegation)**, chosen because `compare::compare` already accepts `&ShadowConfig` by reference and `main.rs:963-967` already proves the branch-record → `schema_override` mapping for `rocky run --branch`. No refactor needed.

```rust
// commands/branch.rs
let shadow_config = ShadowConfig {
    suffix: "_rocky_shadow".to_string(),
    schema_override: Some(record.schema_prefix),
    cleanup_after: false,
};
super::compare::compare(config_path, filter, None, &shadow_config, &thresholds, json).await
```

**Known quirks inherited from Option A (intentional, documented):**
- `CompareOutput.command` is the literal `"compare"` (hardcoded inside `compare::compare`). Generalizing that string requires lifting it to a parameter — deferred to keep this PR zero-schema-change. Dagster/VS Code consumers don't switch on that value today.
- `shadow_table` / `shadow_count` fields carry branch-side data with slightly awkward legacy nomenclature. Output could be generalized to `variant_table`/`variant_count` in a later PR; not needed for the Arc 1 outcome.
- If a branch has not yet been run, the missing branch-side tables surface as `shadow_count=0` / schema diff (describe + count use `unwrap_or_default` in the existing compare path) — not a crash, but it will verdict `fail` on a 100% delta. Users should `rocky run --branch <name>` before comparing. Called out in `run_branch_compare`'s doc comment.

## Out of scope (separate follow-ups, per the plan)

- Warehouse-native clone on `rocky branch create` (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`).
- `rocky replay` re-execution (waits on content-addressed write path / Exp 4).
- Any change to the existing `rocky compare` subcommand surface.

## Smoke test

Ran against `examples/playground/pocs/00-foundations/06-branches-replay-lineage` (DuckDB, no credentials):

```
$ rocky -c rocky.toml branch compare testbranch --output json
{
  "version": "1.11.0",
  "command": "compare",
  "filter": "",
  "tables_compared": 1,
  "tables_passed": 1,
  "tables_warned": 0,
  "tables_failed": 0,
  "results": [
    {
      "production_table": "poc.staging__orders.orders",
      "shadow_table": "poc.branch__testbranch.orders",
      "row_count_match": true,
      "production_count": 200,
      "shadow_count": 200,
      "row_count_diff_pct": 0.0,
      "schema_match": true,
      "schema_diffs": [],
      "verdict": "pass"
    }
  ],
  "overall_verdict": "pass"
}

$ rocky -c rocky.toml -o table branch compare testbranch
  Rocky Compare

  Tables: 1 compared, 1 passed, 0 warned, 0 failed
  Overall: PASS

  [  OK] poc.staging__orders.orders (prod=200, shadow=200, diff=0.00%)

$ rocky -c rocky.toml -o json branch compare testbranch --filter source=orders
  "filter": "source=orders",
  "tables_compared": 1, "tables_passed": 1, ...

$ rocky -c rocky.toml branch compare nonexistent
Error: branch 'nonexistent' not found — see 'rocky branch list'
```

`rocky branch --help` now lists `compare` alongside `create` / `delete` / `list` / `show`.

## Test plan

- [x] `cargo build --release` — clean
- [x] `cargo test -p rocky-cli -p rocky-core` — pass (new `branch_compare_maps_schema_prefix_to_shadow_override` and `branch_compare_missing_branch_crisp_error` green; pre-existing `every_committed_poc_matches_project_schema` failure on `main` is unrelated — `"bq"` portability target_dialect drift in `06-developer-experience/08-portability-lint/rocky.toml`)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `just codegen` from monorepo root — verified no-op on `git status` (no `Output` struct changed)
- [x] End-to-end DuckDB smoke (above) — verdict pass; crisp error on missing branch
- [x] `rocky branch compare --help` + `rocky branch --help` render the new subcommand