### PR TITLE
docs(engine/rocky-snowflake): document why bytes_scanned is deferred

### DIFF
--- a/engine/crates/rocky-snowflake/src/adapter.rs
+++ b/engine/crates/rocky-snowflake/src/adapter.rs
@@ -44,6 +44,27 @@ impl WarehouseAdapter for SnowflakeWarehouseAdapter {
             .map_err(AdapterError::new)
     }
 
+    // `execute_statement_with_stats` intentionally NOT overridden.
+    //
+    // Snowflake does not return `bytes_scanned` in the immediate SQL API
+    // response; it only surfaces per-statement in QUERY_HISTORY (keyed
+    // by `query_id`), so populating it would add a second round-trip per
+    // statement — violating the implicit "cheap, piggybacked on the
+    // existing response" contract that BigQuery and Databricks satisfy.
+    //
+    // More importantly, Snowflake cost is duration-based, not
+    // bytes-based: `rocky_core::cost::compute_observed_cost_usd` routes
+    // the Snowflake branch through `duration_hours × dbu_per_hour ×
+    // cost_per_dbu` and never reads `bytes_scanned`. Adding a
+    // QUERY_HISTORY lookup per statement would only affect display in
+    // `rocky trace` / `rocky history`, not `rocky cost` accuracy.
+    //
+    // If bytes_scanned is wanted for display, revisit with a batched
+    // QUERY_HISTORY lookup at run-finalise time (one query for all
+    // statement IDs, not N queries). If Snowflake's pricing ever shifts
+    // to bytes-based (e.g., serverless compute, query acceleration),
+    // reconsider the trade-off — at that point the cost-correctness win
+    // would justify the extra round-trip.
     async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
         let result = self
             .connector


### PR DESCRIPTION
## Summary

- Adds a doc comment on `SnowflakeWarehouseAdapter`'s `impl WarehouseAdapter` block explaining why `execute_statement_with_stats` is intentionally **not** overridden.
- Sibling to #219 (BigQuery bytes slice) and the pending Databricks slice — makes the gap self-documenting instead of implicit.
- Comment only. No behavior change. No new functionality.

## Why bytes_scanned is deferred for Snowflake

Two independent reasons:

1. **No free piggyback path.** Snowflake does not return `bytes_scanned` in the immediate SQL API statement response. The per-statement figure only surfaces in `QUERY_HISTORY`, keyed by `query_id`. Populating `ExecutionStats::bytes_scanned` from Snowflake would require a second round-trip per materialize statement — violating the implicit "cheap, piggybacked on the existing response" contract that BigQuery (`statistics.query.totalBytesBilled`) and Databricks (`result.manifest.total_byte_count`) satisfy.

2. **Cost calculator doesn't consume it.** `rocky_core::cost::compute_observed_cost_usd` routes the Snowflake branch through `duration_hours × dbu_per_hour × cost_per_dbu` and never reads `bytes_scanned` — the test `observed_cost_databricks_ignores_bytes` (cost.rs:962) documents the same invariant for the Databricks/Snowflake arm. A QUERY_HISTORY round-trip would only affect display in `rocky trace` / `rocky history` output, not `rocky cost` correctness.

If Snowflake's pricing ever shifts to bytes-based (serverless compute, query acceleration), revisit. If `bytes_scanned` is wanted for display, do it as a **batched** QUERY_HISTORY lookup at run-finalise time (one query for all statement IDs), not a per-statement round-trip.

## Scope

- `engine/crates/rocky-snowflake/src/adapter.rs` only — 21 lines of comment added to the `WarehouseAdapter` impl, right after `execute_statement`, so future readers asking "where's `execute_statement_with_stats`?" land on the rationale.
- No other crate touched. `rocky-core::traits` (trait definition) and `rocky-databricks` / `rocky-bigquery` untouched.

## Test plan

- [x] `cargo check -p rocky-snowflake` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

## Notes

- No schema / JSON-output changes, so no codegen cascade needed.
- Follows #219's scope split (BigQuery / Databricks / Snowflake as separate PRs).