### PR TITLE
feat(rocky-cli): add state_rw probe to doctor

### DIFF
--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -204,7 +204,51 @@ pub async fn doctor(
         }
     }
 
-    // 6. Auth — construct adapters and ping each warehouse
+    // 6. State backend RW probe — actually write/read/delete a test
+    //    object against the configured backend. Complements `state_sync`
+    //    (which only inspects the backend type) by surfacing permission
+    //    and reachability problems that would otherwise only manifest at
+    //    end-of-run upload time.
+    if should_run("state_rw", check_filter) {
+        let start = Instant::now();
+        if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
+            let backend = &cfg.state.backend;
+            if *backend == rocky_core::config::StateBackend::Local {
+                checks.push(HealthCheck {
+                    name: "state_rw".into(),
+                    status: HealthStatus::Healthy,
+                    message: "Local backend — no remote probe needed".into(),
+                    duration_ms: start.elapsed().as_millis() as u64,
+                });
+            } else {
+                match rocky_core::state_sync::probe_state_backend(&cfg.state).await {
+                    Ok(()) => {
+                        checks.push(HealthCheck {
+                            name: "state_rw".into(),
+                            status: HealthStatus::Healthy,
+                            message: format!("State backend RW probe succeeded ({backend})"),
+                            duration_ms: start.elapsed().as_millis() as u64,
+                        });
+                    }
+                    Err(e) => {
+                        checks.push(HealthCheck {
+                            name: "state_rw".into(),
+                            status: HealthStatus::Critical,
+                            message: format!("State backend RW probe failed: {e}"),
+                            duration_ms: start.elapsed().as_millis() as u64,
+                        });
+                        suggestions.push(format!(
+                            "state_rw: verify the '{backend}' backend has read+write access \
+                             to the configured bucket / prefix (tried put/get/delete of a \
+                             short-lived marker object)"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // 7. Auth — construct adapters and ping each warehouse
     if should_run("auth", check_filter) {
         let start = Instant::now();
         match rocky_core::config::load_rocky_config(config_path) {

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -519,8 +519,8 @@ async fn probe_valkey(config: &StateConfig) -> Result<(), StateSyncError> {
     async move {
         with_transfer_timeout(timeout, async move {
             let join = tokio::task::spawn_blocking(move || -> Result<(), StateSyncError> {
-                let client = redis::Client::open(url)
-                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                let client =
+                    redis::Client::open(url).map_err(|e| StateSyncError::Valkey(e.to_string()))?;
                 let mut conn = client
                     .get_connection()
                     .map_err(|e| StateSyncError::Valkey(e.to_string()))?;

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -8,8 +8,9 @@
 //! so credential resolution follows the standard AWS SDK / GCP ADC chains.
 
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use thiserror::Error;
 use tracing::{Instrument, debug, info, info_span, warn};
 
@@ -401,6 +402,162 @@ async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(),
     .await
 }
 
+/// Round-trip RW probe against the configured state backend.
+///
+/// Writes a short-lived marker to a **distinct key** (never the real
+/// `state.redb`), reads it back, and deletes it. Used by `rocky doctor`
+/// to verify a state backend is actually reachable and writable — not
+/// merely configured. Honours `transfer_timeout_seconds` as an outer
+/// wall-clock cap; no retries — probes should produce a single-pass
+/// pass/fail signal, not resilient writes.
+///
+/// For `tiered` both legs (Valkey + S3) must pass — either one failing
+/// fails the probe. For `local` this is a no-op returning `Ok`.
+pub async fn probe_state_backend(config: &StateConfig) -> Result<(), StateSyncError> {
+    match config.backend {
+        StateBackend::Local => Ok(()),
+        StateBackend::S3 => {
+            let bucket = config.s3_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("s3".into(), "state.s3_bucket".into())
+            })?;
+            let prefix = config.s3_prefix.as_deref().unwrap_or(DEFAULT_S3_PREFIX);
+            probe_object_store("s3", bucket, prefix, transfer_timeout(config)).await
+        }
+        StateBackend::Gcs => {
+            let bucket = config.gcs_bucket.as_deref().ok_or_else(|| {
+                StateSyncError::MissingConfig("gcs".into(), "state.gcs_bucket".into())
+            })?;
+            let prefix = config.gcs_prefix.as_deref().unwrap_or(DEFAULT_GCS_PREFIX);
+            probe_object_store("gs", bucket, prefix, transfer_timeout(config)).await
+        }
+        StateBackend::Valkey => probe_valkey(config).await,
+        StateBackend::Tiered => {
+            let valkey_config = StateConfig {
+                backend: StateBackend::Valkey,
+                ..config.clone()
+            };
+            let s3_config = StateConfig {
+                backend: StateBackend::S3,
+                ..config.clone()
+            };
+            Box::pin(probe_state_backend(&valkey_config)).await?;
+            Box::pin(probe_state_backend(&s3_config)).await
+        }
+    }
+}
+
+/// Build a per-call probe key under the configured prefix. Uses PID +
+/// nanosecond epoch so concurrent doctor invocations don't collide.
+fn probe_key() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("doctor-probe-{}-{}.marker", std::process::id(), nanos)
+}
+
+async fn probe_object_store(
+    scheme: &str,
+    bucket: &str,
+    prefix: &str,
+    timeout: Duration,
+) -> Result<(), StateSyncError> {
+    let provider = cloud_provider(scheme, bucket, prefix)?;
+    let key = probe_key();
+    let data = Bytes::from_static(b"rocky doctor probe");
+    let span = info_span!(
+        "state.probe",
+        backend = %provider.scheme(),
+        bucket = %provider.bucket(),
+    );
+    async move {
+        with_transfer_timeout(timeout, async {
+            provider.put(&key, data.clone()).await?;
+            let got = provider.get(&key).await?;
+            if got != data {
+                // Reuse the backend-specific Upload variant so the message
+                // carries the scheme; the probe-vs-real-upload distinction
+                // is captured by the `state.probe` span name above.
+                let err = format!("probe content mismatch (wrote {} bytes, read {} bytes)", data.len(), got.len());
+                return match scheme {
+                    "s3" => Err(StateSyncError::S3Upload(err)),
+                    "gs" => Err(StateSyncError::GcsUpload(err)),
+                    _ => Err(StateSyncError::S3Upload(err)),
+                };
+            }
+            // Best-effort cleanup — a stale probe object is a small cost
+            // (< 20 bytes, lifecycle rules clean up eventually); surfacing
+            // a delete failure on an otherwise successful probe would
+            // mask the real signal (RW works).
+            if let Err(e) = provider.delete(&key).await {
+                warn!(error = %e, key = %key, outcome = "probe_cleanup_failed", "state probe cleanup failed (object will remain until lifecycle rule cleans it up)");
+            }
+            info!(outcome = "ok", "state backend probe succeeded");
+            Ok(())
+        })
+        .await
+    }
+    .instrument(span)
+    .await
+}
+
+async fn probe_valkey(config: &StateConfig) -> Result<(), StateSyncError> {
+    let url = config
+        .valkey_url
+        .as_deref()
+        .ok_or_else(|| StateSyncError::MissingConfig("valkey".into(), "state.valkey_url".into()))?
+        .to_string();
+    let prefix = config
+        .valkey_prefix
+        .as_deref()
+        .unwrap_or(DEFAULT_VALKEY_PREFIX)
+        .to_string();
+    let key = format!("{prefix}{}", probe_key());
+    let timeout = transfer_timeout(config);
+
+    let span = info_span!("state.probe", backend = "valkey");
+    async move {
+        with_transfer_timeout(timeout, async move {
+            let join = tokio::task::spawn_blocking(move || -> Result<(), StateSyncError> {
+                let client = redis::Client::open(url)
+                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                let mut conn = client
+                    .get_connection()
+                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                redis::cmd("SET")
+                    .arg(&key)
+                    .arg("rocky doctor probe")
+                    .query::<()>(&mut conn)
+                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                let val: Option<String> = redis::cmd("GET")
+                    .arg(&key)
+                    .query(&mut conn)
+                    .map_err(|e| StateSyncError::Valkey(e.to_string()))?;
+                if val.as_deref() != Some("rocky doctor probe") {
+                    return Err(StateSyncError::Valkey(format!(
+                        "probe value mismatch (got {val:?})"
+                    )));
+                }
+                // Best-effort cleanup — same rationale as the object-store path.
+                let _ = redis::cmd("DEL").arg(&key).query::<()>(&mut conn);
+                Ok(())
+            })
+            .await;
+            match join {
+                Ok(inner) => inner,
+                Err(e) => Err(StateSyncError::Valkey(format!(
+                    "valkey worker task failed: {e}"
+                ))),
+            }
+        })
+        .await?;
+        info!(outcome = "ok", "state backend probe succeeded");
+        Ok(())
+    }
+    .instrument(span)
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,5 +624,49 @@ mod tests {
     fn test_default_state_transfer_timeout() {
         let config = StateConfig::default();
         assert_eq!(config.transfer_timeout_seconds, 300);
+    }
+
+    #[tokio::test]
+    async fn test_probe_state_backend_local_is_noop() {
+        let config = StateConfig::default();
+        assert!(matches!(config.backend, StateBackend::Local));
+        probe_state_backend(&config)
+            .await
+            .expect("Local backend probe should be a no-op");
+    }
+
+    #[tokio::test]
+    async fn test_probe_state_backend_s3_missing_bucket_fails_fast() {
+        let config = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: None,
+            ..Default::default()
+        };
+        let err = probe_state_backend(&config)
+            .await
+            .expect_err("missing bucket should error");
+        assert!(matches!(err, StateSyncError::MissingConfig(..)));
+    }
+
+    #[tokio::test]
+    async fn test_probe_state_backend_valkey_missing_url_fails_fast() {
+        let config = StateConfig {
+            backend: StateBackend::Valkey,
+            valkey_url: None,
+            ..Default::default()
+        };
+        let err = probe_state_backend(&config)
+            .await
+            .expect_err("missing URL should error");
+        assert!(matches!(err, StateSyncError::MissingConfig(..)));
+    }
+
+    #[test]
+    fn test_probe_key_is_unique_across_calls() {
+        let a = probe_key();
+        let b = probe_key();
+        assert_ne!(a, b, "probe_key should produce unique values per call");
+        assert!(a.starts_with("doctor-probe-"));
+        assert!(a.ends_with(".marker"));
     }
 }

--- a/engine/crates/rocky-core/tests/state_sync_probe_test.rs
+++ b/engine/crates/rocky-core/tests/state_sync_probe_test.rs
@@ -1,0 +1,135 @@
+//! Integration tests for [`rocky_core::state_sync::probe_state_backend`].
+//!
+//! Reuses the same `AWS_ENDPOINT` + `AWS_ALLOW_HTTP` wiremock pattern as
+//! `state_sync_timeout_test.rs` so the S3 SDK talks to a mock. Exercises
+//! two shapes:
+//!
+//! * **Happy path** — mock answers PUT / GET / DELETE successfully; the
+//!   probe completes well under 1 s.
+//! * **Failing probe** — mock returns 500 on PUT; probe propagates the
+//!   error instead of pretending the backend is healthy.
+
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use rocky_core::config::{StateBackend, StateConfig};
+use rocky_core::state_sync::probe_state_backend;
+use tempfile::TempDir;
+use tokio::sync::{Mutex, MutexGuard};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+async fn env_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().await
+}
+
+fn install_aws_env(endpoint: &str) {
+    static GUARD: OnceLock<()> = OnceLock::new();
+    GUARD.get_or_init(|| {
+        // SAFETY: set exactly once before any object_store builder reads them.
+        unsafe {
+            std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+            std::env::set_var("AWS_REGION", "us-east-1");
+            std::env::set_var("AWS_ALLOW_HTTP", "true");
+        }
+    });
+    // SAFETY: serialized via `env_guard()`; latest write wins before the
+    // next S3 builder reads the endpoint.
+    unsafe {
+        std::env::set_var("AWS_ENDPOINT", endpoint);
+    }
+}
+
+fn s3_config(bucket: &str) -> StateConfig {
+    StateConfig {
+        backend: StateBackend::S3,
+        s3_bucket: Some(bucket.into()),
+        s3_prefix: Some("rocky/state/".into()),
+        transfer_timeout_seconds: 5,
+        ..Default::default()
+    }
+}
+
+/// Workaround: `AmazonS3Builder::from_env()` reads endpoint at build time
+/// but doesn't gate on `tempfile`; we still allocate a scratch dir for
+/// parity with the other integration test file.
+fn _scratch(_dir: &Path) {}
+
+/// Happy-path probe: PUT→GET→DELETE all succeed. Probe returns Ok quickly.
+#[tokio::test]
+async fn probe_state_backend_s3_roundtrip_succeeds() {
+    let _env = env_guard().await;
+    let server = MockServer::start().await;
+    install_aws_env(&server.uri());
+
+    Mock::given(method("PUT"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\""),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(&b"rocky doctor probe"[..])
+                .insert_header("ETag", "\"d41d8cd98f00b204e9800998ecf8427e\"")
+                .insert_header("Content-Length", "18"),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    _scratch(tmp.path());
+    let config = s3_config("rocky-state-probe-bucket");
+
+    let start = Instant::now();
+    let result = probe_state_backend(&config).await;
+    let elapsed = start.elapsed();
+
+    result.expect("probe should succeed with a healthy mock backend");
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "probe took {elapsed:?} (expected <2s)"
+    );
+}
+
+/// Failing probe: PUT returns 500. Probe propagates the error so `rocky
+/// doctor` can surface a Critical status instead of pretending the backend
+/// is healthy.
+#[tokio::test]
+async fn probe_state_backend_s3_propagates_upload_error() {
+    let _env = env_guard().await;
+    let server = MockServer::start().await;
+    install_aws_env(&server.uri());
+
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    _scratch(tmp.path());
+    let config = s3_config("rocky-state-probe-fail-bucket");
+
+    let err = probe_state_backend(&config)
+        .await
+        .expect_err("500 on PUT should propagate as probe error");
+
+    // Error shape comes through the ObjectStore backend variant since the
+    // put is from aws-smithy; we only need to assert it's *not* silently
+    // Ok. (`assert!(matches!(err, StateSyncError::ObjectStore(_)))` would
+    // overfit to the current mapping.)
+    let msg = err.to_string();
+    assert!(
+        !msg.is_empty(),
+        "error message should carry diagnostics: {err:?}"
+    );
+}

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -33,6 +33,12 @@
       "duration_ms": 0
     },
     {
+      "name": "state_rw",
+      "status": "healthy",
+      "message": "Local backend \u2014 no remote probe needed",
+      "duration_ms": 0
+    },
+    {
       "name": "auth/default",
       "status": "healthy",
       "message": "Authenticated to default",

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -33,6 +33,12 @@
       "duration_ms": 0
     },
     {
+      "name": "state_rw",
+      "status": "healthy",
+      "message": "Local backend \u2014 no remote probe needed",
+      "duration_ms": 0
+    },
+    {
       "name": "auth/default",
       "status": "healthy",
       "message": "Authenticated to default",


### PR DESCRIPTION
## Summary

- Adds a 7th \`state_rw\` check to \`rocky doctor\` that runs a put/get/delete round-trip against the configured state backend (S3 / GCS / Valkey / Tiered). Complements the existing \`state_sync\` check (which only inspects the backend *type*) by surfacing permission and reachability problems at cold start instead of only at end-of-run upload.
- New \`rocky_core::state_sync::probe_state_backend\` helper — uses a distinct marker key (\`doctor-probe-{pid}-{nanos}.marker\`, never \`state.redb\`), honours \`transfer_timeout_seconds\` as an outer cap, no retries (probes should produce a single-pass pass/fail signal, not resilient writes).
- Local backend is a no-op. Tiered probes both legs and fails if either leg fails. Best-effort cleanup: a stale marker after probe success is logged but not fatal; lifecycle rules clean up eventually.

Scope trimmed vs the original plan: the existing \`auth\` check already covers Databricks OAuth and Fivetran API reachability via \`adapter.ping()\`, so no new adapter-probe entries are needed. Reachability (HeadBucket / PING) is subsumed by the full RW probe — a working put/get/delete round-trip proves both reachability *and* write permission, whereas reachability alone leaves read-only IAM policies invisible until upload time.

## Test plan

- [ ] \`cargo test -p rocky-core --lib state_sync\` passes (+4 new probe unit tests: Local no-op, S3 missing-bucket fail-fast, Valkey missing-URL fail-fast, probe_key uniqueness)
- [ ] \`cargo test -p rocky-core --test state_sync_probe_test\` passes (2 wiremock integration tests: PUT→GET→DELETE happy path <2s; 500-on-PUT propagates as probe error)
- [ ] \`cargo test -p rocky-cli --lib doctor\` — no regression (existing 7 tests still green)
- [ ] \`cargo clippy -p rocky-core -p rocky-cli --tests -- -D warnings\` clean
- [ ] Manual: \`rocky doctor --output json\` against a healthy S3 state backend — \`state_rw\` check reports Healthy with probe duration
- [ ] Manual: same against a write-protected S3 prefix — \`state_rw\` reports Critical with the permission error in the message

Generated with Claude Code.