### PR TITLE
feat(rocky-core): wire state backend retry + circuit-breaker

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2214,6 +2214,33 @@
             "null"
           ]
         },
+        "on_upload_failure": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StateUploadFailureMode"
+            }
+          ],
+          "default": "skip",
+          "description": "What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`]."
+        },
+        "retry": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RetryConfig"
+            }
+          ],
+          "default": {
+            "backoff_multiplier": 2.0,
+            "circuit_breaker_recovery_timeout_secs": null,
+            "circuit_breaker_threshold": 5,
+            "initial_backoff_ms": 1000,
+            "jitter": true,
+            "max_backoff_ms": 30000,
+            "max_retries": 3,
+            "max_retries_per_run": null
+          },
+          "description": "Retry policy applied to transient state-transfer failures (network hiccups, hung endpoints that hit the per-request HTTP timeout, transient 5xx, etc.). Shares the same shape as the adapter retry config so operators can reason about both with a single mental model. Retries share the outer `transfer_timeout_seconds` budget, so the total wall-clock ceiling is unchanged."
+        },
         "s3_bucket": {
           "description": "S3 bucket for state persistence",
           "type": [
@@ -2251,6 +2278,25 @@
         }
       },
       "type": "object"
+    },
+    "StateUploadFailureMode": {
+      "description": "Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].",
+      "oneOf": [
+        {
+          "description": "Log a warning and continue the run successfully. State becomes stale until the next healthy upload; the next run's `discover` re-derives watermarks from target-table metadata. Trades state durability for run liveness — matches the de-facto behaviour of the pre-retry callers in `rocky run`, which already `warn + continue` on a failed upload.",
+          "enum": [
+            "skip"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Propagate the error to the caller. Appropriate for strict environments where state durability matters more than liveness (e.g. long-running backfills where re-deriving watermarks is prohibitively expensive).",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "TableRef": {
       "additionalProperties": false,
@@ -2613,6 +2659,17 @@
         "backend": "local",
         "gcs_bucket": null,
         "gcs_prefix": null,
+        "on_upload_failure": "skip",
+        "retry": {
+          "backoff_multiplier": 2.0,
+          "circuit_breaker_recovery_timeout_secs": null,
+          "circuit_breaker_threshold": 5,
+          "initial_backoff_ms": 1000,
+          "jitter": true,
+          "max_backoff_ms": 30000,
+          "max_retries": 3,
+          "max_retries_per_run": null
+        },
         "s3_bucket": null,
         "s3_prefix": null,
         "transfer_timeout_seconds": 300,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -272,6 +272,10 @@ export type Dialect = "databricks" | "snowflake" | "bigquery" | "duckdb";
  * State storage backend variants.
  */
 export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
+/**
+ * Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].
+ */
+export type StateUploadFailureMode = "skip" | "fail";
 
 /**
  * Top-level Rocky configuration (v2 format).
@@ -1157,6 +1161,14 @@ export interface StateConfig {
    * GCS key prefix (default: "rocky/state/")
    */
   gcs_prefix?: string | null;
+  /**
+   * What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
+   */
+  on_upload_failure?: StateUploadFailureMode & string;
+  /**
+   * Retry policy applied to transient state-transfer failures (network hiccups, hung endpoints that hit the per-request HTTP timeout, transient 5xx, etc.). Shares the same shape as the adapter retry config so operators can reason about both with a single mental model. Retries share the outer `transfer_timeout_seconds` budget, so the total wall-clock ceiling is unchanged.
+   */
+  retry?: RetryConfig;
   /**
    * S3 bucket for state persistence
    */

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -410,6 +410,26 @@ impl std::fmt::Display for StateBackend {
     }
 }
 
+/// Policy applied when state upload fails after retries + circuit-breaker
+/// are exhausted. See [`StateConfig::on_upload_failure`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StateUploadFailureMode {
+    /// Log a warning and continue the run successfully. State becomes
+    /// stale until the next healthy upload; the next run's `discover`
+    /// re-derives watermarks from target-table metadata. Trades state
+    /// durability for run liveness — matches the de-facto behaviour of
+    /// the pre-retry callers in `rocky run`, which already `warn + continue`
+    /// on a failed upload.
+    #[default]
+    Skip,
+    /// Propagate the error to the caller. Appropriate for strict
+    /// environments where state durability matters more than liveness
+    /// (e.g. long-running backfills where re-deriving watermarks is
+    /// prohibitively expensive).
+    Fail,
+}
+
 /// State persistence configuration.
 ///
 /// Controls where Rocky stores watermarks and anomaly history between runs.
@@ -442,6 +462,20 @@ pub struct StateConfig {
     /// Defaults to 300s; raise for large state or slow networks.
     #[serde(default = "default_state_transfer_timeout_secs")]
     pub transfer_timeout_seconds: u64,
+    /// Retry policy applied to transient state-transfer failures (network
+    /// hiccups, hung endpoints that hit the per-request HTTP timeout,
+    /// transient 5xx, etc.). Shares the same shape as the adapter retry
+    /// config so operators can reason about both with a single mental
+    /// model. Retries share the outer `transfer_timeout_seconds` budget,
+    /// so the total wall-clock ceiling is unchanged.
+    #[serde(default)]
+    pub retry: RetryConfig,
+    /// What to do when state upload exhausts retries + circuit-breaker.
+    /// Defaults to `skip` — rocky continues the run and the next run
+    /// re-derives state from target-table metadata. See
+    /// [`StateUploadFailureMode`].
+    #[serde(default)]
+    pub on_upload_failure: StateUploadFailureMode,
 }
 
 impl Default for StateConfig {
@@ -455,6 +489,8 @@ impl Default for StateConfig {
             valkey_url: None,
             valkey_prefix: None,
             transfer_timeout_seconds: default_state_transfer_timeout_secs(),
+            retry: RetryConfig::default(),
+            on_upload_failure: StateUploadFailureMode::default(),
         }
     }
 }

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -203,16 +203,17 @@ async fn download_from_object_store(
                     provider.download_file(STATE_FILE, local_path).await?;
                     info!(
                         size = local_path.metadata().map(|m| m.len()).unwrap_or(0),
+                        outcome = "ok",
                         "state restored from object store"
                     );
                     Ok(())
                 }
                 Ok(false) => {
-                    info!("No existing state in object store — starting fresh");
+                    info!(outcome = "absent", "No existing state in object store — starting fresh");
                     Ok(())
                 }
                 Err(e) => {
-                    warn!(error = %e, "state existence check failed (non-fatal, starting fresh)");
+                    warn!(error = %e, outcome = "error_then_fresh", "state existence check failed (non-fatal, starting fresh)");
                     Ok(())
                 }
             }
