### PR TITLE
feat(engine/rocky-bigquery): plumb totalBytesBilled into bytes_scanned

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -254,6 +254,14 @@ export interface ExecutionSummary {
 export interface MaterializationOutput {
   asset_key: string[];
   /**
+   * Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).
+   */
+  bytes_scanned?: number | null;
+  /**
+   * Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.
+   */
+  bytes_written?: number | null;
+  /**
    * Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.
    */
   cost_usd?: number | null;

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -9,7 +9,9 @@ use tokio::time::Instant;
 use tracing::{debug, warn};
 
 use rocky_core::ir::{ColumnInfo, TableRef};
-use rocky_core::traits::{AdapterError, AdapterResult, QueryResult, SqlDialect, WarehouseAdapter};
+use rocky_core::traits::{
+    AdapterError, AdapterResult, ExecutionStats, QueryResult, SqlDialect, WarehouseAdapter,
+};
 
 use crate::auth::BigQueryAuth;
 use crate::dialect::BigQueryDialect;
@@ -265,6 +267,11 @@ impl WarehouseAdapter for BigQueryAdapter {
             .map_err(AdapterError::new)
     }
 
+    async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
+        let response = self.run_query(sql).await.map_err(AdapterError::new)?;
+        Ok(stats_from_response(&response))
+    }
+
     async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
         let response = self.run_query(sql).await.map_err(AdapterError::new)?;
 
@@ -331,6 +338,41 @@ impl WarehouseAdapter for BigQueryAdapter {
     }
 }
 
+/// Extract [`ExecutionStats`] from a successful [`BigQueryResponse`].
+///
+/// # The "billed-in-scanned" slot
+///
+/// The field is called `bytes_scanned` but BigQuery emits **two** byte
+/// counts per query job: `totalBytesProcessed` (what the engine read)
+/// and `totalBytesBilled` (what the customer pays for — strictly `>=`
+/// processed due to the 10 MB per-query minimum floor). This function
+/// stores **billed** bytes in [`ExecutionStats::bytes_scanned`]
+/// because [`rocky_core::cost::compute_observed_cost_usd`] multiplies
+/// that field by the per-TB rate to produce the dollar figure
+/// displayed in `rocky cost`. Using `processed` here would
+/// under-report the cost for sub-10 MB queries. The semantic impurity
+/// (field name says "scanned" but holds "billed") is accepted so that
+/// every downstream consumer can keep treating `bytes_scanned` as the
+/// single cost driver without BigQuery-specific branching.
+///
+/// Returns an all-`None` [`ExecutionStats`] when BigQuery omits the
+/// `statistics` block (most commonly for DDL that completes without a
+/// query job) or when `totalBytesBilled` is missing / unparseable.
+/// `bytes_written` is always `None` — BigQuery query jobs don't expose
+/// a bytes-written figure naturally.
+fn stats_from_response(response: &BigQueryResponse) -> ExecutionStats {
+    let bytes_scanned = response
+        .statistics
+        .as_ref()
+        .and_then(|s| s.query.as_ref())
+        .and_then(BigQueryQueryStatistics::total_bytes_billed_u64);
+    ExecutionStats {
+        bytes_scanned,
+        bytes_written: None,
+        rows_affected: None,
+    }
+}
+
 // -- BigQuery REST API types --
 
 #[derive(Debug, Serialize)]
