### PR TITLE
fix(examples/playground): use canonical target_dialect in portability POC

### DIFF
--- a/examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml
@@ -6,7 +6,7 @@ path = "poc.duckdb"
 
 # Project-wide portability settings. Per-model overrides via `-- rocky-allow` pragma.
 [portability]
-target_dialect = "bq"
+target_dialect = "bigquery"
 allow = ["QUALIFY"]  # QUALIFY is BigQuery-supported, so allow it project-wide
 
 [pipeline.poc]


### PR DESCRIPTION
## Summary

`examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml` had `target_dialect = "bq"`, which is invalid both at the TOML schema level and at runtime — `rocky_sql::transpile::Dialect` uses `#[serde(rename_all = "lowercase")]` and only accepts `databricks` / `snowflake` / `bigquery` / `duckdb` in `[portability]` blocks. The short-form `bq` / `sf` / `dbx` are **CLI-flag ergonomics only** (`rocky compile --target-dialect bq`), converted to the long form at the clap boundary.

Flipping one TOML line to `"bigquery"` unblocks `every_committed_poc_matches_project_schema` on `main`, which has been red since the POC landed in #196.

## Why POC behavior is unchanged

`run.sh` already overrides the TOML with `--target-dialect bq` on the CLI — that short form stays valid at the flag level. The TOML value is only consulted when no CLI override is present, so the POC's demonstration flow is identical.

## Test plan

- [x] `cargo test -p rocky-core --test project_schema every_committed_poc_matches_project_schema` — now passes
- [x] Confirmed on main (pre-fix): test fails with `"bq" is not valid under any of the schemas listed in the 'anyOf' keyword at /portability/target_dialect`
- [ ] POC smoke: `./run.sh` still exits 0 in the 08-portability-lint POC (reviewer sanity-check)

Context: drift caught by the parallel agent while implementing `rocky branch compare` (PR #200).