### PR TITLE
docs: cover rocky cost + rocky branch compare + Arc 1 wave 2 cascade

### DIFF
--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -150,7 +150,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 `playground` · `serve` · `lsp` · `init-adapter` · `test-adapter` · `import-dbt` · `validate-migration`
 
 ### Administration
-`doctor` · `history` · `replay` · `trace` · `metrics` · `optimize` · `compact` · `profile-storage` · `archive` · `bench` · `hooks list` · `hooks test`
+`doctor` · `history` · `replay` · `trace` · `cost` · `metrics` · `optimize` · `compact` · `profile-storage` · `archive` · `bench` · `hooks list` · `hooks test`
 
 ## Observability
 
@@ -161,6 +161,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 - **OTLP metrics export** (feature-gated via `--features otel`) — `rocky run` exports in-process counters and histograms to any OTLP-compatible collector.
 - **Run-level budgets** — `[budget] max_usd` + `max_duration_ms` with `on_breach = "warn" | "error"`; fires `budget_breach` events. See [`[budget]`](/reference/configuration/#budget).
 - **Per-run cost attribution** — `RunOutput.cost_summary` carries per-run total cost; per-materialization `cost_usd` flows through `MaterializationMetadata`.
+- **`rocky cost <run_id|latest>`** — historical rollup over stored runs. Reads the same `RunRecord` as `replay` / `trace`; recomputes per-model cost via the adapter-appropriate formula (duration × DBU for Databricks/Snowflake; bytes × $/TB for BigQuery; zero for DuckDB).
 
 ## IDE / Language Server (11 capabilities)
 

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -670,5 +670,106 @@ parallelism: 2 lanes
 ### Related Commands
 
 - [`rocky replay`](#rocky-replay) -- flat per-model dump of the same run
+- [`rocky cost`](#rocky-cost) -- per-model cost rollup for the same run
 - [`rocky history`](#rocky-history) -- list recent runs
 - [`rocky metrics`](#rocky-metrics) -- quality metrics captured during runs
+
+---
+
+## `rocky cost`
+
+Historical cost rollup for a completed run. Reads the same `RunRecord` as [`rocky replay`](#rocky-replay) and [`rocky trace`](#rocky-trace), then recomputes per-model cost via the adapter-appropriate formula (Databricks / Snowflake duration × DBU rate; BigQuery bytes × $/TB; DuckDB zero). Sibling commands — replay shows what ran, trace shows when, `cost` shows what it cost.
+
+```bash
+rocky cost <target> [flags]
+```
+
+### Arguments
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `target` | `string` | **(required)** | A specific `run_id`, or the literal `latest` for the most recent run. |
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--model <NAME>` | `string` | | Filter to a single model within the run. |
+| `--output <FORMAT>` | `json|table` | `json` | Output format. Table form is a compact per-model breakdown. |
+
+### Examples
+
+Roll up cost for the most recent run:
+
+```bash
+rocky cost latest
+```
+
+```json
+{
+  "version": "1.11.0",
+  "command": "cost",
+  "run_id": "run-20260421-142430-017",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2026-04-21T14:24:29.881087+00:00",
+  "finished_at": "2026-04-21T14:24:30.031036+00:00",
+  "duration_ms": 149,
+  "adapter_type": "databricks",
+  "total_cost_usd": 0.101,
+  "total_duration_ms": 910000,
+  "total_bytes_scanned": 104857600,
+  "total_bytes_written": 20971520,
+  "per_model": [
+    {
+      "model_name": "stg_orders",
+      "status": "success",
+      "duration_ms": 310000,
+      "rows_affected": 150000,
+      "bytes_scanned": 41943040,
+      "bytes_written": 10485760,
+      "cost_usd": 0.034
+    },
+    {
+      "model_name": "fct_revenue",
+      "status": "success",
+      "duration_ms": 600000,
+      "rows_affected": 8900,
+      "bytes_scanned": 62914560,
+      "bytes_written": 10485760,
+      "cost_usd": 0.067
+    }
+  ]
+}
+```
+
+Human-readable table form:
+
+```bash
+rocky cost latest --output table
+```
+
+```
+run: run-20260421-142430-017
+status: success   adapter: databricks   total: $0.101
+
+  model            duration       rows   bytes_scanned  cost
+  stg_orders        5m 10s    150,000           40 MB  $0.034
+  fct_revenue      10m  0s      8,900           60 MB  $0.067
+```
+
+### Adapter coverage
+
+- **Databricks / Snowflake** — cost computed from recorded duration × DBU rate × `$/DBU`. Configure via `[cost]` in `rocky.toml` (see [configuration reference](/reference/configuration/#cost)).
+- **BigQuery** — computed from recorded `bytes_scanned` × `$6.25/TB`. `rocky cost` surfaces real dollars here even when the live `rocky run` still reports `None` for BQ bytes on its own `RunOutput.cost_summary`, because the state-store record is written before that plumbing completes.
+- **DuckDB / local** — `$0.00` by definition (no billed compute).
+- **Discovery adapters (Fivetran, Airbyte, etc.)** — skipped; cost is `None`.
+
+Missing `adapter_type` or unconfigured `[cost]` degrades cleanly: the command still emits duration + bytes totals but leaves `cost_usd` as `null`.
+
+### Related Commands
+
+- [`rocky replay`](#rocky-replay) -- same `RunRecord`, shown as a per-model execution dump
+- [`rocky trace`](#rocky-trace) -- same `RunRecord`, shown as a Gantt-style timeline
+- [`rocky history`](#rocky-history) -- list recent runs to find a `run_id`
+- [`[budget]`](/reference/configuration/#budget) -- run-level budget that fires `budget_breach` events during the run itself

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -462,6 +462,7 @@ rocky branch create <name> [--description <text>]
 rocky branch delete <name>
 rocky branch list
 rocky branch show <name>
+rocky branch compare <name> [--filter <key=value>]
 ```
 
 Branch names accept `[A-Za-z0-9_.\-]` up to 64 characters. The default schema prefix is `branch__<name>`. Deleting a branch removes the state-store entry but does **not** drop warehouse tables that were materialized under it.
@@ -509,7 +510,15 @@ rocky run --filter client=acme --branch fix-price
 rocky branch delete fix-price
 ```
 
+Diff a branch's materialized tables against production (row counts + schemas):
+
+```bash
+rocky branch compare fix-price
+```
+
+Internally this is `rocky compare` pointed at the branch's `schema_prefix` via `ShadowConfig.schema_override` — the same mechanism `rocky run --branch` uses for writes, so compare always hits exactly the tables the branch produced. Accepts the shared [`--filter`](/reference/filters/) flag.
+
 ### Related Commands
 
 - [`rocky run`](#rocky-run) -- execute a pipeline against a branch via `--run --branch`
-- [`rocky compare`](/reference/cli/#rocky-compare) -- diff branch output against production
+- [`rocky compare`](/reference/cli/#rocky-compare) -- diff an ad-hoc shadow against production (the generic form `rocky branch compare` specialises)

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky cost <run_id|latest>`** (#202) — historical cost rollup over stored runs. Recomputes per-model cost via `rocky_core::cost::compute_observed_cost_usd` from `ModelExecution.duration_ms` / `bytes_scanned`. New `CostOutput` + `PerModelCostHistorical` through the codegen cascade. BigQuery cost now computes from stored bytes even when the live `rocky run` path still emits `None`. Arc 2 wave 2 first PR.
+- **`rocky branch compare <name>`** (#200) — diff a named branch's targets against main. Delegates to the existing `compare::compare` entry point with the branch's `schema_prefix` routed through `ShadowConfig.schema_override` — same mechanism `rocky run --branch` uses for writes, so compare hits exactly the tables the branch produced. Zero JSON-schema drift.
+- **`rocky run` now persists `RunRecord` to the state store** (#203) — `StateStore::record_run` wired at every exit path (happy / interrupted / model-only) after `populate_cost_summary`. `rocky history`, `rocky replay`, `rocky trace`, and `rocky cost` now return real data instead of reading from an empty store. Per-model timestamps are lossily captured as `finished_at = run.finished_at`, `started_at = finished_at - duration`; actual per-model wall-clock windows require execution-loop instrumentation and land in a later wave. Arc 1 wave 2.
+- **`OptimizeRecommendation`** (#203) gained `compute_cost_per_run`, `storage_cost_per_month`, `downstream_references` — projected through from `rocky_core::optimize::MaterializationCost` so Dagster `checks.py` can surface the values as asset metadata without re-deriving.
+
+### Fixed
+
+- **SIGPIPE now handled gracefully** (#199) — `rocky <cmd> | head` / `| jq | head` no longer SIGABRTs. Rust's default was to ignore `SIGPIPE` at the kernel level and panic from `println!` on the resulting EPIPE; restored the POSIX default in `main()` before `Cli::parse()` so `--help` / `--version` are also covered. `#[cfg(not(unix))]` stub preserves Windows builds.
+- **`target_dialect = "bq"` rejected by the project schema** (#201) — `examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml` had the CLI-flag short form where only the long form (`bigquery`) is valid in `[portability]`. Updated the POC; `every_committed_poc_matches_project_schema` is green again.
+- **`HistoryResult` Pydantic drift** (#203) — hand-written class mirrored the state-store `RunRecord` shape (`finished_at`, `config_hash`, `models_executed` as a list) rather than what `rocky history --json` actually emits. Completed the Phase 2 soft-swap that history had been missing: `HistoryResult = HistoryOutput`, `ModelHistoryResult = ModelHistoryOutput`. Invisible until runs stopped being empty.
+
+### Internal
+
+- **`scripts/_normalize_fixture.py`** (#203) gained `WALL_CLOCK_ID_FIELDS = {"run_id"}` and `DERIVED_FROM_WALL_CLOCK_FIELDS = {"compute_cost_per_run", "estimated_monthly_savings"}` so dagster test fixtures stay byte-stable across regens now that `run_id` and wall-clock-derived cost numbers appear in non-empty arrays.
+
 ## [1.11.0] — 2026-04-20
 
 Closes the **first wave of every trust-system arc** (Arcs 1–7) plus two


### PR DESCRIPTION
## Summary

Documents the commands that landed in PRs #199-#203 and populates the CHANGELOG's `[Unreleased]` section for the next coordinated release cut (`engine-v1.12.0` / `dagster-v1.8.0` / `vscode-v1.6.2`).

## What's added

- **`rocky cost <run_id|latest>`** — full reference section in `administration.md` with JSON + table examples plus adapter-coverage notes (Databricks/Snowflake duration-based; BigQuery bytes; DuckDB zero; discovery adapters skipped). Cross-linked from `rocky trace`'s related-commands list so the three sibling `RunRecord` readers (replay/trace/cost) all reference each other.
- **`rocky branch compare <name>`** — added to the branch subcommand header in `core-pipeline.md` with a short usage example explaining the `ShadowConfig.schema_override` mechanism it shares with `rocky run --branch`.
- **`all-features.md`** — added `cost` to the administration command roster and a bullet under Observability for the historical-rollup surface.
- **`engine/CHANGELOG.md`** — populated `[Unreleased]` with all five PRs from 2026-04-21 (SIGPIPE, branch compare, POC portability cleanup, rocky cost, record_run wiring) plus the Pydantic soft-swap + fixture normalizer internals.

## What's *not* changed

- No changes to the `rocky replay` / `rocky trace` existing sections — they already described the intended behaviour; PR #203 made them actually work without the docs needing to move. Reviewing those pages now reads as an accurate description of shipped behaviour.
- No dagster integration docs changes for `rocky cost` — PR #202 explicitly deferred the `RockyResource.cost()` wiring to a follow-up. When that lands, dagster/resource docs get the method reference.

## Test plan

- [x] `cd docs && npm run build` — 69 pages built, no warnings, no broken links.
- [ ] Reviewer sanity-check on the `rocky cost` example JSON — the Databricks numbers shown ($0.101 total, stg_orders at $0.034, fct_revenue at $0.067) are illustrative of the `duration × DBU × $/DBU` math, not captured from a real run. Flag if they look unrealistic.