### PR TITLE
chore(justfile): self-heal codegen-vscode + add codegen-all recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,20 @@ vendor-dagster:
 # --- Phase 2 schema codegen ---
 
 # Run the full codegen pipeline: rust → JSON schemas → Pydantic + TypeScript + VS Code project schema
+#
+# Use `just codegen` when editing Rust *Output structs or adding new CLI
+# commands. For release cuts — and any change that bumps version strings
+# or output shapes that show up in dagster fixtures — use `just codegen-all`
+# instead, which also runs `regen-fixtures`. Release CI fails
+# (codegen-drift.yml) if either side is stale.
 codegen: codegen-rust codegen-dagster codegen-vscode codegen-vscode-project-schema
+
+# Bundle `codegen` + `regen-fixtures` for release cuts and any change that
+# alters the shape of command output (e.g. new fields on MaterializationOutput,
+# a version bump). Fixture regen takes 1-2 min vs. codegen's ~30s — so
+# `codegen` stays as the fast dev loop and `codegen-all` is the "about to
+# land a release PR" loop.
+codegen-all: codegen regen-fixtures
 
 # Export JSON schemas from the engine's typed CLI output structs.
 #
@@ -110,11 +123,23 @@ codegen-dagster:
 # Regenerate TypeScript interfaces in editors/vscode from schemas/
 # (writes to editors/vscode/src/types/generated/)
 #
-# Self-healing: like the dagster recipe, this nukes the generated dir
-# and restores the curated index.ts barrel from git after json2ts runs.
+# Self-healing:
+#   1. Auto-runs `npm install` if editors/vscode/node_modules is missing.
+#      Without this guard the recipe used to fail silently on fresh
+#      worktrees and release PR merges — codegen-rust + codegen-dagster
+#      had already written their outputs by the time json2ts failed, so
+#      a partial codegen would leak into main and trigger
+#      codegen-drift.yml on the next PR. The install is ~15s on a warm
+#      npm cache, skipped entirely when deps are present.
+#   2. Like the dagster recipe, nukes the generated dir and restores the
+#      curated index.ts barrel from git after json2ts runs.
 codegen-vscode:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [ ! -d editors/vscode/node_modules ]; then
+        echo "==> installing editors/vscode/ deps (required for json2ts codegen)"
+        (cd editors/vscode && npm install --silent)
+    fi
     rm -rf editors/vscode/src/types/generated
     mkdir -p editors/vscode/src/types/generated
     for schema in schemas/*.schema.json; do


### PR DESCRIPTION
## Summary

Closes two silent-drift classes that hit three times in a single day during the Arc 1 wave 2 cascade (fixtures drift on release PR #207 → engine codegen drift on #210 hotfix → same pattern caught me on #204).

## Fix 1 — `codegen-vscode` auto-installs deps

**Before:** `just codegen-vscode` assumed `editors/vscode/node_modules` was populated. When it wasn't (fresh worktree, CI runner, release PR checkout), the `npx json2ts` step failed with *"could not determine executable to run"* — **but `codegen-rust` + `codegen-dagster` had already written their outputs**, so half the pipeline ran. If you didn't notice the error scroll and committed anyway, the partial state landed on main and `codegen-drift.yml` fired on the next PR.

**After:** the recipe checks for `node_modules` and runs `npm install --silent` automatically. ~15s cold, skipped when deps are present. Mirrors the self-heal pattern `codegen-dagster` already has via `uv run`.

## Fix 2 — new `codegen-all` recipe bundles fixture regen

**Before:** `just codegen` regenerated schemas + bindings but not dagster fixtures. Engine version bumps cascaded every fixture's `"version"` field out of sync (exactly what hit PR #207). Muscle memory was "run codegen and you're done" — wrong for anything that touches output shapes.

**After:** `just codegen-all = codegen + regen-fixtures`. `codegen` stays as the fast dev loop (~30s); `codegen-all` is the release-PR loop (adds ~1-2 min for fixture regen). Docstring on `codegen` now points at the alternative.

## Verification

- [x] Deleted `editors/vscode/node_modules`, ran `just codegen` — self-heal triggered, npm install ran, codegen completed; `git status` shows only `justfile` modified (idempotent vs. main).
- [x] `just --list` surfaces both `codegen` and `codegen-all`.

## Out of scope — logged for later if needed

- **Upfront preflight check.** Decided against — with self-heal in place, both dagster (uv-managed) and vscode (npm-managed) codegen steps now recover from missing deps on their own, so there's nothing to preflight.
- **Default-on pre-commit hook.** `.git-hooks/pre-commit` already runs codegen drift detection when schema files are staged; opt-in via `just install-hooks`. Making it default is a separate friction conversation for a solo-project repo.