@@ -354,6 +396,58 @@ struct BigQueryResponse {
     #[allow(dead_code)]
     #[serde(default)]
     total_rows: Option<String>,
+    /// Query-job statistics. Populated for completed query jobs;
+    /// BigQuery may omit the field for DDL statements or async jobs
+    /// that haven't yet finished, so it's `Option`.
+    #[serde(default)]
+    statistics: Option<BigQueryStatistics>,
+}
+
+/// Top-level `statistics` block on a BigQuery job response. Only the
+/// `query` slice is currently parsed; other nested shapes (load, extract,
+/// copy) are ignored.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BigQueryStatistics {
+    #[serde(default)]
+    query: Option<BigQueryQueryStatistics>,
+}
+
+/// `statistics.query` subset we care about today.
+///
+/// BigQuery returns byte counts as decimal strings (JSON doesn't have a
+/// native 64-bit integer; GCP APIs encode `int64` fields as strings), so
+/// both fields are `Option<String>` and parsed to `u64` via
+/// [`BigQueryQueryStatistics::total_bytes_billed_u64`].
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BigQueryQueryStatistics {
+    /// Bytes BigQuery read to produce the result. Strictly `>=`
+    /// `total_bytes_billed` because the billable figure has the 10 MB
+    /// minimum floor applied.
+    #[allow(dead_code)]
+    #[serde(default)]
+    total_bytes_processed: Option<String>,
+    /// Bytes the user is actually billed for. This is the figure
+    /// threaded into [`ExecutionStats::bytes_scanned`] because
+    /// [`rocky_core::cost::compute_observed_cost_usd`] multiplies it by
+    /// the per-TB rate to produce the billed cost. Storing "billed" in
+    /// a field named "scanned" is a deliberate impurity — the cost
+    /// formula wants billed, and introducing a separate "billed" field
+    /// would force every downstream consumer to special-case BigQuery.
+    #[serde(default)]
+    total_bytes_billed: Option<String>,
+}
+
+impl BigQueryQueryStatistics {
+    /// Parse `totalBytesBilled` to `u64`. Invalid / overflowing / missing
+    /// values all return `None` so the stats remain best-effort and
+    /// never fail a run.
+    fn total_bytes_billed_u64(&self) -> Option<u64> {
+        self.total_bytes_billed
+            .as_deref()
+            .and_then(|s| s.parse::<u64>().ok())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -477,6 +571,87 @@ mod tests {
         assert!(!resp.job_complete);
         let job_ref = resp.job_reference.unwrap();
         assert_eq!(job_ref.job_id, "job_abc");
+    }
+
+    #[test]
+    fn statistics_deserializes_when_present() {
+        // Happy path: completed query job with totalBytesBilled.
+        // BigQuery always encodes int64 as decimal strings — parser
+        // must handle the string form.
+        let json = r#"{
+            "jobComplete": true,
+            "statistics": {
+                "query": {
+                    "totalBytesProcessed": "12345678",
+                    "totalBytesBilled": "10485760"
+                }
+            }
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, Some(10_485_760));
+        assert_eq!(stats.bytes_written, None);
+        assert_eq!(stats.rows_affected, None);
+    }
+
+    #[test]
+    fn statistics_absent_yields_all_none() {
+        // BigQuery omits `statistics` for some DDL responses — must not
+        // fail to deserialize, and stats should be all-None.
+        let json = r#"{"jobComplete": true}"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.statistics.is_none());
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
+        assert_eq!(stats.bytes_written, None);
+    }
+
+    #[test]
+    fn statistics_query_absent_yields_none() {
+        // The outer `statistics` block is present but the `query` slice
+        // isn't — shouldn't blow up.
+        let json = r#"{
+            "jobComplete": true,
+            "statistics": {}
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
+    }
+
+    #[test]
+    fn statistics_total_bytes_billed_absent_yields_none() {
+        // `statistics.query` is present but only `totalBytesProcessed`
+        // is set — the billed-field parse returns None.
+        let json = r#"{
+            "jobComplete": true,
+            "statistics": {
+                "query": {
+                    "totalBytesProcessed": "12345678"
+                }
+            }
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
+    }
+
+    #[test]
+    fn statistics_unparseable_bytes_yields_none() {
+        // Defensive: if BigQuery ever returns a non-integer (never
+        // observed but the REST contract is a string), parsing must
+        // fail softly rather than erroring the whole run.
+        let json = r#"{
+            "jobComplete": true,
+            "statistics": {
+                "query": {
+                    "totalBytesBilled": "not-a-number"
+                }
+            }
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2931,11 +2931,27 @@ async fn run_one_partition(
     // Execute each statement in order. On any failure, attempt ROLLBACK so
     // transactional dialects (Snowflake / DuckDB) don't leave partial state
     // visible.
+    //
+    // Accumulate warehouse-reported bytes across all statements — the BQ
+    // `insert_overwrite_partition` contract emits 4 statements
+    // (BEGIN / DELETE / INSERT / COMMIT), each of which potentially reports
+    // its own `totalBytesBilled`. Summing gives the partition-total cost
+    // input. Non-BQ adapters return `None` from the default trait method,
+    // so `bytes_acc` stays `None` and `compute_observed_cost_usd` falls
+    // through to the duration-based branch.
     let mut exec_err: Option<anyhow::Error> = None;
+    let mut bytes_scanned_acc: Option<u64> = None;
+    let mut bytes_written_acc: Option<u64> = None;
     for stmt in &stmts {
-        if let Err(e) = warehouse.execute_statement(stmt).await {
-            exec_err = Some(anyhow::anyhow!("{e}"));
-            break;
+        match warehouse.execute_statement_with_stats(stmt).await {
+            Ok(stats) => {
+                bytes_scanned_acc = accumulate_bytes(bytes_scanned_acc, stats.bytes_scanned);
+                bytes_written_acc = accumulate_bytes(bytes_written_acc, stats.bytes_written);
+            }
+            Err(e) => {
+                exec_err = Some(anyhow::anyhow!("{e}"));
+                break;
+            }
         }
     }
 
@@ -2996,7 +3012,25 @@ async fn run_one_partition(
                 batched_with: partition_plan.batch_with.clone(),
             }),
             cost_usd: None,
+            bytes_scanned: bytes_scanned_acc,
+            bytes_written: bytes_written_acc,
         }),
+    }
+}
+
+/// Combine an existing byte accumulator with a newly reported value.
+///
+/// `None + None` stays `None` (adapter reported nothing). `Some(n) +
+/// None` keeps the partial figure because at least one statement in
+/// the transaction did report bytes. `Some(a) + Some(b)` uses
+/// `saturating_add` so a 64-bit overflow can't panic (would require a
+/// single partition to scan ~18 exabytes — defensive, not expected).
+fn accumulate_bytes(acc: Option<u64>, next: Option<u64>) -> Option<u64> {
+    match (acc, next) {
+        (None, None) => None,
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (Some(a), Some(b)) => Some(a.saturating_add(b)),
     }
 }
 
