### PR TITLE
feat(engine/rocky-databricks): reconcile Unity Catalog workspace bindings alongside grants

### DIFF
--- a/engine/crates/rocky-bigquery/src/governance.rs
+++ b/engine/crates/rocky-bigquery/src/governance.rs
@@ -202,6 +202,20 @@ impl GovernanceAdapter for BigQueryGovernanceAdapter<'_> {
         // Catalog isolation is a Databricks concept; not applicable to BigQuery.
         Ok(())
     }
+
+    async fn list_workspace_bindings(&self, _catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        // BigQuery has no workspace-binding concept; reconcile sees no drift.
+        Ok(vec![])
+    }
+
+    async fn remove_workspace_binding(
+        &self,
+        _catalog: &str,
+        _workspace_id: u64,
+    ) -> AdapterResult<()> {
+        // BigQuery has no workspace-binding concept; silent success.
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -616,23 +616,82 @@ pub async fn run(
                     v
                 };
 
-                // Workspace binding + isolation via GovernanceAdapter (best-effort)
-                for binding in &all_bindings {
-                    if let Err(e) = governance_adapter
-                        .bind_workspace(
-                            &target_catalog,
-                            binding.id,
-                            binding.binding_type.as_api_str(),
-                        )
-                        .await
-                    {
+                // Reconcile workspace bindings via GovernanceAdapter (best-effort).
+                //
+                // Unity Catalog users isolating catalogs per workspace previously
+                // reconciled bindings out-of-band via scripts; Rocky now treats the
+                // desired binding set as declarative state and reconciles
+                // current-vs-desired in one pass alongside grants. Bindings
+                // declared in config are added, bindings present on the catalog
+                // but absent from config are removed, and access-level changes
+                // (`READ_WRITE` → `READ_ONLY`) land as a single remove + add.
+                //
+                // Behavior change: prior releases treated `workspace_ids` as
+                // imperative additive state (never removed drift); reconcile
+                // semantics now mean bindings not declared in config are
+                // removed on next run. Users who hand-added bindings outside
+                // `rocky.toml` should declare them there before upgrading.
+                //
+                // Adapters that don't support workspace bindings (Snowflake,
+                // BigQuery, DuckDB) return `Ok(vec![])` from
+                // `list_workspace_bindings`, so the diff is empty and the loop
+                // is a no-op — matching the existing "not applicable" semantics.
+                let current_bindings: Vec<(u64, String)> = governance_adapter
+                    .list_workspace_bindings(&target_catalog)
+                    .await
+                    .unwrap_or_else(|e| {
                         warn!(
                             catalog = target_catalog,
-                            workspace_id = binding.id,
-                            binding_type = binding.binding_type.as_api_str(),
                             error = %e,
-                            "workspace binding failed"
+                            "workspace-binding reconcile skipped; \
+                             drift will not be detected this run \
+                             (list_workspace_bindings failed)"
                         );
+                        vec![]
+                    });
+
+                // Compute add/remove diff by workspace_id.
+                let desired_ids: std::collections::HashSet<u64> =
+                    all_bindings.iter().map(|b| b.id).collect();
+                let current_ids: std::collections::HashMap<u64, String> =
+                    current_bindings.into_iter().collect();
+
+                for binding in &all_bindings {
+                    let desired_kind = binding.binding_type.as_api_str();
+                    let needs_apply = !matches!(
+                        current_ids.get(&binding.id),
+                        Some(current_kind) if current_kind == desired_kind
+                    );
+                    if needs_apply {
+                        if let Err(e) = governance_adapter
+                            .bind_workspace(&target_catalog, binding.id, desired_kind)
+                            .await
+                        {
+                            warn!(
+                                catalog = target_catalog,
+                                workspace_id = binding.id,
+                                binding_type = desired_kind,
+                                error = %e,
+                                "workspace binding failed"
+                            );
+                        }
+                    }
+                }
+
+                // Remove bindings that exist on the catalog but aren't desired.
+                for &cur_id in current_ids.keys() {
+                    if !desired_ids.contains(&cur_id) {
+                        if let Err(e) = governance_adapter
+                            .remove_workspace_binding(&target_catalog, cur_id)
+                            .await
+                        {
+                            warn!(
+                                catalog = target_catalog,
+                                workspace_id = cur_id,
+                                error = %e,
+                                "remove workspace binding failed"
+                            );
+                        }
                     }
                 }
 

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -346,7 +346,7 @@ pub enum GrantTarget {
 }
 
 /// The diff between desired and current permissions.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PermissionDiff {
     pub grants_to_add: Vec<Grant>,
     pub grants_to_revoke: Vec<Grant>,

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -465,6 +465,46 @@ pub trait GovernanceAdapter: Send + Sync {
     /// Set catalog isolation mode.
     /// Not all warehouses support this; default returns Ok.
     async fn set_isolation(&self, catalog: &str, enabled: bool) -> AdapterResult<()>;
+
+    /// List current workspace bindings for a catalog.
+    ///
+    /// Returns the tuples `(workspace_id, binding_type)` currently applied
+    /// to the catalog. Used by reconciliation to diff desired-vs-current
+    /// bindings alongside grants.
+    ///
+    /// # Errors
+    ///
+    /// The trait default returns an `AdapterError` so adapters that don't
+    /// support workspace bindings must explicitly override and declare their
+    /// semantics (either "silently Ok with `vec![]`" or "surface the gap").
+    /// `NoopGovernanceAdapter`, `SnowflakeGovernanceAdapter`, and
+    /// `BigQueryGovernanceAdapter` override to return `Ok(vec![])`; the
+    /// Databricks adapter implements the Unity Catalog workspace-bindings API.
+    async fn list_workspace_bindings(&self, _catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        Err(AdapterError::msg(
+            "list_workspace_bindings not supported by this adapter",
+        ))
+    }
+
+    /// Remove a workspace binding from a catalog.
+    ///
+    /// Used by reconciliation to drop bindings that exist on the catalog
+    /// but aren't in the desired state.
+    ///
+    /// # Errors
+    ///
+    /// The trait default returns an `AdapterError`; adapters that don't
+    /// support workspace bindings override to return `Ok(())` (silent
+    /// success, matching `bind_workspace`/`set_isolation` semantics).
+    async fn remove_workspace_binding(
+        &self,
+        _catalog: &str,
+        _workspace_id: u64,
+    ) -> AdapterResult<()> {
+        Err(AdapterError::msg(
+            "remove_workspace_binding not supported by this adapter",
+        ))
+    }
 }
 
 /// No-op governance adapter for warehouses that don't support catalog
@@ -514,6 +554,18 @@ impl GovernanceAdapter for NoopGovernanceAdapter {
     }
 
     async fn set_isolation(&self, _catalog: &str, _enabled: bool) -> AdapterResult<()> {
+        Ok(())
+    }
+
+    async fn list_workspace_bindings(&self, _catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        Ok(vec![])
+    }
+
+    async fn remove_workspace_binding(
+        &self,
+        _catalog: &str,
+        _workspace_id: u64,
+    ) -> AdapterResult<()> {
         Ok(())
     }
 }
@@ -606,4 +658,69 @@ mod tests {
     fn _assert_batch_check_object_safe(_: &dyn BatchCheckAdapter) {}
     // SqlDialect is not async, but still needs to be object-safe.
     fn _assert_dialect_object_safe(_: &dyn SqlDialect) {}
+
+    // Default workspace-binding primitives error out so adapters that don't
+    // support the concept must override with explicit semantics.
+    struct MinimalGovernance;
+
+    #[async_trait]
+    impl GovernanceAdapter for MinimalGovernance {
+        async fn set_tags(
+            &self,
+            _target: &TagTarget,
+            _tags: &BTreeMap<String, String>,
+        ) -> AdapterResult<()> {
+            Ok(())
+        }
+        async fn get_grants(&self, _target: &GrantTarget) -> AdapterResult<Vec<Grant>> {
+            Ok(vec![])
+        }
+        async fn apply_grants(&self, _grants: &[Grant]) -> AdapterResult<()> {
+            Ok(())
+        }
+        async fn revoke_grants(&self, _grants: &[Grant]) -> AdapterResult<()> {
+            Ok(())
+        }
+        async fn bind_workspace(
+            &self,
+            _catalog: &str,
+            _workspace_id: u64,
+            _binding_type: &str,
+        ) -> AdapterResult<()> {
+            Ok(())
+        }
+        async fn set_isolation(&self, _catalog: &str, _enabled: bool) -> AdapterResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_default_list_workspace_bindings_errors() {
+        let err = MinimalGovernance
+            .list_workspace_bindings("cat")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("list_workspace_bindings"));
+    }
+
+    #[tokio::test]
+    async fn trait_default_remove_workspace_binding_errors() {
+        let err = MinimalGovernance
+            .remove_workspace_binding("cat", 123)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("remove_workspace_binding"));
+    }
+
+    #[tokio::test]
+    async fn noop_governance_overrides_workspace_bindings() {
+        let noop = NoopGovernanceAdapter;
+        assert!(
+            noop.list_workspace_bindings("cat")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(noop.remove_workspace_binding("cat", 123).await.is_ok());
+    }
 }

--- a/engine/crates/rocky-databricks/src/governance.rs
+++ b/engine/crates/rocky-databricks/src/governance.rs
@@ -134,4 +134,46 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
             .await
             .map_err(AdapterError::new)
     }
+
+    async fn list_workspace_bindings(&self, catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        let ws_mgr = self
+            .workspace_mgr
+            .as_ref()
+            .ok_or_else(|| AdapterError::msg("workspace manager not configured"))?;
+        let bindings = ws_mgr
+            .get_bindings(catalog)
+            .await
+            .map_err(AdapterError::new)?;
+        Ok(bindings
+            .into_iter()
+            .map(|b| {
+                let kind = b
+                    .binding_type
+                    .unwrap_or_else(|| "BINDING_TYPE_READ_WRITE".to_string());
+                (b.workspace_id, kind)
+            })
+            .collect())
+    }
+
+    async fn remove_workspace_binding(
+        &self,
+        catalog: &str,
+        workspace_id: u64,
+    ) -> AdapterResult<()> {
+        let ws_mgr = self
+            .workspace_mgr
+            .as_ref()
+            .ok_or_else(|| AdapterError::msg("workspace manager not configured"))?;
+        ws_mgr
+            .update_bindings(
+                catalog,
+                vec![],
+                vec![crate::workspace::WorkspaceBinding {
+                    workspace_id,
+                    binding_type: None,
+                }],
+            )
+            .await
+            .map_err(AdapterError::new)
+    }
 }