@@ -249,6 +250,7 @@ async fn upload_to_object_store(
             Ok::<(), StateSyncError>(())
         })
         .await?;
+        info!(bytes = size_bytes, outcome = "ok", "state upload complete");
         Ok(())
     }
     .instrument(span)
@@ -271,6 +273,7 @@ where
         Err(_) => {
             warn!(
                 duration_ms = timeout.as_millis() as u64,
+                outcome = "timeout",
                 "state transfer exceeded timeout budget"
             );
             Err(StateSyncError::Timeout(timeout))
@@ -327,10 +330,10 @@ async fn download_from_valkey(
                         let size = std::fs::metadata(&local_for_task)
                             .map(|m| m.len())
                             .unwrap_or(0);
-                        info!(size, "state restored from Valkey");
+                        info!(size, outcome = "ok", "state restored from Valkey");
                     }
                     None => {
-                        info!("No existing state in Valkey — starting fresh");
+                        info!(outcome = "absent", "No existing state in Valkey — starting fresh");
                     }
                 }
                 Ok(())
@@ -396,7 +399,9 @@ async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(),
                 ))),
             }
         })
-        .await
+        .await?;
+        info!(bytes = size_bytes, outcome = "ok", "state upload complete");
+        Ok(())
     }
     .instrument(span)
     .await

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -14,8 +14,10 @@ use bytes::Bytes;
 use thiserror::Error;
 use tracing::{Instrument, debug, info, info_span, warn};
 
-use crate::config::{StateBackend, StateConfig};
+use crate::circuit_breaker::TransitionOutcome;
+use crate::config::{RetryConfig, StateBackend, StateConfig, StateUploadFailureMode};
 use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
+use crate::retry_budget::RetryBudget;
 
 #[derive(Debug, Error)]
 pub enum StateSyncError {
@@ -45,6 +47,14 @@ pub enum StateSyncError {
 
     #[error("state transfer timed out after {0:?}")]
     Timeout(Duration),
+
+    #[error(
+        "state backend circuit breaker tripped after {consecutive_failures} consecutive transient failures"
+    )]
+    CircuitOpen { consecutive_failures: u32 },
+
+    #[error("state retry budget exhausted (limit {limit}); aborting remaining retries")]
+    RetryBudgetExhausted { limit: u32 },
 }
 
 /// State file name within the configured prefix.
@@ -124,12 +134,27 @@ pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(
 }
 
 /// Uploads state from a local file to remote storage after a run.
+///
+/// Applies `config.retry` to transient failures and `config.on_upload_failure`
+/// to the final result — by default (`Skip`) a post-retry failure is logged
+/// and reported back as `Ok` so the run continues in degraded mode, matching
+/// the de-facto behaviour of existing callers that `warn + continue` on upload
+/// errors. Set `on_upload_failure = "fail"` for strict environments that must
+/// treat state durability as a hard requirement.
 pub async fn upload_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
     if !local_path.exists() {
         debug!("No local state file to upload");
         return Ok(());
     }
+    let result = dispatch_upload(config, local_path).await;
+    apply_upload_failure_policy(config, result)
+}
 
+/// Internal upload dispatch — runs the raw upload (with retry) without
+/// applying the `on_upload_failure` policy. Tiered recursion uses this
+/// directly so the skip/fail decision is evaluated exactly once at the
+/// outermost `upload_state` call, not per-leg.
+async fn dispatch_upload(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
     match config.backend {
         StateBackend::Local => {
             debug!("State backend: local (no sync needed)");
@@ -140,14 +165,30 @@ pub async fn upload_state(config: &StateConfig, local_path: &Path) -> Result<(),
                 StateSyncError::MissingConfig("s3".into(), "state.s3_bucket".into())
             })?;
             let prefix = config.s3_prefix.as_deref().unwrap_or(DEFAULT_S3_PREFIX);
-            upload_to_object_store("s3", bucket, prefix, local_path, transfer_timeout(config)).await
+            upload_to_object_store(
+                "s3",
+                bucket,
+                prefix,
+                local_path,
+                transfer_timeout(config),
+                &config.retry,
+            )
+            .await
         }
         StateBackend::Gcs => {
             let bucket = config.gcs_bucket.as_deref().ok_or_else(|| {
                 StateSyncError::MissingConfig("gcs".into(), "state.gcs_bucket".into())
             })?;
             let prefix = config.gcs_prefix.as_deref().unwrap_or(DEFAULT_GCS_PREFIX);
-            upload_to_object_store("gs", bucket, prefix, local_path, transfer_timeout(config)).await
+            upload_to_object_store(
+                "gs",
+                bucket,
+                prefix,
+                local_path,
+                transfer_timeout(config),
+                &config.retry,
+            )
+            .await
         }
         StateBackend::Valkey => upload_to_valkey(config, local_path).await,
         StateBackend::Tiered => {
@@ -162,14 +203,40 @@ pub async fn upload_state(config: &StateConfig, local_path: &Path) -> Result<(),
                 ..config.clone()
             };
 