@@ -3181,8 +3215,8 @@ async fn process_table(
         strategy = strategy_name,
         "copying data"
     );
-    warehouse
-        .execute_statement(&sql)
+    let exec_stats = warehouse
+        .execute_statement_with_stats(&sql)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -3267,6 +3301,8 @@ async fn process_table(
             // Replication tables are never time_interval; no partition info.
             partition: None,
             cost_usd: None,
+            bytes_scanned: exec_stats.bytes_scanned,
+            bytes_written: exec_stats.bytes_written,
         },
         drift_checked: true,
         drift_detected: drift_action,

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -674,6 +674,11 @@ pub async fn run_snapshot(
             },
             partition: None,
             cost_usd: None,
+            // snapshot_scd2 uses `execute_query` (multi-statement) and
+            // doesn't thread stats through yet — BigQuery snapshot cost
+            // attribution is a follow-up wave.
+            bytes_scanned: None,
+            bytes_written: None,
         });
     } else {
         output.tables_failed = 1;

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -339,6 +339,22 @@ pub struct MaterializationOutput {
     /// `rocky_core::cost::compute_observed_cost_usd`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost_usd: Option<f64>,
+    /// Bytes the warehouse reported reading to produce the result, summed
+    /// across all statements executed for this materialization. For
+    /// BigQuery on-demand this is `statistics.query.totalBytesBilled`
+    /// (with the 10 MB minimum already applied) — fed straight into
+    /// [`rocky_core::cost::compute_observed_cost_usd`] to produce
+    /// `cost_usd`. `None` when the adapter does not report bytes (today:
+    /// Databricks / Snowflake / DuckDB).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes_scanned: Option<u64>,
+    /// Bytes the warehouse reported writing to the destination, summed
+    /// across all statements. Currently `None` on every adapter — BigQuery
+    /// doesn't expose a natural bytes-written figure for query jobs, and
+    /// the Databricks / Snowflake paths haven't wired it yet. Field
+    /// reserved so future waves can populate it without a schema break.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes_written: Option<u64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1881,16 +1897,17 @@ impl RunOutput {
         let mut total_duration_ms: u64 = 0;
 
         for mat in &mut self.materializations {
-            // `bytes_scanned` is not yet plumbed into `MaterializationOutput`
-            // from the adapter layer — a later wave will wire
-            // Databricks's `result.manifest.total_byte_count` /
-            // Snowflake's `statistics.queryLoad` / BigQuery's
-            // `totalBytesProcessed` through. Until then BigQuery cost
-            // stays `None`; Databricks/Snowflake/DuckDB compute from
-            // `duration_ms` alone.
+            // BigQuery: `mat.bytes_scanned` is populated by the adapter
+            // from `statistics.query.totalBytesBilled` (Arc 2 wave 3).
+            // Databricks / Snowflake / DuckDB still inherit the default
+            // [`rocky_core::traits::WarehouseAdapter::execute_statement_with_stats`]
+            // stub which returns `None`, so those adapters continue to
+            // compute cost from `duration_ms` alone; wiring their native
+            // stats (Databricks `result.manifest.total_byte_count`,
+            // Snowflake `statistics.queryLoad`) is a follow-up wave.
             let cost = rocky_core::cost::compute_observed_cost_usd(
                 wh,
-                None,
+                mat.bytes_scanned,
                 mat.duration_ms,
                 dbu_per_hour,
                 cost_per_dbu,
@@ -2036,8 +2053,8 @@ impl RunOutput {
                 rows_affected: mat.rows_copied,
                 status: "success".to_string(),
                 sql_hash: mat.metadata.sql_hash.clone().unwrap_or_default(),
-                bytes_scanned: None,
-                bytes_written: None,
+                bytes_scanned: mat.bytes_scanned,
+                bytes_written: mat.bytes_written,
             });
         }
 
@@ -2279,6 +2296,8 @@ mod cost_finalize_tests {
             },
             partition: None,
             cost_usd: None,
+            bytes_scanned: None,
+            bytes_written: None,
         }
     }
 
