### PR TITLE
docs: cover engine v1.13 state retry + state_rw doctor probe

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -63,7 +63,7 @@ Scope on the ELT spectrum:
 - `rocky ai-test` — Generate test assertions from intent
 
 ### Administration
-- `rocky doctor` — Aggregate health check
+- `rocky doctor` — Aggregate health check (7 categories: `config`, `state`, `adapters`, `pipelines`, `state_sync`, `state_rw` live RW probe, `auth`/`auth/<adapter>`)
 - `rocky compare` — Shadow-vs-production comparison
 - `rocky history` — Run + model execution history
 - `rocky metrics <model>` — Quality metrics and trends
@@ -109,7 +109,7 @@ Top-level sections:
 - `[pipeline.NAME.source.schema_pattern]` — multi-tenant schema name parser
 - `[pipeline.NAME.checks]` — inline data quality checks
 - `[pipeline.NAME.governance]` — tags, permissions, workspace isolation
-- `[state]` — watermark backend (`local`, `s3`, `valkey`)
+- `[state]` — watermark backend (`local`, `s3`, `gcs`, `valkey`, `tiered`) with `[state.retry]` exponential-backoff + circuit-breaker and `on_upload_failure = "skip" | "fail"`
 - `[cache]` / `[cost]` / `[hooks]` — optional subsystems
 
 Select pipelines at runtime with `--pipeline NAME`.

--- a/docs/src/content/docs/concepts/state-management.md
+++ b/docs/src/content/docs/concepts/state-management.md
@@ -166,7 +166,45 @@ When `backend` is not `local`, Rocky syncs state automatically:
 2. **During run**: Read/write from local `.redb` (fast, no network)
 3. **After run**: Upload local `.redb` → remote storage
 
