### PR TITLE
feat(integrations/dagster): wave 1 — Pipes execution mode + strict doctor on startup

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -271,6 +271,39 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     sensor_granularity: Literal["per_source", "per_group"] = "per_source"
     #: Minimum interval between sensor evaluations in seconds.
     sensor_interval_seconds: int = 300
+    #: Execution mode for the component-backed multi-asset.
+    #:
+    #: * ``"streaming"`` (default) — each ``rocky run`` invocation is
+    #:   buffered by :meth:`RockyResource.run_streaming`, and the
+    #:   component's own ``_emit_results`` translates Rocky's JSON output
+    #:   into Dagster events (materializations, checks, drift
+    #:   observations, anomalies, contract results). Preserves the
+    #:   historical behaviour so upgrading is a no-op.
+    #: * ``"pipes"`` — each ``rocky run`` invocation goes through the
+    #:   Dagster Pipes protocol via :meth:`RockyResource.run_pipes`. The
+    #:   engine emits structured materialization / check events directly
+    #:   over the Pipes wire, and the run viewer's
+    #:   ``MaterializationEvent`` / ``AssetCheckEvaluation`` entries come
+    #:   from the engine rather than from JSON post-processing. Asset-key
+    #:   translation and subset filtering happen at the reader layer via
+    #:   :class:`RockyPipesMessageReader`, so engine-native paths
+    #:   (``[source_type, *components, table]``) resolve to the
+    #:   Dagster-translated keys this component declares. The buffered
+    #:   ``_emit_results`` pass is skipped in this mode — Pipes is the
+    #:   single source of truth for run events, so running both would
+    #:   double-emit.
+    execution_mode: Literal["streaming", "pipes"] = "streaming"
+    #: When ``True``, run ``rocky doctor`` at resource startup and fail
+    #: fast on critical checks. Forwarded to
+    #: :attr:`RockyResource.strict_doctor`. Default ``False`` preserves
+    #: the tolerant behaviour of earlier releases — doctor is not
+    #: invoked on startup.
+    strict_doctor: bool = False
+    #: Per-check allowlist for the strict doctor gate. Forwarded to
+    #: :attr:`RockyResource.strict_doctor_checks`. Empty (default) +
+    #: ``strict_doctor=True`` means fail on any critical check;
+    #: non-empty scopes the fail-fast gate to just those check names.
+    strict_doctor_checks: list[str] = []
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -290,6 +323,8 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             state_path=self.state_path,
             models_dir=self.models_dir,
             contracts_dir=self.contracts_dir,
+            strict_doctor=self.strict_doctor,
+            strict_doctor_checks=self.strict_doctor_checks,
         )
 
     def _get_translator(self) -> RockyDagsterTranslator:
@@ -502,6 +537,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 rocky=rocky,
                 compile_state=compile_state,
                 contract_rules_by_model=contract_rules_by_model,
+                execution_mode=self.execution_mode,
             )
             for group in groups
         ]
@@ -920,12 +956,23 @@ def _make_rocky_asset(
     rocky: RockyResource,
     compile_state: _CompileState,
     contract_rules_by_model: dict[str, ContractRules] | None = None,
+    execution_mode: Literal["streaming", "pipes"] = "streaming",
 ) -> dg.AssetsDefinition:
     """Create a multi-asset that executes ``rocky run`` for one group.
 
     Subset-aware: when Dagster selects only some of the group's assets,
     we run ``--filter id=<source_id>`` per selected source instead of the
     full group filter.
+
+    Two execution modes, controlled by ``execution_mode``:
+
+    * ``"streaming"`` — Rocky's JSON output is post-processed by
+      :func:`_emit_results` to produce Dagster events.
+    * ``"pipes"`` — Rocky emits Dagster events directly over the Pipes
+      protocol; the buffered ``_emit_results`` pass is skipped.
+      Contract check results remain sourced from compile diagnostics in
+      both modes because those are a build-time signal, not a run-time
+      signal.
     """
     contract_rules_by_model = contract_rules_by_model or {}
 
