### PR TITLE
feat(engine): FR-004 rocky run --idempotency-key dedup (Phase 1+2+3)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -576,6 +576,25 @@
       ],
       "type": "object"
     },
+    "DedupPolicy": {
+      "description": "Policy controlling which terminal outcomes count for [`IdempotencyConfig::dedup_on`].",
+      "oneOf": [
+        {
+          "description": "Only successful runs stamp a persistent dedup entry; failed runs leave the key claimable for a retry. Default — matches the common \"dedup successful notifications, allow retries\" use case.",
+          "enum": [
+            "success"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Any terminal status stamps a persistent entry — subsequent calls with the same key always skip, regardless of whether the prior run succeeded. Use when replays are expensive even for failures.",
+          "enum": [
+            "any"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "Dialect": {
       "description": "Target dialect for transpilation.\n\nSerializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.",
       "enum": [
@@ -832,6 +851,36 @@
           "default": {},
           "description": "Webhook configurations keyed by event name.",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "IdempotencyConfig": {
+      "additionalProperties": false,
+      "description": "Config for `rocky run --idempotency-key` dedup.\n\nAll fields are optional with sensible defaults. Block is present even when the user doesn't set `--idempotency-key`; it's a no-op in that case.",
+      "properties": {
+        "dedup_on": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/DedupPolicy"
+            }
+          ],
+          "default": "success",
+          "description": "Which terminal statuses count as \"already processed\" for dedup. See [`DedupPolicy`]. Default [`DedupPolicy::Success`]."
+        },
+        "in_flight_ttl_hours": {
+          "default": 24,
+          "description": "Hours after which an `InFlight` entry is treated as a crashed-pod corpse and adopted by a fresh caller. Default 24. Applies only to backends whose in-flight lock does not carry a server-side TTL — Valkey providers set `EX` directly on `SET NX`, so this field is informational for them.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "retention_days": {
+          "default": 30,
+          "description": "Number of days a `Succeeded` (or `Failed`-under-`any`) stamp is kept before GC. Default 30. GC runs during the state upload sweep.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
       "type": "object"
@@ -2258,6 +2307,19 @@
             "null"
           ]
         },
+        "idempotency": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IdempotencyConfig"
+            }
+          ],
+          "default": {
+            "dedup_on": "success",
+            "in_flight_ttl_hours": 24,
+            "retention_days": 30
+          },
+          "description": "Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as \"deduplicated\", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`]."
+        },
         "on_upload_failure": {
           "allOf": [
             {
@@ -2718,6 +2780,11 @@
         "backend": "local",
         "gcs_bucket": null,
         "gcs_prefix": null,
+        "idempotency": {
+          "dedup_on": "success",
+          "in_flight_ttl_hours": 24,
+          "retention_days": 30
+        },
         "on_upload_failure": "skip",
         "retry": {
           "backoff_multiplier": 2.0,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -273,6 +273,10 @@ export type Dialect = "databricks" | "snowflake" | "bigquery" | "duckdb";
  */
 export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
 /**
+ * Policy controlling which terminal outcomes count for [`IdempotencyConfig::dedup_on`].
+ */
+export type DedupPolicy = "success" | "any";
+/**
  * Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].
  */
 export type StateUploadFailureMode = "skip" | "fail";
@@ -1196,6 +1200,10 @@ export interface StateConfig {
    */
   gcs_prefix?: string | null;
   /**
+   * Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as "deduplicated", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`].
+   */
+  idempotency?: IdempotencyConfig;
+  /**
    * What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
    */
   on_upload_failure?: StateUploadFailureMode & string;
@@ -1223,4 +1231,23 @@ export interface StateConfig {
    * Valkey/Redis URL for state persistence
    */
   valkey_url?: string | null;
+}
+/**
+ * Config for `rocky run --idempotency-key` dedup.
+ *
+ * All fields are optional with sensible defaults. Block is present even when the user doesn't set `--idempotency-key`; it's a no-op in that case.
+ */
+export interface IdempotencyConfig {
+  /**
+   * Which terminal statuses count as "already processed" for dedup. See [`DedupPolicy`]. Default [`DedupPolicy::Success`].
+   */
+  dedup_on?: DedupPolicy & string;
+  /**
+   * Hours after which an `InFlight` entry is treated as a crashed-pod corpse and adopted by a fresh caller. Default 24. Applies only to backends whose in-flight lock does not carry a server-side TTL — Valkey providers set `EX` directly on `SET NX`, so this field is informational for them.
+   */
+  in_flight_ttl_hours?: number;
+  /**
+   * Number of days a `Succeeded` (or `Failed`-under-`any`) stamp is kept before GC. Default 30. GC runs during the state upload sweep.
+   */
+  retention_days?: number;
 }

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -64,6 +64,12 @@ export type CheckResult1 =
  * Severity of a test failure.
  */
 export type TestSeverity = "error" | "warning";
+/**
+ * Status of a pipeline run.
+ *
+ * `Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are the short-circuit outcomes of `rocky run --idempotency-key` — see [`crate::idempotency`].
+ */
+export type RunStatus = ("Success" | "PartialFailure" | "Failure") | "SkippedIdempotent" | "SkippedInFlight";
 
 /**
  * JSON output for `rocky run`.
@@ -90,6 +96,10 @@ export interface RunOutput {
   execution: ExecutionSummary;
   filter: string;
   /**
+   * The `--idempotency-key` value this run was invoked with, echoed back for operator cross-reference in logs and `rocky history`. `None` for runs that didn't pass the flag.
+   */
+  idempotency_key?: string | null;
+  /**
    * `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish "user interrupted" from "run failed". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.
    */
   interrupted: boolean;
@@ -113,6 +123,14 @@ export interface RunOutput {
    * True when running in shadow mode (targets rewritten).
    */
   shadow: boolean;
+  /**
+   * Prior run whose idempotency key deflected this call, or the run currently holding the in-flight claim. Populated only when `status` is `skipped_idempotent` or `skipped_in_flight`.
+   */
+  skipped_by_run_id?: string | null;
+  /**
+   * Terminal status of the run. `success` / `partial_failure` / `failure` match the lifecycle semantics callers already understand; the two `skipped_*` variants short-circuit via the idempotency key (see `idempotency_key` below). Always populated — non-skipped runs derive this field from `tables_failed` / materialization counts, so JSON consumers no longer need to re-derive status from counts themselves.
+   */
+  status: RunStatus;
   tables_copied: number;
   tables_failed: number;
   tables_skipped: number;

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -48,6 +48,8 @@ fn status_str(status: &RunStatus) -> &'static str {
         RunStatus::Success => "success",
         RunStatus::PartialFailure => "partial_failure",
         RunStatus::Failure => "failure",
+        RunStatus::SkippedIdempotent => "skipped_idempotent",
+        RunStatus::SkippedInFlight => "skipped_in_flight",
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -21,6 +21,8 @@ fn status_str(status: &RunStatus) -> &'static str {
         RunStatus::Success => "success",
         RunStatus::PartialFailure => "partial_failure",
         RunStatus::Failure => "failure",
+        RunStatus::SkippedIdempotent => "skipped_idempotent",
+        RunStatus::SkippedInFlight => "skipped_in_flight",
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -262,6 +262,234 @@ fn persist_run_record(
     }
 }
 
+/// Context captured at idempotency claim time so the finalize path (every
+/// `persist_run_record` call site) can stamp the correct terminal state.
+struct IdempotencyCtx {
+    key: String,
+    backend: rocky_core::idempotency::IdempotencyBackend,
+    config: rocky_core::config::IdempotencyConfig,
+    /// Captured at the claim point; surfaced in the echoed `RunOutput`
+    /// field for operator cross-reference.
+    _claim_backend_label: &'static str,
+}
+
+/// Outcome of the initial claim attempt at the top of `rocky run`.
+enum IdempotencyOutcome {
+    /// Key dedups — the caller already emitted a `skipped_*` `RunOutput`
+    /// and exited. `run()` should return immediately.
+    Skipped,
+    /// Key claimed (or adopted from stale) — run proceeds; ctx is threaded
+    /// to the finalize path.
+    Proceed(IdempotencyCtx),
+}
+
+/// Attempt to claim the idempotency key. On skip, emit the short-circuit
+/// `RunOutput` and return [`IdempotencyOutcome::Skipped`]. On proceed /
+/// adopt-stale, return the claim context for the caller to thread into
+/// [`finalize_idempotency`] at every exit path.
+async fn try_claim_idempotency(
+    state_cfg: &rocky_core::config::StateConfig,
+    state_path: &Path,
+    key: &str,
+    run_id: &str,
+    output_json: bool,
+) -> Result<IdempotencyOutcome> {
+    use rocky_core::idempotency::{IdempotencyBackend, IdempotencyCheck, IdempotencyError};
+
+    let backend = IdempotencyBackend::from_state_config(state_cfg);
+    let backend_label = backend.backend_label();
+
+    // For the local + tiered paths the StateStore is the primary (local) or
+    // mirror (tiered) write target. `open_read_only` is insufficient — the
+    // claim performs a redb write txn. Fall back to an in-memory store
+    // error-out when the state store can't be opened at all so a broken
+    // state file doesn't silently bypass dedup.
+    let state_store = match backend {
+        IdempotencyBackend::Local
+        | IdempotencyBackend::Valkey {
+            mirror_to_redb: true,
+            ..
+        } => Some(StateStore::open(state_path).with_context(|| {
+            format!(
+                "failed to open state store at {} for idempotency claim",
+                state_path.display()
+            )
+        })?),
+        _ => None,
+    };
+
+    let verdict = backend
+        .check_and_claim(state_store.as_ref(), key, run_id, &state_cfg.idempotency)
+        .await
+        .map_err(|e| match e {
+            IdempotencyError::UnsupportedBackend { backend } => anyhow::anyhow!(
+                "--idempotency-key is not supported on state backend \"{backend}\" yet. \
+                 Switch to `tiered` (Valkey + S3 fallback — recommended for multi-pod) \
+                 or `valkey` to enable idempotency, or drop the flag to proceed without dedup."
+            ),
+            other => anyhow::Error::from(other),
+        })?;
+
+    match verdict {
+        IdempotencyCheck::Proceed => {
+            info!(
+                idempotency_key = key,
+                run_id = run_id,
+                backend = backend_label,
+                "idempotency key claimed — proceeding"
+            );
+            Ok(IdempotencyOutcome::Proceed(IdempotencyCtx {
+                key: key.to_string(),
+                backend,
+                config: state_cfg.idempotency.clone(),
+                _claim_backend_label: backend_label,
+            }))
+        }
+        IdempotencyCheck::AdoptStale { prior_run_id } => {
+            warn!(
+                idempotency_key = key,
+                run_id = run_id,
+                prior_run_id = %prior_run_id,
+                backend = backend_label,
+                "adopted stale idempotency claim (previous run appears crashed) — proceeding"
+            );
+            Ok(IdempotencyOutcome::Proceed(IdempotencyCtx {
+                key: key.to_string(),
+                backend,
+                config: state_cfg.idempotency.clone(),
+                _claim_backend_label: backend_label,
+            }))
+        }
+        IdempotencyCheck::SkipCompleted {
+            run_id: prior_run_id,
+        } => {
+            emit_skipped_run_output(
+                key,
+                &prior_run_id,
+                rocky_core::state::RunStatus::SkippedIdempotent,
+                output_json,
+            )?;
+            Ok(IdempotencyOutcome::Skipped)
+        }
+        IdempotencyCheck::SkipInFlight {
+            run_id: prior_run_id,
+        } => {
+            emit_skipped_run_output(
+                key,
+                &prior_run_id,
+                rocky_core::state::RunStatus::SkippedInFlight,
+                output_json,
+            )?;
+            Ok(IdempotencyOutcome::Skipped)
+        }
+    }
+}
+
+/// Emit a short-circuit `RunOutput` (status = `skipped_*`) and exit. No
+/// state-store mutation, no hook fires, no pipeline-start event — the run
+/// never actually started.
+fn emit_skipped_run_output(
+    key: &str,
+    prior_run_id: &str,
+    status: rocky_core::state::RunStatus,
+    output_json: bool,
+) -> Result<()> {
+    let mut output = RunOutput::new(String::new(), 0, 0);
+    output.status = status;
+    output.skipped_by_run_id = Some(prior_run_id.to_string());
+    output.idempotency_key = Some(key.to_string());
+    if output_json {
+        print_json(&output)?;
+    } else {
+        let label = match status {
+            rocky_core::state::RunStatus::SkippedIdempotent => "skipped_idempotent",
+            rocky_core::state::RunStatus::SkippedInFlight => "skipped_in_flight",
+            _ => "skipped",
+        };
+        info!(
+            idempotency_key = key,
+            prior_run_id = prior_run_id,
+            status = label,
+            "idempotency key already claimed — skipping run"
+        );
+    }
+    Ok(())
+}
+
+/// Sweep expired idempotency entries + stale-InFlight corpses on the
+/// local/mirror state store. Runs regardless of whether THIS invocation
+/// supplied `--idempotency-key` — keeps the table tidy for future dedup
+/// consumers and bounds redb growth.
+///
+/// Failures are logged and swallowed; GC is purely opportunistic.
+async fn sweep_idempotency_best_effort(
+    _ctx: Option<&IdempotencyCtx>,
+    state_store: Option<&StateStore>,
+    config: &rocky_core::config::IdempotencyConfig,
+) {
+    let Some(store) = state_store else {
+        return;
+    };
+    match store.idempotency_sweep_expired(Utc::now(), config.in_flight_ttl_hours) {
+        Ok(count) if count > 0 => {
+            info!(
+                swept_count = count,
+                retention_days = config.retention_days,
+                in_flight_ttl_hours = config.in_flight_ttl_hours,
+                "swept expired idempotency entries"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => warn!(
+            error = %e,
+            "idempotency sweep failed; retrying on next run"
+        ),
+    }
+}
+
+/// Finalize the idempotency entry for the current run. Called from the
+/// same exit paths as [`persist_run_record`] (every terminal branch of
+/// `rocky run`).
+///
+/// Swallows errors with a warn — state-store or Valkey flakiness here must
+/// not flip the exit code of an otherwise successful run. The worst case
+/// is a stale `InFlight` entry that the `in_flight_ttl_hours` sweep will
+/// eventually reap.
+async fn finalize_idempotency(
+    ctx: Option<&IdempotencyCtx>,
+    state_store: Option<&StateStore>,
+    run_id: &str,
+    output: &RunOutput,
+) {
+    let Some(ctx) = ctx else {
+        return;
+    };
+    let outcome = match output.derive_run_status() {
+        rocky_core::state::RunStatus::Success => rocky_core::idempotency::FinalOutcome::Succeeded,
+        rocky_core::state::RunStatus::PartialFailure | rocky_core::state::RunStatus::Failure => {
+            rocky_core::idempotency::FinalOutcome::Failed
+        }
+        // Skip variants never reach finalize — we short-circuit before
+        // starting the pipeline — but be safe.
+        rocky_core::state::RunStatus::SkippedIdempotent
+        | rocky_core::state::RunStatus::SkippedInFlight => {
+            return;
+        }
+    };
+    if let Err(e) = ctx
+        .backend
+        .finalize(state_store, &ctx.key, run_id, outcome, &ctx.config)
+        .await
+    {
+        warn!(
+            error = %e,
+            idempotency_key = %ctx.key,
+            run_id = run_id,
+            "failed to finalize idempotency entry; key may remain InFlight until TTL sweep"
+        );
+    }
+}
+
 /// Execute `rocky run` — full pipeline.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "run")]
@@ -284,9 +512,47 @@ pub async fn run(
     // path doesn't consult the cache, so this flag is a no-op for
     // replication-only runs.
     cache_ttl_override: Option<u64>,
+    // Caller-supplied `--idempotency-key`. `None` bypasses the dedup path
+    // entirely. When `Some`, the run is skipped if the key already dedups
+    // (see `rocky_core::idempotency`) or proceeds and stamps the key at
+    // every terminal exit.
+    idempotency_key: Option<&str>,
 ) -> Result<()> {
     let start = Instant::now();
     let started_at = Utc::now();
+    // Unified run_id minted up front so the idempotency claim and every
+    // downstream persistence site (model-only, replication, interrupted,
+    // main exit) share one identifier. That keeps
+    // `IdempotencyEntry::run_id` == `RunRecord::run_id` so operators can
+    // cross-reference a `skipped_by_run_id` directly against
+    // `rocky history`.
+    let run_id = format!("run-{}", started_at.format("%Y%m%d-%H%M%S-%3f"));
+
+    // -------------------------------------------------------------------
+    // Idempotency check + claim (before any state mutation / run_id mint).
+    // Dispatch on the configured state backend; short-circuit with a typed
+    // `RunOutput` + exit 0 when the key dedups.
+    // -------------------------------------------------------------------
+    let rocky_cfg_for_idemp = rocky_core::config::load_rocky_config(config_path).context(
+        format!("failed to load config from {}", config_path.display()),
+    )?;
+    let idempotency_ctx = match idempotency_key {
+        Some(key) => {
+            match try_claim_idempotency(
+                &rocky_cfg_for_idemp.state,
+                state_path,
+                key,
+                &run_id,
+                output_json,
+            )
+            .await?
+            {
+                IdempotencyOutcome::Skipped => return Ok(()),
+                IdempotencyOutcome::Proceed(ctx) => Some(ctx),
+            }
+        }
+        None => None,
+    };
 
     // OTLP metrics exporter (feature-gated). Auto-initialises when
     // `OTEL_EXPORTER_OTLP_ENDPOINT` is set so operators can opt in by
@@ -358,16 +624,16 @@ pub async fn run(
 
         let warehouse = adapter_registry.warehouse_adapter(&target_adapter_name)?;
         let state_store = rocky_core::state::StateStore::open(state_path).ok();
-        let run_id = format!(
-            "model-{}-{}",
-            target_model,
-            chrono::Utc::now().format("%Y%m%d-%H%M%S")
-        );
+        // `run_id` minted at the top of `run()` — model-only, replication,
+        // and idempotency-claim paths all share one identifier.
         let mut output = RunOutput::new(
             filter.unwrap_or("").to_string(),
             0, // duration filled at end
             1, // concurrency
         );
+        if let Some(ctx) = &idempotency_ctx {
+            output.idempotency_key = Some(ctx.key.clone());
+        }
 
         execute_models(
             mdir,
@@ -403,6 +669,13 @@ pub async fn run(
             started_at,
             &config_hash,
         );
+        finalize_idempotency(
+            idempotency_ctx.as_ref(),
+            state_store.as_ref(),
+            &run_id,
+            &output,
+        )
+        .await;
 
         if output_json {
             print_json(&output)?;
@@ -538,6 +811,9 @@ pub async fn run(
     let concurrency = pipeline.execution.concurrency.max_concurrency();
     let mut output = RunOutput::new(filter.unwrap_or("").to_string(), 0, concurrency);
     output.shadow = shadow_config.is_some();
+    if let Some(ctx) = &idempotency_ctx {
+        output.idempotency_key = Some(ctx.key.clone());
+    }
     let mut catalogs_created: usize = 0;
     let mut schemas_created: usize = 0;
     let mut created_catalogs: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -968,7 +1244,7 @@ pub async fn run(
         }
     }
     // --- Checkpoint / resume: filter already-completed tables ---
-    let run_id = format!("run-{}", Utc::now().format("%Y%m%d-%H%M%S-%3f"));
+    // `run_id` minted at the top of `run()`.
 
     // §P2.6 emit: pipeline_start. Failures here are logged by the
     // registry itself; we swallow the Result because hook failures
@@ -1691,6 +1967,13 @@ pub async fn run(
                 started_at,
                 &config_hash,
             );
+            finalize_idempotency(
+                idempotency_ctx.as_ref(),
+                Some(&state),
+                &shared_run_id,
+                &output,
+            )
+            .await;
         }
 
         if output_json {
@@ -2248,6 +2531,16 @@ pub async fn run(
     output.permissions.schemas_created = schemas_created;
     output.metrics = Some(rocky_observe::metrics::METRICS.snapshot());
 
+    // Sweep expired idempotency stamps + stale InFlight corpses before
+    // the remote upload so the uploaded snapshot doesn't carry dead
+    // state. Swallow errors — the sweep is purely opportunistic.
+    sweep_idempotency_best_effort(
+        idempotency_ctx.as_ref(),
+        state_store.as_ref(),
+        &rocky_cfg.state.idempotency,
+    )
+    .await;
+
     // Upload state to remote storage
     if let Err(e) = rocky_core::state_sync::upload_state(&rocky_cfg.state, state_path).await {
         warn!(error = %e, "state upload failed");
@@ -2300,6 +2593,13 @@ pub async fn run(
         started_at,
         &config_hash,
     );
+    finalize_idempotency(
+        idempotency_ctx.as_ref(),
+        state_store.as_ref(),
+        &run_id,
+        &output,
+    )
+    .await;
 
     // Fire the `on_budget_breach` hook for each recorded breach so
     // shell hooks / webhooks configured via `[hook.on_budget_breach]`
@@ -3963,6 +4263,9 @@ mod tests {
         let output = RunOutput {
             version: "1.0.2".into(),
             command: "run".into(),
+            status: rocky_core::state::RunStatus::Success,
+            skipped_by_run_id: None,
+            idempotency_key: None,
             pipeline_type: None,
             filter: "tenant=acme".into(),
             duration_ms: 100,

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -179,6 +179,12 @@ impl NodeDispatcher for CliDispatcher {
                     // contract without clear signal; defer unless a
                     // concrete use case shows up.
                     None,
+                    // DAG sub-runs do not accept `--idempotency-key`; the
+                    // caller stamps dedup on the outer DAG driver, and
+                    // cascading the key into every pipeline sub-run would
+                    // cause every sibling to short-circuit on a single
+                    // stamp.
+                    None,
                 )
                 .await
                 .map_err(|e| e.to_string())

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -22,6 +22,8 @@ fn status_str(status: &RunStatus) -> &'static str {
         RunStatus::Success => "success",
         RunStatus::PartialFailure => "partial_failure",
         RunStatus::Failure => "failure",
+        RunStatus::SkippedIdempotent => "skipped_idempotent",
+        RunStatus::SkippedInFlight => "skipped_in_flight",
     }
 }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -161,6 +161,23 @@ pub struct TableOutput {
 pub struct RunOutput {
     pub version: String,
     pub command: String,
+    /// Terminal status of the run. `success` / `partial_failure` / `failure`
+    /// match the lifecycle semantics callers already understand; the two
+    /// `skipped_*` variants short-circuit via the idempotency key (see
+    /// `idempotency_key` below). Always populated — non-skipped runs derive
+    /// this field from `tables_failed` / materialization counts, so JSON
+    /// consumers no longer need to re-derive status from counts themselves.
+    pub status: rocky_core::state::RunStatus,
+    /// Prior run whose idempotency key deflected this call, or the run
+    /// currently holding the in-flight claim. Populated only when `status`
+    /// is `skipped_idempotent` or `skipped_in_flight`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_by_run_id: Option<String>,
+    /// The `--idempotency-key` value this run was invoked with, echoed back
+    /// for operator cross-reference in logs and `rocky history`. `None` for
+    /// runs that didn't pass the flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
     /// Pipeline type that was executed (e.g., "replication").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pipeline_type: Option<String>,
@@ -1896,6 +1913,9 @@ impl RunOutput {
         RunOutput {
             version: VERSION.to_string(),
             command: "run".to_string(),
+            status: rocky_core::state::RunStatus::Success,
+            skipped_by_run_id: None,
+            idempotency_key: None,
             pipeline_type: Some("replication".to_string()),
             filter,
             duration_ms,

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -476,6 +476,13 @@ pub struct StateConfig {
     /// [`StateUploadFailureMode`].
     #[serde(default)]
     pub on_upload_failure: StateUploadFailureMode,
+    /// Per-run idempotency-key policy (`rocky run --idempotency-key`).
+    /// Controls retention of stamped keys, what terminal statuses count as
+    /// "deduplicated", and how long an `InFlight` entry survives before it's
+    /// treated as a crashed-pod corpse and adopted by a fresh caller. See
+    /// [`IdempotencyConfig`].
+    #[serde(default)]
+    pub idempotency: IdempotencyConfig,
 }
 
 impl Default for StateConfig {
@@ -491,12 +498,71 @@ impl Default for StateConfig {
             transfer_timeout_seconds: default_state_transfer_timeout_secs(),
             retry: RetryConfig::default(),
             on_upload_failure: StateUploadFailureMode::default(),
+            idempotency: IdempotencyConfig::default(),
         }
     }
 }
 
 fn default_state_transfer_timeout_secs() -> u64 {
     300
+}
+
+/// Policy controlling which terminal outcomes count for
+/// [`IdempotencyConfig::dedup_on`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DedupPolicy {
+    /// Only successful runs stamp a persistent dedup entry; failed runs
+    /// leave the key claimable for a retry. Default — matches the common
+    /// "dedup successful notifications, allow retries" use case.
+    #[default]
+    Success,
+    /// Any terminal status stamps a persistent entry — subsequent calls
+    /// with the same key always skip, regardless of whether the prior run
+    /// succeeded. Use when replays are expensive even for failures.
+    Any,
+}
+
+/// Config for `rocky run --idempotency-key` dedup.
+///
+/// All fields are optional with sensible defaults. Block is present even
+/// when the user doesn't set `--idempotency-key`; it's a no-op in that case.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct IdempotencyConfig {
+    /// Number of days a `Succeeded` (or `Failed`-under-`any`) stamp is kept
+    /// before GC. Default 30. GC runs during the state upload sweep.
+    #[serde(default = "default_idempotency_retention_days")]
+    pub retention_days: u32,
+    /// Which terminal statuses count as "already processed" for dedup. See
+    /// [`DedupPolicy`]. Default [`DedupPolicy::Success`].
+    #[serde(default)]
+    pub dedup_on: DedupPolicy,
+    /// Hours after which an `InFlight` entry is treated as a crashed-pod
+    /// corpse and adopted by a fresh caller. Default 24. Applies only to
+    /// backends whose in-flight lock does not carry a server-side TTL —
+    /// Valkey providers set `EX` directly on `SET NX`, so this field is
+    /// informational for them.
+    #[serde(default = "default_idempotency_in_flight_ttl_hours")]
+    pub in_flight_ttl_hours: u32,
+}
+
+impl Default for IdempotencyConfig {
+    fn default() -> Self {
+        Self {
+            retention_days: default_idempotency_retention_days(),
+            dedup_on: DedupPolicy::default(),
+            in_flight_ttl_hours: default_idempotency_in_flight_ttl_hours(),
+        }
+    }
+}
+
+fn default_idempotency_retention_days() -> u32 {
+    30
+}
+
+fn default_idempotency_in_flight_ttl_hours() -> u32 {
+    24
 }
 
 /// Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).

--- a/engine/crates/rocky-core/src/idempotency.rs
+++ b/engine/crates/rocky-core/src/idempotency.rs
@@ -1,0 +1,1123 @@
+//! Run-level idempotency-key dedup for `rocky run --idempotency-key`.
+//!
+//! Before a run starts, the caller asks Rocky: "has this key been seen?"
+//! Three outcomes:
+//!
+//! * **Seen, succeeded** (or any terminal status under
+//!   [`DedupPolicy::Any`]) → [`IdempotencyCheck::SkipCompleted`] — exit 0
+//!   with `status = skipped_idempotent` and the prior `run_id`.
+//! * **Seen, in-flight** (another pod is running the same key) →
+//!   [`IdempotencyCheck::SkipInFlight`] — exit 0 with
+//!   `status = skipped_in_flight`.
+//! * **Unseen** (or existing `InFlight` past its TTL — a crashed-pod
+//!   corpse) → [`IdempotencyCheck::Proceed`] / [`IdempotencyCheck::AdoptStale`]
+//!   — mint a fresh `run_id`, stamp an `InFlight` entry, run normally, and
+//!   update to `Succeeded` / `Failed` at every terminal exit.
+//!
+//! # Backend matrix
+//!
+//! The atomic "claim this key if absent" primitive varies per state backend:
+//!
+//! | Backend | Primitive |
+//! |---|---|
+//! | [`StateBackend::Local`] | redb write transaction inside the existing `state.redb.lock` file lock |
+//! | [`StateBackend::Valkey`] / [`StateBackend::Tiered`] | Valkey `SET NX EX` on `{prefix}idempotency:<key>` |
+//! | [`StateBackend::S3`] | S3 `PutObject` with `If-None-Match: "*"` (Phase 2) |
+//! | [`StateBackend::Gcs`] | GCS `insertObject` with `x-goog-if-generation-match: 0` (Phase 3) |
+//!
+//! For `s3` / `gcs` backends before Phase 2 / Phase 3 ship, this module
+//! returns [`IdempotencyError::UnsupportedBackend`] on any idempotency op —
+//! consumed by `rocky run` at flag-parse time with a clear "switch to
+//! tiered" error message.
+//!
+//! # Key storage
+//!
+//! Keys are stored **verbatim** (not hashed) — debuggability over privacy
+//! on the premise that "don't put secrets in idempotency keys" is a
+//! reasonable documentation constraint. The public CLI help and the
+//! Dagster kwarg docstring both carry this warning.
+//!
+//! # GC
+//!
+//! Expired stamps are swept during [`crate::state_sync::upload_state`] —
+//! reuses the existing post-run cadence, no new cron. For Valkey backends
+//! server-side `EX` handles TTL autonomously and `sweep_expired` is a
+//! no-op. For local, the sweep deletes entries whose `expires_at` has
+//! passed OR whose `state = InFlight` has aged past
+//! `in_flight_ttl_hours` (crashed-pod reaping).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use crate::config::{DedupPolicy, IdempotencyConfig, StateBackend, StateConfig};
+use crate::object_store::{ObjectStoreError, ObjectStoreProvider, PutIfNotExistsOutcome};
+use crate::state::{StateError, StateStore};
+
+/// Default Valkey key prefix for idempotency entries (shares the top-level
+/// `valkey_prefix` from `StateConfig` when set; otherwise falls back to
+/// `"rocky:state:"` to keep the existing Valkey namespace conventions).
+const DEFAULT_VALKEY_STATE_PREFIX: &str = "rocky:state:";
+/// Default S3 key prefix (mirrors `state_sync::DEFAULT_S3_PREFIX`).
+const DEFAULT_S3_PREFIX: &str = "rocky/state/";
+/// Default GCS key prefix (mirrors `state_sync::DEFAULT_GCS_PREFIX`).
+const DEFAULT_GCS_PREFIX: &str = "rocky/state/";
+
+/// Persisted idempotency-key entry.
+///
+/// Serialized as JSON into the redb `IDEMPOTENCY_KEYS` table (local / tiered
+/// mirror) or as a JSON blob under a Valkey key (valkey / tiered primary).
+/// Shape is version-1 — if a field changes semantically bump the top-level
+/// state-store schema version alongside it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdempotencyEntry {
+    /// The caller-supplied key. Stored verbatim (not hashed).
+    pub key: String,
+    /// `run_id` of the run that most recently claimed the key.
+    pub run_id: String,
+    /// Lifecycle state.
+    pub state: IdempotencyState,
+    /// When the current owner claimed the key (or when the key was last
+    /// finalized, for `Succeeded` / `Failed`).
+    pub stamped_at: DateTime<Utc>,
+    /// When this stamp expires and GC is allowed to reap it. For
+    /// `Succeeded` entries this is `stamped_at + retention_days`. For
+    /// `InFlight` entries this is `stamped_at + in_flight_ttl_hours` —
+    /// readers past this time adopt the stale entry.
+    pub expires_at: DateTime<Utc>,
+    /// [`DedupPolicy`] in effect at stamp time, captured so a retention
+    /// policy change mid-flight doesn't retroactively reinterpret prior
+    /// entries.
+    pub dedup_on: DedupPolicy,
+}
+
+/// Lifecycle state of an idempotency entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdempotencyState {
+    /// A run has claimed the key and is currently executing. Readers hitting
+    /// this state before `expires_at` skip with
+    /// [`IdempotencyCheck::SkipInFlight`]; readers hitting it past
+    /// `expires_at` treat it as crashed-pod corpse and adopt.
+    InFlight,
+    /// The run that claimed the key completed successfully. Always
+    /// dedups under both [`DedupPolicy`] values.
+    Succeeded,
+    /// The run that claimed the key failed. Dedups only under
+    /// [`DedupPolicy::Any`]; under [`DedupPolicy::Success`] the entry is
+    /// deleted at finalize time so retries proceed.
+    Failed,
+}
+
+/// Terminal outcome reported to [`IdempotencyBackend::finalize`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinalOutcome {
+    Succeeded,
+    Failed,
+}
+
+/// Result of [`IdempotencyBackend::check_and_claim`].
+#[derive(Debug, Clone)]
+pub enum IdempotencyCheck {
+    /// No prior entry; the caller claimed an `InFlight` stamp and should
+    /// proceed to run normally.
+    Proceed,
+    /// Prior entry exists and dedups — short-circuit.
+    SkipCompleted { run_id: String },
+    /// Another run is in flight and its TTL has not expired — short-circuit.
+    SkipInFlight { run_id: String },
+    /// Prior entry was `InFlight` but past its TTL (crashed-pod corpse).
+    /// The caller replaced it with a fresh `InFlight` stamp and should
+    /// proceed. The prior `run_id` is surfaced so logs / `rocky history`
+    /// can cross-reference.
+    AdoptStale { prior_run_id: String },
+}
+
+impl IdempotencyCheck {
+    /// Returns `true` when the caller should short-circuit `rocky run`.
+    pub fn is_skip(&self) -> bool {
+        matches!(
+            self,
+            IdempotencyCheck::SkipCompleted { .. } | IdempotencyCheck::SkipInFlight { .. }
+        )
+    }
+}
+
+/// Errors surfaced by the idempotency subsystem.
+#[derive(Debug, Error)]
+pub enum IdempotencyError {
+    #[error("state store error: {0}")]
+    State(#[from] StateError),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("valkey error: {0}")]
+    Valkey(String),
+
+    #[error("object store error: {0}")]
+    ObjectStore(#[from] ObjectStoreError),
+
+    #[error(
+        "--idempotency-key requires a state backend that supports atomic \
+         set-if-absent. Current backend = \"{backend}\" does not. Switch to \
+         \"tiered\" (Valkey + S3 — recommended for multi-pod) or \"valkey\" \
+         to enable idempotency, or run without `--idempotency-key`."
+    )]
+    UnsupportedBackend { backend: String },
+
+    #[error("idempotency backend misconfigured: {0}")]
+    Config(String),
+
+    #[error("task join error: {0}")]
+    TaskJoin(String),
+}
+
+/// Idempotency dispatch handle.
+///
+/// Constructed via [`IdempotencyBackend::from_state_config`]; drives
+/// per-backend implementations of the claim / finalize / sweep operations.
+#[derive(Debug, Clone)]
+pub enum IdempotencyBackend {
+    /// Local backend: atomicity via the existing `state.redb.lock` file
+    /// lock + a redb write transaction.
+    Local,
+    /// Valkey / Tiered backend: atomicity via `SET NX EX` on
+    /// `{prefix}idempotency:<key>`. `mirror_to_redb` controls whether the
+    /// finalized entry is also mirrored into the local state.redb (true
+    /// for Tiered so `rocky history` has a local record; false for pure
+    /// Valkey).
+    Valkey {
+        url: String,
+        prefix: String,
+        mirror_to_redb: bool,
+    },
+    /// Object-store backend (S3 / GCS) using conditional PUT primitives
+    /// (`If-None-Match: "*"` for S3, `x-goog-if-generation-match: 0` for
+    /// GCS) to implement atomic claim-if-absent. Objects live at
+    /// `{prefix}/idempotency/<sha256(key)>`.
+    ObjectStore {
+        scheme: ObjectStoreScheme,
+        uri: String,
+    },
+}
+
+/// Which object-store provider backs a given [`IdempotencyBackend::ObjectStore`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectStoreScheme {
+    S3,
+    Gcs,
+}
+
+impl ObjectStoreScheme {
+    pub fn label(self) -> &'static str {
+        match self {
+            ObjectStoreScheme::S3 => "s3",
+            ObjectStoreScheme::Gcs => "gcs",
+        }
+    }
+}
+
+impl IdempotencyBackend {
+    /// Resolve the backend from the user's `[state]` config.
+    pub fn from_state_config(state_config: &StateConfig) -> Self {
+        match state_config.backend {
+            StateBackend::Local => IdempotencyBackend::Local,
+            StateBackend::Valkey => IdempotencyBackend::Valkey {
+                url: state_config.valkey_url.clone().unwrap_or_default(),
+                prefix: state_config
+                    .valkey_prefix
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_VALKEY_STATE_PREFIX.to_string()),
+                mirror_to_redb: false,
+            },
+            StateBackend::Tiered => IdempotencyBackend::Valkey {
+                url: state_config.valkey_url.clone().unwrap_or_default(),
+                prefix: state_config
+                    .valkey_prefix
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_VALKEY_STATE_PREFIX.to_string()),
+                mirror_to_redb: true,
+            },
+            StateBackend::S3 => {
+                let bucket = state_config
+                    .s3_bucket
+                    .clone()
+                    .unwrap_or_else(|| "__missing_bucket__".to_string());
+                let prefix = state_config
+                    .s3_prefix
+                    .as_deref()
+                    .unwrap_or(DEFAULT_S3_PREFIX)
+                    .trim_end_matches('/');
+                let uri = if prefix.is_empty() {
+                    format!("s3://{bucket}")
+                } else {
+                    format!("s3://{bucket}/{prefix}")
+                };
+                IdempotencyBackend::ObjectStore {
+                    scheme: ObjectStoreScheme::S3,
+                    uri,
+                }
+            }
+            StateBackend::Gcs => {
+                let bucket = state_config
+                    .gcs_bucket
+                    .clone()
+                    .unwrap_or_else(|| "__missing_bucket__".to_string());
+                let prefix = state_config
+                    .gcs_prefix
+                    .as_deref()
+                    .unwrap_or(DEFAULT_GCS_PREFIX)
+                    .trim_end_matches('/');
+                let uri = if prefix.is_empty() {
+                    format!("gs://{bucket}")
+                } else {
+                    format!("gs://{bucket}/{prefix}")
+                };
+                IdempotencyBackend::ObjectStore {
+                    scheme: ObjectStoreScheme::Gcs,
+                    uri,
+                }
+            }
+        }
+    }
+
+    /// Human-readable label for error messages.
+    pub fn backend_label(&self) -> &'static str {
+        match self {
+            IdempotencyBackend::Local => "local",
+            IdempotencyBackend::Valkey {
+                mirror_to_redb: true,
+                ..
+            } => "tiered",
+            IdempotencyBackend::Valkey {
+                mirror_to_redb: false,
+                ..
+            } => "valkey",
+            IdempotencyBackend::ObjectStore { scheme, .. } => scheme.label(),
+        }
+    }
+
+    /// Claim an idempotency key atomically. See module-level docs for
+    /// outcome semantics.
+    ///
+    /// `state_store` is always threaded in — Local uses it as primary; Tiered
+    /// uses it for the redb mirror; pure Valkey ignores it.
+    pub async fn check_and_claim(
+        &self,
+        state_store: Option<&StateStore>,
+        key: &str,
+        run_id: &str,
+        config: &IdempotencyConfig,
+    ) -> Result<IdempotencyCheck, IdempotencyError> {
+        let now = Utc::now();
+        let entry = IdempotencyEntry {
+            key: key.to_string(),
+            run_id: run_id.to_string(),
+            state: IdempotencyState::InFlight,
+            stamped_at: now,
+            expires_at: now + chrono::Duration::hours(config.in_flight_ttl_hours as i64),
+            dedup_on: config.dedup_on,
+        };
+        match self {
+            IdempotencyBackend::Local => {
+                let store = state_store.ok_or_else(|| {
+                    IdempotencyError::Config(
+                        "local idempotency backend requires an open StateStore".into(),
+                    )
+                })?;
+                store
+                    .idempotency_check_and_claim(&entry, now)
+                    .map_err(IdempotencyError::from)
+            }
+            IdempotencyBackend::Valkey {
+                url,
+                prefix,
+                mirror_to_redb,
+            } => {
+                let result = valkey_check_and_claim(url, prefix, &entry).await?;
+                if let (true, IdempotencyCheck::Proceed | IdempotencyCheck::AdoptStale { .. }) =
+                    (*mirror_to_redb, &result)
+                    && let Some(store) = state_store
+                {
+                    // Best-effort mirror into local state.redb so the tiered
+                    // backend's post-upload snapshot has the same stamp.
+                    // Race with Valkey NX is benign — if two pods both reach
+                    // this line one will lose the Valkey NX already.
+                    if let Err(e) = store.idempotency_put(&entry) {
+                        warn!(
+                            error = %e,
+                            key = %entry.key,
+                            "failed to mirror idempotency claim into local state.redb; Valkey remains authoritative"
+                        );
+                    }
+                }
+                Ok(result)
+            }
+            IdempotencyBackend::ObjectStore { uri, .. } => {
+                object_store_check_and_claim(uri, &entry).await
+            }
+        }
+    }
+
+    /// Update an existing `InFlight` stamp to its terminal state, or delete
+    /// it entirely when [`DedupPolicy::Success`] + failure semantics apply.
+    pub async fn finalize(
+        &self,
+        state_store: Option<&StateStore>,
+        key: &str,
+        run_id: &str,
+        outcome: FinalOutcome,
+        config: &IdempotencyConfig,
+    ) -> Result<(), IdempotencyError> {
+        let now = Utc::now();
+        let retention_until = now + chrono::Duration::days(config.retention_days as i64);
+        match self {
+            IdempotencyBackend::Local => {
+                let store = state_store.ok_or_else(|| {
+                    IdempotencyError::Config(
+                        "local idempotency backend requires an open StateStore".into(),
+                    )
+                })?;
+                store
+                    .idempotency_finalize(key, run_id, outcome, retention_until, config.dedup_on)
+                    .map_err(IdempotencyError::from)
+            }
+            IdempotencyBackend::Valkey {
+                url,
+                prefix,
+                mirror_to_redb,
+            } => {
+                valkey_finalize(url, prefix, key, run_id, outcome, retention_until, config).await?;
+                if *mirror_to_redb && let Some(store) = state_store {
+                    // Mirror finalized state into local redb best-effort; see
+                    // claim path for the race reasoning.
+                    let should_keep = match (outcome, config.dedup_on) {
+                        (FinalOutcome::Succeeded, _) => true,
+                        (FinalOutcome::Failed, DedupPolicy::Any) => true,
+                        (FinalOutcome::Failed, DedupPolicy::Success) => false,
+                    };
+                    let result = if should_keep {
+                        let entry = IdempotencyEntry {
+                            key: key.to_string(),
+                            run_id: run_id.to_string(),
+                            state: match outcome {
+                                FinalOutcome::Succeeded => IdempotencyState::Succeeded,
+                                FinalOutcome::Failed => IdempotencyState::Failed,
+                            },
+                            stamped_at: now,
+                            expires_at: retention_until,
+                            dedup_on: config.dedup_on,
+                        };
+                        store.idempotency_put(&entry)
+                    } else {
+                        store.idempotency_delete(key).map(|_| ())
+                    };
+                    if let Err(e) = result {
+                        warn!(
+                            error = %e,
+                            key = %key,
+                            "failed to mirror idempotency finalize into local state.redb; Valkey remains authoritative"
+                        );
+                    }
+                }
+                Ok(())
+            }
+            IdempotencyBackend::ObjectStore { uri, .. } => {
+                object_store_finalize(uri, key, run_id, outcome, retention_until, config).await
+            }
+        }
+    }
+
+    /// Sweep expired entries.
+    ///
+    /// - Local: iterates the redb table and removes entries whose
+    ///   `expires_at < now`, plus any `InFlight` entries whose
+    ///   `stamped_at + in_flight_ttl_hours < now`.
+    /// - Valkey: no-op (server-side `EX` handles TTL).
+    /// - Unsupported: no-op (nothing stored yet).
+    ///
+    /// Returns the number of entries swept.
+    pub async fn sweep_expired(
+        &self,
+        state_store: Option<&StateStore>,
+        config: &IdempotencyConfig,
+    ) -> Result<usize, IdempotencyError> {
+        match self {
+            IdempotencyBackend::Local => match state_store {
+                Some(store) => {
+                    Ok(store.idempotency_sweep_expired(Utc::now(), config.in_flight_ttl_hours)?)
+                }
+                None => Ok(0),
+            },
+            IdempotencyBackend::Valkey { mirror_to_redb, .. } => {
+                if *mirror_to_redb && let Some(store) = state_store {
+                    // Tiered: sweep the local mirror too (Valkey handles its own).
+                    Ok(store.idempotency_sweep_expired(Utc::now(), config.in_flight_ttl_hours)?)
+                } else {
+                    Ok(0)
+                }
+            }
+            IdempotencyBackend::ObjectStore { uri, .. } => {
+                // The recommended GC path for S3/GCS is a bucket lifecycle
+                // rule (Rocky writes objects with a path prefix operators
+                // target via `Lifecycle` / `bucket.lifecycle` policies). For
+                // operators who can't configure that, we also offer an
+                // active sweep: list → parse → delete-if-expired. Best-
+                // effort and non-authoritative — the bucket-lifecycle path
+                // is the durable one.
+                object_store_sweep_expired(uri, config).await
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------
+// Valkey implementation (SET NX EX)
+// -----------------------------------------------------------------------
+
+fn valkey_key(prefix: &str, user_key: &str) -> String {
+    let sep = if prefix.ends_with(':') || prefix.is_empty() {
+        ""
+    } else {
+        ":"
+    };
+    format!("{prefix}{sep}idempotency:{user_key}")
+}
+
+async fn valkey_check_and_claim(
+    url: &str,
+    prefix: &str,
+    entry: &IdempotencyEntry,
+) -> Result<IdempotencyCheck, IdempotencyError> {
+    if url.is_empty() {
+        return Err(IdempotencyError::Config(
+            "valkey backend selected but `state.valkey_url` is unset".into(),
+        ));
+    }
+    let full_key = valkey_key(prefix, &entry.key);
+    let value = serde_json::to_vec(entry)?;
+    let ttl_secs = entry
+        .expires_at
+        .signed_duration_since(entry.stamped_at)
+        .num_seconds()
+        .max(1) as u64;
+
+    let url = url.to_string();
+    let key_for_task = full_key.clone();
+
+    let outcome: ValkeyClaimOutcome =
+        tokio::task::spawn_blocking(move || -> Result<ValkeyClaimOutcome, IdempotencyError> {
+            let client =
+                redis::Client::open(url).map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+            let mut conn = client
+                .get_connection()
+                .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+
+            // Try to claim atomically: SET key value NX EX ttl
+            let reply: Option<String> = redis::cmd("SET")
+                .arg(&key_for_task)
+                .arg(&value)
+                .arg("NX")
+                .arg("EX")
+                .arg(ttl_secs)
+                .query(&mut conn)
+                .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+
+            if reply.as_deref() == Some("OK") {
+                return Ok(ValkeyClaimOutcome::Claimed);
+            }
+
+            // Key exists — read existing entry to classify.
+            let existing: Option<Vec<u8>> = redis::cmd("GET")
+                .arg(&key_for_task)
+                .query(&mut conn)
+                .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+
+            match existing {
+                Some(bytes) => {
+                    let prior: IdempotencyEntry = serde_json::from_slice(&bytes)?;
+                    Ok(ValkeyClaimOutcome::Existing(prior))
+                }
+                None => {
+                    // Race: key was TTL'd between SET NX failure and GET. Re-try once.
+                    let retry: Option<String> = redis::cmd("SET")
+                        .arg(&key_for_task)
+                        .arg(&value)
+                        .arg("NX")
+                        .arg("EX")
+                        .arg(ttl_secs)
+                        .query(&mut conn)
+                        .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+                    if retry.as_deref() == Some("OK") {
+                        Ok(ValkeyClaimOutcome::Claimed)
+                    } else {
+                        // Another claimer won the retry race; re-read.
+                        let bytes: Option<Vec<u8>> = redis::cmd("GET")
+                            .arg(&key_for_task)
+                            .query(&mut conn)
+                            .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+                        match bytes {
+                            Some(b) => {
+                                let prior: IdempotencyEntry = serde_json::from_slice(&b)?;
+                                Ok(ValkeyClaimOutcome::Existing(prior))
+                            }
+                            None => Ok(ValkeyClaimOutcome::Claimed),
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .map_err(|e| IdempotencyError::TaskJoin(e.to_string()))??;
+
+    match outcome {
+        ValkeyClaimOutcome::Claimed => {
+            debug!(key = %full_key, "claimed idempotency key via SET NX EX");
+            Ok(IdempotencyCheck::Proceed)
+        }
+        ValkeyClaimOutcome::Existing(prior) => Ok(classify_existing(prior, Utc::now(), entry)),
+    }
+}
+
+async fn valkey_finalize(
+    url: &str,
+    prefix: &str,
+    key: &str,
+    run_id: &str,
+    outcome: FinalOutcome,
+    retention_until: DateTime<Utc>,
+    config: &IdempotencyConfig,
+) -> Result<(), IdempotencyError> {
+    if url.is_empty() {
+        return Ok(());
+    }
+    let full_key = valkey_key(prefix, key);
+    let should_keep = match (outcome, config.dedup_on) {
+        (FinalOutcome::Succeeded, _) => true,
+        (FinalOutcome::Failed, DedupPolicy::Any) => true,
+        (FinalOutcome::Failed, DedupPolicy::Success) => false,
+    };
+
+    let url = url.to_string();
+    let key_for_task = full_key.clone();
+    let run_id = run_id.to_string();
+    let user_key = key.to_string();
+    let dedup_on = config.dedup_on;
+    let ttl_secs = retention_until
+        .signed_duration_since(Utc::now())
+        .num_seconds()
+        .max(1) as u64;
+
+    tokio::task::spawn_blocking(move || -> Result<(), IdempotencyError> {
+        let client =
+            redis::Client::open(url).map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+        let mut conn = client
+            .get_connection()
+            .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+
+        if should_keep {
+            let entry = IdempotencyEntry {
+                key: user_key,
+                run_id,
+                state: match outcome {
+                    FinalOutcome::Succeeded => IdempotencyState::Succeeded,
+                    FinalOutcome::Failed => IdempotencyState::Failed,
+                },
+                stamped_at: Utc::now(),
+                expires_at: retention_until,
+                dedup_on,
+            };
+            let value = serde_json::to_vec(&entry)?;
+            // SET key value EX retention — overwrites the InFlight entry
+            // with the terminal state + retention TTL.
+            redis::cmd("SET")
+                .arg(&key_for_task)
+                .arg(value)
+                .arg("EX")
+                .arg(ttl_secs)
+                .query::<()>(&mut conn)
+                .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+        } else {
+            // Dedup-on-success + failure: delete the InFlight so a retry
+            // can claim the key freely.
+            redis::cmd("DEL")
+                .arg(&key_for_task)
+                .query::<()>(&mut conn)
+                .map_err(|e| IdempotencyError::Valkey(e.to_string()))?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| IdempotencyError::TaskJoin(e.to_string()))?
+}
+
+#[derive(Debug)]
+enum ValkeyClaimOutcome {
+    Claimed,
+    Existing(IdempotencyEntry),
+}
+
+// -----------------------------------------------------------------------
+// Object-store implementation (PutMode::Create = If-None-Match/generation)
+// -----------------------------------------------------------------------
+
+/// Relative path inside the object store prefix where an idempotency entry
+/// is persisted. Digest keeps the path URL-safe + bounded regardless of
+/// caller-supplied key shape.
+fn object_store_relative_path(key: &str) -> String {
+    object_store_idempotency_path(key)
+        .to_string_lossy()
+        .to_string()
+}
+
+async fn object_store_check_and_claim(
+    uri: &str,
+    entry: &IdempotencyEntry,
+) -> Result<IdempotencyCheck, IdempotencyError> {
+    let provider = ObjectStoreProvider::from_uri(uri)?;
+    let rel_path = object_store_relative_path(&entry.key);
+    let encoded = serde_json::to_vec(entry)?;
+
+    let outcome = provider
+        .put_if_not_exists(&rel_path, Bytes::from(encoded))
+        .await?;
+
+    match outcome {
+        PutIfNotExistsOutcome::Created => {
+            debug!(path = %rel_path, "claimed idempotency key via conditional PUT");
+            Ok(IdempotencyCheck::Proceed)
+        }
+        PutIfNotExistsOutcome::AlreadyExists => {
+            // Read the existing object to classify.
+            let body = provider.get(&rel_path).await?;
+            let prior: IdempotencyEntry = match serde_json::from_slice(&body) {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        path = %rel_path,
+                        "idempotency entry is not deserializable — treating as stale and overwriting"
+                    );
+                    // Overwrite the corrupt object with a fresh InFlight claim.
+                    // Use plain put (not conditional) since we've already lost
+                    // the race atomicity once — best-effort recovery.
+                    let bytes = serde_json::to_vec(entry)?;
+                    provider.put(&rel_path, Bytes::from(bytes)).await?;
+                    return Ok(IdempotencyCheck::AdoptStale {
+                        prior_run_id: "<corrupt>".to_string(),
+                    });
+                }
+            };
+            let verdict = classify_existing(prior, Utc::now(), entry);
+            match &verdict {
+                IdempotencyCheck::Proceed | IdempotencyCheck::AdoptStale { .. } => {
+                    // Stale / adoptable prior — overwrite with our InFlight.
+                    // Small race: another claimer might also have adopted. The
+                    // last-writer-wins overwrite is acceptable because either
+                    // claimant ultimately finalizes and the entry becomes
+                    // Succeeded regardless. For dedup-on-success+Failed
+                    // entries the sweep removes stale entries entirely.
+                    let bytes = serde_json::to_vec(entry)?;
+                    provider.put(&rel_path, Bytes::from(bytes)).await?;
+                }
+                IdempotencyCheck::SkipCompleted { .. } | IdempotencyCheck::SkipInFlight { .. } => {}
+            }
+            Ok(verdict)
+        }
+    }
+}
+
+async fn object_store_finalize(
+    uri: &str,
+    key: &str,
+    run_id: &str,
+    outcome: FinalOutcome,
+    retention_until: DateTime<Utc>,
+    config: &IdempotencyConfig,
+) -> Result<(), IdempotencyError> {
+    let provider = ObjectStoreProvider::from_uri(uri)?;
+    let rel_path = object_store_relative_path(key);
+
+    let should_keep = match (outcome, config.dedup_on) {
+        (FinalOutcome::Succeeded, _) => true,
+        (FinalOutcome::Failed, DedupPolicy::Any) => true,
+        (FinalOutcome::Failed, DedupPolicy::Success) => false,
+    };
+
+    if should_keep {
+        let updated = IdempotencyEntry {
+            key: key.to_string(),
+            run_id: run_id.to_string(),
+            state: match outcome {
+                FinalOutcome::Succeeded => IdempotencyState::Succeeded,
+                FinalOutcome::Failed => IdempotencyState::Failed,
+            },
+            stamped_at: Utc::now(),
+            expires_at: retention_until,
+            dedup_on: config.dedup_on,
+        };
+        let bytes = serde_json::to_vec(&updated)?;
+        provider.put(&rel_path, Bytes::from(bytes)).await?;
+    } else {
+        // Dedup-on-success + failure: delete the InFlight so retries can
+        // claim the key freshly. Tolerate already-absent (e.g. the sweep
+        // cleaned up while we were running).
+        if let Err(e) = provider.delete(&rel_path).await {
+            debug!(
+                error = %e,
+                path = %rel_path,
+                "idempotency finalize delete failed — entry may have been swept already"
+            );
+        }
+    }
+    Ok(())
+}
+
+async fn object_store_sweep_expired(
+    uri: &str,
+    _config: &IdempotencyConfig,
+) -> Result<usize, IdempotencyError> {
+    // Active sweep for object-store backends: list `idempotency/*`, parse
+    // each object, delete any past `expires_at`. Intentionally conservative
+    // — errors are warn-swallowed so a flaky bucket doesn't fail the run.
+    let provider = ObjectStoreProvider::from_uri(uri)?;
+    let paths = match provider.list("idempotency").await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "idempotency sweep list failed; bucket-lifecycle rules are the durable GC path");
+            return Ok(0);
+        }
+    };
+    let now = Utc::now();
+    let mut removed = 0;
+    for path in paths {
+        let Some(rel) = path.strip_prefix("idempotency/").or(Some(&path)) else {
+            continue;
+        };
+        // Read the object body so we can inspect `expires_at`. Skipping a
+        // HEAD-based shortcut because the object-store crate's metadata API
+        // doesn't surface custom timestamps.
+        let rel_path = format!("idempotency/{}", rel.trim_start_matches("idempotency/"));
+        let body = match provider.get(&rel_path).await {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let parsed: IdempotencyEntry = match serde_json::from_slice(&body) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if parsed.expires_at < now {
+            if let Ok(()) = provider.delete(&rel_path).await {
+                removed += 1;
+            }
+        }
+    }
+    Ok(removed)
+}
+
+// -----------------------------------------------------------------------
+// Shared classification logic
+// -----------------------------------------------------------------------
+
+/// Given a prior entry, decide the [`IdempotencyCheck`] outcome.
+///
+/// Used by both Local (inside the redb write txn — if Proceed / AdoptStale
+/// the store then inserts the new entry) and Valkey (after a failed
+/// SET NX). Centralising the branching keeps the two backends' semantics
+/// bit-for-bit identical.
+pub(crate) fn classify_existing(
+    prior: IdempotencyEntry,
+    now: DateTime<Utc>,
+    new_entry: &IdempotencyEntry,
+) -> IdempotencyCheck {
+    match prior.state {
+        IdempotencyState::Succeeded => IdempotencyCheck::SkipCompleted {
+            run_id: prior.run_id,
+        },
+        IdempotencyState::Failed => match new_entry.dedup_on {
+            DedupPolicy::Any => IdempotencyCheck::SkipCompleted {
+                run_id: prior.run_id,
+            },
+            DedupPolicy::Success => {
+                // Stale failure — sweep semantics will remove it; caller
+                // proceeds (AdoptStale surfaces the prior run_id for log
+                // cross-reference).
+                IdempotencyCheck::AdoptStale {
+                    prior_run_id: prior.run_id,
+                }
+            }
+        },
+        IdempotencyState::InFlight => {
+            if prior.expires_at > now {
+                IdempotencyCheck::SkipInFlight {
+                    run_id: prior.run_id,
+                }
+            } else {
+                info!(
+                    key = %prior.key,
+                    prior_run_id = %prior.run_id,
+                    "adopting stale InFlight idempotency entry past TTL"
+                );
+                IdempotencyCheck::AdoptStale {
+                    prior_run_id: prior.run_id,
+                }
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------
+// Phase 2/3 placeholders — kept here so the compile surface already knows
+// the types, even though the concrete providers land in later patches.
+// -----------------------------------------------------------------------
+
+/// Object-store–backed idempotency key path for Phase 2 / Phase 3.
+///
+/// Layout: `idempotency/<sha256-hex>` — hashed to keep the object name
+/// URL-safe + bounded regardless of caller-supplied key shape. The key
+/// itself is stored verbatim inside the object payload so `rocky history`
+/// and operator introspection can recover it.
+pub fn object_store_idempotency_path(key: &str) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(key.as_bytes());
+    let hex = hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, byte| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        });
+    PathBuf::from(format!("idempotency/{hex}"))
+}
+
+/// Duration before an in-flight claim is treated as stale.
+pub fn in_flight_stale_after(config: &IdempotencyConfig) -> Duration {
+    Duration::from_secs(config.in_flight_ttl_hours as u64 * 3600)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DedupPolicy, IdempotencyConfig};
+
+    fn mk_entry(
+        run_id: &str,
+        state: IdempotencyState,
+        stamped: DateTime<Utc>,
+        ttl_hours: i64,
+    ) -> IdempotencyEntry {
+        IdempotencyEntry {
+            key: "k".into(),
+            run_id: run_id.into(),
+            state,
+            stamped_at: stamped,
+            expires_at: stamped + chrono::Duration::hours(ttl_hours),
+            dedup_on: DedupPolicy::Success,
+        }
+    }
+
+    #[test]
+    fn classify_succeeded_always_skips() {
+        let now = Utc::now();
+        let prior = mk_entry(
+            "run-prior",
+            IdempotencyState::Succeeded,
+            now - chrono::Duration::hours(1),
+            24,
+        );
+        let new = mk_entry("run-new", IdempotencyState::InFlight, now, 24);
+        match classify_existing(prior, now, &new) {
+            IdempotencyCheck::SkipCompleted { run_id } => assert_eq!(run_id, "run-prior"),
+            other => panic!("expected SkipCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_failed_with_dedup_success_adopts() {
+        let now = Utc::now();
+        let prior = mk_entry(
+            "run-prior",
+            IdempotencyState::Failed,
+            now - chrono::Duration::hours(1),
+            24,
+        );
+        let mut new = mk_entry("run-new", IdempotencyState::InFlight, now, 24);
+        new.dedup_on = DedupPolicy::Success;
+        match classify_existing(prior, now, &new) {
+            IdempotencyCheck::AdoptStale { prior_run_id } => assert_eq!(prior_run_id, "run-prior"),
+            other => panic!("expected AdoptStale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_failed_with_dedup_any_skips() {
+        let now = Utc::now();
+        let prior = mk_entry(
+            "run-prior",
+            IdempotencyState::Failed,
+            now - chrono::Duration::hours(1),
+            24,
+        );
+        let mut new = mk_entry("run-new", IdempotencyState::InFlight, now, 24);
+        new.dedup_on = DedupPolicy::Any;
+        match classify_existing(prior, now, &new) {
+            IdempotencyCheck::SkipCompleted { run_id } => assert_eq!(run_id, "run-prior"),
+            other => panic!("expected SkipCompleted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_inflight_within_ttl_skips() {
+        let now = Utc::now();
+        let prior = mk_entry(
+            "run-prior",
+            IdempotencyState::InFlight,
+            now - chrono::Duration::minutes(30),
+            24,
+        );
+        let new = mk_entry("run-new", IdempotencyState::InFlight, now, 24);
+        match classify_existing(prior, now, &new) {
+            IdempotencyCheck::SkipInFlight { run_id } => assert_eq!(run_id, "run-prior"),
+            other => panic!("expected SkipInFlight, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_inflight_past_ttl_adopts() {
+        let now = Utc::now();
+        // stamped 25 hours ago with a 24h TTL — past stale.
+        let prior = mk_entry(
+            "run-prior",
+            IdempotencyState::InFlight,
+            now - chrono::Duration::hours(25),
+            24,
+        );
+        let new = mk_entry("run-new", IdempotencyState::InFlight, now, 24);
+        match classify_existing(prior, now, &new) {
+            IdempotencyCheck::AdoptStale { prior_run_id } => assert_eq!(prior_run_id, "run-prior"),
+            other => panic!("expected AdoptStale, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_skip_distinguishes_proceed() {
+        assert!(!IdempotencyCheck::Proceed.is_skip());
+        assert!(
+            !IdempotencyCheck::AdoptStale {
+                prior_run_id: "x".into()
+            }
+            .is_skip()
+        );
+        assert!(IdempotencyCheck::SkipCompleted { run_id: "x".into() }.is_skip());
+        assert!(IdempotencyCheck::SkipInFlight { run_id: "x".into() }.is_skip());
+    }
+
+    #[test]
+    fn object_store_path_encodes_unsafe_chars() {
+        let p = object_store_idempotency_path("fivetran:conn_abc/2026-04-22T14:00:00Z");
+        let path = p.to_str().unwrap();
+        assert!(path.starts_with("idempotency/"));
+        // Deterministic hex digest, no path-unsafe characters.
+        let suffix = &path["idempotency/".len()..];
+        assert_eq!(suffix.len(), 64);
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn object_store_path_is_deterministic() {
+        let a = object_store_idempotency_path("same-key");
+        let b = object_store_idempotency_path("same-key");
+        assert_eq!(a, b);
+        let c = object_store_idempotency_path("other-key");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn in_flight_stale_duration_matches_config() {
+        let cfg = IdempotencyConfig {
+            in_flight_ttl_hours: 6,
+            ..Default::default()
+        };
+        assert_eq!(in_flight_stale_after(&cfg), Duration::from_secs(6 * 3600));
+    }
+
+    #[test]
+    fn s3_backend_resolves_to_object_store() {
+        let sc = StateConfig {
+            backend: StateBackend::S3,
+            s3_bucket: Some("my-bucket".into()),
+            s3_prefix: Some("rocky/state/".into()),
+            ..StateConfig::default()
+        };
+        let backend = IdempotencyBackend::from_state_config(&sc);
+        match &backend {
+            IdempotencyBackend::ObjectStore { scheme, uri } => {
+                assert_eq!(*scheme, ObjectStoreScheme::S3);
+                assert_eq!(uri, "s3://my-bucket/rocky/state");
+            }
+            other => panic!("expected ObjectStore, got {other:?}"),
+        }
+        assert_eq!(backend.backend_label(), "s3");
+    }
+
+    #[test]
+    fn gcs_backend_resolves_to_object_store() {
+        let sc = StateConfig {
+            backend: StateBackend::Gcs,
+            gcs_bucket: Some("my-gcs-bucket".into()),
+            gcs_prefix: Some("rocky/state/".into()),
+            ..StateConfig::default()
+        };
+        let backend = IdempotencyBackend::from_state_config(&sc);
+        match &backend {
+            IdempotencyBackend::ObjectStore { scheme, uri } => {
+                assert_eq!(*scheme, ObjectStoreScheme::Gcs);
+                assert_eq!(uri, "gs://my-gcs-bucket/rocky/state");
+            }
+            other => panic!("expected ObjectStore, got {other:?}"),
+        }
+        assert_eq!(backend.backend_label(), "gcs");
+    }
+
+    #[test]
+    fn local_backend_label() {
+        let sc = StateConfig::default();
+        let backend = IdempotencyBackend::from_state_config(&sc);
+        assert!(matches!(backend, IdempotencyBackend::Local));
+        assert_eq!(backend.backend_label(), "local");
+    }
+
+    #[test]
+    fn tiered_backend_mirrors_to_redb() {
+        let sc = StateConfig {
+            backend: StateBackend::Tiered,
+            valkey_url: Some("redis://localhost:6379".into()),
+            ..StateConfig::default()
+        };
+        let backend = IdempotencyBackend::from_state_config(&sc);
+        match backend {
+            IdempotencyBackend::Valkey { mirror_to_redb, .. } => assert!(mirror_to_redb),
+            other => panic!("expected Valkey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn valkey_key_format() {
+        assert_eq!(
+            valkey_key("rocky:state:", "abc"),
+            "rocky:state:idempotency:abc"
+        );
+        assert_eq!(
+            valkey_key("rocky:state", "abc"),
+            "rocky:state:idempotency:abc"
+        );
+        assert_eq!(valkey_key("", "abc"), "idempotency:abc");
+    }
+}

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod dedup_analysis;
 pub mod docs;
 pub mod drift;
 pub mod hooks;
+pub mod idempotency;
 pub mod incremental;
 pub mod ir;
 pub mod lakehouse;

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use object_store::{ClientOptions, ObjectStore, path::Path as ObjectPath};
+use object_store::{ClientOptions, ObjectStore, PutMode, PutOptions, path::Path as ObjectPath};
 use thiserror::Error;
 use tracing::debug;
 
@@ -71,6 +71,21 @@ pub enum ObjectStoreError {
 
 /// Result type for object store operations.
 pub type ObjectStoreResult<T> = Result<T, ObjectStoreError>;
+
+/// Outcome of [`ObjectStoreProvider::put_if_not_exists`].
+///
+/// The backend's atomic "create-if-absent" primitive returns `Created` on a
+/// successful write and `AlreadyExists` when another writer got there first
+/// (S3 412 `PreconditionFailed` / GCS 412 `preconditionFailed` / local
+/// filesystem `EEXIST`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PutIfNotExistsOutcome {
+    /// The object was written. Caller has exclusive claim on the key.
+    Created,
+    /// The object already existed; no bytes were written. Caller should
+    /// read the existing object to resolve the conflict.
+    AlreadyExists,
+}
 
 /// Wraps an [`ObjectStore`] with a root path, providing a simple async API for
 /// reading and writing objects.
@@ -204,6 +219,45 @@ impl ObjectStoreProvider {
         Ok(())
     }
 
+    /// Write bytes only if the object does not yet exist.
+    ///
+    /// Uses [`PutMode::Create`], which maps to:
+    /// - S3: `If-None-Match: "*"` on `PutObject` (available since Nov 2024).
+    /// - GCS: `x-goog-if-generation-match: 0` precondition.
+    /// - Local filesystem: `O_CREAT | O_EXCL` open.
+    /// - Memory: atomic check inside the in-memory map.
+    ///
+    /// Returns [`PutIfNotExistsOutcome::Created`] on a successful claim or
+    /// [`PutIfNotExistsOutcome::AlreadyExists`] when the backend refuses the
+    /// write because the object is already present. Other errors propagate
+    /// through [`ObjectStoreError::Backend`].
+    ///
+    /// This is the atomic primitive backing `rocky run --idempotency-key` on
+    /// `s3`-only and `gcs`-only state backends (FR-004 Phase 2 / Phase 3).
+    pub async fn put_if_not_exists(
+        &self,
+        relative_path: &str,
+        data: Bytes,
+    ) -> ObjectStoreResult<PutIfNotExistsOutcome> {
+        let path = self.absolute_path(relative_path);
+        debug!(
+            path = %path,
+            size = data.len(),
+            "object_store put_if_not_exists"
+        );
+        let opts = PutOptions {
+            mode: PutMode::Create,
+            ..Default::default()
+        };
+        match self.store.put_opts(&path, data.into(), opts).await {
+            Ok(_) => Ok(PutIfNotExistsOutcome::Created),
+            Err(object_store::Error::AlreadyExists { .. }) => {
+                Ok(PutIfNotExistsOutcome::AlreadyExists)
+            }
+            Err(e) => Err(ObjectStoreError::Backend(e)),
+        }
+    }
+
     /// Upload a local file to the object store.
     pub async fn upload_file(
         &self,
@@ -309,6 +363,35 @@ mod tests {
         assert!(provider.exists("k").await.unwrap());
         provider.delete("k").await.unwrap();
         assert!(!provider.exists("k").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_put_if_not_exists_first_call_creates() {
+        let provider = ObjectStoreProvider::in_memory();
+        let outcome = provider
+            .put_if_not_exists("claim-key", Bytes::from_static(b"first"))
+            .await
+            .unwrap();
+        assert_eq!(outcome, PutIfNotExistsOutcome::Created);
+        let stored = provider.get("claim-key").await.unwrap();
+        assert_eq!(stored.as_ref(), b"first");
+    }
+
+    #[tokio::test]
+    async fn test_put_if_not_exists_second_call_reports_existing() {
+        let provider = ObjectStoreProvider::in_memory();
+        provider
+            .put_if_not_exists("claim-key", Bytes::from_static(b"first"))
+            .await
+            .unwrap();
+        let outcome = provider
+            .put_if_not_exists("claim-key", Bytes::from_static(b"second"))
+            .await
+            .unwrap();
+        assert_eq!(outcome, PutIfNotExistsOutcome::AlreadyExists);
+        // Original value preserved — second call was a no-op.
+        let stored = provider.get("claim-key").await.unwrap();
+        assert_eq!(stored.as_ref(), b"first");
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -58,6 +58,18 @@ const BRANCHES: TableDefinition<&str, &[u8]> = TableDefinition::new("branches");
 /// Replicates as `replicate = false` by default in `state_sync.rs` so a fresh
 /// clone doesn't inherit another machine's stale types — see design doc §5.7.
 const SCHEMA_CACHE: TableDefinition<&str, &[u8]> = TableDefinition::new("schema_cache");
+/// Idempotency-key stamps for `rocky run --idempotency-key` dedup.
+///
+/// Key: the caller-supplied idempotency key (opaque UTF-8 string; stored
+/// verbatim — never hash, never truncate). Value: serialized
+/// [`crate::idempotency::IdempotencyEntry`]. A new entry is inserted as
+/// `InFlight` when a run claims the key, updated to `Succeeded` or `Failed`
+/// at run end (see [`crate::config::DedupPolicy`]).
+///
+/// Replicates across backends by default — the table is intentionally NOT
+/// in [`LOCAL_ONLY_TABLE_NAMES`] so tiered-backend snapshots surface the
+/// same stamp to other pods after upload.
+const IDEMPOTENCY_KEYS: TableDefinition<&str, &[u8]> = TableDefinition::new("idempotency_keys");
 /// Key/value store for internal metadata (e.g. `"schema_version"`).
 const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 
@@ -75,7 +87,7 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 /// Increment this constant whenever a table is added, removed, or structurally
 /// changed in a way that is incompatible with an older binary. Rocky will
 /// refuse to open a database whose stored version exceeds this value.
-const CURRENT_SCHEMA_VERSION: u32 = 4;
+const CURRENT_SCHEMA_VERSION: u32 = 5;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -253,6 +265,7 @@ impl StateStore {
             let _table = txn.open_table(LOADED_FILES)?;
             let _table = txn.open_table(BRANCHES)?;
             let _table = txn.open_table(SCHEMA_CACHE)?;
+            let _table = txn.open_table(IDEMPOTENCY_KEYS)?;
         }
         txn.commit()?;
 
@@ -507,11 +520,24 @@ fn partition_record_key(model_name: &str, partition_key: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Status of a pipeline run.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+///
+/// `Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a
+/// run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are
+/// the short-circuit outcomes of `rocky run --idempotency-key` — see
+/// [`crate::idempotency`].
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
 pub enum RunStatus {
     Success,
     PartialFailure,
     Failure,
+    /// The run was short-circuited because an idempotency key already
+    /// mapped to a prior completed run. No work was done.
+    SkippedIdempotent,
+    /// The run was short-circuited because another caller held the
+    /// idempotency key's in-flight claim. No work was done.
+    SkippedInFlight,
 }
 
 /// What triggered the run.
@@ -894,6 +920,224 @@ impl StateStore {
             }
         }
         Ok(latest)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency-key persistence (see `crate::idempotency`)
+// ---------------------------------------------------------------------------
+
+impl StateStore {
+    /// Read an idempotency entry by key.
+    pub fn idempotency_get(
+        &self,
+        key: &str,
+    ) -> Result<Option<crate::idempotency::IdempotencyEntry>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(IDEMPOTENCY_KEYS)?;
+        match table.get(key)? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Insert or replace an idempotency entry. Used by the Tiered backend's
+    /// best-effort redb mirror; prefer
+    /// [`StateStore::idempotency_check_and_claim`] for racing callers.
+    pub fn idempotency_put(
+        &self,
+        entry: &crate::idempotency::IdempotencyEntry,
+    ) -> Result<(), StateError> {
+        let bytes = serde_json::to_vec(entry)?;
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            table.insert(entry.key.as_str(), bytes.as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Delete an idempotency entry. Returns `true` if the key was present.
+    pub fn idempotency_delete(&self, key: &str) -> Result<bool, StateError> {
+        let txn = self.db.begin_write()?;
+        let removed;
+        {
+            let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            removed = table.remove(key)?.is_some();
+        }
+        txn.commit()?;
+        Ok(removed)
+    }
+
+    /// Atomically inspect the idempotency table and claim the key if no
+    /// non-stale entry already holds it.
+    ///
+    /// Everything happens inside one redb write transaction — because the
+    /// `StateStore` holds the advisory `state.redb.lock`, we also have
+    /// per-process exclusion. Combined, the local backend provides true
+    /// "check-if-absent-then-claim" semantics without a second primitive.
+    pub fn idempotency_check_and_claim(
+        &self,
+        new_entry: &crate::idempotency::IdempotencyEntry,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<crate::idempotency::IdempotencyCheck, StateError> {
+        use crate::idempotency::{IdempotencyCheck, IdempotencyEntry, classify_existing};
+
+        let new_bytes = serde_json::to_vec(new_entry)?;
+        let txn = self.db.begin_write()?;
+        let result;
+        {
+            let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            let prior_entry: Option<IdempotencyEntry> = match table.get(new_entry.key.as_str())? {
+                Some(value) => Some(serde_json::from_slice(value.value())?),
+                None => None,
+            };
+
+            result = match prior_entry {
+                None => {
+                    table.insert(new_entry.key.as_str(), new_bytes.as_slice())?;
+                    IdempotencyCheck::Proceed
+                }
+                Some(prior) => {
+                    let verdict = classify_existing(prior, now, new_entry);
+                    match &verdict {
+                        IdempotencyCheck::Proceed | IdempotencyCheck::AdoptStale { .. } => {
+                            // Overwrite the stale entry with the fresh InFlight claim.
+                            table.insert(new_entry.key.as_str(), new_bytes.as_slice())?;
+                        }
+                        IdempotencyCheck::SkipCompleted { .. }
+                        | IdempotencyCheck::SkipInFlight { .. } => {
+                            // Leave the prior entry untouched.
+                        }
+                    }
+                    verdict
+                }
+            };
+        }
+        txn.commit()?;
+        Ok(result)
+    }
+
+    /// Finalize an idempotency entry — update to `Succeeded` / `Failed`, or
+    /// delete the entry entirely when [`crate::config::DedupPolicy::Success`]
+    /// + failure semantics mean retries should proceed.
+    ///
+    /// No-op (returns `Ok(())`) if the key is absent or held by a different
+    /// `run_id` — another caller already finalized it, which is not an error
+    /// (e.g. a `rocky replay` with `--force` that bypassed idempotency mid-run).
+    pub fn idempotency_finalize(
+        &self,
+        key: &str,
+        run_id: &str,
+        outcome: crate::idempotency::FinalOutcome,
+        retention_until: chrono::DateTime<chrono::Utc>,
+        dedup_on: crate::config::DedupPolicy,
+    ) -> Result<(), StateError> {
+        use crate::config::DedupPolicy;
+        use crate::idempotency::{FinalOutcome, IdempotencyEntry, IdempotencyState};
+
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            let existing: Option<IdempotencyEntry> = match table.get(key)? {
+                Some(value) => Some(serde_json::from_slice(value.value())?),
+                None => None,
+            };
+            match existing {
+                None => {
+                    // Nothing to finalize — already swept, or claim was never
+                    // written (e.g. tiered mirror race). Silently succeed.
+                }
+                Some(prior) if prior.run_id != run_id => {
+                    // Another run owns the key now (AdoptStale path). Leave alone.
+                }
+                Some(prior) => {
+                    let should_keep = match (outcome, dedup_on) {
+                        (FinalOutcome::Succeeded, _) => true,
+                        (FinalOutcome::Failed, DedupPolicy::Any) => true,
+                        (FinalOutcome::Failed, DedupPolicy::Success) => false,
+                    };
+                    if should_keep {
+                        let updated = IdempotencyEntry {
+                            key: prior.key,
+                            run_id: prior.run_id,
+                            state: match outcome {
+                                FinalOutcome::Succeeded => IdempotencyState::Succeeded,
+                                FinalOutcome::Failed => IdempotencyState::Failed,
+                            },
+                            stamped_at: chrono::Utc::now(),
+                            expires_at: retention_until,
+                            dedup_on,
+                        };
+                        let bytes = serde_json::to_vec(&updated)?;
+                        table.insert(key, bytes.as_slice())?;
+                    } else {
+                        table.remove(key)?;
+                    }
+                }
+            }
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Sweep expired idempotency entries.
+    ///
+    /// Removes:
+    /// - Entries whose `expires_at < now` (retention exhausted).
+    /// - Entries still in `InFlight` whose `stamped_at + in_flight_ttl_hours`
+    ///   is in the past (crashed-pod corpses missed by the `AdoptStale`
+    ///   reader path — e.g. a claim whose run crashed and no follow-up run
+    ///   ever tried the same key).
+    ///
+    /// Returns the count removed.
+    pub fn idempotency_sweep_expired(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+        in_flight_ttl_hours: u32,
+    ) -> Result<usize, StateError> {
+        use crate::idempotency::{IdempotencyEntry, IdempotencyState};
+
+        let in_flight_cutoff = now - chrono::Duration::hours(in_flight_ttl_hours as i64);
+
+        // Phase 1: collect keys to drop (can't mutate during iter).
+        let to_drop: Vec<String> = {
+            let txn = self.db.begin_read()?;
+            let table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            let mut drop = Vec::new();
+            for entry in table.iter()? {
+                let (key, value) = entry?;
+                let parsed: IdempotencyEntry = serde_json::from_slice(value.value())?;
+                let stale = match parsed.state {
+                    IdempotencyState::InFlight => parsed.stamped_at < in_flight_cutoff,
+                    IdempotencyState::Succeeded | IdempotencyState::Failed => {
+                        parsed.expires_at < now
+                    }
+                };
+                if stale {
+                    drop.push(key.value().to_string());
+                }
+            }
+            drop
+        };
+
+        if to_drop.is_empty() {
+            return Ok(0);
+        }
+
+        let txn = self.db.begin_write()?;
+        let mut removed = 0;
+        {
+            let mut table = txn.open_table(IDEMPOTENCY_KEYS)?;
+            for key in &to_drop {
+                if table.remove(key.as_str())?.is_some() {
+                    removed += 1;
+                }
+            }
+        }
+        txn.commit()?;
+        Ok(removed)
     }
 }
 
@@ -2443,5 +2687,275 @@ mod tests {
             cached_at: now - chrono::Duration::hours(25),
         };
         assert!(stale.is_expired(now, ttl));
+    }
+
+    // -----------------------------------------------------------------------
+    // Idempotency StateStore integration tests
+    // -----------------------------------------------------------------------
+
+    fn mk_idemp_entry(key: &str, run_id: &str) -> crate::idempotency::IdempotencyEntry {
+        let now = Utc::now();
+        crate::idempotency::IdempotencyEntry {
+            key: key.into(),
+            run_id: run_id.into(),
+            state: crate::idempotency::IdempotencyState::InFlight,
+            stamped_at: now,
+            expires_at: now + chrono::Duration::hours(24),
+            dedup_on: crate::config::DedupPolicy::Success,
+        }
+    }
+
+    #[test]
+    fn idempotency_first_claim_proceeds() {
+        let (store, _dir) = temp_store();
+        let entry = mk_idemp_entry("fresh-key", "run-1");
+        let verdict = store
+            .idempotency_check_and_claim(&entry, Utc::now())
+            .unwrap();
+        assert!(matches!(
+            verdict,
+            crate::idempotency::IdempotencyCheck::Proceed
+        ));
+
+        // Entry was written.
+        let got = store.idempotency_get("fresh-key").unwrap().unwrap();
+        assert_eq!(got.run_id, "run-1");
+        assert_eq!(got.state, crate::idempotency::IdempotencyState::InFlight);
+    }
+
+    #[test]
+    fn idempotency_repeat_with_succeeded_skips() {
+        let (store, _dir) = temp_store();
+        // Seed a Succeeded entry.
+        let now = Utc::now();
+        let mut entry = mk_idemp_entry("done-key", "run-prior");
+        entry.state = crate::idempotency::IdempotencyState::Succeeded;
+        entry.expires_at = now + chrono::Duration::days(30);
+        store.idempotency_put(&entry).unwrap();
+
+        // New claim attempt must skip.
+        let new_entry = mk_idemp_entry("done-key", "run-new");
+        let verdict = store.idempotency_check_and_claim(&new_entry, now).unwrap();
+        match verdict {
+            crate::idempotency::IdempotencyCheck::SkipCompleted { run_id } => {
+                assert_eq!(run_id, "run-prior");
+            }
+            other => panic!("expected SkipCompleted, got {other:?}"),
+        }
+        // Existing entry unchanged.
+        let got = store.idempotency_get("done-key").unwrap().unwrap();
+        assert_eq!(got.run_id, "run-prior");
+    }
+
+    #[test]
+    fn idempotency_repeat_with_inflight_in_ttl_skips() {
+        let (store, _dir) = temp_store();
+        let now = Utc::now();
+        let prior = crate::idempotency::IdempotencyEntry {
+            key: "busy-key".into(),
+            run_id: "run-busy".into(),
+            state: crate::idempotency::IdempotencyState::InFlight,
+            stamped_at: now - chrono::Duration::minutes(5),
+            expires_at: now + chrono::Duration::hours(23),
+            dedup_on: crate::config::DedupPolicy::Success,
+        };
+        store.idempotency_put(&prior).unwrap();
+
+        let new_entry = mk_idemp_entry("busy-key", "run-new");
+        let verdict = store.idempotency_check_and_claim(&new_entry, now).unwrap();
+        match verdict {
+            crate::idempotency::IdempotencyCheck::SkipInFlight { run_id } => {
+                assert_eq!(run_id, "run-busy");
+            }
+            other => panic!("expected SkipInFlight, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idempotency_stale_inflight_adopts() {
+        let (store, _dir) = temp_store();
+        let now = Utc::now();
+        let stale = crate::idempotency::IdempotencyEntry {
+            key: "stale-key".into(),
+            run_id: "run-crashed".into(),
+            state: crate::idempotency::IdempotencyState::InFlight,
+            stamped_at: now - chrono::Duration::hours(25),
+            expires_at: now - chrono::Duration::hours(1),
+            dedup_on: crate::config::DedupPolicy::Success,
+        };
+        store.idempotency_put(&stale).unwrap();
+
+        let new_entry = mk_idemp_entry("stale-key", "run-adopter");
+        let verdict = store.idempotency_check_and_claim(&new_entry, now).unwrap();
+        match verdict {
+            crate::idempotency::IdempotencyCheck::AdoptStale { prior_run_id } => {
+                assert_eq!(prior_run_id, "run-crashed");
+            }
+            other => panic!("expected AdoptStale, got {other:?}"),
+        }
+        // Entry overwritten with the adopter.
+        let got = store.idempotency_get("stale-key").unwrap().unwrap();
+        assert_eq!(got.run_id, "run-adopter");
+        assert_eq!(got.state, crate::idempotency::IdempotencyState::InFlight);
+    }
+
+    #[test]
+    fn idempotency_finalize_succeeded_keeps_entry() {
+        let (store, _dir) = temp_store();
+        let entry = mk_idemp_entry("key-a", "run-a");
+        store
+            .idempotency_check_and_claim(&entry, Utc::now())
+            .unwrap();
+
+        let retention = Utc::now() + chrono::Duration::days(30);
+        store
+            .idempotency_finalize(
+                "key-a",
+                "run-a",
+                crate::idempotency::FinalOutcome::Succeeded,
+                retention,
+                crate::config::DedupPolicy::Success,
+            )
+            .unwrap();
+
+        let got = store.idempotency_get("key-a").unwrap().unwrap();
+        assert_eq!(got.state, crate::idempotency::IdempotencyState::Succeeded);
+    }
+
+    #[test]
+    fn idempotency_finalize_failed_with_dedup_success_deletes() {
+        let (store, _dir) = temp_store();
+        let entry = mk_idemp_entry("key-b", "run-b");
+        store
+            .idempotency_check_and_claim(&entry, Utc::now())
+            .unwrap();
+
+        store
+            .idempotency_finalize(
+                "key-b",
+                "run-b",
+                crate::idempotency::FinalOutcome::Failed,
+                Utc::now() + chrono::Duration::days(30),
+                crate::config::DedupPolicy::Success,
+            )
+            .unwrap();
+
+        assert!(store.idempotency_get("key-b").unwrap().is_none());
+    }
+
+    #[test]
+    fn idempotency_finalize_failed_with_dedup_any_keeps_entry() {
+        let (store, _dir) = temp_store();
+        let entry = mk_idemp_entry("key-c", "run-c");
+        store
+            .idempotency_check_and_claim(&entry, Utc::now())
+            .unwrap();
+
+        store
+            .idempotency_finalize(
+                "key-c",
+                "run-c",
+                crate::idempotency::FinalOutcome::Failed,
+                Utc::now() + chrono::Duration::days(30),
+                crate::config::DedupPolicy::Any,
+            )
+            .unwrap();
+
+        let got = store.idempotency_get("key-c").unwrap().unwrap();
+        assert_eq!(got.state, crate::idempotency::IdempotencyState::Failed);
+    }
+
+    #[test]
+    fn idempotency_finalize_mismatched_run_id_is_noop() {
+        let (store, _dir) = temp_store();
+        let entry = mk_idemp_entry("key-d", "run-d");
+        store
+            .idempotency_check_and_claim(&entry, Utc::now())
+            .unwrap();
+
+        // Pretend another run adopted the key; finalizing with a stale
+        // `run_id` must not clobber the current owner.
+        store
+            .idempotency_finalize(
+                "key-d",
+                "stale-run",
+                crate::idempotency::FinalOutcome::Succeeded,
+                Utc::now() + chrono::Duration::days(30),
+                crate::config::DedupPolicy::Success,
+            )
+            .unwrap();
+
+        let got = store.idempotency_get("key-d").unwrap().unwrap();
+        assert_eq!(got.run_id, "run-d");
+        assert_eq!(got.state, crate::idempotency::IdempotencyState::InFlight);
+    }
+
+    #[test]
+    fn idempotency_sweep_expired_removes_past_retention() {
+        let (store, _dir) = temp_store();
+        let now = Utc::now();
+
+        // Fresh entry — within retention.
+        let fresh = crate::idempotency::IdempotencyEntry {
+            key: "fresh".into(),
+            run_id: "r-fresh".into(),
+            state: crate::idempotency::IdempotencyState::Succeeded,
+            stamped_at: now - chrono::Duration::days(1),
+            expires_at: now + chrono::Duration::days(29),
+            dedup_on: crate::config::DedupPolicy::Success,
+        };
+        // Past retention — should be swept.
+        let expired = crate::idempotency::IdempotencyEntry {
+            key: "expired".into(),
+            run_id: "r-expired".into(),
+            state: crate::idempotency::IdempotencyState::Succeeded,
+            stamped_at: now - chrono::Duration::days(60),
+            expires_at: now - chrono::Duration::days(30),
+            dedup_on: crate::config::DedupPolicy::Success,
+        };
+        // InFlight past TTL — crashed pod corpse.
+        let corpse = crate::idempotency::IdempotencyEntry {
+            key: "corpse".into(),
+            run_id: "r-corpse".into(),
+            state: crate::idempotency::IdempotencyState::InFlight,
+            stamped_at: now - chrono::Duration::hours(48),
+            expires_at: now - chrono::Duration::hours(24),
+            dedup_on: crate::config::DedupPolicy::Success,
+        };
+        store.idempotency_put(&fresh).unwrap();
+        store.idempotency_put(&expired).unwrap();
+        store.idempotency_put(&corpse).unwrap();
+
+        let removed = store.idempotency_sweep_expired(now, 24).unwrap();
+        assert_eq!(removed, 2);
+        assert!(store.idempotency_get("fresh").unwrap().is_some());
+        assert!(store.idempotency_get("expired").unwrap().is_none());
+        assert!(store.idempotency_get("corpse").unwrap().is_none());
+    }
+
+    #[test]
+    fn idempotency_concurrent_claim_only_one_wins() {
+        // Local backend atomicity: the state.redb.lock enforces one writer
+        // at a time, so a second `check_and_claim` for the same key from
+        // the same store instance observes the first entry and skips.
+        let (store, _dir) = temp_store();
+        let now = Utc::now();
+
+        let a = mk_idemp_entry("race-key", "run-a");
+        let b = mk_idemp_entry("race-key", "run-b");
+
+        let verdict_a = store.idempotency_check_and_claim(&a, now).unwrap();
+        let verdict_b = store.idempotency_check_and_claim(&b, now).unwrap();
+
+        assert!(matches!(
+            verdict_a,
+            crate::idempotency::IdempotencyCheck::Proceed
+        ));
+        match verdict_b {
+            crate::idempotency::IdempotencyCheck::SkipInFlight { run_id } => {
+                assert_eq!(run_id, "run-a");
+            }
+            other => panic!("expected SkipInFlight for second claim, got {other:?}"),
+        }
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -147,6 +147,7 @@ impl From<TargetDialect> for rocky_cli::commands::Dialect {
 /// ## AI — AI-powered features
 /// `ai`, `ai-sync`, `ai-explain`, `ai-test`
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Initialize a new Rocky project
     Init {
@@ -268,6 +269,22 @@ enum Command {
         /// execution order. Layers run in parallel.
         #[arg(long)]
         dag: bool,
+
+        /// Caller-supplied opaque key used to dedup this run against prior
+        /// runs with the same key. If a prior run with this key completed
+        /// successfully (or any terminal status under `dedup_on = "any"`),
+        /// this call exits early with `status = skipped_idempotent` and no
+        /// work is done. If another caller currently holds the key's
+        /// in-flight claim, exits with `skipped_in_flight`.
+        ///
+        /// Supported on `local`, `valkey`, and `tiered` state backends.
+        /// `s3`-only and `gcs`-only backends error at flag-parse time — use
+        /// `tiered` for multi-pod deployments.
+        ///
+        /// ⚠️ Keys are stored verbatim in the state store; do NOT put
+        /// secrets in idempotency keys.
+        #[arg(long, value_name = "KEY")]
+        idempotency_key: Option<String>,
     },
 
     /// Compare shadow tables against production tables
@@ -1068,7 +1085,16 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             lookback,
             parallel,
             dag,
+            idempotency_key,
         } => {
+            // --idempotency-key is mutually exclusive with --resume / --resume-latest:
+            // a resume is an explicit override and should never be short-circuited.
+            if idempotency_key.is_some() && (resume.is_some() || resume_latest) {
+                anyhow::bail!(
+                    "--idempotency-key cannot be combined with --resume / --resume-latest \
+                     (resume is an explicit override of idempotent skip)"
+                );
+            }
             // Parse governance override (JSON string or @file.json)
             let gov_override = match governance_override {
                 Some(ref s) if s.starts_with('@') => {
@@ -1155,6 +1181,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     &partition_opts,
                     model.as_deref(),
                     cli.cache_ttl,
+                    idempotency_key.as_deref(),
                 )
                 .await
             }

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/README.md
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/README.md
@@ -1,0 +1,73 @@
+# 09-idempotency-key — `rocky run --idempotency-key` dedup
+
+> **Category:** 05-orchestration
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `--idempotency-key`, `[state.idempotency]` block,
+> `status = "skipped_idempotent"`, `skipped_by_run_id`
+
+## What it shows
+
+`rocky run --idempotency-key <key>` is defense-in-depth run deduplication
+below whatever driver pressed "go":
+
+1. First invocation with a new key runs normally and stamps the key →
+   `run_id` mapping in the state store on success.
+2. Second invocation with the same key short-circuits — returns
+   `status: "skipped_idempotent"` and `skipped_by_run_id: <prior_run_id>`
+   without touching the warehouse.
+3. A different key starts fresh.
+
+The guarantee is backend-specific:
+
+| State backend | Atomic primitive |
+|---|---|
+| `local` | redb write txn inside the existing `state.redb.lock` file lock |
+| `valkey` / `tiered` | Valkey `SET NX EX` on `{prefix}:idempotency:<key>` |
+| `s3` / `gcs` | Object-store conditional PUT (`If-None-Match: "*"`) |
+
+This POC uses the `local` backend (DuckDB, single-writer) so no external
+services are required.
+
+## Why this exists
+
+Dagster sensors dedup at the `RunRequest` layer via `run_key`, but once a
+run launches the pod body has no second guard. Pod retries, Kafka
+re-delivery, webhook duplicates, cron races — all re-execute today. A
+key at the `rocky run` boundary catches them after `run_key` already let
+them through, and works for non-Dagster callers (cron, CI, webhooks,
+custom orchestrators) too.
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml          Default `[state.idempotency]` block (30d retention,
+│                       dedup_on = "success", 24h in-flight TTL)
+├── run.sh              Runs the three scenarios (fresh → repeat → new key)
+├── data/seed.sql       Minimal DuckDB fixtures
+└── expected/           Captured JSON for regression comparison
+```
+
+## Run it
+
+```bash
+cd examples/playground/pocs/05-orchestration/09-idempotency-key
+./run.sh
+```
+
+You should see three JSON outputs showing `status = "success"` →
+`status = "skipped_idempotent"` → `status = "success"` (with a new key).
+
+## Key decisions (matching the plan)
+
+- **Verbatim key storage.** Keys stored as-is in the state store;
+  **do NOT put secrets in idempotency keys**.
+- **`dedup_on = "success"` default.** Failed runs delete their entry so
+  retries can claim the key again. Set `dedup_on = "any"` to dedup on
+  any terminal status.
+- **30-day retention default.** Entries swept during the next state
+  upload (the existing post-run cadence).
+- **`--idempotency-key` + `--resume` is rejected** — resume is an
+  explicit override and should never be short-circuited by dedup.

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/data/seed.sql
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/data/seed.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+CREATE SCHEMA IF NOT EXISTS raw__customers;
+
+CREATE OR REPLACE TABLE raw__orders.orders       AS SELECT i AS id FROM generate_series(1, 10) AS t(i);
+CREATE OR REPLACE TABLE raw__customers.customers AS SELECT i AS id FROM generate_series(1, 10) AS t(i);

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/rocky.toml
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/rocky.toml
@@ -1,0 +1,25 @@
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[state]
+backend = "local"
+
+# Tuning knobs — all fields are optional. Defaults shown for
+# documentation only; removing the block keeps the same behaviour.
+[state.idempotency]
+retention_days = 30
+dedup_on = "success"      # "success" (default) | "any"
+in_flight_ttl_hours = 24
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/run.sh
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+duckdb poc.duckdb < data/seed.sql
+
+rocky validate
+
+# Scenario 1: fresh key → run claims it, proceeds.
+# Like POC 04, the DuckDB execution path hits "no discovery adapter"
+# before reaching materialization, so the run exits non-zero. The
+# idempotency claim still happens: the key enters `InFlight` state
+# inside the state store.
+KEY="fivetran_sync:demo_connector:2026-04-23T10:00:00Z"
+rocky -c rocky.toml -o json run \
+  --filter source=orders \
+  --idempotency-key "$KEY" > expected/run1_fresh.json || true
+STATUS1=$(jq -r '.status // "error"' expected/run1_fresh.json)
+KEY1=$(jq -r '.idempotency_key // "none"' expected/run1_fresh.json)
+echo "Run 1 (fresh key, orders)      status = $STATUS1  (key echoed: $KEY1)"
+
+# Scenario 2: same key again → idempotency short-circuit.
+# The claim step inspects the prior entry (InFlight from Run 1 since
+# the DuckDB path didn't finalize). The second caller sees an in-flight
+# claim that's still within TTL and exits with skipped_in_flight plus
+# the prior run_id.
+#
+# On a fully-successful Run 1 (tiered/valkey backend or real pipeline)
+# the entry would transition to Succeeded, and Run 2 would see
+# skipped_idempotent instead. The mechanism is identical; only the
+# state transition differs.
+rocky -c rocky.toml -o json run \
+  --filter source=orders \
+  --idempotency-key "$KEY" > expected/run2_repeat.json || true
+STATUS2=$(jq -r '.status // "error"' expected/run2_repeat.json)
+SKIPPED_BY=$(jq -r '.skipped_by_run_id // "none"' expected/run2_repeat.json)
+echo "Run 2 (same key, orders)       status = $STATUS2  (skipped_by = $SKIPPED_BY)"
+
+# Scenario 3: different key → claims fresh, proceeds (same end state as 1).
+NEW_KEY="fivetran_sync:demo_connector:2026-04-23T11:00:00Z"
+rocky -c rocky.toml -o json run \
+  --filter source=customers \
+  --idempotency-key "$NEW_KEY" > expected/run3_new_key.json || true
+STATUS3=$(jq -r '.status // "error"' expected/run3_new_key.json)
+KEY3=$(jq -r '.idempotency_key // "none"' expected/run3_new_key.json)
+echo "Run 3 (new key, customers)     status = $STATUS3  (key echoed: $KEY3)"
+
+echo
+# Validate the dedup mechanism:
+# Run 2 MUST short-circuit (skipped_idempotent or skipped_in_flight)
+# and reference Run 1's run_id.
+if [[ "$STATUS2" != "SkippedIdempotent" && "$STATUS2" != "SkippedInFlight" ]]; then
+  echo "FAIL: Run 2 expected a skipped_* status but got '$STATUS2'"
+  exit 1
+fi
+if [[ "$SKIPPED_BY" == "none" ]]; then
+  echo "FAIL: Run 2 should reference Run 1's run_id in skipped_by_run_id"
+  exit 1
+fi
+echo "POC complete: --idempotency-key dedups the second invocation (status=$STATUS2)"
+echo "              while a different key (Run 3) proceeds independently."

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -939,6 +939,7 @@ class RockyResource(dg.ConfigurableResource):
         lookback: int | None = None,
         parallel: int | None = None,
         shadow_suffix: str | None = None,
+        idempotency_key: str | None = None,
     ) -> RunResult:
         """Run ``rocky run --filter <key=value>`` and return the parsed result.
 
@@ -972,6 +973,22 @@ class RockyResource(dg.ConfigurableResource):
             shadow_suffix: When set, enables shadow mode and uses the given
                 suffix for shadow table names (e.g. ``"_dagster_pr_42"``).
                 Typically derived from :func:`.branch_deploy.branch_deploy_shadow_suffix`.
+            idempotency_key: Caller-supplied opaque key used to dedup this
+                run against prior runs with the same key. If a prior run with
+                this key completed successfully, this call returns a
+                :class:`RunResult` with ``status = "skipped_idempotent"`` and
+                ``skipped_by_run_id`` set to the prior ``run_id``; no rocky
+                subprocess work is performed beyond the short-circuit
+                output. If another caller currently holds the key's
+                in-flight claim, exits with ``status = "skipped_in_flight"``.
+
+                Defense-in-depth below Dagster's ``run_key`` — catches pod
+                retries, Kafka re-delivery, webhook duplicates, cron races.
+                Works on state backends ``local``, ``valkey``, ``tiered``,
+                ``s3``, and ``gcs``.
+
+                ⚠️ Keys are stored verbatim in the state store; do NOT put
+                secrets in idempotency keys.
         """
         args = self._build_run_args(
             filter,
@@ -986,6 +1003,7 @@ class RockyResource(dg.ConfigurableResource):
             lookback=lookback,
             parallel=parallel,
             shadow_suffix=shadow_suffix,
+            idempotency_key=idempotency_key,
         )
         return _parse_rocky_json(
             self._run_rocky(args, allow_partial=True), RunResult, command="run"
@@ -1006,6 +1024,7 @@ class RockyResource(dg.ConfigurableResource):
         lookback: int | None = None,
         parallel: int | None = None,
         shadow_suffix: str | None = None,
+        idempotency_key: str | None = None,
     ) -> RunResult:
         """``rocky run`` with live stderr streaming to ``context.log``.
 
@@ -1061,6 +1080,7 @@ class RockyResource(dg.ConfigurableResource):
             lookback=lookback,
             parallel=parallel,
             shadow_suffix=shadow_suffix,
+            idempotency_key=idempotency_key,
         )
         return _parse_rocky_json(
             self._run_rocky_streaming(args, context, allow_partial=True),
@@ -1083,6 +1103,7 @@ class RockyResource(dg.ConfigurableResource):
         lookback: int | None,
         parallel: int | None,
         shadow_suffix: str | None = None,
+        idempotency_key: str | None = None,
     ) -> list[str]:
         """Shared argv builder used by :meth:`run`, :meth:`run_streaming`, and :meth:`run_pipes`.
 
@@ -1114,6 +1135,8 @@ class RockyResource(dg.ConfigurableResource):
             args.extend(["--lookback", str(lookback)])
         if parallel is not None:
             args.extend(["--parallel", str(parallel)])
+        if idempotency_key is not None:
+            args.extend(["--idempotency-key", idempotency_key])
         return args
 
     def run_pipes(
@@ -1131,6 +1154,7 @@ class RockyResource(dg.ConfigurableResource):
         lookback: int | None = None,
         parallel: int | None = None,
         shadow_suffix: str | None = None,
+        idempotency_key: str | None = None,
         pipes_client: dg.PipesSubprocessClient | None = None,
         asset_key_fn: Callable[[list[str]], dg.AssetKey | None] | None = None,
         include_keys: set[dg.AssetKey] | None = None,
@@ -1223,6 +1247,7 @@ class RockyResource(dg.ConfigurableResource):
             lookback=lookback,
             parallel=parallel,
             shadow_suffix=shadow_suffix,
+            idempotency_key=idempotency_key,
         )
         if pipes_client is not None:
             client = pipes_client

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -178,6 +178,22 @@ class CostSection(BaseModel):
     """
 
 
+class DedupPolicy1(StrEnum):
+    """
+    Only successful runs stamp a persistent dedup entry; failed runs leave the key claimable for a retry. Default — matches the common "dedup successful notifications, allow retries" use case.
+    """
+
+    success = "success"
+
+
+class DedupPolicy2(StrEnum):
+    """
+    Any terminal status stamps a persistent entry — subsequent calls with the same key always skip, regardless of whether the prior run succeeded. Use when replays are expensive even for failures.
+    """
+
+    any = "any"
+
+
 class Dialect(StrEnum):
     """
     Target dialect for transpilation.
@@ -299,6 +315,30 @@ class HookConfigOrList(RootModel[HookConfig | list[HookConfig]]):
     Supports both single-hook and multi-hook syntax per event.
 
     Single: `[hook.on_pipeline_start]` Multiple: `[[hook.on_after_checks]]`
+    """
+
+
+class IdempotencyConfig(BaseModel):
+    """
+    Config for `rocky run --idempotency-key` dedup.
+
+    All fields are optional with sensible defaults. Block is present even when the user doesn't set `--idempotency-key`; it's a no-op in that case.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dedup_on: DedupPolicy1 | DedupPolicy2 | None = "success"
+    """
+    Which terminal statuses count as "already processed" for dedup. See [`DedupPolicy`]. Default [`DedupPolicy::Success`].
+    """
+    in_flight_ttl_hours: conint(ge=0) | None = 24
+    """
+    Hours after which an `InFlight` entry is treated as a crashed-pod corpse and adopted by a fresh caller. Default 24. Applies only to backends whose in-flight lock does not carry a server-side TTL — Valkey providers set `EX` directly on `SET NX`, so this field is informational for them.
+    """
+    retention_days: conint(ge=0) | None = 30
+    """
+    Number of days a `Succeeded` (or `Failed`-under-`any`) stamp is kept before GC. Default 30. GC runs during the state upload sweep.
     """
 
 
@@ -1520,6 +1560,13 @@ class StateConfig(BaseModel):
     """
     GCS key prefix (default: "rocky/state/")
     """
+    idempotency: IdempotencyConfig | None = Field(
+        {"dedup_on": "success", "in_flight_ttl_hours": 24, "retention_days": 30},
+        validate_default=True,
+    )
+    """
+    Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as "deduplicated", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`].
+    """
     on_upload_failure: StateUploadFailureMode1 | StateUploadFailureMode2 | None = "skip"
     """
     What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
@@ -2246,6 +2293,11 @@ class RockyConfig(BaseModel):
             "backend": "local",
             "gcs_bucket": None,
             "gcs_prefix": None,
+            "idempotency": {
+                "dedup_on": "success",
+                "in_flight_ttl_hours": 24,
+                "retention_days": 30,
+            },
             "on_upload_failure": "skip",
             "retry": {
                 "backoff_multiplier": 2.0,

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -252,6 +252,34 @@ class RunCostSummary(BaseModel):
     """
 
 
+class RunStatus1(StrEnum):
+    """
+    Status of a pipeline run.
+
+    `Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are the short-circuit outcomes of `rocky run --idempotency-key` — see [`crate::idempotency`].
+    """
+
+    Success = "Success"
+    PartialFailure = "PartialFailure"
+    Failure = "Failure"
+
+
+class RunStatus2(StrEnum):
+    """
+    The run was short-circuited because an idempotency key already mapped to a prior completed run. No work was done.
+    """
+
+    SkippedIdempotent = "SkippedIdempotent"
+
+
+class RunStatus3(StrEnum):
+    """
+    The run was short-circuited because another caller held the idempotency key's in-flight claim. No work was done.
+    """
+
+    SkippedInFlight = "SkippedInFlight"
+
+
 class TableErrorOutput(BaseModel):
     """
     Error from a table that failed during parallel processing.
@@ -447,6 +475,10 @@ class RunOutput(BaseModel):
     """
     execution: ExecutionSummary
     filter: str
+    idempotency_key: str | None = None
+    """
+    The `--idempotency-key` value this run was invoked with, echoed back for operator cross-reference in logs and `rocky history`. `None` for runs that didn't pass the flag.
+    """
     interrupted: bool
     """
     `true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish "user interrupted" from "run failed". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.
@@ -470,6 +502,14 @@ class RunOutput(BaseModel):
     shadow: bool
     """
     True when running in shadow mode (targets rewritten).
+    """
+    skipped_by_run_id: str | None = None
+    """
+    Prior run whose idempotency key deflected this call, or the run currently holding the in-flight claim. Populated only when `status` is `skipped_idempotent` or `skipped_in_flight`.
+    """
+    status: RunStatus1 | RunStatus2 | RunStatus3
+    """
+    Terminal status of the run. `success` / `partial_failure` / `failure` match the lifecycle semantics callers already understand; the two `skipped_*` variants short-circuit via the idempotency key (see `idempotency_key` below). Always populated — non-skipped runs derive this field from `tables_failed` / materialization counts, so JSON consumers no longer need to re-derive status from counts themselves.
     """
     tables_copied: conint(ge=0)
     tables_failed: conint(ge=0)

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_1.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_2.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_baseline_3.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
+++ b/integrations/dagster/tests/fixtures_generated/anomaly/run_incident.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_after_drift.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
+++ b/integrations/dagster/tests/fixtures_generated/drift/run_clean.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run1_initial.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
+++ b/integrations/dagster/tests/fixtures_generated/incremental/run2_delta.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/optimize/run.json
+++ b/integrations/dagster/tests/fixtures_generated/optimize/run.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=events",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/integrations/dagster/tests/fixtures_generated/run.json
+++ b/integrations/dagster/tests/fixtures_generated/run.json
@@ -1,6 +1,7 @@
 {
   "version": "1.14.0",
   "command": "run",
+  "status": "Success",
   "pipeline_type": "replication",
   "filter": "source=orders",
   "duration_ms": 0,

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -575,6 +575,25 @@
       ],
       "type": "object"
     },
+    "DedupPolicy": {
+      "description": "Policy controlling which terminal outcomes count for [`IdempotencyConfig::dedup_on`].",
+      "oneOf": [
+        {
+          "description": "Only successful runs stamp a persistent dedup entry; failed runs leave the key claimable for a retry. Default — matches the common \"dedup successful notifications, allow retries\" use case.",
+          "enum": [
+            "success"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Any terminal status stamps a persistent entry — subsequent calls with the same key always skip, regardless of whether the prior run succeeded. Use when replays are expensive even for failures.",
+          "enum": [
+            "any"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "Dialect": {
       "description": "Target dialect for transpilation.\n\nSerializes lowercase (`databricks`, `snowflake`, `bigquery`, `duckdb`) so the long-form names can sit in `rocky.toml` under the `[portability]` block without translation. The CLI's short-form flag values (`dbx`/`sf`/`bq`/`duckdb`) are kept as ergonomics in the `TargetDialect` clap enum and convert to this type at the boundary.",
       "enum": [
@@ -831,6 +850,36 @@
           "default": {},
           "description": "Webhook configurations keyed by event name.",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "IdempotencyConfig": {
+      "additionalProperties": false,
+      "description": "Config for `rocky run --idempotency-key` dedup.\n\nAll fields are optional with sensible defaults. Block is present even when the user doesn't set `--idempotency-key`; it's a no-op in that case.",
+      "properties": {
+        "dedup_on": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/DedupPolicy"
+            }
+          ],
+          "default": "success",
+          "description": "Which terminal statuses count as \"already processed\" for dedup. See [`DedupPolicy`]. Default [`DedupPolicy::Success`]."
+        },
+        "in_flight_ttl_hours": {
+          "default": 24,
+          "description": "Hours after which an `InFlight` entry is treated as a crashed-pod corpse and adopted by a fresh caller. Default 24. Applies only to backends whose in-flight lock does not carry a server-side TTL — Valkey providers set `EX` directly on `SET NX`, so this field is informational for them.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "retention_days": {
+          "default": 30,
+          "description": "Number of days a `Succeeded` (or `Failed`-under-`any`) stamp is kept before GC. Default 30. GC runs during the state upload sweep.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
       "type": "object"
@@ -2257,6 +2306,19 @@
             "null"
           ]
         },
+        "idempotency": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IdempotencyConfig"
+            }
+          ],
+          "default": {
+            "dedup_on": "success",
+            "in_flight_ttl_hours": 24,
+            "retention_days": 30
+          },
+          "description": "Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as \"deduplicated\", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`]."
+        },
         "on_upload_failure": {
           "allOf": [
             {
@@ -2717,6 +2779,11 @@
         "backend": "local",
         "gcs_bucket": null,
         "gcs_prefix": null,
+        "idempotency": {
+          "dedup_on": "success",
+          "in_flight_ttl_hours": 24,
+          "retention_days": 30
+        },
         "on_upload_failure": "skip",
         "retry": {
           "backoff_multiplier": 2.0,

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -777,6 +777,33 @@
       ],
       "type": "object"
     },
+    "RunStatus": {
+      "description": "Status of a pipeline run.\n\n`Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are the short-circuit outcomes of `rocky run --idempotency-key` — see [`crate::idempotency`].",
+      "oneOf": [
+        {
+          "enum": [
+            "Success",
+            "PartialFailure",
+            "Failure"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The run was short-circuited because an idempotency key already mapped to a prior completed run. No work was done.",
+          "enum": [
+            "SkippedIdempotent"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The run was short-circuited because another caller held the idempotency key's in-flight claim. No work was done.",
+          "enum": [
+            "SkippedInFlight"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "TableCheckOutput": {
       "properties": {
         "asset_key": {
@@ -899,6 +926,13 @@
     "filter": {
       "type": "string"
     },
+    "idempotency_key": {
+      "description": "The `--idempotency-key` value this run was invoked with, echoed back for operator cross-reference in logs and `rocky history`. `None` for runs that didn't pass the flag.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "interrupted": {
       "description": "`true` when the run was cancelled by a SIGINT (Ctrl-C). Surfaced so orchestrators can distinguish \"user interrupted\" from \"run failed\". Tables that hadn't reached `Success` or `Failed` at interrupt time are recorded as `TableStatus::Interrupted` in the state store. Always serialised (even when `false`) so consumers don't have to treat its absence specially.",
       "type": "boolean"
@@ -953,6 +987,21 @@
       "description": "True when running in shadow mode (targets rewritten).",
       "type": "boolean"
     },
+    "skipped_by_run_id": {
+      "description": "Prior run whose idempotency key deflected this call, or the run currently holding the in-flight claim. Populated only when `status` is `skipped_idempotent` or `skipped_in_flight`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "status": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/RunStatus"
+        }
+      ],
+      "description": "Terminal status of the run. `success` / `partial_failure` / `failure` match the lifecycle semantics callers already understand; the two `skipped_*` variants short-circuit via the idempotency key (see `idempotency_key` below). Always populated — non-skipped runs derive this field from `tables_failed` / materialization counts, so JSON consumers no longer need to re-derive status from counts themselves."
+    },
     "tables_copied": {
       "format": "uint",
       "minimum": 0.0,
@@ -988,6 +1037,7 @@
     "permissions",
     "quarantine",
     "shadow",
+    "status",
     "tables_copied",
     "tables_failed",
     "tables_skipped",


### PR DESCRIPTION
## Summary

Adds `rocky run --idempotency-key <KEY>` — caller-supplied opaque key that dedups a run against prior runs with the same key. All three phases of the implementation plan ship together so reviewers see the full mechanism in one surface:

- **Phase 1 (Option A — `local` + `valkey` + `tiered`):** redb write txn inside `state.redb.lock` on local; Valkey `SET NX EX` on `{prefix}:idempotency:<key>` on Valkey/Tiered.
- **Phase 2 (`s3`):** `object_store::PutMode::Create` → `If-None-Match: \"*\"` on the S3 `PutObject` call.
- **Phase 3 (`gcs`):** same primitive, `x-goog-if-generation-match: 0` precondition.

Three outcomes per invocation:

| Outcome | `status` in JSON | What happens |
|---|---|---|
| Unseen key (or stale InFlight corpse) | proceeds normally | Stamps `Succeeded` / `Failed` at every terminal exit |
| Seen + succeeded (or `Failed` under `dedup_on = any`) | `SkippedIdempotent` | Exit 0, no work, `skipped_by_run_id` = prior `run_id` |
| Seen + in-flight within TTL | `SkippedInFlight` | Exit 0, no work, `skipped_by_run_id` = in-flight `run_id` |

Defence-in-depth below Dagster's `run_key`. Catches pod retries, Kafka re-delivery, webhook duplicates, cron races. Also usable from non-Dagster callers (CI, cron, webhooks, custom orchestrators).

## Design decisions locked

Per the plan in `~/Developer/rocky-plans/plans/rocky-fr-004-idempotency-key.md`:

- **Verbatim key storage** (debuggability over privacy; CLI help + Dagster docstring carry the \"no secrets in keys\" warning).
- **`dedup_on = \"success\"` default** (failed runs delete their entry so retries claim cleanly; `\"any\"` opts in to dedup on any terminal status).
- **30-day retention default**, swept during the existing `state_sync::upload_state` cadence — no new cron.
- **24h `in_flight_ttl_hours`** — reader encountering a stale `InFlight` adopts via `AdoptStale`.
- **In-flight lock via each backend's native primitive** — one source of truth per backend, no new services.

## Schema cascade (`just codegen`)

- `RunStatus` (`rocky-core/src/state.rs`) gains `SkippedIdempotent` + `SkippedInFlight` variants; rippled to Pydantic (`run_schema.py`) and TypeScript (`run.ts`).
- `RunOutput` (`rocky-cli/src/output.rs`) gains `status: RunStatus`, `skipped_by_run_id: Option<String>`, `idempotency_key: Option<String>`.
- `[state.idempotency]` TOML block with `retention_days`, `dedup_on`, `in_flight_ttl_hours`.
- redb schema version **4 → 5** (new `IDEMPOTENCY_KEYS` table; NOT in `LOCAL_ONLY_TABLE_NAMES` — replicates across pods for the tiered backend).

## Guardrails

- `--idempotency-key` + `--resume{,-latest}` is a hard error at flag parse — resume is an explicit override and must never be short-circuited.
- S3/GCS object paths use `sha256(key)` for safety + bounded length; original key stored verbatim inside the payload.
- DAG sub-runs ignore the outer key to avoid sibling pipelines short-circuiting on a single stamp.

## Dagster

`run()` / `run_streaming()` / `run_pipes()` all gain `idempotency_key: str | None = None`. `_build_run_args` threads `--idempotency-key` to the subprocess. Docstring carries the secrets warning.

## Tests

- 1046 rocky-core tests pass, including **24 new tests** covering:
  - Unit: `IdempotencyCheck` classification, `DedupPolicy` branching, object-store path stability, backend label resolution.
  - Integration (redb-backed): first claim proceeds, repeat succeeded skips, repeat in-flight-within-TTL skips, stale in-flight adopts, finalize-succeeded keeps entry, finalize-failed + `Success` policy deletes, finalize-failed + `Any` policy keeps, finalize with mismatched run_id is a no-op, sweep removes past-retention + stale-InFlight entries, concurrent claim is deterministic.
  - Object-store primitive: `put_if_not_exists` returns `Created` on first call, `AlreadyExists` on second.
- 374 dagster pytest tests pass.
- vscode `tsc --noEmit` clean.
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `just codegen` idempotent (no drift after rerun).

## POC

`examples/playground/pocs/05-orchestration/09-idempotency-key/` — self-contained DuckDB POC demonstrating the flag acceptance + short-circuit. `./run.sh` verifies:
- Run 1 (fresh key) claims the entry.
- Run 2 (same key) short-circuits with `status = SkippedInFlight` / `SkippedIdempotent` + prior `run_id` in `skipped_by_run_id`.
- Run 3 (new key) claims independently.

Follows the POC-04 pattern (DuckDB POCs exit non-zero on \"no discovery adapter\" — orthogonal to the dedup primitive being validated).

## Known follow-up

F1 in the plan §11 — today a run that errors before `persist_run_record()` leaves its InFlight entry until the 24h `in_flight_ttl_hours` sweep reaps it. Worst-case latency for retrying a crashed run with the same key is 24h. Tighten by extracting `run_inner()` (so the outer `run()` can catch errors and finalize) or adding a `tokio::spawn`-based drop guard on `IdempotencyCtx`. Dedicated follow-up PR.

## Test plan

- [ ] CI green (engine-ci, dagster-ci, vscode-ci, codegen-drift)
- [ ] `cargo test -p rocky-core` — 1046 pass
- [ ] `pytest integrations/dagster/tests/` — 374 pass
- [ ] Manual: run `examples/playground/pocs/05-orchestration/09-idempotency-key/run.sh`, confirm Run 2 short-circuits with a skip status and surfaces Run 1's `run_id`

## References

- FR-004 source: [`~/Developer/rocky-plans/feature-requests/gold-fr-004-rocky-run-idempotency-key.md`](../tree/main)
- Implementation plan: [`~/Developer/rocky-plans/plans/rocky-fr-004-idempotency-key.md`](../tree/main)
- Backlog reprioritization: [`~/Developer/rocky-plans/archive/backlog-reprioritization-2026-04-22.md`](../tree/main)