@@ -2303,6 +2322,42 @@ mod cost_finalize_tests {
         assert_eq!(summary.per_model.len(), 1);
         assert_eq!(summary.per_model[0].cost_usd, Some(0.0));
         assert_eq!(out.materializations[0].cost_usd, Some(0.0));
+    }
+
+    #[test]
+    fn populate_cost_summary_bigquery_uses_bytes_scanned() {
+        // Arc 2 wave 3: when the BigQuery adapter populates
+        // `bytes_scanned` from `statistics.query.totalBytesBilled`,
+        // `populate_cost_summary` must produce a real dollar figure
+        // rather than the `None` it returned before the plumbing landed.
+        // 1 TB billed at $6.25/TB → $6.25.
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        let mut m = mat(&["orders"], 1_000);
+        m.bytes_scanned = Some(1_000_000_000_000); // 1 TB.
+        out.materializations.push(m);
+        out.populate_cost_summary("bigquery", &CostSection::default());
+        let summary = out
+            .cost_summary
+            .as_ref()
+            .expect("BigQuery is a billed warehouse");
+        let total = summary.total_cost_usd.expect("bytes_scanned drives cost");
+        assert!((total - 6.25).abs() < 1.0e-6, "total cost = {total}");
+        assert_eq!(out.materializations[0].cost_usd, Some(6.25));
+    }
+
+    #[test]
+    fn populate_cost_summary_bigquery_none_when_bytes_missing() {
+        // When the adapter doesn't report bytes (e.g. a DDL that
+        // BigQuery returned without `statistics`), the cost column
+        // stays `None` — don't silently fall back to a duration-based
+        // figure that would be off by orders of magnitude for a
+        // bytes-priced warehouse.
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        out.materializations.push(mat(&["orders"], 1_000));
+        out.populate_cost_summary("bigquery", &CostSection::default());
+        let summary = out.cost_summary.as_ref().unwrap();
+        assert!(summary.total_cost_usd.is_none());
+        assert!(out.materializations[0].cost_usd.is_none());
     }
 
     #[test]
