### PR TITLE
refactor(engine/rocky-core): dedup compute_backoff across adapter crates

### DIFF
--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod plan_partition;
 pub mod preview;
 pub mod quarantine;
 pub mod redacted;
+pub mod retry;
 pub mod retry_budget;
 pub mod schema;
 pub mod seeds;

--- a/engine/crates/rocky-core/src/retry.rs
+++ b/engine/crates/rocky-core/src/retry.rs
@@ -1,0 +1,91 @@
+//! Shared retry helpers.
+//!
+//! Historically, `compute_backoff` lived as a private copy inside
+//! `rocky-databricks::connector`, `rocky-snowflake::connector`, and
+//! `rocky-core::state_sync`. All three copies implemented the same
+//! exponential-with-jitter policy and were called from per-crate retry
+//! loops. This module hoists the helper into a single shared location
+//! so the adapter crates and the state-sync machinery agree on backoff
+//! semantics by construction.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::config::RetryConfig;
+
+/// Computes backoff duration in milliseconds with exponential growth,
+/// capped at [`RetryConfig::max_backoff_ms`], with optional jitter.
+///
+/// The base delay for attempt `attempt` is
+/// `initial_backoff_ms * backoff_multiplier ^ attempt`, clamped to
+/// `max_backoff_ms`. When [`RetryConfig::jitter`] is `true`, the returned
+/// value is randomized within ±25 % of the capped base using subsecond
+/// nanos as a cheap entropy source (no `rand` dependency).
+pub fn compute_backoff(cfg: &RetryConfig, attempt: u32) -> u64 {
+    let base = (cfg.initial_backoff_ms as f64) * cfg.backoff_multiplier.powi(attempt as i32);
+    let capped = base.min(cfg.max_backoff_ms as f64) as u64;
+
+    if cfg.jitter {
+        // Use subsecond nanos as cheap jitter source (no rand dependency needed)
+        let jitter_range = capped / 4; // +-25% jitter
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos() as u64;
+        let jitter = nanos % (jitter_range.max(1));
+        capped
+            .saturating_sub(jitter_range / 2)
+            .saturating_add(jitter)
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backoff_exponential_no_jitter() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 1000,
+            max_backoff_ms: 30000,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..Default::default()
+        };
+        assert_eq!(compute_backoff(&cfg, 0), 1000); // 1000 * 2^0
+        assert_eq!(compute_backoff(&cfg, 1), 2000); // 1000 * 2^1
+        assert_eq!(compute_backoff(&cfg, 2), 4000); // 1000 * 2^2
+    }
+
+    #[test]
+    fn test_backoff_capped() {
+        let cfg = RetryConfig {
+            max_retries: 5,
+            initial_backoff_ms: 1000,
+            max_backoff_ms: 5000,
+            backoff_multiplier: 2.0,
+            jitter: false,
+            ..Default::default()
+        };
+        assert_eq!(compute_backoff(&cfg, 3), 5000); // 1000 * 2^3 = 8000, capped at 5000
+        assert_eq!(compute_backoff(&cfg, 4), 5000); // still capped
+    }
+
+    #[test]
+    fn test_backoff_with_jitter_in_range() {
+        let cfg = RetryConfig {
+            max_retries: 3,
+            initial_backoff_ms: 1000,
+            max_backoff_ms: 30000,
+            backoff_multiplier: 2.0,
+            jitter: true,
+            ..Default::default()
+        };
+        // With jitter, result should be within +-25% of base (1000)
+        let result = compute_backoff(&cfg, 0);
+        assert!(result >= 750, "backoff {result} should be >= 750");
+        assert!(result <= 1250, "backoff {result} should be <= 1250");
+    }
+}

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -17,6 +17,7 @@ use tracing::{Instrument, debug, info, info_span, warn};
 use crate::circuit_breaker::TransitionOutcome;
 use crate::config::{RetryConfig, StateBackend, StateConfig, StateUploadFailureMode};
 use crate::object_store::{ObjectStoreError, ObjectStoreProvider};
+use crate::retry::compute_backoff;
 use crate::retry_budget::RetryBudget;
 
 #[derive(Debug, Error)]
@@ -787,31 +788,6 @@ fn is_transient(err: &StateSyncError) -> bool {
     }
 }
 
