### PR TITLE
feat(engine): stamp real per-model started_at on MaterializationOutput

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -264,6 +264,10 @@ export interface MaterializationOutput {
    */
   partition?: PartitionInfo | null;
   rows_copied?: number | null;
+  /**
+   * Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.
+   */
+  started_at: string;
   [k: string]: unknown;
 }
 export interface MaterializationMetadata {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2876,6 +2876,7 @@ async fn run_one_partition(
     use rocky_core::incremental::{PartitionRecord, PartitionStatus};
     let key = partition_plan.partition_key.clone();
     let partition_start = std::time::Instant::now();
+    let partition_started_at = chrono::Utc::now();
 
     // Mark InProgress before executing so a crashed runner leaves a
     // diagnostic breadcrumb in the state store.
@@ -2979,6 +2980,7 @@ async fn run_one_partition(
             asset_key: asset_key.to_vec(),
             rows_copied: None,
             duration_ms: record.duration_ms,
+            started_at: partition_started_at,
             metadata: MaterializationMetadata {
                 strategy: "time_interval".to_string(),
                 watermark: None,
@@ -3012,6 +3014,7 @@ async fn process_table(
     task: &TableTask,
 ) -> Result<TableResult> {
     let table_start = Instant::now();
+    let table_started_at = Utc::now();
     let dialect = warehouse.dialect();
 
     let source_table = TableRef {
@@ -3252,6 +3255,7 @@ async fn process_table(
             asset_key: asset_key.clone(),
             rows_copied: None,
             duration_ms: table_duration,
+            started_at: table_started_at,
             metadata: MaterializationMetadata {
                 strategy: strategy_name.to_string(),
                 watermark: Some(now),

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -599,6 +599,7 @@ pub async fn run_snapshot(
     output_json: bool,
 ) -> Result<()> {
     let start = Instant::now();
+    let started_at = chrono::Utc::now();
 
     let pipes = crate::pipes::PipesEmitter::detect();
     if let Some(p) = &pipes {
@@ -662,6 +663,7 @@ pub async fn run_snapshot(
             ],
             rows_copied: None,
             duration_ms: start.elapsed().as_millis() as u64,
+            started_at,
             metadata: MaterializationMetadata {
                 strategy: "snapshot_scd2".to_string(),
                 watermark: None,

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -316,6 +316,14 @@ pub struct MaterializationOutput {
     pub asset_key: Vec<String>,
     pub rows_copied: Option<u64>,
     pub duration_ms: u64,
+    /// Wall-clock timestamp captured at the moment the engine began
+    /// executing this model. Used by `RunOutput::to_run_record` to
+    /// build accurate per-model windows on the persisted
+    /// `ModelExecution` — replaces the prior lossy reconstruction
+    /// (`finished_at - duration`) that mis-ordered parallel runs.
+    /// `finished_at` is derived as `started_at + duration_ms`; keeping
+    /// one source of truth avoids drift between the two.
+    pub started_at: DateTime<Utc>,
     pub metadata: MaterializationMetadata,
     /// Partition window this materialization targeted, present only when
     /// the model's strategy is `time_interval`. `None` for unpartitioned
@@ -1991,12 +1999,10 @@ impl RunOutput {
     /// Each [`MaterializationOutput`] becomes a success-status
     /// [`rocky_core::state::ModelExecution`]; each
     /// [`TableErrorOutput`] becomes a failure-status entry. Per-model
-    /// timestamps are lossy: `finished_at` is set to the run's
-    /// `finished_at` (every model) and `started_at` is computed as
-    /// `finished_at - duration_ms`. Actual per-model wall-clock windows
-    /// require execution-loop instrumentation and land in a later wave —
-    /// this mirrors how `populate_cost_summary` leaves `bytes_scanned`
-    /// as `None` until the adapter layer plumbs real values.
+    /// windows use `MaterializationOutput::started_at` (stamped at
+    /// execution time) and derive `finished_at` as
+    /// `started_at + duration_ms` — parallel runs preserve their real
+    /// ordering on the stored `RunRecord`.
     ///
     /// `model_name` is derived from the last element of
     /// [`MaterializationOutput::asset_key`] to match how `rocky cost` /
@@ -2014,8 +2020,9 @@ impl RunOutput {
 
         for mat in &self.materializations {
             let duration_ms = mat.duration_ms;
-            let model_start = finished_at
-                - chrono::Duration::milliseconds(duration_ms.min(i64::MAX as u64) as i64);
+            let model_started = mat.started_at;
+            let model_finished = model_started
+                + chrono::Duration::milliseconds(duration_ms.min(i64::MAX as u64) as i64);
             let model_name = mat
                 .asset_key
                 .last()
@@ -2023,8 +2030,8 @@ impl RunOutput {
                 .unwrap_or_else(|| "<unknown>".to_string());
             models.push(rocky_core::state::ModelExecution {
                 model_name,
-                started_at: model_start,
-                finished_at,
+                started_at: model_started,
+                finished_at: model_finished,
                 duration_ms,
                 rows_affected: mat.rows_copied,
                 status: "success".to_string(),
@@ -2261,6 +2268,7 @@ mod cost_finalize_tests {
             asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
             rows_copied: None,
             duration_ms,
+            started_at: Utc::now(),
             metadata: MaterializationMetadata {
                 strategy: "full_refresh".to_string(),
                 watermark: None,
@@ -2369,11 +2377,17 @@ mod run_record_tests {
     use super::*;
     use rocky_core::state::{RunStatus, RunTrigger};
 
-    fn mat(asset_key: &[&str], duration_ms: u64, sql_hash: Option<&str>) -> MaterializationOutput {
+    fn mat(
+        asset_key: &[&str],
+        duration_ms: u64,
+        sql_hash: Option<&str>,
+        started_at: DateTime<Utc>,
+    ) -> MaterializationOutput {
         MaterializationOutput {
             asset_key: asset_key.iter().map(|s| (*s).to_string()).collect(),
             rows_copied: Some(42),
             duration_ms,
+            started_at,
             metadata: MaterializationMetadata {
                 strategy: "full_refresh".to_string(),
                 watermark: None,
@@ -2394,20 +2408,26 @@ mod run_record_tests {
     }
 
     #[test]
-    fn to_run_record_maps_materializations_to_success_entries() {
+    fn to_run_record_uses_per_model_started_at() {
         let mut out = RunOutput::new(String::new(), 5_000, 1);
         out.tables_copied = 2;
+        let run_started = fixed_start();
+        // Simulate parallel execution: orders starts at +0s (runs
+        // 1.5s), customers starts at +0.5s (runs 0.8s). Under the old
+        // lossy reconstruction both would share the same finished_at
+        // and have started_at rebuilt from the wrong end.
+        let orders_start = run_started;
+        let customers_start = run_started + chrono::Duration::milliseconds(500);
         out.materializations
-            .push(mat(&["s", "orders"], 1_500, Some("abc123")));
+            .push(mat(&["s", "orders"], 1_500, Some("abc123"), orders_start));
         out.materializations
-            .push(mat(&["s", "customers"], 800, None));
+            .push(mat(&["s", "customers"], 800, None, customers_start));
 
-        let started = fixed_start();
-        let finished = started + chrono::Duration::seconds(5);
+        let run_finished = run_started + chrono::Duration::seconds(5);
         let record = out.to_run_record(
             "run-test-1",
-            started,
-            finished,
+            run_started,
+            run_finished,
             "cfghash".to_string(),
             RunTrigger::Manual,
             RunStatus::Success,
@@ -2423,15 +2443,23 @@ mod run_record_tests {
         assert_eq!(orders.duration_ms, 1_500);
         assert_eq!(orders.rows_affected, Some(42));
         assert_eq!(orders.sql_hash, "abc123");
-        assert_eq!(orders.finished_at, finished);
+        // Each model's started_at mirrors the MaterializationOutput's;
+        // finished_at is derived as started_at + duration (preserves
+        // parallel overlap rather than collapsing to run.finished_at).
+        assert_eq!(orders.started_at, orders_start);
         assert_eq!(
-            orders.started_at,
-            finished - chrono::Duration::milliseconds(1_500)
+            orders.finished_at,
+            orders_start + chrono::Duration::milliseconds(1_500)
         );
 
         let customers = &record.models_executed[1];
         assert_eq!(customers.model_name, "customers");
         assert_eq!(customers.sql_hash, "", "sql_hash none → empty string");
+        assert_eq!(customers.started_at, customers_start);
+        assert_eq!(
+            customers.finished_at,
+            customers_start + chrono::Duration::milliseconds(800)
+        );
     }
 
     #[test]
@@ -2439,8 +2467,9 @@ mod run_record_tests {
         let mut out = RunOutput::new(String::new(), 2_000, 1);
         out.tables_copied = 1;
         out.tables_failed = 1;
+        let run_started = fixed_start();
         out.materializations
-            .push(mat(&["s", "orders"], 1_000, Some("ok")));
+            .push(mat(&["s", "orders"], 1_000, Some("ok"), run_started));
         out.errors.push(TableErrorOutput {
             asset_key: vec!["s".to_string(), "broken".to_string()],
             error: "connection refused".to_string(),

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -394,6 +394,10 @@ class MaterializationOutput(BaseModel):
     Partition window this materialization targeted, present only when the model's strategy is `time_interval`. `None` for unpartitioned strategies (full_refresh, incremental, merge).
     """
     rows_copied: conint(ge=0) | None = None
+    started_at: AwareDatetime
+    """
+    Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.
+    """
 
 
 class TableCheckOutput(BaseModel):

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "incremental",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
@@ -30,6 +31,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
@@ -52,6 +54,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
@@ -74,6 +77,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
@@ -96,6 +100,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
@@ -118,6 +123,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
@@ -30,6 +31,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",
@@ -30,6 +31,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -15,6 +15,7 @@
       ],
       "rows_copied": null,
       "duration_ms": 0,
+      "started_at": "2000-01-01T00:00:00Z",
       "metadata": {
         "strategy": "full_refresh",
         "watermark": "2000-01-01T00:00:00Z",

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -435,12 +435,18 @@
             "integer",
             "null"
           ]
+        },
+        "started_at": {
+          "description": "Wall-clock timestamp captured at the moment the engine began executing this model. Used by `RunOutput::to_run_record` to build accurate per-model windows on the persisted `ModelExecution` — replaces the prior lossy reconstruction (`finished_at - duration`) that mis-ordered parallel runs. `finished_at` is derived as `started_at + duration_ms`; keeping one source of truth avoids drift between the two.",
+          "format": "date-time",
+          "type": "string"
         }
       },
       "required": [
         "asset_key",
         "duration_ms",
-        "metadata"
+        "metadata",
+        "started_at"
       ],
       "type": "object"
     },


### PR DESCRIPTION
## Summary

Closes the remaining unblocked Arc 1 wave 2 item from `TODO.md` §1. PR #203 captured run-level `started_at` / `finished_at` but lossily reconstructed per-model windows as `finished_at = run.finished_at`, `started_at = finished_at - duration_ms` — every model shared the same finished_at and parallel execution ordering was collapsed.

This PR stamps a real wall-clock `DateTime<Utc>` on each model at the moment execution begins, propagates it through `MaterializationOutput`, and uses it to build honest per-model windows on the persisted `RunRecord`.

## Changes

- **`MaterializationOutput::started_at: DateTime<Utc>`** (required). Captured with `Utc::now()` at the three sites that construct a materialization:
  - `process_table` — parallel-dispatch path (`table_started_at` alongside `table_start` Instant).
  - `execute_time_interval_partition` — per-partition (`partition_started_at` alongside `partition_start`).
  - `run_snapshot` — transformation pipeline (`started_at` alongside `start`).
- **`RunOutput::to_run_record`** now uses each materialization's `started_at` directly and derives `finished_at` as `started_at + duration_ms`. Parallel runs preserve their real ordering; the old finish-relative collapse is gone.
- **Tests** — the two `mat()` helpers in `output.rs` now take an explicit `started_at`. The rewritten `to_run_record_uses_per_model_started_at` test exercises the parallel-overlap case: two models with staggered starts and overlapping windows end up with correct, distinct windows on the RunRecord.

## Downstream cascade

- `schemas/run.schema.json`, `types_generated/run_schema.py`, `src/types/generated/run.ts` all regenerated — `started_at` added as required in the nested `MaterializationOutput`.
- `just regen-fixtures` picked up the new field on 11 fixtures; normalizer's existing `WALL_CLOCK_FIELDS` handles it (sentinelled to `2000-01-01T00:00:00Z`). Byte-stable across two consecutive regens.

## End-to-end check

```
$ rocky run --filter source=orders --output json >/dev/null
$ rocky replay latest --output json | jq '.models[0] | {model_name, started_at, duration_ms}'
{
  "model_name": "orders",
  "started_at": "2026-04-21T16:56:33.165966+00:00",   # real wall clock
  "duration_ms": 1
}
```

Pre-PR the `started_at` would have mirrored the run's own `finished_at`.

## Test plan

- [x] `cargo test -p rocky-cli -p rocky-core` — 205 + 976 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `just codegen` regenerated; `codegen-drift` CI will confirm
- [x] `just regen-fixtures` byte-stable across two regens
- [x] `uv run pytest` in `integrations/dagster/` — 307 tests pass
- [x] `npm run compile` in `editors/vscode/` — clean
- [x] End-to-end smoke: `rocky run` → `rocky replay latest` shows a real wall-clock `started_at`

## What's still deferred

- **Real per-model `finished_at`** — derived from `started_at + duration_ms`. Keeping the derivation means a single source of truth; adding a second stamp at completion would double-count the invariant. Can flip later if strict fidelity becomes important.
- **`bytes_scanned` / `bytes_written`** — still `None` on `MaterializationOutput` (adapter-layer plumbing). Same follow-up called out on `populate_cost_summary`.

Completes TODO.md §1 "Real per-model start timestamps" — the last unblocked Arc 1 wave 2 item. Warehouse-native clone and replay re-execution remain blocked on external prerequisites (sandbox access, Exp 4).