@@ -2398,6 +2453,8 @@ mod run_record_tests {
             },
             partition: None,
             cost_usd: None,
+            bytes_scanned: None,
+            bytes_written: None,
         }
     }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -88,6 +88,39 @@ pub struct ExplainResult {
     pub raw_explain: String,
 }
 
+/// Statistics the warehouse reported for a single executed statement.
+///
+/// Returned by [`WarehouseAdapter::execute_statement_with_stats`]. Every
+/// field is `Option<u64>` because not every adapter reports every number:
+/// DuckDB returns `None` everywhere, BigQuery populates `bytes_scanned`
+/// from `statistics.query.totalBytesBilled`, Databricks / Snowflake
+/// currently return `None` but may populate these in a future wave.
+///
+/// Threaded up into [`crate::state::ModelExecution`] and
+/// `MaterializationOutput.bytes_scanned` / `.bytes_written` so
+/// `rocky cost` can compute real dollar figures without re-querying the
+/// warehouse.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct ExecutionStats {
+    /// Bytes read by the warehouse to produce the result. For BigQuery
+    /// on-demand this is `totalBytesBilled` (what the user is actually
+    /// charged for — the 10 MB minimum floor is already applied),
+    /// intentionally stored in this field because
+    /// [`crate::cost::compute_observed_cost_usd`] multiplies it by the
+    /// per-TB rate to compute the billed cost.
+    pub bytes_scanned: Option<u64>,
+    /// Bytes written to the destination. Only populated by adapters
+    /// that report it natively (none today — Databricks and Snowflake
+    /// return bytes-written in statement results but aren't wired yet;
+    /// BigQuery doesn't expose a bytes-written figure for query jobs).
+    pub bytes_written: Option<u64>,
+    /// Rows affected by the statement (inserts + updates + deletes).
+    /// Not populated yet — reserved so a follow-up wave can thread
+    /// per-adapter row counts through without another trait-method
+    /// addition.
+    pub rows_affected: Option<u64>,
+}
+
 // ---------------------------------------------------------------------------
 // Discovery
 // ---------------------------------------------------------------------------
@@ -123,6 +156,26 @@ pub trait WarehouseAdapter: Send + Sync {
 
     /// Execute a SQL statement (DDL/DML) without returning rows.
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()>;
+
+    /// Execute a SQL statement and return the warehouse-reported
+    /// [`ExecutionStats`] (bytes scanned, bytes written, rows affected).
+    ///
+    /// Default: delegates to [`Self::execute_statement`] and returns
+    /// [`ExecutionStats::default`] (all `None`). Adapters that have
+    /// access to statement-level stats (BigQuery's
+    /// `statistics.query.totalBytesBilled`, Databricks's
+    /// `result.manifest.total_byte_count`, Snowflake's
+    /// `statistics.queryLoad`) should override to populate the fields.
+    ///
+    /// Used by the materialize path in `rocky-cli` to populate
+    /// `MaterializationOutput.bytes_scanned` / `.bytes_written` so
+    /// `rocky cost` can derive a real dollar figure for bytes-priced
+    /// warehouses (BigQuery on-demand).
+    async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
+        self.execute_statement(sql)
+            .await
+            .map(|()| ExecutionStats::default())
+    }
 
     /// Execute a SQL query and return rows.
     async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult>;

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -383,6 +383,14 @@ class CheckResult6(BaseModel):
 
 class MaterializationOutput(BaseModel):
     asset_key: list[str]
