### PR TITLE
feat(integrations/dagster): add RockyResource.state_health() accessor

### DIFF
--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -42,7 +42,7 @@ from .freshness import (
     freshness_policy_from_model,
     per_model_freshness_policies,
 )
-from .health import HealthcheckResult, rocky_healthcheck
+from .health import HealthcheckResult, rocky_healthcheck, state_health
 from .observability import (
     ANOMALY_CHECK_NAME,
     anomaly_check_results,
@@ -98,6 +98,7 @@ from .types import (
     HealthCheck,
     HealthStatus,
     HistoryResult,
+    LastRunStatus,
     LineageEdge,
     MaterializationCost,
     MaterializationInfo,
@@ -112,6 +113,7 @@ from .types import (
     PartitionSummary,
     PermissionInfo,
     PlanResult,
+    ProbeOutcome,
     QualifiedColumn,
     QualityMetrics,
     QualitySnapshot,
@@ -120,6 +122,8 @@ from .types import (
     Severity,
     SourceInfo,
     SourceSpan,
+    StateBackendKind,
+    StateHealthResult,
     StateResult,
     TableInfo,
     TestResult,
@@ -189,6 +193,11 @@ __all__ = [
     # Health (T5.5)
     "HealthcheckResult",
     "rocky_healthcheck",
+    "state_health",
+    "StateHealthResult",
+    "StateBackendKind",
+    "LastRunStatus",
+    "ProbeOutcome",
     # Project bootstrap (T5.1)
     "init_rocky_project",
     # Branch deployment detection (T5.3, descoped)

--- a/integrations/dagster/src/dagster_rocky/health.py
+++ b/integrations/dagster/src/dagster_rocky/health.py
@@ -15,14 +15,23 @@ the resource itself.
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, cast, get_args
 
 import dagster as dg
 
+from .types import (
+    StateBackendKind,
+    StateHealthResult,
+)
+
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from .resource import RockyResource
-    from .types import DoctorResult
+    from .types import DoctorResult, ProbeOutcome
 
 
 @dataclass(frozen=True)
@@ -92,3 +101,207 @@ def _is_critical(check: object) -> bool:
     status = getattr(check, "status", None)
     status_str = status.value if hasattr(status, "value") else str(status)
     return status_str.lower() == "critical"
+
+
+# ---------------------------------------------------------------------------
+# State health accessor
+# ---------------------------------------------------------------------------
+
+_VALID_BACKENDS: frozenset[str] = frozenset(get_args(StateBackendKind))
+
+#: Mapping from ``RunHistoryRecord.status`` wire values to the normalised
+#: :data:`~.types.LastRunStatus` the accessor exposes. The engine formats
+#: ``RunStatus`` via ``{:?}`` on the CLI side, so CamelCase variant names
+#: land on the wire. Unknown values map to ``"failure"`` — the safer
+#: default for anything we don't explicitly recognise as success.
+_RUN_STATUS_NORMALISE: dict[str, str] = {
+    "success": "success",
+    "partialfailure": "partial_failure",
+    "partial_failure": "partial_failure",
+    "failure": "failure",
+}
+
+
+def state_health(rocky: RockyResource, *, probe_write: bool = False) -> StateHealthResult:
+    """Return a live snapshot of Rocky's state-backend health.
+
+    Aggregates the two already-shipped surfaces that expose state-backend
+    observability:
+
+    1. A best-effort parse of the configured backend from ``rocky.toml``
+       (``[state] backend``). Cheap and network-free; defaults to
+       ``"local"`` when the config can't be read or doesn't declare the
+       field.
+    2. The most recent :class:`~.types.RunHistoryRecord` from
+       :meth:`RockyResource.history`. Populates :attr:`~.types.StateHealthResult.last_run_status`
+       and :attr:`~.types.StateHealthResult.last_run_at`. A fresh state
+       store with no runs yields ``None`` for both, as does a binary
+       failure — the accessor is tolerant of ``dagster.Failure`` so a
+       caller running this every sensor tick doesn't crash the tick
+       when rocky itself can't be invoked.
+    3. Optional ``state_rw`` probe: when ``probe_write=True``, runs
+       ``rocky doctor`` and extracts the ``state_rw`` check into
+       :attr:`~.types.StateHealthResult.probe_outcome` / duration /
+       error fields. A probe failure populates the ``probe_*`` fields
+       rather than raising. Full doctor is invoked because
+       :meth:`RockyResource.doctor` does not currently accept a
+       ``--check`` filter — selectively running just the ``state_rw``
+       check is a follow-up optimisation that would cut the probe cost
+       to the same sub-second figure the engine's
+       :func:`rocky_core::state_sync::probe_state_backend` helper runs
+       in, without the surrounding config/adapter/pipelines checks.
+
+    The design is a thin facade over existing CLI surfaces — the FR's
+    stretch-goal "recent outcomes" rollup (persisted ring buffer of
+    state-upload / state-download outcomes) stays deferred because that
+    data is tracing-only today and would require new engine-side
+    persistence.
+
+    Args:
+        rocky: The :class:`~.resource.RockyResource` whose configured
+            state backend we're probing.
+        probe_write: When ``True``, run ``rocky doctor`` to exercise
+            the engine's ``state_rw`` put/get/delete round-trip against
+            the configured backend. Default ``False`` — cheap-path only.
+
+    Returns:
+        A :class:`~.types.StateHealthResult` describing the current
+        state-backend health.
+    """
+    backend = _read_state_backend(rocky.config_path)
+    last_run_status, last_run_at = _last_run_from_history(rocky)
+
+    probe_outcome: ProbeOutcome | None = None
+    probe_duration_ms: int | None = None
+    probe_error: str | None = None
+    if probe_write:
+        probe_outcome, probe_duration_ms, probe_error = _run_state_rw_probe(rocky)
+
+    return StateHealthResult(
+        backend=backend,
+        last_run_status=last_run_status,
+        last_run_at=last_run_at,
+        probe_outcome=probe_outcome,
+        probe_duration_ms=probe_duration_ms,
+        probe_error=probe_error,
+    )
+
+
+def _read_state_backend(config_path: str) -> StateBackendKind:
+    """Parse ``[state] backend`` from ``rocky.toml`` with local fallback.
+
+    Uses :mod:`tomllib` directly rather than the full engine config
+    loader so the accessor stays cheap (no env-var substitution, no
+    pipeline parsing) and side-effect-free. Unknown backend strings
+    fall back to ``"local"`` — matches what the engine itself assumes
+    when the config omits the field.
+    """
+    try:
+        with Path(config_path).open("rb") as fp:
+            raw = tomllib.load(fp)
+    except (FileNotFoundError, PermissionError, tomllib.TOMLDecodeError, IsADirectoryError):
+        return "local"
+
+    state_section = raw.get("state")
+    if not isinstance(state_section, dict):
+        return "local"
+    backend = state_section.get("backend")
+    if not isinstance(backend, str):
+        return "local"
+    normalised = backend.strip().lower()
+    if normalised in _VALID_BACKENDS:
+        return cast("StateBackendKind", normalised)
+    return "local"
+
+
+def _last_run_from_history(rocky: RockyResource) -> tuple[str | None, datetime | None]:
+    """Fetch the most recent run from ``rocky history``, tolerant of failures.
+
+    Returns a two-tuple of (normalised last-run status, ``started_at``
+    datetime). Either element is ``None`` when the state store has no
+    runs or when the binary itself fails — the accessor is meant to be
+    sensor-tick-safe, so ``dagster.Failure`` from a missing binary /
+    unreadable state store / parse error is swallowed and reported as
+    "unknown" rather than propagated.
+    """
+    try:
+        result = rocky.history()
+    except dg.Failure:
+        return None, None
+
+    runs = getattr(result, "runs", None)
+    if not runs:
+        return None, None
+
+    # The CLI returns runs newest-first; take the first entry.
+    first = runs[0]
+    wire_status = str(getattr(first, "status", "") or "")
+    normalised = _RUN_STATUS_NORMALISE.get(wire_status.strip().lower(), "failure")
+    started_at = getattr(first, "started_at", None)
+    # Guard against the rare case where a (legacy) shape lacks ``runs``
+    # or ``started_at`` — treat as "unknown" rather than synthesising.
+    if started_at is None:
+        return normalised, None
+    return normalised, started_at
+
+
+def _run_state_rw_probe(rocky: RockyResource) -> tuple[ProbeOutcome, int | None, str | None]:
+    """Run ``rocky doctor`` and translate the ``state_rw`` check into probe fields.
+
+    Returns a three-tuple of (outcome, duration_ms, error_message). The
+    mapping is deliberately tight to the engine's
+    :func:`rocky_core::state_sync::probe_state_backend` helper:
+
+    * ``status == healthy`` → ``("ok", duration_ms, None)``.
+    * ``status == critical`` with ``"timed out"`` / ``"timeout"`` in
+      the message → ``("timeout", duration_ms, message)``. Distinguishes
+      the operator-actionable timeout case from generic errors.
+    * ``status == critical`` otherwise → ``("error", duration_ms, message)``.
+    * ``status == warning`` → ``("error", duration_ms, message)`` —
+      the probe is binary on the engine side today, but we degrade
+      gracefully if that ever changes.
+
+    When the check is missing (older binary that doesn't emit it yet)
+    or the binary itself fails, the probe is reported as an ``error``
+    with an explanatory message — a strict caller can then surface it
+    as a warning observation without having to distinguish "probe
+    wasn't run" from "probe failed."
+    """
+    try:
+        report = rocky.doctor()
+    except dg.Failure as exc:
+        return "error", None, str(exc.description or exc)
+
+    state_rw = next((c for c in report.checks if _check_name(c) == "state_rw"), None)
+    if state_rw is None:
+        return "error", None, "rocky doctor did not emit a state_rw check"
+
+    status_str = _check_status(state_rw).lower()
+    duration_ms = int(getattr(state_rw, "duration_ms", 0) or 0)
+    message = str(getattr(state_rw, "message", "") or "")
+
+    if status_str == "healthy":
+        return "ok", duration_ms, None
+
+    # Everything else (critical / warning / unknown) is a probe failure.
+    # Surface "timeout" separately when the message carries the engine's
+    # canonical timeout substring, otherwise bucket as "error".
+    lowered = message.lower()
+    if "timed out" in lowered or "timeout" in lowered:
+        return "timeout", duration_ms, message
+    return "error", duration_ms, message or f"state_rw check returned status={status_str}"
+
+
+def _check_name(check: object) -> str:
+    """Return a check's ``name`` field as a plain string."""
+    return str(getattr(check, "name", "") or "")
+
+
+def _check_status(check: object) -> str:
+    """Return a check's ``status`` field as a plain string.
+
+    Tolerates both :class:`~.types.HealthStatus` (hand-written enum) and
+    the generated equivalent (plain string), same as :func:`_is_critical`.
+    """
+    status = getattr(check, "status", None)
+    return status.value if hasattr(status, "value") else str(status or "")

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -57,6 +57,7 @@ from .types import (
     OptimizeResult,
     PlanResult,
     RunResult,
+    StateHealthResult,
     StateResult,
     TestResult,
     ValidateMigrationResult,
@@ -1608,6 +1609,55 @@ class RockyResource(dg.ConfigurableResource):
     def doctor(self) -> DoctorResult:
         """Run ``rocky doctor`` and return the parsed health-check results."""
         return _parse_rocky_json(self._run_rocky(["doctor"]), DoctorResult, command="doctor")
+
+    def state_health(self, *, probe_write: bool = False) -> StateHealthResult:
+        """Return a live snapshot of Rocky's state-backend health.
+
+        Aggregates two already-shipped observability signals — the
+        configured ``[state] backend`` plus the most recent run
+        recorded in the state store — into a single typed snapshot
+        that Dagster sensors / schedules / asset checks can gate on
+        without having to shell out to ``rocky doctor`` on every
+        tick or log-scrape state-sync events.
+
+        The cheap path (the default, ``probe_write=False``) does one
+        ``rocky history`` subprocess plus a ``tomllib`` read of
+        :attr:`config_path` — bounded sub-second on any backend. When
+        ``probe_write=True`` we additionally invoke ``rocky doctor``
+        (which reuses the engine's ``probe_state_backend`` helper to
+        do a bounded put/get/delete round-trip against the configured
+        backend) and translate its ``state_rw`` check into the
+        :attr:`~.types.StateHealthResult.probe_outcome` /
+        :attr:`~.types.StateHealthResult.probe_duration_ms` /
+        :attr:`~.types.StateHealthResult.probe_error` fields.
+
+        Tolerance: the accessor is deliberately designed to survive a
+        sensor tick even when the underlying rocky binary is missing
+        or the state store is unreadable — in both cases the recent-run
+        fields degrade to ``None`` rather than raising. The probe
+        branch surfaces failures through the ``probe_*`` fields too
+        (``probe_outcome="error"``, ``probe_error=<description>``) so
+        a caller has a single source of truth for state-backend
+        liveness without wrapping this method in try/except.
+
+        Delegates to :func:`dagster_rocky.health.state_health` to keep
+        the resource thin and match the standalone
+        :func:`~.health.rocky_healthcheck` pattern.
+
+        Args:
+            probe_write: When ``True``, run the ``state_rw`` put/get/delete
+                probe. Default ``False`` — the cheap path.
+
+        Returns:
+            A :class:`~.types.StateHealthResult` describing the current
+            state-backend health.
+        """
+        # Import locally to avoid a module-level cycle between
+        # ``resource`` and ``health`` (health uses ``RockyResource`` via
+        # ``TYPE_CHECKING``).
+        from .health import state_health as _state_health
+
+        return _state_health(self, probe_write=probe_write)
 
     def resume_run(
         self,

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -784,6 +784,75 @@ class DoctorResult(BaseModel):
     overall: str
     checks: list[HealthCheck]
     suggestions: list[str]
+
+
+# ---------------------------------------------------------------------------
+# State health — accessor aggregating doctor + history
+# ---------------------------------------------------------------------------
+
+
+#: State backend identifiers, mirroring ``rocky_core::config::StateBackend``.
+#: The CLI emits the lowercase variant name for each backend kind.
+StateBackendKind = Literal["local", "tiered", "valkey", "s3", "gcs"]
+
+
+#: Whole-run status captured by ``rocky_core::state::RunStatus``. Emitted by
+#: ``rocky history --output json`` via Rust ``{:?}`` formatting, so values use
+#: CamelCase on the wire (``"Success"``/``"PartialFailure"``/``"Failure"``).
+#: :class:`StateHealthResult` normalises these to the snake_case variants
+#: below so callers can match string-literal equality without knowing the
+#: wire encoding.
+LastRunStatus = Literal["success", "partial_failure", "failure"]
+
+
+#: Outcome of the optional state-backend write probe. Mirrors the tri-state the
+#: engine's ``probe_state_backend`` helper surfaces via the ``state_rw``
+#: doctor check: probe wrote + read + deleted cleanly (``ok``), probe exceeded
+#: the configured ``transfer_timeout_seconds`` (``timeout``), or some other
+#: failure (auth/permissions/network/missing config).
+ProbeOutcome = Literal["ok", "timeout", "error"]
+
+
+class StateHealthResult(BaseModel):
+    """Aggregated snapshot of Rocky's state-backend health.
+
+    Surfaces the pair of already-shipped signals — :meth:`RockyResource.doctor`
+    for the live ``state_rw`` probe and :meth:`RockyResource.history` for the
+    most recent whole-run status — behind one typed API. The primary consumer
+    is a Dagster sensor that wants to observe state-backend health per tick
+    (see :meth:`RockyResource.state_health`).
+
+    Always-populated fields (cheap path — one ``rocky history`` call plus a
+    ``tomllib.load`` of the config):
+
+    * :attr:`backend` — the configured :data:`StateBackendKind`. Defaults to
+      ``"local"`` when the config can't be parsed or doesn't declare a
+      ``[state]`` table, which matches the engine's default.
+    * :attr:`last_run_status` — normalised :data:`LastRunStatus` from the most
+      recent run the state store has recorded, or ``None`` when the store
+      has no run history yet.
+    * :attr:`last_run_at` — ``started_at`` of that same record, or ``None``.
+
+    Probe fields (populated only when the caller passes
+    ``probe_write=True``):
+
+    * :attr:`probe_outcome` — :data:`ProbeOutcome` mapped from the ``state_rw``
+      doctor check status / message (``healthy`` → ``"ok"``; ``critical`` with
+      a ``"timed out"`` / ``"timeout"`` substring in the message → ``"timeout"``;
+      any other ``critical`` / ``warning`` → ``"error"``).
+    * :attr:`probe_duration_ms` — wall-clock time the probe took, from the
+      matching :class:`HealthCheck`. ``None`` when the probe wasn't requested.
+    * :attr:`probe_error` — human-readable failure message from the same
+      check when :attr:`probe_outcome` is ``"timeout"`` or ``"error"``.
+      ``None`` on success and when the probe wasn't requested.
+    """
+
+    backend: StateBackendKind
+    last_run_status: LastRunStatus | None = None
+    last_run_at: datetime | None = None
+    probe_outcome: ProbeOutcome | None = None
+    probe_duration_ms: int | None = None
+    probe_error: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/tests/test_state_health.py
+++ b/integrations/dagster/tests/test_state_health.py
@@ -1,0 +1,504 @@
+"""Tests for :func:`dagster_rocky.health.state_health` and
+:meth:`RockyResource.state_health`.
+
+The accessor aggregates two already-shipped surfaces:
+
+* ``rocky history --output json`` (for ``last_run_status`` / ``last_run_at``)
+* ``rocky doctor`` (for the ``state_rw`` probe, when ``probe_write=True``)
+
+plus a ``tomllib`` read of the configured ``rocky.toml`` for the backend
+type. All three sources are mocked here via ``patch.object`` so the tests
+stay binary-free and rely on hand-written fixtures rather than the
+playground POC corpus.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import dagster as dg
+import pytest
+
+from dagster_rocky.health import state_health
+from dagster_rocky.resource import RockyResource
+from dagster_rocky.types import (
+    DoctorResult,
+    HealthCheck,
+    HealthStatus,
+    HistoryResult,
+    StateHealthResult,
+)
+from dagster_rocky.types_generated import RunHistoryRecord
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _doctor(
+    *,
+    state_rw: HealthCheck | None,
+    extras: list[HealthCheck] | None = None,
+) -> DoctorResult:
+    """Build a :class:`DoctorResult` containing the given state_rw check.
+
+    ``extras`` lets a test include other checks (config, state, auth) so
+    the parser exercises the name-filtering logic rather than picking
+    the first entry blindly.
+    """
+    checks: list[HealthCheck] = list(extras or [])
+    if state_rw is not None:
+        checks.append(state_rw)
+    # Overall is irrelevant to ``state_health`` — keep it healthy to
+    # avoid confusing assertions when the probe itself is unhealthy.
+    return DoctorResult(
+        command="doctor",
+        overall="healthy",
+        checks=checks,
+        suggestions=[],
+    )
+
+
+def _history_with_runs(*runs: RunHistoryRecord) -> HistoryResult:
+    """Wrap one or more :class:`RunHistoryRecord`s in a :class:`HistoryResult`."""
+    return HistoryResult(
+        version="1.13.0",
+        command="history",
+        count=len(runs),
+        runs=list(runs),
+    )
+
+
+def _run_history_record(
+    *,
+    run_id: str = "run-001",
+    status: str = "Success",
+    started_at: datetime | None = None,
+) -> RunHistoryRecord:
+    """Build a single :class:`RunHistoryRecord` with defaults suitable for tests."""
+    return RunHistoryRecord(
+        run_id=run_id,
+        started_at=started_at or datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+        status=status,
+        trigger="Manual",
+        models_executed=1,
+        duration_ms=42,
+        models=[],
+    )
+
+
+@pytest.fixture
+def rocky_with_local_backend(tmp_path: Path) -> RockyResource:
+    """:class:`RockyResource` pointed at a minimal ``rocky.toml``.
+
+    Writing a real config file is the simplest way to exercise the
+    ``tomllib`` branch in ``_read_state_backend`` without having to
+    patch :mod:`tomllib` itself. Each test can override the file to
+    test other backends.
+    """
+    config = tmp_path / "rocky.toml"
+    config.write_text('[state]\nbackend = "local"\n')
+    return RockyResource(config_path=str(config))
+
+
+# ---------------------------------------------------------------------------
+# Backend parsing
+# ---------------------------------------------------------------------------
+
+
+def test_state_health_reads_local_backend_from_config(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+    ):
+        result = state_health(rocky_with_local_backend)
+
+    assert isinstance(result, StateHealthResult)
+    assert result.backend == "local"
+
+
+@pytest.mark.parametrize("backend", ["tiered", "valkey", "s3", "gcs"])
+def test_state_health_reads_non_local_backend_from_config(tmp_path: Path, backend: str) -> None:
+    config = tmp_path / "rocky.toml"
+    config.write_text(f'[state]\nbackend = "{backend}"\n')
+    rocky = RockyResource(config_path=str(config))
+
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky)
+
+    assert result.backend == backend
+
+
+def test_state_health_falls_back_to_local_when_config_missing(tmp_path: Path) -> None:
+    """A non-existent config path should not crash — defaults to ``local``."""
+    rocky = RockyResource(config_path=str(tmp_path / "does-not-exist.toml"))
+
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky)
+
+    assert result.backend == "local"
+
+
+def test_state_health_falls_back_to_local_on_malformed_toml(tmp_path: Path) -> None:
+    """Garbage in ``rocky.toml`` should not crash the sensor tick."""
+    config = tmp_path / "rocky.toml"
+    config.write_text("this is not = valid [toml\n")
+    rocky = RockyResource(config_path=str(config))
+
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky)
+
+    assert result.backend == "local"
+
+
+def test_state_health_falls_back_to_local_when_backend_field_missing(tmp_path: Path) -> None:
+    """A config with no ``[state]`` table should default to ``local``."""
+    config = tmp_path / "rocky.toml"
+    config.write_text('[adapter]\nkind = "duckdb"\n')
+    rocky = RockyResource(config_path=str(config))
+
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky)
+
+    assert result.backend == "local"
+
+
+def test_state_health_falls_back_to_local_on_unknown_backend_string(tmp_path: Path) -> None:
+    """Future backend names we don't know about yet map to ``local``.
+
+    Keeps the ``Literal`` invariant on :class:`StateHealthResult` intact
+    even if a consumer points Rocky at a bleeding-edge config.
+    """
+    config = tmp_path / "rocky.toml"
+    config.write_text('[state]\nbackend = "cassandra"\n')
+    rocky = RockyResource(config_path=str(config))
+
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky)
+
+    assert result.backend == "local"
+
+
+# ---------------------------------------------------------------------------
+# History parsing
+# ---------------------------------------------------------------------------
+
+
+def test_state_health_empty_history_yields_none_last_run(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """Fresh state store — no runs — surfaces ``None`` for both last-run fields."""
+    with patch.object(RockyResource, "history", return_value=_history_with_runs()):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status is None
+    assert result.last_run_at is None
+
+
+def test_state_health_normalises_success_status(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """Wire value ``"Success"`` (CamelCase from Rust ``{:?}``) normalises to ``"success"``."""
+    started = datetime(2026, 4, 22, 9, 30, 0, tzinfo=UTC)
+    record = _run_history_record(status="Success", started_at=started)
+    with patch.object(RockyResource, "history", return_value=_history_with_runs(record)):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status == "success"
+    assert result.last_run_at == started
+
+
+def test_state_health_normalises_partial_failure_status(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """Wire value ``"PartialFailure"`` normalises to ``"partial_failure"``."""
+    record = _run_history_record(status="PartialFailure")
+    with patch.object(RockyResource, "history", return_value=_history_with_runs(record)):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status == "partial_failure"
+
+
+def test_state_health_normalises_failure_status(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    record = _run_history_record(status="Failure")
+    with patch.object(RockyResource, "history", return_value=_history_with_runs(record)):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status == "failure"
+
+
+def test_state_health_unknown_status_maps_to_failure(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """A wire value we don't recognise falls back to ``"failure"``.
+
+    Safer than guessing "success" — the caller gating on a status
+    they can't identify should treat it as a potential regression.
+    """
+    record = _run_history_record(status="Cancelled")
+    with patch.object(RockyResource, "history", return_value=_history_with_runs(record)):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status == "failure"
+
+
+def test_state_health_picks_most_recent_run_as_first(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """``rocky history`` returns runs newest-first; the accessor trusts that."""
+    newest = _run_history_record(
+        run_id="newest",
+        status="Success",
+        started_at=datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC),
+    )
+    older = _run_history_record(
+        run_id="older",
+        status="Failure",
+        started_at=datetime(2026, 4, 22, 10, 0, 0, tzinfo=UTC),
+    )
+    with patch.object(RockyResource, "history", return_value=_history_with_runs(newest, older)):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status == "success"
+    assert result.last_run_at == newest.started_at
+
+
+def test_state_health_tolerates_history_binary_failure(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """A ``dg.Failure`` from the binary is swallowed to keep sensor ticks alive.
+
+    Matches :func:`rocky_healthcheck`'s pattern — when the accessor
+    runs every minute, a missing binary / unreadable state store
+    shouldn't crash every tick.
+    """
+    with patch.object(
+        RockyResource,
+        "history",
+        side_effect=dg.Failure(description="Rocky binary not found"),
+    ):
+        result = state_health(rocky_with_local_backend)
+
+    assert result.last_run_status is None
+    assert result.last_run_at is None
+    # Backend still reported (it doesn't depend on the binary).
+    assert result.backend == "local"
+
+
+# ---------------------------------------------------------------------------
+# Probe path (probe_write=True)
+# ---------------------------------------------------------------------------
+
+
+def test_state_health_probe_skipped_by_default(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """``probe_write=False`` (the default) must never invoke ``rocky doctor``."""
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(RockyResource, "doctor") as doctor_mock,
+    ):
+        result = state_health(rocky_with_local_backend)
+
+    doctor_mock.assert_not_called()
+    assert result.probe_outcome is None
+    assert result.probe_duration_ms is None
+    assert result.probe_error is None
+
+
+def test_state_health_probe_healthy_check_maps_to_ok(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.healthy,
+        message="State backend RW probe succeeded (valkey)",
+        duration_ms=87,
+    )
+    # Include a sibling check so the filter exercises name-matching.
+    extras = [
+        HealthCheck(
+            name="config",
+            status=HealthStatus.healthy,
+            message="Config syntax valid",
+            duration_ms=3,
+        ),
+    ]
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw, extras=extras),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "ok"
+    assert result.probe_duration_ms == 87
+    assert result.probe_error is None
+
+
+def test_state_health_probe_critical_timeout_message_maps_to_timeout(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """The engine prefixes timeout failures with the ``state transfer timed out`` string."""
+    message = "State backend RW probe failed: state transfer timed out after 30s"
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.critical,
+        message=message,
+        duration_ms=30_000,
+    )
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "timeout"
+    assert result.probe_duration_ms == 30_000
+    assert result.probe_error == message
+
+
+def test_state_health_probe_critical_generic_maps_to_error(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    message = "State backend RW probe failed: S3 upload failed: AccessDenied"
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.critical,
+        message=message,
+        duration_ms=512,
+    )
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "error"
+    assert result.probe_duration_ms == 512
+    assert result.probe_error == message
+
+
+def test_state_health_probe_missing_check_maps_to_error(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """An older binary that doesn't emit ``state_rw`` should surface as error."""
+    extras = [
+        HealthCheck(
+            name="config",
+            status=HealthStatus.healthy,
+            message="Config syntax valid",
+            duration_ms=3,
+        ),
+    ]
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=None, extras=extras),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "error"
+    assert result.probe_duration_ms is None
+    assert result.probe_error is not None
+    assert "state_rw" in result.probe_error
+
+
+def test_state_health_probe_binary_failure_maps_to_error(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """Doctor itself failing should populate ``probe_error`` rather than raise."""
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            side_effect=dg.Failure(description="Rocky binary not found"),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "error"
+    assert result.probe_duration_ms is None
+    assert result.probe_error is not None
+    assert "binary" in result.probe_error.lower()
+
+
+def test_state_health_probe_warning_maps_to_error(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """Defensive — the engine's probe is binary today, but ``warning`` degrades to error."""
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.warning,
+        message="Probe skipped: Valkey not reachable yet",
+        duration_ms=0,
+    )
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw),
+        ),
+    ):
+        result = state_health(rocky_with_local_backend, probe_write=True)
+
+    assert result.probe_outcome == "error"
+    assert result.probe_error == state_rw.message
+
+
+# ---------------------------------------------------------------------------
+# Resource facade
+# ---------------------------------------------------------------------------
+
+
+def test_rocky_resource_state_health_delegates_to_health_module(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """The method on :class:`RockyResource` should be a thin facade.
+
+    The exact shape of delegation isn't part of the public API, but the
+    method must accept ``probe_write`` and return a
+    :class:`StateHealthResult`.
+    """
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.healthy,
+        message="Local backend — no remote probe needed",
+        duration_ms=0,
+    )
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw),
+        ),
+    ):
+        cheap = rocky_with_local_backend.state_health()
+        probed = rocky_with_local_backend.state_health(probe_write=True)
+
+    assert isinstance(cheap, StateHealthResult)
+    assert cheap.probe_outcome is None
+    assert isinstance(probed, StateHealthResult)
+    assert probed.probe_outcome == "ok"


### PR DESCRIPTION
## Summary

Adds a focused programmatic accessor for Rocky state-backend health to the Dagster integration. Dagster users observing Rocky state-backend health can now read `RockyResource.state_health()` to get a live snapshot of the configured backend + the most recent run's status; with `probe_write=True` it additionally exercises the engine's `state_rw` put/get/delete probe and surfaces the outcome as typed fields. Closes the reprioritization-doc wave 2 follow-up (FR-003) now that wave 1 (#224) has merged.

## Design

- **Data sources — both already-shipped in v1.13.0.** The accessor aggregates two existing CLI surfaces:
  1. `rocky history --output json` for `last_run_status` / `last_run_at` (normalised from `RunStatus`'s CamelCase wire values into snake_case literals so callers don't need to know the serialisation).
  2. `rocky doctor` for the optional `state_rw` probe (translated into a tri-state `ok` / `timeout` / `error` outcome).
  Plus a cheap `tomllib.load` of `config_path` for the `backend` field.
- **No new engine CLI commands.** The FR's proposed `rocky state-health` CLI verb stays out of scope — all the substrate (`probe_state_backend` helper, `record_run` wiring) already ships, so a new verb would just cascade through codegen without adding signal the existing surfaces don't already carry.
- **No schema changes, no codegen cascade, no fixture regen.** Pure Python.
- **Sensor-tick safety.** `history()` raising `dg.Failure` (missing binary, unreadable state store) degrades to `last_run_status=None` rather than crashing the sensor tick. A failing probe populates `probe_outcome="error"` + `probe_error` rather than raising. Mirrors the existing `rocky_healthcheck` tolerance pattern.
- **Thin facade.** The method on `RockyResource` delegates to `health.state_health()` — same split as the existing `rocky_healthcheck` function so the resource stays easy to diff against wave 1's additions.

## Shape

Matches the FR's explicit Python sketch:

```python
class StateHealthResult(BaseModel):
    backend: Literal["local", "tiered", "valkey", "s3", "gcs"]
    last_run_status: Literal["success", "partial_failure", "failure"] | None
    last_run_at: datetime | None
    probe_outcome: Literal["ok", "timeout", "error"] | None
    probe_duration_ms: int | None
    probe_error: str | None
```

The FR's stretch-goal "recent outcomes" rollup (persisted ring buffer of state-upload / state-download outcomes) stays deferred — those signals are `tracing::info!` events only today and would require new engine-side persistence. Flagging explicitly so the decision is visible in history rather than buried.

### Known follow-up optimisation

`RockyResource.doctor()` today doesn't accept a `--check` filter — the probe path therefore invokes the full doctor (~1-2s cold). The engine CLI itself supports `--check state_rw`; wiring a `check: str | None = None` kwarg on `RockyResource.doctor()` would cut the probe cost to the engine's sub-second `probe_state_backend` helper and is a natural follow-up. Not landed here to keep the scope tight.

## Test plan

- [x] `uv run pytest` — 366 tests pass (24 new in `test_state_health.py`, covering the full matrix: all 5 backends, fresh state store, each `RunStatus` variant, unknown status → failure fallback, binary failure tolerance, probe-skipped-by-default, healthy probe → ok, critical + timeout message → timeout, critical generic → error, probe check missing, probe binary failure, probe warning severity, resource-method facade).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] `uv run ruff format --check src/ tests/` — clean.
- [x] No engine changes, no codegen cascade, no fixture regen.
- [x] Wave 1 surface (`setup_for_execution`, `run_pipes`, `RockyPipesMessageReader`, `strict_doctor*`) untouched — the new method sits next to `doctor()` and does not intersect.

## Wave 2 follow-up

This closes the wave 2 item in the 2026-04-22 reprio — the Python-only state-health accessor. Wave 3 (workspace-binding reconciliation, engine-side) and wave 4 (adapter-namespaced source metadata, codegen cascade) remain.