### PR TITLE
feat(engine/rocky-cli): add `rocky discover --with-schemas` (PR 3)

### DIFF
--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -18,6 +18,12 @@ export interface DiscoverOutput {
    * Tables filtered out of `sources` because they were reported by the discovery adapter but do not exist in the source warehouse. Same shape as `RunOutput.excluded_tables` so consumers can use one parser. Empty when nothing was filtered.
    */
   excluded_tables: ExcludedTableOutput[];
+  /**
+   * Number of schema-cache entries written by this invocation.
+   *
+   * Populated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache (design doc §4.2 route B at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`). Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
+   */
+  schemas_cached?: number;
   sources: SourceOutput[];
   version: string;
   [k: string]: unknown;

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky discover --with-schemas`** — explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache (design doc §4.2 route B). When set, walks each unique `(catalog, schema)` pair reachable via the source's `BatchCheckAdapter`, issues one `batch_describe_schema` round-trip, and persists every returned table as a `SchemaCacheEntry` in `state.redb::schema_cache`. Intended for CI warm-up so downstream `rocky compile` / `rocky lsp` invocations typecheck leaf models against real warehouse types. Per-schema describe failures and per-entry write failures are logged at `warn` and skipped — one bad source does not abort the warm-up. Missing `source.catalog` or an adapter without a `BatchCheckAdapter` (DuckDB today) warns once and skips writes. Passing `--with-schemas` when `[cache.schemas] enabled = false` errors with a clear message instead of silently no-op'ing. New `schemas_cached: usize` field on `DiscoverOutput` (skipped from JSON when zero, so existing fixtures stay byte-stable).
+
 ## [1.13.0] — 2026-04-22
 
 Reliability hardening for the state backend. Closes the last mutation path in `rocky-core` without retry / circuit-breaker parity with the adapter layer, and turns `rocky doctor` into a real smoke test of state-backend connectivity instead of a credentials-only check. Two PRs since v1.12.0.

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -1,7 +1,12 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use tracing::{debug, warn};
+use chrono::Utc;
+use tracing::{debug, info, warn};
+
+use rocky_core::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};
+use rocky_core::state::StateStore;
 
 use crate::output::*;
 use crate::registry;
@@ -12,12 +17,28 @@ use super::parsed_to_json_map;
 pub async fn discover(
     config_path: &Path,
     pipeline_name: Option<&str>,
+    state_path: &Path,
+    with_schemas: bool,
     output_json: bool,
 ) -> Result<()> {
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
         "failed to load config from {}",
         config_path.display()
     ))?;
+
+    // Two contradictory signals — user explicitly asked for cache warm-up
+    // via `--with-schemas` but also disabled the cache in `rocky.toml`.
+    // Erroring is the trust-aligned call: silently skipping would leave
+    // the user guessing why `schemas_cached=0`. Design doc §5.4 pairs
+    // with the explicit opt-out of `[cache.schemas] enabled = false`.
+    if with_schemas && !rocky_cfg.cache.schemas.enabled {
+        anyhow::bail!(
+            "`--with-schemas` conflicts with `[cache.schemas] enabled = false` in {}; \
+             remove the flag or set `enabled = true` to warm the cache",
+            config_path.display()
+        );
+    }
+
     let (_name, pipeline) = registry::resolve_replication_pipeline(&rocky_cfg, pipeline_name)?;
     let pattern = pipeline.schema_pattern()?;
 
@@ -125,10 +146,21 @@ pub async fn discover(
         });
     }
 
+    // Cache warm-up (Arc 7 wave 2 wave-2 PR 3, design doc §4.2 route B).
+    // Only runs when `--with-schemas` is set; config gating already happened
+    // at the top of this function. Errors inside the warm-up are logged and
+    // counted as misses — a bad source shouldn't abort the whole discovery.
+    let schemas_cached = if with_schemas {
+        warm_schema_cache(&adapter_registry, &pipeline.source, &connectors, state_path).await?
+    } else {
+        0
+    };
+
     let checks_output = ChecksConfigOutput::from_engine(&pipeline.checks);
     let output = DiscoverOutput::new(output_sources)
         .with_checks(checks_output)
-        .with_excluded_tables(excluded_tables);
+        .with_excluded_tables(excluded_tables)
+        .with_schemas_cached(schemas_cached);
     if output_json {
         print_json(&output)?;
     } else {
@@ -140,6 +172,9 @@ pub async fn discover(
                 .collect::<Vec<_>>()
                 .join(" ");
             println!("{} | {} | {} tables", s.id, desc, s.tables.len());
+        }
+        if with_schemas {
+            println!("schemas cached: {schemas_cached}");
         }
     }
     Ok(())
@@ -208,4 +243,372 @@ async fn build_source_table_sets(
     }
 
     map
+}
+
+/// Populate the Arc 7 wave 2 wave-2 schema cache for every discovered source.
+///
+/// For each unique `(catalog, schema)` pair reachable via the source's
+/// warehouse `BatchCheckAdapter`, issues a single `batch_describe_schema`
+/// round-trip and persists one `SchemaCacheEntry` per returned table via
+/// [`StateStore::write_schema_cache_entry`]. Returns the count of entries
+/// actually written (partial successes roll in — one failing schema does not
+/// invalidate writes from another).
+///
+/// Error-to-warn rules:
+/// - missing `source.catalog` → warn once, return 0 (no keys possible).
+/// - `batch_check_adapter` returns `None` (adapter is DuckDB/etc.) →
+///   warn once, return 0.
+/// - per-schema `batch_describe_schema` failure → warn and continue.
+/// - per-entry `write_schema_cache_entry` failure → warn and continue.
+/// - state store won't open → bail (the user asked for writes; a broken
+///   state dir is a hard fail, not a silent no-op).
+async fn warm_schema_cache(
+    adapter_registry: &registry::AdapterRegistry,
+    source_config: &rocky_core::config::PipelineSourceConfig,
+    connectors: &[rocky_core::source::DiscoveredConnector],
+    state_path: &Path,
+) -> Result<usize> {
+    let source_catalog = match source_config.catalog.as_deref() {
+        Some(c) if !c.is_empty() => c.to_string(),
+        _ => {
+            warn!(
+                "discover --with-schemas: source.catalog not configured — \
+                 cannot key cache entries, skipping"
+            );
+            return Ok(0);
+        }
+    };
+
+    let Some(batch_adapter) = adapter_registry.batch_check_adapter(&source_config.adapter) else {
+        warn!(
+            adapter = source_config.adapter.as_str(),
+            "discover --with-schemas: no batch-describe-capable adapter \
+             registered for this source (e.g. DuckDB has no batched describe) \
+             — cache warm-up skipped"
+        );
+        return Ok(0);
+    };
+
+    let schemas = dedup_schemas(connectors);
+
+    let store = StateStore::open(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+
+    warm_schema_cache_inner(batch_adapter.as_ref(), &store, &source_catalog, &schemas).await
+}
+
+/// Dedup the schema names reported by discovered connectors.
+///
+/// Mirrors the dedup in `build_source_table_sets` — Fivetran commonly hands
+/// back two connectors against the same `src__*` schema, and a `BatchCheck`
+/// `information_schema` round-trip keyed on `<catalog, schema>` is wasted
+/// work when repeated.
+fn dedup_schemas(connectors: &[rocky_core::source::DiscoveredConnector]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    connectors
+        .iter()
+        .filter_map(|c| {
+            if seen.insert(c.schema.clone()) {
+                Some(c.schema.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Inner warm-up loop — split out so unit tests can drive it with a stub
+/// [`rocky_core::traits::BatchCheckAdapter`].
+///
+/// Per-schema `batch_describe_schema` errors log a warn and are counted as
+/// zero writes; per-entry `write_schema_cache_entry` errors also warn and
+/// skip. Both paths preserve the "one bad source shouldn't abort warm-up"
+/// contract the design doc §4.2 gives.
+async fn warm_schema_cache_inner(
+    batch_adapter: &dyn rocky_core::traits::BatchCheckAdapter,
+    store: &StateStore,
+    source_catalog: &str,
+    schemas: &[String],
+) -> Result<usize> {
+    let cached_at = Utc::now();
+    let mut written: usize = 0;
+
+    for schema in schemas {
+        let describe = batch_adapter
+            .batch_describe_schema(source_catalog, schema)
+            .await;
+        let tables = match describe {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(
+                    catalog = source_catalog,
+                    schema = schema.as_str(),
+                    error = %e,
+                    "discover --with-schemas: batch_describe_schema failed, \
+                     skipping schema"
+                );
+                continue;
+            }
+        };
+
+        for (table_name, column_infos) in tables {
+            let key = schema_cache_key(source_catalog, schema, &table_name);
+            let entry = SchemaCacheEntry {
+                columns: column_infos
+                    .into_iter()
+                    .map(|c| StoredColumn {
+                        name: c.name,
+                        data_type: c.data_type,
+                        nullable: c.nullable,
+                    })
+                    .collect(),
+                cached_at,
+            };
+            match store.write_schema_cache_entry(&key, &entry) {
+                Ok(()) => {
+                    debug!(
+                        key = key.as_str(),
+                        "discover --with-schemas: wrote cache entry"
+                    );
+                    written += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        key = key.as_str(),
+                        error = %e,
+                        "discover --with-schemas: failed to write cache entry, skipping"
+                    );
+                }
+            }
+        }
+    }
+
+    info!(
+        schemas = schemas.len(),
+        entries_written = written,
+        "discover --with-schemas: cache warm-up complete"
+    );
+
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use rocky_core::ir::ColumnInfo;
+    use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+    use rocky_core::traits::{AdapterError, AdapterResult, BatchCheckAdapter};
+
+    /// Alias for the describe-response payload — keeps the stub's field
+    /// type under clippy's `type_complexity` limit.
+    type DescribeResponse = AdapterResult<HashMap<String, Vec<ColumnInfo>>>;
+
+    /// Stub adapter whose `batch_describe_schema` replays a pre-seeded
+    /// `(catalog, schema)`-keyed map. Any unknown key returns an error so
+    /// tests can cover the "one bad source doesn't abort warm-up" case.
+    struct StubBatchAdapter {
+        responses: HashMap<(String, String), DescribeResponse>,
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    impl StubBatchAdapter {
+        fn new() -> Self {
+            Self {
+                responses: HashMap::new(),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_ok(
+            mut self,
+            catalog: &str,
+            schema: &str,
+            cols: HashMap<String, Vec<ColumnInfo>>,
+        ) -> Self {
+            self.responses
+                .insert((catalog.to_string(), schema.to_string()), Ok(cols));
+            self
+        }
+
+        fn with_err(mut self, catalog: &str, schema: &str, message: &str) -> Self {
+            self.responses.insert(
+                (catalog.to_string(), schema.to_string()),
+                Err(AdapterError::msg(message)),
+            );
+            self
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl BatchCheckAdapter for StubBatchAdapter {
+        async fn batch_row_counts(
+            &self,
+            _tables: &[rocky_core::ir::TableRef],
+        ) -> AdapterResult<Vec<rocky_core::traits::RowCountResult>> {
+            Err(AdapterError::msg("not needed in tests"))
+        }
+
+        async fn batch_freshness(
+            &self,
+            _tables: &[rocky_core::ir::TableRef],
+            _timestamp_col: &str,
+        ) -> AdapterResult<Vec<rocky_core::traits::FreshnessResult>> {
+            Err(AdapterError::msg("not needed in tests"))
+        }
+
+        async fn batch_describe_schema(
+            &self,
+            catalog: &str,
+            schema: &str,
+        ) -> AdapterResult<HashMap<String, Vec<ColumnInfo>>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((catalog.to_string(), schema.to_string()));
+            match self
+                .responses
+                .get(&(catalog.to_string(), schema.to_string()))
+            {
+                Some(Ok(map)) => Ok(map.clone()),
+                Some(Err(e)) => Err(AdapterError::msg(format!("{e}"))),
+                None => Err(AdapterError::msg("stub: unknown (catalog, schema) pair")),
+            }
+        }
+    }
+
+    fn col(name: &str, ty: &str, nullable: bool) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            data_type: ty.to_string(),
+            nullable,
+        }
+    }
+
+    fn discovered(schema: &str) -> DiscoveredConnector {
+        DiscoveredConnector {
+            id: format!("conn_{schema}"),
+            schema: schema.to_string(),
+            source_type: "shopify".to_string(),
+            last_sync_at: None,
+            tables: vec![DiscoveredTable {
+                name: "orders".to_string(),
+                row_count: None,
+            }],
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn dedup_schemas_drops_repeat_connector_schemas() {
+        let connectors = vec![
+            discovered("raw__shopify"),
+            discovered("raw__shopify"),
+            discovered("raw__netsuite"),
+        ];
+        let schemas = dedup_schemas(&connectors);
+        assert_eq!(schemas, vec!["raw__shopify", "raw__netsuite"]);
+    }
+
+    #[tokio::test]
+    async fn warm_inner_writes_one_entry_per_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&tmp.path().join("state.redb")).unwrap();
+
+        let mut cols = HashMap::new();
+        cols.insert(
+            "orders".to_string(),
+            vec![col("id", "BIGINT", false), col("email", "STRING", true)],
+        );
+        cols.insert(
+            "order_items".to_string(),
+            vec![col("order_id", "BIGINT", false)],
+        );
+        let adapter = StubBatchAdapter::new().with_ok("prod", "raw__shopify", cols);
+
+        let written =
+            warm_schema_cache_inner(&adapter, &store, "prod", &["raw__shopify".to_string()])
+                .await
+                .unwrap();
+        assert_eq!(written, 2);
+        assert_eq!(adapter.call_count(), 1);
+
+        let orders_key = schema_cache_key("prod", "raw__shopify", "orders");
+        let entry = store.read_schema_cache_entry(&orders_key).unwrap().unwrap();
+        assert_eq!(entry.columns.len(), 2);
+        assert_eq!(entry.columns[0].name, "id");
+        assert_eq!(entry.columns[0].data_type, "BIGINT");
+        assert!(!entry.columns[0].nullable);
+
+        let items_key = schema_cache_key("prod", "raw__shopify", "order_items");
+        assert!(store.read_schema_cache_entry(&items_key).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn warm_inner_continues_past_schema_describe_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&tmp.path().join("state.redb")).unwrap();
+
+        let mut good = HashMap::new();
+        good.insert("orders".to_string(), vec![col("id", "BIGINT", false)]);
+        let adapter = StubBatchAdapter::new()
+            .with_err("prod", "raw__broken", "Databricks: permission denied")
+            .with_ok("prod", "raw__good", good);
+
+        let schemas = vec!["raw__broken".to_string(), "raw__good".to_string()];
+        let written = warm_schema_cache_inner(&adapter, &store, "prod", &schemas)
+            .await
+            .unwrap();
+        assert_eq!(written, 1);
+        assert_eq!(adapter.call_count(), 2);
+
+        let bad_key = schema_cache_key("prod", "raw__broken", "anything");
+        assert!(store.read_schema_cache_entry(&bad_key).unwrap().is_none());
+        let ok_key = schema_cache_key("prod", "raw__good", "orders");
+        assert!(store.read_schema_cache_entry(&ok_key).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn warm_inner_returns_zero_for_empty_schema_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&tmp.path().join("state.redb")).unwrap();
+        let adapter = StubBatchAdapter::new();
+
+        let written = warm_schema_cache_inner(&adapter, &store, "prod", &[])
+            .await
+            .unwrap();
+        assert_eq!(written, 0);
+        assert_eq!(adapter.call_count(), 0);
+        assert!(store.list_schema_cache().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn warm_inner_lowercases_key_components() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(&tmp.path().join("state.redb")).unwrap();
+
+        let mut cols = HashMap::new();
+        cols.insert("Orders".to_string(), vec![col("ID", "BIGINT", false)]);
+        let adapter = StubBatchAdapter::new().with_ok("PROD", "RAW__Shopify", cols);
+
+        let written =
+            warm_schema_cache_inner(&adapter, &store, "PROD", &["RAW__Shopify".to_string()])
+                .await
+                .unwrap();
+        assert_eq!(written, 1);
+
+        // Keys are stored lowercase (design §4.1). The adapter call itself
+        // preserves casing — it's the key composition that lowercases.
+        let key = schema_cache_key("PROD", "RAW__Shopify", "Orders");
+        assert_eq!(key, "prod.raw__shopify.orders");
+        assert!(store.read_schema_cache_entry(&key).unwrap().is_some());
+    }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -86,6 +86,17 @@ pub struct DiscoverOutput {
     /// parser. Empty when nothing was filtered.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub excluded_tables: Vec<ExcludedTableOutput>,
+    /// Number of schema-cache entries written by this invocation.
+    ///
+    /// Populated by `rocky discover --with-schemas` — the explicit
+    /// warm-up path for the Arc 7 wave 2 wave-2 schema cache (design
+    /// doc §4.2 route B at
+    /// `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`).
+    /// Zero — and omitted from the wire format — when `--with-schemas`
+    /// isn't set, so fixtures captured without the flag stay
+    /// byte-stable.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub schemas_cached: usize,
 }
 
 /// Pipeline-level checks configuration projected into the discover output.
@@ -1820,6 +1831,7 @@ impl DiscoverOutput {
             sources,
             checks: None,
             excluded_tables: vec![],
+            schemas_cached: 0,
         }
     }
 
@@ -1834,6 +1846,18 @@ impl DiscoverOutput {
     #[must_use]
     pub fn with_excluded_tables(mut self, excluded: Vec<ExcludedTableOutput>) -> Self {
         self.excluded_tables = excluded;
+        self
+    }
+
+    /// Record the number of schema-cache entries written by
+    /// `rocky discover --with-schemas` and return self.
+    ///
+    /// Zero is the canonical "flag absent" value and is skipped from the
+    /// wire format (see the `#[serde(skip_serializing_if = "is_zero")]`
+    /// attribute on the field).
+    #[must_use]
+    pub fn with_schemas_cached(mut self, schemas_cached: usize) -> Self {
+        self.schemas_cached = schemas_cached;
         self
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -149,6 +149,18 @@ enum Command {
         /// Pipeline name (required if multiple pipelines are defined)
         #[arg(long)]
         pipeline: Option<String>,
+        /// Warm the schema cache for every discovered source.
+        ///
+        /// For each `(catalog, schema)` pair reachable via the source
+        /// adapter, issues one `batch_describe_schema` round-trip and
+        /// persists the per-table columns to `state.redb::schema_cache`.
+        /// Subsequent `rocky compile` / `rocky lsp` invocations pick up
+        /// the entries via the Arc 7 wave 2 wave-2 schema cache instead
+        /// of typechecking leaf models as `Unknown`. Errors on individual
+        /// sources are logged and skipped — one bad source does not
+        /// abort the warm-up.
+        #[arg(long)]
+        with_schemas: bool,
     },
 
     /// Generate SQL without executing (dry-run)
@@ -963,8 +975,18 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
     let result: Result<()> = match cli.command {
         Command::Init { path, template } => rocky_cli::commands::init(&path, Some(&template)),
         Command::Validate => rocky_cli::commands::validate(&cli.config, json),
-        Command::Discover { pipeline } => {
-            rocky_cli::commands::discover(&cli.config, pipeline.as_deref(), json).await
+        Command::Discover {
+            pipeline,
+            with_schemas,
+        } => {
+            rocky_cli::commands::discover(
+                &cli.config,
+                pipeline.as_deref(),
+                &cli.state_path,
+                with_schemas,
+                json,
+            )
+            .await
         }
         Command::Plan { filter, pipeline } => {
             rocky_cli::commands::plan(&cli.config, filter.as_deref(), pipeline.as_deref(), json)

--- a/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
@@ -93,5 +93,11 @@ class DiscoverOutput(BaseModel):
     """
     Tables filtered out of `sources` because they were reported by the discovery adapter but do not exist in the source warehouse. Same shape as `RunOutput.excluded_tables` so consumers can use one parser. Empty when nothing was filtered.
     """
+    schemas_cached: conint(ge=0) | None = None
+    """
+    Number of schema-cache entries written by this invocation.
+
+    Populated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache (design doc §4.2 route B at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`). Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
+    """
     sources: list[SourceOutput]
     version: str

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -146,6 +146,12 @@
       },
       "type": "array"
     },
+    "schemas_cached": {
+      "description": "Number of schema-cache entries written by this invocation.\n\nPopulated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache (design doc §4.2 route B at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`). Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.",
+      "format": "uint",
+      "minimum": 0.0,
+      "type": "integer"
+    },
     "sources": {
       "items": {
         "$ref": "#/definitions/SourceOutput"


### PR DESCRIPTION
## Summary

- Adds `--with-schemas` to `rocky discover`. When set, for every unique `(catalog, schema)` pair reachable via the source's `BatchCheckAdapter`, the command issues one `batch_describe_schema` round-trip and persists every returned table as a `SchemaCacheEntry` in `state.redb::schema_cache`. Downstream `rocky compile` / `rocky lsp` then typecheck leaf models against real warehouse types (via the read path wired in #228 / PR 1b) instead of falling back to `Unknown`.
- Arc 7 wave 2 wave-2 PR 3 of 4. Depends on #223 (PR 1a — schema cache infra) and #228 (PR 1b — read-path wiring). The `rocky run` write tap (PR 2) and `rocky state clear-schema-cache` (PR 4) ship separately. Plan at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md` §4.2 (route B) and §6 (PR breakdown).
- `DiscoverOutput` gains `schemas_cached: usize` (skipped from the wire format when zero, so existing fixtures stay byte-stable). Full codegen cascade ran — Pydantic + TypeScript bindings regenerated alongside the schema.

### Config-disabled semantics (decision point from the task brief)

**Hard error, not warn+skip.** When `--with-schemas` is passed alongside `[cache.schemas] enabled = false` in `rocky.toml`, Rocky exits with:

> \`--with-schemas\` conflicts with \`[cache.schemas] enabled = false\` in <path>; remove the flag or set \`enabled = true\` to warm the cache

The two signals are contradictory — user explicitly asked for cache warm-up *and* explicitly disabled the cache. Silently no-op'ing would leave them guessing at why `schemas_cached=0`. Erroring keeps the user's mental model aligned with what the cache does and is the trust-aligned call for Rocky's positioning.

### Other error paths (all warn + continue)

- Missing `source.catalog` → warn once, skip (cannot key entries without a catalog).
- Source adapter has no `BatchCheckAdapter` (DuckDB today) → warn once, skip.
- Per-schema `batch_describe_schema` failure → warn and continue (one bad source doesn't abort warm-up).
- Per-entry `write_schema_cache_entry` failure → warn and continue.

### Out of scope (do not touch)

- `rocky run` write tap (PR 2).
- `rocky state clear-schema-cache` and CLI TTL overrides (PR 4).
- Any changes to the read path or cache-entry format.

## Test plan

- [x] `cargo test -p rocky-cli -p rocky-core` — 1236 tests green (5 new `discover::tests` covering dedup + happy / failure / empty / lowercase paths via a stub `BatchCheckAdapter`).
- [x] `cargo clippy --all-targets -- -D warnings` — clean on full workspace.
- [x] `cargo fmt --all --check` — clean.
- [x] `just codegen` — only the expected `schemas_cached` node added to `schemas/discover.schema.json`, Pydantic + TypeScript bindings regenerated.
- [x] `uv run pytest` in `integrations/dagster/` — 370 tests green after Pydantic regeneration.
- [x] `npm run compile` in `editors/vscode/` — clean.
- [x] `scripts/regen_fixtures.sh` — fixtures byte-stable (field skipped when zero).
- [x] Smoke-tested against the 00-playground-default POC:
  - `rocky -c rocky.toml discover` → same JSON as before, no `schemas_cached` field.
  - `rocky -c rocky.toml discover --with-schemas` → warns about missing DuckDB `BatchCheckAdapter`, returns same JSON (no entries written, `schemas_cached=0` elided).
  - `rocky -c <disabled>.toml discover --with-schemas` → errors cleanly with the config-conflict message.