-/// Compute exponential-with-jitter backoff (ms) for retry attempt `attempt`.
-///
-/// Intentionally duplicated from `rocky-databricks::connector::compute_backoff`
-/// and `rocky-snowflake::connector::compute_backoff`. A follow-up PR should
-/// hoist the three copies into a single shared helper; this PR keeps scope
-/// narrow to the state-backend wiring.
-fn compute_backoff(cfg: &RetryConfig, attempt: u32) -> u64 {
-    let base = (cfg.initial_backoff_ms as f64) * cfg.backoff_multiplier.powi(attempt as i32);
-    let capped = base.min(cfg.max_backoff_ms as f64) as u64;
-
-    if cfg.jitter {
-        let jitter_range = capped / 4;
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos() as u64;
-        let jitter = nanos % (jitter_range.max(1));
-        capped
-            .saturating_sub(jitter_range / 2)
-            .saturating_add(jitter)
-    } else {
-        capped
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -954,45 +930,6 @@ mod tests {
         assert!(!is_transient(&StateSyncError::RetryBudgetExhausted {
             limit: 3
         }));
-    }
-
-    #[test]
-    fn test_compute_backoff_without_jitter() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 100,
-            max_backoff_ms: 1000,
-            backoff_multiplier: 2.0,
-            jitter: false,
-            ..RetryConfig::default()
-        };
-        assert_eq!(compute_backoff(&cfg, 0), 100);
-        assert_eq!(compute_backoff(&cfg, 1), 200);
-        assert_eq!(compute_backoff(&cfg, 2), 400);
-        assert_eq!(compute_backoff(&cfg, 3), 800);
-        // caps at max_backoff_ms
-        assert_eq!(compute_backoff(&cfg, 10), 1000);
-    }
-
-    #[test]
-    fn test_compute_backoff_jitter_within_bounds() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 400,
-            max_backoff_ms: 10_000,
-            backoff_multiplier: 2.0,
-            jitter: true,
-            ..RetryConfig::default()
-        };
-        // With jitter, the returned value is within ±25 % of the base
-        // (400 ms at attempt=0). Allow 300..=500 as the safe envelope.
-        for _ in 0..50 {
-            let b = compute_backoff(&cfg, 0);
-            assert!(
-                (300..=500).contains(&b),
-                "jittered backoff out of envelope: {b}"
-            );
-        }
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -1,8 +1,9 @@
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use reqwest::Client;
 use rocky_core::config::RetryConfig;
+use rocky_core::retry::compute_backoff;
 use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -568,27 +569,6 @@ fn poll_delay(attempt: usize) -> Duration {
     Duration::from_millis(delay_ms)
 }
 
-/// Computes backoff duration with exponential growth, capped at max, with optional jitter.
-fn compute_backoff(cfg: &RetryConfig, attempt: u32) -> u64 {
-    let base = (cfg.initial_backoff_ms as f64) * cfg.backoff_multiplier.powi(attempt as i32);
-    let capped = base.min(cfg.max_backoff_ms as f64) as u64;
-
-    if cfg.jitter {
-        // Use subsecond nanos as cheap jitter source (no rand dependency needed)
-        let jitter_range = capped / 4; // +-25% jitter
-        let nanos = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos() as u64;
-        let jitter = nanos % (jitter_range.max(1));
-        capped
-            .saturating_sub(jitter_range / 2)
-            .saturating_add(jitter)
-    } else {
-        capped
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -762,51 +742,6 @@ mod tests {
     fn test_not_transient_canceled() {
         let err = ConnectorError::Canceled { id: "id-1".into() };
         assert!(!is_transient(&err));
-    }
-
-    #[test]
-    fn test_backoff_exponential_no_jitter() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 30000,
-            backoff_multiplier: 2.0,
-            jitter: false,
-            ..Default::default()
-        };
-        assert_eq!(compute_backoff(&cfg, 0), 1000); // 1000 * 2^0
-        assert_eq!(compute_backoff(&cfg, 1), 2000); // 1000 * 2^1
-        assert_eq!(compute_backoff(&cfg, 2), 4000); // 1000 * 2^2
-    }
-
-    #[test]
-    fn test_backoff_capped() {
-        let cfg = RetryConfig {
-            max_retries: 5,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 5000,
-            backoff_multiplier: 2.0,
-            jitter: false,
-            ..Default::default()
-        };
-        assert_eq!(compute_backoff(&cfg, 3), 5000); // 1000 * 2^3 = 8000, capped at 5000
-        assert_eq!(compute_backoff(&cfg, 4), 5000); // still capped
-    }
-
-    #[test]
-    fn test_backoff_with_jitter_in_range() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 30000,
-            backoff_multiplier: 2.0,
-            jitter: true,
-            ..Default::default()
-        };
-        // With jitter, result should be within +-25% of base (1000)
-        let result = compute_backoff(&cfg, 0);
-        assert!(result >= 750, "backoff {result} should be >= 750");
-        assert!(result <= 1250, "backoff {result} should be <= 1250");
     }
 
     #[test]

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -8,11 +8,12 @@
 //! Supports retry with exponential backoff for transient failures.
 
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use reqwest::Client;
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
 use rocky_core::config::RetryConfig;
