### PR TITLE
docs(engine): clarify bytes_scanned holds billing-relevant bytes, not scan volume

### DIFF
--- a/editors/vscode/src/types/generated/cost.ts
+++ b/editors/vscode/src/types/generated/cost.ts
@@ -56,7 +56,15 @@ export interface CostOutput {
  * Distinct from [`ModelCostEntry`] (which lives on [`RunCostSummary`]) because the historical surface carries the richer fields the state store actually persists: model name (not asset-key vector), row/byte counts, and the recorded per-model status.
  */
 export interface PerModelCostHistorical {
+  /**
+   * Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+   *
+   * - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+   */
   bytes_scanned?: number | null;
+  /**
+   * Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+   */
   bytes_written?: number | null;
   /**
    * Observed cost for this execution. `None` when the adapter isn't a billed warehouse, the config couldn't be loaded, or the formula inputs were unavailable (e.g. BigQuery without `bytes_scanned`).

--- a/editors/vscode/src/types/generated/replay.ts
+++ b/editors/vscode/src/types/generated/replay.ts
@@ -26,7 +26,15 @@ export interface ReplayOutput {
  * A single model execution inside a replayed run.
  */
 export interface ReplayModelOutput {
+  /**
+   * Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+   *
+   * - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+   */
   bytes_scanned?: number | null;
+  /**
+   * Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+   */
   bytes_written?: number | null;
   duration_ms: number;
   finished_at: string;

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -254,11 +254,13 @@ export interface ExecutionSummary {
 export interface MaterializationOutput {
   asset_key: string[];
   /**
-   * Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).
+   * Adapter-reported bytes figure used for cost accounting, summed across all statements executed for this materialization. This is the *billing-relevant* number per adapter, not literal scan volume — so anyone comparing this to a warehouse console should know which column lines up.
+   *
+   * - **BigQuery:** `statistics.query.totalBytesBilled` (with the 10 MB per-query minimum already applied) — matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". Fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
    */
   bytes_scanned?: number | null;
   /**
-   * Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.
+   * Adapter-reported bytes-written figure, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Reserved so future waves can populate it without a schema break.
    */
   bytes_written?: number | null;
   /**

--- a/editors/vscode/src/types/generated/trace.ts
+++ b/editors/vscode/src/types/generated/trace.ts
@@ -30,7 +30,15 @@ export interface TraceOutput {
  * One model execution entry inside [`TraceOutput`]. `start_offset_ms` is the wall-clock offset from the run start; `lane` identifies the concurrency lane for Gantt rendering (entries on the same lane never overlap in time).
  */
 export interface TraceModelEntry {
+  /**
+   * Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+   *
+   * - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+   */
   bytes_scanned?: number | null;
+  /**
+   * Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+   */
   bytes_written?: number | null;
   duration_ms: number;
   /**

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -339,20 +339,32 @@ pub struct MaterializationOutput {
     /// `rocky_core::cost::compute_observed_cost_usd`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost_usd: Option<f64>,
-    /// Bytes the warehouse reported reading to produce the result, summed
-    /// across all statements executed for this materialization. For
-    /// BigQuery on-demand this is `statistics.query.totalBytesBilled`
-    /// (with the 10 MB minimum already applied) — fed straight into
-    /// [`rocky_core::cost::compute_observed_cost_usd`] to produce
-    /// `cost_usd`. `None` when the adapter does not report bytes (today:
-    /// Databricks / Snowflake / DuckDB).
+    /// Adapter-reported bytes figure used for cost accounting, summed
+    /// across all statements executed for this materialization. This
+    /// is the *billing-relevant* number per adapter, not literal scan
+    /// volume — so anyone comparing this to a warehouse console should
+    /// know which column lines up.
+    ///
+    /// - **BigQuery:** `statistics.query.totalBytesBilled` (with the
+    ///   10 MB per-query minimum already applied) — matches the
+    ///   BigQuery console's "Bytes billed" field, **not** "Bytes
+    ///   processed". Fed straight into
+    ///   [`rocky_core::cost::compute_observed_cost_usd`] to produce
+    ///   `cost_usd`.
+    /// - **Databricks:** when populated, byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design (QUERY_HISTORY
+    ///   round-trip cost; Snowflake cost is duration × DBU, not
+    ///   bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_scanned: Option<u64>,
-    /// Bytes the warehouse reported writing to the destination, summed
-    /// across all statements. Currently `None` on every adapter — BigQuery
-    /// doesn't expose a natural bytes-written figure for query jobs, and
-    /// the Databricks / Snowflake paths haven't wired it yet. Field
-    /// reserved so future waves can populate it without a schema break.
+    /// Adapter-reported bytes-written figure, summed across all
+    /// statements. Currently `None` on every adapter — BigQuery doesn't
+    /// expose a bytes-written figure for query jobs, and the Databricks
+    /// / Snowflake paths haven't wired it yet. Reserved so future waves
+    /// can populate it without a schema break.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
 }
@@ -2742,8 +2754,26 @@ pub struct ReplayModelOutput {
     pub sql_hash: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rows_affected: Option<u64>,
+    /// Adapter-reported bytes figure used for cost accounting. This is
+    /// the *billing-relevant* number per adapter, not literal scan
+    /// volume:
+    ///
+    /// - **BigQuery:** `totalBytesBilled` — includes the 10 MB
+    ///   per-query minimum floor; matches the BigQuery console's
+    ///   "Bytes billed" field, **not** "Bytes processed".
+    /// - **Databricks:** when populated, byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design (QUERY_HISTORY
+    ///   round-trip cost; Snowflake cost is duration × DBU, not
+    ///   bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_scanned: Option<u64>,
+    /// Adapter-reported bytes-written figure. Currently `None` on
+    /// every adapter — BigQuery doesn't expose a bytes-written figure
+    /// for query jobs, and the Databricks / Snowflake paths haven't
+    /// wired it yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
 }
@@ -2787,8 +2817,26 @@ pub struct TraceModelEntry {
     pub lane: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rows_affected: Option<u64>,
+    /// Adapter-reported bytes figure used for cost accounting. This is
+    /// the *billing-relevant* number per adapter, not literal scan
+    /// volume:
+    ///
+    /// - **BigQuery:** `totalBytesBilled` — includes the 10 MB
+    ///   per-query minimum floor; matches the BigQuery console's
+    ///   "Bytes billed" field, **not** "Bytes processed".
+    /// - **Databricks:** when populated, byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design (QUERY_HISTORY
+    ///   round-trip cost; Snowflake cost is duration × DBU, not
+    ///   bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_scanned: Option<u64>,
+    /// Adapter-reported bytes-written figure. Currently `None` on
+    /// every adapter — BigQuery doesn't expose a bytes-written figure
+    /// for query jobs, and the Databricks / Snowflake paths haven't
+    /// wired it yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
 }
@@ -2865,8 +2913,26 @@ pub struct PerModelCostHistorical {
     pub duration_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rows_affected: Option<u64>,
+    /// Adapter-reported bytes figure used for cost accounting. This is
+    /// the *billing-relevant* number per adapter, not literal scan
+    /// volume:
+    ///
+    /// - **BigQuery:** `totalBytesBilled` — includes the 10 MB
+    ///   per-query minimum floor; matches the BigQuery console's
+    ///   "Bytes billed" field, **not** "Bytes processed".
+    /// - **Databricks:** when populated, byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design (QUERY_HISTORY
+    ///   round-trip cost; Snowflake cost is duration × DBU, not
+    ///   bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_scanned: Option<u64>,
+    /// Adapter-reported bytes-written figure. Currently `None` on
+    /// every adapter — BigQuery doesn't expose a bytes-written figure
+    /// for query jobs, and the Databricks / Snowflake paths haven't
+    /// wired it yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
     /// Observed cost for this execution. `None` when the adapter

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -509,7 +509,28 @@ pub struct ModelExecution {
     pub rows_affected: Option<u64>,
     pub status: String,
     pub sql_hash: String,
+    /// Adapter-reported bytes figure used for cost accounting. This is
+    /// the *billing-relevant* number per adapter, not literal scan
+    /// volume:
+    ///
+    /// - **BigQuery:** `totalBytesBilled` — includes the 10 MB
+    ///   per-query minimum floor; matches the BigQuery console's
+    ///   "Bytes billed" field, **not** "Bytes processed".
+    /// - **Databricks:** when populated, byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design (QUERY_HISTORY
+    ///   round-trip cost; Snowflake cost is duration × DBU, not
+    ///   bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
+    ///
+    /// Persisted mirror of `MaterializationOutput.bytes_scanned`.
     pub bytes_scanned: Option<u64>,
+    /// Adapter-reported bytes-written figure. Currently `None` on
+    /// every adapter — BigQuery doesn't expose a bytes-written figure
+    /// for query jobs, and the Databricks / Snowflake paths haven't
+    /// wired it yet. Reserved for adapters that produce a natural
+    /// bytes-written figure via their statistics surface.
     pub bytes_written: Option<u64>,
 }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -102,17 +102,36 @@ pub struct ExplainResult {
 /// warehouse.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct ExecutionStats {
-    /// Bytes read by the warehouse to produce the result. For BigQuery
-    /// on-demand this is `totalBytesBilled` (what the user is actually
-    /// charged for — the 10 MB minimum floor is already applied),
-    /// intentionally stored in this field because
-    /// [`crate::cost::compute_observed_cost_usd`] multiplies it by the
-    /// per-TB rate to compute the billed cost.
+    /// Adapter-reported bytes figure used for cost accounting. This is
+    /// the *billing-relevant* number per adapter, not literal scan
+    /// volume — so anyone comparing this to a warehouse console should
+    /// know which column lines up.
+    ///
+    /// - **BigQuery:** `totalBytesBilled` (with the 10 MB per-query
+    ///   minimum floor already applied) — matches the BigQuery
+    ///   console's "Bytes billed" field, **not** "Bytes processed".
+    ///   Stored in this field because
+    ///   [`crate::cost::compute_observed_cost_usd`] multiplies it by
+    ///   the per-TB rate to compute the billed cost.
+    /// - **Databricks:** when populated, the byte count from the
+    ///   statement-execution manifest (`total_byte_count`); `None`
+    ///   today until the manifest plumbing lands.
+    /// - **Snowflake:** `None` — deferred by design
+    ///   (QUERY_HISTORY round-trip cost; Snowflake cost is
+    ///   duration × DBU, not bytes-driven).
+    /// - **DuckDB:** `None` — no billed-bytes concept.
     pub bytes_scanned: Option<u64>,
-    /// Bytes written to the destination. Only populated by adapters
-    /// that report it natively (none today — Databricks and Snowflake
-    /// return bytes-written in statement results but aren't wired yet;
-    /// BigQuery doesn't expose a bytes-written figure for query jobs).
+    /// Adapter-reported bytes-written figure. Only populated by
+    /// adapters that report it natively:
+    ///
+    /// - **BigQuery:** `None` — query jobs don't surface a
+    ///   bytes-written figure.
+    /// - **Databricks / Snowflake:** `None` today; statement results
+    ///   expose a bytes-written figure but it's not wired yet.
+    /// - **DuckDB:** `None`.
+    ///
+    /// Reserved so a future wave can populate it without a schema
+    /// break.
     pub bytes_written: Option<u64>,
     /// Rows affected by the statement (inserts + updates + deletes).
     /// Not populated yet — reserved so a follow-up wave can thread

--- a/integrations/dagster/src/dagster_rocky/types_generated/cost_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/cost_schema.py
@@ -14,7 +14,15 @@ class PerModelCostHistorical(BaseModel):
     """
 
     bytes_scanned: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+
+    - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+    """
     bytes_written: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+    """
     cost_usd: float | None = None
     """
     Observed cost for this execution. `None` when the adapter isn't a billed warehouse, the config couldn't be loaded, or the formula inputs were unavailable (e.g. BigQuery without `bytes_scanned`).

--- a/integrations/dagster/src/dagster_rocky/types_generated/replay_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/replay_schema.py
@@ -12,7 +12,15 @@ class ReplayModelOutput(BaseModel):
     """
 
     bytes_scanned: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+
+    - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+    """
     bytes_written: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+    """
     duration_ms: conint(ge=0)
     finished_at: str
     model_name: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -385,11 +385,13 @@ class MaterializationOutput(BaseModel):
     asset_key: list[str]
     bytes_scanned: conint(ge=0) | None = None
     """
-    Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).
+    Adapter-reported bytes figure used for cost accounting, summed across all statements executed for this materialization. This is the *billing-relevant* number per adapter, not literal scan volume — so anyone comparing this to a warehouse console should know which column lines up.
+
+    - **BigQuery:** `statistics.query.totalBytesBilled` (with the 10 MB per-query minimum already applied) — matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". Fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
     """
     bytes_written: conint(ge=0) | None = None
     """
-    Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.
+    Adapter-reported bytes-written figure, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Reserved so future waves can populate it without a schema break.
     """
     cost_usd: float | None = None
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/trace_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/trace_schema.py
@@ -12,7 +12,15 @@ class TraceModelEntry(BaseModel):
     """
 
     bytes_scanned: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:
+
+    - **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's "Bytes billed" field, **not** "Bytes processed". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.
+    """
     bytes_written: conint(ge=0) | None = None
+    """
+    Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.
+    """
     duration_ms: conint(ge=0)
     lane: conint(ge=0) | None = 0
     """

--- a/schemas/cost.schema.json
+++ b/schemas/cost.schema.json
@@ -5,6 +5,7 @@
       "description": "A single model's cost attribution inside [`CostOutput`].\n\nDistinct from [`ModelCostEntry`] (which lives on [`RunCostSummary`]) because the historical surface carries the richer fields the state store actually persists: model name (not asset-key vector), row/byte counts, and the recorded per-model status.",
       "properties": {
         "bytes_scanned": {
+          "description": "Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:\n\n- **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's \"Bytes billed\" field, **not** \"Bytes processed\". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [
@@ -13,6 +14,7 @@
           ]
         },
         "bytes_written": {
+          "description": "Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [

--- a/schemas/replay.schema.json
+++ b/schemas/replay.schema.json
@@ -5,6 +5,7 @@
       "description": "A single model execution inside a replayed run.",
       "properties": {
         "bytes_scanned": {
+          "description": "Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:\n\n- **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's \"Bytes billed\" field, **not** \"Bytes processed\". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [
@@ -13,6 +14,7 @@
           ]
         },
         "bytes_written": {
+          "description": "Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -402,7 +402,7 @@
           "type": "array"
         },
         "bytes_scanned": {
-          "description": "Bytes the warehouse reported reading to produce the result, summed across all statements executed for this materialization. For BigQuery on-demand this is `statistics.query.totalBytesBilled` (with the 10 MB minimum already applied) — fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. `None` when the adapter does not report bytes (today: Databricks / Snowflake / DuckDB).",
+          "description": "Adapter-reported bytes figure used for cost accounting, summed across all statements executed for this materialization. This is the *billing-relevant* number per adapter, not literal scan volume — so anyone comparing this to a warehouse console should know which column lines up.\n\n- **BigQuery:** `statistics.query.totalBytesBilled` (with the 10 MB per-query minimum already applied) — matches the BigQuery console's \"Bytes billed\" field, **not** \"Bytes processed\". Fed straight into [`rocky_core::cost::compute_observed_cost_usd`] to produce `cost_usd`. - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [
@@ -411,7 +411,7 @@
           ]
         },
         "bytes_written": {
-          "description": "Bytes the warehouse reported writing to the destination, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a natural bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Field reserved so future waves can populate it without a schema break.",
+          "description": "Adapter-reported bytes-written figure, summed across all statements. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet. Reserved so future waves can populate it without a schema break.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [

--- a/schemas/trace.schema.json
+++ b/schemas/trace.schema.json
@@ -5,6 +5,7 @@
       "description": "One model execution entry inside [`TraceOutput`]. `start_offset_ms` is the wall-clock offset from the run start; `lane` identifies the concurrency lane for Gantt rendering (entries on the same lane never overlap in time).",
       "properties": {
         "bytes_scanned": {
+          "description": "Adapter-reported bytes figure used for cost accounting. This is the *billing-relevant* number per adapter, not literal scan volume:\n\n- **BigQuery:** `totalBytesBilled` — includes the 10 MB per-query minimum floor; matches the BigQuery console's \"Bytes billed\" field, **not** \"Bytes processed\". - **Databricks:** when populated, byte count from the statement-execution manifest (`total_byte_count`); `None` today until the manifest plumbing lands. - **Snowflake:** `None` — deferred by design (QUERY_HISTORY round-trip cost; Snowflake cost is duration × DBU, not bytes-driven). - **DuckDB:** `None` — no billed-bytes concept.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [
@@ -13,6 +14,7 @@
           ]
         },
         "bytes_written": {
+          "description": "Adapter-reported bytes-written figure. Currently `None` on every adapter — BigQuery doesn't expose a bytes-written figure for query jobs, and the Databricks / Snowflake paths haven't wired it yet.",
           "format": "uint64",
           "minimum": 0.0,
           "type": [


### PR DESCRIPTION
## Summary

Follow-up clarification to #219.

`bytes_scanned` carries the adapter's *billed* bytes figure, not literal scan volume. For BigQuery that's `totalBytesBilled` (with the 10 MB per-query minimum floor), which matches the BigQuery console's **"Bytes billed"** field — **not** "Bytes processed". The previous field-level docs either omitted that distinction or buried it; anyone comparing Rocky's output to the warehouse console would have reached for the wrong column.

This PR adds adapter-state-neutral docstrings covering all four adapters (BigQuery, Databricks, Snowflake, DuckDB) to every `bytes_scanned` and `bytes_written` field declaration — 6 sites across `ExecutionStats`, `ModelExecution`, `MaterializationOutput`, `ReplayModelOutput`, `TraceModelEntry`, and `PerModelCostHistorical`.

### The cascade is the whole point

`schemars` emits `///` rustdoc as the `description` field in generated JSON schemas, so the documented semantic cascades through `just codegen` into:

- `schemas/{run,replay,trace,cost}.schema.json` — `description` field
- `integrations/dagster/src/dagster_rocky/types_generated/{run,replay,trace,cost}_schema.py` — Pydantic v2 `Field(description=...)`
- `editors/vscode/src/types/generated/{run,replay,trace,cost}.ts` — TypeScript JSDoc

Net effect: the BQ-console-comparison nugget is now visible in **VS Code hover** (rustdoc), **Dagster's Pydantic IDE integrations** (Python docstrings), and any **downstream JSON schema consumer**.

## Files touched

**Rust source (6 field sites, 3 files):**
- `engine/crates/rocky-core/src/traits.rs` — `ExecutionStats.{bytes_scanned, bytes_written}` (internal adapter-trait type; rustdoc only)
- `engine/crates/rocky-core/src/state.rs` — `ModelExecution.{bytes_scanned, bytes_written}` (persisted mirror; rustdoc only)
- `engine/crates/rocky-cli/src/output.rs`:
  - `MaterializationOutput.{bytes_scanned, bytes_written}` — cascades to `run.*`
  - `ReplayModelOutput.{bytes_scanned, bytes_written}` — cascades to `replay.*`
  - `TraceModelEntry.{bytes_scanned, bytes_written}` — cascades to `trace.*`
  - `PerModelCostHistorical.{bytes_scanned, bytes_written}` — cascades to `cost.*`

**Generated (4 commands × 3 surfaces = 12 files):** `schemas/{run,replay,trace,cost}.schema.json`, `integrations/dagster/src/dagster_rocky/types_generated/{run,replay,trace,cost}_schema.py`, `editors/vscode/src/types/generated/{run,replay,trace,cost}.ts`.

## Test plan

- [x] `cargo test --workspace` — green (doc-only change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `uv run pytest` in `integrations/dagster/` — 312 passed
- [x] `npm run compile` in `editors/vscode/` — clean
- [x] `just regen-fixtures` — no fixture diff (byte-stable; descriptions live in the schema, not the emitted payload)
- [x] Spot-checked that the "Bytes billed" / "Bytes processed" phrase appears in all 4 target schemas + 4 Pydantic files + 4 TS files

## Notes

- Zero behavior change. Only rustdoc + the expected codegen cascade.
- Wording is adapter-state-neutral (e.g. "Databricks: when populated, byte count from the statement-execution manifest; `None` today until the manifest plumbing lands"), so it stays correct whether the in-flight Databricks `bytes_scanned` override lands before or after this PR.