### PR TITLE
feat(integrations/dagster): add RockyResource.cost() method + fixture

### DIFF
--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -46,6 +46,7 @@ from .types import (
     ColumnLineageResult,
     CompileResult,
     ConformanceResult,
+    CostOutput,
     DagResult,
     DiscoverResult,
     DoctorResult,
@@ -1167,6 +1168,22 @@ class RockyResource(dg.ConfigurableResource):
         if model is not None:
             args.extend(["--model", model])
         return _parse_rocky_json(self._run_rocky(args), OptimizeResult, command="optimize")
+
+    def cost(self, run_id: str = "latest") -> CostOutput:
+        """Run ``rocky cost <run_id>`` and return the historical cost attribution.
+
+        Reads the persisted ``RunRecord`` from the embedded state store and
+        rolls per-model duration / bytes_scanned / bytes_written / cost_usd up
+        from the stored materialization records. The same formula
+        ``rocky_core::cost::compute_observed_cost_usd`` applied at the end of a
+        live run is re-applied here, so the historical surface stays consistent
+        with the per-run summary on ``RunOutput``.
+
+        Args:
+            run_id: Specific run ID to attribute, or the literal ``"latest"``
+                (the default) to look up the most recent recorded run.
+        """
+        return _parse_rocky_json(self._run_rocky(["cost", run_id]), CostOutput, command="cost")
 
     # ------------------------------------------------------------------ #
     # AI Level 3 commands                                                #

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -843,6 +843,7 @@ from .types_generated import (  # noqa: E402, F401
     ColumnLineageOutput,
     ColumnTrendPoint,
     CompileOutput,
+    CostOutput,
     DagEdgeOutput,
     DagNodeOutput,
     DagOutput,
@@ -870,6 +871,7 @@ from .types_generated import (  # noqa: E402, F401
     OptimizeRecommendation,
     PartitionShapeOutput,
     PermissionSummary,
+    PerModelCostHistorical,
     PhaseTimings,
     PlanOutput,
     ReplayModelOutput,
@@ -918,6 +920,7 @@ RockyOutput = (
     | ModelHistoryResult
     | MetricsResult
     | OptimizeResult
+    | CostOutput
     | AiResult
     | AiSyncResult
     | AiExplainResult
@@ -944,6 +947,7 @@ _SIMPLE_DISPATCH: dict[str, type[BaseModel]] = {
     "ci-diff": CiDiffOutput,
     "metrics": MetricsResult,
     "optimize": OptimizeResult,
+    "cost": CostOutput,
     "ai": AiResult,
     "ai_sync": AiSyncResult,
     "ai_explain": AiExplainResult,

--- a/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
@@ -143,6 +143,9 @@ from .test_schema import TestFailure, TestOutput
 # Compare command
 from .compare_schema import CompareOutput, TableCompareResult
 
+# Cost command (historical per-run cost attribution)
+from .cost_schema import CostOutput, PerModelCostHistorical
+
 # Compact command — canonical source for NamedStatement (also used by archive)
 from .compact_schema import CompactOutput, NamedStatement
 
@@ -259,6 +262,9 @@ __all__ = [
     # compare
     "CompareOutput",
     "TableCompareResult",
+    # cost
+    "CostOutput",
+    "PerModelCostHistorical",
     # compact (canonical source for NamedStatement)
     "CompactOutput",
     "NamedStatement",

--- a/integrations/dagster/tests/fixtures_generated/cost.json
+++ b/integrations/dagster/tests/fixtures_generated/cost.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.13.0",
+  "command": "cost",
+  "run_id": "run-SENTINEL",
+  "status": "success",
+  "trigger": "manual",
+  "started_at": "2000-01-01T00:00:00Z",
+  "finished_at": "2000-01-01T00:00:00Z",
+  "duration_ms": 0,
+  "adapter_type": "duckdb",
+  "total_cost_usd": 0.0,
+  "total_duration_ms": 0,
+  "per_model": [
+    {
+      "model_name": "orders",
+      "status": "success",
+      "duration_ms": 0,
+      "cost_usd": 0.0
+    }
+  ]
+}

--- a/integrations/dagster/tests/test_generated_fixtures.py
+++ b/integrations/dagster/tests/test_generated_fixtures.py
@@ -32,6 +32,7 @@ from dagster_rocky.types import (
     CiResult,
     ColumnLineageResult,
     CompileResult,
+    CostOutput,
     DagResult,
     DiscoverResult,
     DoctorResult,
@@ -68,6 +69,7 @@ EXPECTED_TYPES: dict[str, type] = {
     "optimize": OptimizeResult,
     "doctor": DoctorResult,
     "dag": DagResult,
+    "cost": CostOutput,
 }
 
 

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1016,6 +1016,79 @@ def test_metrics_uses_http_when_server_url_is_set():
 
 
 # ---------------------------------------------------------------------------
+# cost — historical per-run cost attribution
+# ---------------------------------------------------------------------------
+
+
+def _cost_json(run_id: str = "run-abc123") -> str:
+    """Return a minimal valid CostOutput JSON payload for `run_id`."""
+    return json.dumps(
+        {
+            "version": "1.0.0",
+            "command": "cost",
+            "run_id": run_id,
+            "trigger": "Manual",
+            "status": "Success",
+            "started_at": "2026-04-22T10:00:00Z",
+            "finished_at": "2026-04-22T10:00:05Z",
+            "duration_ms": 5000,
+            "total_duration_ms": 5000,
+            "total_bytes_scanned": 1024,
+            "total_bytes_written": 512,
+            "total_cost_usd": 0.0001,
+            "adapter_type": "duckdb",
+            "per_model": [
+                {
+                    "model_name": "orders",
+                    "status": "Success",
+                    "duration_ms": 5000,
+                    "rows_affected": 100,
+                    "bytes_scanned": 1024,
+                    "bytes_written": 512,
+                    "cost_usd": 0.0001,
+                },
+            ],
+        }
+    )
+
+
+def test_cost_defaults_to_latest():
+    """``cost()`` with no arg should shell out with ``cost latest``."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _cost_json()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        result = rocky.cost()
+
+    assert captured[0] == ["cost", "latest"]
+    assert result.command == "cost"
+    assert result.run_id == "run-abc123"
+    assert result.total_cost_usd == 0.0001
+    assert len(result.per_model) == 1
+    assert result.per_model[0].model_name == "orders"
+
+
+def test_cost_passes_explicit_run_id():
+    """A specific run_id is forwarded positionally to the CLI."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _cost_json(run_id="run-xyz789")
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        result = rocky.cost("run-xyz789")
+
+    assert captured[0] == ["cost", "run-xyz789"]
+    assert result.run_id == "run-xyz789"
+
+
+# ---------------------------------------------------------------------------
 # _http_get
 # ---------------------------------------------------------------------------
 

--- a/scripts/regen_fixtures.sh
+++ b/scripts/regen_fixtures.sh
@@ -102,6 +102,9 @@ capture history history
 capture metrics metrics revenue_summary
 capture optimize optimize
 capture dag dag --models models
+# The bootstrap `rocky run` above persists a RunRecord to the state store,
+# so `rocky cost latest` rolls up real per-model durations / bytes / cost.
+capture cost cost latest
 
 # Drift detection requires the engine to detect schema changes against an
 # already-existing target. The 00-playground-default POC always uses


### PR DESCRIPTION
## Summary

- Adds `RockyResource.cost(run_id="latest")` — shells out to `rocky cost <target>` and returns the generated `CostOutput` Pydantic model. Mirrors the shape of the sibling observability methods (`history`, `optimize`, `doctor`).
- Wires `CostOutput` / `PerModelCostHistorical` through the `types_generated` barrel and `types.py`, registers `CostOutput` in the `RockyOutput` union and the `parse_rocky_output` dispatch under the `"cost"` command literal.
- Extends `scripts/regen_fixtures.sh` with a `capture cost cost latest` step (the existing bootstrap `rocky run` persists the `RunRecord` the new command rolls up). `fixtures_generated/cost.json` is committed; the fixture is deterministic through the existing normalizer.
- `test_generated_fixtures.py::EXPECTED_TYPES` maps `"cost" → CostOutput` so the parse-guard covers the new live-binary capture.
- Finishes the follow-up explicitly deferred in engine PR #202; the Pydantic type was already generated in that PR but wasn't reachable via the resource or `parse_rocky_output`.

Follow-ups not included here (matches the task spec of a single `run_id` arg):
- `--model` filter pass-through (CLI flag already exists; add when a caller needs it).

## Test plan

- [x] `uv run pytest -v` from `integrations/dagster/` — 312 tests pass locally
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [x] `just regen-fixtures` from the monorepo root produces a stable `fixtures_generated/cost.json`
- [x] `test_generated_fixtures.py::test_generated_fixture_parses[cost.json]` passes against the captured fixture
- [x] `test_cost_defaults_to_latest` + `test_cost_passes_explicit_run_id` cover the happy path