### PR TITLE
fix(engine/rocky-cli): finalize idempotency on success for non-replication dispatches (FR-004 F2)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Success-path idempotency finalize for non-replication dispatches (FR-004 F2).** A `rocky run --idempotency-key K` against a Transformation / Quality / Snapshot / Load pipeline successfully returned `Ok(())` but left the `InFlight` claim in place — the four non-replication dispatch arms returned directly from `run()` without calling `finalize_idempotency`, and the error-path wrapper from [#237](https://github.com/rocky-data/rocky/pull/237) only fires on `is_err()`. A retry with the same key inside `in_flight_ttl_hours` (default 24h) then returned `skipped_in_flight` for up to 24h instead of `skipped_idempotent`. Each of the four arms now stamps `Succeeded` on its happy-path exit via a new `finalize_idempotency_on_success` helper; the one-shot `.take()` on the shared `IdempotencyCtx` keeps the error-path wrapper a no-op when the success path already drained. Replication was never affected — it already finalized correctly at its main exit in [#235](https://github.com/rocky-data/rocky/pull/235).
+
 ### Changed
 
 - **CLI and LSP state-path unification.** The CLI's `--state-path` default (previously `.rocky-state.redb` in CWD) now resolves through the new `rocky_core::state::resolve_state_path` helper, matching the LSP's `<models>/.rocky-state.redb` convention. Fresh projects land on the canonical `<models>/.rocky-state.redb` path; existing users with a CWD state file keep working and see a one-time deprecation warning on stderr pointing at the migration path. The inlay-hint cache-hit path (PR #228) and the schema-cache write tap (PR #230) now observe the same state file end-to-end — the known follow-up called out in the 1.14.0 release notes. Passing `--state-path` explicitly remains a hard override. Behaviour when both `<models>/.rocky-state.redb` and a legacy CWD state file exist: CWD wins (to preserve existing watermarks / branches / partitions) and a louder warning asks you to reconcile. Merge is lossy, so delete one copy to silence the warning.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -572,6 +572,79 @@ async fn finalize_idempotency_on_error(
     }
 }
 
+/// Finalize the idempotency entry as `Succeeded` on the happy-path exit of
+/// a non-replication dispatch arm (Transformation / Quality / Snapshot /
+/// Load), which returns early from [`run`] without touching the replication
+/// path's `finalize_idempotency` site.
+///
+/// Without this, a successful run of one of those four arms leaves its
+/// `InFlight` stamp in place — the outer error-path wrapper only fires when
+/// the body returns `Err`. The next retry of the same key then returns
+/// `skipped_in_flight` for up to `in_flight_ttl_hours` (default 24h), the
+/// exact latent-landmine behaviour the F1 wrapper closed for the error
+/// path. FR-004 F2.
+///
+/// Opens its own `StateStore` because the four dispatch arms delegate to
+/// helpers in `run_local.rs` / `load.rs` that don't thread the claim's
+/// state store back out. The claim and this finalize both target the
+/// canonical `state_path` owned by `run()`, so stamping here matches the
+/// claim's location exactly.
+///
+/// Best-effort throughout — any error here is swallowed with `warn!` so a
+/// successful pipeline run never exits non-zero due to bookkeeping flake.
+/// One-shot via `.take()` so the outer error-path wrapper is a no-op after
+/// this call, mirroring [`finalize_idempotency`]'s contract.
+async fn finalize_idempotency_on_success(
+    ctx_slot: &mut Option<IdempotencyCtx>,
+    state_path: &Path,
+    run_id: &str,
+) {
+    use rocky_core::idempotency::{FinalOutcome, IdempotencyBackend};
+    let Some(ctx) = ctx_slot.take() else {
+        return;
+    };
+    // Local + mirrored Tiered need an open state store; pure Valkey /
+    // object-store backends finalize through the backend itself.
+    let state_store = match ctx.backend {
+        IdempotencyBackend::Local
+        | IdempotencyBackend::Valkey {
+            mirror_to_redb: true,
+            ..
+        } => match StateStore::open(state_path) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    idempotency_key = %ctx.key,
+                    run_id = run_id,
+                    "failed to open state store to stamp idempotency success; \
+                     key may remain InFlight until TTL sweep"
+                );
+                return;
+            }
+        },
+        _ => None,
+    };
+    if let Err(e) = ctx
+        .backend
+        .finalize(
+            state_store.as_ref(),
+            &ctx.key,
+            run_id,
+            FinalOutcome::Succeeded,
+            &ctx.config,
+        )
+        .await
+    {
+        warn!(
+            error = %e,
+            idempotency_key = %ctx.key,
+            run_id = run_id,
+            "failed to stamp idempotency success; key may remain InFlight until TTL sweep"
+        );
+    }
+}
+
 /// Execute `rocky run` — full pipeline.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, name = "run")]
