### PR TITLE
feat(engine/rocky-databricks): override execute_statement_with_stats with total_byte_count

### DIFF
--- a/engine/crates/rocky-databricks/src/adapter.rs
+++ b/engine/crates/rocky-databricks/src/adapter.rs
@@ -7,8 +7,8 @@ use chrono::{DateTime, Utc};
 
 use rocky_core::ir::{ColumnInfo, TableRef};
 use rocky_core::traits::{
-    AdapterError, AdapterResult, BatchCheckAdapter, FreshnessResult, QueryResult, RowCountResult,
-    SqlDialect, WarehouseAdapter,
+    AdapterError, AdapterResult, BatchCheckAdapter, ExecutionStats, FreshnessResult, QueryResult,
+    RowCountResult, SqlDialect, WarehouseAdapter,
 };
 
 use crate::batch::{self, BatchTableRef};
@@ -47,6 +47,20 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
             .execute_statement(sql)
             .await
             .map(|_| ())
+            .map_err(AdapterError::new)
+    }
+
+    async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
+        // `total_byte_count` from the Databricks manifest is the
+        // byte count Databricks natively reports for a statement —
+        // surfaced here in the `bytes_scanned` slot to match the
+        // BigQuery `totalBytesBilled` convention set in PR #219.
+        // Databricks is DBU-priced (not bytes-priced), so this
+        // figure isn't a cost driver today — it's still threaded
+        // through so downstream observability has a real number.
+        self.connector
+            .execute_statement_with_stats(sql)
+            .await
             .map_err(AdapterError::new)
     }
 

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -117,11 +117,18 @@ pub struct StatusError {
     pub message: Option<String>,
 }
 
-/// Result manifest containing schema and row count metadata.
+/// Result manifest containing schema and row / byte count metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Manifest {
     pub schema: Option<ManifestSchema>,
     pub total_row_count: Option<u64>,
+    /// Total bytes in the statement result payload, aggregated across all
+    /// chunks. Populated for SUCCEEDED `SELECT`s that return data;
+    /// Databricks omits the field (and we see `None`) for DDL / DML
+    /// where the response has no result payload. Surfaced into
+    /// [`rocky_core::traits::ExecutionStats::bytes_scanned`] — see
+    /// [`stats_from_response`] for the semantic-impurity note.
+    pub total_byte_count: Option<u64>,
 }
 
 /// Column schema from a statement result manifest.
@@ -236,6 +243,19 @@ impl DatabricksConnector {
     pub async fn execute_statement(&self, sql: &str) -> Result<String, ConnectorError> {
         let response = self.submit_and_wait(sql).await?;
         Ok(response.statement_id)
+    }
+
+    /// Executes a SQL statement and returns the warehouse-reported
+    /// [`ExecutionStats`] for it — the stats-aware counterpart to
+    /// [`Self::execute_statement`]. Feeds
+    /// [`WarehouseAdapter::execute_statement_with_stats`] on
+    /// [`crate::adapter::DatabricksWarehouseAdapter`].
+    pub async fn execute_statement_with_stats(
+        &self,
+        sql: &str,
+    ) -> Result<rocky_core::traits::ExecutionStats, ConnectorError> {
+        let response = self.submit_and_wait(sql).await?;
+        Ok(stats_from_response(&response))
     }
 
     async fn submit_and_wait(&self, sql: &str) -> Result<StatementResponse, ConnectorError> {
@@ -551,6 +571,38 @@ fn classify_error(err: &ConnectorError) -> ErrorClass {
     }
 }
 
+/// Extract [`rocky_core::traits::ExecutionStats`] from a successful
+/// [`StatementResponse`].
+///
+/// Maps `response.manifest.total_byte_count` (the aggregate size of the
+/// statement result payload across all chunks, per Databricks's
+/// Statement Execution REST contract) into
+/// [`ExecutionStats::bytes_scanned`]. Databricks is priced in
+/// DBU-hours, not bytes, so this figure isn't a cost driver the way
+/// BigQuery's `totalBytesBilled` is — it's the byte count Databricks
+/// natively reports for the statement, surfaced unchanged so callers
+/// can observe it. The `bytes_scanned` slot name is retained (rather
+/// than introducing a Databricks-specific field) to keep the
+/// [`crate::adapter::DatabricksWarehouseAdapter`] cost path free of
+/// adapter-specific branching — see the matching BigQuery comment in
+/// `rocky_bigquery::connector::stats_from_response`.
+///
+/// Returns all-`None` when Databricks omits the manifest (e.g. on
+/// DDL / DML that produces no result payload) or when the manifest is
+/// present but `total_byte_count` isn't set. `bytes_written` and
+/// `rows_affected` are always `None` — Databricks doesn't expose
+/// bytes-written on the Statement Execution response, and
+/// `total_row_count` on the manifest is the result-row count, not the
+/// rows-affected figure for DML.
+fn stats_from_response(response: &StatementResponse) -> rocky_core::traits::ExecutionStats {
+    let bytes_scanned = response.manifest.as_ref().and_then(|m| m.total_byte_count);
+    rocky_core::traits::ExecutionStats {
+        bytes_scanned,
+        bytes_written: None,
+        rows_affected: None,
+    }
+}
+
 /// Fixed polling delays (ms) for the first 5 statement status checks.
 const POLL_DELAY_STEPS_MS: [u64; 5] = [100, 200, 500, 1000, 2000];
 /// Maximum polling delay after exponential growth.
@@ -750,5 +802,88 @@ mod tests {
             consecutive_failures: 5,
         };
         assert!(!is_transient(&err));
+    }
+
+    #[test]
+    fn manifest_deserializes_total_byte_count() {
+        // Happy path: SUCCEEDED SELECT with a result payload — the
+        // manifest carries `total_byte_count` alongside
+        // `total_row_count`.
+        let json = r#"{
+            "statement_id": "id-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "col1", "type_name": "STRING", "position": 0}
+                    ]
+                },
+                "total_row_count": 10,
+                "total_byte_count": 2843848
+            }
+        }"#;
+        let resp: StatementResponse = serde_json::from_str(json).unwrap();
+        let manifest = resp.manifest.unwrap();
+        assert_eq!(manifest.total_byte_count, Some(2_843_848));
+        assert_eq!(manifest.total_row_count, Some(10));
+    }
+
+    #[test]
+    fn stats_from_response_populates_bytes_scanned() {
+        // Happy path into `stats_from_response`: `manifest.total_byte_count`
+        // flows into `ExecutionStats.bytes_scanned`. `bytes_written`
+        // and `rows_affected` stay `None` (Databricks doesn't expose
+        // them on the Statement Execution response).
+        let json = r#"{
+            "statement_id": "id-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "total_row_count": 10,
+                "total_byte_count": 2843848
+            }
+        }"#;
+        let resp: StatementResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, Some(2_843_848));
+        assert_eq!(stats.bytes_written, None);
+        assert_eq!(stats.rows_affected, None);
+    }
+
+    #[test]
+    fn stats_from_response_without_manifest_is_all_none() {
+        // DDL / DML case: Databricks omits the manifest when there's
+        // no result payload. `stats_from_response` must degrade to
+        // all-`None` rather than erroring, mirroring BigQuery's
+        // `statistics-absent` case.
+        let json = r#"{
+            "statement_id": "id-1",
+            "status": {"state": "SUCCEEDED"}
+        }"#;
+        let resp: StatementResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.manifest.is_none());
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
+        assert_eq!(stats.bytes_written, None);
+        assert_eq!(stats.rows_affected, None);
+    }
+
+    #[test]
+    fn stats_from_response_manifest_without_total_byte_count_is_none() {
+        // Defensive: manifest is present (we have `total_row_count`)
+        // but Databricks didn't include `total_byte_count` — the
+        // helper should return `None` for bytes rather than
+        // inventing a value.
+        let json = r#"{
+            "statement_id": "id-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "total_row_count": 0
+            }
+        }"#;
+        let resp: StatementResponse = serde_json::from_str(json).unwrap();
+        let manifest = resp.manifest.as_ref().unwrap();
+        assert_eq!(manifest.total_byte_count, None);
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, None);
     }
 }


