### PR TITLE
feat(integrations/dagster): thread --check through doctor()

### DIFF
--- a/integrations/dagster/src/dagster_rocky/health.py
+++ b/integrations/dagster/src/dagster_rocky/health.py
@@ -140,16 +140,14 @@ def state_health(rocky: RockyResource, *, probe_write: bool = False) -> StateHea
        caller running this every sensor tick doesn't crash the tick
        when rocky itself can't be invoked.
     3. Optional ``state_rw`` probe: when ``probe_write=True``, runs
-       ``rocky doctor`` and extracts the ``state_rw`` check into
-       :attr:`~.types.StateHealthResult.probe_outcome` / duration /
-       error fields. A probe failure populates the ``probe_*`` fields
-       rather than raising. Full doctor is invoked because
-       :meth:`RockyResource.doctor` does not currently accept a
-       ``--check`` filter — selectively running just the ``state_rw``
-       check is a follow-up optimisation that would cut the probe cost
-       to the same sub-second figure the engine's
-       :func:`rocky_core::state_sync::probe_state_backend` helper runs
-       in, without the surrounding config/adapter/pipelines checks.
+       ``rocky doctor --check state_rw`` and extracts the ``state_rw``
+       check into :attr:`~.types.StateHealthResult.probe_outcome` /
+       duration / error fields. A probe failure populates the
+       ``probe_*`` fields rather than raising. The ``--check`` filter
+       keeps the probe cost bounded to the engine's
+       :func:`rocky_core::state_sync::probe_state_backend` helper —
+       sub-second on every backend — instead of paying for the
+       surrounding config/adapter/pipelines checks.
 
     The design is a thin facade over existing CLI surfaces — the FR's
     stretch-goal "recent outcomes" rollup (persisted ring buffer of
@@ -268,7 +266,7 @@ def _run_state_rw_probe(rocky: RockyResource) -> tuple[ProbeOutcome, int | None,
     wasn't run" from "probe failed."
     """
     try:
-        report = rocky.doctor()
+        report = rocky.doctor(check="state_rw")
     except dg.Failure as exc:
         return "error", None, str(exc.description or exc)
 

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1606,9 +1606,21 @@ class RockyResource(dg.ConfigurableResource):
     # Doctor and resume commands                                         #
     # ------------------------------------------------------------------ #
 
-    def doctor(self) -> DoctorResult:
-        """Run ``rocky doctor`` and return the parsed health-check results."""
-        return _parse_rocky_json(self._run_rocky(["doctor"]), DoctorResult, command="doctor")
+    def doctor(self, *, check: str | None = None) -> DoctorResult:
+        """Run ``rocky doctor`` and return the parsed health-check results.
+
+        Args:
+            check: Optional single-check id (e.g. ``"state_rw"``) forwarded
+                as ``--check <id>``. When set, the engine runs only that
+                check — the output is still a :class:`DoctorResult` with
+                the same schema, just fewer entries in ``checks``. The set
+                of valid ids lives on the engine side; invalid values are
+                surfaced by the engine rather than pre-validated here.
+        """
+        args = ["doctor"]
+        if check is not None:
+            args.extend(["--check", check])
+        return _parse_rocky_json(self._run_rocky(args), DoctorResult, command="doctor")
 
     def state_health(self, *, probe_write: bool = False) -> StateHealthResult:
         """Return a live snapshot of Rocky's state-backend health.
@@ -1623,10 +1635,11 @@ class RockyResource(dg.ConfigurableResource):
         The cheap path (the default, ``probe_write=False``) does one
         ``rocky history`` subprocess plus a ``tomllib`` read of
         :attr:`config_path` — bounded sub-second on any backend. When
-        ``probe_write=True`` we additionally invoke ``rocky doctor``
-        (which reuses the engine's ``probe_state_backend`` helper to
-        do a bounded put/get/delete round-trip against the configured
-        backend) and translate its ``state_rw`` check into the
+        ``probe_write=True`` we additionally invoke
+        ``rocky doctor --check state_rw`` (which reuses the engine's
+        ``probe_state_backend`` helper to do a bounded put/get/delete
+        round-trip against the configured backend) and translate its
+        ``state_rw`` check into the
         :attr:`~.types.StateHealthResult.probe_outcome` /
         :attr:`~.types.StateHealthResult.probe_duration_ms` /
         :attr:`~.types.StateHealthResult.probe_error` fields.

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1295,3 +1295,66 @@ def test_verify_version_called_by_run_rocky_streaming():
 
     # If we got here without a Failure, the version check passed and
     # the streaming path ran successfully.
+
+
+# ---------------------------------------------------------------------------
+# doctor — --check filter argv plumbing
+# ---------------------------------------------------------------------------
+
+
+def _doctor_json() -> str:
+    """Minimal well-formed DoctorResult JSON payload."""
+    return json.dumps(
+        {
+            "command": "doctor",
+            "overall": "healthy",
+            "checks": [],
+            "suggestions": [],
+        }
+    )
+
+
+def test_doctor_without_check_kwarg_omits_check_flag():
+    """Default ``doctor()`` call must not emit ``--check`` — backwards compat."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _doctor_json()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.doctor()
+
+    assert captured[0] == ["doctor"]
+    assert "--check" not in captured[0]
+
+
+def test_doctor_with_check_kwarg_appends_check_flag():
+    """``doctor(check="state_rw")`` must forward ``--check state_rw`` to the CLI."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _doctor_json()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.doctor(check="state_rw")
+
+    assert captured[0] == ["doctor", "--check", "state_rw"]
+
+
+def test_doctor_with_check_kwarg_forwards_arbitrary_id():
+    """The Python side must not pre-validate the check id — the engine owns that set."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _doctor_json()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.doctor(check="totally-made-up-id")
+
+    assert captured[0] == ["doctor", "--check", "totally-made-up-id"]

--- a/integrations/dagster/tests/test_state_health.py
+++ b/integrations/dagster/tests/test_state_health.py
@@ -311,6 +311,32 @@ def test_state_health_probe_skipped_by_default(
     assert result.probe_error is None
 
 
+def test_state_health_probe_forwards_state_rw_check_filter(
+    rocky_with_local_backend: RockyResource,
+) -> None:
+    """The probe path must call ``doctor(check="state_rw")`` so the engine
+    runs only the ``state_rw`` check — keeping the probe sub-second rather
+    than paying for the full doctor suite.
+    """
+    state_rw = HealthCheck(
+        name="state_rw",
+        status=HealthStatus.healthy,
+        message="State backend RW probe succeeded",
+        duration_ms=12,
+    )
+    with (
+        patch.object(RockyResource, "history", return_value=_history_with_runs()),
+        patch.object(
+            RockyResource,
+            "doctor",
+            return_value=_doctor(state_rw=state_rw),
+        ) as doctor_mock,
+    ):
+        state_health(rocky_with_local_backend, probe_write=True)
+
+    doctor_mock.assert_called_once_with(check="state_rw")
+
+
 def test_state_health_probe_healthy_check_maps_to_ok(
     rocky_with_local_backend: RockyResource,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add optional `check: str | None` kwarg to `RockyResource.doctor()` that forwards `--check <id>` to the CLI, and switch `state_health()`'s `state_rw` probe to `doctor(check="state_rw")` — cutting the probe cost from a full doctor suite to a single sub-second `probe_state_backend` round-trip.
- Pure Python argv change: no engine change, no codegen, `DoctorOutput` schema unchanged (filtered output is the same shape with fewer entries in `checks`).
- Client-side check-id validation is deliberately omitted — the engine owns the valid set; duplicating it in Python would drift.

## Test plan
- [x] `uv run pytest tests/test_resource.py tests/test_state_health.py -x -q` (85 passed — includes 4 new tests)
- [x] Full suite: `uv run pytest tests/ -x -q` (374 passed, no regressions)
- [x] `uv run ruff check .` (all checks passed)
- [x] `uv run ruff format --check .` (46 files already formatted)
- [x] `doctor()` without `check` kwarg still emits `["doctor"]` — back-compat for existing callers
- [x] `doctor(check="state_rw")` emits `["doctor", "--check", "state_rw"]`
- [x] `state_health(probe_write=True)` calls `doctor(check="state_rw")` (spy assertion)