@@ -808,9 +881,20 @@ pub async fn run(
 
     // Dispatch by pipeline type. Non-replication types have their own
     // execution paths and don't fall through to the replication logic below.
+    //
+    // Idempotency finalize: each non-replication arm stamps `Succeeded` on
+    // its happy-path exit via `finalize_idempotency_on_success`. We can't
+    // thread the claim into `run_local::run_*` / `load::run_load` without
+    // restructuring those four public entry points, so we stamp at the
+    // dispatch site after the delegated call returns `Ok(())`. The one-
+    // shot `.take()` on the ctx means the outer `run_result.is_err()`
+    // wrapper below is a no-op on the happy path — same invariant #237
+    // established for `finalize_idempotency`. On delegated `Err`, the
+    // `?` propagates out of the async block and the wrapper releases the
+    // `InFlight` stamp. FR-004 F2.
     match pipeline_config {
         rocky_core::config::PipelineConfig::Transformation(t) => {
-            return super::run_local::run_transformation(
+            super::run_local::run_transformation(
                 config_path,
                 t,
                 &rocky_cfg,
@@ -818,20 +902,26 @@ pub async fn run(
                 partition_opts,
                 &schema_cache_cfg,
             )
-            .await;
+            .await?;
+            finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
+            return Ok(());
         }
         rocky_core::config::PipelineConfig::Quality(q) => {
-            return super::run_local::run_quality(config_path, q, &rocky_cfg, output_json).await;
+            super::run_local::run_quality(config_path, q, &rocky_cfg, output_json).await?;
+            finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
+            return Ok(());
         }
         rocky_core::config::PipelineConfig::Snapshot(s) => {
-            return super::run_local::run_snapshot(config_path, s, &rocky_cfg, output_json).await;
+            super::run_local::run_snapshot(config_path, s, &rocky_cfg, output_json).await?;
+            finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
+            return Ok(());
         }
         rocky_core::config::PipelineConfig::Replication(_) => {}
         rocky_core::config::PipelineConfig::Load(_) => {
             // Delegate to the `rocky load` command, driving with the pipeline's
             // own source_dir/format/target. This lets `rocky run --pipeline X`
             // work uniformly across all pipeline types.
-            return super::load::run_load(
+            super::load::run_load(
                 config_path,
                 None, // cli_source_dir — take from config
                 None, // format — take from config
@@ -840,7 +930,9 @@ pub async fn run(
                 false, // truncate — honour config only
                 output_json,
             )
-            .await;
+            .await?;
+            finalize_idempotency_on_success(&mut idempotency_ctx, state_path, &run_id).await;
+            return Ok(());
         }
     }
 
@@ -4625,5 +4717,107 @@ mod tests {
         // Second call is a no-op — no panic, ctx remains None.
         finalize_idempotency(&mut ctx_slot, Some(&store), "run-ok", &output).await;
         assert!(ctx_slot.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // FR-004 F2 — success-path idempotency finalize for non-replication
+    // dispatch arms.
+    //
+    // The four non-replication arms (Transformation, Quality, Snapshot,
+    // Load) delegate to helpers in `run_local.rs` / `load.rs` that don't
+    // receive or produce an `IdempotencyCtx`. Before F2, those arms
+    // returned `Ok(())` directly from their dispatch branch — the happy
+    // path never called `finalize_idempotency`, and the error-path
+    // wrapper's `is_err()` check skipped it. The `InFlight` stamp then
+    // lingered until the 24h `in_flight_ttl_hours` sweep reaped it, and
+    // a retry with the same key inside that window returned
+    // `skipped_in_flight` instead of proceeding — the exact latent
+    // landmine #237 closed for the error path.
+    //
+    // This test drives `run()` end-to-end against a transformation
+    // pipeline and confirms the redb entry is `Succeeded`, not
+    // `InFlight`, after a successful run. Transformation is the cleanest
+    // of the four arms to exercise — a transformation pipeline with a
+    // missing models directory succeeds trivially without needing live
+    // adapter credentials, DDL, or warehouse mocks. Without the F2 fix,
+    // the `Succeeded` assertion fails because the entry is still
+    // `InFlight`.
+    // -----------------------------------------------------------------------
+    #[tokio::test]
+    async fn transformation_success_stamps_idempotency_succeeded_not_inflight() {
+        use rocky_core::idempotency::IdempotencyState;
+        use rocky_core::state::StateStore;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let config_dir = tmp.path();
+        let config_path = config_dir.join("rocky.toml");
+        // Transformation pipeline with a non-existent models dir.
+        // `run_transformation` warns and returns `Ok(())` — perfect for
+        // exercising the happy-path dispatch without needing warehouse
+        // state beyond an in-memory DuckDB handle.
+        std::fs::write(
+            &config_path,
+            r#"
+[adapter]
+type = "duckdb"
+path = ":memory:"
+
+[state]
+backend = "local"
+
+[pipeline.t]
+type = "transformation"
+models = "models_nonexistent/**"
+
+[pipeline.t.target]
+adapter = "default"
+"#,
+        )
+        .expect("write rocky.toml");
+
+        let state_path = config_dir.join("state.redb");
+
+        let key = "fr-004-f2-transformation-success";
+        let opts = PartitionRunOptions::default();
+
+        // Drive `run()` end-to-end. With `--idempotency-key`, the claim
+        // stamps InFlight before dispatch, then the Transformation arm
+        // returns Ok(()) and (post-F2) fires `finalize_idempotency_on_success`.
+        super::run(
+            &config_path,
+            None,
+            None,
+            &state_path,
+            None,
+            false,
+            None,
+            false,
+            None,
+            false,
+            None,
+            &opts,
+            None,
+            None,
+            Some(key),
+        )
+        .await
+        .expect("transformation run should succeed");
+
+        // Post-condition: the idempotency entry exists and is `Succeeded`.
+        // Pre-F2 this fails because the entry is still `InFlight` — the
+        // success-path never called finalize, and the error-path wrapper
+        // is a no-op when the body returned `Ok`.
+        let store = StateStore::open(&state_path).expect("reopen state store");
+        let entry = store
+            .idempotency_get(key)
+            .expect("get idempotency entry")
+            .expect("entry present — claim should have stamped it");
+        assert_eq!(
+            entry.state,
+            IdempotencyState::Succeeded,
+            "success-path finalize on the Transformation dispatch arm must stamp \
+             Succeeded, not leave the InFlight claim for the TTL sweep to reap \
+             (FR-004 F2 regression guard)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the success-path leak that the [#237](https://github.com/rocky-data/rocky/pull/237) (FR-004 F1) agent flagged as a follow-up. `rocky run --idempotency-key K` against a Transformation / Quality / Snapshot / Load pipeline successfully returned `Ok(())` but left its `InFlight` claim in place — the four non-replication dispatch arms delegated straight to `run_local::run_*` / `load::run_load` and returned without calling `finalize_idempotency`, and the error-path wrapper shipped in #237 only fires on `is_err()`. A retry with the same key inside `in_flight_ttl_hours` (default 24h) then returned `skipped_in_flight` for up to 24h instead of `skipped_idempotent`.

Each non-replication arm now stamps `Succeeded` on its happy-path exit via a new `finalize_idempotency_on_success` helper. Replication is unchanged — it already finalized correctly at its main exit in #235.

## Before / After per arm

All four arms previously had the shape `return super::run_local::run_X(...).await;` — the delegated helper returned `Ok(())`, the arm returned directly from `run()`, and the `IdempotencyCtx` stayed `Some(...)` (i.e. `InFlight`) until the outer wrapper's `is_err()` check skipped the error-path finalize.

| Arm | Before (happy path) | After (happy path) |
|---|---|---|
| `PipelineConfig::Transformation` | `return super::run_local::run_transformation(...).await;` — `InFlight` lingers | `.await?` then `finalize_idempotency_on_success(...)` then `return Ok(())` — stamped `Succeeded` |
| `PipelineConfig::Quality` | `return super::run_local::run_quality(...).await;` — `InFlight` lingers | same pattern — stamped `Succeeded` |
| `PipelineConfig::Snapshot` | `return super::run_local::run_snapshot(...).await;` — `InFlight` lingers | same pattern — stamped `Succeeded` |
| `PipelineConfig::Load` | `return super::load::run_load(...).await;` — `InFlight` lingers | same pattern — stamped `Succeeded` |

On the error path, each arm's `.await?` still propagates out of the async block and the `run_result.is_err()` wrapper in #237 releases the claim. The one-shot `.take()` on `IdempotencyCtx` makes the success-path finalize and the error-path wrapper mutually exclusive — whichever fires first drains the ctx.

## New helper

`finalize_idempotency_on_success` mirrors `finalize_idempotency_on_error`:
- Takes `&mut Option<IdempotencyCtx>` and `.take()`s the ctx (one-shot).
- Opens its own `StateStore` from the canonical `state_path` owned by `run()` — the four delegated helpers in `run_local.rs` use `config_dir.join(".rocky_state")` which may differ from the claim's location, so finalizing at `state_path` matches the claim exactly.
- Always stamps `FinalOutcome::Succeeded`.
- Best-effort throughout — any error swallowed with `warn!` so bookkeeping flake never flips a successful run to non-zero.

Why a dedicated helper instead of calling `finalize_idempotency` with a synthesized `RunOutput`? Semantically explicit. Constructing a default `RunOutput` just to feed `derive_run_status()` depends on an implicit "default = Success" assumption — if anyone changes that default, the success-path finalize silently drops to the skip-variant branch and the leak returns.

## New test

`transformation_success_stamps_idempotency_succeeded_not_inflight` drives `run()` end-to-end against a minimal transformation pipeline (DuckDB `:memory:` adapter, non-existent models dir so `run_transformation` warns-and-returns-Ok without needing live DDL) with `--idempotency-key` set. After the run returns `Ok(())`, it re-opens the redb state store and asserts the entry is `IdempotencyState::Succeeded`, not `InFlight`. Transformation is the cleanest arm to exercise — no warehouse credentials, no live DDL, pure happy-path dispatch.

Validated by commenting out the new `finalize_idempotency_on_success` call on the Transformation arm — the test fails with `InFlight != Succeeded`. Restored, it passes.

## Why #237's tests didn't catch this

#237's tests (`finalize_on_error_releases_inflight_claim_allowing_immediate_retry`, `finalize_on_error_is_one_shot_and_idempotent_when_ctx_already_taken`, `finalize_idempotency_is_one_shot_take`) exercise the helpers directly with hand-built `IdempotencyCtx` values. None of them drive `run()` end-to-end through a non-replication dispatch arm with `--idempotency-key` set. The happy-path gap was invisible to the test suite — the wrapper's `is_err()` check made the error path airtight, but nothing exercised the `Ok` case through a non-replication arm.

The new F2 test closes that gap by driving `run()` directly, which is why it catches the issue.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test -p rocky-cli` — 236 passed (including 4 idempotency tests: F1's 3 + F2's new 1)
- [x] `cargo test -p rocky-cli idempot` — 3 passed (the original F1 test name contains "releases_inflight" not "idempot" so shows up under a broader filter)
- [x] `cargo test -p rocky-cli run::tests` — 22 passed
- [x] `cargo test -p rocky-core --lib` — 1053 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `just codegen` — zero schema drift
- [x] `just regen-fixtures` — zero fixture drift

## Follow-ups not in scope

- No codegen cascade (no `*Output` struct or `RunStatus` variant changes).
- No Dagster / VS Code changes — the fix is engine-internal.
- No `CHANGELOG.md` entry for 1.15.0 (the known-follow-up list at line 65 already called F1 out; F2 was implicit). Added an `[Unreleased] / Fixed` entry for the next engine release.