@@ -940,26 +987,38 @@ def _make_rocky_asset(
 
         selected_keys = set(context.selected_asset_keys)
         filters = _select_filters(group, selected_keys, context)
-        results = _run_filters(context, rocky, filters)
 
-        if len(filters) > 1:
-            context.log.info(
-                f"Total across {len(filters)} sources: "
-                f"{sum(r.tables_copied for r in results)} tables in "
-                f"{sum(r.duration_ms for r in results)}ms"
+        if execution_mode == "pipes":
+            yield from _run_filters_pipes(
+                context=context,
+                rocky=rocky,
+                filters=filters,
+                group=group,
+                selected_keys=selected_keys,
             )
+        else:
+            results = _run_filters(context, rocky, filters)
 
-        yield from _emit_results(
-            results=results,
-            check_specs=check_specs,
-            selected_keys=selected_keys,
-            rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
-        )
+            if len(filters) > 1:
+                context.log.info(
+                    f"Total across {len(filters)} sources: "
+                    f"{sum(r.tables_copied for r in results)} tables in "
+                    f"{sum(r.duration_ms for r in results)}ms"
+                )
+
+            yield from _emit_results(
+                results=results,
+                check_specs=check_specs,
+                selected_keys=selected_keys,
+                rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
+            )
 
         # Contract check results — sourced from compile diagnostics, not
         # from the run. Each declared contract spec gets exactly one
         # result (pass/fail) per materialization. Specs without
-        # corresponding rule entries are skipped.
+        # corresponding rule entries are skipped. Emitted in both modes
+        # because compile diagnostics are a build-time signal Pipes
+        # doesn't carry.
         if contract_rules_by_model:
             yield from _emit_contract_check_results(
                 group=group,
@@ -969,6 +1028,51 @@ def _make_rocky_asset(
             )
 
     return _asset
+
+
+def _run_filters_pipes(
+    *,
+    context: dg.AssetExecutionContext,
+    rocky: RockyResource,
+    filters: list[str],
+    group: _GroupBuild,
+    selected_keys: set[dg.AssetKey],
+) -> Iterator[object]:
+    """Execute ``rocky run`` for each filter over the Dagster Pipes protocol.
+
+    Invokes :meth:`RockyResource.run_pipes` per filter with the group's
+    ``rocky_key_to_dagster_key`` lookup plumbed as ``asset_key_fn`` so the
+    engine-native paths in Pipes events resolve to the Dagster keys this
+    component declared. ``include_keys`` is plumbed too so events for
+    unselected tables are dropped at the reader layer — Rocky runs at
+    source granularity even on partial subsets, so without the filter
+    the run viewer would show events for tables the user didn't request.
+    """
+    rocky_key_to_dagster_key = group.rocky_key_to_dagster_key
+
+    def asset_key_fn(path: list[str]) -> dg.AssetKey | None:
+        # Exact tuple match — engine and component agree on the shape
+        # (``[source_type, *components, table]``). Fall through to the
+        # last-segment match for drift events, whose ``asset_key`` is
+        # just the source-side table identifier.
+        key = rocky_key_to_dagster_key.get(tuple(path))
+        if key is not None:
+            return key
+        last = path[-1]
+        for tup, candidate in rocky_key_to_dagster_key.items():
+            if tup and tup[-1] == last:
+                return candidate
+        return None
+
+    for f in filters:
+        context.log.info(f"Executing (pipes): rocky run --filter {f}")
+        invocation = rocky.run_pipes(
+            context,
+            filter=f,
+            asset_key_fn=asset_key_fn,
+            include_keys=selected_keys,
+        )
+        yield from invocation.get_results()
 
 
 def _emit_contract_check_results(

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -35,7 +35,7 @@ import dagster as dg
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 from .types import (
     AiExplainResult,
@@ -207,6 +207,162 @@ def _accumulate_stdout(stdout: IO[str] | None, sink: list[str]) -> None:
         _log.warning("rocky stdout accumulator terminated: %s", exc)
 
 
+class RockyPipesMessageReader(dg.PipesTempFileMessageReader):
+    """Pipes message reader that translates + filters Rocky asset keys in flight.
+
+    The Rocky CLI emits Pipes messages with asset keys keyed by the
+    engine's native ``[source_type, *components, table]`` path (see
+    ``engine/crates/rocky-cli/src/commands/run.rs::emit_pipes_events``),
+    slash-joined per the Dagster wire convention. That is the correct
+    shape for a direct ``@dg.asset`` callsite that picks matching
+    keys, but :class:`RockyComponent` remaps those paths to Dagster
+    asset keys via :class:`RockyDagsterTranslator` before declaring
+    the multi-asset.
+
+    Without this reader the Pipes path would deliver materialization /
+    check events on keys Dagster's asset graph doesn't recognise, so
+    the run viewer would show "unexpected asset key" errors or drop
+    events silently. Intercepting in the reader lets us rewrite keys
+    and drop events for tables outside the selected subset *before*
+    the events reach Dagster's handler — so nothing leaks through and
+    nothing races.
+
+    The interception point is :meth:`handle_message` on the handler
+    wrapper we hand to :class:`PipesFileMessageReader._reader_thread`.
+    Subclassing :class:`PipesTempFileMessageReader` is a small private
+    API dependency (the reader-thread hook is prefixed with an
+    underscore in Dagster); if that contract ever changes, the
+    dagster bump check in CI will surface it before release.
+
+    Two transformations happen on each message:
+
+    1. ``asset_key_fn`` rewrites the wire ``asset_key`` string. It
+       receives the slash-split path (``list[str]``) — the exact tuple
+       the engine emits — and returns a :class:`dagster.AssetKey` or
+       ``None``. Returning ``None`` drops the event (the key isn't
+       known to this component).
+    2. ``include_keys`` filters on the *resolved* :class:`AssetKey`.
+       Events whose resolved key isn't in the set are dropped.
+
+    Both hooks are optional — the default reader is the unmodified
+    file-based tempfile reader.
+    """
+
+    def __init__(
+        self,
+        *,
+        asset_key_fn: Callable[[list[str]], dg.AssetKey | None] | None = None,
+        include_keys: set[dg.AssetKey] | None = None,
+        include_stdio_in_messages: bool = False,
+    ) -> None:
+        super().__init__(include_stdio_in_messages=include_stdio_in_messages)
+        self._asset_key_fn = asset_key_fn
+        self._include_keys = include_keys
+
+    @contextlib.contextmanager
+    def read_messages(self, handler):  # type: ignore[override]
+        """Wrap the upstream handler with a filter + asset-key rewriter.
+
+        We build a tiny proxy whose ``handle_message`` inspects each
+        Pipes envelope, transforms the ``asset_key`` where applicable,
+        then either forwards it to the real handler or drops it. Every
+        other method is delegated to the underlying handler so the
+        upstream reader thread sees the full interface (opened /
+        closed counts, framework exception reporting, etc.).
+        """
+        proxy = _PipesHandlerProxy(
+            handler,
+            asset_key_fn=self._asset_key_fn,
+            include_keys=self._include_keys,
+        )
+        with super().read_messages(proxy) as params:
+            yield params
+
+
+class _PipesHandlerProxy:
+    """Duck-typed handler wrapper that filters Rocky Pipes messages.
+
+    Kept private: this wraps a single call site —
+    :meth:`PipesFileMessageReader._reader_thread` invoking
+    ``handler.handle_message(message)``. Every other attribute is
+    forwarded unchanged via :meth:`__getattr__` so the reader thread's
+    exception-reporting helpers still work.
+    """
+
+    # Messages whose ``params`` dict carries an asset key. Other
+    # messages (``opened``, ``closed``, ``log``, ``log_external_stream``,
+    # ``report_custom_message``) pass through untouched.
+    _ASSET_KEYED_METHODS = frozenset(("report_asset_materialization", "report_asset_check"))
+
+    def __init__(
+        self,
+        inner,
+        *,
+        asset_key_fn: Callable[[list[str]], dg.AssetKey | None] | None,
+        include_keys: set[dg.AssetKey] | None,
+    ) -> None:
+        self._inner = inner
+        self._asset_key_fn = asset_key_fn
+        self._include_keys = include_keys
+
+    def handle_message(self, message) -> None:
+        method = message.get("method")
+        if method in self._ASSET_KEYED_METHODS:
+            transformed = self._transform_asset_key(message)
+            if transformed is None:
+                # Event dropped (either asset_key_fn rejected it or the
+                # resolved key isn't in include_keys). Silent by design
+                # — Rocky always runs at source granularity so emitting
+                # a log per dropped event would flood on any partial
+                # subset run.
+                return
+            message = transformed
+
+        self._inner.handle_message(message)
+
+    def _transform_asset_key(self, message):
+        params = message.get("params") or {}
+        raw_key = params.get("asset_key")
+        if not isinstance(raw_key, str) or not raw_key:
+            # Defensive — let the inner handler raise if the envelope
+            # is malformed. We only transform well-formed wire values.
+            return message
+
+        path = raw_key.split("/")
+
+        if self._asset_key_fn is not None:
+            resolved = self._asset_key_fn(path)
+            if resolved is None:
+                return None
+            # Dagster expects slash-escaped user strings on the wire
+            # (the handler calls AssetKey.from_escaped_user_string).
+            new_key_str = resolved.to_user_string()
+        else:
+            resolved = dg.AssetKey(path)
+            new_key_str = raw_key
+
+        if self._include_keys is not None and resolved not in self._include_keys:
+            return None
+
+        # Only rebuild the envelope when we actually changed the key —
+        # otherwise the inner handler's check.str_param is happy with
+        # the original dict.
+        if new_key_str == raw_key:
+            return message
+
+        new_params = dict(params)
+        new_params["asset_key"] = new_key_str
+        new_message = dict(message)
+        new_message["params"] = new_params
+        return new_message
+
+    def __getattr__(self, name):
+        # Forward every attribute we don't handle explicitly — the
+        # upstream reader needs report_pipes_framework_exception,
+        # on_launched, properties, and internal state.
+        return getattr(self._inner, name)
+
+
 def _kill_process_group(proc: subprocess.Popen[str]) -> None:
     """Terminate ``proc`` and any children via its POSIX process group.
 
@@ -256,9 +412,126 @@ class RockyResource(dg.ConfigurableResource):
     contracts_dir: str | None = None
     server_url: str | None = None
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    #: Run ``rocky doctor`` at resource startup and gate execution on
+    #: the result. Defaults to ``False`` — doctor is *not* invoked, and
+    #: startup cost stays zero for users who don't opt in. When
+    #: ``True``, :meth:`setup_for_execution` runs doctor once per
+    #: resource initialization and may raise :class:`dagster.Failure`
+    #: based on :attr:`strict_doctor_checks`.
+    strict_doctor: bool = False
+    #: Per-check allowlist for the strict doctor gate. Only meaningful
+    #: when :attr:`strict_doctor` is ``True``.
+    #:
+    #: * Empty list (default) — fail on *any* critical check. The
+    #:   fail-fast-on-anything-critical shape.
+    #: * Non-empty — fail only when a critical check whose ``name``
+    #:   appears in this list fires. Critical checks outside the list
+    #:   are logged as warnings so operators still see them.
+    #:
+    #: Non-critical severities (``healthy``, ``warning``) never raise
+    #: regardless of this list — warnings are logged at ``warning``
+    #: level. A failure here blocks the Dagster run from launching
+    #: rather than producing a mid-run error.
+    strict_doctor_checks: list[str] = []
 
     # Instance-level cache for the version check (not a Dagster config field).
     _version_checked: bool = False
+
+    # ------------------------------------------------------------------ #
+    # Startup hook — opt-in strict rocky doctor gate                     #
+    # ------------------------------------------------------------------ #
+
+    def setup_for_execution(self, context: dg.InitResourceContext) -> None:
+        """Run the optional :meth:`rocky doctor` startup gate.
+
+        Invoked by Dagster once per resource initialization before any
+        asset / op body executes. When :attr:`strict_doctor` is
+        ``False`` (the default) this is a cheap no-op — we skip the
+        subprocess entirely to keep cold-start overhead zero for users
+        who don't opt in.
+
+        When enabled, ``rocky doctor`` runs and its result is triaged:
+
+        * Non-critical severities (``healthy``, ``warning``) are never
+          failed on. Warnings are logged at ``warning`` so operators
+          still see them.
+        * Critical checks in :attr:`strict_doctor_checks` (or *all*
+          critical checks when the list is empty) raise a
+          :class:`dagster.Failure`, preventing the run from starting.
+        * Critical checks *outside* the allowlist are logged at
+          ``warning`` so they're visible without being fatal — this is
+          the point of per-check strictness.
+
+        The binary itself failing (missing, timeout, malformed JSON)
+        also raises :class:`dagster.Failure`: when the user has opted
+        into a strict gate, "couldn't run doctor" is more aligned with
+        fail-fast than "silently pretend everything's fine."
+        """
+        if not self.strict_doctor:
+            return
+
+        log = context.log if context is not None and context.log is not None else _log
+
+        try:
+            report = self.doctor()
+        except dg.Failure as exc:
+            # User opted in to strict doctor but the binary can't run —
+            # the whole point of this hook is to fail fast on
+            # infrastructure problems, so surface the failure.
+            description = str(exc.description or exc)
+            raise dg.Failure(
+                description=(
+                    "rocky doctor could not execute during RockyResource startup "
+                    f"(strict_doctor=True, checks={self.strict_doctor_checks!r}): "
+                    f"{description}"
+                ),
+            ) from exc
+
+        log.info(
+            f"rocky doctor: overall={report.overall}, {len(report.checks)} check(s) "
+            f"(strict_doctor=True, checks={self.strict_doctor_checks!r})"
+        )
+
+        strict_failures: list[str] = []
+        warn_failures: list[str] = []
+        for check in report.checks:
+            status = check.status.value if hasattr(check.status, "value") else str(check.status)
+            if status.lower() != "critical":
+                # healthy / warning — surface warnings but never fail.
+                if status.lower() == "warning":
+                    log.warning(f"rocky doctor [{check.name}]: {check.message}")
+                continue
+
+            if self._is_strict_check(check.name):
+                strict_failures.append(f"{check.name}: {check.message}")
+            else:
+                warn_failures.append(f"{check.name}: {check.message}")
+                log.warning(f"rocky doctor [{check.name}] critical (non-strict): {check.message}")
+
+        if strict_failures:
+            raise dg.Failure(
+                description=(
+                    "rocky doctor reported critical issues on strict checks: "
+                    + "; ".join(strict_failures)
+                ),
+                metadata={
+                    "strict_failures": dg.MetadataValue.text("\n".join(strict_failures)),
+                    "non_strict_warnings": dg.MetadataValue.text(
+                        "\n".join(warn_failures) if warn_failures else "(none)"
+                    ),
+                    "strict_doctor_checks": dg.MetadataValue.text(repr(self.strict_doctor_checks)),
+                },
+            )
+
+    def _is_strict_check(self, check_name: str) -> bool:
+        """Return ``True`` when ``check_name`` is treated as strict.
+
+        * Empty allowlist → every critical check is strict (fail-on-any).
+        * Non-empty → only listed names are strict.
+        """
+        if not self.strict_doctor_checks:
+            return True
+        return check_name in self.strict_doctor_checks
 
     # ------------------------------------------------------------------ #
     # Version compatibility check                                        #
@@ -858,6 +1131,8 @@ class RockyResource(dg.ConfigurableResource):
         parallel: int | None = None,
         shadow_suffix: str | None = None,
         pipes_client: dg.PipesSubprocessClient | None = None,
+        asset_key_fn: Callable[[list[str]], dg.AssetKey | None] | None = None,
+        include_keys: set[dg.AssetKey] | None = None,
     ) -> dg.PipesClientCompletedInvocation:
         """Full Dagster Pipes execution: structured events streamed via the protocol.
 
@@ -907,8 +1182,24 @@ class RockyResource(dg.ConfigurableResource):
             pipes_client: Optional pre-configured
                 ``PipesSubprocessClient`` (for tests or for users who
                 need custom env / cwd / message_reader / context_injector).
-                When ``None``, a fresh client is constructed with
-                Dagster defaults.
+                When supplied, ``asset_key_fn`` / ``include_keys`` are
+                ignored — the caller's client wins. When ``None``, a
+                fresh client is constructed with Dagster defaults, plus
+                a :class:`RockyPipesMessageReader` when either
+                ``asset_key_fn`` or ``include_keys`` is non-``None``.
+            asset_key_fn: Optional transform applied to each Pipes
+                event's asset key at the reader layer. The function
+                receives the slash-split path the engine emits (a
+                ``[source_type, *components, table]`` list) and returns
+                a :class:`dagster.AssetKey` — or ``None`` to drop the
+                event. Used by :class:`RockyComponent` to translate
+                engine-native paths into Dagster-translated keys before
+                they reach the handler.
+            include_keys: Optional allowlist of Dagster asset keys.
+                Events whose resolved key is not in the set are dropped
+                before reaching Dagster's materialization bookkeeping.
+                Intended for subset-aware multi-assets that must ignore
+                events for tables outside the requested subset.
 
         Returns:
             A :class:`PipesClientCompletedInvocation` ready for
@@ -932,7 +1223,21 @@ class RockyResource(dg.ConfigurableResource):
             parallel=parallel,
             shadow_suffix=shadow_suffix,
         )
-        client = pipes_client or dg.PipesSubprocessClient()
+        if pipes_client is not None:
+            client = pipes_client
+        elif asset_key_fn is not None or include_keys is not None:
+            # Custom reader only when the caller actually asked for
+            # translation / filtering — keeps the default path identical
+            # to canonical Dagster Pipes and avoids regressions for
+            # users who don't use :class:`RockyComponent`.
+            client = dg.PipesSubprocessClient(
+                message_reader=RockyPipesMessageReader(
+                    asset_key_fn=asset_key_fn,
+                    include_keys=include_keys,
+                ),
+            )
+        else:
+            client = dg.PipesSubprocessClient()
         return client.run(
             context=context,
             command=self._build_cmd(args),

--- a/integrations/dagster/src/dagster_rocky/scaffold.py
+++ b/integrations/dagster/src/dagster_rocky/scaffold.py
@@ -44,6 +44,24 @@ attributes:
   binary_path: rocky
   config_path: rocky.toml
   models_dir: models
+
+  # execution_mode: streaming (default) | pipes
+  #   "streaming" — rocky stderr forwards to context.log, Dagster events
+  #                 are built from rocky's JSON output.
+  #   "pipes"     — Dagster Pipes protocol; rocky emits MaterializationEvent /
+  #                 AssetCheckEvaluation directly over the wire.
+  # execution_mode: streaming
+
+  # strict_doctor (bool, default false) + strict_doctor_checks (list[str], default [])
+  #   When strict_doctor is true, runs `rocky doctor` at startup and fails
+  #   fast on critical checks. strict_doctor_checks scopes the gate:
+  #     []                    → fail on any critical check
+  #     [state_rw, auth, ...] → fail only on the listed critical checks;
+  #                             others are logged as warnings.
+  #   Default (false + []) preserves the tolerant behaviour — doctor is
+  #   not run on startup.
+  # strict_doctor: false
+  # strict_doctor_checks: []
 """
 
 #: Starter ``rocky.toml`` using the DuckDB local-execution adapter so the

--- a/integrations/dagster/tests/test_pipes_mode.py
+++ b/integrations/dagster/tests/test_pipes_mode.py
@@ -233,7 +233,7 @@ def test_run_pipes_injects_custom_reader_when_asset_key_fn_is_set():
         rocky.run_pipes(
             context,
             filter="tenant=acme",
-            asset_key_fn=lambda path: dg.AssetKey(path),
+            asset_key_fn=dg.AssetKey,
         )
 
     # The client was constructed with a message_reader kwarg.
@@ -287,7 +287,7 @@ def test_run_pipes_caller_supplied_client_wins_over_translation_kwargs():
         rocky.run_pipes(
             context,
             filter="tenant=acme",
-            asset_key_fn=lambda path: dg.AssetKey(path),
+            asset_key_fn=dg.AssetKey,
             pipes_client=fake_client,
         )
     # Our branch should never have constructed a default client.

--- a/integrations/dagster/tests/test_pipes_mode.py
+++ b/integrations/dagster/tests/test_pipes_mode.py
@@ -1,0 +1,426 @@
+"""Tests for the ``execution_mode="pipes"`` path on ``RockyComponent``.
+
+Exercises:
+
+* The default ``"streaming"`` mode is unchanged (regression coverage
+  for existing users).
+* Opting in to ``"pipes"`` routes every filter through
+  :meth:`RockyResource.run_pipes` with an ``asset_key_fn`` mapping
+  engine-native paths to the component's declared Dagster keys and
+  ``include_keys`` set to the subset selection.
+* :class:`RockyPipesMessageReader` applies ``asset_key_fn`` to each
+  Pipes event at the handler layer.
+* :class:`RockyPipesMessageReader` drops events whose resolved key is
+  not in ``include_keys``.
+* Messages without an ``asset_key`` (``log``, ``opened``, ``closed``)
+  pass through unchanged.
+* Malformed messages fall through so the inner handler's
+  ``report_pipes_framework_exception`` path fires.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import dagster as dg
+
+from dagster_rocky.resource import (
+    RockyPipesMessageReader,
+    RockyResource,
+    _PipesHandlerProxy,
+)
+
+# ---------------------------------------------------------------------------
+# RockyPipesMessageReader — asset-key translation and filtering
+# ---------------------------------------------------------------------------
+
+
+def _materialization_msg(asset_key: str) -> dict:
+    return {
+        "__dagster_pipes_version": "0.1",
+        "method": "report_asset_materialization",
+        "params": {
+            "asset_key": asset_key,
+            "metadata": {"rows_copied": 10},
+            "data_version": None,
+        },
+    }
+
+
+def _check_msg(asset_key: str, check_name: str = "row_count") -> dict:
+    return {
+        "__dagster_pipes_version": "0.1",
+        "method": "report_asset_check",
+        "params": {
+            "asset_key": asset_key,
+            "check_name": check_name,
+            "passed": True,
+            "severity": "ERROR",
+            "metadata": {},
+        },
+    }
+
+
+def test_handler_proxy_translates_asset_key_to_dagster_key():
+    """asset_key_fn receives the slash-split path and its result is written back."""
+    inner = MagicMock()
+    translated = dg.AssetKey(["warehouse", "raw", "orders"])
+
+    def asset_key_fn(path: list[str]) -> dg.AssetKey | None:
+        assert path == ["fivetran", "acme", "orders"]
+        return translated
+
+    proxy = _PipesHandlerProxy(inner, asset_key_fn=asset_key_fn, include_keys=None)
+    proxy.handle_message(_materialization_msg("fivetran/acme/orders"))
+
+    inner.handle_message.assert_called_once()
+    forwarded = inner.handle_message.call_args.args[0]
+    # The wire format uses Dagster's escaped user string — slash-separated.
+    assert forwarded["params"]["asset_key"] == translated.to_user_string()
+
+
+def test_handler_proxy_drops_events_when_asset_key_fn_returns_none():
+    """asset_key_fn returning None means the event is filtered at source."""
+    inner = MagicMock()
+    proxy = _PipesHandlerProxy(
+        inner,
+        asset_key_fn=lambda _path: None,
+        include_keys=None,
+    )
+    proxy.handle_message(_materialization_msg("fivetran/unknown/table"))
+    inner.handle_message.assert_not_called()
+
+
+def test_handler_proxy_drops_events_not_in_include_keys():
+    """include_keys filter is applied on the resolved AssetKey."""
+    inner = MagicMock()
+    selected = dg.AssetKey(["warehouse", "selected"])
+    other = dg.AssetKey(["warehouse", "not_selected"])
+
+    def asset_key_fn(path: list[str]) -> dg.AssetKey:
+        # Map the last segment to distinct keys so we can test the filter.
+        return other if path[-1] == "not_selected" else selected
+
+    proxy = _PipesHandlerProxy(
+        inner,
+        asset_key_fn=asset_key_fn,
+        include_keys={selected},
+    )
+    proxy.handle_message(_materialization_msg("fivetran/group/selected"))
+    proxy.handle_message(_materialization_msg("fivetran/group/not_selected"))
+
+    # Only the selected key should have reached the inner handler.
+    assert inner.handle_message.call_count == 1
+    msg = inner.handle_message.call_args.args[0]
+    assert msg["params"]["asset_key"] == selected.to_user_string()
+
+
+def test_handler_proxy_applies_translation_to_check_events_too():
+    """report_asset_check messages are translated just like materializations."""
+    inner = MagicMock()
+    translated = dg.AssetKey(["warehouse", "raw", "orders"])
+
+    proxy = _PipesHandlerProxy(
+        inner,
+        asset_key_fn=lambda _path: translated,
+        include_keys=None,
+    )
+    proxy.handle_message(_check_msg("fivetran/acme/orders"))
+
+    forwarded = inner.handle_message.call_args.args[0]
+    assert forwarded["method"] == "report_asset_check"
+    assert forwarded["params"]["asset_key"] == translated.to_user_string()
+    assert forwarded["params"]["check_name"] == "row_count"
+
+
+def test_handler_proxy_passes_non_asset_messages_through_unchanged():
+    """log / opened / closed messages must not trigger any transformation."""
+    inner = MagicMock()
+    proxy = _PipesHandlerProxy(
+        inner,
+        asset_key_fn=lambda _path: dg.AssetKey(["never", "called"]),
+        include_keys=set(),  # would filter everything if applied
+    )
+
+    log_msg = {
+        "__dagster_pipes_version": "0.1",
+        "method": "log",
+        "params": {"message": "hello", "level": "info"},
+    }
+    opened_msg = {
+        "__dagster_pipes_version": "0.1",
+        "method": "opened",
+        "params": {},
+    }
+    closed_msg = {
+        "__dagster_pipes_version": "0.1",
+        "method": "closed",
+        "params": None,
+    }
+    for msg in (log_msg, opened_msg, closed_msg):
+        proxy.handle_message(msg)
+
+    # All three reached the inner handler untouched.
+    assert inner.handle_message.call_count == 3
+    forwarded = [c.args[0] for c in inner.handle_message.call_args_list]
+    assert forwarded == [log_msg, opened_msg, closed_msg]
+
+
+def test_handler_proxy_forwards_malformed_asset_key_for_inner_validation():
+    """A non-string asset_key is forwarded so the inner handler can raise."""
+    inner = MagicMock()
+    proxy = _PipesHandlerProxy(inner, asset_key_fn=None, include_keys=None)
+
+    bad_msg = {
+        "__dagster_pipes_version": "0.1",
+        "method": "report_asset_materialization",
+        "params": {"asset_key": None, "metadata": {}, "data_version": None},
+    }
+    proxy.handle_message(bad_msg)
+    # Inner handler still receives the payload so it can validate/raise.
+    inner.handle_message.assert_called_once_with(bad_msg)
+
+
+def test_handler_proxy_forwards_framework_exception_reports_via_getattr():
+    """The upstream reader's bare-except path calls
+    ``handler.report_pipes_framework_exception`` — verify that attribute
+    access on our proxy reaches the real inner handler."""
+    inner = MagicMock()
+    inner.report_pipes_framework_exception = MagicMock()
+    proxy = _PipesHandlerProxy(inner, asset_key_fn=None, include_keys=None)
+
+    # Access the attribute via normal Python — the same way the reader
+    # thread does when a malformed line raises inside `handle_message`.
+    proxy.report_pipes_framework_exception("some-origin", ("e", "info"))
+    inner.report_pipes_framework_exception.assert_called_once_with("some-origin", ("e", "info"))
+
+
+# ---------------------------------------------------------------------------
+# RockyPipesMessageReader — smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_rocky_pipes_message_reader_wraps_handler_with_proxy():
+    """`read_messages` should wrap the supplied handler in our proxy
+    before delegating to the upstream tempfile reader."""
+    reader = RockyPipesMessageReader(
+        asset_key_fn=lambda _path: dg.AssetKey(["x"]),
+        include_keys=None,
+    )
+    inner_handler = MagicMock()
+
+    # The upstream tempfile reader spins up a thread and temp file; we
+    # only need to confirm that our contextmanager runs and yields
+    # params. Using the context briefly is enough.
+    with reader.read_messages(inner_handler) as params:
+        assert isinstance(params, dict)
+
+
+# ---------------------------------------------------------------------------
+# RockyResource.run_pipes — kwarg plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipes_injects_custom_reader_when_asset_key_fn_is_set():
+    """Supplying asset_key_fn triggers a RockyPipesMessageReader in the client."""
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+
+    with patch("dagster_rocky.resource.dg.PipesSubprocessClient") as client_cls:
+        instance = client_cls.return_value
+        instance.run = MagicMock(return_value=MagicMock())
+
+        rocky.run_pipes(
+            context,
+            filter="tenant=acme",
+            asset_key_fn=lambda path: dg.AssetKey(path),
+        )
+
+    # The client was constructed with a message_reader kwarg.
+    _, kwargs = client_cls.call_args
+    assert "message_reader" in kwargs
+    assert isinstance(kwargs["message_reader"], RockyPipesMessageReader)
+
+
+def test_run_pipes_injects_custom_reader_when_include_keys_is_set():
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+
+    with patch("dagster_rocky.resource.dg.PipesSubprocessClient") as client_cls:
+        instance = client_cls.return_value
+        instance.run = MagicMock(return_value=MagicMock())
+
+        rocky.run_pipes(
+            context,
+            filter="tenant=acme",
+            include_keys={dg.AssetKey(["warehouse", "raw", "orders"])},
+        )
+
+    _, kwargs = client_cls.call_args
+    assert "message_reader" in kwargs
+    assert isinstance(kwargs["message_reader"], RockyPipesMessageReader)
+
+
+def test_run_pipes_uses_default_client_when_no_translation_kwargs():
+    """The default Pipes path stays pristine — no custom reader unless asked."""
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+
+    with patch("dagster_rocky.resource.dg.PipesSubprocessClient") as client_cls:
+        instance = client_cls.return_value
+        instance.run = MagicMock(return_value=MagicMock())
+
+        rocky.run_pipes(context, filter="tenant=acme")
+
+    # The default construction takes no kwargs — same as the pre-FR-001 path.
+    client_cls.assert_called_once_with()
+
+
+def test_run_pipes_caller_supplied_client_wins_over_translation_kwargs():
+    """When a caller provides their own client, it takes precedence."""
+    rocky = RockyResource()
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+
+    with patch("dagster_rocky.resource.dg.PipesSubprocessClient") as client_cls:
+        rocky.run_pipes(
+            context,
+            filter="tenant=acme",
+            asset_key_fn=lambda path: dg.AssetKey(path),
+            pipes_client=fake_client,
+        )
+    # Our branch should never have constructed a default client.
+    client_cls.assert_not_called()
+    fake_client.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# RockyComponent execution_mode — streaming (default) vs pipes
+# ---------------------------------------------------------------------------
+
+
+def test_component_default_execution_mode_is_streaming():
+    """Backwards compatibility: existing users get the unchanged streaming path."""
+    from dagster_rocky.component import RockyComponent
+
+    component = RockyComponent()
+    assert component.execution_mode == "streaming"
+
+
+def test_component_accepts_pipes_execution_mode():
+    from dagster_rocky.component import RockyComponent
+
+    component = RockyComponent(execution_mode="pipes")
+    assert component.execution_mode == "pipes"
+
+
+def test_run_filters_pipes_builds_asset_key_fn_from_group_mapping():
+    """The pipes branch threads the group's rocky_key_to_dagster_key map
+    into ``asset_key_fn`` so engine-native paths resolve to declared keys."""
+    from dagster_rocky.component import _GroupBuild, _run_filters_pipes
+
+    rocky_path = ("fivetran", "acme", "orders")
+    dagster_key = dg.AssetKey(["warehouse", "acme", "orders"])
+    group = _GroupBuild(
+        name="acme",
+        source_ids={"acme_fivetran"},
+        filter="client=acme",
+        rocky_key_to_dagster_key={rocky_path: dagster_key},
+    )
+
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    rocky = MagicMock(spec=RockyResource)
+    fake_invocation = MagicMock()
+    fake_invocation.get_results = MagicMock(return_value=iter([]))
+    rocky.run_pipes = MagicMock(return_value=fake_invocation)
+
+    selected = {dagster_key}
+    list(
+        _run_filters_pipes(
+            context=context,
+            rocky=rocky,
+            filters=["client=acme"],
+            group=group,
+            selected_keys=selected,
+        )
+    )
+
+    rocky.run_pipes.assert_called_once()
+    kwargs = rocky.run_pipes.call_args.kwargs
+    assert kwargs["filter"] == "client=acme"
+    assert kwargs["include_keys"] is selected
+
+    # The asset_key_fn must resolve the engine path to the declared key,
+    # and return None for unknown paths.
+    fn = kwargs["asset_key_fn"]
+    assert fn(list(rocky_path)) == dagster_key
+    assert fn(["unknown", "path"]) is None
+
+
+def test_run_filters_pipes_falls_back_to_last_segment_for_drift_events():
+    """Drift events carry a bare table name as asset_key — the component's
+    fn falls back to matching the trailing segment in rocky_key_to_dagster_key."""
+    from dagster_rocky.component import _GroupBuild, _run_filters_pipes
+
+    rocky_path = ("fivetran", "acme", "orders")
+    dagster_key = dg.AssetKey(["warehouse", "acme", "orders"])
+    group = _GroupBuild(
+        name="acme",
+        source_ids={"acme_fivetran"},
+        filter="client=acme",
+        rocky_key_to_dagster_key={rocky_path: dagster_key},
+    )
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    rocky = MagicMock(spec=RockyResource)
+    fake_invocation = MagicMock()
+    fake_invocation.get_results = MagicMock(return_value=iter([]))
+    rocky.run_pipes = MagicMock(return_value=fake_invocation)
+
+    list(
+        _run_filters_pipes(
+            context=context,
+            rocky=rocky,
+            filters=["client=acme"],
+            group=group,
+            selected_keys={dagster_key},
+        )
+    )
+
+    fn = rocky.run_pipes.call_args.kwargs["asset_key_fn"]
+    # Drift event shape: single-element list containing the table name.
+    assert fn(["orders"]) == dagster_key
+
+
+def test_run_filters_pipes_yields_get_results_unchanged():
+    """The asset body yields whatever `.get_results()` produces — the
+    wrapper is pure plumbing, not a transform."""
+    from dagster_rocky.component import _GroupBuild, _run_filters_pipes
+
+    group = _GroupBuild(
+        name="g",
+        source_ids={"s"},
+        filter="client=g",
+        rocky_key_to_dagster_key={},
+    )
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    rocky = MagicMock(spec=RockyResource)
+
+    sentinel_events = [MagicMock(name="event_a"), MagicMock(name="event_b")]
+    fake_invocation = MagicMock()
+    fake_invocation.get_results = MagicMock(return_value=iter(sentinel_events))
+    rocky.run_pipes = MagicMock(return_value=fake_invocation)
+
+    out = list(
+        _run_filters_pipes(
+            context=context,
+            rocky=rocky,
+            filters=["client=g"],
+            group=group,
+            selected_keys=set(),
+        )
+    )
+    assert out == sentinel_events

--- a/integrations/dagster/tests/test_strict_doctor.py
+++ b/integrations/dagster/tests/test_strict_doctor.py
@@ -1,0 +1,286 @@
+"""Tests for the strict ``rocky doctor`` startup gate on RockyResource.
+
+Exercises :meth:`RockyResource.setup_for_execution`, covering:
+
+* Default ``strict_doctor=False`` — no doctor call, no startup cost.
+* ``strict_doctor=True`` + empty ``strict_doctor_checks`` — fail on any
+  critical check ("all").
+* ``strict_doctor=True`` + populated list — fail only on matching
+  critical checks; non-matching criticals surface as warnings.
+* Warning severity never fails (even when the check name is listed).
+* Binary failures (missing rocky, timeout, malformed JSON) raise in
+  strict mode but are inert in tolerant mode.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import dagster as dg
+import pytest
+
+from dagster_rocky.resource import RockyResource
+from dagster_rocky.types import DoctorResult, HealthCheck, HealthStatus
+
+
+def _doctor_result(*pairs: tuple[str, HealthStatus]) -> DoctorResult:
+    """Build a DoctorResult from ``(check_name, status)`` pairs."""
+    return DoctorResult(
+        command="doctor",
+        overall="healthy" if all(s == HealthStatus.healthy for _, s in pairs) else "warning",
+        checks=[
+            HealthCheck(
+                name=name,
+                status=status,
+                message=f"{name} is {status.value}",
+                duration_ms=5,
+            )
+            for name, status in pairs
+        ],
+        suggestions=[],
+    )
+
+
+def _init_context() -> dg.InitResourceContext:
+    """Build a minimal InitResourceContext substitute with a captured log."""
+    log = SimpleNamespace(
+        info=lambda msg: log._events.append(("info", msg)),  # type: ignore[attr-defined]
+        warning=lambda msg: log._events.append(("warning", msg)),  # type: ignore[attr-defined]
+    )
+    log._events = []  # type: ignore[attr-defined]
+    # Only the ``.log`` attribute is touched by setup_for_execution.
+    return SimpleNamespace(log=log)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Disabled-mode path (default) — the zero-cost branch
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_mode_skips_doctor_entirely():
+    """``strict_doctor=False`` (default) must not call doctor at all."""
+    rocky = RockyResource()
+    context = _init_context()
+
+    with patch.object(RockyResource, "doctor") as doctor_mock:
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    doctor_mock.assert_not_called()
+
+
+def test_disabled_mode_survives_broken_binary():
+    """When doctor is disabled, a missing/broken binary does not fail startup."""
+    rocky = RockyResource()
+    context = _init_context()
+
+    # Even if doctor would raise, disabled mode never reaches it.
+    with patch.object(
+        RockyResource,
+        "doctor",
+        side_effect=dg.Failure(description="rocky not found"),
+    ):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Strict + empty list ("all critical") path
+# ---------------------------------------------------------------------------
+
+
+def test_strict_any_critical_fails_on_any_critical():
+    """Empty ``strict_doctor_checks`` means fail on any critical check."""
+    rocky = RockyResource(strict_doctor=True)
+    context = _init_context()
+    report = _doctor_result(
+        ("config_valid", HealthStatus.healthy),
+        ("state_rw", HealthStatus.critical),
+    )
+
+    with (
+        patch.object(RockyResource, "doctor", return_value=report),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    # The failing check name should appear in the description.
+    assert "state_rw" in str(excinfo.value.description)
+
+
+def test_strict_any_critical_passes_when_all_checks_are_healthy():
+    """Empty list + all checks healthy → no failure."""
+    rocky = RockyResource(strict_doctor=True)
+    context = _init_context()
+    report = _doctor_result(
+        ("config_valid", HealthStatus.healthy),
+        ("state_rw", HealthStatus.healthy),
+    )
+
+    with patch.object(RockyResource, "doctor", return_value=report):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Strict + allowlist path
+# ---------------------------------------------------------------------------
+
+
+def test_strict_allowlist_fails_only_on_listed_critical():
+    """Critical check outside the allowlist logs a warning but does not fail."""
+    rocky = RockyResource(strict_doctor=True, strict_doctor_checks=["state_rw"])
+    context = _init_context()
+    report = _doctor_result(
+        ("state_rw", HealthStatus.healthy),
+        ("adapter_connect", HealthStatus.critical),  # NOT in allowlist
+    )
+
+    with patch.object(RockyResource, "doctor", return_value=report):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    # The non-strict critical was surfaced as a warning.
+    events = context.log._events  # type: ignore[attr-defined]
+    warning_msgs = [m for lvl, m in events if lvl == "warning"]
+    assert any("adapter_connect" in m for m in warning_msgs), events
+
+
+def test_strict_allowlist_fails_on_matching_critical():
+    rocky = RockyResource(strict_doctor=True, strict_doctor_checks=["state_rw"])
+    context = _init_context()
+    report = _doctor_result(
+        ("config_valid", HealthStatus.healthy),
+        ("state_rw", HealthStatus.critical),
+    )
+
+    with (
+        patch.object(RockyResource, "doctor", return_value=report),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    assert "state_rw" in str(excinfo.value.description)
+
+
+def test_strict_allowlist_with_mixed_critical_reports_both():
+    """Failure description lists strict failures; metadata lists non-strict warns."""
+    rocky = RockyResource(strict_doctor=True, strict_doctor_checks=["state_rw"])
+    context = _init_context()
+    report = _doctor_result(
+        ("state_rw", HealthStatus.critical),
+        ("adapter_connect", HealthStatus.critical),
+    )
+
+    with (
+        patch.object(RockyResource, "doctor", return_value=report),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    metadata = excinfo.value.metadata
+    assert "strict_failures" in metadata
+    assert "non_strict_warnings" in metadata
+    # Only state_rw should be in the strict-failures metadata.
+    strict_failures_text = metadata["strict_failures"].text  # type: ignore[union-attr]
+    non_strict_text = metadata["non_strict_warnings"].text  # type: ignore[union-attr]
+    assert "state_rw" in strict_failures_text
+    assert "adapter_connect" in non_strict_text
+
+
+# ---------------------------------------------------------------------------
+# Severity-gating — warnings must never raise
+# ---------------------------------------------------------------------------
+
+
+def test_warning_severity_never_fails_even_when_listed():
+    """A check in the allowlist that fires with ``warning`` must not raise."""
+    rocky = RockyResource(
+        strict_doctor=True,
+        strict_doctor_checks=["state_rw"],
+    )
+    context = _init_context()
+    report = _doctor_result(("state_rw", HealthStatus.warning))
+
+    with patch.object(RockyResource, "doctor", return_value=report):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    # And it should still be logged as a warning so operators can see it.
+    events = context.log._events  # type: ignore[attr-defined]
+    assert any(lvl == "warning" and "state_rw" in msg for lvl, msg in events)
+
+
+def test_warning_severity_never_fails_with_empty_allowlist():
+    """Empty allowlist (fail-on-any-critical) must not fail on warnings."""
+    rocky = RockyResource(strict_doctor=True)
+    context = _init_context()
+    report = _doctor_result(
+        ("config_valid", HealthStatus.healthy),
+        ("freshness", HealthStatus.warning),
+    )
+
+    with patch.object(RockyResource, "doctor", return_value=report):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Binary-failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_wraps_binary_failure_as_startup_failure():
+    """A missing rocky binary under strict mode surfaces as a startup Failure."""
+    rocky = RockyResource(strict_doctor=True)
+    context = _init_context()
+
+    with (
+        patch.object(
+            RockyResource,
+            "doctor",
+            side_effect=dg.Failure(description="Rocky binary not found"),
+        ),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+    description = str(excinfo.value.description)
+    assert "rocky doctor could not execute" in description
+    assert "not found" in description.lower()
+
+
+def test_strict_mode_with_no_critical_checks_passes_silently():
+    """Doctor with only healthy checks passes in strict mode."""
+    rocky = RockyResource(strict_doctor=True, strict_doctor_checks=["state_rw"])
+    context = _init_context()
+    report = _doctor_result(
+        ("config_valid", HealthStatus.healthy),
+        ("state_rw", HealthStatus.healthy),
+    )
+
+    with patch.object(RockyResource, "doctor", return_value=report):
+        rocky.setup_for_execution(context)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Component pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_component_forwards_strict_doctor_to_resource():
+    """RockyComponent._get_rocky_resource must propagate both strict fields."""
+    from dagster_rocky.component import RockyComponent
+
+    component = RockyComponent(
+        strict_doctor=True,
+        strict_doctor_checks=["state_rw", "auth"],
+    )
+    rocky = component._get_rocky_resource()
+    assert rocky.strict_doctor is True
+    assert rocky.strict_doctor_checks == ["state_rw", "auth"]
+
+
+def test_component_default_leaves_resource_tolerant():
+    """Default component config means strict_doctor=False on the resource."""
+    from dagster_rocky.component import RockyComponent
+
+    component = RockyComponent()
+    rocky = component._get_rocky_resource()
+    assert rocky.strict_doctor is False
+    assert rocky.strict_doctor_checks == []


### PR DESCRIPTION
## Summary

Two Python-only dagster-rocky opt-in features, bundled into one
coordinated release. Default behaviour is unchanged on upgrade for
both — every existing user gets the current buffered/streaming
execution path and the current tolerant doctor behaviour with no
config change required.

### FR-001 — `RockyComponent.execution_mode: Literal["streaming", "pipes"]`

The component-backed multi-asset now supports the Dagster Pipes
protocol as a first-class execution mode. When `execution_mode` is
set to `"pipes"`, each `rocky run` invocation goes through
`RockyResource.run_pipes` and the engine emits
`MaterializationEvent` / `AssetCheckEvaluation` entries directly
over the Pipes wire. The buffered `_emit_results` JSON
post-processing path is skipped in this mode — Pipes becomes the
single source of truth for run events (no double-emit).

Asset-key translation and subset filtering happen at the reader
layer via a new `RockyPipesMessageReader`: a subclass of
`PipesTempFileMessageReader` that wraps the handler with a small
proxy. The proxy rewrites the wire `asset_key` (a slash-joined path
of `[source_type, *components, table]`) to the Dagster key the
component declared via its translator, and drops events whose
resolved key is outside the subset selection.

Opt-in per-component:

```yaml
type: dagster_rocky.RockyComponent
attributes:
  execution_mode: pipes
```

### FR-006 — `RockyResource.strict_doctor` + `strict_doctor_checks`

Opt-in strict `rocky doctor` gate at resource startup via
`setup_for_execution`. Tri-state surface via two fields:

| `strict_doctor` | `strict_doctor_checks` | Behaviour |
|---|---|---|
| `False` (default) | — | Doctor not invoked at startup. Zero cold-start cost. |
| `True` | `[]` | Fail on any critical check. |
| `True` | `["state_rw", "auth"]` | Fail only on listed critical checks; others log as warnings. |

Warnings (non-critical severities) never raise regardless of the
list. Critical-but-not-listed checks are surfaced via
`context.log.warning` so operators still see them. Both fields
pass through from `RockyComponent` to the constructed resource.

Opt-in per-component:

```yaml
type: dagster_rocky.RockyComponent
attributes:
  strict_doctor: true
  strict_doctor_checks: [state_rw]
```

## Design decisions

* **Custom `PipesMessageReader` subclass, not post-filter.**
  Translation + filtering happen at the reader layer so events for
  unselected tables never reach Dagster's handler in the first
  place. The interception point is private
  (`PipesFileMessageReader._reader_thread` calls
  `handler.handle_message`); if that contract shifts, the dagster
  bump in CI will surface the breakage before release.
* **Two-field strictness surface (`bool` + `list[str]`).** The FR
  doc's optimistic `Literal["none", "all"] | list[str]` shape
  doesn't round-trip through Dagster's Pydantic config serializer
  (`DagsterInvalidPythonicConfigDefinitionError` on `Union[list,
  Literal]`). Two fields cover the same three semantic cases
  cleanly and type-check.
* **Contract checks still sourced from compile diagnostics in
  pipes mode.** Contract violations are a build-time signal the
  Pipes wire doesn't carry, so the component keeps emitting them
  post-run in both execution modes.
* **`run_pipes` only wraps the client when translation/filter
  kwargs are passed.** Users calling `run_pipes` directly (not via
  `RockyComponent`) get the unchanged canonical Dagster Pipes path.

## Test plan

- [x] `tests/test_pipes_mode.py` — 17 new tests covering:
  - Handler-proxy asset-key translation for materializations and
    check events.
  - `include_keys` filtering at the handler layer.
  - Non-asset messages (`log`, `opened`, `closed`) pass through
    untouched.
  - Malformed `asset_key` payloads forwarded to the inner handler
    for validation.
  - `report_pipes_framework_exception` delegation via `__getattr__`
    (private-API safety net).
  - `run_pipes` kwarg plumbing: custom reader only when
    `asset_key_fn` or `include_keys` is supplied; caller-supplied
    client wins.
  - `RockyComponent.execution_mode` default is `"streaming"`.
  - `_run_filters_pipes` builds an `asset_key_fn` from the group's
    `rocky_key_to_dagster_key` map, with last-segment fallback for
    drift events.
- [x] `tests/test_strict_doctor.py` — 13 new tests covering:
  - Disabled mode (default) skips doctor entirely; a broken binary
    is inert.
  - `strict_doctor=True` + empty list fails on any critical.
  - Allowlist matches: only listed critical checks raise;
    non-listed critical checks surface as warnings.
  - Warning severity never fails (even when listed; even under
    fail-on-any).
  - Binary failures under strict mode wrap into a startup
    `dg.Failure`.
  - `RockyComponent` forwards both fields to the resource factory.
- [x] `uv run pytest -q` → **342 passed** (up from 312; 30 new, 0
  regressions).
- [x] `uv run ruff check src/ tests/` → clean.
- [x] `uv run ruff format --check src/ tests/` → clean.
- [x] No engine-side changes; no codegen regen; no fixture refresh
  needed.

## Wave 2 follow-up

`RockyResource.state_health()` (FR-003) — programmatic state-backend
health probe — ships separately once this lands.