-If download fails, Rocky logs a warning and starts fresh. If upload fails with S3 or Valkey, it logs an error but the run still succeeds.
+If download fails, Rocky logs a warning and starts fresh from target-table metadata. Upload failure behaviour is governed by the [retry + failure policy](#retry-and-failure-policy) below.
+
+### Retry and Failure Policy
+
+Every remote transfer (upload *or* download) runs inside a wall-clock budget with exponential-backoff retries and a three-state circuit breaker — the same machinery the Databricks and Snowflake adapters already use. Configuration lives under `[state.retry]` in `rocky.toml`; the full field list is in the [configuration reference](/reference/configuration/#stateretry).
+
+```toml
+[state]
+backend = "s3"
+s3_bucket = "${ROCKY_STATE_BUCKET}"
+transfer_timeout_seconds = 300       # total wall-clock ceiling — retries share this budget
+on_upload_failure = "skip"           # "skip" (default) or "fail"
+
+[state.retry]
+max_retries = 3                       # defaults shown; omit the block to use them
+circuit_breaker_threshold = 5
+```
+
+**`on_upload_failure`** controls what happens when retries *and* the circuit breaker are both exhausted:
+
+| Mode | Behaviour | When to use |
+|---|---|---|
+| `"skip"` (default) | Log a warning, mark the run successful, leave remote state stale. The next run re-derives watermarks from target-table metadata. | Most callers — the de-facto pre-1.13 behaviour. Trades state durability for run liveness. |
+| `"fail"` | Propagate a `StateSyncError::RetryBudgetExhausted` or `CircuitOpen` to the caller; the run fails. | Strict environments where re-deriving watermarks is prohibitively expensive (long-running backfills, multi-hour syncs). |
+
+**Terminal outcomes are structured.** Every `state.upload` / `state.download` event now carries an `outcome` field so you can alert on state-layer health without log-message regex:
+
+| `outcome` | Meaning |
+|---|---|
+| `ok` | Transfer completed successfully. |
+| `absent` | Remote state was empty — first run against this backend. |
+| `timeout` | Hit `transfer_timeout_seconds` wall-clock cap. |
+| `error_then_fresh` | Existence check failed; Rocky started fresh. |
+| `transient_exhausted` | `max_retries` exhausted on transient errors. |
+| `budget_exhausted` | `max_retries_per_run` exhausted across transfers. |
+| `circuit_open` | Breaker is open; transfer skipped without attempting. |
+| `skipped_after_failure` | Upload failed, `on_upload_failure = "skip"` applied. |
+
+Run `rocky doctor --check state_rw` at cold start to catch IAM / reachability problems before they show up as end-of-run upload failures.
 
 ## State Per Environment
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -270,7 +270,7 @@ Governance (tags, workspace bindings, permissions) is NOT a separate CLI command
 
 ### `rocky doctor`
 
-Runs aggregate health checks on your Rocky project: config validation, state store health, adapter connectivity, pipeline consistency, and state sync status.
+Runs aggregate health checks on your Rocky project: config validation, state store health, adapter connectivity, pipeline consistency, state backend configuration, live state read/write, and auth.
 
 ```bash
 rocky doctor
@@ -278,14 +278,15 @@ rocky doctor
 
 **Checks performed:**
 
-| Check | Description |
-|-------|-------------|
-| Config | Parses `rocky.toml`, validates adapters and pipelines |
-| State | Verifies the state store is readable and not corrupted |
-| Adapters | Tests connectivity to configured adapters |
-| Pipelines | Validates schema patterns, templates, and governance config |
-| State Sync | Checks remote state backends (S3, Valkey) if configured |
-| Auth | Pings each warehouse and discovery adapter to verify credentials and connectivity |
+| Check | Name | Description |
+|-------|------|-------------|
+| Config | `config` | Parses `rocky.toml`, validates adapters and pipelines |
+| State | `state` | Verifies the local state store is readable and not corrupted |
+| Adapters | `adapters` | Tests connectivity to configured adapters |
+| Pipelines | `pipelines` | Validates schema patterns, templates, and governance config |
+| State Sync | `state_sync` | Inspects the configured remote state backend (type only) |
+| State RW | `state_rw` | Round-trips a marker object against the configured backend (put → get → delete). Surfaces IAM and reachability problems at cold start instead of end-of-run upload. No-op for `local`; tiered probes both legs. |
+| Auth | `auth`, `auth/<adapter>` | Pings each warehouse and discovery adapter to verify credentials and connectivity |
 
 **JSON output:**
 
@@ -308,6 +309,7 @@ Run a specific check:
 
 ```bash
 rocky doctor --check auth
+rocky doctor --check state_rw   # live round-trip probe against the remote state backend
 ```
 
 ---

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -404,15 +404,18 @@ Running conformance tests for duckdb...
 
 ## `rocky doctor`
 
-Health checks for your Rocky project: config validation, state store integrity, adapter connectivity, pipeline consistency, state sync, and auth verification.
+Health checks for your Rocky project: config validation, local state store integrity, adapter connectivity, pipeline consistency, state backend configuration, live state read/write, and auth verification.
 
 ```bash
-rocky doctor                   # Run all checks
-rocky doctor --check config    # Run only the config check
-rocky doctor --check auth      # Verify credentials + connectivity for all adapters
+rocky doctor                     # Run all checks
+rocky doctor --check config      # Run only the config check
+rocky doctor --check auth        # Verify credentials + connectivity for all adapters
+rocky doctor --check state_rw    # Round-trip a marker object against the state backend
 ```
 
 The `auth` check pings each registered warehouse adapter (via `SELECT 1` or an adapter-specific cheaper query) and each discovery adapter. Reports per-adapter pass/fail with latency.
+
+The `state_rw` check (v1.13.0+) runs a put → get → delete probe against the configured state backend so IAM and reachability problems surface at cold start rather than at end-of-run upload. Local backend is a no-op; tiered probes both legs.
 
 See the [CLI Reference](/reference/cli/#rocky-doctor) for the full check list and JSON output format.
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -523,11 +523,15 @@ Global state persistence — where Rocky stores watermarks, run history, and che
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `backend` | string | `"local"` | Storage backend: `"local"`, `"s3"`, `"valkey"`, or `"tiered"`. |
+| `backend` | string | `"local"` | Storage backend: `"local"`, `"s3"`, `"gcs"`, `"valkey"`, or `"tiered"`. |
 | `s3_bucket` | string | | S3 bucket name. Required when `backend` is `"s3"` or `"tiered"`. |
 | `s3_prefix` | string | `"rocky/state/"` | S3 key prefix for state files. |
+| `gcs_bucket` | string | | GCS bucket name. Required when `backend` is `"gcs"`. |
+| `gcs_prefix` | string | `"rocky/state/"` | GCS object prefix for state files. |
 | `valkey_url` | string | | Valkey/Redis connection URL. Required when `backend` is `"valkey"` or `"tiered"`. |
 | `valkey_prefix` | string | `"rocky:state:"` | Valkey key prefix for state entries. |
+| `transfer_timeout_seconds` | int | `300` | Wall-clock budget for each transfer (upload *or* download). Retries share this budget rather than extending it — raise for large state or slow networks. |
+| `on_upload_failure` | string | `"skip"` | What to do when upload exhausts retries + circuit-breaker. `"skip"` logs a warning and continues (state goes stale, next run re-derives); `"fail"` propagates the error. |
 
 **Local (default):**
 
@@ -563,6 +567,35 @@ s3_bucket = "${ROCKY_STATE_BUCKET}"
 ```
 
 Tiered downloads from Valkey first (fast), falls back to S3 (durable). Uploads to both.
+
+### `[state.retry]`
+
+Retry policy applied to transient state-transfer failures (network hiccups, transient 5xx, hung endpoints that hit the per-request HTTP timeout). Same shape as [`[adapter.NAME.retry]`](#adapternameretry) so both layers share one mental model. Retries share the outer `transfer_timeout_seconds` budget — the total wall-clock ceiling is unchanged.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_retries` | int | `3` | Maximum retry attempts per transfer. Set to `0` to disable retries. |
+| `initial_backoff_ms` | int | `1000` | Initial backoff before the first retry. |
+| `max_backoff_ms` | int | `30000` | Cap on exponential backoff growth. |
+| `backoff_multiplier` | float | `2.0` | Multiplier applied between retries (e.g. 2.0 = doubling). |
+| `jitter` | bool | `true` | Add random jitter to prevent concurrent runs from retrying in lockstep. |
+| `circuit_breaker_threshold` | int | `5` | Trip the breaker after this many consecutive failures. `0` disables. |
+| `circuit_breaker_recovery_timeout_secs` | int \| null | `null` | Seconds in `Open` before a half-open trial is allowed. `null` = manual reset only. |
+| `max_retries_per_run` | int \| null | `null` | Cross-transfer retry budget for a single run. `null` = unbounded (per-transfer `max_retries` is the only cap). |
+
+```toml
+[state]
+backend = "s3"
+s3_bucket = "${ROCKY_STATE_BUCKET}"
+on_upload_failure = "fail"    # strict: treat state durability as required
+
+[state.retry]
+max_retries = 5
+circuit_breaker_threshold = 3
+circuit_breaker_recovery_timeout_secs = 30
+```
+
+Terminal outcomes surface as structured `outcome` fields on `state.upload` / `state.download` events — `ok`, `absent`, `timeout`, `error_then_fresh`, `skipped_after_failure`, `transient_exhausted`, `circuit_open`, `budget_exhausted`. Grep those instead of the free-form log message when building alerts.
 
 ---
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -344,7 +344,7 @@ Aggregate health checks across config, state, adapters, and pipelines.
 | Field | Type | Description |
 |-------|------|-------------|
 | `overall` | string | Aggregate status: `"healthy"`, `"warning"`, or `"critical"`. |
-| `checks[].name` | string | Check category (`"config"`, `"state"`, `"adapters"`, `"pipelines"`, `"state_sync"`). |
+| `checks[].name` | string | Check category: `"config"`, `"state"`, `"adapters"`, `"pipelines"`, `"state_sync"`, `"state_rw"`, `"auth"`, or `"auth/<adapter>"` (per-adapter auth result). |
 | `checks[].status` | string | `"healthy"`, `"warning"`, or `"critical"`. |
 | `checks[].message` | string | Human-readable result. |
 | `checks[].duration_ms` | integer | Time spent on this check in milliseconds. |

--- a/examples/playground/pocs/05-orchestration/03-remote-state-s3/README.md
+++ b/examples/playground/pocs/05-orchestration/03-remote-state-s3/README.md
@@ -3,7 +3,7 @@
 > **Category:** 05-orchestration
 > **Credentials:** none (MinIO via docker-compose)
 > **Runtime:** < 30s (first run pulls MinIO image)
-> **Rocky features:** `[state] backend = "s3"`, watermark upload/download, incremental persistence
+> **Rocky features:** `[state] backend = "s3"`, `[state.retry]`, `on_upload_failure`, `rocky doctor --check state_rw`, watermark upload/download, incremental persistence
 
 ## What it shows
 
@@ -11,26 +11,30 @@ Stores Rocky's `.rocky-state.redb` in S3 — except instead of real AWS,
 this POC runs MinIO via docker-compose so you can verify the upload/download
 flow without an account.
 
-The demo runs a three-step sequence:
+The demo runs:
 
-1. **Initial load** — 100 rows replicated, state uploaded to MinIO.
+0. **`state_rw` probe** (v1.13.0+) — `rocky doctor --check state_rw` round-trips a marker object against MinIO *before* any pipeline work so IAM / reachability problems surface at cold start instead of end-of-run upload.
+1. **Initial load** — 100 rows replicated, state uploaded to MinIO (under the retry + circuit-breaker policy configured in `[state.retry]`).
 2. **Incremental run** — 25 delta rows appended, only new rows replicated (watermark persisted via S3).
 3. **Round-trip restore** — local state file deleted, re-downloaded from S3 on next run, proving zero duplicate rows.
 
 ## Why it's distinctive
 
 - **Stateless CI/CD** — pod restarts don't lose watermarks.
+- **Transient failures don't take down runs** — every S3 transfer runs inside `[state.retry]` exponential-backoff + a three-state circuit breaker, same machinery as the Databricks / Snowflake adapters (see [`08-circuit-breaker/`](../08-circuit-breaker/)). Terminal outcomes surface as structured `outcome=ok|absent|timeout|transient_exhausted|circuit_open|…` fields on the `state.upload` / `state.download` events.
+- **Cold-start connectivity check** — `rocky doctor --check state_rw` proves write permission + reachability before the first pipeline run. No more silent IAM drift.
+- **Pick your failure posture** — default `on_upload_failure = "skip"` keeps runs live and lets the next run re-derive state; switch to `"fail"` for strict environments where state durability trumps liveness.
 - The same `[state]` block works against AWS S3 by changing `endpoint`.
 - All credential-free thanks to MinIO.
 
 ## Layout
 
 ```
-rocky.toml              # [state] backend = "s3", s3_bucket, s3_prefix
+rocky.toml              # [state] backend = "s3" + [state.retry] block
 docker-compose.yml      # MinIO server + init container (creates bucket)
 data/seed.sql           # Initial 100-row source table
 data/seed_delta.sql     # 25 delta rows for incremental run
-run.sh                  # End-to-end demo: 3 runs + S3 round-trip
+run.sh                  # End-to-end demo: state_rw probe + 3 runs + S3 round-trip
 expected/               # Captured JSON output (gitignored)
 ```
 
@@ -48,6 +52,16 @@ Without Docker, the script shows config validation only.
 ```
 === Starting MinIO ===
 === Source after seed: 100 rows ===
+
+=== rocky doctor --check state_rw (live round-trip probe vs MinIO) ===
+{
+  "command": "doctor",
+  "overall": "healthy",
+  "checks": [
+    { "name": "state_rw", "status": "healthy", "message": "Probed s3 backend OK …", "duration_ms": 12 }
+  ],
+  ...
+}
 
 === Run 1 (initial — full load of 100 rows) ===
     target rows: 100

--- a/examples/playground/pocs/05-orchestration/03-remote-state-s3/rocky.toml
+++ b/examples/playground/pocs/05-orchestration/03-remote-state-s3/rocky.toml
@@ -19,3 +19,14 @@ schema_template = "staging__{source}"
 backend = "s3"
 s3_bucket = "rocky-state"
 s3_prefix = "playground/"
+# on_upload_failure = "skip" is the default — swap to "fail" in strict environments
+# transfer_timeout_seconds = 300 is the default (raise for large state / slow networks)
+
+# Retry + circuit-breaker for transient S3 failures.
+# Same shape as [adapter.NAME.retry] so operators reason about both layers with
+# one mental model. Retries share transfer_timeout_seconds — they don't extend it.
+[state.retry]
+max_retries = 3
+initial_backoff_ms = 500
+circuit_breaker_threshold = 5
+circuit_breaker_recovery_timeout_secs = 30

--- a/examples/playground/pocs/05-orchestration/03-remote-state-s3/run.sh
+++ b/examples/playground/pocs/05-orchestration/03-remote-state-s3/run.sh
@@ -36,6 +36,16 @@ export AWS_REGION="us-east-1"
 rocky validate
 echo
 
+# --- state_rw probe: confirm the MinIO bucket is writable before any pipeline
+#     work (fails fast at cold start on IAM / reachability issues instead of
+#     at end-of-run upload). Local backend = no-op; tiered probes both legs.
+if $HAVE_DOCKER; then
+    echo "=== rocky doctor --check state_rw (live round-trip probe vs MinIO) ==="
+    rocky -c rocky.toml -o json doctor --check state_rw > expected/doctor_state_rw.json 2>&1 || true
+    head -20 expected/doctor_state_rw.json
+    echo
+fi
+
 # --- Run 1: initial load ---
 echo "=== Run 1 (initial — full load of 100 rows) ==="
 rocky -c rocky.toml -o json run --filter source=orders > expected/run1.json 2>&1 || true

--- a/examples/playground/pocs/05-orchestration/08-circuit-breaker/README.md
+++ b/examples/playground/pocs/05-orchestration/08-circuit-breaker/README.md
@@ -75,5 +75,10 @@ event bus — `circuit_breaker_tripped` (Closed/HalfOpen → Open) and
   `engine/crates/rocky-core/src/config.rs` (`RetryConfig`)
 - Adapters wired: `rocky-databricks/src/connector.rs`,
   `rocky-snowflake/src/connector.rs`
+- **State backend wired (v1.13.0+):** `[state.retry]` shares the exact
+  shape and semantics of `[adapter.NAME.retry]` — same `RetryConfig`,
+  same breaker, same events. See [`03-remote-state-s3/`](../03-remote-state-s3/)
+  for a live MinIO demo that includes the retry block and a
+  `rocky doctor --check state_rw` cold-start probe.
 - Sibling POC: [`04-checkpoint-resume/`](../04-checkpoint-resume/)
   covers the other half of Arc 3 — state-store-backed resume.

--- a/examples/playground/pocs/06-developer-experience/05-doctor-and-ci/README.md
+++ b/examples/playground/pocs/06-developer-experience/05-doctor-and-ci/README.md
@@ -7,9 +7,11 @@
 
 ## What it shows
 
-`rocky doctor` aggregates health checks across config, state, adapters,
-pipelines, and state sync — all in one JSON output. `rocky ci` is a
-combined `compile + test` command with proper exit codes for CI.
+`rocky doctor` aggregates health checks across config, local state, adapters,
+pipelines, state backend config (`state_sync`), live state read/write
+(`state_rw`, v1.13.0+), and auth (`auth` + per-adapter `auth/<name>`) — all
+in one JSON output. `rocky ci` is a combined `compile + test` command with
+proper exit codes for CI.
 
 This POC also ships an example `.github/workflows/rocky-ci.yml` that you
 can drop into any project to wire Rocky into GitHub Actions.


### PR DESCRIPTION
## Summary

Engine v1.13.0 landed three user-facing surfaces that weren't in the docs site or the POC catalogue:

- **`[state.retry]`** — exponential-backoff + three-state circuit breaker wired into every state-backend transfer. Same shape as `[adapter.NAME.retry]` so operators reason about both with one mental model.
- **`on_upload_failure = "skip" | "fail"`** — policy applied after retries + breaker exhausted. `"skip"` (default) keeps the run live and re-derives state next run; `"fail"` enforces strict durability.
- **`rocky doctor --check state_rw`** — 7th doctor check, round-trips a marker object (put → get → delete) so IAM / reachability problems surface at cold start instead of end-of-run upload.

## Docs (6 files)

- `reference/configuration.md` — `[state]` table gains `transfer_timeout_seconds` + `on_upload_failure` + `gcs` backend; new `[state.retry]` subsection with every field + defaults and a worked example
- `reference/cli.md` — doctor checks table gains a 7th `State RW` row; adds `rocky doctor --check state_rw` example
- `reference/commands/development.md` — doctor intro mentions the live read/write probe; adds `--check state_rw` to the example list
- `reference/json-output.md` — `checks[].name` enum extended to include `state_rw`, `auth`, and `auth/<adapter>`
- `concepts/state-management.md` — fixes now-inaccurate "upload failure logs + run succeeds" sentence (it's now conditional on `on_upload_failure`), adds a full Retry and Failure Policy section with the policy table + terminal-outcome reference (`ok` / `timeout` / `transient_exhausted` / `circuit_open` / `budget_exhausted` / `skipped_after_failure` / …)
- `public/llms.txt` — `[state]` and doctor one-liners refreshed

## POCs (3)

- `05-orchestration/03-remote-state-s3/` — `[state.retry]` block in `rocky.toml`; `rocky doctor --check state_rw` step before Run 1 in `run.sh`; README reframed around trust-grade resilience (retry policy, cold-start probe, on_upload_failure trade-off)
- `05-orchestration/08-circuit-breaker/` — Related section cross-refs `03-remote-state-s3/` — same `RetryConfig` shape, now on the state backend
- `06-developer-experience/05-doctor-and-ci/` — README check list includes `state_rw` (the `expected/doctor.json` fixture is gitignored and regenerates each run, so no fixture edit needed)

## Scope decisions

- **No `docker compose pause` demo in the S3 POC.** The POC has a `<30s` runtime budget; a retry-loop + circuit-breaker replay would blow past it and would be timing-sensitive on reviewers' machines. Left as a potential follow-up POC.
- **GCS added to the `[state]` backend list but no worked GCS example.** The fields (`gcs_bucket`, `gcs_prefix`) have been in `StateConfig` longer than v1.13 — this PR just closes a pre-existing gap while the section was already open, without bloating the diff.

## Test plan

- [x] Built v1.13 `rocky` from the worktree — `cargo build --release --bin rocky` → `rocky 1.13.0`
- [x] `rocky -c rocky.toml validate` on the updated `03-remote-state-s3/rocky.toml` — `valid: true` with only pre-existing L006 lint warnings; the new `[state.retry]` block parses cleanly
- [x] `rocky -c rocky.toml -o json doctor` against `05-doctor-and-ci` — emits `state_rw` check in position 6 (between `state_sync` and `auth/default`), with message `"Local backend — no remote probe needed"`
- [x] `rocky doctor --check state_rw` filter — returns only the single `state_rw` check row
- [ ] Optional: spin up MinIO locally and run the full `03-remote-state-s3/run.sh` to capture a `doctor_state_rw.json` fixture against a real remote backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)