### PR TITLE
feat(engine): role-graph reconciliation (Wave C-1)

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2075,6 +2075,29 @@
       },
       "type": "object"
     },
+    "RoleConfig": {
+      "additionalProperties": false,
+      "description": "A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.\n\n```toml [role.reader] permissions = [\"SELECT\", \"USE CATALOG\", \"USE SCHEMA\"]\n\n[role.analytics_engineer] inherits = [\"reader\"] permissions = [\"MODIFY\"]\n\n[role.admin] inherits = [\"analytics_engineer\"] permissions = [\"MANAGE\"] ```\n\nResolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.\n\nPermission strings must match the canonical uppercase spellings of [`crate::ir::Permission`] (`\"SELECT\"`, `\"USE CATALOG\"`, ...).",
+      "properties": {
+        "inherits": {
+          "default": [],
+          "description": "Immediate parent role names. Rocky walks these transitively at reconcile time; cycles are rejected. Defaults to `[]` when omitted.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "permissions": {
+          "default": [],
+          "description": "Permissions this role grants. Rocky unions these with every ancestor's permissions before passing the flattened set to the governance adapter. Defaults to `[]` (permissionless grouping roles are legal — they exist only for inheritance).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "RunRetryConfig": {
       "additionalProperties": false,
       "description": "Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.",
@@ -2845,6 +2868,14 @@
       ],
       "default": null,
       "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
+    },
+    "role": {
+      "additionalProperties": {
+        "$ref": "#/definitions/RoleConfig"
+      },
+      "default": {},
+      "description": "Hierarchical role declarations reconciled against the warehouse's native role/group system.\n\nSee [`RoleConfig`] for the TOML shape and [`crate::role_graph::flatten_role_graph`] for the inheritance resolution semantics (DAG walk with cycle detection).",
+      "type": "object"
     },
     "schema_evolution": {
       "allOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -360,6 +360,14 @@ export interface RockyConfig {
    */
   retry?: RunRetryConfig | null;
   /**
+   * Hierarchical role declarations reconciled against the warehouse's native role/group system.
+   *
+   * See [`RoleConfig`] for the TOML shape and [`crate::role_graph::flatten_role_graph`] for the inheritance resolution semantics (DAG walk with cycle detection).
+   */
+  role?: {
+    [k: string]: RoleConfig;
+  };
+  /**
    * Schema evolution configuration (grace-period column drops).
    */
   schema_evolution?: SchemaEvolutionConfig;
@@ -1214,6 +1222,29 @@ export interface RunRetryConfig {
    * Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.
+ *
+ * ```toml [role.reader] permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+ *
+ * [role.analytics_engineer] inherits = ["reader"] permissions = ["MODIFY"]
+ *
+ * [role.admin] inherits = ["analytics_engineer"] permissions = ["MANAGE"] ```
+ *
+ * Resolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.
+ *
+ * Permission strings must match the canonical uppercase spellings of [`crate::ir::Permission`] (`"SELECT"`, `"USE CATALOG"`, ...).
+ */
+export interface RoleConfig {
+  /**
+   * Immediate parent role names. Rocky walks these transitively at reconcile time; cycles are rejected. Defaults to `[]` when omitted.
+   */
+  inherits?: string[];
+  /**
+   * Permissions this role grants. Rocky unions these with every ancestor's permissions before passing the flattened set to the governance adapter. Defaults to `[]` (permissionless grouping roles are legal — they exist only for inheritance).
+   */
+  permissions?: string[];
 }
 /**
  * Schema evolution configuration.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2829,6 +2829,34 @@ pub async fn run(
                     }
                 }
             }
+
+            // Governance: role-graph reconcile (§1.1 + §1.2 Wave C-1).
+            // Flatten the `[role.*]` config and dispatch through the same
+            // `GovernanceAdapter` that handled classification + masking
+            // above. Best-effort: failures warn but never abort, mirroring
+            // the Wave A semantics.
+            //
+            // Cycle detection + unknown-parent validation already ran when
+            // the config was loaded (see `RockyConfig::role_graph`), so a
+            // failure here is an adapter-side one (e.g., SCIM API down
+            // when group creation lands in a follow-up).
+            match rocky_cfg.role_graph() {
+                Ok(resolved) if !resolved.is_empty() => {
+                    if let Err(e) = governance_adapter.reconcile_role_graph(&resolved).await {
+                        warn!(
+                            roles = resolved.len(),
+                            error = %e,
+                            "reconcile role graph failed"
+                        );
+                    }
+                }
+                Ok(_) => {
+                    // No `[role.*]` block — nothing to reconcile.
+                }
+                Err(e) => {
+                    warn!(error = %e, "role graph flatten failed; skipping role reconcile");
+                }
+            }
         }
     }
 

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -309,6 +309,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1052,6 +1052,47 @@ pub struct GrantConfig {
     pub permissions: Vec<String>,
 }
 
+/// A single entry in the top-level `[role.*]` block, declaring a
+/// hierarchical role with optional inheritance and a list of
+/// permissions.
+///
+/// ```toml
+/// [role.reader]
+/// permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+///
+/// [role.analytics_engineer]
+/// inherits = ["reader"]
+/// permissions = ["MODIFY"]
+///
+/// [role.admin]
+/// inherits = ["analytics_engineer"]
+/// permissions = ["MANAGE"]
+/// ```
+///
+/// Resolution happens at reconcile time via
+/// [`crate::role_graph::flatten_role_graph`], which walks the
+/// `inherits` DAG and unions permissions from the role and every
+/// transitive ancestor. Cycles and unknown parents are caught as
+/// structured [`crate::role_graph::RoleGraphError`] values.
+///
+/// Permission strings must match the canonical uppercase spellings of
+/// [`crate::ir::Permission`] (`"SELECT"`, `"USE CATALOG"`, ...).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RoleConfig {
+    /// Immediate parent role names. Rocky walks these transitively at
+    /// reconcile time; cycles are rejected. Defaults to `[]` when
+    /// omitted.
+    #[serde(default)]
+    pub inherits: Vec<String>,
+    /// Permissions this role grants. Rocky unions these with every
+    /// ancestor's permissions before passing the flattened set to the
+    /// governance adapter. Defaults to `[]` (permissionless grouping
+    /// roles are legal — they exist only for inheritance).
+    #[serde(default)]
+    pub permissions: Vec<String>,
+}
+
 /// One entry in the top-level `[mask]` block. A scalar value (`pii =
 /// "hash"`) binds a classification tag to a default masking strategy; a
 /// nested table (`[mask.prod] pii = "none"`) overrides strategies for a
@@ -1625,6 +1666,15 @@ pub struct RockyConfig {
     /// `allow_unmasked` list that suppresses W004 warnings.
     #[serde(default)]
     pub classifications: ClassificationsConfig,
+
+    /// Hierarchical role declarations reconciled against the warehouse's
+    /// native role/group system.
+    ///
+    /// See [`RoleConfig`] for the TOML shape and
+    /// [`crate::role_graph::flatten_role_graph`] for the inheritance
+    /// resolution semantics (DAG walk with cycle detection).
+    #[serde(default, rename = "role", alias = "roles")]
+    pub roles: std::collections::BTreeMap<String, RoleConfig>,
 }
 
 impl RockyConfig {
@@ -1663,6 +1713,23 @@ impl RockyConfig {
         }
 
         out
+    }
+
+    /// Flatten the `[role.*]` config into a deterministic `name →
+    /// ResolvedRole` map, ready to pass to
+    /// [`crate::traits::GovernanceAdapter::reconcile_role_graph`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::role_graph::RoleGraphError`] on cycles, unknown
+    /// parents, or unknown permission spellings.
+    pub fn role_graph(
+        &self,
+    ) -> Result<
+        std::collections::BTreeMap<String, crate::ir::ResolvedRole>,
+        crate::role_graph::RoleGraphError,
+    > {
+        crate::role_graph::flatten_role_graph(&self.roles)
     }
 }
 

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -577,6 +577,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -713,6 +713,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         };
 
         let models = vec![
@@ -789,6 +790,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         };
 
         let models = vec![Model {
@@ -860,6 +862,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None);

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -315,7 +315,12 @@ pub struct Grant {
 }
 
 /// Databricks permissions that Rocky manages.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+///
+/// `Ord` / `PartialOrd` are derived so that callers which need a
+/// deterministic enumeration (e.g. [`crate::role_graph::flatten_role_graph`]
+/// collecting permissions into a `BTreeSet`) get a stable ordering keyed by
+/// the declaration order below, independent of input traversal order.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Permission {
     Browse,
     UseCatalog,
@@ -338,6 +343,41 @@ impl std::fmt::Display for Permission {
     }
 }
 
+impl std::str::FromStr for Permission {
+    type Err = UnknownPermission;
+
+    /// Parse one of the managed Rocky permissions from its canonical
+    /// uppercase spelling (`"SELECT"`, `"USE CATALOG"`, ...).
+    ///
+    /// Unknown strings return [`UnknownPermission`] so callers can surface
+    /// a typed error (e.g. [`crate::role_graph::RoleGraphError::UnknownPermission`])
+    /// rather than silently skipping the entry.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BROWSE" => Ok(Permission::Browse),
+            "USE CATALOG" => Ok(Permission::UseCatalog),
+            "USE SCHEMA" => Ok(Permission::UseSchema),
+            "SELECT" => Ok(Permission::Select),
+            "MODIFY" => Ok(Permission::Modify),
+            "MANAGE" => Ok(Permission::Manage),
+            other => Err(UnknownPermission(other.to_string())),
+        }
+    }
+}
+
+/// Error returned by [`Permission`]'s `FromStr` impl when the input string
+/// isn't one of the managed permissions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownPermission(pub String);
+
+impl std::fmt::Display for UnknownPermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown permission: {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownPermission {}
+
 /// Target of a GRANT/REVOKE statement.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum GrantTarget {
@@ -350,6 +390,27 @@ pub enum GrantTarget {
 pub struct PermissionDiff {
     pub grants_to_add: Vec<Grant>,
     pub grants_to_revoke: Vec<Grant>,
+}
+
+/// A role with its fully flattened permission set, after walking the
+/// `inherits` DAG and deduplicating.
+///
+/// Produced by [`crate::role_graph::flatten_role_graph`] and consumed by
+/// [`crate::traits::GovernanceAdapter::reconcile_role_graph`]. The
+/// `flattened_permissions` list is deterministically sorted via
+/// [`Permission`]'s `Ord` impl so adapter-level SQL generation is stable
+/// across runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedRole {
+    /// Role name, matching the key in the owning `BTreeMap`.
+    pub name: String,
+    /// Union of the role's own permissions and every ancestor's
+    /// permissions, deduplicated and sorted.
+    pub flattened_permissions: Vec<Permission>,
+    /// Immediate parents declared via the role's `inherits` list,
+    /// preserved verbatim for audit/debug reporting — **not** the full
+    /// transitive closure.
+    pub inherits_from: Vec<String>,
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod quarantine;
 pub mod redacted;
 pub mod retry;
 pub mod retry_budget;
+pub mod role_graph;
 pub mod schema;
 pub mod schema_cache;
 pub mod seeds;

--- a/engine/crates/rocky-core/src/role_graph.rs
+++ b/engine/crates/rocky-core/src/role_graph.rs
@@ -1,0 +1,424 @@
+//! Role-graph reconciliation: flatten hierarchical `[role.*]` config into
+//! a deterministic `name → ResolvedRole` map for the governance adapter
+//! layer.
+//!
+//! ```toml
+//! [role.reader]
+//! permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+//!
+//! [role.analytics_engineer]
+//! inherits = ["reader"]
+//! permissions = ["MODIFY"]
+//!
+//! [role.admin]
+//! inherits = ["analytics_engineer"]
+//! permissions = ["MANAGE"]
+//! ```
+//!
+//! After flattening, `admin` resolves to `SELECT + USE CATALOG + USE
+//! SCHEMA + MODIFY + MANAGE` — the union of its own permissions and
+//! every transitive ancestor's.
+//!
+//! Errors are surfaced as [`RoleGraphError`] so config loaders can render
+//! structured diagnostics (unknown parent, inheritance cycle, unknown
+//! permission spelling).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+use crate::config::RoleConfig;
+use crate::ir::{Permission, ResolvedRole};
+
+/// Things that can go wrong when flattening `[role.*]` into a resolved
+/// map.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RoleGraphError {
+    /// A role declared `inherits = ["<parent>"]` but `<parent>` has no
+    /// matching `[role.<parent>]` block.
+    #[error("role '{role}' inherits from unknown parent '{parent}'")]
+    UnknownParent {
+        /// The role that declared the bad `inherits` entry.
+        role: String,
+        /// The unresolved parent name.
+        parent: String,
+    },
+    /// The `inherits` chain forms a cycle. `path` starts at the role
+    /// where the cycle was first detected and ends with the repeated
+    /// role, so error messages like `"a -> b -> c -> a"` read cleanly.
+    #[error("inheritance cycle detected at role '{role}': {}", path.join(" -> "))]
+    Cycle {
+        /// The role where the cycle was detected (also the last entry in
+        /// `path`).
+        role: String,
+        /// The traversal order from the detection point through the
+        /// cycle back to the repeated role.
+        path: Vec<String>,
+    },
+    /// A role listed a permission string that isn't one of the managed
+    /// permissions (see [`Permission`]).
+    #[error("role '{role}' declares unknown permission '{permission}'")]
+    UnknownPermission {
+        /// The role that declared the bad permission.
+        role: String,
+        /// The unrecognized permission spelling.
+        permission: String,
+    },
+}
+
+/// Flatten a role-graph config into a `name → ResolvedRole` map.
+///
+/// Runs a DFS from every role and unions permissions from itself and
+/// each transitive ancestor. The output is a `BTreeMap` so ordering is
+/// deterministic for snapshot tests and audit reporting.
+///
+/// # Errors
+///
+/// Returns [`RoleGraphError`] if any role references an unknown parent,
+/// the graph contains a cycle, or any permission string fails
+/// [`Permission::from_str`].
+pub fn flatten_role_graph(
+    roles: &BTreeMap<String, RoleConfig>,
+) -> Result<BTreeMap<String, ResolvedRole>, RoleGraphError> {
+    // First pass: parse and cache each role's own permissions + inherits
+    // list. Fail fast on bad permission spellings so the caller learns
+    // about all of them before the DAG walk runs.
+    let mut own_perms: BTreeMap<String, BTreeSet<Permission>> = BTreeMap::new();
+    for (name, cfg) in roles {
+        let mut perms: BTreeSet<Permission> = BTreeSet::new();
+        for p in &cfg.permissions {
+            let parsed =
+                p.parse::<Permission>()
+                    .map_err(|_| RoleGraphError::UnknownPermission {
+                        role: name.clone(),
+                        permission: p.clone(),
+                    })?;
+            perms.insert(parsed);
+        }
+        own_perms.insert(name.clone(), perms);
+    }
+
+    // Second pass: validate every `inherits` entry resolves to a known
+    // role. Doing this upfront makes the DFS's unknown-parent signal
+    // unreachable (and keeps the cycle detector focused on just cycles).
+    for (name, cfg) in roles {
+        for parent in &cfg.inherits {
+            if !roles.contains_key(parent) {
+                return Err(RoleGraphError::UnknownParent {
+                    role: name.clone(),
+                    parent: parent.clone(),
+                });
+            }
+        }
+    }
+
+    // Third pass: for each role, collect transitive ancestors via DFS
+    // using a gray/black color map to detect cycles while reusing black
+    // nodes as a "fully-explored" fast path.
+    let mut resolved: BTreeMap<String, ResolvedRole> = BTreeMap::new();
+    for name in roles.keys() {
+        let mut ancestors: BTreeSet<String> = BTreeSet::new();
+        collect_ancestors(name, roles, &mut ancestors, &mut Vec::new())?;
+
+        // Union own + ancestor permissions. `ancestors` is the transitive
+        // closure minus the role itself.
+        let mut merged: BTreeSet<Permission> = own_perms.get(name).cloned().unwrap_or_default();
+        for anc in &ancestors {
+            if let Some(p) = own_perms.get(anc) {
+                merged.extend(p.iter().cloned());
+            }
+        }
+
+        let cfg = &roles[name];
+        resolved.insert(
+            name.clone(),
+            ResolvedRole {
+                name: name.clone(),
+                flattened_permissions: merged.into_iter().collect(),
+                inherits_from: cfg.inherits.clone(),
+            },
+        );
+    }
+
+    Ok(resolved)
+}
+
+/// Recursive helper: fill `ancestors` with every transitive parent of
+/// `node`, using `stack` to detect cycles.
+///
+/// `stack` is the in-progress DFS path (role names from the entry point
+/// down to `node`'s parent). A parent already in `stack` is a back-edge
+/// and signals a cycle; we slice `stack` from that parent onwards + the
+/// repeated name for the error path.
+fn collect_ancestors(
+    node: &str,
+    roles: &BTreeMap<String, RoleConfig>,
+    ancestors: &mut BTreeSet<String>,
+    stack: &mut Vec<String>,
+) -> Result<(), RoleGraphError> {
+    stack.push(node.to_string());
+
+    // Safe: we validated every `inherits` entry above, so `roles[node]`
+    // always has a matching entry.
+    if let Some(cfg) = roles.get(node) {
+        for parent in &cfg.inherits {
+            // Cycle: parent already in the active DFS stack.
+            if let Some(idx) = stack.iter().position(|n| n == parent) {
+                let mut path: Vec<String> = stack[idx..].to_vec();
+                path.push(parent.clone());
+                stack.pop();
+                return Err(RoleGraphError::Cycle {
+                    role: parent.clone(),
+                    path,
+                });
+            }
+
+            if ancestors.insert(parent.clone()) {
+                // First time we've seen this ancestor — recurse.
+                collect_ancestors(parent, roles, ancestors, stack)?;
+            }
+        }
+    }
+
+    stack.pop();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role(inherits: &[&str], permissions: &[&str]) -> RoleConfig {
+        RoleConfig {
+            inherits: inherits.iter().map(ToString::to_string).collect(),
+            permissions: permissions.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    fn build(entries: &[(&str, RoleConfig)]) -> BTreeMap<String, RoleConfig> {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn single_role_with_own_permissions() {
+        let roles = build(&[("reader", role(&[], &["SELECT", "USE CATALOG"]))]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+        assert_eq!(resolved.len(), 1);
+        let reader = &resolved["reader"];
+        assert_eq!(reader.name, "reader");
+        assert_eq!(reader.inherits_from, Vec::<String>::new());
+        assert_eq!(
+            reader.flattened_permissions,
+            vec![Permission::UseCatalog, Permission::Select]
+        );
+    }
+
+    #[test]
+    fn linear_inheritance_flattens_transitively() {
+        // admin -> analytics_engineer -> reader
+        let roles = build(&[
+            (
+                "reader",
+                role(&[], &["SELECT", "USE CATALOG", "USE SCHEMA"]),
+            ),
+            ("analytics_engineer", role(&["reader"], &["MODIFY"])),
+            ("admin", role(&["analytics_engineer"], &["MANAGE"])),
+        ]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+
+        let reader = &resolved["reader"];
+        assert_eq!(
+            reader.flattened_permissions,
+            vec![
+                Permission::UseCatalog,
+                Permission::UseSchema,
+                Permission::Select
+            ]
+        );
+
+        let ae = &resolved["analytics_engineer"];
+        assert_eq!(ae.inherits_from, vec!["reader".to_string()]);
+        assert_eq!(
+            ae.flattened_permissions,
+            vec![
+                Permission::UseCatalog,
+                Permission::UseSchema,
+                Permission::Select,
+                Permission::Modify,
+            ]
+        );
+
+        let admin = &resolved["admin"];
+        assert_eq!(admin.inherits_from, vec!["analytics_engineer".to_string()]);
+        assert_eq!(
+            admin.flattened_permissions,
+            vec![
+                Permission::UseCatalog,
+                Permission::UseSchema,
+                Permission::Select,
+                Permission::Modify,
+                Permission::Manage,
+            ]
+        );
+    }
+
+    #[test]
+    fn diamond_inheritance_dedupes() {
+        // D inherits from both B and C; B and C both inherit from A.
+        //
+        //     A (SELECT)
+        //    / \
+        //   B   C
+        //    \ /
+        //     D
+        let roles = build(&[
+            ("a", role(&[], &["SELECT"])),
+            ("b", role(&["a"], &["USE CATALOG"])),
+            ("c", role(&["a"], &["USE SCHEMA"])),
+            ("d", role(&["b", "c"], &["MODIFY"])),
+        ]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+
+        let d = &resolved["d"];
+        // SELECT should appear exactly once even though both B and C
+        // transitively contribute it via A.
+        assert_eq!(
+            d.flattened_permissions,
+            vec![
+                Permission::UseCatalog,
+                Permission::UseSchema,
+                Permission::Select,
+                Permission::Modify,
+            ]
+        );
+        assert_eq!(d.inherits_from, vec!["b".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn self_cycle_detected() {
+        let roles = build(&[("a", role(&["a"], &["SELECT"]))]);
+        let err = flatten_role_graph(&roles).unwrap_err();
+        assert!(
+            matches!(&err, RoleGraphError::Cycle { role, path } if role == "a" && path == &vec!["a".to_string(), "a".to_string()]),
+            "expected self-cycle, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn two_role_cycle_detected() {
+        let roles = build(&[
+            ("a", role(&["b"], &["SELECT"])),
+            ("b", role(&["a"], &["MODIFY"])),
+        ]);
+        let err = flatten_role_graph(&roles).unwrap_err();
+        match err {
+            RoleGraphError::Cycle { role, path } => {
+                // Either "a -> b -> a" or "b -> a -> b" is acceptable —
+                // BTreeMap iteration order decides which role we start the
+                // DFS from. Both spellings must name the same repeated role
+                // at the endpoints.
+                assert_eq!(path.first(), path.last());
+                assert_eq!(path.first(), Some(&role));
+                assert_eq!(path.len(), 3);
+            }
+            other => panic!("expected cycle error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn three_role_cycle_has_full_path() {
+        // a -> b -> c -> a
+        let roles = build(&[
+            ("a", role(&["b"], &["SELECT"])),
+            ("b", role(&["c"], &["MODIFY"])),
+            ("c", role(&["a"], &["MANAGE"])),
+        ]);
+        let err = flatten_role_graph(&roles).unwrap_err();
+        match err {
+            RoleGraphError::Cycle { role: _, path } => {
+                // 3-node cycle: 4 entries with first == last.
+                assert_eq!(path.first(), path.last());
+                assert_eq!(path.len(), 4);
+            }
+            other => panic!("expected cycle error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_parent_errors_before_dfs() {
+        let roles = build(&[("reader", role(&["nonexistent"], &["SELECT"]))]);
+        let err = flatten_role_graph(&roles).unwrap_err();
+        assert_eq!(
+            err,
+            RoleGraphError::UnknownParent {
+                role: "reader".to_string(),
+                parent: "nonexistent".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_permission_errors() {
+        let roles = build(&[("reader", role(&[], &["ROOT_ACCESS"]))]);
+        let err = flatten_role_graph(&roles).unwrap_err();
+        assert_eq!(
+            err,
+            RoleGraphError::UnknownPermission {
+                role: "reader".to_string(),
+                permission: "ROOT_ACCESS".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn empty_role_graph_is_ok() {
+        let roles: BTreeMap<String, RoleConfig> = BTreeMap::new();
+        let resolved = flatten_role_graph(&roles).unwrap();
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn role_with_no_permissions_is_ok() {
+        // A role may exist purely as a grouping for inheritance.
+        let roles = build(&[
+            ("base", role(&[], &[])),
+            ("extended", role(&["base"], &["SELECT"])),
+        ]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+        assert!(resolved["base"].flattened_permissions.is_empty());
+        assert_eq!(
+            resolved["extended"].flattened_permissions,
+            vec![Permission::Select]
+        );
+    }
+
+    #[test]
+    fn multiple_parents_union_permissions() {
+        // c inherits from both a and b (no shared ancestor).
+        let roles = build(&[
+            ("a", role(&[], &["SELECT"])),
+            ("b", role(&[], &["MODIFY"])),
+            ("c", role(&["a", "b"], &["MANAGE"])),
+        ]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+        assert_eq!(
+            resolved["c"].flattened_permissions,
+            vec![Permission::Select, Permission::Modify, Permission::Manage]
+        );
+    }
+
+    #[test]
+    fn permissions_are_sorted_deterministically() {
+        // Regardless of declaration order, the output follows Permission's
+        // Ord impl (declaration order in the enum).
+        let roles = build(&[("r1", role(&[], &["MANAGE", "SELECT", "BROWSE"]))]);
+        let resolved = flatten_role_graph(&roles).unwrap();
+        assert_eq!(
+            resolved["r1"].flattened_permissions,
+            vec![Permission::Browse, Permission::Select, Permission::Manage]
+        );
+    }
+}

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -644,6 +644,36 @@ pub trait GovernanceAdapter: Send + Sync {
             "apply_masking_policy not supported by this adapter",
         ))
     }
+
+    /// Reconcile a flattened role graph against the warehouse's native
+    /// role/group system.
+    ///
+    /// `roles` is the post-[`crate::role_graph::flatten_role_graph`]
+    /// map: each [`crate::ir::ResolvedRole`] carries its own permissions
+    /// plus every transitive ancestor's, deduped and sorted. Adapters
+    /// translate this into warehouse-specific primitives — on
+    /// Databricks / Unity Catalog that means a group per role
+    /// (convention: `rocky_role_<name>`) plus GRANT statements bound to
+    /// the group; on Snowflake it would be `CREATE ROLE` + per-role
+    /// GRANTs.
+    ///
+    /// # Errors
+    ///
+    /// The trait default returns an `AdapterError` to match the other
+    /// optional capabilities (`apply_column_tags`,
+    /// `apply_masking_policy`). [`NoopGovernanceAdapter`] overrides to
+    /// `Ok(())` so pipelines with a `[role.*]` block against a
+    /// no-governance warehouse degrade gracefully — the resolver itself
+    /// still catches cycles at config-load time, the adapter just skips
+    /// the no-op application.
+    async fn reconcile_role_graph(
+        &self,
+        _roles: &BTreeMap<String, crate::ir::ResolvedRole>,
+    ) -> AdapterResult<()> {
+        Err(AdapterError::msg(
+            "reconcile_role_graph not supported by this adapter",
+        ))
+    }
 }
 
 /// No-op governance adapter for warehouses that don't support catalog
@@ -727,6 +757,17 @@ impl GovernanceAdapter for NoopGovernanceAdapter {
         _env: &str,
     ) -> AdapterResult<()> {
         // Same rationale as `apply_column_tags`.
+        Ok(())
+    }
+
+    async fn reconcile_role_graph(
+        &self,
+        _roles: &BTreeMap<String, crate::ir::ResolvedRole>,
+    ) -> AdapterResult<()> {
+        // Same rationale as `apply_column_tags` / `apply_masking_policy`:
+        // a no-governance warehouse silently accepts role-graph config so
+        // pipelines downgrade gracefully. Cycle / unknown-parent errors
+        // still surface at config-load time via flatten_role_graph.
         Ok(())
     }
 }
@@ -931,6 +972,21 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn trait_default_reconcile_role_graph_errors() {
+        let err = MinimalGovernance
+            .reconcile_role_graph(&BTreeMap::new())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("reconcile_role_graph"));
+    }
+
+    #[tokio::test]
+    async fn noop_governance_accepts_role_graph() {
+        let noop = NoopGovernanceAdapter;
+        assert!(noop.reconcile_role_graph(&BTreeMap::new()).await.is_ok());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -929,6 +929,7 @@ mod tests {
             cache: Default::default(),
             mask: Default::default(),
             classifications: Default::default(),
+            roles: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-databricks/src/governance.rs
+++ b/engine/crates/rocky-databricks/src/governance.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::debug;
 
-use rocky_core::ir::{Grant, GrantTarget, PermissionDiff, TableRef};
+use rocky_core::ir::{Grant, GrantTarget, PermissionDiff, ResolvedRole, TableRef};
 use rocky_core::masking;
 use rocky_core::traits::{
     AdapterError, AdapterResult, GovernanceAdapter, MaskStrategy, MaskingPolicy, TagTarget,
@@ -208,6 +208,13 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
         Ok(())
     }
 
+    async fn reconcile_role_graph(
+        &self,
+        roles: &BTreeMap<String, ResolvedRole>,
+    ) -> AdapterResult<()> {
+        reconcile_role_graph_impl(&self.connector, roles).await
+    }
+
     async fn apply_masking_policy(
         &self,
         table: &TableRef,
@@ -294,5 +301,190 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
         }
 
         Ok(())
+    }
+}
+
+/// Prefix Rocky prepends to every group it provisions for a role, to
+/// keep its managed groups disjoint from user-created groups in the
+/// Unity Catalog metastore.
+///
+/// `role.admin` -> `rocky_role_admin`. Changing this string is a
+/// breaking change — existing grants in the wild reference the old
+/// name.
+const ROCKY_ROLE_GROUP_PREFIX: &str = "rocky_role_";
+
+/// Compute the Databricks UC group name for a Rocky role.
+///
+/// See [`ROCKY_ROLE_GROUP_PREFIX`] for the naming convention. Exposed as
+/// a free function so tests + downstream tooling can reason about the
+/// mapping without instantiating an adapter.
+pub fn role_group_name(role_name: &str) -> String {
+    format!("{ROCKY_ROLE_GROUP_PREFIX}{role_name}")
+}
+
+/// v1 implementation of `reconcile_role_graph`.
+///
+/// Databricks / Unity Catalog does not have "roles" natively; Rocky
+/// maps each role to a UC group (`rocky_role_<name>`). A fully-native
+/// impl would:
+///
+/// 1. Create each group via the SCIM `POST /api/2.0/preview/scim/v2/Groups`
+///    endpoint if missing.
+/// 2. For every catalog Rocky manages, emit a `GRANT <permission> ON
+///    CATALOG ... TO <group>` per flattened permission.
+///
+/// Neither piece exists in `rocky-databricks` yet — there's no SCIM
+/// client, and the catalogs-to-apply set isn't plumbed through the
+/// [`GovernanceAdapter::reconcile_role_graph`] signature. Both are
+/// deliberate follow-ups (see `feat/governance-role-graph` PR body).
+///
+/// In v1 this function validates each group name against the principal
+/// rules and emits a structured `debug` log of the reconciled role
+/// graph. It returns `Ok(())` so pipelines that declare `[role.*]` in
+/// their `rocky.toml` against a Databricks target don't abort — the
+/// role graph is still flattened + validated by [`rocky_core::role_graph`]
+/// at config-load time, which is where real failures surface.
+async fn reconcile_role_graph_impl(
+    _connector: &DatabricksConnector,
+    roles: &BTreeMap<String, ResolvedRole>,
+) -> AdapterResult<()> {
+    if roles.is_empty() {
+        return Ok(());
+    }
+
+    for (name, role) in roles {
+        let group = role_group_name(name);
+        // Validate the group name matches Databricks principal syntax
+        // so the deferred GRANT-emission path can't silently generate
+        // invalid SQL later.
+        rocky_sql::validation::validate_principal(&group).map_err(AdapterError::new)?;
+
+        debug!(
+            role = name.as_str(),
+            group = group.as_str(),
+            inherits = ?role.inherits_from,
+            permissions = ?role
+                .flattened_permissions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            "reconciled role graph entry (v1: log-only; SCIM group creation + per-catalog GRANT application are follow-ups)"
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_core::ir::Permission;
+
+    #[test]
+    fn role_group_name_prefixes_rocky_role() {
+        assert_eq!(role_group_name("reader"), "rocky_role_reader");
+        assert_eq!(
+            role_group_name("analytics_engineer"),
+            "rocky_role_analytics_engineer"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_role_graph_impl_accepts_empty_map() {
+        // We don't actually use the connector in v1, but the signature
+        // requires one. Construct a minimal one via the same test helpers
+        // that wiremock_tests uses — except we never make a network call,
+        // so the URL/token values are fake.
+        let auth = crate::auth::Auth::from_config(crate::auth::AuthConfig {
+            host: "example.databricks.com".into(),
+            token: Some("fake".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .unwrap();
+        let config = crate::connector::ConnectorConfig {
+            host: "example.databricks.com".into(),
+            warehouse_id: "w".into(),
+            timeout: std::time::Duration::from_secs(1),
+            retry: rocky_core::config::RetryConfig::default(),
+        };
+        let connector = crate::connector::DatabricksConnector::new(config, auth);
+
+        let empty = BTreeMap::new();
+        assert!(reconcile_role_graph_impl(&connector, &empty).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reconcile_role_graph_impl_accepts_valid_roles() {
+        let auth = crate::auth::Auth::from_config(crate::auth::AuthConfig {
+            host: "example.databricks.com".into(),
+            token: Some("fake".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .unwrap();
+        let config = crate::connector::ConnectorConfig {
+            host: "example.databricks.com".into(),
+            warehouse_id: "w".into(),
+            timeout: std::time::Duration::from_secs(1),
+            retry: rocky_core::config::RetryConfig::default(),
+        };
+        let connector = crate::connector::DatabricksConnector::new(config, auth);
+
+        let mut roles = BTreeMap::new();
+        roles.insert(
+            "reader".to_string(),
+            ResolvedRole {
+                name: "reader".into(),
+                flattened_permissions: vec![Permission::Select, Permission::UseCatalog],
+                inherits_from: vec![],
+            },
+        );
+        roles.insert(
+            "admin".to_string(),
+            ResolvedRole {
+                name: "admin".into(),
+                flattened_permissions: vec![
+                    Permission::UseCatalog,
+                    Permission::Select,
+                    Permission::Manage,
+                ],
+                inherits_from: vec!["reader".to_string()],
+            },
+        );
+        assert!(reconcile_role_graph_impl(&connector, &roles).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reconcile_role_graph_impl_rejects_invalid_group_name() {
+        // A role name with characters outside the principal regex (e.g.
+        // backtick or semicolon) would produce an invalid UC group name.
+        // The v1 impl catches this via validate_principal so the deferred
+        // GRANT path can't generate invalid SQL later.
+        let auth = crate::auth::Auth::from_config(crate::auth::AuthConfig {
+            host: "example.databricks.com".into(),
+            token: Some("fake".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .unwrap();
+        let config = crate::connector::ConnectorConfig {
+            host: "example.databricks.com".into(),
+            warehouse_id: "w".into(),
+            timeout: std::time::Duration::from_secs(1),
+            retry: rocky_core::config::RetryConfig::default(),
+        };
+        let connector = crate::connector::DatabricksConnector::new(config, auth);
+
+        let mut roles = BTreeMap::new();
+        roles.insert(
+            "bad;name".to_string(),
+            ResolvedRole {
+                name: "bad;name".into(),
+                flattened_permissions: vec![Permission::Select],
+                inherits_from: vec![],
+            },
+        );
+        assert!(reconcile_role_graph_impl(&connector, &roles).await.is_err());
     }
 }

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -852,3 +852,79 @@ async fn test_reconcile_access_combined_grants_and_bindings() {
     assert_eq!(diff.bindings.bindings_to_remove.len(), 1);
     assert_eq!(diff.bindings.bindings_to_remove[0].workspace_id, 3);
 }
+
+/// Verifies `reconcile_role_graph` routes through the GovernanceAdapter
+/// trait dispatch on `DatabricksGovernanceAdapter`.
+///
+/// v1 is log-only (no SCIM group creation, no per-catalog GRANT
+/// application), so this test asserts the trait method returns `Ok(())`
+/// and, critically, **no HTTP request is made** — the adapter's failure
+/// mode if it accidentally started calling the warehouse would be a
+/// wiremock "unmatched request" panic.
+#[tokio::test]
+async fn test_reconcile_role_graph_is_log_only_v1() {
+    use rocky_core::ir::{Permission, ResolvedRole};
+    use rocky_core::traits::GovernanceAdapter as _;
+    use rocky_databricks::governance::{DatabricksGovernanceAdapter, role_group_name};
+    use std::collections::BTreeMap;
+
+    let server = MockServer::start().await;
+    // Intentionally no mocks mounted: the test fails fast if v1
+    // accidentally starts calling the warehouse.
+
+    let connector = test_connector(&server);
+    let adapter = DatabricksGovernanceAdapter::without_workspace(Arc::new(connector));
+
+    let mut roles: BTreeMap<String, ResolvedRole> = BTreeMap::new();
+    roles.insert(
+        "reader".into(),
+        ResolvedRole {
+            name: "reader".into(),
+            flattened_permissions: vec![Permission::UseCatalog, Permission::Select],
+            inherits_from: vec![],
+        },
+    );
+    roles.insert(
+        "admin".into(),
+        ResolvedRole {
+            name: "admin".into(),
+            flattened_permissions: vec![
+                Permission::UseCatalog,
+                Permission::Select,
+                Permission::Manage,
+            ],
+            inherits_from: vec!["reader".into()],
+        },
+    );
+
+    adapter
+        .reconcile_role_graph(&roles)
+        .await
+        .expect("v1 reconcile_role_graph should succeed without network calls");
+
+    // Naming-convention assertion lives alongside the dispatch test so
+    // anyone refactoring the helper sees this test pin the public
+    // contract.
+    assert_eq!(role_group_name("reader"), "rocky_role_reader");
+    assert_eq!(role_group_name("admin"), "rocky_role_admin");
+}
+
+/// Empty role graph is a no-op — exercise the early-return path through
+/// the trait dispatch.
+#[tokio::test]
+async fn test_reconcile_role_graph_empty_is_ok() {
+    use rocky_core::ir::ResolvedRole;
+    use rocky_core::traits::GovernanceAdapter as _;
+    use rocky_databricks::governance::DatabricksGovernanceAdapter;
+    use std::collections::BTreeMap;
+
+    let server = MockServer::start().await;
+    let connector = test_connector(&server);
+    let adapter = DatabricksGovernanceAdapter::without_workspace(Arc::new(connector));
+
+    let empty: BTreeMap<String, ResolvedRole> = BTreeMap::new();
+    adapter
+        .reconcile_role_graph(&empty)
+        .await
+        .expect("empty role graph should be a no-op");
+}

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -619,6 +619,34 @@ class RetryConfig(BaseModel):
     """
 
 
+class RoleConfig(BaseModel):
+    """
+    A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.
+
+    ```toml [role.reader] permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+
+    [role.analytics_engineer] inherits = ["reader"] permissions = ["MODIFY"]
+
+    [role.admin] inherits = ["analytics_engineer"] permissions = ["MANAGE"] ```
+
+    Resolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.
+
+    Permission strings must match the canonical uppercase spellings of [`crate::ir::Permission`] (`"SELECT"`, `"USE CATALOG"`, ...).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    inherits: list[str] | None = []
+    """
+    Immediate parent role names. Rocky walks these transitively at reconcile time; cycles are rejected. Defaults to `[]` when omitted.
+    """
+    permissions: list[str] | None = []
+    """
+    Permissions this role grants. Rocky unions these with every ancestor's permissions before passing the flattened set to the governance adapter. Defaults to `[]` (permissionless grouping roles are legal — they exist only for inheritance).
+    """
+
+
 class RunRetryConfig(BaseModel):
     """
     Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.
@@ -2357,6 +2385,12 @@ class RockyConfig(BaseModel):
     When set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.
 
     Unset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits.
+    """
+    role: dict[str, RoleConfig] | None = Field({}, validate_default=True)
+    """
+    Hierarchical role declarations reconciled against the warehouse's native role/group system.
+
+    See [`RoleConfig`] for the TOML shape and [`crate::role_graph::flatten_role_graph`] for the inheritance resolution semantics (DAG walk with cycle detection).
     """
     schema_evolution: SchemaEvolutionConfig | None = Field(
         {"grace_period_days": 7}, validate_default=True

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2074,6 +2074,29 @@
       },
       "type": "object"
     },
+    "RoleConfig": {
+      "additionalProperties": false,
+      "description": "A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.\n\n```toml [role.reader] permissions = [\"SELECT\", \"USE CATALOG\", \"USE SCHEMA\"]\n\n[role.analytics_engineer] inherits = [\"reader\"] permissions = [\"MODIFY\"]\n\n[role.admin] inherits = [\"analytics_engineer\"] permissions = [\"MANAGE\"] ```\n\nResolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.\n\nPermission strings must match the canonical uppercase spellings of [`crate::ir::Permission`] (`\"SELECT\"`, `\"USE CATALOG\"`, ...).",
+      "properties": {
+        "inherits": {
+          "default": [],
+          "description": "Immediate parent role names. Rocky walks these transitively at reconcile time; cycles are rejected. Defaults to `[]` when omitted.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "permissions": {
+          "default": [],
+          "description": "Permissions this role grants. Rocky unions these with every ancestor's permissions before passing the flattened set to the governance adapter. Defaults to `[]` (permissionless grouping roles are legal — they exist only for inheritance).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "RunRetryConfig": {
       "additionalProperties": false,
       "description": "Top-level retry configuration applied across every adapter for this run. See [`RockyConfig::retry`] for the cross-adapter semantics this unlocks.",
@@ -2844,6 +2867,14 @@
       ],
       "default": null,
       "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
+    },
+    "role": {
+      "additionalProperties": {
+        "$ref": "#/definitions/RoleConfig"
+      },
+      "default": {},
+      "description": "Hierarchical role declarations reconciled against the warehouse's native role/group system.\n\nSee [`RoleConfig`] for the TOML shape and [`crate::role_graph::flatten_role_graph`] for the inheritance resolution semantics (DAG walk with cycle detection).",
+      "type": "object"
     },
     "schema_evolution": {
       "allOf": [


### PR DESCRIPTION
## Summary
Wave C-1 of the governance waveplan — hierarchical roles declared in `rocky.toml`, flattened via a DAG walk, and reconciled against the warehouse via a new `GovernanceAdapter::reconcile_role_graph` trait method.

### Config surface
```toml
[role.reader]
permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]

[role.analytics_engineer]
inherits = ["reader"]
permissions = ["MODIFY"]        # added to reader's, flattened at reconcile

[role.admin]
inherits = ["analytics_engineer"]
permissions = ["MANAGE"]
```

`admin` resolves to `SELECT + USE CATALOG + USE SCHEMA + MODIFY + MANAGE` via the inheritance chain.

### Core types
- `RoleConfig { inherits, permissions }` on `RockyConfig.roles` — parsed from `[role.<name>]` blocks.
- `ResolvedRole` in `rocky-core::ir` — flattened per-role result (full permission set + retained `inherits_from` for audit/debug).
- `RoleGraphError` in `rocky-core::role_graph` — `Cycle { role, path }`, `UnknownParent { role, parent }`, `UnknownPermission { role, permission }`.

### Algorithm
- DFS traversal with in-stack tracking for cycle detection (produces the exact cycle path).
- `BTreeSet<Permission>` dedup; `BTreeMap` output for deterministic iteration.
- 12 unit tests: linear inheritance, diamond dedup, self-/2-/3-node cycles, unknown parent, unknown permission, empty graph, grouping-only roles, deterministic sort.

### Trait extension
```rust
async fn reconcile_role_graph(
    &self,
    roles: &BTreeMap<String, ResolvedRole>,
) -> AdapterResult<()>;
```
Default-unsupported on all adapters; `NoopGovernanceAdapter` overrides to `Ok(())`.

### Databricks impl — v1 log-only
Validates each `rocky_role_<name>` against Databricks principal syntax (fails fast on bad names) and emits a structured `debug!` record per role. Does **not** call SCIM or emit GRANT DDL in v1 — see follow-ups below.

### Runtime wiring
`rocky run` now calls `rocky_cfg.role_graph()` (flatten) + `governance_adapter.reconcile_role_graph(&resolved)` alongside the Wave A classification / masking applies. Best-effort semantics: failures `warn!`, pipeline continues.

### Explicit v1 deferrals (tracked follow-ups, not in this PR)
1. **SCIM client in `rocky-databricks`** — create / reconcile Unity Catalog groups programmatically. The `rocky_role_<name>` naming is pinned; SCIM work is isolated to group lifecycle.
2. **Per-catalog GRANT emission**. The trait sig has no catalog parameter, so the Databricks impl can't emit `GRANT ... ON CATALOG` today. Two paths forward — (a) extend the sig with `&[catalog]`, or (b) have `run.rs` iterate managed catalogs and call per catalog. Either is a small, isolated change.
3. **`--env` threading** into `reconcile_role_graph` for parity with masking's env override.

## Files touched (16 files, +1040 / -2 LOC)

| Area | Change |
|---|---|
| `rocky-core/src/role_graph.rs` (new) | Flattening + error types + 12 unit tests |
| `rocky-core/src/ir.rs` | `ResolvedRole`, `Permission` Ord/PartialOrd/FromStr, `UnknownPermission` |
| `rocky-core/src/config.rs` | `RoleConfig`, `RockyConfig.roles`, `role_graph()` helper |
| `rocky-core/src/traits.rs` | New trait method + default + Noop override + 2 tests |
| `rocky-core/src/{bridge,cross_engine,docs,unified_dag}.rs` | Add `roles: Default::default()` to test literals |
| `rocky-databricks/src/governance.rs` | v1 log-only impl + `role_group_name()` + 4 unit tests |
| `rocky-databricks/tests/wiremock_tests.rs` | 2 trait-dispatch tests pinning v1 as no-network |
| `rocky-cli/src/commands/run.rs` | Best-effort wiring after Wave A masking reconcile |
| `schemas/rocky_project.schema.json` + dagster Pydantic + vscode TS | Codegen cascade for `RoleConfig` |

## Test plan
- [x] `cargo test --workspace --features rocky-databricks/test-support` — 1097+22 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `cargo fmt --check` — green (rustfmt 1.95.0)
- [x] `just codegen` idempotent (re-run produces no drift)
- [ ] Declare a 3-level inheritance chain in a playground POC rocky.toml, run `rocky run` against a Databricks workspace with pre-created `rocky_role_*` groups, confirm debug logs list the right flattened permissions (real GRANT emission is Wave C-1-followup)
- [ ] Cycle + unknown-parent error surfacing in `rocky compile` / `rocky run`