+use rocky_core::retry::compute_backoff;
 use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -500,26 +501,6 @@ fn classify_error(err: &ConnectorError) -> ErrorClass {
     }
 }
 
-/// Computes backoff duration with exponential growth, capped at max, with optional jitter.
-fn compute_backoff(cfg: &RetryConfig, attempt: u32) -> u64 {
-    let base = (cfg.initial_backoff_ms as f64) * cfg.backoff_multiplier.powi(attempt as i32);
-    let capped = base.min(cfg.max_backoff_ms as f64) as u64;
-
-    if cfg.jitter {
-        let jitter_range = capped / 4;
-        let nanos = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos() as u64;
-        let jitter = nanos % (jitter_range.max(1));
-        capped
-            .saturating_sub(jitter_range / 2)
-            .saturating_add(jitter)
-    } else {
-        capped
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -643,49 +624,5 @@ mod tests {
             consecutive_failures: 5,
         };
         assert!(!is_transient(&err));
-    }
-
-    #[test]
-    fn test_backoff_exponential_no_jitter() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 30000,
-            backoff_multiplier: 2.0,
-            jitter: false,
-            ..Default::default()
-        };
-        assert_eq!(compute_backoff(&cfg, 0), 1000);
-        assert_eq!(compute_backoff(&cfg, 1), 2000);
-        assert_eq!(compute_backoff(&cfg, 2), 4000);
-    }
-
-    #[test]
-    fn test_backoff_capped() {
-        let cfg = RetryConfig {
-            max_retries: 5,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 5000,
-            backoff_multiplier: 2.0,
-            jitter: false,
-            ..Default::default()
-        };
-        assert_eq!(compute_backoff(&cfg, 3), 5000);
-        assert_eq!(compute_backoff(&cfg, 4), 5000);
-    }
-
-    #[test]
-    fn test_backoff_with_jitter_in_range() {
-        let cfg = RetryConfig {
-            max_retries: 3,
-            initial_backoff_ms: 1000,
-            max_backoff_ms: 30000,
-            backoff_multiplier: 2.0,
-            jitter: true,
-            ..Default::default()
-        };
-        let result = compute_backoff(&cfg, 0);
-        assert!(result >= 750, "backoff {result} should be >= 750");
-        assert!(result <= 1250, "backoff {result} should be <= 1250");
     }
 }


### PR DESCRIPTION
## Summary

- Hoists the three identical `compute_backoff` copies from `rocky-core::state_sync`, `rocky-databricks::connector`, and `rocky-snowflake::connector` into a single shared helper at `rocky_core::retry::compute_backoff`.
- Adapter crates already depend on `rocky-core`; no `Cargo.toml` changes needed.
- Zero behaviour change — bodies were already behaviourally identical (only trivial cosmetic diffs: `SystemTime::UNIX_EPOCH` vs `UNIX_EPOCH`, inline comments, doc wording).
- Follow-up to #213, which flagged the third copy as a deliberate duplicate to be deduped separately.

## Before / after layout

Before:

```
rocky-core/src/state_sync.rs        fn compute_backoff(..) { .. }   // private
rocky-databricks/src/connector.rs   fn compute_backoff(..) { .. }   // private
rocky-snowflake/src/connector.rs    fn compute_backoff(..) { .. }   // private
```

After:

```
rocky-core/src/retry.rs             pub fn compute_backoff(..) { .. }   // single source
rocky-core/src/state_sync.rs        use crate::retry::compute_backoff;
rocky-databricks/src/connector.rs   use rocky_core::retry::compute_backoff;
rocky-snowflake/src/connector.rs    use rocky_core::retry::compute_backoff;
```

Net: 5 files changed, +97 / -196 lines (the new `retry.rs` ships 90 lines of impl + consolidated tests; the three duplicates and their per-crate test blocks are deleted).

Consolidated tests in `retry.rs` (covering exponential-no-jitter, capped, with-jitter-in-range) are the superset of what the adapter crates had; the two `state_sync` tests covered a proper subset.

## Test plan

- [x] `cargo test -p rocky-core -p rocky-databricks -p rocky-snowflake` — all green (991 + 30 + 20 + supporting suites)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] CI green on `engine-ci.yml`