-            // Valkey first (fast, best-effort)
-            if let Err(e) = Box::pin(upload_state(&valkey_config, local_path)).await {
+            // Valkey first (fast, best-effort). Recurse into the *inner*
+            // dispatch so `on_upload_failure` is not applied here — the
+            // outer `upload_state` owns that decision for the tiered leg
+            // as a whole.
+            if let Err(e) = Box::pin(dispatch_upload(&valkey_config, local_path)).await {
                 warn!(error = %e, "Valkey upload failed (non-fatal, S3 is durable)");
             }
 
             // S3 second (durable, required)
-            Box::pin(upload_state(&s3_config, local_path)).await
+            Box::pin(dispatch_upload(&s3_config, local_path)).await
         }
+    }
+}
+
+/// Apply the `on_upload_failure` policy to a terminal upload result. `Skip`
+/// converts Err → Ok with a structured warn; `Fail` propagates Err unchanged.
+fn apply_upload_failure_policy(
+    config: &StateConfig,
+    result: Result<(), StateSyncError>,
+) -> Result<(), StateSyncError> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => match config.on_upload_failure {
+            StateUploadFailureMode::Skip => {
+                warn!(
+                    error = %e,
+                    outcome = "skipped_after_failure",
+                    "state upload failed after retries; continuing in degraded mode \
+                     (next run's discover will re-derive state)"
+                );
+                Ok(())
+            }
+            StateUploadFailureMode::Fail => Err(e),
+        },
     }
 }
 
@@ -225,12 +292,18 @@ async fn download_from_object_store(
 }
 
 /// Upload `STATE_FILE` to an object store rooted at `<scheme>://<bucket>/<prefix>`.
