### PR TITLE
fix(vscode): regenerate project-schema mirror for transfer_timeout_seconds

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2228,6 +2228,13 @@
             "null"
           ]
         },
+        "transfer_timeout_seconds": {
+          "default": 300,
+          "description": "Wall-clock budget (seconds) for each state transfer operation (download or upload). Catches stuck SDK retry loops, DNS, TLS, and hung endpoints that the per-request HTTP timeout does not see. Defaults to 300s; raise for large state or slow networks.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
         "valkey_prefix": {
           "description": "Valkey key prefix (default: \"rocky:state:\")",
           "type": [
@@ -2608,6 +2615,7 @@
         "gcs_prefix": null,
         "s3_bucket": null,
         "s3_prefix": null,
+        "transfer_timeout_seconds": 300,
         "valkey_prefix": null,
         "valkey_url": null
       },

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1166,6 +1166,10 @@ export interface StateConfig {
    */
   s3_prefix?: string | null;
   /**
+   * Wall-clock budget (seconds) for each state transfer operation (download or upload). Catches stuck SDK retry loops, DNS, TLS, and hung endpoints that the per-request HTTP timeout does not see. Defaults to 300s; raise for large state or slow networks.
+   */
+  transfer_timeout_seconds?: number;
+  /**
    * Valkey key prefix (default: "rocky:state:")
    */
   valkey_prefix?: string | null;


### PR DESCRIPTION
## Summary

Unblocks `codegen-drift.yml` on main after engine-v1.12.0 merged.

The engine release added `StateConfig.transfer_timeout_seconds` (wall-clock budget for state transfers), and `schemas/rocky-project.schema.json` was regenerated correctly — but the vscode mirror files (`editors/vscode/schemas/rocky-project.schema.json` + `editors/vscode/src/types/generated/rocky_project.ts`) stayed on the pre-1.12.0 shape.

Root cause: `just codegen-vscode` depends on `npm` + `npx` tools available in `editors/vscode/node_modules`. When the dir doesn't have deps installed, the step fails partway through — but because `just` doesn't abort the overall `codegen` recipe on that sub-failure in a way that leaves the repo clean, the engine-side outputs get written while the vscode ones silently don't update. Whoever ran codegen during the engine-release PR hit that, the change didn't get caught in review, and it landed on main with the drift baked in.

## What's in this PR

- **`editors/vscode/schemas/rocky-project.schema.json`** — regenerated; adds `transfer_timeout_seconds: integer` under `StateConfig.properties` + default `300` in the example block.
- **`editors/vscode/src/types/generated/rocky_project.ts`** — regenerated; adds `transfer_timeout_seconds?: number` to the `StateConfig` interface.
- **`editors/vscode/package-lock.json`** — synced to `"version": "1.6.2"` (PR #209 bumped `package.json` but not the lockfile).

## Test plan

- [x] `npm install` in `editors/vscode/`
- [x] `cargo build --release --bin rocky` from `engine/` (1.12.0 binary)
- [x] `just codegen` from monorepo root → diff matches the drift CI reported
- [x] Post-edit `git status` shows only the three files above
- [ ] CI codegen-drift passes on this PR (confirms idempotency)

## Follow-up

Once this merges, cutting `vscode-v1.6.3` is the clean way to get the corrected schema mirror onto the Marketplace. The `vscode-v1.6.2` VSIX that published moments ago is functional but missing `transfer_timeout_seconds` IDE validation — no user-visible break.

See the `avoid-codegen-drift` discussion below for systemic fixes.