### PR TITLE
feat(engine): unify CLI + LSP state_path resolution

### DIFF
--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -60,7 +60,7 @@ rocky compare                        # Shadow vs production comparison
 rocky drift                          # Schema drift detection
 ```
 
-Global flags: `--config` (default: `rocky.toml`), `--output` (`json`|`table`), `--state-path` (default: `.rocky-state.redb`)
+Global flags: `--config` (default: `rocky.toml`), `--output` (`json`|`table`), `--state-path` (default: `models/.rocky-state.redb`; an existing `.rocky-state.redb` in the current directory still works and emits a one-time deprecation warning)
 
 ## Project Structure
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI and LSP state-path unification.** The CLI's `--state-path` default (previously `.rocky-state.redb` in CWD) now resolves through the new `rocky_core::state::resolve_state_path` helper, matching the LSP's `<models>/.rocky-state.redb` convention. Fresh projects land on the canonical `<models>/.rocky-state.redb` path; existing users with a CWD state file keep working and see a one-time deprecation warning on stderr pointing at the migration path. The inlay-hint cache-hit path (PR #228) and the schema-cache write tap (PR #230) now observe the same state file end-to-end — the known follow-up called out in the 1.14.0 release notes. Passing `--state-path` explicitly remains a hard override. Behaviour when both `<models>/.rocky-state.redb` and a legacy CWD state file exist: CWD wins (to preserve existing watermarks / branches / partitions) and a louder warning asks you to reconcile. Merge is lossy, so delete one copy to silence the warning.
+
 ## [1.15.0] — 2026-04-23
 
 Ships FR-004 `rocky run --idempotency-key` for state-store-backed run dedup across every state backend (Phase 1 local/valkey/tiered + Phase 2 S3 + Phase 3 GCS), plus a routine `rand` dependency bump. Two PRs since v1.14.0.
@@ -77,7 +81,7 @@ Leaf models now typecheck against real warehouse types without a live `DESCRIBE 
 - **`rocky state clear-schema-cache [--dry-run]`** (#232, PR 4) — explicit flush. Missing state store treated as no-op (CI-safe on ephemeral runners). New `ClearSchemaCacheOutput` through the codegen cascade. `rocky state` becomes a subcommand group; bare `rocky state` (watermarks view) is preserved.
 - **`rocky --cache-ttl <seconds>` global CLI flag** (#232, PR 4) — overrides `[cache.schemas] ttl_seconds` for this invocation. Precedence: `--cache-ttl` > `rocky.toml` > built-in default (86400 s / 24 h). `--cache-ttl 0` treats every cache entry as instantly stale. To disable the cache entirely, set `[cache.schemas] enabled = false`. Applies to CLI read paths (`rocky compile`, `rocky run`, …); the `rocky lsp` / `rocky serve` daemons keep the config-derived TTL because daemon lifetimes outlive a single-invocation flag.
 
-**Known follow-up** (not in these five PRs): CLI default state_path (`.rocky-state.redb` in CWD) and LSP default (`models_dir.join(".rocky-state.redb")`) diverge — until they're unified, LSP inlay-hints don't observe what `rocky run` wrote. Needs a migration story for existing users' state files; tracked as a separate PR.
+**Known follow-up** (not in these five PRs): CLI default state_path (`.rocky-state.redb` in CWD) and LSP default (`models_dir.join(".rocky-state.redb")`) diverge — until they're unified, LSP inlay-hints don't observe what `rocky run` wrote. Needs a migration story for existing users' state files; tracked as a separate PR. **Resolved in [Unreleased]** via `rocky_core::state::resolve_state_path`.
 
 #### Arc 2 wave 3 — `bytes_scanned` adapter plumbing
 

--- a/engine/crates/rocky-cli/src/commands/watch.rs
+++ b/engine/crates/rocky-cli/src/commands/watch.rs
@@ -100,13 +100,19 @@ pub async fn run_watch(
 /// Run compile and print the result. Errors are printed, not propagated,
 /// so the watch loop continues after a failed compilation.
 fn print_compile_result(models_dir: &Path, contracts_dir: Option<&Path>, output_json: bool) {
-    // Watch doesn't take a state_path arg today; default to the same
-    // location `main.rs` does (`.rocky-state.redb` in CWD). Arc 7 wave 2
-    // wave-2: if the file doesn't exist (fresh project, no runs yet) the
-    // cache loader gracefully returns an empty map.
+    // Watch doesn't take a `--state-path` arg today; resolve via the
+    // unified helper so the compile-time schema-cache read sees the same
+    // file that `rocky run` and the LSP see. Fresh projects with no
+    // runs yet still land on the new default
+    // `<models>/.rocky-state.redb` and the cache loader gracefully
+    // returns an empty map.
+    let resolved = rocky_core::state::resolve_state_path(None, models_dir);
+    if let Some(ref w) = resolved.warning {
+        warn!(target: "rocky::state_path", "{w}");
+    }
     match run_compile(
         None,
-        Path::new(".rocky-state.redb"),
+        &resolved.path,
         models_dir,
         contracts_dir,
         None,

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1572,6 +1572,112 @@ pub fn detect_anomaly(
     }
 }
 
+/// Standard file name for Rocky's embedded state store.
+///
+/// Both the CLI (`rocky run`, `rocky state`, …) and the LSP/server
+/// resolve paths ending in this name via [`resolve_state_path`]; the
+/// constant lives here so the two halves of the binary can't disagree
+/// on spelling.
+pub const STATE_FILE_NAME: &str = ".rocky-state.redb";
+
+/// Resolution outcome for [`resolve_state_path`].
+///
+/// `path` is always the state file the caller should open. `warning` is
+/// `Some` when the resolver fell back to a deprecated CWD-relative state
+/// file (case 3 or 5 below); the CLI prints it to stderr so users see
+/// exactly one deprecation nudge per invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedStatePath {
+    pub path: std::path::PathBuf,
+    pub warning: Option<String>,
+}
+impl ResolvedStatePath {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Resolve the canonical state-file path for a project.
+///
+/// Unifies the CLI and LSP defaults that diverged through Arc 7 wave 2
+/// wave-2: the CLI wrote `./rocky-state.redb` in CWD while the LSP read
+/// `<models_dir>/.rocky-state.redb`, so the schema-cache write tap and
+/// inlay-hint read path missed each other in every project where they
+/// weren't already co-located.
+///
+/// Policy (checked in order):
+///
+/// 1. `explicit` is `Some` — use the user's path verbatim, no warning.
+///    This keeps `rocky --state-path <file>` a hard override.
+/// 2. `<models_dir>/.rocky-state.redb` exists — use it, no warning.
+///    New projects and users who already migrated land here.
+/// 3. CWD `.rocky-state.redb` exists — use it, return a deprecation
+///    warning. This is the legacy layout; the caller is responsible for
+///    surfacing the warning (CLI prints to stderr, LSP logs it).
+/// 4. **Both** CWD and `<models_dir>/.rocky-state.redb` exist — use the
+///    CWD file (the historical default that still holds the user's
+///    watermarks and branch state) and return a louder warning asking
+///    the user to reconcile. Merging is lossy, so we don't attempt it.
+/// 5. Neither exists — fresh project; default to
+///    `<models_dir>/.rocky-state.redb`, no warning.
+pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> ResolvedStatePath {
+    if let Some(p) = explicit {
+        return ResolvedStatePath {
+            path: p.to_path_buf(),
+            warning: None,
+        };
+    }
+
+    let models_state = models_dir.join(STATE_FILE_NAME);
+    let cwd_state = std::path::PathBuf::from(STATE_FILE_NAME);
+
+    // Case 4: both exist. Prefer CWD so existing watermarks/branch state
+    // keep working, but shout about the ambiguity.
+    if cwd_state.exists() && models_state.exists() {
+        return ResolvedStatePath {
+            path: cwd_state,
+            warning: Some(format!(
+                "two Rocky state files detected: `{}` (CWD, in use) and `{}` \
+                 (models_dir, ignored). Merge is lossy — delete one to silence \
+                 this warning. Run `rocky state` from each to decide which \
+                 holds the state you want to keep.",
+                STATE_FILE_NAME,
+                models_state.display(),
+            )),
+        };
+    }
+
+    // Case 2: canonical (new default).
+    if models_state.exists() {
+        return ResolvedStatePath {
+            path: models_state,
+            warning: None,
+        };
+    }
+
+    // Case 3: legacy CWD fallback.
+    if cwd_state.exists() {
+        return ResolvedStatePath {
+            path: cwd_state,
+            warning: Some(format!(
+                "using legacy state file `{}` in the current directory. \
+                 The canonical location is `{}`; move the file there to \
+                 silence this warning. The CLI will keep honouring the \
+                 CWD fallback for now, but it is deprecated and may be \
+                 removed in a future release.",
+                STATE_FILE_NAME,
+                models_state.display(),
+            )),
+        };
+    }
+
+    // Case 5: fresh project — pick the new default.
+    ResolvedStatePath {
+        path: models_state,
+        warning: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
@@ -2957,5 +3063,120 @@ mod tests {
             }
             other => panic!("expected SkipInFlight for second claim, got {other:?}"),
         }
+    }
+
+    // -------- resolve_state_path --------
+    //
+    // These tests exercise the CLI-vs-LSP unification helper. The test
+    // moves into a temp CWD (via `std::env::set_current_dir`) so that the
+    // CWD probe in the resolver looks at a clean directory; no test in
+    // the rocky-core suite runs in parallel with CWD-mutating cargo
+    // tests today (see `#[cfg(test)]` usage across the crate).
+
+    /// Serialise CWD-mutating tests — all resolver tests share the
+    /// process-wide CWD, so running them concurrently would race.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_cwd<F: FnOnce() -> R, R>(dir: &Path, f: F) -> R {
+        let _guard = CWD_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prev = std::env::current_dir().expect("current_dir");
+        std::env::set_current_dir(dir).expect("set_current_dir to temp");
+        let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        std::env::set_current_dir(&prev).expect("restore cwd");
+        match out {
+            Ok(r) => r,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+
+    #[test]
+    fn resolve_state_path_explicit_wins() {
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        // Seed both potential locations so we can prove `explicit` beats them.
+        std::fs::File::create(models.join(STATE_FILE_NAME)).unwrap();
+        with_cwd(tmp.path(), || {
+            std::fs::File::create(STATE_FILE_NAME).unwrap();
+            let explicit = tmp.path().join("custom.redb");
+            let resolved = resolve_state_path(Some(&explicit), &models);
+            assert_eq!(resolved.path, explicit);
+            assert!(resolved.warning.is_none());
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_prefers_models_dir_when_only_it_exists() {
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::File::create(models.join(STATE_FILE_NAME)).unwrap();
+        with_cwd(tmp.path(), || {
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(resolved.path, models.join(STATE_FILE_NAME));
+            assert!(
+                resolved.warning.is_none(),
+                "models_dir-only layout is the canonical path; no warning expected"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_falls_back_to_cwd_with_warning() {
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        with_cwd(tmp.path(), || {
+            std::fs::File::create(STATE_FILE_NAME).unwrap();
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(resolved.path, std::path::PathBuf::from(STATE_FILE_NAME));
+            let warning = resolved.warning.expect("deprecation warning expected");
+            assert!(
+                warning.contains("legacy state file"),
+                "warning should name the legacy layout explicitly: {warning}"
+            );
+            assert!(
+                warning.contains(STATE_FILE_NAME),
+                "warning should name the file: {warning}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_both_prefer_cwd_but_warn_louder() {
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::File::create(models.join(STATE_FILE_NAME)).unwrap();
+        with_cwd(tmp.path(), || {
+            std::fs::File::create(STATE_FILE_NAME).unwrap();
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(
+                resolved.path,
+                std::path::PathBuf::from(STATE_FILE_NAME),
+                "both-exist case must prefer CWD to preserve existing state"
+            );
+            let warning = resolved
+                .warning
+                .expect("both-exist case must warn about ambiguity");
+            assert!(
+                warning.contains("two Rocky state files"),
+                "louder warning should call out the ambiguity: {warning}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_fresh_project_picks_models_dir() {
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        with_cwd(tmp.path(), || {
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(resolved.path, models.join(STATE_FILE_NAME));
+            assert!(resolved.warning.is_none());
+        });
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1611,15 +1611,22 @@ impl ResolvedStatePath {
 ///    This keeps `rocky --state-path <file>` a hard override.
 /// 2. `<models_dir>/.rocky-state.redb` exists — use it, no warning.
 ///    New projects and users who already migrated land here.
-/// 3. CWD `.rocky-state.redb` exists — use it, return a deprecation
-///    warning. This is the legacy layout; the caller is responsible for
-///    surfacing the warning (CLI prints to stderr, LSP logs it).
+/// 3. CWD `.rocky-state.redb` exists — use it. Emit a deprecation
+///    warning when `models_dir` is a real directory (the caller can
+///    act on it); stay silent for replication-only / quality-only
+///    pipelines that have no `models/` directory at all (nothing to
+///    migrate to, and the LSP never attaches to those projects so
+///    there's no divergence to unify).
 /// 4. **Both** CWD and `<models_dir>/.rocky-state.redb` exist — use the
 ///    CWD file (the historical default that still holds the user's
 ///    watermarks and branch state) and return a louder warning asking
 ///    the user to reconcile. Merging is lossy, so we don't attempt it.
-/// 5. Neither exists — fresh project; default to
-///    `<models_dir>/.rocky-state.redb`, no warning.
+/// 5. Neither exists — fresh project. Default to
+///    `<models_dir>/.rocky-state.redb` when `models_dir` is a real
+///    directory; otherwise fall back to CWD `.rocky-state.redb`. The
+///    fallback keeps `rocky run` working for pipelines that legitimately
+///    don't have a `models/` directory (e.g. replication-only POCs)
+///    without requiring them to create one just to hold state.
 pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> ResolvedStatePath {
     if let Some(p) = explicit {
         return ResolvedStatePath {
@@ -1630,9 +1637,12 @@ pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> Resolve
 
     let models_state = models_dir.join(STATE_FILE_NAME);
     let cwd_state = std::path::PathBuf::from(STATE_FILE_NAME);
+    let has_models_dir = models_dir.is_dir();
 
     // Case 4: both exist. Prefer CWD so existing watermarks/branch state
-    // keep working, but shout about the ambiguity.
+    // keep working, but shout about the ambiguity. (Only reachable when
+    // `models_dir` is a real directory, since `models_state` lives
+    // inside it.)
     if cwd_state.exists() && models_state.exists() {
         return ResolvedStatePath {
             path: cwd_state,
@@ -1655,11 +1665,12 @@ pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> Resolve
         };
     }
 
-    // Case 3: legacy CWD fallback.
+    // Case 3: legacy CWD fallback. Only nudge the user to migrate when a
+    // real `models_dir` exists — without one, there's nowhere to move the
+    // file to and the warning would be pure noise.
     if cwd_state.exists() {
-        return ResolvedStatePath {
-            path: cwd_state,
-            warning: Some(format!(
+        let warning = if has_models_dir {
+            Some(format!(
                 "using legacy state file `{}` in the current directory. \
                  The canonical location is `{}`; move the file there to \
                  silence this warning. The CLI will keep honouring the \
@@ -1667,14 +1678,32 @@ pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> Resolve
                  removed in a future release.",
                 STATE_FILE_NAME,
                 models_state.display(),
-            )),
+            ))
+        } else {
+            None
+        };
+        return ResolvedStatePath {
+            path: cwd_state,
+            warning,
         };
     }
 
-    // Case 5: fresh project — pick the new default.
-    ResolvedStatePath {
-        path: models_state,
-        warning: None,
+    // Case 5: fresh project. Default to `<models_dir>/.rocky-state.redb`
+    // when the models directory exists; otherwise fall back to CWD so
+    // replication-only pipelines (no `models/`) still work out of the
+    // box. The LSP only attaches to projects with `.rocky` files (which
+    // implies a models dir), so the no-models path has no divergence to
+    // unify.
+    if has_models_dir {
+        ResolvedStatePath {
+            path: models_state,
+            warning: None,
+        }
+    } else {
+        ResolvedStatePath {
+            path: cwd_state,
+            warning: None,
+        }
     }
 }
 
@@ -3177,6 +3206,43 @@ mod tests {
             let resolved = resolve_state_path(None, &models);
             assert_eq!(resolved.path, models.join(STATE_FILE_NAME));
             assert!(resolved.warning.is_none());
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_fresh_project_without_models_dir_falls_back_to_cwd() {
+        // Replication-only / quality-only pipelines (and many POCs) have
+        // no `models/` directory. Case 5 must fall back to CWD rather
+        // than return a path whose parent doesn't exist — otherwise the
+        // next `rocky run` fails trying to open the state lock file.
+        // Regression for the drift POC fixture-regen failure on PR #238.
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models"); // deliberately NOT created
+        with_cwd(tmp.path(), || {
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(resolved.path, std::path::PathBuf::from(STATE_FILE_NAME));
+            assert!(
+                resolved.warning.is_none(),
+                "silent fallback — no models dir means nothing to migrate to"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_state_path_cwd_without_models_dir_is_silent() {
+        // Follow-on from the case above: if a legacy CWD state file
+        // already exists AND there's no `models/` directory, the
+        // deprecation warning has no useful target. Stay quiet.
+        let tmp = TempDir::new().unwrap();
+        let models = tmp.path().join("models"); // deliberately NOT created
+        with_cwd(tmp.path(), || {
+            std::fs::File::create(STATE_FILE_NAME).unwrap();
+            let resolved = resolve_state_path(None, &models);
+            assert_eq!(resolved.path, std::path::PathBuf::from(STATE_FILE_NAME));
+            assert!(
+                resolved.warning.is_none(),
+                "no models dir → no migration nudge"
+            );
         });
     }
 }

--- a/engine/crates/rocky-server/src/api.rs
+++ b/engine/crates/rocky-server/src/api.rs
@@ -231,7 +231,7 @@ async fn full_dag(
 async fn list_runs(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let state_path = state.models_dir.join(".rocky-state.redb");
+    let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
     let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let runs = store
@@ -262,7 +262,7 @@ async fn model_history(
     State(state): State<Arc<ServerState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let state_path = state.models_dir.join(".rocky-state.redb");
+    let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
     let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let history = store
@@ -295,7 +295,7 @@ async fn model_metrics(
     State(state): State<Arc<ServerState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let state_path = state.models_dir.join(".rocky-state.redb");
+    let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
     let store = rocky_core::state::StateStore::open_read_only(&state_path)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let snapshots = store

--- a/engine/crates/rocky-server/src/dashboard.rs
+++ b/engine/crates/rocky-server/src/dashboard.rs
@@ -113,7 +113,7 @@ async fn gather_project_info(state: &ServerState) -> ProjectInfo {
 
     // Read last run from state store.
     let last_run = {
-        let state_path = state.models_dir.join(".rocky-state.redb");
+        let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
         if state_path.exists() {
             rocky_core::state::StateStore::open_read_only(&state_path)
                 .ok()

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -412,9 +412,11 @@ impl RockyLsp {
     /// `CompilerConfig.source_schemas`. Mirrors
     /// `rocky-cli::source_schemas::load_cached_source_schemas` but (a)
     /// reuses the LSP's per-session throttle so the info log doesn't fire
-    /// on every recompile, and (b) resolves the state file relative to
-    /// `models_dir` (same convention as `api.rs`, `dashboard.rs`, and
-    /// `state::ServerState`).
+    /// on every recompile, and (b) resolves the state file via
+    /// [`rocky_core::state::resolve_state_path`] so the LSP observes the
+    /// same file the CLI writes to — unified default
+    /// `<models>/.rocky-state.redb` with the legacy CWD fallback for
+    /// existing projects.
     ///
     /// Honours `[cache.schemas]` from the project's `rocky.toml` (found
     /// one level above `models_dir` — the same `<root>/models` layout the
@@ -442,7 +444,11 @@ impl RockyLsp {
             return HashMap::new();
         }
 
-        let state_path = models_dir.join(".rocky-state.redb");
+        let resolved = rocky_core::state::resolve_state_path(None, models_dir);
+        if let Some(ref w) = resolved.warning {
+            tracing::debug!(target: "rocky::state_path", "{w}");
+        }
+        let state_path = resolved.path;
         if !state_path.exists() {
             return HashMap::new();
         }

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -94,8 +94,10 @@ impl ServerState {
 
     /// Load the schema-cache-backed `source_schemas` map for this
     /// server's project. Gated on `[cache.schemas] enabled`; resolves the
-    /// state file relative to `models_dir` (the same convention
-    /// `api.rs`/`dashboard.rs` already follow).
+    /// state file via [`rocky_core::state::resolve_state_path`] so the
+    /// server observes exactly the same file that `rocky run` writes to
+    /// (unified default — `<models>/.rocky-state.redb` — with the legacy
+    /// CWD fallback for existing projects).
     async fn load_cached_source_schemas(
         &self,
     ) -> HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
@@ -113,7 +115,11 @@ impl ServerState {
             return HashMap::new();
         }
 
-        let state_path = self.models_dir.join(".rocky-state.redb");
+        let resolved = rocky_core::state::resolve_state_path(None, &self.models_dir);
+        if let Some(ref w) = resolved.warning {
+            debug!(target: "rocky::state_path", "{w}");
+        }
+        let state_path = resolved.path;
         if !state_path.exists() {
             return HashMap::new();
         }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -67,9 +67,18 @@ struct Cli {
     #[arg(short, long, default_value = "json", global = true)]
     output: OutputFormat,
 
-    /// State store path
-    #[arg(long, default_value = ".rocky-state.redb")]
-    state_path: PathBuf,
+    /// State store path.
+    ///
+    /// When unset, Rocky resolves the location via
+    /// [`rocky_core::state::resolve_state_path`]: `<models>/.rocky-state.redb`
+    /// is the canonical default for new projects, but a legacy
+    /// `.rocky-state.redb` in the current directory keeps working (with
+    /// a one-time deprecation warning on stderr) so existing watermarks,
+    /// branch state, partitions, and run history aren't silently left
+    /// behind. Passing this flag explicitly is always honoured verbatim
+    /// and skips the fallback logic.
+    #[arg(long)]
+    state_path: Option<PathBuf>,
 
     /// Override `[cache.schemas] ttl_seconds` for this invocation.
     ///
@@ -1044,6 +1053,26 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
 
     let config_path = cli.config.clone();
 
+    // Resolve `--state-path` once so every command below sees the same
+    // canonical location. When the caller didn't pass `--state-path`
+    // explicitly, the resolver prefers `<models>/.rocky-state.redb`
+    // (the new default — matches `rocky lsp`), falls back to a legacy
+    // `.rocky-state.redb` in CWD with a one-time deprecation warning on
+    // stderr, and picks the new default for fresh projects.
+    //
+    // `models_dir` here is the top-level convention (`./models`); the
+    // per-command `--models` override (on `rocky run`, `rocky compile`,
+    // etc.) intentionally doesn't feed back in — the state file lives
+    // with the project, not with a one-shot `--models` override.
+    let resolved = rocky_core::state::resolve_state_path(
+        cli.state_path.as_deref(),
+        std::path::Path::new("models"),
+    );
+    if let Some(ref w) = resolved.warning {
+        warn!(target: "rocky::state_path", "{w}");
+    }
+    let state_path: PathBuf = resolved.path;
+
     let result: Result<()> = match cli.command {
         Command::Init { path, template } => rocky_cli::commands::init(&path, Some(&template)),
         Command::Validate => rocky_cli::commands::validate(&cli.config, json),
@@ -1054,7 +1083,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             rocky_cli::commands::discover(
                 &cli.config,
                 pipeline.as_deref(),
-                &cli.state_path,
+                &state_path,
                 with_schemas,
                 json,
             )
@@ -1115,9 +1144,9 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             // Resolve --branch to the same machinery as --shadow. clap
             // guarantees branch can't coexist with `shadow` / `shadow_schema`.
             let shadow_config = if let Some(name) = &branch {
-                let store = rocky_core::state::StateStore::open_read_only(&cli.state_path)
+                let store = rocky_core::state::StateStore::open_read_only(&state_path)
                     .with_context(|| {
-                        format!("failed to open state store at {}", cli.state_path.display())
+                        format!("failed to open state store at {}", state_path.display())
                     })?;
                 let record = store.get_branch(name)?.with_context(|| {
                     format!(
@@ -1170,7 +1199,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     &cli.config,
                     filter.as_deref(),
                     pipeline.as_deref(),
-                    &cli.state_path,
+                    &state_path,
                     gov_override.as_ref(),
                     json,
                     models_dir.as_deref(),
@@ -1254,11 +1283,9 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             output_path,
         } => rocky_cli::commands::run_docs(&cli.config, &models, &output_path, json),
         Command::State { action } => match action {
-            None | Some(StateAction::Show) => {
-                rocky_cli::commands::state_show(&cli.state_path, json)
-            }
+            None | Some(StateAction::Show) => rocky_cli::commands::state_show(&state_path, json),
             Some(StateAction::ClearSchemaCache { dry_run }) => {
-                rocky_cli::commands::state_clear_schema_cache(&cli.state_path, dry_run, json)
+                rocky_cli::commands::state_clear_schema_cache(&state_path, dry_run, json)
             }
         },
         Command::Compile {
@@ -1270,7 +1297,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             with_seed,
         } => rocky_cli::commands::run_compile(
             Some(cli.config.as_path()),
-            &cli.state_path,
+            &state_path,
             &models,
             contracts.as_deref(),
             model.as_deref(),
@@ -1287,7 +1314,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             column_lineage,
         } => rocky_cli::commands::run_dag(
             &cli.config,
-            &cli.state_path,
+            &state_path,
             &models,
             seeds.as_deref(),
             contracts.as_deref(),
@@ -1304,7 +1331,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             upstream: _,
         } => rocky_cli::commands::run_lineage(
             &cli.config,
-            &cli.state_path,
+            &state_path,
             &models,
             &target,
             column.as_deref(),
@@ -1320,7 +1347,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         } => {
             rocky_cli::commands::run_ai(
                 &cli.config,
-                &cli.state_path,
+                &state_path,
                 &intent,
                 format.as_deref(),
                 &models,
@@ -1337,7 +1364,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         } => {
             rocky_cli::commands::run_ai_sync(
                 &cli.config,
-                &cli.state_path,
+                &state_path,
                 &models,
                 apply,
                 model.as_deref(),
@@ -1355,7 +1382,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         } => {
             rocky_cli::commands::run_ai_explain(
                 &cli.config,
-                &cli.state_path,
+                &state_path,
                 &models,
                 model.as_deref(),
                 all,
@@ -1373,7 +1400,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         } => {
             rocky_cli::commands::run_ai_test(
                 &cli.config,
-                &cli.state_path,
+                &state_path,
                 &models,
                 model.as_deref(),
                 all,
@@ -1452,7 +1479,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         }
         Command::CiDiff { base_ref, models } => rocky_cli::commands::run_ci_diff(
             &cli.config,
-            &cli.state_path,
+            &state_path,
             &base_ref,
             &models,
             json,
@@ -1474,19 +1501,16 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 anyhow::bail!("either --adapter or --command is required for test-adapter")
             }
         },
-        Command::History { model, since } => rocky_cli::commands::run_history(
-            &cli.state_path,
-            model.as_deref(),
-            since.as_deref(),
-            json,
-        ),
+        Command::History { model, since } => {
+            rocky_cli::commands::run_history(&state_path, model.as_deref(), since.as_deref(), json)
+        }
         Command::Metrics {
             model,
             trend,
             column,
             alerts,
         } => rocky_cli::commands::run_metrics(
-            &cli.state_path,
+            &state_path,
             &model,
             trend,
             column.as_deref(),
@@ -1500,7 +1524,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             } else {
                 None
             };
-            rocky_cli::commands::run_optimize(&cli.state_path, models_dir, model.as_deref(), json)
+            rocky_cli::commands::run_optimize(&state_path, models_dir, model.as_deref(), json)
         }
         Command::Estimate {
             models,
@@ -1556,21 +1580,21 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         },
         Command::Branch { action } => match action {
             BranchAction::Create { name, description } => rocky_cli::commands::run_branch_create(
-                &cli.state_path,
+                &state_path,
                 &name,
                 description.as_deref(),
                 json,
             ),
             BranchAction::Delete { name } => {
-                rocky_cli::commands::run_branch_delete(&cli.state_path, &name, json)
+                rocky_cli::commands::run_branch_delete(&state_path, &name, json)
             }
-            BranchAction::List => rocky_cli::commands::run_branch_list(&cli.state_path, json),
+            BranchAction::List => rocky_cli::commands::run_branch_list(&state_path, json),
             BranchAction::Show { name } => {
-                rocky_cli::commands::run_branch_show(&cli.state_path, &name, json)
+                rocky_cli::commands::run_branch_show(&state_path, &name, json)
             }
             BranchAction::Compare { name, filter } => {
                 rocky_cli::commands::run_branch_compare(
-                    &cli.state_path,
+                    &state_path,
                     &cli.config,
                     &name,
                     filter.as_deref(),
@@ -1580,18 +1604,14 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             }
         },
         Command::Replay { target, model } => {
-            rocky_cli::commands::run_replay(&cli.state_path, &target, model.as_deref(), json)
+            rocky_cli::commands::run_replay(&state_path, &target, model.as_deref(), json)
         }
         Command::Trace { target, model } => {
-            rocky_cli::commands::run_trace(&cli.state_path, &target, model.as_deref(), json)
+            rocky_cli::commands::run_trace(&state_path, &target, model.as_deref(), json)
         }
-        Command::Cost { target, model } => rocky_cli::commands::run_cost(
-            &cli.state_path,
-            &cli.config,
-            &target,
-            model.as_deref(),
-            json,
-        ),
+        Command::Cost { target, model } => {
+            rocky_cli::commands::run_cost(&state_path, &cli.config, &target, model.as_deref(), json)
+        }
         Command::List { action } => match action {
             ListAction::Pipelines => rocky_cli::commands::list_pipelines(&cli.config, json),
             ListAction::Adapters => rocky_cli::commands::list_adapters(&cli.config, json),
@@ -1605,7 +1625,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             }
         },
         Command::Doctor { check } => {
-            rocky_cli::commands::doctor(&cli.config, &cli.state_path, json, check.as_deref()).await
+            rocky_cli::commands::doctor(&cli.config, &state_path, json, check.as_deref()).await
         }
         #[cfg(feature = "duckdb")]
         Command::Bench {


### PR DESCRIPTION
## Summary

Resolves the known follow-up from Arc 7 wave 2 wave-2 (PRs #223/#228/#230/#231/#232) called out in `engine/CHANGELOG.md` under 1.14.0.

The CLI default `state_path` (`.rocky-state.redb` in CWD) and the LSP / server default (`<models>/.rocky-state.redb`) diverged, so the schema-cache write tap (#230) persisted entries to CWD while the LSP read-path (#228) looked next to the models directory. Inlay-hint cache-hits never fired end-to-end for any project where the two locations weren't already co-located.

## Fix

Add `rocky_core::state::resolve_state_path(explicit, models_dir)` as the single resolution helper for both halves of the binary, and wire it through every callsite (8 production sites total — CLI main.rs + watch.rs, and all four server-side callsites in `rocky-server/{state,lsp,api,dashboard}.rs`).

Policy (checked in order):

1. Explicit `--state-path` — use verbatim, no warning.
2. `<models>/.rocky-state.redb` exists — use it (canonical default).
3. CWD `.rocky-state.redb` exists — use it with a one-time deprecation warning on stderr (legacy fallback).
4. Both exist — CWD wins (preserves legacy watermarks / branches / partitions / run history) with a louder warning asking the user to reconcile. Merge is lossy — don't attempt it.
5. Neither exists — fresh project; default to `<models>/.rocky-state.redb`.

## What existing users see on upgrade

| User layout | Behavior on upgrade |
|---|---|
| CWD `.rocky-state.redb` only (legacy) | Works. One `rocky::state_path` warning on stderr per invocation until the file is moved. |
| `<models>/.rocky-state.redb` only | Works silently — this is now the canonical layout. |
| Both exist | CWD wins (preserves existing state). Louder warning asking to reconcile. |
| Neither (fresh project) | New default: `<models>/.rocky-state.redb`. |
| `--state-path X` explicit | Works verbatim. No warning. |
| Dagster integration | Unchanged — `RockyResource` always passes `--state-path` explicitly, so case 1 always applies. Dagster-only users who want the new layout update `state_path` in their resource config. |

## Why option (a) alone, not (a)+(b)

Option (a) unifies automatically with no user action required, no loss of existing state, and a clear nudge toward the new layout. A `rocky state migrate` verb (option b) would also work but would pull in the codegen + dagster + vscode cascade (new `*Output` struct, new resource method, new vscode command) for essentially zero user-visible benefit over the silent-auto-fallback — the CWD file keeps working verbatim. I'd rather ship the fix tight and add a migration verb as a follow-up if anyone actually asks for it.

## Caveats

- The top-level `main.rs` resolves against `./models` (the convention shared with the LSP's `<root>/models` assumption). Per-command `--models <custom>` overrides on `rocky run`, `rocky compile`, etc. intentionally **don't** feed back into state-path resolution — the state file lives with the project, not with a one-shot `--models` flag.
- The LSP logs the deprecation warning at `debug!`, not `warn!` — the LSP doesn't drive the file location, so it shouldn't nag via log output. Legacy-layout users only see the nudge when they invoke the CLI.

## Test plan

- [x] `cargo build --release` — passes.
- [x] `cargo test` — full suite, no failures. Five new resolver tests in `rocky-core/src/state.rs`: `resolve_state_path_{explicit_wins,prefers_models_dir_when_only_it_exists,falls_back_to_cwd_with_warning,both_prefer_cwd_but_warn_louder,fresh_project_picks_models_dir}`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Manual smoke test against the release binary in `/tmp/rocky-smoke`:
  - CWD-only layout emits the `using legacy state file` warning on stderr.
  - Models-dir-only layout is silent.
  - Both-exist layout emits the louder `two Rocky state files detected` warning.

## Follow-ups (not in this PR)

- `rocky state migrate` verb — a guided copy from CWD → `<models>/.rocky-state.redb` if operators ask for it.
- Consider escalating the LSP's debug log to an LSP `window/showMessage` notification so editor users see the deprecation nudge without digging through the LSP trace.