+///
+/// Wraps the put in a retry loop driven by `retry` (shared-shape
+/// [`RetryConfig`]) and a call-local circuit breaker + retry budget. The
+/// outer `with_transfer_timeout` still caps total wall-clock, so retries
+/// share — not extend — the configured transfer budget.
 async fn upload_to_object_store(
     scheme: &str,
     bucket: &str,
     prefix: &str,
     local_path: &Path,
     timeout: Duration,
+    retry: &RetryConfig,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
     let size_bytes = local_path.metadata().map(|m| m.len()).unwrap_or(0);
@@ -245,12 +318,22 @@ async fn upload_to_object_store(
             uri = format!("{scheme}://{bucket}/{prefix}{STATE_FILE}"),
             "uploading state to object store"
         );
-        with_transfer_timeout(timeout, async {
-            provider.upload_file(local_path, STATE_FILE).await?;
-            Ok::<(), StateSyncError>(())
+        let retries = with_transfer_timeout(timeout, async {
+            retry_transient(retry, "state.upload.object_store", || async {
+                provider
+                    .upload_file(local_path, STATE_FILE)
+                    .await
+                    .map_err(StateSyncError::from)
+            })
+            .await
         })
         .await?;
-        info!(bytes = size_bytes, outcome = "ok", "state upload complete");
+        info!(
+            bytes = size_bytes,
+            retries,
+            outcome = "ok",
+            "state upload complete"
+        );
         Ok(())
     }
     .instrument(span)
@@ -333,7 +416,10 @@ async fn download_from_valkey(
                         info!(size, outcome = "ok", "state restored from Valkey");
                     }
                     None => {
-                        info!(outcome = "absent", "No existing state in Valkey — starting fresh");
+                        info!(
+                            outcome = "absent",
+                            "No existing state in Valkey — starting fresh"
+                        );
                     }
                 }
                 Ok(())
@@ -372,35 +458,50 @@ async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(),
     let data = std::fs::read(local_path)?;
     let size_bytes = data.len() as u64;
     let timeout = transfer_timeout(config);
+    let retry = &config.retry;
 
     let span = info_span!("state.upload", backend = "valkey", size_bytes);
     async move {
         info!(key = %key, size = size_bytes, "uploading state to Valkey");
-        with_transfer_timeout(timeout, async move {
-            let join = tokio::task::spawn_blocking(move || -> Result<(), StateSyncError> {
-                let client =
-                    redis::Client::open(url).map_err(|e| StateSyncError::Valkey(e.to_string()))?;
-                let mut conn = client
-                    .get_connection()
-                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+        let retries = with_transfer_timeout(timeout, async {
+            retry_transient(retry, "state.upload.valkey", || {
+                let url = url.clone();
+                let key = key.clone();
+                let data = data.clone();
+                async move {
+                    let join =
+                        tokio::task::spawn_blocking(move || -> Result<(), StateSyncError> {
+                            let client = redis::Client::open(url)
+                                .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                            let mut conn = client
+                                .get_connection()
+                                .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
 
-                redis::cmd("SET")
-                    .arg(&key)
-                    .arg(data)
-                    .query::<()>(&mut conn)
-                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
-                Ok(())
+                            redis::cmd("SET")
+                                .arg(&key)
+                                .arg(data)
+                                .query::<()>(&mut conn)
+                                .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                            Ok(())
+                        })
+                        .await;
+                    match join {
+                        Ok(inner) => inner,
+                        Err(e) => Err(StateSyncError::Valkey(format!(
+                            "valkey worker task failed: {e}"
+                        ))),
+                    }
+                }
             })
-            .await;
-            match join {
-                Ok(inner) => inner,
-                Err(e) => Err(StateSyncError::Valkey(format!(
-                    "valkey worker task failed: {e}"
-                ))),
-            }
+            .await
         })
         .await?;
-        info!(bytes = size_bytes, outcome = "ok", "state upload complete");
+        info!(
+            bytes = size_bytes,
+            retries,
+            outcome = "ok",
+            "state upload complete"
+        );
         Ok(())
     }
     .instrument(span)
@@ -563,6 +664,154 @@ async fn probe_valkey(config: &StateConfig) -> Result<(), StateSyncError> {
     .await
 }
 
+/// Drive `op` through the shared retry + circuit-breaker + budget policy.
+///
+/// Returns the number of retries consumed by the successful attempt (0 when
+/// the first try wins) so the caller can stamp `retries` on the terminal
+/// span event. On permanent failure returns the underlying
+/// [`StateSyncError`] — or [`StateSyncError::CircuitOpen`] /
+/// [`StateSyncError::RetryBudgetExhausted`] when the abort happens inside
+/// this helper rather than at the transport layer.
+///
+/// The circuit breaker and retry budget are built per-call from `cfg`. This
+/// keeps state-sync's lifecycle simple (each upload/download is independent)
+/// and mirrors the `[adapter.databricks.retry]` shape end-to-end for
+/// operational parity. Cross-call breaker state could be wired in later via
+/// a state-sync context struct, but no caller needs that today.
+async fn retry_transient<F, Fut>(
+    cfg: &RetryConfig,
+    op_name: &str,
+    mut op: F,
+) -> Result<u32, StateSyncError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<(), StateSyncError>>,
+{
+    let breaker = cfg.build_circuit_breaker();
+    let budget = RetryBudget::from_config(cfg.max_retries_per_run);
+
+    if let Err(e) = breaker.check() {
+        return Err(StateSyncError::CircuitOpen {
+            consecutive_failures: e.consecutive_failures,
+        });
+    }
+
+    for attempt in 0..=cfg.max_retries {
+        match op().await {
+            Ok(()) => {
+                if breaker.record_success() == TransitionOutcome::Recovered {
+                    info!(
+                        op = op_name,
+                        outcome = "recovered",
+                        "state backend circuit breaker recovered"
+                    );
+                }
+                return Ok(attempt);
+            }
+            Err(err) if is_transient(&err) => {
+                if breaker.record_failure(&err.to_string()) == TransitionOutcome::Tripped {
+                    warn!(
+                        op = op_name,
+                        outcome = "circuit_open",
+                        error = %err,
+                        "state backend circuit breaker tripped"
+                    );
+                }
+                if attempt < cfg.max_retries {
+                    if !budget.try_consume() {
+                        let limit = budget.total().unwrap_or(0);
+                        warn!(
+                            op = op_name,
+                            attempt = attempt + 1,
+                            budget_limit = limit,
+                            error = %err,
+                            outcome = "budget_exhausted",
+                            "state retry budget exhausted; aborting further retries"
+                        );
+                        return Err(StateSyncError::RetryBudgetExhausted { limit });
+                    }
+                    let backoff_ms = compute_backoff(cfg, attempt);
+                    warn!(
+                        op = op_name,
+                        attempt = attempt + 1,
+                        max_retries = cfg.max_retries,
+                        backoff_ms,
+                        error = %err,
+                        outcome = "retry",
+                        "state transient error, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                    continue;
+                }
+                warn!(
+                    op = op_name,
+                    attempts = attempt + 1,
+                    error = %err,
+                    outcome = "transient_exhausted",
+                    "state transient retries exhausted"
+                );
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop always returns within the for body")
+}
+
+/// Classify a state-sync error for retry decisions.
+///
+/// Network/SDK-level errors and timeouts are treated as transient — a
+/// fresh attempt might clear a single flake. Config errors and local disk
+/// I/O are permanent; retrying them wastes budget. The breaker/budget
+/// sentinels are already terminal by construction and must not re-enter
+/// the retry loop.
+fn is_transient(err: &StateSyncError) -> bool {
+    match err {
+        StateSyncError::S3Download(_)
+        | StateSyncError::S3Upload(_)
+        | StateSyncError::GcsDownload(_)
+        | StateSyncError::GcsUpload(_)
+        | StateSyncError::Valkey(_)
+        | StateSyncError::Timeout(_) => true,
+        StateSyncError::ObjectStore(ObjectStoreError::Backend(_)) => true,
+        StateSyncError::ObjectStore(
+            ObjectStoreError::InvalidUri(..)
+            | ObjectStoreError::UnsupportedScheme(_)
+            | ObjectStoreError::Io(_),
+        )
+        | StateSyncError::Io(_)
+        | StateSyncError::MissingConfig(..)
+        | StateSyncError::CircuitOpen { .. }
+        | StateSyncError::RetryBudgetExhausted { .. } => false,
+    }
+}
+
+/// Compute exponential-with-jitter backoff (ms) for retry attempt `attempt`.
+///
+/// Intentionally duplicated from `rocky-databricks::connector::compute_backoff`
+/// and `rocky-snowflake::connector::compute_backoff`. A follow-up PR should
+/// hoist the three copies into a single shared helper; this PR keeps scope
+/// narrow to the state-backend wiring.
+fn compute_backoff(cfg: &RetryConfig, attempt: u32) -> u64 {
+    let base = (cfg.initial_backoff_ms as f64) * cfg.backoff_multiplier.powi(attempt as i32);
+    let capped = base.min(cfg.max_backoff_ms as f64) as u64;
+
+    if cfg.jitter {
+        let jitter_range = capped / 4;
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos() as u64;
+        let jitter = nanos % (jitter_range.max(1));
+        capped
+            .saturating_sub(jitter_range / 2)
+            .saturating_add(jitter)
+    } else {
+        capped
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -673,5 +922,173 @@ mod tests {
         assert_ne!(a, b, "probe_key should produce unique values per call");
         assert!(a.starts_with("doctor-probe-"));
         assert!(a.ends_with(".marker"));
+    }
+
+    #[test]
+    fn test_default_on_upload_failure_is_skip() {
+        let config = StateConfig::default();
+        assert_eq!(config.on_upload_failure, StateUploadFailureMode::Skip);
+    }
+
+    #[test]
+    fn test_is_transient_network_and_timeout() {
+        assert!(is_transient(&StateSyncError::S3Upload("boom".into())));
+        assert!(is_transient(&StateSyncError::S3Download("boom".into())));
+        assert!(is_transient(&StateSyncError::GcsUpload("boom".into())));
+        assert!(is_transient(&StateSyncError::GcsDownload("boom".into())));
+        assert!(is_transient(&StateSyncError::Valkey("boom".into())));
+        assert!(is_transient(&StateSyncError::Timeout(Duration::from_secs(
+            1
+        ))));
+    }
+
+    #[test]
+    fn test_is_transient_permanent_errors_not_retried() {
+        assert!(!is_transient(&StateSyncError::MissingConfig(
+            "s3".into(),
+            "bucket".into()
+        )));
+        assert!(!is_transient(&StateSyncError::CircuitOpen {
+            consecutive_failures: 5
+        }));
+        assert!(!is_transient(&StateSyncError::RetryBudgetExhausted {
+            limit: 3
+        }));
+    }
+
+    #[test]
+    fn test_compute_backoff_without_jitter() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 100,
+            max_backoff_ms: 1000,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        assert_eq!(compute_backoff(&cfg, 0), 100);
+        assert_eq!(compute_backoff(&cfg, 1), 200);
+        assert_eq!(compute_backoff(&cfg, 2), 400);
+        assert_eq!(compute_backoff(&cfg, 3), 800);
+        // caps at max_backoff_ms
+        assert_eq!(compute_backoff(&cfg, 10), 1000);
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_within_bounds() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 400,
+            max_backoff_ms: 10_000,
+            backoff_multiplier: 2.0,
+            jitter: true,
+            ..RetryConfig::default()
+        };
+        // With jitter, the returned value is within ±25 % of the base
+        // (400 ms at attempt=0). Allow 300..=500 as the safe envelope.
+        for _ in 0..50 {
+            let b = compute_backoff(&cfg, 0);
+            assert!(
+                (300..=500).contains(&b),
+                "jittered backoff out of envelope: {b}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_transient_succeeds_after_two_transient_failures() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 5,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = retry_transient(&cfg, "test", || {
+            let n = attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            async move {
+                if n < 2 {
+                    Err(StateSyncError::S3Upload(format!("flake {n}")))
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 2, "should have taken 2 retries");
+    }
+
+    #[tokio::test]
+    async fn test_retry_transient_gives_up_after_max_retries() {
+        let cfg = RetryConfig {
+            max_retries: 2,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 5,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let result = retry_transient(&cfg, "test", || async {
+            Err(StateSyncError::S3Upload("always fails".into()))
+        })
+        .await;
+        assert!(matches!(result, Err(StateSyncError::S3Upload(_))));
+    }
+
+    #[tokio::test]
+    async fn test_retry_transient_does_not_retry_permanent_errors() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 5,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = retry_transient(&cfg, "test", || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            async { Err(StateSyncError::MissingConfig("s3".into(), "bucket".into())) }
+        })
+        .await;
+        assert!(matches!(result, Err(StateSyncError::MissingConfig(..))));
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "permanent errors should not be retried"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_budget_exhaustion_aborts_early() {
+        let cfg = RetryConfig {
+            max_retries: 5,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 5,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            max_retries_per_run: Some(1),
+            ..RetryConfig::default()
+        };
+        let attempts = std::sync::atomic::AtomicU32::new(0);
+        let result = retry_transient(&cfg, "test", || {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            async { Err(StateSyncError::S3Upload("always flakes".into())) }
+        })
+        .await;
+        // With budget=1: first attempt fails → consume retry slot → one
+        // retry attempt → fails → budget exhausted → return
+        // RetryBudgetExhausted. Total 2 calls to op() before we error.
+        assert!(matches!(
+            result,
+            Err(StateSyncError::RetryBudgetExhausted { limit: 1 })
+        ));
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "budget should abort after first retry",
+        );
     }
 }

--- a/engine/crates/rocky-core/tests/state_sync_timeout_test.rs
+++ b/engine/crates/rocky-core/tests/state_sync_timeout_test.rs
@@ -1,25 +1,32 @@
-//! Integration tests for [`rocky_core::state_sync::upload_state`] timeout
-//! behaviour.
+//! Integration tests for [`rocky_core::state_sync::upload_state`] timeout +
+//! retry + `on_upload_failure` behaviour.
 //!
 //! Front-ends a fake S3 endpoint with `wiremock` and routes the
 //! `AmazonS3Builder::from_env()` code path through it via `AWS_ENDPOINT` +
-//! `AWS_ALLOW_HTTP`. Exercises two shapes:
+//! `AWS_ALLOW_HTTP`. Exercises four shapes:
 //!
-//! * **Hung endpoint** — the mock holds PUT requests for 1h. We configure
-//!   `transfer_timeout_seconds = 2` and assert `StateSyncError::Timeout`
-//!   returns within a 4 s wall-clock budget (2 s timeout + 2 s grace).
-//! * **Prompt endpoint** — the mock replies `200 OK` immediately. Same
-//!   2 s budget; upload must complete well under 1 s.
+//! * **Hung endpoint, fail mode** — mock holds PUT for 1h;
+//!   `on_upload_failure = Fail`. `StateSyncError::Timeout` must return
+//!   within `transfer_timeout_seconds` + grace.
+//! * **Hung endpoint, skip mode** — same hang, default `on_upload_failure = Skip`.
+//!   The timeout still fires within budget, but the policy converts the
+//!   error to `Ok(())` — this matches the de-facto behaviour of existing
+//!   `rocky run` callers that `warn + continue` on upload failure.
+//! * **Prompt endpoint** — mock replies `200 OK` immediately; upload
+//!   completes well under 1 s (no retries, no timeout).
+//! * **Retry succeeds after transient failure** — mock returns one 500
+//!   then 200. The retry loop must observe the 500, back off, and succeed
+//!   on the second attempt without tripping the outer timeout.
 //!
 //! Because `AmazonS3Builder::from_env()` reads process-wide env vars, the
-//! two tests share a `tokio::sync::Mutex` to serialize env mutation —
+//! tests share a `tokio::sync::Mutex` to serialize env mutation —
 //! cargo otherwise runs `#[tokio::test]`s on separate threads.
 
 use std::path::Path;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-use rocky_core::config::{StateBackend, StateConfig};
+use rocky_core::config::{RetryConfig, StateBackend, StateConfig, StateUploadFailureMode};
 use rocky_core::state_sync::{StateSyncError, upload_state};
 use tempfile::TempDir;
 use tokio::sync::{Mutex, MutexGuard};
@@ -72,20 +79,37 @@ fn write_stub_state(dir: &Path) -> std::path::PathBuf {
     path
 }
 
-fn s3_config(bucket: &str, timeout_seconds: u64) -> StateConfig {
+/// Retry policy with zero retries — use for timeout tests so a single
+/// attempt fills the transfer budget without the retry loop consuming it
+/// in backoff sleeps.
+fn retry_disabled() -> RetryConfig {
+    RetryConfig {
+        max_retries: 0,
+        ..RetryConfig::default()
+    }
+}
+
+fn s3_config(
+    bucket: &str,
+    timeout_seconds: u64,
+    on_upload_failure: StateUploadFailureMode,
+    retry: RetryConfig,
+) -> StateConfig {
     StateConfig {
         backend: StateBackend::S3,
         s3_bucket: Some(bucket.into()),
         s3_prefix: Some("rocky/state/".into()),
         transfer_timeout_seconds: timeout_seconds,
+        on_upload_failure,
+        retry,
         ..Default::default()
     }
 }
 
-/// Hung S3 endpoint — `upload_state` must return `StateSyncError::Timeout`
-/// within `transfer_timeout_seconds` + a small grace window, not hang forever.
+/// Hung S3 endpoint with `on_upload_failure = Fail` — `upload_state` must
+/// return `StateSyncError::Timeout` within budget + grace.
 #[tokio::test]
-async fn upload_state_times_out_on_hung_endpoint() {
+async fn upload_state_times_out_on_hung_endpoint_fail_mode() {
     let _env = env_guard().await;
     let server = MockServer::start().await;
     install_aws_env(&server.uri());
@@ -98,7 +122,12 @@ async fn upload_state_times_out_on_hung_endpoint() {
 
     let tmp = TempDir::new().unwrap();
     let state_path = write_stub_state(tmp.path());
-    let config = s3_config("rocky-state-test-bucket", 2);
+    let config = s3_config(
+        "rocky-state-test-bucket",
+        2,
+        StateUploadFailureMode::Fail,
+        retry_disabled(),
+    );
 
     let start = Instant::now();
     let result = upload_state(&config, &state_path).await;
@@ -121,9 +150,45 @@ async fn upload_state_times_out_on_hung_endpoint() {
     );
 }
 
+/// Hung S3 endpoint with default `on_upload_failure = Skip` — the timeout
+/// still honours the configured budget, but the skip policy converts the
+/// terminal error to `Ok(())` so the caller's run continues in degraded
+/// mode. Matches the pre-R1 behaviour of `rocky run` callers that already
+/// `warn + continue`.
+#[tokio::test]
+async fn upload_state_hung_endpoint_skip_mode_converts_to_ok() {
+    let _env = env_guard().await;
+    let server = MockServer::start().await;
+    install_aws_env(&server.uri());
+
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(3600)))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let state_path = write_stub_state(tmp.path());
+    let config = s3_config(
+        "rocky-state-skip-mode-bucket",
+        2,
+        StateUploadFailureMode::Skip,
+        retry_disabled(),
+    );
+
+    let start = Instant::now();
+    let result = upload_state(&config, &state_path).await;
+    let elapsed = start.elapsed();
+
+    result.expect("skip-mode should swallow terminal upload error");
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "upload_state did not honour the 2 s timeout budget (elapsed {elapsed:?})"
+    );
+}
+
 /// Prompt S3 endpoint — the same config must succeed well inside the budget.
-/// Guards against a regression where the timeout change accidentally starts
-/// to fire on healthy requests.
+/// Guards against a regression where the timeout or retry change accidentally
+/// starts to fire on healthy requests.
 #[tokio::test]
 async fn upload_state_succeeds_when_endpoint_is_prompt() {
     let _env = env_guard().await;
@@ -143,7 +208,12 @@ async fn upload_state_succeeds_when_endpoint_is_prompt() {
 
     let tmp = TempDir::new().unwrap();
     let state_path = write_stub_state(tmp.path());
-    let config = s3_config("rocky-state-happy-bucket", 2);
+    let config = s3_config(
+        "rocky-state-happy-bucket",
+        2,
+        StateUploadFailureMode::Fail,
+        retry_disabled(),
+    );
 
     let start = Instant::now();
     let result = upload_state(&config, &state_path).await;
@@ -153,5 +223,67 @@ async fn upload_state_succeeds_when_endpoint_is_prompt() {
     assert!(
         elapsed < Duration::from_secs(1),
         "prompt upload took {elapsed:?} (expected <1s)"
+    );
+}
+
+/// First PUT returns 500, second returns 200 — the retry loop must observe
+/// the transient error, apply backoff, and succeed on the second attempt.
+/// `max_retries = 1` is enough; `initial_backoff_ms = 50` keeps the test
+/// snappy. The outer 3 s transfer budget comfortably covers one retry
+/// with 50 ms backoff plus both HTTP round-trips.
+#[tokio::test]
+async fn upload_state_retries_transient_then_succeeds() {
+    let _env = env_guard().await;
+    let server = MockServer::start().await;
+    install_aws_env(&server.uri());
+
+    // First PUT: 500 (transient). Second PUT: 200. Wiremock matches in
+    // reverse registration order, so register the 200 first with
+    // `up_to_n_times(1)` won't help here — use explicit priority via a
+    // mount order + expect. Simpler: single mock that responds 500 once
+    // then 200 forever isn't built-in, so register two mocks with
+    // `respond_with` priorities via `mount_as_scoped` on up_to_n_times.
+
+    // Register the 500 response first with `up_to_n_times(1)`. Wiremock
+    // matches mounted mocks in registration order, so the first PUT
+    // matches the 500 and consumes its single-use budget; the second PUT
+    // falls through to the 200 default.
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(500))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\""),
+        )
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let state_path = write_stub_state(tmp.path());
+    let config = s3_config(
+        "rocky-state-retry-bucket",
+        3,
+        StateUploadFailureMode::Fail,
+        RetryConfig {
+            max_retries: 1,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 100,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..RetryConfig::default()
+        },
+    );
+
+    let start = Instant::now();
+    let result = upload_state(&config, &state_path).await;
+    let elapsed = start.elapsed();
+
+    result.expect("retry after transient 500 should succeed");
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "retry+upload took {elapsed:?} (expected <3s)"
     );
 }

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -629,57 +629,20 @@ class StateBackend5(StrEnum):
     tiered = "tiered"
 
 
-class StateConfig(BaseModel):
+class StateUploadFailureMode1(StrEnum):
     """
-    State persistence configuration.
-
-    Controls where Rocky stores watermarks and anomaly history between runs. On ephemeral environments (EKS pods), use S3, GCS, or Valkey for persistence.
-
-    When both S3 and Valkey are configured (`backend = "tiered"`): - Download: Valkey first (fast), S3 fallback (durable) - Upload: write to both Valkey + S3
+    Log a warning and continue the run successfully. State becomes stale until the next healthy upload; the next run's `discover` re-derives watermarks from target-table metadata. Trades state durability for run liveness — matches the de-facto behaviour of the pre-retry callers in `rocky run`, which already `warn + continue` on a failed upload.
     """
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    backend: (
-        StateBackend1
-        | StateBackend2
-        | StateBackend3
-        | StateBackend4
-        | StateBackend5
-        | None
-    ) = "local"
+    skip = "skip"
+
+
+class StateUploadFailureMode2(StrEnum):
     """
-    Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)
+    Propagate the error to the caller. Appropriate for strict environments where state durability matters more than liveness (e.g. long-running backfills where re-deriving watermarks is prohibitively expensive).
     """
-    gcs_bucket: str | None = None
-    """
-    GCS bucket for state persistence
-    """
-    gcs_prefix: str | None = None
-    """
-    GCS key prefix (default: "rocky/state/")
-    """
-    s3_bucket: str | None = None
-    """
-    S3 bucket for state persistence
-    """
-    s3_prefix: str | None = None
-    """
-    S3 key prefix (default: "rocky/state/")
-    """
-    transfer_timeout_seconds: conint(ge=0) | None = 300
-    """
-    Wall-clock budget (seconds) for each state transfer operation (download or upload). Catches stuck SDK retry loops, DNS, TLS, and hung endpoints that the per-request HTTP timeout does not see. Defaults to 300s; raise for large state or slow networks.
-    """
-    valkey_prefix: str | None = None
-    """
-    Valkey key prefix (default: "rocky:state:")
-    """
-    valkey_url: str | None = None
-    """
-    Valkey/Redis URL for state persistence
-    """
+
+    fail = "fail"
 
 
 class TableRef(BaseModel):
@@ -1483,6 +1446,79 @@ class QuarantineConfig(BaseModel):
     """
 
 
+class StateConfig(BaseModel):
+    """
+    State persistence configuration.
+
+    Controls where Rocky stores watermarks and anomaly history between runs. On ephemeral environments (EKS pods), use S3, GCS, or Valkey for persistence.
+
+    When both S3 and Valkey are configured (`backend = "tiered"`): - Download: Valkey first (fast), S3 fallback (durable) - Upload: write to both Valkey + S3
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: (
+        StateBackend1
+        | StateBackend2
+        | StateBackend3
+        | StateBackend4
+        | StateBackend5
+        | None
+    ) = "local"
+    """
+    Storage backend: local (default), s3, gcs, valkey, or tiered (valkey + s3 fallback)
+    """
+    gcs_bucket: str | None = None
+    """
+    GCS bucket for state persistence
+    """
+    gcs_prefix: str | None = None
+    """
+    GCS key prefix (default: "rocky/state/")
+    """
+    on_upload_failure: StateUploadFailureMode1 | StateUploadFailureMode2 | None = "skip"
+    """
+    What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
+    """
+    retry: RetryConfig | None = Field(
+        {
+            "backoff_multiplier": 2.0,
+            "circuit_breaker_recovery_timeout_secs": None,
+            "circuit_breaker_threshold": 5,
+            "initial_backoff_ms": 1000,
+            "jitter": True,
+            "max_backoff_ms": 30000,
+            "max_retries": 3,
+            "max_retries_per_run": None,
+        },
+        validate_default=True,
+    )
+    """
+    Retry policy applied to transient state-transfer failures (network hiccups, hung endpoints that hit the per-request HTTP timeout, transient 5xx, etc.). Shares the same shape as the adapter retry config so operators can reason about both with a single mental model. Retries share the outer `transfer_timeout_seconds` budget, so the total wall-clock ceiling is unchanged.
+    """
+    s3_bucket: str | None = None
+    """
+    S3 bucket for state persistence
+    """
+    s3_prefix: str | None = None
+    """
+    S3 key prefix (default: "rocky/state/")
+    """
+    transfer_timeout_seconds: conint(ge=0) | None = 300
+    """
+    Wall-clock budget (seconds) for each state transfer operation (download or upload). Catches stuck SDK retry loops, DNS, TLS, and hung endpoints that the per-request HTTP timeout does not see. Defaults to 300s; raise for large state or slow networks.
+    """
+    valkey_prefix: str | None = None
+    """
+    Valkey key prefix (default: "rocky:state:")
+    """
+    valkey_url: str | None = None
+    """
+    Valkey/Redis URL for state persistence
+    """
+
+
 class ChecksConfig(BaseModel):
     """
     Data quality checks configuration (row count, column match, freshness, null rate, custom).
@@ -2160,6 +2196,17 @@ class RockyConfig(BaseModel):
             "backend": "local",
             "gcs_bucket": None,
             "gcs_prefix": None,
+            "on_upload_failure": "skip",
+            "retry": {
+                "backoff_multiplier": 2.0,
+                "circuit_breaker_recovery_timeout_secs": None,
+                "circuit_breaker_threshold": 5,
+                "initial_backoff_ms": 1000,
+                "jitter": True,
+                "max_backoff_ms": 30000,
+                "max_retries": 3,
+                "max_retries_per_run": None,
+            },
             "s3_bucket": None,
             "s3_prefix": None,
             "transfer_timeout_seconds": 300,

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2213,6 +2213,33 @@
             "null"
           ]
         },
+        "on_upload_failure": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StateUploadFailureMode"
+            }
+          ],
+          "default": "skip",
+          "description": "What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`]."
+        },
+        "retry": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RetryConfig"
+            }
+          ],
+          "default": {
+            "backoff_multiplier": 2.0,
+            "circuit_breaker_recovery_timeout_secs": null,
+            "circuit_breaker_threshold": 5,
+            "initial_backoff_ms": 1000,
+            "jitter": true,
+            "max_backoff_ms": 30000,
+            "max_retries": 3,
+            "max_retries_per_run": null
+          },
+          "description": "Retry policy applied to transient state-transfer failures (network hiccups, hung endpoints that hit the per-request HTTP timeout, transient 5xx, etc.). Shares the same shape as the adapter retry config so operators can reason about both with a single mental model. Retries share the outer `transfer_timeout_seconds` budget, so the total wall-clock ceiling is unchanged."
+        },
         "s3_bucket": {
           "description": "S3 bucket for state persistence",
           "type": [
@@ -2250,6 +2277,25 @@
         }
       },
       "type": "object"
+    },
+    "StateUploadFailureMode": {
+      "description": "Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].",
+      "oneOf": [
+        {
+          "description": "Log a warning and continue the run successfully. State becomes stale until the next healthy upload; the next run's `discover` re-derives watermarks from target-table metadata. Trades state durability for run liveness — matches the de-facto behaviour of the pre-retry callers in `rocky run`, which already `warn + continue` on a failed upload.",
+          "enum": [
+            "skip"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Propagate the error to the caller. Appropriate for strict environments where state durability matters more than liveness (e.g. long-running backfills where re-deriving watermarks is prohibitively expensive).",
+          "enum": [
+            "fail"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "TableRef": {
       "additionalProperties": false,
@@ -2612,6 +2658,17 @@
         "backend": "local",
         "gcs_bucket": null,
         "gcs_prefix": null,
+        "on_upload_failure": "skip",
+        "retry": {
+          "backoff_multiplier": 2.0,
+          "circuit_breaker_recovery_timeout_secs": null,
+          "circuit_breaker_threshold": 5,
+          "initial_backoff_ms": 1000,
+          "jitter": true,
+          "max_backoff_ms": 30000,
+          "max_retries": 3,
+          "max_retries_per_run": null
+        },
         "s3_bucket": null,
         "s3_prefix": null,
         "transfer_timeout_seconds": 300,


### PR DESCRIPTION
## Summary

- Wires the state backend in `rocky-core` into the shared retry + circuit-breaker infra already used by the Databricks adapter: adds `[state.retry]` (same shape as `[adapter.databricks.retry]`) and an `on_upload_failure = "skip" | "fail"` policy to `StateConfig`. Default `skip` matches the de-facto behaviour of existing callers that already `warn + continue` on upload failure; `fail` is the strict opt-in.
- Retry loop is wrapped by the existing `with_transfer_timeout` — `transfer_timeout_seconds` (default 300 s) remains the total wall-clock cap and retries *share* the budget rather than extend it. No liveness regression.
- Groundwork commit first: adds a structured `outcome` field to all terminal `state.upload` / `state.download` events (`ok` / `absent` / `timeout` / `error_then_fresh` / `skipped_after_failure` / `transient_exhausted` / `circuit_open`) so next-incident diagnostics land on a structured signal instead of free-form log strings.

New `StateSyncError::CircuitOpen` and `StateSyncError::RetryBudgetExhausted` surface terminal-by-construction outcomes with attribution instead of masquerading as transport errors. Tiered recursion now uses the internal `dispatch_upload` so the skip/fail policy is evaluated exactly once at the outermost call, not twice per leg. `compute_backoff` is intentionally duplicated from `rocky-databricks` / `rocky-snowflake` for now — dedup across all three crates is a follow-up PR.

Regenerated via `just codegen`: `schemas/rocky_project.schema.json`, `editors/vscode/schemas/rocky-project.schema.json`, `editors/vscode/src/types/generated/rocky_project.ts`, `integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py`.

## Test plan

- [ ] \`cargo test -p rocky-core\` passes (+9 new state_sync unit tests covering is_transient classification, compute_backoff math, retry-success, retry-give-up, permanent-error, budget-exhaustion paths)
- [ ] \`cargo test -p rocky-core --test state_sync_timeout_test\` passes (4 wiremock integration tests: fail-mode timeout, skip-mode timeout, prompt-endpoint happy path, retry-on-transient-500)
- [ ] \`cargo clippy -p rocky-core -- -D warnings\` clean
- [ ] \`codegen-drift\` CI check passes (regenerated bindings already committed)
- [ ] Manual: \`rocky run\` against a healthy S3 state backend → no behaviour change (happy path unchanged)
- [ ] Manual: \`rocky run\` with an intentionally write-protected S3 prefix and default \`on_upload_failure = "skip"\` → run completes; stderr carries \`outcome = "skipped_after_failure"\` warn
- [ ] Manual: same setup with \`on_upload_failure = "fail"\` → run fails with the underlying upload error propagated

Generated with Claude Code.