+    bytes_scanned: conint(ge=0) | None = None
+    """
+    Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).
+    """
+    bytes_written: conint(ge=0) | None = None
+    """
+    Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.
+    """
     cost_usd: float | None = None
     """
     Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -401,6 +401,24 @@
           },
           "type": "array"
         },
+        "bytes_scanned": {
+          "description": "Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "bytes_written": {
+          "description": "Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "cost_usd": {
           "description": "Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.",
           "format": "double",


### PR DESCRIPTION
## Summary

- Adds a non-breaking `WarehouseAdapter::execute_statement_with_stats` trait method with a default impl delegating to `execute_statement` — other adapters pick up all-`None` stats for free.
- BigQuery overrides it to parse `statistics.query.totalBytesBilled` out of the REST response; those bytes flow into new `MaterializationOutput.bytes_scanned` / `.bytes_written` fields and into persisted `ModelExecution`, so both live `rocky run` and historical `rocky cost` produce real dollar figures on BigQuery.
- Wires the new stats through the two materialize call sites that actually build a `MaterializationOutput`: `run_one_partition` (time_interval, accumulates across the 4-statement BQ insert-overwrite transaction) and `process_table` (replication).
- BigQuery-only slice of Trust-system Arc 2 wave 3; Databricks / Snowflake adapters still inherit the default no-op stats and keep their existing duration-based cost formula — their slices ship as separate PRs.

## Why `bytes_scanned` holds `totalBytesBilled` (not `totalBytesProcessed`)

BigQuery emits both. `compute_observed_cost_usd`'s BQ branch multiplies `bytes_scanned` by the per-TB rate. Using `processed` here would under-report cost for any query under the 10 MB minimum floor Google actually charges against. The semantic impurity (field name says "scanned", holds "billed") is deliberate so downstream consumers keep treating `bytes_scanned` as the single cost input without BigQuery-specific branching. Documented inline at `stats_from_response` in `connector.rs`.

## Scope notes (deliberately out of scope)

- **Databricks / Snowflake bytes plumbing**: separate PRs. Those adapters inherit the default trait method → `ExecutionStats::default()` → `None` everywhere, which keeps the existing duration-based cost formula intact.
- **Plain transformation models** (non-time_interval, non-replication — the `execute_models` loop at `run.rs:2582-2611`) don't construct a `MaterializationOutput` today. BigQuery cost attribution for derived models via `full_refresh` / `incremental` / `merge` still reports `None` after this PR. Pre-existing gap — can be closed by a follow-up that makes that loop push to `output.materializations`.
- **`snapshot_scd2` path**: uses `execute_query` (multi-statement), stats not threaded. Another follow-up.

## Test plan

- [x] `cargo test -p rocky-bigquery` — new unit tests for `BigQueryStatistics` deserialization (present / absent / absent-query / unparseable / total_bytes_processed-only)
- [x] `cargo test -p rocky-cli` — new unit tests proving `populate_cost_summary` emits real `cost_usd` when `mat.bytes_scanned` is `Some` on BigQuery, and stays `None` when bytes are missing
- [x] `cargo test --workspace` — full suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `just codegen` — regenerated `schemas/run.schema.json`, `run_schema.py`, `run.ts` deterministically; no drift against committed bindings
- [x] `just regen-fixtures` — run twice, byte-stable (new fields are `skip_serializing_if = Option::is_none` and DuckDB returns `None`, so fixtures don't shift)
- [x] `uv run pytest` in `integrations/dagster/` — 312 passed
- [x] `npm run compile` in `editors/vscode/` — clean

## Files touched (8)

- `engine/crates/rocky-core/src/traits.rs` — new `ExecutionStats` type + `execute_statement_with_stats` default trait method
- `engine/crates/rocky-bigquery/src/connector.rs` — `BigQueryResponse` parses `statistics.query.totalBytesBilled`; override threads bytes through
- `engine/crates/rocky-cli/src/output.rs` — `MaterializationOutput` gains `bytes_scanned` / `bytes_written`; `populate_cost_summary` + `to_run_record` wire them through
- `engine/crates/rocky-cli/src/commands/run.rs` — materialize call sites switched to `execute_statement_with_stats`, bytes accumulated across BQ transactions
- `engine/crates/rocky-cli/src/commands/run_local.rs` — snapshot_scd2 constructor carries explicit `None`s
- `schemas/run.schema.json`, `integrations/dagster/src/dagster_rocky/types_generated/run_schema.py`, `editors/vscode/src/types/generated/run.ts` — regenerated by `just codegen`