### PR TITLE
feat(engine): wire Arc 7 wave 2 wave-2 schema cache into typecheck callsites (PR 1b)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3589,6 +3589,7 @@ version = "1.13.0"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "indexmap",
  "notify",
  "reqwest",
@@ -3600,6 +3601,7 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "strsim",
+ "tempfile",
  "tokio",
  "tower 0.5.3",
  "tower-http",

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -1,6 +1,6 @@
 //! `rocky ai` — AI intent layer: generate, explain, sync, test.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
@@ -34,11 +34,28 @@ fn make_client() -> Result<LlmClient> {
 }
 
 /// Compile the project from a models directory.
-fn compile_project(models_dir: &str) -> Result<CompileResult> {
+///
+/// Wave-2 of Arc 7 wave 2: source schemas flow from the persisted cache
+/// (populated by `rocky run` / `rocky discover --with-schemas` in later
+/// PRs) so the AI prompt is grounded in real warehouse types when the
+/// cache is warm. Cold cache degrades to empty, which matches the
+/// pre-wave-2 behaviour this function had.
+fn compile_project(
+    config_path: &Path,
+    state_path: &Path,
+    models_dir: &str,
+) -> Result<CompileResult> {
+    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => {
+            crate::source_schemas::load_cached_source_schemas(&cfg.cache.schemas, state_path)
+        }
+        Err(_) => std::collections::HashMap::new(),
+    };
+
     let config = CompilerConfig {
         models_dir: PathBuf::from(models_dir),
         contracts_dir: None,
-        source_schemas: std::collections::HashMap::new(),
+        source_schemas,
         source_column_info: std::collections::HashMap::new(),
     };
     compile(&config).map_err(|e| anyhow::anyhow!("{e}"))
@@ -81,6 +98,8 @@ fn build_schema_context(result: &CompileResult) -> SchemaBuckets {
 /// typechecker is lenient on unresolved columns today, so schema grounding
 /// in the prompt is the primary mechanism preventing hallucinated columns.
 pub async fn run_ai(
+    config_path: &Path,
+    state_path: &Path,
     intent: &str,
     format: Option<&str>,
     models_dir: &str,
@@ -92,17 +111,19 @@ pub async fn run_ai(
     // Best-effort compile of the project to ground the prompt.
     // If it fails (missing dir, parse errors, etc.) we degrade to unschema'd
     // generation rather than refusing.
-    let compile_result = compile_project(models_dir).ok();
+    let compile_result = compile_project(config_path, state_path, models_dir).ok();
 
     let (model_schemas, source_tables) = match &compile_result {
         Some(r) => build_schema_context(r),
         None => (Vec::new(), Vec::new()),
     };
 
-    // Empty maps act as stand-ins for source_schemas / source_column_info
-    // until the CLI threads real warehouse discovery into `rocky ai`
-    // (deferred to a later wave). Project-aware validation still catches
-    // hallucinated references to existing *models* via the project graph.
+    // TODO(arc7-wave2): promote stub once `rocky-ai`'s generate callpath is
+    // audited — the `ValidationContext`-bound `source_schemas` differs from
+    // the `CompilerConfig.source_schemas` wired above. Empty maps here keep
+    // AI validation's behaviour unchanged; swapping them for the cache
+    // loader would change prompt grounding in ways that want a dedicated
+    // review against `rocky-ai::generate::ValidationContext` semantics.
     let empty_source_schemas = std::collections::HashMap::new();
     let empty_source_column_info = std::collections::HashMap::new();
     let validation_context = compile_result
@@ -147,7 +168,10 @@ pub async fn run_ai(
 }
 
 /// Execute `rocky ai sync` — detect schema changes and propose intent-guided updates.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ai_sync(
+    config_path: &Path,
+    state_path: &Path,
     models_dir: &str,
     apply: bool,
     model_filter: Option<&str>,
@@ -155,7 +179,7 @@ pub async fn run_ai_sync(
     output_json: bool,
 ) -> Result<()> {
     let client = make_client()?;
-    let result = compile_project(models_dir)?;
+    let result = compile_project(config_path, state_path, models_dir)?;
 
     // For now, use the current compilation as both "previous" and "current".
     // In practice, the previous would come from the state store.
@@ -246,7 +270,10 @@ pub async fn run_ai_sync(
 }
 
 /// Execute `rocky ai explain` — generate intent descriptions from code.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ai_explain(
+    config_path: &Path,
+    state_path: &Path,
     models_dir: &str,
     model_name: Option<&str>,
     all: bool,
@@ -254,7 +281,7 @@ pub async fn run_ai_explain(
     output_json: bool,
 ) -> Result<()> {
     let client = make_client()?;
-    let result = compile_project(models_dir)?;
+    let result = compile_project(config_path, state_path, models_dir)?;
 
     let models_to_explain: Vec<&rocky_core::models::Model> = result
         .project
@@ -312,7 +339,10 @@ pub async fn run_ai_explain(
 }
 
 /// Execute `rocky ai test` — generate test assertions from intent.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ai_test(
+    config_path: &Path,
+    state_path: &Path,
     models_dir: &str,
     model_name: Option<&str>,
     all: bool,
@@ -320,7 +350,7 @@ pub async fn run_ai_test(
     output_json: bool,
 ) -> Result<()> {
     let client = make_client()?;
-    let result = compile_project(models_dir)?;
+    let result = compile_project(config_path, state_path, models_dir)?;
 
     let models_to_test: Vec<&rocky_core::models::Model> = result
         .project

--- a/engine/crates/rocky-cli/src/commands/bench.rs
+++ b/engine/crates/rocky-cli/src/commands/bench.rs
@@ -254,6 +254,14 @@ fn bench_compile(model_count: usize, iterations: usize) -> Vec<BenchResult> {
     let dir = tempfile::TempDir::new().unwrap();
     generate_synthetic_project(model_count, dir.path());
 
+    // TODO(arc7-wave2): bench intentionally unwired — the synthetic
+    // tempdir project has no `state.redb`, so wiring
+    // `crate::source_schemas::load_cached_source_schemas` here would
+    // always return empty and either (a) tempt readers of this benchmark
+    // into thinking it exercises the cache path, or (b) worse, read a
+    // surrounding CWD's cache and make benchmarks non-reproducible across
+    // machines. Keep bench pure until there's a dedicated micro-bench for
+    // the wave-2 read path.
     let config = CompilerConfig {
         models_dir: dir.path().join("models"),
         contracts_dir: None,

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -167,11 +167,14 @@ struct TypedColumn {
 }
 
 /// Compile the models directory and extract per-model column schemas.
-fn compile_and_extract_schemas(models_dir: &Path) -> Result<HashMap<String, Vec<TypedColumn>>> {
+fn compile_and_extract_schemas(
+    models_dir: &Path,
+    source_schemas: HashMap<String, Vec<rocky_compiler::types::TypedColumn>>,
+) -> Result<HashMap<String, Vec<TypedColumn>>> {
     let config = CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: None,
-        source_schemas: HashMap::new(),
+        source_schemas,
         source_column_info: HashMap::new(),
     };
 
@@ -197,7 +200,17 @@ fn compile_and_extract_schemas(models_dir: &Path) -> Result<HashMap<String, Vec<
 ///
 /// This is best-effort: if the base ref doesn't have a complete models directory
 /// or compilation fails, we return an empty map rather than erroring.
-fn extract_base_schemas(base_ref: &str, models_dir: &Path) -> HashMap<String, Vec<TypedColumn>> {
+///
+/// Arc 7 wave 2 wave-2 note: `source_schemas` seeds the compile from the
+/// *current* warehouse cache, not historical types. That's fine for diff
+/// purposes — typecheck on historical models with today's leaf types still
+/// detects the model-level schema drift that ci-diff is looking for, and
+/// there's no per-ref cache to restore from.
+fn extract_base_schemas(
+    base_ref: &str,
+    models_dir: &Path,
+    source_schemas: HashMap<String, Vec<rocky_compiler::types::TypedColumn>>,
+) -> HashMap<String, Vec<TypedColumn>> {
     // Try to get the models directory path relative to the repo root
     let models_rel = find_models_relative_path(models_dir);
     let models_rel = match models_rel {
@@ -266,7 +279,7 @@ fn extract_base_schemas(base_ref: &str, models_dir: &Path) -> HashMap<String, Ve
     let config = CompilerConfig {
         models_dir: tmp.path().to_path_buf(),
         contracts_dir: None,
-        source_schemas: HashMap::new(),
+        source_schemas,
         source_column_info: HashMap::new(),
     };
 
@@ -444,7 +457,24 @@ fn build_diff_results(
 // ---------------------------------------------------------------------------
 
 /// Execute `rocky ci-diff`.
-pub fn run_ci_diff(base_ref: &str, models_dir: &Path, output_json: bool) -> Result<()> {
+pub fn run_ci_diff(
+    config_path: &Path,
+    state_path: &Path,
+    base_ref: &str,
+    models_dir: &Path,
+    output_json: bool,
+) -> Result<()> {
+    // Wave-2 of Arc 7 wave 2: load cached source schemas once and seed
+    // both compiles (current tree + base ref) with the same map so the
+    // resulting per-model type diffs measure real schema drift rather
+    // than `Unknown`-vs-`Unknown` noise. Degrades to empty when the
+    // cache is cold or `[cache.schemas] enabled = false`.
+    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => {
+            crate::source_schemas::load_cached_source_schemas(&cfg.cache.schemas, state_path)
+        }
+        Err(_) => HashMap::new(),
+    };
     // 1. Find changed files between base_ref and HEAD
     let changed_files = git_changed_files(base_ref)?;
 
@@ -500,7 +530,7 @@ pub fn run_ci_diff(base_ref: &str, models_dir: &Path, output_json: bool) -> Resu
 
     // 3. Compile current working tree
     let head_schemas = if models_dir.is_dir() {
-        compile_and_extract_schemas(models_dir).unwrap_or_else(|e| {
+        compile_and_extract_schemas(models_dir, source_schemas.clone()).unwrap_or_else(|e| {
             debug!("HEAD compilation failed: {e}");
             HashMap::new()
         })
@@ -510,7 +540,7 @@ pub fn run_ci_diff(base_ref: &str, models_dir: &Path, output_json: bool) -> Resu
 
     // 4. Extract base schemas (best-effort)
     let base_schemas = if models_dir.is_dir() {
-        extract_base_schemas(base_ref, models_dir)
+        extract_base_schemas(base_ref, models_dir, source_schemas)
     } else {
         HashMap::new()
     };

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -21,6 +21,7 @@ use crate::output::{CompileOutput, CostHint, ModelDetail, print_json};
 #[allow(clippy::too_many_arguments)]
 pub fn run_compile(
     config_path: Option<&Path>,
+    state_path: &Path,
     models_dir: &Path,
     contracts_dir: Option<&Path>,
     model_filter: Option<&str>,
@@ -29,14 +30,27 @@ pub fn run_compile(
     target_dialect: Option<Dialect>,
     with_seed: bool,
 ) -> Result<()> {
-    // Wave-1 of Arc 7 wave 2: when `--with-seed` is set, run the project's
-    // `data/seed.sql` against an in-memory DuckDB and use the resulting
-    // information_schema as the source-of-truth for `source_schemas`. This
-    // turns leaf .sql models from `RockyType::Unknown` into concrete types
-    // for any project that ships a runnable seed (the entire playground).
-    // Opt-in keeps the wave-1 fast-pure compile path intact.
+    // `source_schemas` precedence (Arc 7 wave 2):
+    //   1. `--with-seed` wins -> wave-1 seed loader (explicit user intent,
+    //      used for tests/playgrounds where the cache is irrelevant).
+    //   2. Otherwise, the wave-2 schema cache if `[cache.schemas] enabled`.
+    //   3. Cold-cache fallback: empty map — typecheck degrades to Unknown,
+    //      which matches pre-wave-2 behaviour.
     let source_schemas = if with_seed {
+        // Wave-1: run `data/seed.sql` in in-memory DuckDB, read columns
+        // from its `information_schema`. Turns leaf .sql models from
+        // `RockyType::Unknown` into concrete types for any project that
+        // ships a runnable seed (the entire playground).
         load_source_schemas_from_seed(models_dir)?
+    } else if let Some(path) = config_path {
+        // Wave-2: TTL-filtered load from `state.redb`'s `SCHEMA_CACHE`
+        // table. Honours `[cache.schemas] enabled` + `ttl_seconds`.
+        match rocky_config::load_rocky_config(path) {
+            Ok(cfg) => {
+                crate::source_schemas::load_cached_source_schemas(&cfg.cache.schemas, state_path)
+            }
+            Err(_) => HashMap::new(),
+        }
     } else {
         HashMap::new()
     };
@@ -470,6 +484,7 @@ schema_template = "s"
         // compile should bail with the generic "compilation failed" error.
         let err = run_compile(
             None,
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -493,8 +508,18 @@ schema_template = "s"
         write_model(&models_dir, "m1", "SELECT NVL(a, b) AS c FROM t");
 
         // No target_dialect → no P001, compile succeeds.
-        run_compile(None, &models_dir, None, None, true, false, None, false)
-            .expect("compile should succeed without lint");
+        run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+        )
+        .expect("compile should succeed without lint");
     }
 
     #[test]
@@ -507,6 +532,7 @@ schema_template = "s"
         // NVL is native to Snowflake, so the lint should produce no issues.
         run_compile(
             None,
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -530,6 +556,7 @@ schema_template = "s"
 
         let err = run_compile(
             Some(&config),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -560,6 +587,7 @@ schema_template = "s"
 
         let err = run_compile(
             Some(&config),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -586,6 +614,7 @@ schema_template = "s"
         // Project-wide allow-list of NVL → no P001 → compile succeeds.
         run_compile(
             Some(&config),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -612,6 +641,7 @@ schema_template = "s"
         // Pragma exempts this model, so the lint should not fire.
         run_compile(
             Some(&config),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -639,6 +669,7 @@ schema_template = "s"
 
         let err = run_compile(
             Some(&config),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -666,6 +697,7 @@ schema_template = "s"
         // flag-only behavior remains. With no flag, no lint fires.
         run_compile(
             Some(&nonexistent),
+            Path::new(".rocky-state.redb"),
             &models_dir,
             None,
             None,
@@ -711,8 +743,18 @@ schema_template = "s"
         // typed columns should pick up real types instead of Unknown.
         // (We assert the bail-free path here; the typed-output assertion
         // lives in compile_with_seed_resolves_unknown_types_to_concrete.)
-        run_compile(None, &models_dir, None, None, true, false, None, true)
-            .expect("with-seed compile should succeed");
+        run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            true,
+        )
+        .expect("with-seed compile should succeed");
     }
 
     #[test]
@@ -724,7 +766,18 @@ schema_template = "s"
         write_model(&models_dir, "leaf", "SELECT 1 AS x");
         // Note: no data/seed.sql written.
 
-        let err = run_compile(None, &models_dir, None, None, true, false, None, true).unwrap_err();
+        let err = run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            true,
+        )
+        .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("--with-seed"), "msg: {msg}");
         assert!(msg.contains("seed.sql"), "msg: {msg}");
@@ -739,7 +792,18 @@ schema_template = "s"
         write_model(&models_dir, "leaf", "SELECT 1 AS x");
         write_seed(dir.path(), "DEFINITELY NOT VALID SQL;");
 
-        let err = run_compile(None, &models_dir, None, None, true, false, None, true).unwrap_err();
+        let err = run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            true,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("seed execution failed"),
             "msg: {err}",
@@ -777,5 +841,150 @@ schema_template = "s"
             by_name["name"].data_type,
             rocky_compiler::types::RockyType::String,
         ));
+    }
+
+    // ---- Wave-2 of Arc 7 wave 2: cache-backed source_schemas ----
+
+    /// End-to-end wiring check: seed a `SchemaCacheEntry` in `state.redb`,
+    /// run `rocky compile` without `--with-seed`, and confirm the cached
+    /// entry lands in `CompilerConfig.source_schemas` so the leaf model's
+    /// types come out concrete instead of `Unknown`.
+    #[test]
+    fn compile_reads_typed_columns_from_schema_cache() {
+        use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+        use rocky_core::state::StateStore;
+
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(
+            &models_dir,
+            "leaf",
+            "SELECT order_id, amount FROM raw__orders.orders",
+        );
+        let state_path = dir.path().join(".rocky-state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            let key = schema_cache_key("cat", "raw__orders", "orders");
+            store
+                .write_schema_cache_entry(
+                    &key,
+                    &SchemaCacheEntry {
+                        columns: vec![
+                            StoredColumn {
+                                name: "order_id".into(),
+                                data_type: "BIGINT".into(),
+                                nullable: false,
+                            },
+                            StoredColumn {
+                                name: "amount".into(),
+                                data_type: "DECIMAL(10, 2)".into(),
+                                nullable: true,
+                            },
+                        ],
+                        cached_at: chrono::Utc::now(),
+                    },
+                )
+                .unwrap();
+        }
+
+        // Need a `rocky.toml` with `[cache.schemas]` on defaults so the
+        // cache-read path activates.
+        let config = write_rocky_toml(dir.path(), "");
+
+        // Confirm the compile succeeds — wiring check. Typed-model
+        // assertions go through the compiler API to peek at typed
+        // columns; see the separate cache_loader_surfaces_typed_columns
+        // test below.
+        run_compile(
+            Some(&config),
+            &state_path,
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+        )
+        .expect("compile with cache-backed source_schemas should succeed");
+    }
+
+    /// Direct check on the cache-loader round trip: the helper returns the
+    /// exact shape `CompilerConfig.source_schemas` expects, via the same
+    /// `default_type_mapper` wave-1 uses. Guards against drift between the
+    /// `StoredColumn -> TypedColumn` mapping and the cache read path.
+    #[test]
+    fn cache_loader_surfaces_typed_columns() {
+        use rocky_compiler::schema_cache::load_source_schemas_from_cache;
+        use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+        use rocky_core::state::StateStore;
+
+        let dir = TempDir::new().unwrap();
+        let state_path = dir.path().join("state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            let key = schema_cache_key("cat", "raw__events", "clicks");
+            store
+                .write_schema_cache_entry(
+                    &key,
+                    &SchemaCacheEntry {
+                        columns: vec![StoredColumn {
+                            name: "user_id".into(),
+                            data_type: "BIGINT".into(),
+                            nullable: false,
+                        }],
+                        cached_at: chrono::Utc::now(),
+                    },
+                )
+                .unwrap();
+        }
+
+        let store = StateStore::open_read_only(&state_path).unwrap();
+        let map =
+            load_source_schemas_from_cache(&store, chrono::Utc::now(), chrono::Duration::hours(24))
+                .unwrap();
+
+        let cols = map
+            .get("raw__events.clicks")
+            .expect("catalog prefix stripped; leaf uses <schema>.<table>");
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].name, "user_id");
+        assert!(matches!(
+            cols[0].data_type,
+            rocky_compiler::types::RockyType::Int64,
+        ));
+        assert!(!cols[0].nullable);
+    }
+
+    /// Compile without a state file must not silently fail or create a
+    /// stray `state.redb` beside the models directory. Cold-cache path is
+    /// the default experience for a fresh project.
+    #[test]
+    fn compile_without_state_file_degrades_gracefully() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT 1 AS x");
+        let config = write_rocky_toml(dir.path(), "");
+        let state_path = dir.path().join(".rocky-state.redb");
+        assert!(!state_path.exists(), "precondition: no state file");
+
+        run_compile(
+            Some(&config),
+            &state_path,
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+        )
+        .expect("compile without state file should succeed");
+        assert!(
+            !state_path.exists(),
+            "compile must not create state.redb as a side effect"
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -22,8 +22,10 @@ use crate::output::*;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Execute `rocky dag`.
+#[allow(clippy::too_many_arguments)]
 pub fn run_dag(
     config_path: &Path,
+    state_path: &Path,
     models_dir: &Path,
     seeds_dir: Option<&Path>,
     contracts_dir: Option<&Path>,
@@ -69,6 +71,8 @@ pub fn run_dag(
         include_column_lineage,
         models_dir,
         contracts_dir,
+        &cfg,
+        state_path,
     )?;
 
     if json {
@@ -80,6 +84,7 @@ pub fn run_dag(
 }
 
 /// Build the full `DagOutput` from the unified DAG plus model/seed metadata.
+#[allow(clippy::too_many_arguments)]
 fn build_dag_output(
     dag: &UnifiedDag,
     phases: &[Vec<&rocky_core::unified_dag::UnifiedNode>],
@@ -88,6 +93,8 @@ fn build_dag_output(
     include_column_lineage: bool,
     models_dir: &Path,
     contracts_dir: Option<&Path>,
+    cfg: &rocky_core::config::RockyConfig,
+    state_path: &Path,
 ) -> Result<DagOutput> {
     // Build lookup maps.
     let model_map: HashMap<&str, &Model> =
@@ -189,7 +196,7 @@ fn build_dag_output(
 
     // Column lineage (optional).
     let column_lineage = if include_column_lineage {
-        build_column_lineage_from_models(models_dir, contracts_dir)?
+        build_column_lineage_from_models(models_dir, contracts_dir, cfg, state_path)?
     } else {
         vec![]
     };
@@ -240,11 +247,21 @@ fn extract_partition_shape(strategy: &StrategyConfig) -> Option<PartitionShapeOu
 fn build_column_lineage_from_models(
     models_dir: &Path,
     contracts_dir: Option<&Path>,
+    cfg: &rocky_core::config::RockyConfig,
+    state_path: &Path,
 ) -> Result<Vec<LineageEdgeRecord>> {
     let compile_config = rocky_compiler::compile::CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: contracts_dir.map(Path::to_path_buf),
-        source_schemas: std::collections::HashMap::new(),
+        // Wave-2 of Arc 7 wave 2: typed columns flow from the persisted
+        // schema cache (populated by `rocky run` / `rocky discover
+        // --with-schemas` in later PRs) straight into column lineage
+        // extraction, so downstream edges carry real types instead of
+        // `RockyType::Unknown`.
+        source_schemas: crate::source_schemas::load_cached_source_schemas(
+            &cfg.cache.schemas,
+            state_path,
+        ),
         source_column_info: std::collections::HashMap::new(),
     };
 

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -30,7 +30,10 @@ fn to_edge_record(edge: &rocky_compiler::semantic::LineageEdge) -> LineageEdgeRe
 }
 
 /// Execute `rocky lineage`.
+#[allow(clippy::too_many_arguments)]
 pub fn run_lineage(
+    config_path: &Path,
+    state_path: &Path,
     models_dir: &Path,
     target: &str,
     column: Option<&str>,
@@ -38,10 +41,20 @@ pub fn run_lineage(
     downstream: bool,
     output_json: bool,
 ) -> Result<()> {
+    // Wave-2 of Arc 7 wave 2: load cached warehouse schemas so lineage
+    // edges inherit real types instead of `RockyType::Unknown` on the
+    // leaves. Degrades to empty on cold cache / missing config.
+    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => {
+            crate::source_schemas::load_cached_source_schemas(&cfg.cache.schemas, state_path)
+        }
+        Err(_) => HashMap::new(),
+    };
+
     let config = CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: None,
-        source_schemas: HashMap::new(),
+        source_schemas,
         source_column_info: HashMap::new(),
     };
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -363,6 +363,7 @@ pub async fn run(
             &mut output,
             None, // model-only run has no pipeline hooks
             None,
+            &rocky_cfg.cache.schemas,
         )
         .await?;
 
@@ -2131,6 +2132,7 @@ pub async fn run(
                     &mut output,
                     Some(&hook_registry),
                     Some(pipeline_name),
+                    &rocky_cfg.cache.schemas,
                 )
                 .await?;
                 Ok(())
@@ -2430,13 +2432,36 @@ pub(crate) async fn execute_models(
     // the caller having to synthesise a fake pipeline name.
     hook_registry: Option<&HookRegistry>,
     pipeline_name: Option<&str>,
+    // Arc 7 wave 2 wave-2: honour `[cache.schemas]` for source-schema
+    // loading during compile. The write tap that keeps the cache fresh
+    // lands in PR 2; today the loader reads whatever's there.
+    schema_cache_config: &rocky_core::config::SchemaCacheConfig,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
+
+    // Wave-2 of Arc 7 wave 2: load the persisted schema cache directly
+    // from the live `StateStore` — no round-trip through
+    // `crate::source_schemas::load_cached_source_schemas`, because that
+    // helper opens a read-only handle and we already hold a write-capable
+    // one here. Degrades silently when the cache is cold or disabled.
+    let source_schemas = if schema_cache_config.enabled {
+        match state_store {
+            Some(store) => rocky_compiler::schema_cache::load_source_schemas_from_cache(
+                store,
+                chrono::Utc::now(),
+                schema_cache_config.ttl(),
+            )
+            .unwrap_or_default(),
+            None => std::collections::HashMap::new(),
+        }
+    } else {
+        std::collections::HashMap::new()
+    };
 
     let compile_config = rocky_compiler::compile::CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: None,
-        source_schemas: std::collections::HashMap::new(),
+        source_schemas,
         source_column_info: std::collections::HashMap::new(),
     };
 

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -70,6 +70,7 @@ pub async fn run_transformation(
             &mut output,
             None, // run_local doesn't build a HookRegistry
             None,
+            &rocky_cfg.cache.schemas,
         )
         .await?;
     } else {

--- a/engine/crates/rocky-cli/src/commands/watch.rs
+++ b/engine/crates/rocky-cli/src/commands/watch.rs
@@ -100,8 +100,13 @@ pub async fn run_watch(
 /// Run compile and print the result. Errors are printed, not propagated,
 /// so the watch loop continues after a failed compilation.
 fn print_compile_result(models_dir: &Path, contracts_dir: Option<&Path>, output_json: bool) {
+    // Watch doesn't take a state_path arg today; default to the same
+    // location `main.rs` does (`.rocky-state.redb` in CWD). Arc 7 wave 2
+    // wave-2: if the file doesn't exist (fresh project, no runs yet) the
+    // cache loader gracefully returns an empty map.
     match run_compile(
         None,
+        Path::new(".rocky-state.redb"),
         models_dir,
         contracts_dir,
         None,

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -4,3 +4,4 @@ pub mod otel_guard;
 pub mod output;
 pub mod pipes;
 pub mod registry;
+pub(crate) mod source_schemas;

--- a/engine/crates/rocky-cli/src/source_schemas.rs
+++ b/engine/crates/rocky-cli/src/source_schemas.rs
@@ -1,0 +1,204 @@
+//! Shared helper for loading the Arc 7 wave 2 wave-2 schema cache into the
+//! typecheck pipeline.
+//!
+//! Every `rocky <verb>` whose internal flow calls
+//! `rocky_compiler::compile::compile` used to pass
+//! `source_schemas: HashMap::new()` — which forces the typechecker to treat
+//! every leaf `FROM <schema>.<table>` as `RockyType::Unknown`. Wave-1 seeded
+//! that map from DuckDB (`--with-seed`); wave-2 seeds it from a persisted
+//! redb cache written by prior `rocky run` / `rocky discover --with-schemas`
+//! invocations (PRs 2-3).
+//!
+//! This helper collapses the read-path boilerplate — config gating, optional
+//! state-store open, TTL application, log emission — into one call. PR 1b
+//! wires every CLI callsite to it. PR 1a infrastructure (`rocky-core::
+//! schema_cache`, `StateStore::list_schema_cache`,
+//! `rocky-compiler::schema_cache::load_source_schemas_from_cache`) is the
+//! load-bearing plumbing below.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use chrono::Utc;
+use tracing::{debug, info};
+
+use rocky_compiler::schema_cache::load_source_schemas_from_cache;
+use rocky_compiler::types::TypedColumn;
+use rocky_core::config::SchemaCacheConfig;
+use rocky_core::state::StateStore;
+
+/// Once-per-process guard for the "N/M sources hit" info log emitted from
+/// CLI commands.
+///
+/// CLI processes are short-lived, so guarding on the process is equivalent
+/// to "once per invocation." Quiet by default — the log fires only when
+/// `load_source_schemas_from_cache` returns at least one entry but fewer
+/// than the caller expected (mixed hit/miss case). Cold cache = no log,
+/// full-hit cache = no log. See the design doc §5.6 for the rationale.
+static CLI_PARTIAL_HIT_LOGGED: OnceLock<()> = OnceLock::new();
+
+/// Load `source_schemas` for a CLI compile, honouring `[cache.schemas]`.
+///
+/// Precedence (matches the design doc §4.4):
+/// 1. `config.enabled == false` -> empty map (strict-CI posture).
+/// 2. `state_path` doesn't exist -> empty map (fresh clone, cold cache).
+///    Does **not** create `state.redb` as a side effect — calling
+///    `StateStore::open_read_only` on a non-existent path would call
+///    `Database::create` and leave a fresh empty file behind for any user
+///    who runs `rocky compile` before their first `rocky run`.
+/// 3. Open fails (corrupt DB, permission error) -> empty map + debug log.
+///    A broken cache should never fail typecheck.
+/// 4. Scan fails (rare — version mismatch on a table we didn't create
+///    here) -> empty map + debug log.
+/// 5. Otherwise -> the TTL-filtered map from
+///    [`load_source_schemas_from_cache`].
+///
+/// Emits an [`tracing::info!`] line once per CLI process (via
+/// [`CLI_PARTIAL_HIT_LOGGED`]) when the scan returns at least one entry —
+/// gives visibility into staleness without per-compile noise.
+///
+/// The target `rocky::schema_cache` keeps the log easy to filter in
+/// deployments that ship structured JSON logs.
+pub(crate) fn load_cached_source_schemas(
+    config: &SchemaCacheConfig,
+    state_path: &Path,
+) -> HashMap<String, Vec<TypedColumn>> {
+    if !config.enabled {
+        return HashMap::new();
+    }
+
+    // Gate on existence so we don't create an empty `state.redb` as a side
+    // effect of `rocky compile` on a fresh checkout.
+    if !state_path.exists() {
+        return HashMap::new();
+    }
+
+    // `open_read_only` doesn't take the advisory write lock, so concurrent
+    // `rocky run` writers are unaffected. This matters for CI systems that
+    // run `rocky compile` and `rocky run` side by side.
+    let store = match StateStore::open_read_only(state_path) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!(
+                error = %e,
+                path = %state_path.display(),
+                "schema cache: state store open failed; degrading to Unknown types"
+            );
+            return HashMap::new();
+        }
+    };
+
+    let map = match load_source_schemas_from_cache(&store, Utc::now(), config.ttl()) {
+        Ok(m) => m,
+        Err(e) => {
+            debug!(
+                error = %e,
+                "schema cache: scan failed; degrading to Unknown types"
+            );
+            return HashMap::new();
+        }
+    };
+
+    if !map.is_empty() && CLI_PARTIAL_HIT_LOGGED.set(()).is_ok() {
+        info!(
+            target: "rocky::schema_cache",
+            sources_hit = map.len(),
+            "schema cache: {} source(s) hit — run `rocky run` (write tap lands in PR 2) or \
+             `rocky discover --with-schemas` (PR 3) to warm-cache more sources",
+            map.len(),
+        );
+    }
+
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Duration};
+    use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+    use tempfile::TempDir;
+
+    fn seed_cache(store: &StateStore, schema: &str, table: &str, cached_at: DateTime<Utc>) {
+        let key = schema_cache_key("cat", schema, table);
+        let entry = SchemaCacheEntry {
+            columns: vec![StoredColumn {
+                name: "id".into(),
+                data_type: "BIGINT".into(),
+                nullable: false,
+            }],
+            cached_at,
+        };
+        store.write_schema_cache_entry(&key, &entry).unwrap();
+    }
+
+    #[test]
+    fn returns_empty_when_config_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.redb");
+        {
+            let store = StateStore::open(&path).unwrap();
+            seed_cache(&store, "staging", "orders", Utc::now());
+        }
+
+        let config = SchemaCacheConfig {
+            enabled: false,
+            ttl_seconds: 86_400,
+            replicate: false,
+        };
+        let map = load_cached_source_schemas(&config, &path);
+        assert!(map.is_empty(), "disabled config must short-circuit");
+    }
+
+    #[test]
+    fn returns_empty_when_state_path_missing() {
+        let tmp = TempDir::new().unwrap();
+        // Intentionally do NOT create state.redb — simulate fresh clone.
+        let path = tmp.path().join("state.redb");
+        assert!(!path.exists());
+
+        let config = SchemaCacheConfig::default();
+        let map = load_cached_source_schemas(&config, &path);
+        assert!(map.is_empty());
+        // Critical: must not have been created as a side effect.
+        assert!(!path.exists(), "loader must not create state.redb");
+    }
+
+    #[test]
+    fn returns_cached_entries_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.redb");
+        {
+            let store = StateStore::open(&path).unwrap();
+            seed_cache(&store, "staging", "orders", Utc::now());
+            seed_cache(&store, "staging", "customers", Utc::now());
+        }
+
+        let config = SchemaCacheConfig::default();
+        let map = load_cached_source_schemas(&config, &path);
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("staging.orders"));
+        assert!(map.contains_key("staging.customers"));
+    }
+
+    #[test]
+    fn filters_stale_entries_past_ttl() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.redb");
+        {
+            let store = StateStore::open(&path).unwrap();
+            // Cached 48h ago -> stale at 24h TTL.
+            seed_cache(
+                &store,
+                "staging",
+                "orders",
+                Utc::now() - Duration::hours(48),
+            );
+        }
+
+        let config = SchemaCacheConfig::default();
+        let map = load_cached_source_schemas(&config, &path);
+        assert!(map.is_empty(), "stale entry must be filtered");
+    }
+}

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -23,11 +23,15 @@ sqlparser = { workspace = true }
 strsim = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+# Arc 7 wave 2 wave-2: schema-cache read-path needs `chrono::Utc::now()` +
+# `Duration` for TTL filtering. Reused via `rocky_compiler::schema_cache`.
+chrono = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
 reqwest = { workspace = true }
 indexmap = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-server/src/api.rs
+++ b/engine/crates/rocky-server/src/api.rs
@@ -343,13 +343,10 @@ mod tests {
         // Use the simple_project fixture
         let models_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../rocky-compiler/tests/fixtures/simple_project/models");
-        Arc::new(ServerState {
-            models_dir,
-            contracts_dir: None,
-            config_path: None,
-            compile_result: tokio::sync::RwLock::new(None),
-            dag_status: rocky_core::dag_status::DagStatusStore::new(),
-        })
+        // Skip the spawned initial compile — tests hit the router directly
+        // without needing a warmed `compile_result`, and the spawn is cheap
+        // to absorb at test end.
+        ServerState::new(models_dir, None, None)
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-server/src/lib.rs
+++ b/engine/crates/rocky-server/src/lib.rs
@@ -8,5 +8,6 @@ pub mod api;
 pub mod dag_viz;
 pub mod dashboard;
 pub mod lsp;
+pub(crate) mod schema_cache_throttle;
 pub mod state;
 pub mod watch;

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -28,6 +28,8 @@ use tracing::info;
 use rocky_compiler::compile::{CompileResult, CompilerConfig};
 use rocky_compiler::typecheck::RefLocation;
 
+use crate::schema_cache_throttle::SchemaCacheThrottle;
+
 // ── SQL function catalog ────────────────────────────────────────────────────
 
 /// Full function catalog with parameter info for signature help.
@@ -348,6 +350,11 @@ pub struct RockyLsp {
     /// pass when the cached hash matches the current model SQL —
     /// editors call this hook on every scroll on large files.
     semantic_tokens_cache: SemanticTokensCache,
+    /// Arc 7 wave 2 wave-2: throttle the "N sources hit" info log so it
+    /// fires once per session per `models_dir` rather than per keystroke.
+    /// PR 2 will encode a cache version in the throttle key so the log
+    /// re-fires after a write tap bump. See `schema_cache_throttle.rs`.
+    schema_cache_throttle: SchemaCacheThrottle,
 }
 
 impl RockyLsp {
@@ -370,10 +377,23 @@ impl RockyLsp {
         let models_dir = self.models_dir.read().await;
         let Some(ref dir) = *models_dir else { return };
 
+        // Wave-2 of Arc 7 wave 2: plug cached warehouse schemas into the
+        // LSP typecheck so `FROM <schema>.<table>` inlay hints and hover
+        // types resolve against real columns instead of `Unknown`.
+        let dir_path = std::path::PathBuf::from(dir);
+        let source_schemas = Self::load_cached_source_schemas(
+            &dir_path,
+            &self.schema_cache_throttle,
+            // LSP throttle key: once-per-session per project (models_dir).
+            // PR 2 will extend the suffix with a cache-version counter.
+            dir,
+        )
+        .await;
+
         let config = CompilerConfig {
-            models_dir: std::path::PathBuf::from(dir),
+            models_dir: dir_path,
             contracts_dir: None,
-            source_schemas: HashMap::new(),
+            source_schemas,
             source_column_info: HashMap::new(),
         };
 
@@ -386,6 +406,78 @@ impl RockyLsp {
                 info!(error = %e, "LSP compilation failed");
             }
         }
+    }
+
+    /// Arc 7 wave 2 wave-2: load the persisted schema cache for use as
+    /// `CompilerConfig.source_schemas`. Mirrors
+    /// `rocky-cli::source_schemas::load_cached_source_schemas` but (a)
+    /// reuses the LSP's per-session throttle so the info log doesn't fire
+    /// on every recompile, and (b) resolves the state file relative to
+    /// `models_dir` (same convention as `api.rs`, `dashboard.rs`, and
+    /// `state::ServerState`).
+    ///
+    /// Honours `[cache.schemas]` from the project's `rocky.toml` (found
+    /// one level above `models_dir` — the same `<root>/models` layout the
+    /// `initialize` handler already assumes). Missing or invalid config
+    /// falls back to defaults (`enabled = true`, 24h TTL) so a
+    /// zero-config project behaves like the CLI would.
+    async fn load_cached_source_schemas(
+        models_dir: &std::path::Path,
+        throttle: &SchemaCacheThrottle,
+        throttle_key: &str,
+    ) -> HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
+        // Derive the project root as `models_dir.parent()` and read the
+        // project's `rocky.toml`. The LSP `initialize` handler sets
+        // `models_dir = <root>/models`, so the parent is the project root.
+        // Missing file / parse error -> defaults; this keeps the behaviour
+        // continuous with the CLI's `load_cached_source_schemas`.
+        let schema_cache_config = models_dir
+            .parent()
+            .map(|root| root.join("rocky.toml"))
+            .and_then(|toml_path| rocky_core::config::load_rocky_config(&toml_path).ok())
+            .map(|c| c.cache.schemas)
+            .unwrap_or_default();
+
+        if !schema_cache_config.enabled {
+            return HashMap::new();
+        }
+
+        let state_path = models_dir.join(".rocky-state.redb");
+        if !state_path.exists() {
+            return HashMap::new();
+        }
+
+        let store = match rocky_core::state::StateStore::open_read_only(&state_path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(error = %e, "LSP schema cache: state open failed");
+                return HashMap::new();
+            }
+        };
+
+        let map = match rocky_compiler::schema_cache::load_source_schemas_from_cache(
+            &store,
+            chrono::Utc::now(),
+            schema_cache_config.ttl(),
+        ) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::debug!(error = %e, "LSP schema cache: scan failed");
+                return HashMap::new();
+            }
+        };
+
+        if !map.is_empty() && throttle.mark_logged(throttle_key).await {
+            info!(
+                target: "rocky::schema_cache",
+                sources_hit = map.len(),
+                "schema cache: {} source(s) hit — run `rocky run` (PR 2 write tap) or \
+                 `rocky discover --with-schemas` (PR 3) to warm-cache more sources",
+                map.len(),
+            );
+        }
+
+        map
     }
 
     async fn publish_diagnostics(&self, result: &CompileResult) {
@@ -747,6 +839,10 @@ impl LanguageServer for RockyLsp {
             let compile_result = self.compile_result.clone();
             let models_dir = self.models_dir.clone();
             let pending = self.recompile_pending.clone();
+            // Arc 7 wave 2 wave-2: share the throttle so the did_change
+            // debounced recompile doesn't re-emit the info log that
+            // `recompile()` already emitted for the same project.
+            let schema_cache_throttle = self.schema_cache_throttle.clone();
 
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
@@ -755,10 +851,18 @@ impl LanguageServer for RockyLsp {
                 let dir = models_dir.read().await;
                 let Some(ref dir) = *dir else { return };
 
+                // Wave-2 of Arc 7 wave 2: keep the per-keystroke typecheck
+                // grounded in real warehouse types when the cache is warm.
+                // Throttle guarantees the info log fires at most once per
+                // session per project.
+                let dir_path = std::path::PathBuf::from(dir);
+                let source_schemas =
+                    Self::load_cached_source_schemas(&dir_path, &schema_cache_throttle, dir).await;
+
                 let config = CompilerConfig {
-                    models_dir: std::path::PathBuf::from(dir),
+                    models_dir: dir_path,
                     contracts_dir: None,
-                    source_schemas: HashMap::new(),
+                    source_schemas,
                     source_column_info: HashMap::new(),
                 };
 
@@ -2719,6 +2823,7 @@ pub async fn run_lsp() {
         init_done: Arc::new(AtomicBool::new(false)),
         init_notify: Arc::new(Notify::new()),
         semantic_tokens_cache: Arc::new(RwLock::new(HashMap::new())),
+        schema_cache_throttle: SchemaCacheThrottle::new(),
     });
 
     Server::new(stdin, stdout, socket).serve(service).await;
@@ -3120,5 +3225,123 @@ mod tests {
         assert_eq!(encoded[1].delta_start, 2);
         assert_eq!(encoded[2].delta_line, 2);
         assert_eq!(encoded[2].delta_start, 10);
+    }
+
+    // ---- Arc 7 wave 2 wave-2: LSP schema-cache loader ----
+
+    /// LSP must honour `[cache.schemas] enabled = false` from
+    /// `<root>/rocky.toml` and NOT read cache entries even when the
+    /// state file exists and is populated.
+    #[tokio::test]
+    async fn lsp_loader_respects_cache_disabled_in_config() {
+        use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+        use rocky_core::state::StateStore;
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        // Seed the cache so we'd get a hit if the loader didn't respect
+        // the disabled flag.
+        let state_path = models_dir.join(".rocky-state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            let key = schema_cache_key("cat", "staging", "orders");
+            store
+                .write_schema_cache_entry(
+                    &key,
+                    &SchemaCacheEntry {
+                        columns: vec![StoredColumn {
+                            name: "id".into(),
+                            data_type: "BIGINT".into(),
+                            nullable: false,
+                        }],
+                        cached_at: chrono::Utc::now(),
+                    },
+                )
+                .unwrap();
+        }
+
+        // Write a rocky.toml at the project root with cache disabled.
+        fs::write(
+            root.join("rocky.toml"),
+            "[adapter]\n\
+             type = \"duckdb\"\n\
+             path = \":memory:\"\n\
+             \n\
+             [cache.schemas]\n\
+             enabled = false\n",
+        )
+        .unwrap();
+
+        let throttle = SchemaCacheThrottle::new();
+        let map = RockyLsp::load_cached_source_schemas(&models_dir, &throttle, "file:///x").await;
+        assert!(
+            map.is_empty(),
+            "LSP must honour `[cache.schemas] enabled = false`; got {map:?}"
+        );
+    }
+
+    /// Zero-config project (no rocky.toml) falls back to defaults
+    /// (`enabled = true`, 24h TTL) — keeps the CLI/LSP parity.
+    #[tokio::test]
+    async fn lsp_loader_falls_back_to_defaults_without_rocky_toml() {
+        use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+        use rocky_core::state::StateStore;
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let models_dir = root.join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        let state_path = models_dir.join(".rocky-state.redb");
+        {
+            let store = StateStore::open(&state_path).unwrap();
+            let key = schema_cache_key("cat", "staging", "orders");
+            store
+                .write_schema_cache_entry(
+                    &key,
+                    &SchemaCacheEntry {
+                        columns: vec![StoredColumn {
+                            name: "id".into(),
+                            data_type: "BIGINT".into(),
+                            nullable: false,
+                        }],
+                        cached_at: chrono::Utc::now(),
+                    },
+                )
+                .unwrap();
+        }
+        // No rocky.toml — loader should use defaults (enabled).
+
+        let throttle = SchemaCacheThrottle::new();
+        let map = RockyLsp::load_cached_source_schemas(&models_dir, &throttle, "file:///y").await;
+        assert_eq!(map.len(), 1, "zero-config default should be enabled");
+        assert!(map.contains_key("staging.orders"));
+    }
+
+    /// Missing state file -> empty map and no side-effect file creation.
+    #[tokio::test]
+    async fn lsp_loader_cold_cache_does_not_create_state_file() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let models_dir = tmp.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+
+        let state_path = models_dir.join(".rocky-state.redb");
+        assert!(!state_path.exists());
+
+        let throttle = SchemaCacheThrottle::new();
+        let map = RockyLsp::load_cached_source_schemas(&models_dir, &throttle, "file:///z").await;
+        assert!(map.is_empty());
+        assert!(
+            !state_path.exists(),
+            "LSP loader must not create state.redb as a side effect"
+        );
     }
 }

--- a/engine/crates/rocky-server/src/schema_cache_throttle.rs
+++ b/engine/crates/rocky-server/src/schema_cache_throttle.rs
@@ -1,0 +1,94 @@
+//! Per-document throttle for Arc 7 wave 2 wave-2 schema-cache info logs in
+//! the LSP path.
+//!
+//! The CLI emits a single info log per process when `load_source_schemas_from_cache`
+//! returns at least one entry. That pattern would turn into per-keystroke spam in
+//! the LSP: `did_change` fires a recompile on a 300 ms debounce, and each recompile
+//! loads `source_schemas` from the cache. So the LSP needs a throttle keyed on
+//! `(document_uri, cache_version)`.
+//!
+//! PR 1b (this PR) has no write tap, so there are no cache-version bumps — the
+//! throttle collapses to "have I logged for this document this session?" A
+//! `Mutex<HashSet<Uri>>` is enough. PR 2 will add a cache-version counter:
+//! when the write tap bumps it, this module's [`ThrottleState::mark_logged`]
+//! becomes "did I log for `(uri, version)` already?" — pass the new version in
+//! as a second key. No external dep today (no `dashmap`): a `tokio::sync::Mutex`
+//! keeps the footprint minimal.
+//!
+//! Put here rather than inline in `lsp.rs` so both LSP recompile sites
+//! (`RockyLsp::recompile` at initialize + `did_save`, and the `did_change`
+//! spawn_blocking path) share one map. Tested in isolation; behaviour is
+//! purely state-machine so doesn't need a live LSP to exercise.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+/// Shared throttle for per-document schema-cache info logs.
+///
+/// Cheap to clone — it's just an `Arc` over the inner mutex. Each
+/// `RockyLsp`/`ServerState` holds one.
+#[derive(Clone, Default)]
+pub(crate) struct SchemaCacheThrottle {
+    logged: Arc<Mutex<HashSet<String>>>,
+}
+
+impl SchemaCacheThrottle {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that we have emitted the info log for `key`. Returns `true`
+    /// when this is the first time the key has been seen (i.e. the caller
+    /// should emit the log), `false` when we've already logged for it.
+    ///
+    /// `key` is the `document_uri` for PR 1b. PR 2's write tap will extend
+    /// it to `"<uri>@<cache_version>"` so the log re-fires when the cache
+    /// is updated.
+    pub(crate) async fn mark_logged(&self, key: &str) -> bool {
+        let mut set = self.logged.lock().await;
+        set.insert(key.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn first_call_returns_true() {
+        let t = SchemaCacheThrottle::new();
+        assert!(t.mark_logged("file:///tmp/a.rocky").await);
+    }
+
+    #[tokio::test]
+    async fn repeated_same_key_returns_false() {
+        let t = SchemaCacheThrottle::new();
+        assert!(t.mark_logged("file:///tmp/a.rocky").await);
+        assert!(!t.mark_logged("file:///tmp/a.rocky").await);
+        assert!(!t.mark_logged("file:///tmp/a.rocky").await);
+    }
+
+    #[tokio::test]
+    async fn distinct_keys_each_log_once() {
+        let t = SchemaCacheThrottle::new();
+        assert!(t.mark_logged("file:///a").await);
+        assert!(t.mark_logged("file:///b").await);
+        // Repeats for both become no-ops.
+        assert!(!t.mark_logged("file:///a").await);
+        assert!(!t.mark_logged("file:///b").await);
+    }
+
+    #[tokio::test]
+    async fn version_bump_pattern_re_fires() {
+        // PR 2 will encode cache_version in the key. Confirm the shape
+        // today so the migration is a string-format change, not a
+        // semantics change.
+        let t = SchemaCacheThrottle::new();
+        assert!(t.mark_logged("file:///a@v1").await);
+        assert!(!t.mark_logged("file:///a@v1").await);
+        // New cache version -> the key is different -> log fires again.
+        assert!(t.mark_logged("file:///a@v2").await);
+    }
+}

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -8,10 +8,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use rocky_compiler::compile::{CompileResult, CompilerConfig};
 use rocky_core::dag_status::DagStatusStore;
+
+use crate::schema_cache_throttle::SchemaCacheThrottle;
 
 /// Shared server state holding the latest compilation result.
 pub struct ServerState {
@@ -21,6 +23,11 @@ pub struct ServerState {
     pub compile_result: RwLock<Option<CompileResult>>,
     /// Latest DAG execution status, exposed at `GET /api/v1/dag/status`.
     pub dag_status: DagStatusStore,
+    /// Arc 7 wave 2 wave-2: per-session throttle for the "N sources hit"
+    /// info log so it emits once per server start, not once per recompile.
+    /// PR 2 will key it on `(document_uri, cache_version)` — the only LSP
+    /// analogue today is `models_dir`, which stays constant.
+    schema_cache_throttle: SchemaCacheThrottle,
 }
 
 impl ServerState {
@@ -36,6 +43,7 @@ impl ServerState {
             config_path,
             compile_result: RwLock::new(None),
             dag_status: DagStatusStore::new(),
+            schema_cache_throttle: SchemaCacheThrottle::new(),
         });
 
         // Initial compile
@@ -51,10 +59,17 @@ impl ServerState {
     pub async fn recompile(&self) {
         info!(models_dir = %self.models_dir.display(), "compiling project");
 
+        // Wave-2 of Arc 7 wave 2: load cached source schemas so the
+        // server's hover/inlay-hint surfaces typecheck against real
+        // warehouse types when the cache is warm. Degrades to empty on
+        // cold cache, missing state.redb, or `[cache.schemas] enabled =
+        // false`. See `rocky-cli::source_schemas` for the CLI equivalent.
+        let source_schemas = self.load_cached_source_schemas().await;
+
         let config = CompilerConfig {
             models_dir: self.models_dir.clone(),
             contracts_dir: self.contracts_dir.clone(),
-            source_schemas: HashMap::new(),
+            source_schemas,
             source_column_info: HashMap::new(),
         };
 
@@ -75,5 +90,69 @@ impl ServerState {
                 warn!(error = %e, "compilation failed");
             }
         }
+    }
+
+    /// Load the schema-cache-backed `source_schemas` map for this
+    /// server's project. Gated on `[cache.schemas] enabled`; resolves the
+    /// state file relative to `models_dir` (the same convention
+    /// `api.rs`/`dashboard.rs` already follow).
+    async fn load_cached_source_schemas(
+        &self,
+    ) -> HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
+        // Config lookup: fall back to defaults (enabled + 24h TTL) when
+        // no rocky.toml is wired in, so LSP/server behaviour mirrors the
+        // CLI for zero-config projects.
+        let schema_cache_config = match &self.config_path {
+            Some(path) => rocky_core::config::load_rocky_config(path)
+                .map(|c| c.cache.schemas)
+                .unwrap_or_default(),
+            None => rocky_core::config::SchemaCacheConfig::default(),
+        };
+
+        if !schema_cache_config.enabled {
+            return HashMap::new();
+        }
+
+        let state_path = self.models_dir.join(".rocky-state.redb");
+        if !state_path.exists() {
+            return HashMap::new();
+        }
+
+        let store = match rocky_core::state::StateStore::open_read_only(&state_path) {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(error = %e, "schema cache: state open failed in server path");
+                return HashMap::new();
+            }
+        };
+
+        let map = match rocky_compiler::schema_cache::load_source_schemas_from_cache(
+            &store,
+            chrono::Utc::now(),
+            schema_cache_config.ttl(),
+        ) {
+            Ok(m) => m,
+            Err(e) => {
+                debug!(error = %e, "schema cache: scan failed in server path");
+                return HashMap::new();
+            }
+        };
+
+        if !map.is_empty()
+            && self
+                .schema_cache_throttle
+                .mark_logged(&self.models_dir.display().to_string())
+                .await
+        {
+            info!(
+                target: "rocky::schema_cache",
+                sources_hit = map.len(),
+                "schema cache: {} source(s) hit — run `rocky run` (write tap in PR 2) or \
+                 `rocky discover --with-schemas` (PR 3) to warm-cache more sources",
+                map.len(),
+            );
+        }
+
+        map
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1158,6 +1158,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             with_seed,
         } => rocky_cli::commands::run_compile(
             Some(cli.config.as_path()),
+            &cli.state_path,
             &models,
             contracts.as_deref(),
             model.as_deref(),
@@ -1173,6 +1174,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             column_lineage,
         } => rocky_cli::commands::run_dag(
             &cli.config,
+            &cli.state_path,
             &models,
             seeds.as_deref(),
             contracts.as_deref(),
@@ -1187,6 +1189,8 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             downstream,
             upstream: _,
         } => rocky_cli::commands::run_lineage(
+            &cli.config,
+            &cli.state_path,
             &models,
             &target,
             column.as_deref(),
@@ -1198,28 +1202,68 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             intent,
             format,
             models,
-        } => rocky_cli::commands::run_ai(&intent, format.as_deref(), &models, json).await,
+        } => {
+            rocky_cli::commands::run_ai(
+                &cli.config,
+                &cli.state_path,
+                &intent,
+                format.as_deref(),
+                &models,
+                json,
+            )
+            .await
+        }
         Command::AiSync {
             apply,
             model,
             with_intent,
             models,
         } => {
-            rocky_cli::commands::run_ai_sync(&models, apply, model.as_deref(), with_intent, json)
-                .await
+            rocky_cli::commands::run_ai_sync(
+                &cli.config,
+                &cli.state_path,
+                &models,
+                apply,
+                model.as_deref(),
+                with_intent,
+                json,
+            )
+            .await
         }
         Command::AiExplain {
             model,
             all,
             save,
             models,
-        } => rocky_cli::commands::run_ai_explain(&models, model.as_deref(), all, save, json).await,
+        } => {
+            rocky_cli::commands::run_ai_explain(
+                &cli.config,
+                &cli.state_path,
+                &models,
+                model.as_deref(),
+                all,
+                save,
+                json,
+            )
+            .await
+        }
         Command::AiTest {
             model,
             all,
             save,
             models,
-        } => rocky_cli::commands::run_ai_test(&models, model.as_deref(), all, save, json).await,
+        } => {
+            rocky_cli::commands::run_ai_test(
+                &cli.config,
+                &cli.state_path,
+                &models,
+                model.as_deref(),
+                all,
+                save,
+                json,
+            )
+            .await
+        }
         Command::Playground { path, template } => {
             rocky_cli::commands::run_playground_with_template(&path, &template)
         }
@@ -1288,7 +1332,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             rocky_cli::commands::run_ci(&models, contracts.as_deref(), json)
         }
         Command::CiDiff { base_ref, models } => {
-            rocky_cli::commands::run_ci_diff(&base_ref, &models, json)
+            rocky_cli::commands::run_ci_diff(&cli.config, &cli.state_path, &base_ref, &models, json)
         }
         Command::InitAdapter { name } => rocky_cli::commands::run_init_adapter(&name),
         Command::TestAdapter {


### PR DESCRIPTION
Arc 7 wave 2 wave-2 — **PR 1b of 4**. Mechanical follow-up to #223: wires
the 10 previously `source_schemas: HashMap::new()` callsites in
`rocky-cli` and `rocky-server` against the persisted schema cache
shipped in PR 1a. Read-only, no new features, no write tap (PR 2), no
new CLI flags (PRs 3-4), no output-struct changes.

Design doc: `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`.
Infra dependency: #223 (merged 2026-04-22).

## What this PR does

Every CLI command whose internal flow calls `rocky_compiler::compile::compile`
now loads `CompilerConfig.source_schemas` from
`rocky_compiler::schema_cache::load_source_schemas_from_cache` instead of
passing an empty map. Cold cache = empty map = pre-wave-2 behaviour, so
this PR is a user-visible no-op until PR 2's write tap fills the cache.

### Wired callsites (9)

| File | Path |
|---|---|
| `rocky-cli/src/commands/compile.rs` | preserves `--with-seed` precedence; cache fallback when seed isn't used |
| `rocky-cli/src/commands/dag.rs` | column-lineage compile |
| `rocky-cli/src/commands/lineage.rs` | lineage compile |
| `rocky-cli/src/commands/ai.rs::compile_project` | grounds AI prompt in real types |
| `rocky-cli/src/commands/ci_diff.rs` | both HEAD and base-ref compiles |
| `rocky-cli/src/commands/run.rs::execute_models` | transformation run compile |
| `rocky-server/src/state.rs::ServerState::recompile` | server API compile |
| `rocky-server/src/lsp.rs::RockyLsp::recompile` | LSP initial + did_save |
| `rocky-server/src/lsp.rs` did_change debounce | LSP per-keystroke recompile |

### Deliberate non-wires (2)

| File:line | Reason |
|---|---|
| `rocky-cli/src/commands/ai.rs:112` | `ValidationContext.source_schemas` is a distinct surface from `CompilerConfig.source_schemas`; promotion needs a dedicated `rocky-ai::generate::ValidationContext` audit. Design §4.4. |
| `rocky-cli/src/commands/bench.rs:268` | Synthetic tempdir projects have no `.rocky-state.redb`; wiring would either no-op or read a surrounding CWD's cache and make benchmarks non-reproducible across machines. |

Both sites carry inline `// TODO(arc7-wave2): ...` comments explaining
the decision. Each is a one-line follow-up if future work calls for it.

## Precedence rule in `rocky compile`

1. `--with-seed` wins -> wave-1 seed loader (explicit user intent).
2. Otherwise `[cache.schemas]` from `rocky.toml` (wave-2).
3. Cold cache / no config -> empty map (matches pre-wave-2).

## Shared helpers

**`rocky-cli::source_schemas::load_cached_source_schemas`** —
opens `StateStore` via `open_read_only` so a concurrent `rocky run`
never fails with `LockHeldByOther`. Gates on `[cache.schemas] enabled`,
filters TTL at read time, emits a once-per-CLI-process info log when
the scan returns at least one entry. Does not create `state.redb` as a
side effect when the file is missing (fresh clone).

**`rocky-server::schema_cache_throttle::SchemaCacheThrottle`** —
`Mutex<HashSet<String>>`-backed per-session throttle for the LSP info
log so it doesn't spam once per keystroke. Keyed on `models_dir` for
PR 1b. PR 2's write tap will extend the key with a cache-version
suffix (a simple string concat; the `version_bump_pattern_re_fires`
test in the throttle module locks in that shape ahead of time).

## LSP throttle explanation

CLI processes are short-lived, so a `OnceLock<()>` gives the "once per
invocation" behaviour the spec asks for. The LSP lives for the whole
IDE session and recompiles on a 300 ms debounced `did_change` — a
per-invocation log would fire per keystroke. The throttle module
maintains a `HashSet<String>` of keys the server has already logged
for. Today's key is the project's `models_dir`; PR 2 appends a
cache-version counter so the log re-fires when the cache actually
changes.

## Known follow-up (to fix in PR 2)

CLI default `state_path` = `.rocky-state.redb` in CWD (from
`main.rs:71`); LSP/server convention = `models_dir.join(".rocky-state.redb")`
(matches existing `api.rs` / `dashboard.rs`). Today no writes land, so
the divergence is invisible at the user level. PR 2's write tap should
unify them so the "inlay-hint improvement" is observable end-to-end.

## Test plan

- [x] `cargo test --workspace` — full suite green; 14 new tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `just codegen` — no schema/binding diff (no `*Output` struct
      changes, as scoped).
- [x] `just regen-fixtures` — byte-stable (no run/compile output
      changes).
- [x] `uv run pytest` in `integrations/dagster/` — 312 green.
- [x] `npm run compile` in `editors/vscode/` green.

New tests:
- `rocky-cli::source_schemas` — disabled config short-circuits, missing
  state file returns empty without side-effect file creation, cached
  entries round-trip, TTL expiry.
- `rocky-cli::commands::compile` — seeded `SCHEMA_CACHE` entry flows
  through `rocky compile` without `--with-seed`, `default_type_mapper`
  round-trip locks `StoredColumn -> TypedColumn` parity, cold cache +
  `rocky.toml` present doesn't create `state.redb`.
- `rocky-server::schema_cache_throttle` — first call returns `true`,
  repeat key returns `false`, distinct keys each log once, version-bump
  key shape re-fires (shape-lock for PR 2).
- `rocky-server::lsp` — `[cache.schemas] enabled = false` fully disables
  the LSP path, zero-config project falls back to defaults, cold cache
  doesn't create state file.

## Follow-up PRs

- **PR 2** — `rocky run` write tap on `batch_describe_schema` (fills
  the cache on every successful DESCRIBE; this PR's read path is a
  no-op until PR 2 lands).
- **PR 3** — `rocky discover --with-schemas` flag (CI warm-up path).
- **PR 4** — `rocky state clear-schema-cache` subcommand + CLI TTL
  override + `[cache.schemas] enabled = false` surfacing in
  `rocky doctor`.