### PR TITLE
feat(engine): FR-006 RunRecord audit trail + rocky history --audit

### DIFF
--- a/editors/vscode/src/types/generated/history.ts
+++ b/editors/vscode/src/types/generated/history.ts
@@ -19,6 +19,8 @@ export interface HistoryOutput {
 }
 /**
  * One run from the state store, mirroring `rocky_core::state::RunRecord` with serializable field types (no enums or non-JSON-friendly Rust types).
+ *
+ * The governance audit fields (`triggering_identity`, `session_source`, `git_commit`, `git_branch`, `idempotency_key`, `target_catalog`, `hostname`, `rocky_version`) are only populated in the `rocky history --audit` shape; the default shape continues to emit just the existing 7 fields. The `#[serde(skip_serializing_if = "…")]` attributes keep the default payload byte-identical to schema v5 unless `--audit` flips the fields on.
  */
 export interface RunHistoryRecord {
   /**
@@ -26,14 +28,46 @@ export interface RunHistoryRecord {
    */
   duration_ms: number;
   /**
+   * `git symbolic-ref --short HEAD` at claim time, or `None` on detached HEAD.
+   */
+  git_branch?: string | null;
+  /**
+   * `git rev-parse HEAD` at claim time.
+   */
+  git_commit?: string | null;
+  /**
+   * Machine hostname that produced the run.
+   */
+  hostname?: string | null;
+  /**
+   * The `--idempotency-key` value supplied to `rocky run`, if any.
+   */
+  idempotency_key?: string | null;
+  /**
    * Per-model execution details for this run.
    */
   models: RunModelRecord[];
   models_executed: number;
+  /**
+   * `CARGO_PKG_VERSION` of the `rocky` binary, or `"<pre-audit>"` on schema-v5 rows that predate the audit trail.
+   */
+  rocky_version?: string | null;
   run_id: string;
+  /**
+   * Session origin — `"cli"`, `"dagster"`, `"lsp"`, or `"http_api"`. Emitted as the lowercase variant string so JSON consumers can match on it without knowing the Rust enum shape.
+   */
+  session_source?: string | null;
   started_at: string;
   status: string;
+  /**
+   * Best-available target catalog — the `catalog_template` for replication pipelines, the literal `target.catalog` for transformation/quality/snapshot/load.
+   */
+  target_catalog?: string | null;
   trigger: string;
+  /**
+   * Resolved caller identity (Unix `$USER` / Windows `$USERNAME`). `None` in CI / container contexts where no human caller is discernible.
+   */
+  triggering_identity?: string | null;
   [k: string]: unknown;
 }
 /**

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1571,6 +1571,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,6 +3382,7 @@ dependencies = [
  "chrono",
  "criterion",
  "futures",
+ "hostname",
  "indexmap",
  "miette",
  "notify",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -45,6 +45,11 @@ large_enum_variant = "warn"
 # Async traits
 async-trait = "0.1"
 
+# Machine hostname detection for governance audit trail
+# (portable across Linux/macOS/Windows — std::env::var("HOSTNAME")
+# is Linux-only and unset on macOS by default).
+hostname = "0.4"
+
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -40,6 +40,7 @@ futures = { workspace = true }
 base64 = { workspace = true }
 notify = { workspace = true }
 blake3 = { workspace = true }
+hostname = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/engine/crates/rocky-cli/src/commands/cost.rs
+++ b/engine/crates/rocky-cli/src/commands/cost.rs
@@ -359,6 +359,14 @@ mod tests {
             models_executed: models,
             trigger: RunTrigger::Manual,
             config_hash: "cfghash".to_string(),
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "cost-test-host".to_string(),
+            rocky_version: "0.0.0-test".to_string(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -180,8 +180,10 @@ pub fn run_history(
         };
 
         if output_json {
-            let runs: Vec<RunHistoryRecord> =
-                filtered.iter().map(|r| record_to_history(r, audit)).collect();
+            let runs: Vec<RunHistoryRecord> = filtered
+                .iter()
+                .map(|r| record_to_history(r, audit))
+                .collect();
             let output = HistoryOutput {
                 version: VERSION.to_string(),
                 command: "history".to_string(),
@@ -239,10 +241,7 @@ fn print_audit_table(runs: &[RunRecord]) {
     println!("{}", "-".repeat(100));
     for run in runs {
         let run_id = &run.run_id[..run.run_id.len().min(11)];
-        let identity = run
-            .triggering_identity
-            .as_deref()
-            .unwrap_or("-");
+        let identity = run.triggering_identity.as_deref().unwrap_or("-");
         let identity = if identity.len() > 17 {
             &identity[..17]
         } else {

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 
-use rocky_core::state::StateStore;
+use rocky_core::state::{RunRecord, SessionSource, StateStore};
 
 use crate::output::{
     HistoryOutput, ModelExecutionRecord, ModelHistoryOutput, RunHistoryRecord, RunModelRecord,
@@ -14,11 +14,91 @@ use crate::output::{
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Convert a [`SessionSource`] enum value to its JSON wire string.
+/// Kept as a free fn (not a `Display` impl) so the string shape stays
+/// local to `history.rs` — adding or renaming a variant shouldn't ripple
+/// through other `rocky` commands that read the enum without emitting
+/// JSON.
+fn session_source_str(source: SessionSource) -> &'static str {
+    match source {
+        SessionSource::Cli => "cli",
+        SessionSource::Dagster => "dagster",
+        SessionSource::Lsp => "lsp",
+        SessionSource::HttpApi => "http_api",
+    }
+}
+
+/// Build a [`RunHistoryRecord`] from the state-store [`RunRecord`].
+/// The `audit` flag controls whether the 8-field governance audit
+/// trail is populated on the output record — default `false` keeps the
+/// JSON payload byte-identical to schema v5 for downstream consumers
+/// that haven't updated yet.
+fn record_to_history(run: &RunRecord, audit: bool) -> RunHistoryRecord {
+    let duration_ms = (run.finished_at - run.started_at).num_milliseconds().max(0) as u64;
+    let models: Vec<RunModelRecord> = run
+        .models_executed
+        .iter()
+        .map(|m| RunModelRecord {
+            model_name: m.model_name.clone(),
+            duration_ms: m.duration_ms,
+            rows_affected: m.rows_affected,
+            status: m.status.clone(),
+        })
+        .collect();
+    let (
+        triggering_identity,
+        session_source,
+        git_commit,
+        git_branch,
+        idempotency_key,
+        target_catalog,
+        hostname,
+        rocky_version,
+    ) = if audit {
+        (
+            run.triggering_identity.clone(),
+            Some(session_source_str(run.session_source).to_string()),
+            run.git_commit.clone(),
+            run.git_branch.clone(),
+            run.idempotency_key.clone(),
+            run.target_catalog.clone(),
+            Some(run.hostname.clone()),
+            Some(run.rocky_version.clone()),
+        )
+    } else {
+        (None, None, None, None, None, None, None, None)
+    };
+    RunHistoryRecord {
+        run_id: run.run_id.clone(),
+        started_at: run.started_at,
+        status: format!("{:?}", run.status),
+        trigger: format!("{:?}", run.trigger),
+        models_executed: run.models_executed.len(),
+        duration_ms,
+        models,
+        triggering_identity,
+        session_source,
+        git_commit,
+        git_branch,
+        idempotency_key,
+        target_catalog,
+        hostname,
+        rocky_version,
+    }
+}
+
 /// Execute `rocky history`.
+///
+/// When `audit` is true, both the JSON output (the eight new optional
+/// fields on [`RunHistoryRecord`]) and the text output (a second
+/// governance table below the default table) include the full audit
+/// trail. Defaults preserved so existing consumers don't see a
+/// schema change.
 pub fn run_history(
     state_path: &Path,
     model_filter: Option<&str>,
     since: Option<&str>,
+    audit: bool,
     output_json: bool,
 ) -> Result<()> {
     let store = StateStore::open_read_only(state_path)?;
@@ -100,32 +180,8 @@ pub fn run_history(
         };
 
         if output_json {
-            let runs: Vec<RunHistoryRecord> = filtered
-                .iter()
-                .map(|r| {
-                    let duration_ms =
-                        (r.finished_at - r.started_at).num_milliseconds().max(0) as u64;
-                    let models: Vec<RunModelRecord> = r
-                        .models_executed
-                        .iter()
-                        .map(|m| RunModelRecord {
-                            model_name: m.model_name.clone(),
-                            duration_ms: m.duration_ms,
-                            rows_affected: m.rows_affected,
-                            status: m.status.clone(),
-                        })
-                        .collect();
-                    RunHistoryRecord {
-                        run_id: r.run_id.clone(),
-                        started_at: r.started_at,
-                        status: format!("{:?}", r.status),
-                        trigger: format!("{:?}", r.trigger),
-                        models_executed: r.models_executed.len(),
-                        duration_ms,
-                        models,
-                    }
-                })
-                .collect();
+            let runs: Vec<RunHistoryRecord> =
+                filtered.iter().map(|r| record_to_history(r, audit)).collect();
             let output = HistoryOutput {
                 version: VERSION.to_string(),
                 command: "history".to_string(),
@@ -153,8 +209,157 @@ pub fn run_history(
                 );
             }
             println!("\nTotal runs: {}", filtered.len());
+
+            if audit {
+                print_audit_table(&filtered);
+            }
         }
     }
 
     Ok(())
+}
+
+/// Print the governance audit trail as a second table below the
+/// default run summary. Keeps the default output untouched; operators
+/// explicitly pass `--audit` when they need the governance view.
+///
+/// Column widths are intentionally modest — `git_commit` is printed
+/// short (8 chars) and `hostname` truncated to 16, so the table stays
+/// usable in a 160-column terminal.
+fn print_audit_table(runs: &[RunRecord]) {
+    if runs.is_empty() {
+        return;
+    }
+    println!();
+    println!("Governance audit trail (--audit):");
+    println!(
+        "{:<12} {:<18} {:<8} {:<10} {:<16} {:<20} {:<12}",
+        "RUN ID", "IDENTITY", "SOURCE", "COMMIT", "BRANCH", "CATALOG", "HOST"
+    );
+    println!("{}", "-".repeat(100));
+    for run in runs {
+        let run_id = &run.run_id[..run.run_id.len().min(11)];
+        let identity = run
+            .triggering_identity
+            .as_deref()
+            .unwrap_or("-");
+        let identity = if identity.len() > 17 {
+            &identity[..17]
+        } else {
+            identity
+        };
+        let source = session_source_str(run.session_source);
+        let commit = run
+            .git_commit
+            .as_deref()
+            .map(|c| &c[..c.len().min(8)])
+            .unwrap_or("-");
+        let branch_full = run.git_branch.as_deref().unwrap_or("-");
+        let branch = if branch_full.len() > 15 {
+            &branch_full[..15]
+        } else {
+            branch_full
+        };
+        let catalog_full = run.target_catalog.as_deref().unwrap_or("-");
+        let catalog = if catalog_full.len() > 19 {
+            &catalog_full[..19]
+        } else {
+            catalog_full
+        };
+        let host_full = run.hostname.as_str();
+        let host = if host_full.len() > 11 {
+            &host_full[..11]
+        } else {
+            host_full
+        };
+        println!(
+            "{:<12} {:<18} {:<8} {:<10} {:<16} {:<20} {:<12}",
+            run_id, identity, source, commit, branch, catalog, host
+        );
+    }
+    println!();
+    // Emit version + idempotency key as an extra per-run detail line
+    // because they don't fit a fixed-column layout cleanly.
+    for run in runs {
+        let run_id = &run.run_id[..run.run_id.len().min(11)];
+        let key = run.idempotency_key.as_deref().unwrap_or("-");
+        println!(
+            "  {}  version={}  idempotency_key={}",
+            run_id, run.rocky_version, key
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_core::state::{ModelExecution, RunStatus, RunTrigger};
+
+    fn sample_record() -> RunRecord {
+        RunRecord {
+            run_id: "run-abc-001".to_string(),
+            started_at: Utc::now(),
+            finished_at: Utc::now() + chrono::Duration::seconds(30),
+            status: RunStatus::Success,
+            models_executed: vec![ModelExecution {
+                model_name: "orders".to_string(),
+                started_at: Utc::now(),
+                finished_at: Utc::now(),
+                duration_ms: 1234,
+                rows_affected: Some(100),
+                status: "success".to_string(),
+                sql_hash: "hash1".to_string(),
+                bytes_scanned: None,
+                bytes_written: None,
+            }],
+            trigger: RunTrigger::Manual,
+            config_hash: "cfg-hash".to_string(),
+            triggering_identity: Some("hugo".to_string()),
+            session_source: SessionSource::Dagster,
+            git_commit: Some("1234567890abcdef1234567890abcdef12345678".to_string()),
+            git_branch: Some("feat/governance".to_string()),
+            idempotency_key: Some("my-key".to_string()),
+            target_catalog: Some("warehouse_main".to_string()),
+            hostname: "dev-laptop".to_string(),
+            rocky_version: "1.16.0".to_string(),
+        }
+    }
+
+    #[test]
+    fn record_to_history_skips_audit_fields_by_default() {
+        let record = sample_record();
+        let history = record_to_history(&record, false);
+        assert_eq!(history.run_id, "run-abc-001");
+        assert_eq!(history.trigger, "Manual");
+        assert!(history.triggering_identity.is_none());
+        assert!(history.session_source.is_none());
+        assert!(history.git_commit.is_none());
+        assert!(history.hostname.is_none());
+        assert!(history.rocky_version.is_none());
+    }
+
+    #[test]
+    fn record_to_history_populates_audit_fields_when_requested() {
+        let record = sample_record();
+        let history = record_to_history(&record, true);
+        assert_eq!(history.triggering_identity.as_deref(), Some("hugo"));
+        assert_eq!(history.session_source.as_deref(), Some("dagster"));
+        assert_eq!(
+            history.git_commit.as_deref(),
+            Some("1234567890abcdef1234567890abcdef12345678")
+        );
+        assert_eq!(history.git_branch.as_deref(), Some("feat/governance"));
+        assert_eq!(history.idempotency_key.as_deref(), Some("my-key"));
+        assert_eq!(history.target_catalog.as_deref(), Some("warehouse_main"));
+        assert_eq!(history.hostname.as_deref(), Some("dev-laptop"));
+        assert_eq!(history.rocky_version.as_deref(), Some("1.16.0"));
+    }
+
+    #[test]
+    fn session_source_str_round_trip() {
+        assert_eq!(session_source_str(SessionSource::Cli), "cli");
+        assert_eq!(session_source_str(SessionSource::Dagster), "dagster");
+        assert_eq!(session_source_str(SessionSource::Lsp), "lsp");
+        assert_eq!(session_source_str(SessionSource::HttpApi), "http_api");
+    }
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -34,6 +34,7 @@ mod playground;
 mod profile_storage;
 mod replay;
 mod run;
+mod run_audit;
 mod run_dag_exec;
 mod run_local;
 mod seed;

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -156,6 +156,14 @@ mod tests {
             models_executed,
             trigger: RunTrigger::Manual,
             config_hash: "cfghash".to_string(),
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "replay-test-host".to_string(),
+            rocky_version: "0.0.0-test".to_string(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -27,6 +27,7 @@ use crate::output::*;
 use crate::registry::{self, AdapterRegistry};
 use crate::schema_cache_writer::{SchemaCacheWriteTap, persist_batch_describe};
 
+use super::run_audit::AuditContext;
 use super::{matches_filter, parse_filter, parsed_to_json_map};
 
 /// Accumulated check results for a table, assembled after batched execution.
@@ -233,12 +234,31 @@ impl<'a> ExecutionContext<'a> {
 /// succeeded (or not) by the time we reach here; a state-store write
 /// failure must not flip the exit code. Matches the resilience posture
 /// of state_sync aborts elsewhere in this file.
+/// Convert the CLI-level [`AuditContext`] into the output-layer
+/// [`RunRecordAudit`] bundle. Kept as a free fn (not a `From` impl) so
+/// `run_audit` stays free of a dependency on `crate::output` — the
+/// audit module is pure environment-probing with no JSON-schema
+/// surface.
+fn audit_to_record(ctx: &AuditContext) -> RunRecordAudit {
+    RunRecordAudit {
+        triggering_identity: ctx.triggering_identity.clone(),
+        session_source: ctx.session_source,
+        git_commit: ctx.git_commit.clone(),
+        git_branch: ctx.git_branch.clone(),
+        idempotency_key: ctx.idempotency_key.clone(),
+        target_catalog: ctx.target_catalog.clone(),
+        hostname: ctx.hostname.clone(),
+        rocky_version: ctx.rocky_version.clone(),
+    }
+}
+
 fn persist_run_record(
     state_store: Option<&StateStore>,
     output: &RunOutput,
     run_id: &str,
     started_at: DateTime<Utc>,
     config_hash: &str,
+    audit: &RunRecordAudit,
 ) {
     let Some(store) = state_store else {
         return;
@@ -252,6 +272,7 @@ fn persist_run_record(
         config_hash.to_string(),
         rocky_core::state::RunTrigger::Manual,
         status,
+        audit.clone(),
     );
     if let Err(e) = store.record_run(&record) {
         warn!(
@@ -829,12 +850,23 @@ pub async fn run(
         // Persist the model-only RunRecord. `rocky replay <run_id>` + cost
         // queries work against per-asset materializations the same way as
         // full-pipeline runs.
+        //
+        // Audit context: model-only runs have no single target catalog
+        // (we don't know which pipeline's templates are in scope), so
+        // `target_catalog = None`. Every other audit field populates
+        // normally.
+        let audit_ctx = AuditContext::detect(
+            idempotency_ctx.as_ref().map(|c| c.key.clone()),
+            None,
+        );
+        let audit = audit_to_record(&audit_ctx);
         persist_run_record(
             state_store.as_ref(),
             &output,
             &run_id,
             started_at,
             &config_hash,
+            &audit,
         );
         finalize_idempotency(
             &mut idempotency_ctx,
@@ -939,6 +971,21 @@ pub async fn run(
     let pipeline = pipeline_config
         .as_replication()
         .context("expected replication pipeline")?;
+
+    // Build the governance audit context once, at the top of the
+    // replication path. Every `persist_run_record` call site (happy
+    // exit, interrupted exit) pulls from the same bundle so a single
+    // `rocky run` invocation produces a consistent stamp across all
+    // terminal branches. For replication pipelines the target catalog
+    // is templated (`{client}`, etc.) and resolves per-table — we
+    // record the literal template string here as the "best available
+    // at claim time" answer; per-table resolutions remain on each
+    // `ModelExecution`.
+    let audit_ctx = AuditContext::detect(
+        idempotency_ctx.as_ref().map(|c| c.key.clone()),
+        Some(pipeline.target.catalog_template.clone()),
+    );
+    let audit = audit_to_record(&audit_ctx);
 
     // All adapters flow through this production-grade execution path.
     // Databricks-specific batch optimizations (batch describe, batch tagging,
@@ -2152,6 +2199,7 @@ pub async fn run(
                 &shared_run_id,
                 started_at,
                 &config_hash,
+                &audit,
             );
             finalize_idempotency(
                 &mut idempotency_ctx,
@@ -2778,6 +2826,7 @@ pub async fn run(
         &run_id,
         started_at,
         &config_hash,
+        &audit,
     );
     finalize_idempotency(
         &mut idempotency_ctx,

--- a/engine/crates/rocky-cli/src/commands/run_audit.rs
+++ b/engine/crates/rocky-cli/src/commands/run_audit.rs
@@ -1,0 +1,313 @@
+//! Governance audit-trail field derivation for `rocky run` (§1.4).
+//!
+//! Each field is populated *best-effort* — no single helper here is
+//! permitted to fail the pipeline. Identity / git / session-source are
+//! all environment-dependent and commonly unknowable in CI / container
+//! contexts, so every detector returns either an [`Option`] (truly
+//! optional) or a sentinel string (for the required fields).
+//!
+//! Call [`AuditContext::detect`] at `rocky run` claim time. The
+//! resulting struct is threaded into
+//! [`crate::output::RunOutput::to_run_record`] and stamped onto the
+//! persisted [`rocky_core::state::RunRecord`].
+//!
+//! # Environment variables consulted
+//!
+//! | Variable | Purpose |
+//! |---|---|
+//! | `DAGSTER_PIPES_CONTEXT` | If present, session source = Dagster |
+//! | `ROCKY_SESSION_SOURCE` | Explicit override (`cli` / `dagster` / `lsp` / `http_api`) |
+//! | `USER` (Unix) / `USERNAME` (Windows) | Triggering identity |
+//!
+//! # Subprocess usage
+//!
+//! Git info is collected by shelling out to the system `git` binary
+//! (no `gix` dep in the workspace, and shelling is simpler for v1 given
+//! we only need two fixed commands). Each subprocess is synchronous
+//! but short-lived — `git rev-parse HEAD` typically completes in
+//! single-digit milliseconds on any non-pathological checkout. Timeouts
+//! are not enforced because the detector runs once per invocation; a
+//! hung `git` would be already evident from shell tooling.
+
+use std::process::Command;
+
+use rocky_core::state::SessionSource;
+
+/// Bundle of audit fields stamped onto every [`rocky_core::state::RunRecord`]
+/// at `rocky run` claim time. Required fields (`hostname`,
+/// `rocky_version`, `session_source`) always resolve to some value;
+/// optional fields remain [`None`] when the environment doesn't offer
+/// enough signal.
+#[derive(Debug, Clone)]
+pub(crate) struct AuditContext {
+    pub triggering_identity: Option<String>,
+    pub session_source: SessionSource,
+    pub git_commit: Option<String>,
+    pub git_branch: Option<String>,
+    pub idempotency_key: Option<String>,
+    pub target_catalog: Option<String>,
+    pub hostname: String,
+    pub rocky_version: String,
+}
+
+impl AuditContext {
+    /// Run every detector against the live process environment. Never
+    /// fails — fallback sentinels are baked into the individual helpers.
+    ///
+    /// # Arguments
+    ///
+    /// * `idempotency_key` — the `--idempotency-key` value threaded
+    ///   through from the CLI, or `None` if unset.
+    /// * `target_catalog` — best-available catalog at claim time. For
+    ///   replication pipelines this is typically the raw
+    ///   `catalog_template` string (pre-resolution); for
+    ///   transformation/quality/snapshot/load pipelines it's the fully
+    ///   resolved `target.catalog`. `None` on model-only runs where no
+    ///   pipeline context exists.
+    pub fn detect(
+        idempotency_key: Option<String>,
+        target_catalog: Option<String>,
+    ) -> Self {
+        Self {
+            triggering_identity: detect_triggering_identity(),
+            session_source: detect_session_source(),
+            git_commit: detect_git_commit(),
+            git_branch: detect_git_branch(),
+            idempotency_key,
+            target_catalog,
+            hostname: detect_hostname(),
+            rocky_version: ROCKY_VERSION.to_string(),
+        }
+    }
+}
+
+/// Version string baked into the binary at compile time. Exposed as a
+/// module constant so tests can reference the exact same value the
+/// production code stamps.
+const ROCKY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Name of the env var an HTTP API caller sets to mark themselves as
+/// the session origin. Exposed (pub(crate)) so tests can flip it.
+const ENV_ROCKY_SESSION_SOURCE: &str = "ROCKY_SESSION_SOURCE";
+
+/// Env var set by Dagster's Pipes subprocess client. Detecting it is
+/// sufficient signal for `SessionSource::Dagster` even when Rocky
+/// isn't emitting Pipes messages back — the caller shape is what
+/// matters for audit purposes.
+const ENV_DAGSTER_PIPES_CONTEXT: &str = "DAGSTER_PIPES_CONTEXT";
+
+/// Best-effort caller identity. Returns `$USER` on Unix, `$USERNAME`
+/// on Windows, or [`None`] if neither is set (common in minimal CI
+/// containers). Both values are read uncritically — no validation —
+/// because this is an audit stamp, not an authentication boundary.
+fn detect_triggering_identity() -> Option<String> {
+    // $USER covers Linux + macOS; $USERNAME is Windows' equivalent.
+    // Both are standard shell / C-runtime conventions.
+    std::env::var("USER")
+        .ok()
+        .or_else(|| std::env::var("USERNAME").ok())
+        .filter(|s| !s.is_empty())
+}
+
+/// Classify where the current `rocky` invocation originated, based on
+/// environment signals. Precedence (highest to lowest):
+///
+/// 1. Explicit `ROCKY_SESSION_SOURCE=<value>` — the caller's own
+///    declaration wins. Unknown values fall through to step 2.
+/// 2. `DAGSTER_PIPES_CONTEXT` set → [`SessionSource::Dagster`].
+/// 3. Default → [`SessionSource::Cli`].
+///
+/// Values accepted for `ROCKY_SESSION_SOURCE` (case-insensitive):
+/// `"cli"`, `"dagster"`, `"lsp"`, `"http_api"`. Anything else is
+/// silently ignored — better to fall back to the env-detected default
+/// than to reject a run over a typo'd audit-stamp var.
+fn detect_session_source() -> SessionSource {
+    if let Ok(explicit) = std::env::var(ENV_ROCKY_SESSION_SOURCE) {
+        match explicit.to_ascii_lowercase().as_str() {
+            "cli" => return SessionSource::Cli,
+            "dagster" => return SessionSource::Dagster,
+            "lsp" => return SessionSource::Lsp,
+            "http_api" | "http-api" | "httpapi" => return SessionSource::HttpApi,
+            _ => {}
+        }
+    }
+    if std::env::var(ENV_DAGSTER_PIPES_CONTEXT).is_ok() {
+        return SessionSource::Dagster;
+    }
+    SessionSource::Cli
+}
+
+/// Run `git rev-parse HEAD` in the current working directory and
+/// return the stdout trimmed. Returns [`None`] when `git` is absent,
+/// when the command exits non-zero (e.g. not a git checkout), or when
+/// the stdout is empty.
+fn detect_git_commit() -> Option<String> {
+    run_git(&["rev-parse", "HEAD"])
+}
+
+/// Run `git symbolic-ref --short HEAD`. Returns [`None`] on detached
+/// HEAD (common in CI / GitHub Actions checkout-ref mode), non-git
+/// checkouts, or missing `git` binary.
+fn detect_git_branch() -> Option<String> {
+    run_git(&["symbolic-ref", "--short", "HEAD"])
+}
+
+/// Shared helper for the two `git` subprocess calls. Suppresses
+/// stderr so the `rocky` process log stays quiet when `git` isn't
+/// available or the checkout isn't a git repo — those are both
+/// expected on production hosts.
+fn run_git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Hostname of the machine running `rocky`. Uses the `hostname` crate
+/// which portably covers Linux / macOS / Windows; falls back to
+/// `"unknown"` only if the underlying libc call somehow fails (in
+/// practice: never — `gethostname` is infallible on all three major
+/// platforms).
+fn detect_hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|os_str| os_str.into_string().ok())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The env-var tests mutate process-global state. `cargo test` runs
+    // them in parallel by default, so we serialise via a crate-local
+    // mutex. Each test takes the lock before touching env vars.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// SAFETY: these tests run under `ENV_LOCK`, which serialises every
+    /// env-mutating test in this module. Rust flags `std::env::set_var`
+    /// as unsafe from 2024 edition because it races with reads in
+    /// other threads; the lock closes that hole for *our* tests, not
+    /// for unrelated code running under `cargo test`. That's
+    /// considered acceptable here because (a) the remaining engine
+    /// test suite doesn't read these particular env vars in parallel,
+    /// and (b) the cost of a bug here is a misattributed audit stamp
+    /// in a unit test — not a production correctness issue.
+    fn set_env(key: &str, value: &str) {
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    fn remove_env(key: &str) {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn rocky_version_is_compile_time_constant() {
+        let ctx = AuditContext::detect(None, None);
+        assert_eq!(ctx.rocky_version, env!("CARGO_PKG_VERSION"));
+        assert!(!ctx.rocky_version.is_empty());
+    }
+
+    #[test]
+    fn hostname_is_always_populated() {
+        let ctx = AuditContext::detect(None, None);
+        assert!(!ctx.hostname.is_empty());
+    }
+
+    #[test]
+    fn session_source_defaults_to_cli() {
+        let _g = ENV_LOCK.lock().unwrap();
+        remove_env(ENV_ROCKY_SESSION_SOURCE);
+        remove_env(ENV_DAGSTER_PIPES_CONTEXT);
+        assert_eq!(detect_session_source(), SessionSource::Cli);
+    }
+
+    #[test]
+    fn session_source_dagster_from_pipes_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        remove_env(ENV_ROCKY_SESSION_SOURCE);
+        set_env(ENV_DAGSTER_PIPES_CONTEXT, "{}");
+        assert_eq!(detect_session_source(), SessionSource::Dagster);
+        remove_env(ENV_DAGSTER_PIPES_CONTEXT);
+    }
+
+    #[test]
+    fn session_source_explicit_override() {
+        let _g = ENV_LOCK.lock().unwrap();
+        remove_env(ENV_DAGSTER_PIPES_CONTEXT);
+
+        set_env(ENV_ROCKY_SESSION_SOURCE, "http_api");
+        assert_eq!(detect_session_source(), SessionSource::HttpApi);
+
+        set_env(ENV_ROCKY_SESSION_SOURCE, "lsp");
+        assert_eq!(detect_session_source(), SessionSource::Lsp);
+
+        set_env(ENV_ROCKY_SESSION_SOURCE, "DAGSTER");
+        assert_eq!(detect_session_source(), SessionSource::Dagster);
+
+        // Garbage value falls through to env-detected default.
+        set_env(ENV_ROCKY_SESSION_SOURCE, "garbage_value");
+        assert_eq!(detect_session_source(), SessionSource::Cli);
+
+        remove_env(ENV_ROCKY_SESSION_SOURCE);
+    }
+
+    #[test]
+    fn session_source_explicit_overrides_pipes_env() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_env(ENV_DAGSTER_PIPES_CONTEXT, "{}");
+        set_env(ENV_ROCKY_SESSION_SOURCE, "cli");
+        assert_eq!(
+            detect_session_source(),
+            SessionSource::Cli,
+            "explicit ROCKY_SESSION_SOURCE=cli must override DAGSTER_PIPES_CONTEXT"
+        );
+        remove_env(ENV_DAGSTER_PIPES_CONTEXT);
+        remove_env(ENV_ROCKY_SESSION_SOURCE);
+    }
+
+    #[test]
+    fn git_detection_returns_some_in_repo() {
+        // This test runs from the rocky monorepo, which is itself a
+        // git checkout, so both calls should succeed. In a release
+        // tarball build (where `git` isn't available on the test host)
+        // they'd return None — both outcomes are valid, so we assert
+        // only the "at least one looks like a SHA when Some" invariant.
+        if let Some(commit) = detect_git_commit() {
+            assert_eq!(
+                commit.len(),
+                40,
+                "git rev-parse HEAD should return 40-char SHA: {commit}"
+            );
+            assert!(commit.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn idempotency_and_target_catalog_threaded_through() {
+        let ctx = AuditContext::detect(
+            Some("my-idemp-key-123".to_string()),
+            Some("warehouse_main".to_string()),
+        );
+        assert_eq!(ctx.idempotency_key, Some("my-idemp-key-123".to_string()));
+        assert_eq!(ctx.target_catalog, Some("warehouse_main".to_string()));
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/run_audit.rs
+++ b/engine/crates/rocky-cli/src/commands/run_audit.rs
@@ -64,10 +64,7 @@ impl AuditContext {
     ///   transformation/quality/snapshot/load pipelines it's the fully
     ///   resolved `target.catalog`. `None` on model-only runs where no
     ///   pipeline context exists.
-    pub fn detect(
-        idempotency_key: Option<String>,
-        target_catalog: Option<String>,
-    ) -> Self {
+    pub fn detect(idempotency_key: Option<String>, target_catalog: Option<String>) -> Self {
         Self {
             triggering_identity: detect_triggering_identity(),
             session_source: detect_session_source(),

--- a/engine/crates/rocky-cli/src/commands/trace.rs
+++ b/engine/crates/rocky-cli/src/commands/trace.rs
@@ -264,6 +264,14 @@ mod tests {
             models_executed: models,
             trigger: RunTrigger::Manual,
             config_hash: "cfghash".to_string(),
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "trace-test-host".to_string(),
+            rocky_version: "0.0.0-test".to_string(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -996,6 +996,14 @@ pub struct ModelHistoryOutput {
 
 /// One run from the state store, mirroring `rocky_core::state::RunRecord`
 /// with serializable field types (no enums or non-JSON-friendly Rust types).
+///
+/// The governance audit fields (`triggering_identity`, `session_source`,
+/// `git_commit`, `git_branch`, `idempotency_key`, `target_catalog`,
+/// `hostname`, `rocky_version`) are only populated in the
+/// `rocky history --audit` shape; the default shape continues to emit
+/// just the existing 7 fields. The `#[serde(skip_serializing_if = "…")]`
+/// attributes keep the default payload byte-identical to schema v5
+/// unless `--audit` flips the fields on.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct RunHistoryRecord {
     pub run_id: String,
@@ -1007,6 +1015,40 @@ pub struct RunHistoryRecord {
     pub duration_ms: u64,
     /// Per-model execution details for this run.
     pub models: Vec<RunModelRecord>,
+
+    // --- Governance audit trail (populated only with `--audit`) ---
+    /// Resolved caller identity (Unix `$USER` / Windows `$USERNAME`).
+    /// `None` in CI / container contexts where no human caller is
+    /// discernible.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub triggering_identity: Option<String>,
+    /// Session origin — `"cli"`, `"dagster"`, `"lsp"`, or `"http_api"`.
+    /// Emitted as the lowercase variant string so JSON consumers can
+    /// match on it without knowing the Rust enum shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_source: Option<String>,
+    /// `git rev-parse HEAD` at claim time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
+    /// `git symbolic-ref --short HEAD` at claim time, or `None` on
+    /// detached HEAD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_branch: Option<String>,
+    /// The `--idempotency-key` value supplied to `rocky run`, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Best-available target catalog — the `catalog_template` for
+    /// replication pipelines, the literal `target.catalog` for
+    /// transformation/quality/snapshot/load.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_catalog: Option<String>,
+    /// Machine hostname that produced the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    /// `CARGO_PKG_VERSION` of the `rocky` binary, or `"<pre-audit>"`
+    /// on schema-v5 rows that predate the audit trail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rocky_version: Option<String>,
 }
 
 /// Per-model execution record embedded in [`RunHistoryRecord`].
@@ -1908,6 +1950,50 @@ impl ChecksConfigOutput {
     }
 }
 
+/// Governance audit-trail values threaded into
+/// [`RunOutput::to_run_record`] at run finalise time. Mirrors the 8
+/// audit fields on [`rocky_core::state::RunRecord`] (§1.4).
+///
+/// Populated once per invocation by
+/// `rocky_cli::commands::run_audit::AuditContext::detect` and then
+/// re-used for every `persist_run_record` call site (model-only
+/// happy path, interrupted, replication main exit). Re-collecting at
+/// every call site would stamp the interrupted exit path with a
+/// different `hostname` than the initial claim on a machine that
+/// changed identity mid-run — unlikely, but trivially prevented by
+/// caching the bundle up front.
+#[derive(Debug, Clone)]
+pub struct RunRecordAudit {
+    pub triggering_identity: Option<String>,
+    pub session_source: rocky_core::state::SessionSource,
+    pub git_commit: Option<String>,
+    pub git_branch: Option<String>,
+    pub idempotency_key: Option<String>,
+    pub target_catalog: Option<String>,
+    pub hostname: String,
+    pub rocky_version: String,
+}
+
+impl RunRecordAudit {
+    /// Test-only constructor — every field set to a sentinel that
+    /// makes any field confusion in a unit test obvious. Never used
+    /// outside `#[cfg(test)]` call sites, so the `_test` suffix is an
+    /// API tripwire rather than an invariant.
+    #[cfg(test)]
+    pub fn test_sentinels() -> Self {
+        Self {
+            triggering_identity: None,
+            session_source: rocky_core::state::SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "output-test-host".to_string(),
+            rocky_version: "0.0.0-test".to_string(),
+        }
+    }
+}
+
 impl RunOutput {
     pub fn new(filter: String, duration_ms: u64, concurrency: usize) -> Self {
         RunOutput {
@@ -2112,6 +2198,14 @@ impl RunOutput {
     /// `model_name` is derived from the last element of
     /// [`MaterializationOutput::asset_key`] to match how `rocky cost` /
     /// `rocky history` reference models.
+    ///
+    /// # Audit context
+    ///
+    /// Every `RunRecord` stamps the governance audit trail (schema v6,
+    /// §1.4) from an
+    /// [`rocky_core::state::RunRecordAudit`] bundle. Callers collect
+    /// the fields once at claim time via
+    /// `rocky_cli::commands::run_audit::AuditContext::detect`.
     pub fn to_run_record(
         &self,
         run_id: &str,
@@ -2120,6 +2214,7 @@ impl RunOutput {
         config_hash: String,
         trigger: rocky_core::state::RunTrigger,
         status: rocky_core::state::RunStatus,
+        audit: RunRecordAudit,
     ) -> rocky_core::state::RunRecord {
         let mut models = Vec::with_capacity(self.materializations.len() + self.errors.len());
 
@@ -2173,6 +2268,14 @@ impl RunOutput {
             models_executed: models,
             trigger,
             config_hash,
+            triggering_identity: audit.triggering_identity,
+            session_source: audit.session_source,
+            git_commit: audit.git_commit,
+            git_branch: audit.git_branch,
+            idempotency_key: audit.idempotency_key,
+            target_catalog: audit.target_catalog,
+            hostname: audit.hostname,
+            rocky_version: audit.rocky_version,
         }
     }
 
@@ -2587,6 +2690,7 @@ mod run_record_tests {
             "cfghash".to_string(),
             RunTrigger::Manual,
             RunStatus::Success,
+            RunRecordAudit::test_sentinels(),
         );
 
         assert_eq!(record.run_id, "run-test-1");
@@ -2640,6 +2744,7 @@ mod run_record_tests {
             String::new(),
             RunTrigger::Manual,
             out.derive_run_status(),
+            RunRecordAudit::test_sentinels(),
         );
 
         assert_eq!(record.models_executed.len(), 2);

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2206,6 +2206,7 @@ impl RunOutput {
     /// [`rocky_core::state::RunRecordAudit`] bundle. Callers collect
     /// the fields once at claim time via
     /// `rocky_cli::commands::run_audit::AuditContext::detect`.
+    #[allow(clippy::too_many_arguments)]
     pub fn to_run_record(
         &self,
         run_id: &str,

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -2371,9 +2371,7 @@ mod tests {
         let txn = store.db.begin_write().unwrap();
         {
             let mut table = txn.open_table(RUN_HISTORY).unwrap();
-            table
-                .insert("run-v5-via-redb", v5_blob.as_slice())
-                .unwrap();
+            table.insert("run-v5-via-redb", v5_blob.as_slice()).unwrap();
         }
         txn.commit().unwrap();
 

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -87,7 +87,21 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 /// Increment this constant whenever a table is added, removed, or structurally
 /// changed in a way that is incompatible with an older binary. Rocky will
 /// refuse to open a database whose stored version exceeds this value.
-const CURRENT_SCHEMA_VERSION: u32 = 5;
+///
+/// # Version history
+///
+/// - **v5** — idempotency keys table; pre-audit `RunRecord` shape
+///   (run_id / started_at / finished_at / status / models_executed /
+///   trigger / config_hash).
+/// - **v6** — adds the 8-field governance audit trail to
+///   [`RunRecord`] (`triggering_identity`, `session_source`, `git_commit`,
+///   `git_branch`, `idempotency_key`, `target_catalog`, `hostname`,
+///   `rocky_version`). v5 records forward-deserialize as v6 via
+///   `#[serde(default)]` on each new field — no in-place blob rewrite
+///   is required. See the `RunRecord` docs for the default-value
+///   contract (`hostname = "unknown"`, `rocky_version = "<pre-audit>"`,
+///   `session_source = Cli`).
+const CURRENT_SCHEMA_VERSION: u32 = 6;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -549,6 +563,50 @@ pub enum RunTrigger {
     Ci,
 }
 
+/// Where the `rocky` invocation originated — the calling surface that
+/// spawned the process.
+///
+/// Stamped on every [`RunRecord`] at claim time for the governance audit
+/// trail (§1.4 item 2). The CLI derives it from the environment:
+///
+/// - [`SessionSource::Dagster`] — `DAGSTER_PIPES_CONTEXT` is set (Dagster's
+///   Pipes protocol populates this when a Pipes client launches the
+///   subprocess — whether or not the binary emits Pipes messages back).
+/// - [`SessionSource::HttpApi`] — `ROCKY_SESSION_SOURCE=http_api` is set
+///   (an HTTP caller explicitly stamps itself; Rocky's server never
+///   spawns `rocky run` today, but the variant is reserved for future
+///   wiring).
+/// - [`SessionSource::Lsp`] — `ROCKY_SESSION_SOURCE=lsp` is set. Reserved
+///   for completeness; the LSP server (`rocky lsp`) handles requests
+///   in-process rather than shelling out to `rocky run`, so this is
+///   effectively unreachable today.
+/// - [`SessionSource::Cli`] — the fallback. A human / script / CI runner
+///   invoking `rocky run` directly.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionSource {
+    /// Direct invocation — shell, script, or CI runner.
+    Cli,
+    /// Dagster Pipes / subprocess client launched the process.
+    Dagster,
+    /// LSP server invoked the run. Reserved; see enum-level docs.
+    Lsp,
+    /// HTTP API caller stamped itself via `ROCKY_SESSION_SOURCE=http_api`.
+    HttpApi,
+}
+
+impl Default for SessionSource {
+    /// The deserialization default for `session_source` on v5→v6 records.
+    /// Pre-audit rows that predate the audit-trail field surface as
+    /// [`SessionSource::Cli`] — a safe, maximally-general choice since the
+    /// overwhelming majority of historical invocations ran via shell.
+    fn default() -> Self {
+        SessionSource::Cli
+    }
+}
+
 /// Execution record for a single model within a run.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelExecution {
@@ -585,6 +643,30 @@ pub struct ModelExecution {
 }
 
 /// A complete pipeline run record.
+///
+/// # Governance audit trail (schema v6)
+///
+/// The eight `triggering_identity` / `session_source` / `git_commit` /
+/// `git_branch` / `idempotency_key` / `target_catalog` / `hostname` /
+/// `rocky_version` fields form the governance audit trail introduced in
+/// state schema v6. They are populated at claim time in
+/// `rocky_cli::commands::run::persist_run_record` via helpers in
+/// `rocky_cli::commands::run_audit`.
+///
+/// Every new field is serde-defaulted so v5 records (which lack these
+/// fields entirely) forward-deserialize cleanly:
+///
+/// - Option-typed fields default to `None`.
+/// - [`SessionSource`] defaults to [`SessionSource::Cli`].
+/// - `hostname` defaults to `"unknown"`.
+/// - `rocky_version` defaults to `"<pre-audit>"` — a sentinel so
+///   operators can tell a pre-audit row apart from a real binary that
+///   happened to read `CARGO_PKG_VERSION` as `"unknown"`.
+///
+/// The redb blob format is `serde_json::to_vec(&record)`, so the upgrade
+/// is zero-touch at the storage layer: no in-place migration, no blob
+/// walk. A `test_v5_run_record_forward_deserializes_with_defaults` guard
+/// in this file pins the contract.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RunRecord {
     pub run_id: String,
@@ -594,6 +676,72 @@ pub struct RunRecord {
     pub models_executed: Vec<ModelExecution>,
     pub trigger: RunTrigger,
     pub config_hash: String,
+
+    // --- Governance audit trail (schema v6 — §1.4) ---
+    /// Best-effort caller identity. `$USER` on Unix, `%USERNAME%` on
+    /// Windows; `None` in CI/containers without a clear human caller.
+    /// SSO `sub` claim extraction (Snowflake / Databricks OAuth) is a
+    /// deferred follow-up.
+    #[serde(default)]
+    pub triggering_identity: Option<String>,
+
+    /// Where the `rocky` invocation originated (CLI / Dagster / LSP /
+    /// HTTP). See [`SessionSource`] for the derivation rules. Defaults
+    /// to [`SessionSource::Cli`] on v5 records.
+    #[serde(default)]
+    pub session_source: SessionSource,
+
+    /// `git rev-parse HEAD` at claim time. `None` when the working
+    /// directory is not a git checkout or `git` is not on PATH.
+    #[serde(default)]
+    pub git_commit: Option<String>,
+
+    /// `git symbolic-ref --short HEAD` at claim time. `None` on detached
+    /// HEAD or non-git checkouts.
+    #[serde(default)]
+    pub git_branch: Option<String>,
+
+    /// The `--idempotency-key` value for this run, or `None` if the flag
+    /// was not supplied. When present, matches the key stamped into the
+    /// `idempotency_keys` table (PR #235).
+    #[serde(default)]
+    pub idempotency_key: Option<String>,
+
+    /// Best-available target catalog for the pipeline at claim time.
+    /// `None` when no catalog is resolvable (e.g. model-only run without
+    /// a concrete pipeline context). For templated catalogs
+    /// (`catalog_template = "{client}"`) this captures the literal
+    /// template string — per-table resolutions are already recorded on
+    /// the individual [`ModelExecution`] entries.
+    #[serde(default)]
+    pub target_catalog: Option<String>,
+
+    /// The machine that produced the run, from the `hostname` crate.
+    /// Defaults to `"unknown"` on v5 records.
+    #[serde(default = "default_hostname_sentinel")]
+    pub hostname: String,
+
+    /// Compile-time `env!("CARGO_PKG_VERSION")` of the `rocky` binary.
+    /// Defaults to `"<pre-audit>"` on v5 records — distinguishes a
+    /// pre-audit row from a future binary that reports a literal
+    /// `"unknown"` version string.
+    #[serde(default = "default_rocky_version_sentinel")]
+    pub rocky_version: String,
+}
+
+/// Default-value contract for `RunRecord.hostname` on v5→v6 upgrade.
+/// Kept as a top-level fn because `#[serde(default = "...")]` requires a
+/// function path, not a closure or const.
+fn default_hostname_sentinel() -> String {
+    "unknown".to_string()
+}
+
+/// Default-value contract for `RunRecord.rocky_version` on v5→v6
+/// upgrade. The `<…>` bracket syntax is intentionally not a valid
+/// semver string — operators inspecting `rocky history --audit` can
+/// tell a pre-audit row apart from any real binary at a glance.
+fn default_rocky_version_sentinel() -> String {
+    "<pre-audit>".to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -2036,15 +2184,35 @@ mod tests {
 
     // --- Run history tests ---
 
-    #[test]
-    fn test_record_and_get_run() {
-        let (store, _dir) = temp_store();
-        let run = RunRecord {
-            run_id: "run-001".to_string(),
+    /// Test-only builder for a minimal [`RunRecord`] with audit fields
+    /// zeroed to their defaults. Centralised so adding a future audit
+    /// field doesn't churn every existing test in this file.
+    fn minimal_run_record(run_id: &str, models: Vec<ModelExecution>) -> RunRecord {
+        RunRecord {
+            run_id: run_id.to_string(),
             started_at: Utc::now(),
             finished_at: Utc::now(),
             status: RunStatus::Success,
-            models_executed: vec![ModelExecution {
+            models_executed: models,
+            trigger: RunTrigger::Manual,
+            config_hash: "config-hash".to_string(),
+            triggering_identity: None,
+            session_source: SessionSource::Cli,
+            git_commit: None,
+            git_branch: None,
+            idempotency_key: None,
+            target_catalog: None,
+            hostname: "test-host".to_string(),
+            rocky_version: "0.0.0-test".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_record_and_get_run() {
+        let (store, _dir) = temp_store();
+        let run = minimal_run_record(
+            "run-001",
+            vec![ModelExecution {
                 model_name: "orders".to_string(),
                 started_at: Utc::now(),
                 finished_at: Utc::now(),
@@ -2055,9 +2223,7 @@ mod tests {
                 bytes_scanned: None,
                 bytes_written: None,
             }],
-            trigger: RunTrigger::Manual,
-            config_hash: "config-hash".to_string(),
-        };
+        );
         store.record_run(&run).unwrap();
 
         let retrieved = store.get_run("run-001").unwrap().unwrap();
@@ -2070,15 +2236,7 @@ mod tests {
     fn test_list_runs() {
         let (store, _dir) = temp_store();
         for i in 0..5 {
-            let run = RunRecord {
-                run_id: format!("run-{i:03}"),
-                started_at: Utc::now(),
-                finished_at: Utc::now(),
-                status: RunStatus::Success,
-                models_executed: vec![],
-                trigger: RunTrigger::Manual,
-                config_hash: "hash".to_string(),
-            };
+            let run = minimal_run_record(&format!("run-{i:03}"), vec![]);
             store.record_run(&run).unwrap();
         }
 
@@ -2089,12 +2247,9 @@ mod tests {
     #[test]
     fn test_get_model_history() {
         let (store, _dir) = temp_store();
-        let run = RunRecord {
-            run_id: "run-001".to_string(),
-            started_at: Utc::now(),
-            finished_at: Utc::now(),
-            status: RunStatus::Success,
-            models_executed: vec![
+        let run = minimal_run_record(
+            "run-001",
+            vec![
                 ModelExecution {
                     model_name: "orders".to_string(),
                     started_at: Utc::now(),
@@ -2118,9 +2273,7 @@ mod tests {
                     bytes_written: None,
                 },
             ],
-            trigger: RunTrigger::Manual,
-            config_hash: "hash".to_string(),
-        };
+        );
         store.record_run(&run).unwrap();
 
         let history = store.get_model_history("orders", 10).unwrap();
@@ -2132,12 +2285,9 @@ mod tests {
     fn test_get_average_duration() {
         let (store, _dir) = temp_store();
         for (i, dur) in [100u64, 200, 300].iter().enumerate() {
-            let run = RunRecord {
-                run_id: format!("run-{i}"),
-                started_at: Utc::now(),
-                finished_at: Utc::now(),
-                status: RunStatus::Success,
-                models_executed: vec![ModelExecution {
+            let run = minimal_run_record(
+                &format!("run-{i}"),
+                vec![ModelExecution {
                     model_name: "orders".to_string(),
                     started_at: Utc::now(),
                     finished_at: Utc::now(),
@@ -2148,14 +2298,90 @@ mod tests {
                     bytes_scanned: None,
                     bytes_written: None,
                 }],
-                trigger: RunTrigger::Manual,
-                config_hash: "hash".to_string(),
-            };
+            );
             store.record_run(&run).unwrap();
         }
 
         let avg = store.get_average_duration("orders", 10).unwrap().unwrap();
         assert!((avg - 200.0).abs() < 0.01);
+    }
+
+    /// Guard the v5→v6 forward-deserialization contract: a JSON blob
+    /// written by a v5 binary (no audit fields at all) must deserialize
+    /// cleanly with every new field populated to its documented default.
+    ///
+    /// The blob shape below is the exact `serde_json::to_vec(&RunRecord)`
+    /// output of the pre-audit struct as of schema v5 — hand-crafted so
+    /// the test fails if someone accidentally drops the serde-default
+    /// on a new field, reintroducing a breaking-change in redb row
+    /// compatibility.
+    #[test]
+    fn test_v5_run_record_forward_deserializes_with_defaults() {
+        let v5_blob = br#"{
+            "run_id": "run-v5-legacy",
+            "started_at": "2024-01-01T12:00:00Z",
+            "finished_at": "2024-01-01T12:05:00Z",
+            "status": "Success",
+            "models_executed": [],
+            "trigger": "Manual",
+            "config_hash": "legacy-hash"
+        }"#;
+
+        let record: RunRecord =
+            serde_json::from_slice(v5_blob).expect("v5 blob must forward-deserialize");
+
+        // Original fields preserved.
+        assert_eq!(record.run_id, "run-v5-legacy");
+        assert_eq!(record.status, RunStatus::Success);
+        assert_eq!(record.config_hash, "legacy-hash");
+
+        // Audit fields populated to documented defaults.
+        assert_eq!(record.triggering_identity, None);
+        assert_eq!(record.session_source, SessionSource::Cli);
+        assert_eq!(record.git_commit, None);
+        assert_eq!(record.git_branch, None);
+        assert_eq!(record.idempotency_key, None);
+        assert_eq!(record.target_catalog, None);
+        assert_eq!(record.hostname, "unknown");
+        assert_eq!(record.rocky_version, "<pre-audit>");
+    }
+
+    /// End-to-end variant of the forward-compat guard: write a v5 blob
+    /// directly into the `run_history` redb table (bypassing
+    /// `record_run`'s serialization), then read it back via the normal
+    /// `get_run` / `list_runs` path. Catches both the serde-level
+    /// default wiring and any downstream code path that would panic on
+    /// a missing field.
+    #[test]
+    fn test_v5_redb_row_reads_as_v6_with_defaults() {
+        let (store, _dir) = temp_store();
+        let v5_blob = br#"{
+            "run_id": "run-v5-via-redb",
+            "started_at": "2024-01-01T12:00:00Z",
+            "finished_at": "2024-01-01T12:05:00Z",
+            "status": "Failure",
+            "models_executed": [],
+            "trigger": "Ci",
+            "config_hash": "legacy-via-redb"
+        }"#;
+
+        // Insert the raw v5 bytes directly into the redb table — no
+        // `record_run` roundtrip, so the blob stays byte-identical to
+        // what a v5 binary would have written.
+        let txn = store.db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(RUN_HISTORY).unwrap();
+            table
+                .insert("run-v5-via-redb", v5_blob.as_slice())
+                .unwrap();
+        }
+        txn.commit().unwrap();
+
+        let retrieved = store.get_run("run-v5-via-redb").unwrap().unwrap();
+        assert_eq!(retrieved.hostname, "unknown");
+        assert_eq!(retrieved.rocky_version, "<pre-audit>");
+        assert!(retrieved.triggering_identity.is_none());
+        assert_eq!(retrieved.session_source, SessionSource::Cli);
     }
 
     // --- Quality metrics tests ---

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -441,7 +441,7 @@ fn test_drift_new_column_not_drift() {
 
 #[test]
 fn test_run_history_flow() {
-    use rocky_core::state::{ModelExecution, RunRecord, RunStatus, RunTrigger};
+    use rocky_core::state::{ModelExecution, RunRecord, RunStatus, RunTrigger, SessionSource};
 
     let (store, _dir) = temp_state();
 
@@ -478,6 +478,14 @@ fn test_run_history_flow() {
         ],
         trigger: RunTrigger::Manual,
         config_hash: "config-abc".to_string(),
+        triggering_identity: None,
+        session_source: SessionSource::Cli,
+        git_commit: None,
+        git_branch: None,
+        idempotency_key: None,
+        target_catalog: None,
+        hostname: "e2e-test-host".to_string(),
+        rocky_version: "0.0.0-e2e".to_string(),
     };
 
     store.record_run(&run).unwrap();

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -647,6 +647,12 @@ enum Command {
         /// Only show runs since this date (ISO 8601 or YYYY-MM-DD)
         #[arg(long)]
         since: Option<String>,
+        /// Include the governance audit trail for each run (identity,
+        /// git commit, branch, hostname, session source, target catalog,
+        /// idempotency key, rocky version). Default output omits these
+        /// fields for byte-stability with schema v5 consumers.
+        #[arg(long)]
+        audit: bool,
     },
 
     /// Show quality metrics for a model
@@ -1501,9 +1507,17 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 anyhow::bail!("either --adapter or --command is required for test-adapter")
             }
         },
-        Command::History { model, since } => {
-            rocky_cli::commands::run_history(&state_path, model.as_deref(), since.as_deref(), json)
-        }
+        Command::History {
+            model,
+            since,
+            audit,
+        } => rocky_cli::commands::run_history(
+            &state_path,
+            model.as_deref(),
+            since.as_deref(),
+            audit,
+            json,
+        ),
         Command::Metrics {
             model,
             trend,

--- a/integrations/dagster/src/dagster_rocky/types_generated/history_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/history_schema.py
@@ -20,21 +20,55 @@ class RunModelRecord(BaseModel):
 class RunHistoryRecord(BaseModel):
     """
     One run from the state store, mirroring `rocky_core::state::RunRecord` with serializable field types (no enums or non-JSON-friendly Rust types).
+
+    The governance audit fields (`triggering_identity`, `session_source`, `git_commit`, `git_branch`, `idempotency_key`, `target_catalog`, `hostname`, `rocky_version`) are only populated in the `rocky history --audit` shape; the default shape continues to emit just the existing 7 fields. The `#[serde(skip_serializing_if = "…")]` attributes keep the default payload byte-identical to schema v5 unless `--audit` flips the fields on.
     """
 
     duration_ms: conint(ge=0)
     """
     Duration in milliseconds (`finished_at - started_at`).
     """
+    git_branch: str | None = None
+    """
+    `git symbolic-ref --short HEAD` at claim time, or `None` on detached HEAD.
+    """
+    git_commit: str | None = None
+    """
+    `git rev-parse HEAD` at claim time.
+    """
+    hostname: str | None = None
+    """
+    Machine hostname that produced the run.
+    """
+    idempotency_key: str | None = None
+    """
+    The `--idempotency-key` value supplied to `rocky run`, if any.
+    """
     models: list[RunModelRecord]
     """
     Per-model execution details for this run.
     """
     models_executed: conint(ge=0)
+    rocky_version: str | None = None
+    """
+    `CARGO_PKG_VERSION` of the `rocky` binary, or `"<pre-audit>"` on schema-v5 rows that predate the audit trail.
+    """
     run_id: str
+    session_source: str | None = None
+    """
+    Session origin — `"cli"`, `"dagster"`, `"lsp"`, or `"http_api"`. Emitted as the lowercase variant string so JSON consumers can match on it without knowing the Rust enum shape.
+    """
     started_at: AwareDatetime
     status: str
+    target_catalog: str | None = None
+    """
+    Best-available target catalog — the `catalog_template` for replication pipelines, the literal `target.catalog` for transformation/quality/snapshot/load.
+    """
     trigger: str
+    triggering_identity: str | None = None
+    """
+    Resolved caller identity (Unix `$USER` / Windows `$USERNAME`). `None` in CI / container contexts where no human caller is discernible.
+    """
 
 
 class HistoryOutput(BaseModel):

--- a/schemas/history.schema.json
+++ b/schemas/history.schema.json
@@ -2,13 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "RunHistoryRecord": {
-      "description": "One run from the state store, mirroring `rocky_core::state::RunRecord` with serializable field types (no enums or non-JSON-friendly Rust types).",
+      "description": "One run from the state store, mirroring `rocky_core::state::RunRecord` with serializable field types (no enums or non-JSON-friendly Rust types).\n\nThe governance audit fields (`triggering_identity`, `session_source`, `git_commit`, `git_branch`, `idempotency_key`, `target_catalog`, `hostname`, `rocky_version`) are only populated in the `rocky history --audit` shape; the default shape continues to emit just the existing 7 fields. The `#[serde(skip_serializing_if = \"…\")]` attributes keep the default payload byte-identical to schema v5 unless `--audit` flips the fields on.",
       "properties": {
         "duration_ms": {
           "description": "Duration in milliseconds (`finished_at - started_at`).",
           "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
+        },
+        "git_branch": {
+          "description": "`git symbolic-ref --short HEAD` at claim time, or `None` on detached HEAD.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git_commit": {
+          "description": "`git rev-parse HEAD` at claim time.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hostname": {
+          "description": "Machine hostname that produced the run.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotency_key": {
+          "description": "The `--idempotency-key` value supplied to `rocky run`, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "models": {
           "description": "Per-model execution details for this run.",
@@ -22,8 +50,22 @@
           "minimum": 0.0,
           "type": "integer"
         },
+        "rocky_version": {
+          "description": "`CARGO_PKG_VERSION` of the `rocky` binary, or `\"<pre-audit>\"` on schema-v5 rows that predate the audit trail.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "run_id": {
           "type": "string"
+        },
+        "session_source": {
+          "description": "Session origin — `\"cli\"`, `\"dagster\"`, `\"lsp\"`, or `\"http_api\"`. Emitted as the lowercase variant string so JSON consumers can match on it without knowing the Rust enum shape.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "started_at": {
           "format": "date-time",
@@ -32,8 +74,22 @@
         "status": {
           "type": "string"
         },
+        "target_catalog": {
+          "description": "Best-available target catalog — the `catalog_template` for replication pipelines, the literal `target.catalog` for transformation/quality/snapshot/load.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "trigger": {
           "type": "string"
+        },
+        "triggering_identity": {
+          "description": "Resolved caller identity (Unix `$USER` / Windows `$USERNAME`). `None` in CI / container contexts where no human caller is discernible.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/scripts/_normalize_fixture.py
+++ b/scripts/_normalize_fixture.py
@@ -33,6 +33,24 @@ WALL_CLOCK_FIELDS: frozenset[str] = frozenset(
 # corpus is byte-stable across regens.
 WALL_CLOCK_ID_FIELDS: frozenset[str] = frozenset({"run_id"})
 
+# Governance audit-trail fields stamped on ``RunRecord`` at claim time
+# (schema v6). Each is wall-clock- or environment-derived and therefore
+# naturally wiggles across regen runs / CI machines. The map pairs each
+# field name with its sentinel replacement so the corpus stays
+# byte-stable regardless of who ran ``just regen-fixtures``.
+#
+# ``idempotency_key`` is intentionally excluded: when set, it's
+# supplied by the caller and deterministic in test runs; when unset,
+# it serialises out entirely (``#[serde(skip_serializing_if)]``).
+AUDIT_FIELD_SENTINELS: dict[str, str] = {
+    "hostname": "host-SENTINEL",
+    "git_commit": "sha-SENTINEL",
+    "git_branch": "branch-SENTINEL",
+    "triggering_identity": "user-SENTINEL",
+    "rocky_version": "0.0.0-SENTINEL",
+    "target_catalog": "catalog-SENTINEL",
+}
+
 # Numeric fields whose value is a deterministic function of a
 # wall-clock-derived number (e.g. ``compute_cost_per_run =
 # avg_duration_seconds * compute_cost_per_second``). Even though the
@@ -66,6 +84,8 @@ def normalize(node: object) -> None:
                 node[k] = SENTINEL_TS
             elif isinstance(v, str) and k in WALL_CLOCK_ID_FIELDS:
                 node[k] = SENTINEL_RUN_ID
+            elif isinstance(v, str) and k in AUDIT_FIELD_SENTINELS:
+                node[k] = AUDIT_FIELD_SENTINELS[k]
             else:
                 normalize(v)
     elif isinstance(node, list):


### PR DESCRIPTION
## Summary
Adds an 8-field governance audit trail to `RunRecord`, captured at `rocky run` claim time and surfaced via `rocky history --audit`.

**Audit fields:**
- `triggering_identity` (best-effort `$USER` / `$USERNAME`)
- `session_source` (`Cli` / `Dagster` / `Lsp` / `HttpApi` — auto-detected via `DAGSTER_PIPES_CONTEXT` + `ROCKY_SESSION_SOURCE`)
- `git_commit` / `git_branch` (shells out to system `git`; `None` for detached HEAD / non-checkout)
- `idempotency_key` (threads existing `--idempotency-key` from FR-004)
- `target_catalog` (resolved adapter catalog)
- `hostname` (via `hostname` crate)
- `rocky_version` (`env!("CARGO_PKG_VERSION")`)

**Schema migration:** redb v5 → v6 with forward-deserialize — v5 rows deserialize as v6 via `#[serde(default)]` on each new field. Defaults for required fields: `hostname="unknown"`, `rocky_version="<pre-audit>"`, `session_source=Cli`. No in-place blob rewrite.

**`rocky history --audit`:** new flag expands the 8 fields in the default text table + JSON output. Default `rocky history` output unchanged (backward compat — tests cover this).

**Codegen cascade regenerated:** `schemas/history.schema.json`, `integrations/dagster/src/dagster_rocky/types_generated/history_schema.py`, `editors/vscode/src/types/generated/history.ts`.

## Test plan
- [x] `cargo test --workspace` (green locally)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (green locally)
- [ ] Run `rocky run` against `examples/playground/pocs/00-foundations/00-playground-default`, confirm `rocky history --audit` populates fields
- [ ] Verify `rocky history` without `--audit` unchanged
- [ ] Dagster fixture normaliser sentinels hide non-determinism (git commit, hostname, rocky version)