### PR DESCRIPTION
## Summary

- Overrides the default [`WarehouseAdapter::execute_statement_with_stats`](https://github.com/rocky-data/rocky/pull/219) on `DatabricksWarehouseAdapter` so Databricks materializations now surface real byte accounting in `MaterializationOutput.bytes_scanned` instead of inheriting the all-`None` stub.
- Extends `Manifest` to deserialize `total_byte_count` from the Databricks SQL Statement Execution response and adds `DatabricksConnector::execute_statement_with_stats` (stats-aware counterpart to `execute_statement`) plus a free `stats_from_response` helper.
- `execute_statement`'s signature and behaviour are unchanged — the default trait impl keeps delegating to it for callers that don't need stats. Databricks slice of Trust-system Arc 2 wave 3.

## Why `bytes_scanned` holds `total_byte_count`

Matches the #219 naming convention: `ExecutionStats.bytes_scanned` is the *billing-relevant* bytes figure for the adapter. Databricks is DBU-priced (not bytes-priced), so `total_byte_count` isn't a cost driver the way BigQuery's `totalBytesBilled` is — it's the byte count Databricks natively reports for a statement, surfaced in the `bytes_scanned` slot so the cost pipeline stays free of adapter-specific branching. Documented inline on `stats_from_response`.

## Scope notes

- Databricks only. Snowflake slice to follow in a sibling PR. DuckDB / rocky-cli / run.rs unchanged — those were already wired in #219.
- No `WarehouseAdapter` trait changes — only the override.
- `bytes_written` stays `None`; Databricks doesn't expose a bytes-written figure on the Statement Execution response. `rows_affected` stays `None` — `total_row_count` is the result-row count, not the DML-affected-row count.

## Test plan

- [x] `cargo test -p rocky-databricks -p rocky-core -p rocky-cli` — all green. 4 new unit tests on `stats_from_response` + `Manifest` deserialization (happy path with `total_byte_count`, missing manifest, manifest-without-`total_byte_count`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `just codegen` — no output-struct change, byte-stable (verified no-op).
- [x] `just regen-fixtures` — DuckDB playground doesn't exercise Databricks, byte-stable (verified no-op).
- [x] `uv run pytest` in `integrations/dagster/` — 312 passed, unaffected.

## Files touched

- `engine/crates/rocky-databricks/src/connector.rs` — `Manifest` parses `total_byte_count`; new `stats_from_response` helper + `DatabricksConnector::execute_statement_with_stats` method; 4 new unit tests.
- `engine/crates/rocky-databricks/src/adapter.rs` — override `WarehouseAdapter::execute_statement_with_stats` on `DatabricksWarehouseAdapter`.