### PR TITLE
chore: release engine-v1.13.0 + dagster-v1.9.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] — 2026-04-22
+
+Reliability hardening for the state backend. Closes the last mutation path in `rocky-core` without retry / circuit-breaker parity with the adapter layer, and turns `rocky doctor` into a real smoke test of state-backend connectivity instead of a credentials-only check. Two PRs since v1.12.0.
+
+### Added
+
+- **`[state.retry]` block on `StateConfig`** (#213) — shape identical to `[adapter.databricks.retry]`, so operators reason about both layers with a single mental model. Fields: `max_retries` (default 3), `initial_backoff_ms` (1000), `max_backoff_ms` (30000), `backoff_multiplier` (2.0), `jitter` (true), `circuit_breaker_threshold` (5), `circuit_breaker_recovery_timeout_secs` (None), `max_retries_per_run` (None). Reuses the existing `rocky_core::circuit_breaker::CircuitBreaker` + `rocky_core::retry_budget::RetryBudget` already battle-tested by the Databricks adapter. The retry loop is wrapped by the existing `with_transfer_timeout`, so `transfer_timeout_seconds` (default 300 s) remains the total wall-clock cap — retries *share* the budget rather than extend it. No liveness regression vs v1.12.0.
+- **`[state] on_upload_failure = "skip" | "fail"`** (#213) — policy applied after retries + circuit are exhausted. Default `skip` matches the de-facto behaviour of existing callers that `warn + continue` on upload failure; `fail` is the opt-in for strict environments where state durability trumps liveness. New `StateUploadFailureMode` enum exported from `rocky_core::config`.
+- **New `StateSyncError::CircuitOpen` + `RetryBudgetExhausted` variants** (#213) — terminal outcomes that were previously masquerading as generic upload/timeout errors now surface with attribution, so log-grep and `match`-based error handling can distinguish "breaker tripped" from "network blip".
+- **`outcome` field on every terminal `state.upload` / `state.download` event** (#213) — `ok` / `absent` / `timeout` / `error_then_fresh` / `skipped_after_failure` / `transient_exhausted` / `circuit_open` / `budget_exhausted`. Terminal success events also carry a `retries` counter. Lets operators diagnose incidents from structured log lines instead of free-form message regex.
+- **`rocky doctor` gains a 7th check: `state_rw`** (#214) — runs a put/get/delete round-trip against the configured state backend (S3 / GCS / Valkey / Tiered). Uses a distinct marker key (`doctor-probe-{pid}-{nanos}.marker`, never `state.redb`), honours `transfer_timeout_seconds`, no retries — probes produce a single-pass pass/fail signal, not resilient writes. Local backend is a no-op. Tiered probes both legs; either failing fails the probe. Complements the existing `state_sync` check (backend-type inspection only) by surfacing IAM / reachability problems at cold start instead of at end-of-run upload time.
+- **`rocky_core::state_sync::probe_state_backend` public helper** (#214) — exposes the RW probe so downstream `doctor`-like tooling (Dagster asset checks, scheduled sensors) can reuse it without shelling out to `rocky doctor`.
+
+### Internal
+
+- **`compute_backoff` + `is_transient` for state sync intentionally duplicated** from `rocky-databricks::connector` and `rocky-snowflake::connector`. A follow-up PR should hoist all three copies into a shared `rocky-core` helper; this release kept scope narrow.
+
 ## [1.12.0] — 2026-04-21
 
 Arc 1 wave 2 shipped + a short cleanup wave around it. Eight PRs since v1.11.0. `record_run` wiring finally makes the run-history query surfaces (`rocky history` / `replay` / `trace` / `cost`) return real data end-to-end, plus two new commands (`rocky cost`, `rocky branch compare`) and a SIGPIPE fix.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "redis",
  "serde",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "bumpalo",
  "indexmap",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "logos",
  "miette",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "miette",
  "regex",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.12.0"
+version = "1.13.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.12.0"
+version = "1.13.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.12.0"
+version = "1.13.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.12.0"
+version = "1.13.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.12.0"
+version = "1.13.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.12.0"
+version = "1.13.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.12.0"
+version = "1.13.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.12.0"
+version = "1.13.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.12.0"
+version = "1.13.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.12.0"
+version = "1.13.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.12.0"
+version = "1.13.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.12.0"
+version = "1.13.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.12.0"
+version = "1.13.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.12.0"
+version = "1.13.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.12.0"
+version = "1.13.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] — 2026-04-22
+
+Tracks engine 1.13.0 (state-backend reliability hardening + `state_rw` doctor check).
+
+### Changed
+
+- **`types_generated/rocky_project_schema.py` picks up the new `StateConfig.retry` + `StateConfig.on_upload_failure` fields** and the new `StateUploadFailureMode` Pydantic enum from engine 1.13.0. Fully additive — existing code consuming `StateConfig` continues to validate; new fields default to the engine's defaults. IDE hover / Pyright on `StateConfig` now shows the new fields.
+- **`tests/fixtures_generated/doctor.json` + `doctor_ci/doctor.json` regenerated** for the new `state_rw` doctor check row in engine 1.13.0. Test-only; no wheel surface change.
+
 ## [1.8.0] — 2026-04-21
 
 Tracks engine 1.12.0 (Arc 1 wave 2 + cleanup cascade).

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.8.0"
+version = "1.9.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/tests/fixtures_generated/anomaly/history.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "history",
   "runs": [
     {

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 2,

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "dag",
   "nodes": [
     {

--- a/integrations/dagster/tests/fixtures_generated/discover.json
+++ b/integrations/dagster/tests/fixtures_generated/discover.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "discover",
   "sources": [
     {

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/ci.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "ci",
   "compile_ok": true,
   "tests_ok": true,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/history.json
+++ b/integrations/dagster/tests/fixtures_generated/history.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "history",
   "runs": [
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run1.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/state_after_run2.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "lineage",
   "model": "revenue_summary",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "compile",
   "models": 3,
   "execution_layers": 3,

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_column.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "lineage",
   "model": "fct_revenue",
   "column": "total",

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "lineage",
   "model": "fct_revenue",
   "columns": [

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/tests/fixtures_generated/metrics.json
+++ b/integrations/dagster/tests/fixtures_generated/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "metrics",
   "model": "revenue_summary",
   "snapshots": [],

--- a/integrations/dagster/tests/fixtures_generated/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "optimize",
   "recommendations": [
     {

--- a/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/optimize.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "optimize",
   "recommendations": [
     {

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=events",

--- a/integrations/dagster/tests/fixtures_generated/partition/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/compile.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "compile",
   "models": 1,
   "execution_layers": 1,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "plan",
   "filter": "source=orders",
   "statements": [

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "run",
   "pipeline_type": "replication",
   "filter": "source=orders",

--- a/integrations/dagster/tests/fixtures_generated/state.json
+++ b/integrations/dagster/tests/fixtures_generated/state.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "state",
   "watermarks": [
     {

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.13.0",
   "command": "test",
   "total": 3,
   "passed": 3,

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Release PR for two tag-namespaced artifacts in one reviewable bundle:

- **engine-v1.13.0** — state-backend reliability hardening: `[state.retry]` + circuit-breaker + `on_upload_failure` (#213); 7th `state_rw` doctor check running a live RW probe against the configured backend (#214); structured `outcome` field on every terminal `state.upload` / `state.download` event.
- **dagster-v1.9.0** — regenerated Pydantic types + doctor test fixtures tracking engine 1.13.0. All additive; no wheel logic change.

Full details per-artifact in the updated CHANGELOGs.

Version bumps: 20 crate \`Cargo.toml\` files (excluding \`rocky-bigquery\` on its own version track) + \`engine/Cargo.lock\`; \`integrations/dagster/pyproject.toml\` + \`integrations/dagster/uv.lock\`. Commits split so git blame / release-notes generation hits one artifact per commit.

## Test plan

- [ ] \`engine-ci\` passes (cargo test + clippy + fmt on every engine crate)
- [ ] \`codegen-drift\` passes (no bindings drift vs regenerated output)
- [ ] Post-merge: tag \`engine-v1.13.0\` on the merged commit + \`git push origin engine-v1.13.0\` — \`engine-release.yml\` builds 5 platform archives + SHA256SUMS
- [ ] Post-merge: tag \`dagster-v1.9.0\` + push — \`dagster-release.yml\` builds wheel + sdist and publishes to PyPI via OIDC
- [ ] Verify \`gh release view engine-v1.13.0\` shows 5 archives + checksums
- [ ] Verify \`pip install dagster-rocky==1.9.0\` resolves on PyPI

Generated with Claude Code.