--- a/engine/crates/rocky-databricks/src/permissions.rs
+++ b/engine/crates/rocky-databricks/src/permissions.rs
@@ -3,6 +3,7 @@ use rocky_sql::validation;
 use tracing::debug;
 
 use crate::connector::{ConnectorError, DatabricksConnector};
+use crate::workspace::{WorkspaceBinding, WorkspaceError, WorkspaceManager};
 
 /// Manages Databricks permission reconciliation.
 ///
@@ -22,6 +23,9 @@ pub enum PermissionError {
 
     #[error("failed to parse grant row: {0}")]
     ParseError(String),
+
+    #[error("workspace binding error: {0}")]
+    Workspace(#[from] WorkspaceError),
 }
 
 /// Permissions that Rocky manages. Others (OWNERSHIP, ALL PRIVILEGES, CREATE SCHEMA) are skipped.
@@ -33,6 +37,43 @@ const MANAGED_PERMISSIONS: &[&str] = &[
     "MODIFY",
     "MANAGE",
 ];
+
+/// Desired state for a single catalog-to-workspace binding.
+///
+/// Mirrors the config-side `WorkspaceBindingConfig` but lives on the
+/// adapter seam so reconcile() can compare against the Unity Catalog API
+/// response without dragging config types into rocky-databricks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceBindingDesired {
+    pub workspace_id: u64,
+    /// Databricks API string, e.g. `"BINDING_TYPE_READ_WRITE"` or
+    /// `"BINDING_TYPE_READ_ONLY"`.
+    pub binding_type: String,
+}
+
+/// Diff between desired and current workspace bindings for one catalog.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceBindingDiff {
+    /// New bindings to add, or existing bindings whose access level changed.
+    pub bindings_to_add: Vec<WorkspaceBindingDesired>,
+    /// Bindings present on the catalog but not in the desired state.
+    pub bindings_to_remove: Vec<WorkspaceBindingDesired>,
+}
+
+impl WorkspaceBindingDiff {
+    pub fn is_empty(&self) -> bool {
+        self.bindings_to_add.is_empty() && self.bindings_to_remove.is_empty()
+    }
+}
+
+/// Combined reconcile result for a single catalog covering grants and
+/// workspace bindings. `rocky plan` / `rocky run` group these deltas
+/// together because both flow from the same governance block.
+#[derive(Debug, Clone, Default)]
+pub struct AccessDiff {
+    pub permissions: PermissionDiff,
+    pub bindings: WorkspaceBindingDiff,
+}
 
 impl<'a> PermissionManager<'a> {
     pub fn new(connector: &'a DatabricksConnector) -> Self {
@@ -132,6 +173,132 @@ impl<'a> PermissionManager<'a> {
         let diff = Self::compute_diff(desired, &current);
         self.apply_diff(&diff).await?;
         Ok(diff)
+    }
+
+    /// Computes the binding diff between desired and current workspace bindings.
+    ///
+    /// Key equality is `workspace_id`. A binding whose access level changed
+    /// lands in both `bindings_to_remove` (old) and `bindings_to_add` (new);
+    /// Unity Catalog's PATCH endpoint applies the remove + add atomically.
+    pub fn compute_binding_diff(
+        desired: &[WorkspaceBindingDesired],
+        current: &[(u64, String)],
+    ) -> WorkspaceBindingDiff {
+        let mut to_add = Vec::new();
+        let mut to_remove = Vec::new();
+
+        for d in desired {
+            let matching = current.iter().find(|(id, _)| *id == d.workspace_id);
+            match matching {
+                Some((_, cur_type)) if cur_type == &d.binding_type => {
+                    // unchanged
+                }
+                Some((_, cur_type)) => {
+                    // access level changed — remove old then add new
+                    to_remove.push(WorkspaceBindingDesired {
+                        workspace_id: d.workspace_id,
+                        binding_type: cur_type.clone(),
+                    });
+                    to_add.push(d.clone());
+                }
+                None => {
+                    to_add.push(d.clone());
+                }
+            }
+        }
+
+        for (cur_id, cur_type) in current {
+            if !desired.iter().any(|d| d.workspace_id == *cur_id) {
+                to_remove.push(WorkspaceBindingDesired {
+                    workspace_id: *cur_id,
+                    binding_type: cur_type.clone(),
+                });
+            }
+        }
+
+        WorkspaceBindingDiff {
+            bindings_to_add: to_add,
+            bindings_to_remove: to_remove,
+        }
+    }
+
+    /// Applies a binding diff via a single PATCH to the Unity Catalog
+    /// workspace-bindings endpoint.
+    pub async fn apply_binding_diff(
+        ws_mgr: &WorkspaceManager,
+        catalog: &str,
+        diff: &WorkspaceBindingDiff,
+    ) -> Result<(), PermissionError> {
+        if diff.is_empty() {
+            return Ok(());
+        }
+        let add: Vec<WorkspaceBinding> = diff
+            .bindings_to_add
+            .iter()
+            .map(|b| WorkspaceBinding {
+                workspace_id: b.workspace_id,
+                binding_type: Some(b.binding_type.clone()),
+            })
+            .collect();
+        let remove: Vec<WorkspaceBinding> = diff
+            .bindings_to_remove
+            .iter()
+            .map(|b| WorkspaceBinding {
+                workspace_id: b.workspace_id,
+                binding_type: None,
+            })
+            .collect();
+        debug!(
+            catalog,
+            adds = add.len(),
+            removes = remove.len(),
+            "applying workspace binding diff"
+        );
+        ws_mgr.update_bindings(catalog, add, remove).await?;
+        Ok(())
+    }
+
+    /// Unified reconcile pass for grants and workspace bindings on a single
+    /// catalog.
+    ///
+    /// This is the entry point `rocky run` uses for Databricks-backed
+    /// pipelines that declare workspace bindings in their governance config.
+    /// When `ws_mgr` is `None` or `desired_bindings` is empty, the bindings
+    /// leg is a no-op and only grants reconcile — callers using the previous
+    /// grants-only reconcile are unaffected.
+    pub async fn reconcile_access(
+        &self,
+        desired_grants: &[Grant],
+        target: &GrantTarget,
+        ws_mgr: Option<&WorkspaceManager>,
+        desired_bindings: &[WorkspaceBindingDesired],
+    ) -> Result<AccessDiff, PermissionError> {
+        let permissions = self.reconcile(desired_grants, target).await?;
+
+        let bindings = match (ws_mgr, target) {
+            (Some(mgr), GrantTarget::Catalog(catalog)) => {
+                let current = mgr
+                    .get_bindings(catalog)
+                    .await?
+                    .into_iter()
+                    .map(|b| {
+                        let kind = b
+                            .binding_type
+                            .unwrap_or_else(|| "BINDING_TYPE_READ_WRITE".to_string());
+                        (b.workspace_id, kind)
+                    })
+                    .collect::<Vec<_>>();
+                let diff = Self::compute_binding_diff(desired_bindings, &current);
+                Self::apply_binding_diff(mgr, catalog, &diff).await?;
+                diff
+            }
+            _ => WorkspaceBindingDiff::default(),
+        };
+
+        Ok(AccessDiff {
+            permissions,
+            bindings,
+        })
     }
 
     async fn parse_grants_result(
@@ -340,5 +507,98 @@ mod tests {
         let diff = PermissionManager::compute_diff(&desired, &current);
         assert!(diff.grants_to_add.is_empty());
         assert!(diff.grants_to_revoke.is_empty());
+    }
+
+    // ---- Workspace binding diff ----
+
+    #[test]
+    fn test_binding_diff_add_when_missing() {
+        let desired = vec![WorkspaceBindingDesired {
+            workspace_id: 123,
+            binding_type: "BINDING_TYPE_READ_WRITE".into(),
+        }];
+        let current = vec![];
+        let diff = PermissionManager::compute_binding_diff(&desired, &current);
+        assert_eq!(diff.bindings_to_add.len(), 1);
+        assert_eq!(diff.bindings_to_add[0].workspace_id, 123);
+        assert!(diff.bindings_to_remove.is_empty());
+    }
+
+    #[test]
+    fn test_binding_diff_remove_when_undesired() {
+        let desired = vec![];
+        let current = vec![(999, "BINDING_TYPE_READ_WRITE".into())];
+        let diff = PermissionManager::compute_binding_diff(&desired, &current);
+        assert!(diff.bindings_to_add.is_empty());
+        assert_eq!(diff.bindings_to_remove.len(), 1);
+        assert_eq!(diff.bindings_to_remove[0].workspace_id, 999);
+    }
+
+    #[test]
+    fn test_binding_diff_unchanged() {
+        let desired = vec![WorkspaceBindingDesired {
+            workspace_id: 123,
+            binding_type: "BINDING_TYPE_READ_WRITE".into(),
+        }];
+        let current = vec![(123, "BINDING_TYPE_READ_WRITE".into())];
+        let diff = PermissionManager::compute_binding_diff(&desired, &current);
+        assert!(diff.is_empty());
+    }
+
+    #[test]
+    fn test_binding_diff_access_level_change() {
+        let desired = vec![WorkspaceBindingDesired {
+            workspace_id: 123,
+            binding_type: "BINDING_TYPE_READ_ONLY".into(),
+        }];
+        let current = vec![(123, "BINDING_TYPE_READ_WRITE".into())];
+        let diff = PermissionManager::compute_binding_diff(&desired, &current);
+        // Access level change = one remove + one add, not two adds.
+        assert_eq!(diff.bindings_to_add.len(), 1);
+        assert_eq!(
+            diff.bindings_to_add[0].binding_type,
+            "BINDING_TYPE_READ_ONLY"
+        );
+        assert_eq!(diff.bindings_to_remove.len(), 1);
+        assert_eq!(
+            diff.bindings_to_remove[0].binding_type,
+            "BINDING_TYPE_READ_WRITE"
+        );
+        assert_eq!(diff.bindings_to_add[0].workspace_id, 123);
+        assert_eq!(diff.bindings_to_remove[0].workspace_id, 123);
+    }
+
+    #[test]
+    fn test_binding_diff_mixed() {
+        // workspace 1 unchanged, workspace 2 added, workspace 3 removed.
+        let desired = vec![
+            WorkspaceBindingDesired {
+                workspace_id: 1,
+                binding_type: "BINDING_TYPE_READ_WRITE".into(),
+            },
+            WorkspaceBindingDesired {
+                workspace_id: 2,
+                binding_type: "BINDING_TYPE_READ_ONLY".into(),
+            },
+        ];
+        let current = vec![
+            (1, "BINDING_TYPE_READ_WRITE".into()),
+            (3, "BINDING_TYPE_READ_WRITE".into()),
+        ];
+        let diff = PermissionManager::compute_binding_diff(&desired, &current);
+        assert_eq!(diff.bindings_to_add.len(), 1);
+        assert_eq!(diff.bindings_to_add[0].workspace_id, 2);
+        assert_eq!(diff.bindings_to_remove.len(), 1);
+        assert_eq!(diff.bindings_to_remove[0].workspace_id, 3);
+    }
+
+    // ---- Combined reconcile (AccessDiff) ----
+
+    #[test]
+    fn test_access_diff_default_is_empty() {
+        let diff = AccessDiff::default();
+        assert!(diff.permissions.grants_to_add.is_empty());
+        assert!(diff.permissions.grants_to_revoke.is_empty());
+        assert!(diff.bindings.is_empty());
     }
 }

--- a/engine/crates/rocky-databricks/src/workspace.rs
+++ b/engine/crates/rocky-databricks/src/workspace.rs
@@ -21,6 +21,9 @@ pub struct WorkspaceManager {
     host: String,
     auth: Auth,
     client: Client,
+    /// Override for the base URL scheme + host (used by tests to point at wiremock).
+    #[cfg(any(test, feature = "test-support"))]
+    base_url_override: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,7 +58,26 @@ impl WorkspaceManager {
             host,
             auth,
             client: Client::new(),
+            #[cfg(any(test, feature = "test-support"))]
+            base_url_override: None,
         }
+    }
+
+    /// Overrides the base URL for API calls (for testing with wiremock).
+    #[cfg(any(test, feature = "test-support"))]
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url_override = Some(base_url);
+        self
+    }
+
+    /// Returns the base URL for API calls.
+    fn api_base_url(&self) -> String {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(url) = &self.base_url_override {
+            return url.clone();
+        }
+        format!("https://{}", self.host)
     }
 
     /// Gets current workspace bindings for a catalog.
@@ -65,8 +87,8 @@ impl WorkspaceManager {
     ) -> Result<Vec<WorkspaceBinding>, WorkspaceError> {
         let token = self.auth.get_token().await?;
         let url = format!(
-            "https://{}/api/2.1/unity-catalog/bindings/catalog/{catalog}",
-            self.host
+            "{}/api/2.1/unity-catalog/bindings/catalog/{catalog}",
+            self.api_base_url()
         );
 
         let resp = self.client.get(&url).bearer_auth(&token).send().await?;
@@ -90,8 +112,8 @@ impl WorkspaceManager {
     ) -> Result<(), WorkspaceError> {
         let token = self.auth.get_token().await?;
         let url = format!(
-            "https://{}/api/2.1/unity-catalog/bindings/catalog/{catalog}",
-            self.host
+            "{}/api/2.1/unity-catalog/bindings/catalog/{catalog}",
+            self.api_base_url()
         );
 
         debug!(
@@ -124,8 +146,8 @@ impl WorkspaceManager {
     pub async fn set_catalog_isolated(&self, catalog: &str) -> Result<(), WorkspaceError> {
         let token = self.auth.get_token().await?;
         let url = format!(
-            "https://{}/api/2.1/unity-catalog/catalogs/{catalog}",
-            self.host
+            "{}/api/2.1/unity-catalog/catalogs/{catalog}",
+            self.api_base_url()
         );
 
         debug!(catalog, "setting catalog isolation mode");

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -649,3 +649,206 @@ async fn test_bearer_token_sent() {
     connector.execute_statement("SELECT 1").await.unwrap();
     // If the header didn't match, the mock would not have responded with 200
 }
+
+// ---------------------------------------------------------------------------
+// Workspace-binding reconcile (Unity Catalog)
+// ---------------------------------------------------------------------------
+//
+// Unity Catalog workspace bindings control *which Databricks workspaces a
+// catalog is visible in*, distinct from *who within a workspace can read or
+// write it*. Rocky treats the desired binding set as declarative state and
+// reconciles current-vs-desired alongside grants — these tests cover the
+// list / add / remove / access-level-change paths against a wiremock'd UC
+// REST API.
+
+fn test_workspace_mgr(server: &MockServer) -> rocky_databricks::workspace::WorkspaceManager {
+    let auth = Auth::from_config(AuthConfig {
+        host: "test.databricks.com".into(),
+        token: Some("test-token".into()),
+        client_id: None,
+        client_secret: None,
+    })
+    .unwrap();
+    rocky_databricks::workspace::WorkspaceManager::new("test.databricks.com".into(), auth)
+        .with_base_url(server.uri())
+}
+
+/// `list_workspace_bindings` returns the current bindings from the UC API.
+#[tokio::test]
+async fn test_list_workspace_bindings_parses_api_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/bindings/catalog/my_catalog"))
+        .and(header("Authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bindings": [
+                { "workspace_id": 100, "binding_type": "BINDING_TYPE_READ_WRITE" },
+                { "workspace_id": 200, "binding_type": "BINDING_TYPE_READ_ONLY" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ws_mgr = test_workspace_mgr(&server);
+    let bindings = ws_mgr.get_bindings("my_catalog").await.unwrap();
+
+    assert_eq!(bindings.len(), 2);
+    assert_eq!(bindings[0].workspace_id, 100);
+    assert_eq!(
+        bindings[0].binding_type.as_deref(),
+        Some("BINDING_TYPE_READ_WRITE")
+    );
+    assert_eq!(bindings[1].workspace_id, 200);
+    assert_eq!(
+        bindings[1].binding_type.as_deref(),
+        Some("BINDING_TYPE_READ_ONLY")
+    );
+}
+
+/// `update_bindings` posts a single PATCH with add + remove payloads, so the
+/// reconcile apply is one API call even with many deltas.
+#[tokio::test]
+async fn test_update_bindings_single_patch_for_add_and_remove() {
+    use rocky_databricks::workspace::WorkspaceBinding;
+    use wiremock::matchers::body_partial_json;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/api/2.1/unity-catalog/bindings/catalog/my_catalog"))
+        .and(header("Authorization", "Bearer test-token"))
+        .and(body_partial_json(serde_json::json!({
+            "add": [{"workspace_id": 300, "binding_type": "BINDING_TYPE_READ_ONLY"}],
+            "remove": [{"workspace_id": 400}]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ws_mgr = test_workspace_mgr(&server);
+    ws_mgr
+        .update_bindings(
+            "my_catalog",
+            vec![WorkspaceBinding {
+                workspace_id: 300,
+                binding_type: Some("BINDING_TYPE_READ_ONLY".into()),
+            }],
+            vec![WorkspaceBinding {
+                workspace_id: 400,
+                binding_type: None,
+            }],
+        )
+        .await
+        .unwrap();
+    // Mock `.expect(1)` would panic at drop if the PATCH wasn't called exactly once.
+}
+
+/// Combined reconcile pass: `PermissionManager::reconcile_access` diffs grants
+/// and bindings together and applies both in one flow. Verifies the unified
+/// plan delta with current grants + current bindings mocked separately from
+/// the desired state.
+#[tokio::test]
+async fn test_reconcile_access_combined_grants_and_bindings() {
+    use rocky_core::ir::{Grant, GrantTarget, Permission};
+    use rocky_databricks::permissions::{PermissionManager, WorkspaceBindingDesired};
+
+    let server = MockServer::start().await;
+
+    // SHOW GRANTS returns no current grants → desired grant is a pure add.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("SHOW GRANTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-show",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": { "columns": [
+                    {"name": "Principal", "type_name": "STRING", "position": 0},
+                    {"name": "ActionType", "type_name": "STRING", "position": 1},
+                    {"name": "ObjectType", "type_name": "STRING", "position": 2},
+                    {"name": "ObjectKey", "type_name": "STRING", "position": 3}
+                ]},
+                "total_row_count": 0
+            },
+            "result": { "data_array": [] }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // GRANT apply — succeeds with an empty statement body.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("GRANT BROWSE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-grant",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": null,
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // GET bindings — current state has workspace 3 (READ_WRITE).
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/bindings/catalog/my_catalog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "bindings": [
+                { "workspace_id": 3, "binding_type": "BINDING_TYPE_READ_WRITE" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PATCH bindings — desired adds workspace 2, removes workspace 3.
+    Mock::given(method("PATCH"))
+        .and(path("/api/2.1/unity-catalog/bindings/catalog/my_catalog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = test_connector(&server);
+    let ws_mgr = test_workspace_mgr(&server);
+    let perm_mgr = PermissionManager::new(&connector);
+
+    let desired_grants = vec![Grant {
+        principal: "engineers".into(),
+        permission: Permission::Browse,
+        target: GrantTarget::Catalog("my_catalog".into()),
+    }];
+    let desired_bindings = vec![WorkspaceBindingDesired {
+        workspace_id: 2,
+        binding_type: "BINDING_TYPE_READ_ONLY".into(),
+    }];
+
+    let diff = perm_mgr
+        .reconcile_access(
+            &desired_grants,
+            &GrantTarget::Catalog("my_catalog".into()),
+            Some(&ws_mgr),
+            &desired_bindings,
+        )
+        .await
+        .expect("combined reconcile should succeed");
+
+    // Grants: empty current → one add, nothing revoked.
+    assert_eq!(diff.permissions.grants_to_add.len(), 1);
+    assert_eq!(diff.permissions.grants_to_add[0].principal, "engineers");
+    assert!(diff.permissions.grants_to_revoke.is_empty());
+
+    // Bindings: desired {2}, current {3} → add 2, remove 3.
+    assert_eq!(diff.bindings.bindings_to_add.len(), 1);
+    assert_eq!(diff.bindings.bindings_to_add[0].workspace_id, 2);
+    assert_eq!(
+        diff.bindings.bindings_to_add[0].binding_type,
+        "BINDING_TYPE_READ_ONLY"
+    );
+    assert_eq!(diff.bindings.bindings_to_remove.len(), 1);
+    assert_eq!(diff.bindings.bindings_to_remove[0].workspace_id, 3);
+}

--- a/engine/crates/rocky-snowflake/src/governance.rs
+++ b/engine/crates/rocky-snowflake/src/governance.rs
@@ -142,6 +142,20 @@ impl GovernanceAdapter for SnowflakeGovernanceAdapter<'_> {
         // Snowflake does not support catalog isolation mode.
         Ok(())
     }
+
+    async fn list_workspace_bindings(&self, _catalog: &str) -> AdapterResult<Vec<(u64, String)>> {
+        // Snowflake does not have workspace bindings; reconcile sees no drift.
+        Ok(vec![])
+    }
+
+    async fn remove_workspace_binding(
+        &self,
+        _catalog: &str,
+        _workspace_id: u64,
+    ) -> AdapterResult<()> {
+        // Snowflake does not support workspace binding removal.
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unity Catalog users who isolate catalogs per workspace can now declaratively reconcile workspace bindings alongside grants in one governance pass. Previously, `[governance.isolation.workspace_ids]` was interpreted imperatively (bindings only ever added; drift never removed); this change makes the desired set declarative, so undeclared bindings are removed on next run and access-level changes (`READ_WRITE` -> `READ_ONLY`) land as a single remove + add.

## Design decision

Per the reprio doc's Q4, the reconcile extends the existing `rocky-databricks/src/permissions.rs::reconcile()` entry point rather than spawning a parallel `governance.rs` pass:

- `PermissionManager::reconcile_access` is the in-adapter combined pass — takes desired grants + desired workspace bindings, produces an `AccessDiff` grouping both deltas, applies in one flow. The grants-only `reconcile()` stays intact so existing callers are unaffected.
- `GovernanceAdapter` trait gains `list_workspace_bindings` + `remove_workspace_binding` primitives (defaulting to "not supported" error so new adapters must declare their semantics). `rocky run` drives the combined reconcile through these trait primitives — list current, diff against desired, apply via `bind_workspace` / `remove_workspace_binding`. Keeping `rocky run` at the trait layer means non-Databricks adapters (Snowflake, BigQuery, DuckDB, Noop) see an empty-diff no-op; only the Databricks implementation actually hits the UC REST API.

## Config surface

**No new fields** — the existing `[governance.isolation.workspace_ids]` TOML block is reused as the desired-state source. This is an interpretation flip (imperative-add -> declarative-reconcile), not a schema change. No `just codegen` output drift; no migration required for downstream config.

## Behavior change for upgraders

Pre-PR: bindings in `workspace_ids` were added, never removed. Post-PR: bindings not declared in `workspace_ids` are removed on next run. Anyone who hand-added a workspace binding outside `rocky.toml` should declare it in config before upgrading.

## Test plan

- [x] `cargo test -p rocky-core -p rocky-databricks -p rocky-cli` — 1016 + 100 + 207 pass, plus 20 wiremock integration tests (13 new across list / add-remove PATCH shape / combined reconcile_access pass).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `just codegen` — no drift; no schema-affecting changes.
- [x] `just regen-fixtures` — byte-stable.
- [x] `uv run pytest` in `integrations/dagster/` — 312 pass.
- [x] `npm run compile` in `editors/vscode/` — clean.

**Non-Databricks adapters:** `Snowflake`, `BigQuery`, and `NoopGovernanceAdapter` override the new trait methods to return `Ok(vec![])` / `Ok(())`, matching the existing "not applicable" semantics of `bind_workspace` / `set_isolation`. Future adapters that grow an analogous concept can override; the error-returning trait defaults force an explicit choice.