### PR TITLE
docs: governance waveplan (Waves A-C2) + two POCs

### DIFF
--- a/docs/src/content/docs/guides/governance.md
+++ b/docs/src/content/docs/guides/governance.md
@@ -5,7 +5,15 @@ sidebar:
   order: 7
 ---
 
-Rocky provides a governance layer that enforces data quality, schema stability, access control, and auditability. Governance features are configured in `rocky.toml` and execute automatically during `rocky run` -- there is no separate governance command.
+Rocky provides a governance layer that enforces data quality, schema stability, access control, masking, retention, and auditability. Most governance features are declarative: you configure them in `rocky.toml` (or a model sidecar) and they execute automatically as part of `rocky run`. Two governance features are exposed as standalone commands for CI gating: `rocky compliance` (classification vs. masking rollup) and `rocky retention-status` (per-model retention report).
+
+The five governance pillars live on the pipeline target and across project-level blocks:
+
+1. **Grants** -- declarative catalog and schema ACLs reconciled against Unity Catalog.
+2. **Column classification + masking** -- per-column classification tags plus project-level `[mask]` / `[mask.<env>]` strategies.
+3. **Compliance rollup** -- `rocky compliance` static resolver for CI gating.
+4. **Role-graph reconciliation** -- hierarchical `[role.<name>]` declarations flattened and reconciled.
+5. **Data retention** -- model-sidecar `retention = "<N>[dy]"` applied as adapter-native TBLPROPERTIES.
 
 This guide walks through each governance feature with practical configuration examples.
 
@@ -166,7 +174,7 @@ rocky ci --models models --contracts contracts
 
 This catches contract violations before code reaches production.
 
-## 3. Permissions
+## 3. Grants (Pillar 1 of 5)
 
 Rocky manages Databricks Unity Catalog permissions declaratively. Define desired grants in `rocky.toml` and Rocky reconciles them during each `rocky run`.
 
@@ -239,7 +247,253 @@ Principal names must match the pattern `^[a-zA-Z0-9_ \-\.@]+$`. In generated SQL
 GRANT USE CATALOG ON CATALOG acme_warehouse TO `group:data engineers`
 ```
 
-## 4. Workspace Isolation
+## 4. Column Classification and Masking (Pillar 2 of 5)
+
+Classification tags identify sensitive columns; masking strategies decide how those columns are obfuscated in the warehouse. Rocky splits the two concerns so teams can tag columns for discovery and lineage without committing to a specific obfuscation policy, then map tags to strategies in one place (with per-environment overrides).
+
+Shipped in engine-v1.16.0 (Wave A). Currently implemented on Databricks; other adapters default to no-op.
+
+### Tag columns in the model sidecar
+
+Classification tags live in the model's `.toml` sidecar under a `[classification]` block. Keys are column names, values are free-form tag strings -- Rocky does not enforce a fixed vocabulary:
+
+```toml
+# models/customers.toml
+name = "customers"
+
+[classification]
+pii_email = "pii"
+phone = "pii"
+ssn = "confidential"
+home_address = "pii"
+```
+
+The tag strings (`pii`, `confidential`, and so on) are matched against the project-level `[mask]` block to pick a masking strategy. Teams can coin new tags (`financial`, `health`, `internal`) without touching the engine.
+
+### Map tags to masking strategies
+
+Project-level `[mask]` in `rocky.toml` binds classification tags to masking strategies. A scalar value sets the workspace default; a nested `[mask.<env>]` table overrides strategies for a specific environment:
+
+```toml
+[mask]
+pii = "hash"             # default: SHA-256 hash of the value
+confidential = "redact"  # default: replace with '***'
+
+[mask.prod]
+pii = "none"             # prod override: do not mask pii
+confidential = "partial" # keep first/last 2 chars, mask the middle
+```
+
+Rocky resolves per-environment masks via `RockyConfig::resolve_mask_for_env`: top-level scalars become defaults, then any matching `[mask.<env>]` table overlays same-key values. When no env is passed, only the defaults apply.
+
+### Supported strategies
+
+| Strategy | Emitted SQL behaviour |
+|---|---|
+| `"hash"` | SHA-256 hash of the column value. |
+| `"redact"` | Replace with the literal `'***'`. |
+| `"partial"` | Keep the first and last 2 characters; mask the middle. |
+| `"none"` | Explicit identity -- no masking applied. Counts as masked for compliance. |
+
+Unknown strategy spellings (e.g., `"mask"`, `"obfuscate"`) hard-fail at config load time. Rocky never silently accepts a strategy it cannot emit SQL for.
+
+### Allowed unmasked tags
+
+The `[classifications]` block carries an escape hatch for tags that are used purely for discovery/lineage and are not expected to have a matching `[mask]` strategy:
+
+```toml
+[classifications]
+allow_unmasked = ["internal", "public"]
+```
+
+Any tag listed here suppresses the `W004` "tag has no masking strategy" compiler warning. This is advisory only -- it does not pretend unmasked columns are enforced; it just silences the warning.
+
+### How apply works
+
+After the DAG completes successfully, `rocky run` iterates each model's `[classification]` block and calls the governance adapter's `apply_column_tags` and `apply_masking_policy` hooks. Both are best-effort: failures emit `warn!` and the pipeline continues, mirroring the `apply_grants` semantics.
+
+On Databricks, Rocky uses Unity Catalog column tags plus `CREATE MASK` / `SET MASKING POLICY`, with **one statement per column** -- UC rejects multi-column masking DDL in a single statement. BigQuery, Snowflake, and DuckDB silently no-op until adapter-specific coverage lands.
+
+See the [configuration reference](../reference/configuration.md) for the full schema of the `[mask]` and `[classifications]` blocks.
+
+## 5. Compliance Rollup (Pillar 3 of 5)
+
+`rocky compliance` is a static resolver that answers one question: **are all classified columns masked wherever policy says they should be?**
+
+It is a thin rollup over the Wave A configuration (classifications + masks) -- no warehouse calls, no network round-trips. Shipped in engine-v1.16.0 (Wave B).
+
+### Basic usage
+
+```bash
+rocky compliance
+```
+
+```
+Compliance report (env: <all>)
+  models scanned:       42
+  classified columns:   87
+  with strategy:        84
+  exceptions:           3
+
+EXCEPTIONS:
+  customers.pii_email    (prod)  no strategy for classification 'pii'
+  orders.card_last_four  (prod)  no strategy for classification 'financial'
+  users.ssn              (dev)   no strategy for classification 'confidential'
+```
+
+### Flags
+
+| Flag | Purpose |
+|---|---|
+| `--env <name>` | Scope the report to a single environment. Without it, Rocky expands across the defaults plus every `[mask.<env>]` override. |
+| `--exceptions-only` | Filter the `per_column` table to rows that produced at least one exception. The `exceptions` list itself is always shown. |
+| `--fail-on exception` | Exit with code `1` when any exception is emitted. Wire this into CI to block merges that leave classified columns unmasked. |
+| `--models <dir>` | Models directory to scan (defaults to `models/`). |
+
+### Exit codes
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Report produced. Exceptions may or may not be present -- exit stays 0 unless `--fail-on exception` is passed. |
+| `1` | `--fail-on exception` was set and at least one exception was emitted. |
+
+### How `none` counts
+
+`MaskStrategy::None` (explicit identity) counts as **masked** for compliance purposes. The rationale: choosing "do not mask" is a deliberate policy decision, not a gap. A tag with no mapping in `[mask]` at all is the gap that produces an exception.
+
+The `[classifications] allow_unmasked = [...]` list suppresses exceptions for specific tags without pretending the columns are enforced. Use it for tags you've deliberately excluded from the mask policy (e.g., `"internal"` data that is explicitly open within the workspace).
+
+### JSON output
+
+```bash
+rocky compliance --env prod --output json
+```
+
+The JSON payload is the `ComplianceOutput` schema: a `summary` block with counters, a `per_column` array, and an `exceptions` array. Use this for dashboards and CI step summaries.
+
+## 6. Role-Graph Reconciliation (Pillar 4 of 5)
+
+Rocky supports hierarchical role declarations that flatten into a resolved permission set per role. Inheritance is declarative and composable; cycles and unknown parents are rejected at config-load time.
+
+Shipped in engine-v1.16.0 (Wave C-1). The Databricks v1 adapter implementation is **log-only** -- it validates the flattened graph and emits `debug!` events, but SCIM group creation and per-catalog GRANT emission are deferred to a follow-up.
+
+### Declare roles in `rocky.toml`
+
+```toml
+[role.reader]
+permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+
+[role.analytics_engineer]
+inherits = ["reader"]
+permissions = ["MODIFY"]
+
+[role.admin]
+inherits = ["analytics_engineer"]
+permissions = ["MANAGE"]
+```
+
+Each `[role.<name>]` block declares:
+
+- `inherits` -- a list of immediate parent roles. Rocky walks these transitively.
+- `permissions` -- a list of canonical Rocky permission strings (`"SELECT"`, `"USE CATALOG"`, `"MODIFY"`, `"MANAGE"`, ...).
+
+Roles with empty `permissions` are legal -- they act as grouping nodes that exist only for inheritance.
+
+### Resolution semantics
+
+At reconcile time, Rocky calls `RockyConfig::role_graph()` which flattens the `[role.*]` map into a deterministic `name → ResolvedRole` map:
+
+1. Walk the `inherits` DAG via DFS with cycle detection.
+2. Union this role's `permissions` with every transitive ancestor's `permissions`.
+3. Reject unknown parents (e.g., `inherits = ["nonexistent_role"]`).
+4. Reject unknown permission spellings.
+
+Cycles and unknown parents are caught at config-load time, regardless of whether the target adapter supports role-graph reconcile. This means the resolver catches misconfiguration even on warehouses where the adapter silently no-ops.
+
+### Databricks v1: log-only
+
+The Databricks implementation of `GovernanceAdapter::reconcile_role_graph` validates each flattened role's `rocky_role_<name>` principal syntax and emits `debug!` log entries with the resolved permission set. It does not yet:
+
+- Create SCIM groups for each role
+- Emit per-catalog / per-schema `GRANT` statements from the flattened role graph
+
+SCIM group creation and GRANT emission are the Wave C-1 follow-up. If you need grants applied today, use the `[pipeline.*.target.governance.grants]` blocks from Pillar 1.
+
+Other adapters default to no-op.
+
+### Why ship the resolver first
+
+Landing the resolver ahead of the warehouse-side apply means teams can:
+
+- Design role hierarchies in `rocky.toml` now with confidence that cycles and typos are rejected early.
+- Inspect `rocky.toml` with `rocky list pipelines` / `rocky validate` and know the graph compiles.
+- Migrate to the full Databricks apply when the follow-up lands without rewriting their config.
+
+## 7. Data Retention (Pillar 5 of 5)
+
+Data retention policies tell the warehouse how long to keep historical data for each table. Rocky expresses retention as a single sidecar key; each adapter translates it to the warehouse-native TBLPROPERTIES or session parameter.
+
+Shipped in engine-v1.16.0 (Wave C-2).
+
+### Declare retention on a model
+
+Model sidecars take a top-level `retention` key:
+
+```toml
+# models/events_daily.toml
+name = "events_daily"
+retention = "90d"   # grammar: \d+[dy] -- days or years
+```
+
+Grammar:
+
+- `<N>d` -- N days
+- `<N>y` -- N years; flat-multiplied to 365 days each (no leap-year math)
+
+Garbage inputs (`"abc"`, `"90"`, `"-3d"`) are rejected at sidecar parse time via `ModelError::InvalidRetention`.
+
+Omitting the `retention` key (or setting it to null) disables retention management for that model -- Rocky leaves the warehouse's default behaviour in place.
+
+### Adapter translation
+
+| Adapter | Translation |
+|---|---|
+| **Databricks** | Paired Delta TBLPROPERTIES: `delta.logRetentionDuration = '<N> days'` and `delta.deletedFileRetentionDuration = '<N> days'`. Applied via `ALTER TABLE ... SET TBLPROPERTIES`. |
+| **Snowflake** | `DATA_RETENTION_TIME_IN_DAYS = <N>` via `ALTER TABLE ... SET`. |
+| **BigQuery** | Default-unsupported. No first-class retention knob; sidecar ignored with a `warn!`. |
+| **DuckDB** | Default-unsupported. Sidecar ignored with a `warn!`. |
+
+Retention apply runs after the DAG completes, in the same post-run reconcile loop as classification + masking. Failures emit `warn!` and never abort the run.
+
+### Inspecting configured retention: `rocky retention-status`
+
+```bash
+rocky retention-status
+```
+
+```
+MODEL              CONFIGURED DAYS   WAREHOUSE DAYS
+─────────────────────────────────────────────────────
+events_daily       90                (not probed)
+orders             365               (not probed)
+customers          (none)            (not probed)
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `--models <dir>` | Models directory (defaults to `models/`). |
+| `--model <name>` | Scope the report to a single model. |
+| `--drift` | Accepted for forward compatibility. Today it filters the report to models with a declared policy and leaves `warehouse_days` null. |
+
+### `--drift` is a v2 feature
+
+The v2 plan for `--drift` is a warehouse probe that reads the currently-applied TBLPROPERTIES / session parameter and fills `warehouse_days` in the report, so teams can detect drift between `rocky.toml` and the live table.
+
+Today the flag is plumbed through with a stable schema (`warehouse_days: Option<u32>` on the report), but the probe itself is deferred. Wire your CI around the configured-days column for now; the warehouse-drift check will slot in without a schema change when the probe lands.
+
+## 8. Workspace Isolation
 
 Rocky can isolate catalogs to specific Databricks workspaces using the Unity Catalog workspace bindings API. Each binding declares both a workspace ID and an access level (`READ_WRITE` or `READ_ONLY`).
 
@@ -273,7 +527,7 @@ This prevents other workspaces from accessing the catalog. Only the listed works
 
 Isolation is applied as best-effort -- if the API call fails (e.g., workspace ID does not exist), Rocky logs a warning but continues the run.
 
-## 5. Tagging Strategy
+## 9. Tagging Strategy
 
 Tags are key-value pairs applied to catalogs, schemas, and tables using Databricks `ALTER ... SET TAGS` SQL.
 
@@ -335,7 +589,7 @@ This means you can deploy Rocky across multiple catalogs and discover all manage
 - Use `cost_center` for chargeback and FinOps
 - Add custom tags for compliance (e.g., `pii = "true"`, `data_classification = "internal"`)
 
-## 6. Quality Checks
+## 10. Quality Checks
 
 Rocky runs data quality checks inline during replication. Checks execute immediately after each table is copied, and results are included in the run output.
 
@@ -439,9 +693,41 @@ threshold = 0
 
 The check passes if the query result is less than or equal to the threshold.
 
-## 7. Audit Trail
+## 11. Audit Trail
 
-Rocky stores run history and quality metrics in the embedded state store (redb), providing a queryable audit trail.
+Rocky stores run history and quality metrics in the embedded state store (redb), providing a queryable audit trail. Every `rocky run` now stamps eight extra governance fields on its `RunRecord` (shipped in engine-v1.16.0, Wave A); the full trail is available via `rocky history --audit`.
+
+### `rocky history --audit` and the 8 audit fields
+
+The default `rocky history` output stays compact for byte-stability with schema v5 consumers. Pass `--audit` to expand every governance field in text or JSON:
+
+```bash
+rocky history --audit
+rocky history --audit --output json
+```
+
+Each `RunRecord` carries:
+
+| Field | Source |
+|---|---|
+| `triggering_identity` | Auth principal that kicked off the run. |
+| `session_source` | Auto-detected: `Cli` / `Dagster` / `Lsp` / `HttpApi`. |
+| `git_commit` | Resolved at run start from the current repo. |
+| `git_branch` | Resolved at run start from the current repo. |
+| `idempotency_key` | Echoed from `rocky run --idempotency-key <KEY>` when passed. |
+| `target_catalog` | The catalog(s) the run wrote to. |
+| `hostname` | The host that executed the run. |
+| `rocky_version` | The CLI version that produced the record. |
+
+### Schema version v5 → v6 (forward-deserialize)
+
+The audit trail expansion bumped the redb schema version from v5 to v6. The migration is forward-deserialize only -- no in-place blob rewrite -- so existing stores open cleanly. Defaults filled in on v5 rows:
+
+- `hostname = "unknown"`
+- `rocky_version = "<pre-audit>"`
+- `session_source = Cli`
+
+This means old runs still render correctly under `rocky history --audit`; they simply show the placeholder strings for the three fields that did not exist yet.
 
 ### View run history
 
@@ -545,7 +831,7 @@ rocky history -o json
 rocky metrics fct_daily_revenue --trend -o json
 ```
 
-## 8. Complete Governance Configuration
+## 12. Complete Governance Configuration
 
 Here is a full pipeline target with every governance feature enabled. Governance lives under each pipeline's target so different pipelines can have different policies:
 
@@ -612,9 +898,101 @@ sql = "SELECT COUNT(*) FROM {target} WHERE order_date > CURRENT_DATE()"
 threshold = 0
 ```
 
+Classification, masking, roles, and retention live outside the pipeline target (they are project-level), but the complete picture is:
+
+```toml
+# Project-level masking policy
+[mask]
+pii = "hash"
+confidential = "redact"
+
+[mask.prod]
+pii = "none"
+confidential = "partial"
+
+[classifications]
+allow_unmasked = ["internal"]
+
+# Project-level role graph
+[role.reader]
+permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+
+[role.analytics_engineer]
+inherits = ["reader"]
+permissions = ["MODIFY"]
+
+[role.admin]
+inherits = ["analytics_engineer"]
+permissions = ["MANAGE"]
+```
+
+Paired with a model sidecar:
+
+```toml
+# models/customers.toml
+name = "customers"
+retention = "365d"
+
+[classification]
+pii_email = "pii"
+phone = "pii"
+ssn = "confidential"
+```
+
 This configuration ensures:
 - Catalogs and schemas are created automatically with appropriate tags
 - Access is controlled via declarative grants with automatic reconciliation
 - Catalogs are isolated to specific workspaces
+- Classified columns are tagged and masked per environment
+- Role hierarchies are validated at config load (cycles + unknown parents rejected)
+- Retention is applied to every model that declares it
 - Data quality is validated after every replication
-- History and metrics provide a complete audit trail
+- History and metrics provide a complete audit trail, including 8 governance fields per run
+
+## 13. CI Gate Example
+
+The CI gate pattern wires `rocky compliance --fail-on exception` into a pipeline step that blocks merges when classified columns are unmasked. For quieter local runs, drop `--fail-on` and add `--exceptions-only` so the output skips the per-column table when nothing is wrong.
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/rocky-compliance.yml
+name: Rocky Compliance
+
+on:
+  pull_request:
+    paths:
+      - 'models/**'
+      - 'rocky.toml'
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rocky
+        run: curl -sSL https://install.rocky.dev | sh
+      - name: Run compliance gate
+        run: rocky compliance --env prod --fail-on exception
+```
+
+The gate exits `0` when every classified column has a resolved strategy (or is listed in `allow_unmasked`), and exits `1` -- failing the job -- the moment any exception is emitted.
+
+### Local quiet-mode run
+
+```bash
+rocky compliance --env prod --exceptions-only
+```
+
+When everything is compliant, this prints the summary counters and an empty exceptions list. When exceptions exist, the `per_column` table is filtered to just the rows that produced them, making it easy to see what needs attention without scrolling through the full classified-column inventory.
+
+### Machine-readable gate
+
+For dashboards and custom policy engines, emit JSON and pipe it into `jq`:
+
+```bash
+rocky compliance --env prod --output json \
+  | jq '.exceptions[] | {model, column, env, reason}'
+```
+
+The `ComplianceOutput` schema is stable across minor versions -- wire downstream tooling against the JSON payload rather than the text-table renderer.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -12,7 +12,7 @@ Rocky provides a single binary with subcommands for the full pipeline lifecycle.
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
 - **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `hooks`, `validate-migration`, `test-adapter`
-- **Administration**: `history`, `replay`, `trace`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`
+- **Administration**: `history`, `replay`, `trace`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`, `compliance`, `retention-status`
 - **Diagnostics**: `doctor`, `compare`
 
 See the dedicated command reference pages for detailed documentation of each category.
@@ -25,11 +25,15 @@ These flags apply to all commands.
 |------|-------|---------|-------------|
 | `--config <PATH>` | `-c` | `rocky.toml` | Path to the pipeline configuration file. |
 | `--output <FORMAT>` | `-o` | `json` | Output format. Accepted values: `json`, `table`. |
-| `--state-path <PATH>` | | `.rocky-state.redb` | Path to the embedded state store used for watermarks. |
+| `--state-path <PATH>` | | resolved (see below) | Path to the embedded state store. When omitted, Rocky resolves to `<models>/.rocky-state.redb` (canonical) or a legacy CWD `.rocky-state.redb` (deprecated, warns on stderr). Passing the flag explicitly is always a hard override. See [`rocky state`](/reference/commands/administration/#rocky-state). |
+| `--cache-ttl <SECONDS>` | | `[cache.schemas] ttl_seconds` or `86400` | Override the `DESCRIBE TABLE` schema-cache TTL for this invocation. Precedence: `--cache-ttl` > `rocky.toml` > `86400` (24 h). `--cache-ttl 0` treats every entry as instantly stale. To disable the cache entirely, set `[cache.schemas] enabled = false` in `rocky.toml`. Applies to the CLI read path only (`rocky compile`, `rocky run`, …); `rocky lsp` / `rocky serve` keep the config-derived TTL. |
 
 ```bash
 # Example: use a custom config and table output
 rocky -c pipelines/prod.toml -o table discover
+
+# Force a fresh typecheck against warehouse metadata
+rocky --cache-ttl 0 compile
 ```
 
 ---
@@ -104,7 +108,7 @@ ok  pipeline.bronze: replication / incremental -> warehouse / stage__{source}
 Lists available connectors and their tables from the configured source.
 
 ```bash
-rocky discover [--pipeline NAME]
+rocky discover [--pipeline NAME] [--with-schemas]
 ```
 
 **Flags:**
@@ -112,6 +116,7 @@ rocky discover [--pipeline NAME]
 | Flag | Description |
 |------|-------------|
 | `--pipeline <NAME>` | Pipeline name. Required when more than one `[pipeline.NAME]` is defined. |
+| `--with-schemas` | Warm the schema cache for every discovered source. For each `(catalog, schema)` pair reachable via the source adapter, issues one `batch_describe_schema` round-trip and persists the per-table columns to `state.redb::schema_cache`. Subsequent `rocky compile` / `rocky lsp` invocations pick up the entries instead of typechecking leaf models as `Unknown`. Errors on individual sources are logged and skipped. Setting this flag with `[cache.schemas] enabled = false` errors with a clear message rather than silently no-op-ing. `DiscoverOutput.schemas_cached` records the count. |
 
 **Behavior:**
 
@@ -209,6 +214,7 @@ rocky run --filter <key=value> [flags]
 | `--shadow-suffix <SUFFIX>` | | Suffix appended to table names in shadow mode (default `_rocky_shadow`). |
 | `--shadow-schema <NAME>` | | Override schema for shadow tables (mutually exclusive with `--shadow-suffix`). |
 | `--branch <NAME>` | | Execute against a named branch created with `rocky branch create`. Mutually exclusive with `--shadow` / `--shadow-schema`. See [`rocky branch`](/reference/commands/core-pipeline/#rocky-branch). |
+| `--idempotency-key <KEY>` | | Caller-supplied opaque key used to dedup this run against prior runs with the same key. Three outcomes: a prior run succeeded (or reached a terminal state under `dedup_on = "any"`) → exit 0 with `status = "skipped_idempotent"` and the prior `skipped_by_run_id`; another caller currently holds the claim within `in_flight_ttl_hours` → exit 0 with `status = "skipped_in_flight"`; otherwise proceed normally. Rejected when combined with `--resume` / `--resume-latest` (resume is an explicit override). Stamps are stored verbatim — do not put secrets in the key. See [`[state.idempotency]`](/reference/configuration/) for tuning. |
 
 **Pipeline stages (in order):**
 
@@ -454,15 +460,35 @@ rocky compare --filter <key=value> [flags]
 
 ### `rocky state`
 
-Displays stored watermarks from the embedded state file.
+Inspect or manage the embedded state store. `rocky state` is a subcommand group; bare `rocky state` continues to display watermarks for backwards compatibility.
 
 ```bash
-rocky state
+rocky state                                # show watermarks (default)
+rocky state show                           # same as bare `rocky state`
+rocky state clear-schema-cache [--dry-run] # flush the DESCRIBE cache
 ```
 
-**Behavior:**
+**Subcommands:**
 
-- Reads the redb state store (default: `.rocky-state.redb`).
+| Subcommand | Description |
+|------------|-------------|
+| `show` (default) | Display stored watermarks. |
+| `clear-schema-cache` | Remove every entry from the `SCHEMA_CACHE` redb table. `--dry-run` reports what would be removed without touching the store. A missing state store is a no-op (CI-safe on ephemeral runners). Emits `ClearSchemaCacheOutput`. See [`rocky state clear-schema-cache`](/reference/commands/administration/#rocky-state-clear-schema-cache). |
+
+**State-path resolution (v1.16.0):**
+
+When `--state-path` is not passed, Rocky resolves the state file via `rocky_core::state::resolve_state_path`:
+
+1. `<models>/.rocky-state.redb` — canonical location for new projects; matches the LSP convention so inlay hints observe the same file `rocky run` writes.
+2. Legacy `.rocky-state.redb` in CWD — still works; emits a one-time deprecation warning on stderr.
+3. Both present — CWD wins (to preserve existing watermarks / branches / partitions); a louder warning asks you to reconcile. Merge is lossy.
+4. Neither present — fresh project lands on `<models>/.rocky-state.redb` when a `models/` directory exists, otherwise CWD.
+
+Explicit `--state-path <PATH>` always overrides the resolver.
+
+**`rocky state` behavior (show):**
+
+- Reads the redb state store at the resolved path.
 - Lists every tracked table with its last watermark value and the timestamp it was recorded.
 
 **JSON output:**
@@ -676,3 +702,53 @@ rocky fmt --check            # Check mode: exit non-zero if any file needs forma
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `paths` | `.` | Files or directories to format. |
+
+---
+
+### `rocky compliance`
+
+Governance rollup over classification sidecars plus the project `[mask]` policy. Answers: "are all classified columns masked wherever policy says they should be?" Static resolver — no warehouse calls.
+
+```bash
+rocky compliance [--env NAME] [--exceptions-only] [--fail-on exception]
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--env <NAME>` | (expand all) | Scope the report to a single environment (e.g. `prod`). When unset, the report expands across the defaults plus every `[mask.<env>]` override block. |
+| `--exceptions-only` | `false` | Filter `per_column` to rows that produced at least one exception. The `exceptions` list is unaffected. |
+| `--fail-on <CONDITION>` | | Gate condition. The only supported value is `exception` — exits `1` when any exception is emitted. Useful as a CI gate to block merges that leave classified columns unmasked. |
+| `--models <PATH>` | `models` | Models directory to scan for `[classification]` sidecars. |
+
+**Behavior:**
+
+- Walks every model's `[classification]` sidecar block and, for each `(model, column, env)` triple, resolves the masking strategy from `[mask]` / `[mask.<env>]`.
+- `MaskStrategy::None` counts as masked — an explicit-identity policy is a conscious decision, not an enforcement gap.
+- Tags listed under `[classifications] allow_unmasked` suppress exception emission but still report `enforced = false` in the per-column breakdown.
+- JSON output is [`ComplianceOutput`](/reference/json-output/) (`summary` / `per_column` / `exceptions`).
+
+---
+
+### `rocky retention-status`
+
+Report each model's declared data-retention policy (`retention = "<N>[dy]"` in the model sidecar).
+
+```bash
+rocky retention-status [--model NAME] [--drift]
+```
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--model <NAME>` | (all) | Scope the report to a single model. |
+| `--drift` | `false` | Stretch goal reserved for v2 — today this filters output to models with a declared policy and leaves `warehouse_days` null. The warehouse probe (`SHOW TBLPROPERTIES` / `SHOW PARAMETERS`) is deferred. |
+| `--models <PATH>` | `models` (via `rocky.toml`) | Models directory. |
+
+**Behavior:**
+
+- Compiles the project, then emits one `ModelRetentionStatus` per model with `configured_days`, `warehouse_days` (always `None` in v1), and `in_sync`.
+- Models without a `retention` sidecar value report `configured_days = null` and `in_sync = true`.
+- JSON output is [`RetentionStatusOutput`](/reference/json-output/).

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -23,6 +23,7 @@ rocky history [flags]
 |------|------|---------|-------------|
 | `--model <NAME>` | `string` | | Filter history to a specific model. |
 | `--since <DATE>` | `string` | | Only show runs since this date (ISO 8601 or `YYYY-MM-DD`). |
+| `--audit` | `bool` | `false` | Include the governance audit trail for each run in JSON output, and print a second governance table after the default summary in text output. See [Audit trail](#audit-trail) below. |
 
 ### Examples
 
@@ -108,6 +109,54 @@ run_id                   | started_at            | duration  | copied | failed |
 run_20260401_143022      | 2026-04-01T14:30:22Z  | 45.2s     | 20     | 0      | success
 run_20260401_080015      | 2026-04-01T08:00:15Z  | 52.1s     | 19     | 1      | partial
 ```
+
+### Audit trail
+
+`--audit` (added in v1.16.0) expands each run record with an eight-field governance trail captured by every `rocky run` against redb schema v6. Default output omits these fields for byte-stability with pre-v1.16 consumers.
+
+| Field | Description |
+|-------|-------------|
+| `triggering_identity` | Principal that initiated the run (OS user, CI service account, etc.). |
+| `session_source` | One of `cli`, `dagster`, `lsp`, `http_api` — auto-detected at run start. |
+| `git_commit` | Commit SHA at the project root (`None` when not a git repo). |
+| `git_branch` | Branch name at the project root (`None` when not a git repo). |
+| `idempotency_key` | Echoed value of `--idempotency-key` (`None` when the flag wasn't used). |
+| `target_catalog` | Resolved target catalog for the executed pipeline. |
+| `hostname` | Hostname where the run executed. Always populated (defaults to `"unknown"` on pre-v6 rows). |
+| `rocky_version` | `CARGO_PKG_VERSION` at run time. Always populated (`"<pre-audit>"` on pre-v6 rows). |
+
+```bash
+rocky history --audit
+```
+
+```json
+{
+  "version": "1.16.0",
+  "command": "history",
+  "count": 1,
+  "runs": [
+    {
+      "run_id": "run_20260423_143022",
+      "started_at": "2026-04-23T14:30:22Z",
+      "duration_ms": 45200,
+      "status": "Success",
+      "trigger": "Cli",
+      "models_executed": 14,
+      "models": [ /* per-model records */ ],
+      "triggering_identity": "alice@acme.io",
+      "session_source": "dagster",
+      "git_commit": "a3f2b1c4...",
+      "git_branch": "main",
+      "idempotency_key": "nightly-2026-04-23",
+      "target_catalog": "acme_warehouse",
+      "hostname": "runner-12",
+      "rocky_version": "1.16.0"
+    }
+  ]
+}
+```
+
+Text output appends a `Governance audit trail (--audit):` section after the default run summary with short-form columns (`git_commit` truncated to 8 chars, `hostname` to 11) plus a per-run detail line carrying `rocky_version` and `idempotency_key`.
 
 ### Related Commands
 
@@ -773,3 +822,232 @@ Missing `adapter_type` or unconfigured `[cost]` degrades cleanly: the command st
 - [`rocky trace`](#rocky-trace) -- same `RunRecord`, shown as a Gantt-style timeline
 - [`rocky history`](#rocky-history) -- list recent runs to find a `run_id`
 - [`[budget]`](/reference/configuration/#budget) -- run-level budget that fires `budget_breach` events during the run itself
+
+---
+
+## `rocky state`
+
+Inspect or manage the embedded state store. `rocky state` is a subcommand group; the bare form continues to show watermarks for backwards compatibility.
+
+```bash
+rocky state                                # show watermarks (default)
+rocky state show                           # same as bare `rocky state`
+rocky state clear-schema-cache [--dry-run] # flush the DESCRIBE cache
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `show` (default) | Display stored watermarks. Same output as bare `rocky state` — the named form is provided so scripts can be explicit. |
+| `clear-schema-cache` | Flush the `DESCRIBE TABLE` schema cache. See [`rocky state clear-schema-cache`](#rocky-state-clear-schema-cache). |
+
+### State-path resolution
+
+When `--state-path` is omitted, Rocky resolves the state file via `rocky_core::state::resolve_state_path`:
+
+1. `<models>/.rocky-state.redb` — canonical location for new projects; matches the LSP convention so inlay hints observe the same file `rocky run` writes.
+2. Legacy CWD `.rocky-state.redb` — still works; emits a one-time deprecation warning on stderr.
+3. Both present — CWD wins (preserves existing watermarks, branches, and partition bookkeeping); a louder warning asks you to reconcile. Merge is lossy — delete one copy to silence the warning.
+4. Neither present — fresh project lands on `<models>/.rocky-state.redb` when a `models/` directory exists; otherwise falls back to CWD (keeps replication-only pipelines working without inventing a `models/` directory just to hold state).
+
+Explicit `--state-path <PATH>` always wins; no resolver logic is applied.
+
+:::note[Upgrading to v1.16.0 state paths]
+Fresh projects land on `<models>/.rocky-state.redb`. Existing users with a CWD `.rocky-state.redb` will see a one-time deprecation warning on stderr and can either move the file into `models/` to silence the warning, or keep using the CWD location (it continues to work). If both files exist, CWD wins on collision — delete one to silence the louder reconcile warning. Passing `--state-path` explicitly bypasses the resolver.
+:::
+
+### Related Commands
+
+- [`rocky state clear-schema-cache`](#rocky-state-clear-schema-cache) -- flush the DESCRIBE cache
+- [`rocky history`](#rocky-history) -- read persisted run records
+- [`rocky replay`](#rocky-replay) / [`rocky trace`](#rocky-trace) / [`rocky cost`](#rocky-cost) -- read the same `RunRecord` the state store persists
+
+---
+
+## `rocky state clear-schema-cache`
+
+Flush the Arc 7 wave-2 `DESCRIBE TABLE` schema cache. Complement to the TTL-driven eviction on the read path — use this when the project needs a fresh typecheck *now* (e.g., after a manual warehouse DDL change, before a strict-CI run, while debugging a suspected stale-cache mismatch).
+
+```bash
+rocky state clear-schema-cache
+rocky state clear-schema-cache --dry-run
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--dry-run` | `bool` | `false` | Report how many entries would be removed without touching the store. Useful for automation that asserts emptiness before a scheduled flush. |
+
+### Behavior
+
+- Removes every row from the `SCHEMA_CACHE` redb table. The cache is cheap to rebuild — the next `rocky run` (write tap) or `rocky discover --with-schemas` warms it back up.
+- **No prompt.** Entries are disposable; explicit opt-in by running the command is sufficient.
+- **Missing state store is a no-op.** A fresh CI runner with no `.rocky-state.redb` yet exits zero with `entries_deleted: 0`. This keeps "flush before build" safe to run unconditionally on ephemeral runners.
+- Uninitialised cache tables return `entries_deleted: 0` without touching redb.
+- JSON output is `ClearSchemaCacheOutput` (`entries_deleted`, `dry_run`).
+
+### Example
+
+```bash
+rocky state clear-schema-cache --dry-run --output json
+```
+
+```json
+{
+  "version": "1.16.0",
+  "command": "state-clear-schema-cache",
+  "entries_deleted": 12,
+  "dry_run": true
+}
+```
+
+### Related Commands
+
+- [`rocky discover --with-schemas`](/reference/cli/#rocky-discover) -- warm the cache after a flush
+- [`rocky --cache-ttl`](/reference/cli/#global-flags) -- per-invocation TTL override (use `--cache-ttl 0` for one-shot bypass without flushing)
+- [`[cache.schemas]`](/reference/configuration/) -- disable the cache entirely with `enabled = false`
+
+---
+
+## `rocky compliance`
+
+Governance rollup over classification sidecars plus the project `[mask]` policy. Static resolver: answers *"are all classified columns masked wherever policy says they should be?"* without issuing a single warehouse call.
+
+```bash
+rocky compliance [--env NAME] [--exceptions-only] [--fail-on exception]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--env <NAME>` | `string` | | Scope the report to a single environment. When unset, the report expands across the defaults plus every `[mask.<env>]` override block declared in `rocky.toml`. A named env that has no matching `[mask.<env>]` block still reports under that label — the resolver falls back to the `[mask]` defaults. |
+| `--exceptions-only` | `bool` | `false` | Filter `per_column` to rows that produced at least one exception. The `exceptions` list is unaffected; allow-listed tags are suppressed from `per_column` under this flag. |
+| `--fail-on <CONDITION>` | `exception` | | Gate condition. Only `exception` is supported in v1. When set, exits `1` when one or more exceptions are emitted. Useful as a CI gate that blocks merges that leave classified columns unmasked. |
+| `--models <PATH>` | `string` | `models` | Models directory to scan for `[classification]` sidecars. |
+
+### Behavior
+
+- Loads `rocky.toml` and every model sidecar with a non-empty `[classification]` block. Each `(model, column, env)` triple is evaluated against the resolved masking strategy.
+- `MaskStrategy::None` ("explicit identity") counts as masked: the project has deliberately opted out, which is a conscious policy decision, not an enforcement gap.
+- Tags listed on `[classifications] allow_unmasked` suppress exception emission but still report `enforced = false` in the per-column breakdown — the allow list doesn't pretend the column is masked.
+- Exit `1` with `--fail-on exception` when any exception is emitted; otherwise exit `0` regardless of exception count (the JSON payload still reports them).
+- **Static rollup — no warehouse calls.** Fast enough to run in every PR.
+- JSON output is `ComplianceOutput` (`summary`, `per_column`, `exceptions`).
+
+### Example
+
+```bash
+rocky compliance --env prod --fail-on exception
+```
+
+```json
+{
+  "version": "1.16.0",
+  "command": "compliance",
+  "summary": {
+    "total_classified": 5,
+    "total_masked": 4,
+    "total_exceptions": 1
+  },
+  "per_column": [
+    {
+      "model": "users",
+      "column": "email",
+      "classification": "pii",
+      "envs": [
+        { "env": "prod", "masking_strategy": "hash", "enforced": true }
+      ]
+    },
+    {
+      "model": "users",
+      "column": "ssn",
+      "classification": "confidential",
+      "envs": [
+        { "env": "prod", "masking_strategy": "unresolved", "enforced": false }
+      ]
+    }
+  ],
+  "exceptions": [
+    {
+      "model": "users",
+      "column": "ssn",
+      "env": "prod",
+      "reason": "no masking strategy resolves for classification tag 'confidential'"
+    }
+  ]
+}
+```
+
+### Related Commands
+
+- [`rocky run`](/reference/commands/core-pipeline/#rocky-run) -- applies classification tags + masking policies inline during the post-DAG governance pass
+- [`rocky retention-status`](#rocky-retention-status) -- sibling governance rollup for retention declarations
+- [Governance configuration](/guides/governance/) -- `[mask]`, `[mask.<env>]`, `[classifications] allow_unmasked`
+
+---
+
+## `rocky retention-status`
+
+Report each model's declared data-retention policy. Walks the compiled model set and emits one row per model with its declared `retention = "<N>[dy]"` value (or `null` when unset).
+
+```bash
+rocky retention-status [--model NAME] [--drift]
+```
+
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--model <NAME>` | `string` | | Scope the report to a single model by name. |
+| `--drift` | `bool` | `false` | **v2 stretch — deferred.** v1 filters output to models with a declared policy and leaves `warehouse_days` `null`. In v2, Rocky will probe the warehouse via `SHOW TBLPROPERTIES` (Databricks) / `SHOW PARAMETERS ... FOR TABLE` (Snowflake) and populate `warehouse_days`. The JSON schema is already stable so v2 fills the field without a shape break. Text output prints a `note: --drift probe is deferred to v2` on stderr. |
+| `--models <PATH>` | `string` | `models` | Models directory. |
+
+### Behavior
+
+- Compiles the project so each model's resolved `retention` sidecar value surfaces as a typed `Option<RetentionPolicy>`.
+- `configured_days` is `None` when the model's sidecar carries no `retention` key.
+- `warehouse_days` is always `None` in v1 (the probe is deferred).
+- `in_sync` is `true` iff `configured_days == warehouse_days`. In v1, unconfigured models collapse to `in_sync = true` (both sides are `None`).
+- Currently applied only by Databricks (Delta `delta.logRetentionDuration` + `delta.deletedFileRetentionDuration`) and Snowflake (`DATA_RETENTION_TIME_IN_DAYS`). BigQuery and DuckDB are default-unsupported.
+- JSON output is `RetentionStatusOutput` (a flat `models` array of `ModelRetentionStatus`).
+
+### Example
+
+```bash
+rocky retention-status --output json
+```
+
+```json
+{
+  "version": "1.16.0",
+  "command": "retention-status",
+  "models": [
+    { "model": "fct_revenue",   "configured_days": 90, "in_sync": true },
+    { "model": "dim_customers",                        "in_sync": true },
+    { "model": "events",        "configured_days": 30, "in_sync": true }
+  ]
+}
+```
+
+Text mode is a fixed-width table:
+
+```bash
+rocky -o table retention-status
+```
+
+```
+MODEL                                    CONFIGURED       WAREHOUSE        IN SYNC
+----------------------------------------------------------------------------------
+fct_revenue                              90 days          -                yes
+dim_customers                            -                -                yes
+events                                   30 days          -                yes
+```
+
+### Related Commands
+
+- [`rocky compliance`](#rocky-compliance) -- sibling governance rollup for classification + masking
+- [`rocky run`](/reference/commands/core-pipeline/#rocky-run) -- applies retention policies inline during the post-DAG governance pass
+- [Model sidecar `retention`](/reference/model-format/) -- configure `retention = "<N>[dy]"`

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -597,6 +597,25 @@ circuit_breaker_recovery_timeout_secs = 30
 
 Terminal outcomes surface as structured `outcome` fields on `state.upload` / `state.download` events — `ok`, `absent`, `timeout`, `error_then_fresh`, `skipped_after_failure`, `transient_exhausted`, `circuit_open`, `budget_exhausted`. Grep those instead of the free-form log message when building alerts.
 
+### `[state.idempotency]`
+
+Tuning knobs for `rocky run --idempotency-key <KEY>` dedup. All fields are optional with the shown defaults; the block is a no-op on runs that don't pass `--idempotency-key`. Unknown fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `retention_days` | integer | `30` | Lifetime of a terminal idempotency stamp before garbage collection. GC runs during the state upload sweep — no separate cron. |
+| `dedup_on` | string | `"success"` | Which terminal statuses count as "already processed". `"success"` only stamps successful runs (failures stay claimable for retries); `"any"` stamps every terminal status. |
+| `in_flight_ttl_hours` | integer | `24` | Hours after which an `InFlight` claim is treated as a crashed-pod corpse and adopted by a fresh caller. Informational on Valkey/tiered backends, which set the TTL server-side via `SET NX EX`. |
+
+```toml
+[state.idempotency]
+retention_days = 30
+dedup_on = "success"
+in_flight_ttl_hours = 24
+```
+
+Stamps live in the `IDEMPOTENCY_KEYS` redb table and replicate on tiered backends so sibling pods see the same entry. See [`rocky run --idempotency-key`](/reference/cli/#rocky-run) for the three possible outcomes (`fresh_run`, `skipped_idempotent`, `skipped_in_flight`).
+
 ---
 
 ## `[cache]`
@@ -707,6 +726,106 @@ Optional top-level cross-adapter retry budget. When set, `AdapterRegistry` build
 [retry]
 max_retries_per_run = 50
 ```
+
+---
+
+## `[mask]`
+
+Workspace-default column-masking strategies keyed by classification tag. Each value is a short string selecting how the warehouse should render masked reads of any column the sidecar tags with that classification. See [Governance](/guides/governance/) for the narrative.
+
+| Strategy | Behavior |
+|---|---|
+| `"hash"` | SHA-256 hex digest of the column value. Deterministic, one-way. |
+| `"redact"` | Replace the value with the literal string `'***'`. |
+| `"partial"` | Keep the first and last two characters; replace the middle with `***`. Values shorter than 5 chars are fully replaced with `'***'`. |
+| `"none"` | Explicit identity — no masking applied. Useful as a per-env override to unmask a column that defaults to masked at the workspace level. |
+
+```toml
+# models/customers.toml tags email + ssn with these classifications
+[mask]
+pii = "hash"
+confidential = "redact"
+```
+
+Unknown strategies (e.g. `"mask"`) hard-fail at config load — Rocky never silently accepts a spelling it can't emit SQL for.
+
+:::note[Adapter support]
+Masking is implemented today against **Databricks** Unity Catalog via column tags + `CREATE MASK` / `SET MASKING POLICY` (one statement per column — UC rejects multi-column masking DDL). Snowflake, BigQuery, and DuckDB default-unsupported until demand. Masks are applied after a successful DAG run, best-effort — failures emit `warn!` and don't abort the pipeline (same semantics as grants).
+:::
+
+### `[mask.<env>]`
+
+Per-environment overrides that win over the workspace default for the matching env name. Rocky resolves `classification → strategy` by taking the `[mask]` defaults, then layering `[mask.<env>]` on top when the active env matches.
+
+```toml
+[mask]
+pii = "hash"
+confidential = "redact"
+
+[mask.prod]
+pii = "none"            # unmask pii in prod (e.g. service principal reads)
+confidential = "partial"
+
+[mask.staging]
+pii = "partial"         # staging gets a softer mask than the dev default
+```
+
+Resolution precedence:
+
+1. `[mask.<env>]` entry for the active env (when supplied to `rocky run --env <env>`).
+2. `[mask]` workspace default.
+3. Unmatched tag — W004 warning unless the tag is listed in [`[classifications] allow_unmasked`](#classifications).
+
+---
+
+## `[classifications]`
+
+Advisory settings for the column-classification feature. Distinct from the per-model `[classification]` sidecar block (see [Model Format](/reference/model-format/#classification)).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allow_unmasked` | list of strings | `[]` | Classification tags allowed to appear in a model sidecar without a matching `[mask]` strategy. Suppresses the W004 compiler warning. |
+
+```toml
+[classifications]
+allow_unmasked = ["internal", "lineage_only"]
+```
+
+Use this escape hatch for tags that exist only for discovery or lineage tracking — Rocky still surfaces them on `rocky compliance` reports, just without enforcing a masking strategy.
+
+### `[classifications.allow_unmasked]` on the compliance resolver
+
+`rocky compliance` suppresses exceptions for every tag in `allow_unmasked`. The flag is advisory — it doesn't pretend those columns are enforced, it just keeps them off the exception list. See [`rocky compliance`](/reference/cli/#rocky-compliance).
+
+---
+
+## `[role.<name>]`
+
+Hierarchical role declarations reconciled against the warehouse's native role/group system. Each `[role.<name>]` block declares one role; Rocky flattens the inheritance DAG at reconcile time (DFS walk with cycle detection + unknown-parent errors at config-load).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `inherits` | list of strings | `[]` | Immediate parent role names. Rocky unions permissions transitively across every ancestor. Cycles and unknown parents are rejected at config-load time. |
+| `permissions` | list of strings | `[]` | Permissions this role grants. Canonical uppercase spellings (e.g. `"SELECT"`, `"USE CATALOG"`, `"USE SCHEMA"`, `"MODIFY"`, `"MANAGE"`). Empty lists are legal — pure grouping roles exist only to aggregate children. |
+
+```toml
+[role.reader]
+permissions = ["SELECT", "USE CATALOG", "USE SCHEMA"]
+
+[role.analyst]
+inherits = ["reader"]
+permissions = ["MODIFY"]
+
+[role.admin]
+inherits = ["analyst"]
+permissions = ["MANAGE"]
+```
+
+Rocky flattens the graph into `admin → {SELECT, USE CATALOG, USE SCHEMA, MODIFY, MANAGE}` and forwards the resolved set to `GovernanceAdapter::reconcile_role_graph` after a successful DAG.
+
+:::caution[v1 is log-only]
+The v1 Databricks implementation validates each `rocky_role_<name>` principal against the identifier grammar and emits a `debug!` trace. SCIM group creation and per-catalog GRANT emission are deferred as a follow-up. The resolver still catches cycles and unknown parents at config-load regardless of adapter capability — so invalid graphs fail fast even before reconcile runs.
+:::
 
 ---
 

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -54,6 +54,7 @@ The `.toml` file specifies the model name, dependencies, materialization strateg
 |-------|------|----------|-------------|
 | `name` | string | Yes | Model identifier. Must be unique across all models. |
 | `depends_on` | list of strings | No | Names of upstream models that must run before this one. Defaults to `[]`. |
+| `retention` | string | No | Data retention policy for this model. Grammar `^\d+[dy]$` — e.g. `"90d"` or `"1y"`. See [Retention](#retention). |
 
 **`[strategy]`** -- Materialization configuration:
 
@@ -89,6 +90,63 @@ Warehouse-managed table shapes — **Delta tables**, **Iceberg tables**, **mater
 | `catalog` | string | Yes | Source catalog name. |
 | `schema` | string | Yes | Source schema name. |
 | `table` | string | Yes | Source table name. |
+
+### `[classification]`
+
+Per-column classification tags. Keys are column names, values are free-form classification strings. Rocky resolves each value against `[mask]` / `[mask.<env>]` in `rocky.toml` to pick the masking strategy, then applies both the column tag and the mask via the governance adapter after a successful DAG.
+
+| Key pattern | Value type | Description |
+|---|---|---|
+| `<column_name>` | string | Free-form classification tag (e.g. `"pii"`, `"confidential"`, `"internal"`). Matched case-insensitively against `[mask]` keys in `rocky.toml`. Tags without a matching strategy emit the W004 compiler warning unless listed in [`[classifications] allow_unmasked`](/reference/configuration/#classifications). |
+
+```toml
+# models/customers.toml
+name = "customers"
+
+[classification]
+email = "pii"
+phone = "pii"
+ssn = "confidential"
+```
+
+Tags are free-form strings — no enum — so teams can coin new classifications without touching the engine. See [Governance](/guides/governance/) for the end-to-end story (classify → mask → audit → compliance rollup) and [`[mask]`](/reference/configuration/#mask) for the resolver semantics.
+
+:::note[Adapter support]
+Classification tags + masking policies are applied today against **Databricks** Unity Catalog (column tags + `CREATE MASK` / `SET MASKING POLICY`, one statement per column). Snowflake, BigQuery, and DuckDB default-unsupported until demand. Best-effort — failures emit `warn!` and don't abort the run.
+:::
+
+### Retention
+
+Top-level `retention` key on the sidecar declares a data-retention policy for the model. Parsed at load time into a typed `RetentionPolicy { duration_days: u32 }`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `retention` | string \| null | `null` (disabled) | Grammar `^\d+[dy]$`. `"d"` = days verbatim, `"y"` = years flattened at 365 days per year (no leap-year semantics). Zero (`"0d"`, `"0y"`) is rejected — use `null` to disable. |
+
+```toml
+# models/fct_orders.toml
+name = "fct_orders"
+retention = "90d"
+
+[strategy]
+type = "incremental"
+timestamp_column = "_fivetran_synced"
+
+[target]
+catalog = "analytics"
+schema = "warehouse"
+table = "fct_orders"
+```
+
+Applied by `GovernanceAdapter::apply_retention_policy` after a successful DAG run:
+
+| Adapter | SQL emitted |
+|---|---|
+| **Databricks (Delta)** | `ALTER TABLE ... SET TBLPROPERTIES ('delta.logRetentionDuration' = '{N} days', 'delta.deletedFileRetentionDuration' = '{N} days')` — both keys written together. |
+| **Snowflake** | `ALTER TABLE ... SET DATA_RETENTION_TIME_IN_DAYS = {N}`. |
+| **BigQuery / DuckDB** | Default-unsupported — those warehouses lack a first-class retention knob at the config level. |
+
+Garbage inputs (`"abc"`, `"90"`, `"-3d"`, `"1.5d"`, leading signs, exponents) are rejected at sidecar parse time with a `ModelError::InvalidRetention` diagnostic naming the offending value. Inspect resolved policies + warehouse state with [`rocky retention-status`](/reference/cli/#rocky-retention-status).
 
 ---
 

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/README.md
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/README.md
@@ -1,0 +1,179 @@
+# 05-classification-masking-compliance — `[classification]` + `[mask]` + `rocky compliance`
+
+> **Category:** 04-governance
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s
+> **Rocky features:** `[classification]` sidecar, `[mask]` / `[mask.<env>]` policy,
+> `rocky compliance`, `--env`, `--exceptions-only`, `--fail-on exception`,
+> `[classifications.allow_unmasked]`
+
+## What it shows
+
+The Wave A + Wave B governance surface shipped in `engine-v1.16.0`:
+
+1. **Model sidecars** declare per-column classification tags
+   (`email = "pii"`, `ssn = "pii_high"`, `region = "internal"`).
+2. **Project `rocky.toml`** binds each tag to a masking strategy in
+   `[mask]` (workspace default) and tightens it in `[mask.<env>]` for
+   specific environments.
+3. **`rocky compliance`** is a static resolver that answers
+   _"are all classified columns masked wherever policy says they
+   should be?"_ — no warehouse I/O, pure resolver over the config +
+   sidecars.
+4. **`--fail-on exception`** turns the rollup into a CI gate: exit 1
+   when any classified column has no resolved strategy and isn't on the
+   `[classifications.allow_unmasked]` advisory list.
+
+## A note on DuckDB and mask enforcement
+
+DuckDB does not implement Unity Catalog column tags or
+`CREATE MASK` / `SET MASKING POLICY` DDL, so `rocky run` against the
+local DuckDB adapter does **not** enforce masking at apply time. The
+governance adapter's classification-tag and masking-policy hooks are
+best-effort no-ops on this backend (mirrors the `apply_grants`
+semantics).
+
+The value of running this POC locally is:
+
+- exercising the **config flow** (sidecar parse, `[mask]` / `[mask.<env>]`
+  resolution, `allow_unmasked` advisory list),
+- seeing the **static compliance report** (`rocky compliance`) in both
+  human and JSON shapes,
+- demonstrating the **CI gate** (`--fail-on exception` returns 1).
+
+See _"Apply the masks for real on Databricks"_ below for the path that
+actually emits the UC DDL.
+
+## Why it's distinctive
+
+- Classification lives in the **model sidecar**, right next to the SQL
+  that produced the columns — not in an external catalog. Reviewable in
+  PRs like any other code.
+- One `[mask]` block governs the workspace; per-env overrides tighten
+  without loosening. No duplicate policy files per environment.
+- `rocky compliance` is a **thin resolver with zero warehouse calls** —
+  safe to run in CI on every PR, fast enough to block merges, and
+  honest about what it does (static config check, not live enforcement
+  probe).
+
+## Layout
+
+```
+.
+├── README.md
+├── rocky.toml                    [mask] defaults + [mask.prod] override
+├── run.sh                        4-step demo: run, compliance dev, prod, CI gate
+├── data/seed.sql                 DuckDB fixtures (users + accounts)
+└── models/
+    ├── users.sql / users.toml    email=pii, ssn=pii_high, region=internal
+    └── accounts.sql / accounts.toml  owner_email=pii, audit_note=audit_only (unmapped)
+```
+
+## Run
+
+```bash
+cd examples/playground/pocs/04-governance/05-classification-masking-compliance
+./run.sh
+```
+
+## Expected output (abridged)
+
+```text
+== Step 1: rocky run (materialize models) ==
+run (users)     status = ...
+
+== Step 2: rocky compliance --env dev ==
+
+Rocky Compliance
+----------------
+
+  accounts.audit_note (audit_only) -> dev=unresolved!
+  accounts.owner_email (pii)       -> dev=hash
+  users.email (pii)                -> dev=hash
+  users.region (internal)          -> dev=none
+  users.ssn (pii_high)             -> dev=redact
+
+  classified=5, masked=4, exceptions=1
+
+Exceptions:
+  - accounts.audit_note [dev]: no masking strategy resolves for classification tag 'audit_only'
+
+== Step 3: rocky compliance --env prod --exceptions-only ==
+  accounts.audit_note (audit_only) -> prod=unresolved!
+  classified=5, masked=4, exceptions=1
+
+== Step 4: rocky compliance --env prod --fail-on exception ==
+CI gate exit code = 1  (1 = exceptions present -> block the merge)
+
+POC complete:
+  - classified columns scanned : 5
+  - exceptions in prod         : 1
+  - CI gate exit code          : 1
+```
+
+## Suppressing a known exception
+
+`audit_note` is tagged `audit_only` — a classification the team has
+decided not to mask (lineage/discovery tag, not a confidentiality
+tag). To silence the exception without pretending the column is
+enforced, add the tag to the advisory list in `rocky.toml`:
+
+```toml
+[classifications]
+allow_unmasked = ["audit_only"]
+```
+
+After this, `rocky compliance` reports the column's `enforced = false`
+state in `per_column` but does **not** emit an exception for it and
+`--fail-on exception` stops firing on it. The knob exists to unstick
+merges without hiding the fact that the column is unmasked.
+
+## Resolved strategies by env
+
+| Tag        | default (dev, staging, ...)  | prod        |
+|------------|------------------------------|-------------|
+| `pii`      | `hash`                       | `redact`    |
+| `pii_high` | `redact`                     | `redact`    |
+| `internal` | `none` (explicit identity)   | `none`      |
+| `audit_only` | **unresolved (exception)** | **unresolved (exception)** |
+
+`none` is an **explicit policy decision** (the team has decided this
+tag does not require masking) and counts as masked in the summary —
+it is not the same as "no strategy resolved."
+
+## Apply the masks for real on Databricks
+
+Set these env vars and switch the `[adapter]` block to a
+`databricks` adapter:
+
+```bash
+export DATABRICKS_HOST="https://your-workspace.cloud.databricks.com"
+export DATABRICKS_TOKEN="dapi..."
+export DATABRICKS_HTTP_PATH="/sql/1.0/warehouses/..."
+```
+
+On a successful `rocky run` against Unity Catalog, Rocky iterates the
+model list post-DAG and emits, **one statement per column** (UC rejects
+multi-column DDL):
+
+- `ALTER TABLE ... ALTER COLUMN <col> SET TAGS ('classification' = '<tag>')`
+- `CREATE MASK rocky_mask_<tag> ...` (idempotent, per-strategy) +
+  `ALTER TABLE ... ALTER COLUMN <col> SET MASKING POLICY rocky_mask_<tag>()`
+
+All three governance applies (classification, masking, retention) run
+in a single post-DAG loop, best-effort: a failure emits `warn!` and
+the pipeline continues — same semantics as `apply_grants`.
+
+`rocky compliance` still works unchanged on the Databricks adapter;
+it remains a static config check regardless of backend. The rollup
+answers "is the config right?" not "is the warehouse in sync?"
+
+## Related
+
+- Source: `engine/crates/rocky-cli/src/commands/compliance.rs`
+- Config shape: `engine/crates/rocky-core/src/config.rs` (`MaskEntry`,
+  `ClassificationsConfig`, `RockyConfig::resolve_mask_for_env`)
+- Governance adapter trait:
+  `engine/crates/rocky-core/src/traits.rs` (`GovernanceAdapter::apply_column_tags`,
+  `apply_masking_policy`)
+- CHANGELOG: `engine/CHANGELOG.md` — `[1.16.0]` Wave A + Wave B entries.

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/data/seed.sql
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/data/seed.sql
@@ -1,0 +1,17 @@
+CREATE SCHEMA IF NOT EXISTS raw__users;
+CREATE SCHEMA IF NOT EXISTS raw__accounts;
+
+CREATE OR REPLACE TABLE raw__users.users AS
+  SELECT
+    i                          AS id,
+    'user' || i || '@test.org' AS email,
+    '555-01-' || lpad(i::TEXT, 2, '0') AS ssn,
+    CASE WHEN i % 2 = 0 THEN 'us_west' ELSE 'eu_central' END AS region
+  FROM generate_series(1, 10) AS t(i);
+
+CREATE OR REPLACE TABLE raw__accounts.accounts AS
+  SELECT
+    i                                   AS id,
+    'owner' || i || '@test.org'         AS owner_email,
+    'ACCT-AUDIT-' || lpad(i::TEXT, 4, '0') AS audit_note
+  FROM generate_series(1, 10) AS t(i);

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/accounts.sql
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/accounts.sql
@@ -1,0 +1,5 @@
+SELECT
+    id,
+    owner_email,
+    audit_note
+FROM raw__accounts.accounts

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/accounts.toml
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/accounts.toml
@@ -1,0 +1,16 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "demo"
+
+# `owner_email` is tagged `pii` which resolves to `hash` (default) /
+# `redact` (prod). `audit_note` is tagged `audit_only` which has NO
+# matching entry in `[mask]` — this is the failure case the compliance
+# rollup is designed to catch. To silence it without adding a strategy,
+# list `audit_only` under `[classifications.allow_unmasked]` in
+# `rocky.toml`.
+[classification]
+owner_email = "pii"
+audit_note = "audit_only"

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/users.sql
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/users.sql
@@ -1,0 +1,6 @@
+SELECT
+    id,
+    email,
+    ssn,
+    region
+FROM raw__users.users

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/users.toml
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/models/users.toml
@@ -1,0 +1,14 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "demo"
+
+# Per-column classification tags. Rocky resolves each tag against
+# [mask] / [mask.<env>] in rocky.toml to pick a masking strategy, then
+# applies the tag + mask via the governance adapter. Tags are free-form.
+[classification]
+email = "pii"
+ssn = "pii_high"
+region = "internal"

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/rocky.toml
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/rocky.toml
@@ -1,0 +1,52 @@
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[state]
+backend = "local"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"
+
+# Workspace-default masking policy. Every classification tag that appears
+# in a model's `[classification]` sidecar should resolve to a strategy
+# here OR be opted out via `[classifications.allow_unmasked]` below.
+#
+# Strategies:
+#   "hash"    — SHA-256 fingerprint (deterministic, join-safe, one-way)
+#   "redact"  — replace with the constant '***'
+#   "partial" — keep first and last 2 chars, redact the middle
+#   "none"    — explicit identity (not a gap; a policy decision)
+[mask]
+pii = "hash"
+pii_high = "redact"
+internal = "none"
+
+# Per-env override. Keys present here shadow the top-level `[mask]`
+# strategy for that env only; keys absent here fall through to the
+# workspace default. Use this to tighten strategies in production
+# without loosening them in dev.
+#
+# Here: `pii` hardens from "hash" (dev) to "redact" (prod) and
+# `pii_high` stays "redact". `internal` is not overridden, so it
+# inherits the workspace "none" in prod too.
+[mask.prod]
+pii = "redact"
+pii_high = "redact"
+
+# Advisory list. Any classification tag listed here is allowed to appear
+# on a column WITHOUT a matching `[mask]` strategy — `rocky compliance`
+# will not emit an exception for it, and the W004 compiler warning is
+# suppressed. Uncomment to silence exceptions for a known unmapped tag:
+#
+# [classifications]
+# allow_unmasked = ["audit_only"]

--- a/examples/playground/pocs/04-governance/05-classification-masking-compliance/run.sh
+++ b/examples/playground/pocs/04-governance/05-classification-masking-compliance/run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# 05-classification-masking-compliance — end-to-end demo
+#
+# Walks the operator through the Wave A + Wave B governance surface:
+#   1. `rocky run`        — materialize models on local DuckDB.
+#   2. `rocky compliance` — static resolver over the [classification]
+#                           sidecars + [mask] / [mask.<env>] policy.
+#   3. `--exceptions-only` — narrow per_column to the unmasked rows.
+#   4. `--fail-on exception` — CI gate (exit 1 when any exception exists).
+#
+# DuckDB does NOT enforce masking at apply time (no Unity Catalog column
+# tags, no CREATE MASK). The POC's value here is showing the config flow
+# + static compliance check + CI gate. See README for the Databricks
+# "apply for real" path.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+# Load seed tables so `rocky run` has something to replicate.
+duckdb poc.duckdb < data/seed.sql
+
+rocky validate
+
+# -------------------------------------------------------------------------
+# Step 1 — run the pipeline.
+#
+# Replication pipeline is the simplest shape that lets us exercise the
+# governance rollup against real `[classification]` sidecars. Like POC
+# 09, the DuckDB path may exit non-zero on edges unrelated to the demo —
+# we tolerate that with `|| true`. The per-column classification is read
+# from the model sidecars, not from the warehouse, so the compliance
+# rollup works regardless.
+echo
+echo "== Step 1: rocky run (materialize models) =="
+rocky -c rocky.toml -o json run \
+  --filter source=users \
+  > expected/run_users.json || true
+STATUS=$(jq -r '.status // "error"' expected/run_users.json)
+echo "run (users)     status = $STATUS"
+
+# -------------------------------------------------------------------------
+# Step 2 — compliance rollup scoped to `dev`.
+#
+# No `[mask.dev]` override exists, so `--env dev` falls back to the
+# workspace [mask] defaults (pii=hash, pii_high=redact, internal=none).
+# `owner_email` resolves (pii); `audit_note` does NOT (audit_only has no
+# strategy) — that's the one exception we expect.
+echo
+echo "== Step 2: rocky compliance --env dev =="
+rocky -c rocky.toml compliance --env dev --models models
+
+# -------------------------------------------------------------------------
+# Step 3 — same report scoped to `prod`, filtered to exceptions only.
+#
+# `[mask.prod]` tightens pii from "hash" -> "redact" (still resolves) but
+# does NOT add a strategy for `audit_only`, so the prod exception set is
+# the same single row. `--exceptions-only` trims per_column to just the
+# offending row.
+echo
+echo "== Step 3: rocky compliance --env prod --exceptions-only =="
+rocky -c rocky.toml compliance --env prod --exceptions-only --models models
+
+# -------------------------------------------------------------------------
+# Step 4 — CI gate. `--fail-on exception` exits 1 when any exception
+# fires. We capture the exit code instead of letting it kill the demo,
+# because the whole point of this step is to SHOW that it returns 1.
+#
+# Note: the `set +e` / `set -e` dance is load-bearing. `|| true` would
+# swallow the exit code and defeat the demonstration; `set -euo pipefail`
+# at the top of the script would abort the demo on a non-zero exit.
+echo
+echo "== Step 4: rocky compliance --env prod --fail-on exception =="
+set +e
+rocky -c rocky.toml compliance \
+    --env prod \
+    --fail-on exception \
+    --models models \
+    -o json \
+    > expected/compliance_prod_fail_on.json
+CI_EXIT=$?
+set -e
+echo "CI gate exit code = $CI_EXIT  (1 = exceptions present -> block the merge)"
+
+# -------------------------------------------------------------------------
+# Demo invariants
+# -------------------------------------------------------------------------
+EXCEPTIONS=$(jq -r '.summary.total_exceptions' expected/compliance_prod_fail_on.json)
+CLASSIFIED=$(jq -r '.summary.total_classified' expected/compliance_prod_fail_on.json)
+if [[ "$CI_EXIT" -ne 1 ]]; then
+  echo "FAIL: expected --fail-on exception to exit 1, got $CI_EXIT" >&2
+  exit 1
+fi
+if [[ "$EXCEPTIONS" -lt 1 ]]; then
+  echo "FAIL: expected >= 1 exception in compliance report, got $EXCEPTIONS" >&2
+  exit 1
+fi
+
+echo
+echo "POC complete:"
+echo "  - classified columns scanned : $CLASSIFIED"
+echo "  - exceptions in prod         : $EXCEPTIONS"
+echo "  - CI gate exit code          : $CI_EXIT"
+echo
+echo "Next: uncomment [classifications.allow_unmasked] in rocky.toml to"
+echo "      suppress the audit_only exception without adding a mask."

--- a/examples/playground/pocs/04-governance/06-retention-policies/README.md
+++ b/examples/playground/pocs/04-governance/06-retention-policies/README.md
@@ -1,0 +1,158 @@
+# 06-retention-policies — declarative data-retention policies
+
+> **Category:** 04-governance
+> **Credentials:** none (DuckDB primary path; Databricks / Snowflake
+> narrative-only in the "for real" section below)
+> **Runtime:** < 5s
+> **Rocky features:** `retention = "<N>[dy]"` sidecar key,
+> `RetentionPolicy`, `rocky retention-status` (`--model`, `--drift`),
+> `GovernanceAdapter::apply_retention_policy`
+
+## What it shows
+
+Wave C-2 of the governance waveplan (engine-v1.16.0) gave every model
+sidecar a declarative `retention = "<N>[dy]"` key. The value is parsed
+once at project-load time into a typed `RetentionPolicy { duration_days: u32 }`
+— grammar is strict (`30d`, `1y`; `-3d`, `90`, `abc` all reject with
+actionable diagnostics). Years are flat 365 days (`1y` → 365, no
+leap-year semantics — confirmed in `rocky-core::retention`).
+
+Three models:
+
+| Model | Sidecar `retention` | `configured_days` |
+|---|---|---|
+| `page_views_30d` | `"30d"` | 30 |
+| `ledger_archive_1y` | `"1y"` | 365 |
+| `ephemeral_summary` | *(absent)* | `null` |
+
+At `rocky run` time, after the DAG succeeds, Rocky calls
+`GovernanceAdapter::apply_retention_policy` on every model with a
+declared policy. `rocky retention-status` is a static reporter over the
+compiled model set — no warehouse probe.
+
+## Why it's distinctive
+
+- **One config → two warehouses.** The same sidecar value becomes Delta
+  TBLPROPERTIES on Databricks and `DATA_RETENTION_TIME_IN_DAYS` on
+  Snowflake. You declare the intent once; Rocky handles the dialect.
+- **Strict grammar, early errors.** `retention = "bad"` fails at
+  project-load time, not at warehouse-apply time — diagnostics surface
+  in `rocky validate` and in the LSP before a single row moves.
+- **Static report alongside the enforcement path.** `rocky retention-status`
+  gives CI a declaration-only audit without touching the warehouse.
+
+## Primary mode: DuckDB (no credentials)
+
+`rocky run` on DuckDB resolves the governance adapter to
+`NoopGovernanceAdapter`. Its `apply_retention_policy` impl returns
+`Ok(())` unconditionally (see `rocky-core/src/traits.rs:811-821`) — **no
+warning, no error, silently skipped.** The POC still exercises the
+full parse-and-wire path:
+
+1. `rocky validate` — confirms all three sidecars parse (a malformed
+   value would fail here).
+2. `rocky run` — the retention apply is a no-op on DuckDB; the run is
+   the same smoke-test shape as the sibling
+   `05-orchestration/09-idempotency-key` POC (DuckDB replication exits
+   non-zero on "no discovery adapter", tolerated with `|| true`).
+3. `rocky retention-status -o table` — text report.
+4. `rocky retention-status` — JSON report (default output).
+5. `rocky retention-status --model ledger_archive_1y -o table` — scoped
+   to a single model.
+6. `rocky retention-status --drift -o table` — `--drift` is accepted
+   for forward-compat but the warehouse probe is deferred to v2. The
+   command filters to models with a declared policy and prints
+   `note: --drift probe is deferred to v2; warehouse_days will be null.`
+   to stderr. `warehouse_days` stays `None` in JSON (schema is stable —
+   `Option<u32>` — so v2 can slot in without a wire break).
+
+## Apply retention for real on Databricks / Snowflake
+
+Swap the `[adapter]` block to Databricks or Snowflake and `rocky run`
+will fire `apply_retention_policy` on every model with a declared
+sidecar:
+
+- **Databricks (Delta).** Rocky writes **both**
+  `delta.logRetentionDuration` **and** `delta.deletedFileRetentionDuration`
+  TBLPROPERTIES in a single `ALTER TABLE` — the pair governs time-travel
+  history readability and physical tombstone retention together.
+- **Snowflake.** Rocky emits
+  `ALTER TABLE <db>.<schema>.<table> SET DATA_RETENTION_TIME_IN_DAYS = <N>`.
+  Snowflake's edition-specific cap (Standard 90, Enterprise 365)
+  enforces server-side — Rocky surfaces any rejection.
+- **BigQuery / DuckDB.** No first-class time-travel retention knob at
+  the config level — the apply is a no-op (silent on DuckDB via
+  `NoopGovernanceAdapter`; the trait default would `warn!` but the
+  Databricks/Snowflake impls override it).
+
+Apply is **best-effort** — failures emit `warn!` and the pipeline
+continues, matching the semantics of `apply_grants` and the rest of
+the Wave C governance reconcile loop.
+
+## Layout
+
+```
+.
+|-- README.md
+|-- rocky.toml                    Minimal DuckDB config, single pipeline `poc`
+|-- run.sh                        Six-step demo (validate -> run -> 4x retention-status)
+|-- data/seed.sql                 raw__events / raw__ledger DuckDB seed
+|-- models/
+|   |-- page_views_30d.sql        -- retention = "30d"
+|   |-- page_views_30d.toml
+|   |-- ledger_archive_1y.sql     -- retention = "1y" (flat 365 days)
+|   |-- ledger_archive_1y.toml
+|   |-- ephemeral_summary.sql     -- no retention sidecar key
+|   `-- ephemeral_summary.toml
+`-- expected/                     Captured JSON / text, regenerated each run
+```
+
+## Run
+
+```bash
+cd examples/playground/pocs/04-governance/06-retention-policies
+./run.sh
+```
+
+## Expected output (abridged)
+
+```
+--- rocky retention-status -o table ---
+MODEL                                    CONFIGURED       WAREHOUSE        IN SYNC
+----------------------------------------------------------------------------------
+ephemeral_summary                        -                -                yes
+ledger_archive_1y                        365 days         -                no
+page_views_30d                           30 days          -                no
+
+--- rocky retention-status --drift -o table ---
+note: --drift probe is deferred to v2; warehouse_days will be null.
+MODEL                                    CONFIGURED       WAREHOUSE        IN SYNC
+----------------------------------------------------------------------------------
+ledger_archive_1y                        365 days         -                no
+page_views_30d                           30 days          -                no
+```
+
+JSON output (default `-o json`):
+
+```json
+{
+  "version": "1.16.0",
+  "command": "retention-status",
+  "models": [
+    { "model": "ephemeral_summary", "in_sync": true },
+    { "model": "ledger_archive_1y", "configured_days": 365, "in_sync": false },
+    { "model": "page_views_30d", "configured_days": 30, "in_sync": false }
+  ]
+}
+```
+
+Note: `configured_days` and `warehouse_days` use `skip_serializing_if`,
+so unset fields are omitted rather than emitted as explicit `null`.
+Consumers should treat missing keys as `null`.
+
+`in_sync` in v1 is a declaration check — `configured_days == warehouse_days`
+where `warehouse_days` is always `None` (hence `true` only for
+unconfigured models, where both sides are `None`). The v2 `--drift`
+probe will populate `warehouse_days` from `SHOW TBLPROPERTIES`
+(Databricks) / `SHOW PARAMETERS` (Snowflake) and make `in_sync` a real
+drift signal.

--- a/examples/playground/pocs/04-governance/06-retention-policies/data/seed.sql
+++ b/examples/playground/pocs/04-governance/06-retention-policies/data/seed.sql
@@ -1,0 +1,8 @@
+CREATE SCHEMA IF NOT EXISTS raw__events;
+CREATE SCHEMA IF NOT EXISTS raw__ledger;
+
+CREATE OR REPLACE TABLE raw__events.page_views AS
+SELECT i AS event_id, 'user_' || i AS user_id FROM generate_series(1, 10) AS t(i);
+
+CREATE OR REPLACE TABLE raw__ledger.entries AS
+SELECT i AS entry_id, i * 100 AS amount_cents FROM generate_series(1, 10) AS t(i);

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/_defaults.toml
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/_defaults.toml
@@ -1,0 +1,3 @@
+[target]
+catalog = "poc"
+schema = "staging"

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/ephemeral_summary.sql
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/ephemeral_summary.sql
@@ -1,0 +1,6 @@
+-- Intentionally has no retention sidecar key. Demonstrates that the
+-- `retention` field is optional and absent models surface as `null` /
+-- `-` in `rocky retention-status`.
+SELECT
+    COUNT(*) AS total_events
+FROM raw__events.page_views

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/ephemeral_summary.toml
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/ephemeral_summary.toml
@@ -1,0 +1,3 @@
+# No `retention` key — retention is optional. `rocky retention-status`
+# reports `configured_days = null` for this model; `rocky run` skips
+# `apply_retention_policy` for it entirely.

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/ledger_archive_1y.sql
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/ledger_archive_1y.sql
@@ -1,0 +1,6 @@
+-- Financial ledger mirror. Long retention so auditors can time-travel
+-- back a year on Databricks/Snowflake.
+SELECT
+    entry_id,
+    amount_cents
+FROM raw__ledger.entries

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/ledger_archive_1y.toml
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/ledger_archive_1y.toml
@@ -1,0 +1,3 @@
+# Year-long retention. Parsed as `1 * 365 = 365` days (flat, no
+# leap-year semantics — source: `rocky_core::retention::RetentionPolicy`).
+retention = "1y"

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/page_views_30d.sql
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/page_views_30d.sql
@@ -1,0 +1,7 @@
+-- Short-lived observability table. Keep 30 days of time-travel history
+-- on Databricks/Snowflake so we can diff recent runs but don't pay for
+-- long-tail storage.
+SELECT
+    event_id,
+    user_id
+FROM raw__events.page_views

--- a/examples/playground/pocs/04-governance/06-retention-policies/models/page_views_30d.toml
+++ b/examples/playground/pocs/04-governance/06-retention-policies/models/page_views_30d.toml
@@ -1,0 +1,13 @@
+# Data retention policy (engine-v1.16.0 / Wave C-2).
+#
+# Grammar: "<N>[dy]" — days (`d`) or years (`y`, flat 365-day
+# multiplication, no leap-year semantics). Parsed into
+# `RetentionPolicy { duration_days: u32 }` at project-load time.
+#
+# On Databricks this becomes a paired
+#   delta.logRetentionDuration / delta.deletedFileRetentionDuration
+# TBLPROPERTIES write. On Snowflake it becomes
+#   ALTER TABLE ... SET DATA_RETENTION_TIME_IN_DAYS = 30.
+# On DuckDB (this POC's default) the apply is a silent no-op — the
+# sidecar still parses and `rocky retention-status` still reports it.
+retention = "30d"

--- a/examples/playground/pocs/04-governance/06-retention-policies/rocky.toml
+++ b/examples/playground/pocs/04-governance/06-retention-policies/rocky.toml
@@ -1,0 +1,15 @@
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"

--- a/examples/playground/pocs/04-governance/06-retention-policies/run.sh
+++ b/examples/playground/pocs/04-governance/06-retention-policies/run.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb models/.rocky-state.redb
+
+echo "===================================================================="
+echo " POC 04-governance/06-retention-policies"
+echo " Data retention policies (Wave C-2 / engine-v1.16.0)"
+echo "===================================================================="
+echo
+echo "Models in this POC:"
+echo "  - page_views_30d.sql      retention = \"30d\"  ->  30 days"
+echo "  - ledger_archive_1y.sql   retention = \"1y\"   ->  365 days (flat)"
+echo "  - ephemeral_summary.sql   (no retention key) ->  null"
+echo
+
+# --- Seed DuckDB so `rocky run` has something to read ---
+duckdb poc.duckdb < data/seed.sql
+
+# --- 1. Validate: confirms the sidecars parse (retention grammar is
+#     enforced at model-load time in rocky-core::models). A bad value
+#     like "abc" would fail here with a clear diagnostic.
+echo "--- rocky validate (sidecars parse) ----------------------------------"
+rocky validate
+echo
+
+# --- 2. rocky run on DuckDB. The pipeline uses replication, which on
+#     DuckDB falls through to a "no discovery adapter" exit — same as
+#     the sibling POC 05-orchestration/09-idempotency-key. The point of
+#     this step is NOT the materialization; it's that the retention
+#     wiring doesn't abort the pipeline. On DuckDB the governance
+#     adapter resolves to NoopGovernanceAdapter::apply_retention_policy
+#     which returns Ok(()) silently (traits.rs:811-821). No warning,
+#     no error.
+echo "--- rocky run (DuckDB; retention apply is a silent no-op) ------------"
+rocky -c rocky.toml run --filter source=events > expected/run.json 2>&1 || true
+echo "  run completed (exit status tolerated on DuckDB; see README)"
+echo
+
+# --- 3. rocky retention-status — text table view ---
+echo "--- rocky retention-status -o table ----------------------------------"
+rocky retention-status --models models -o table | tee expected/retention_status.txt
+echo
+
+# --- 4. rocky retention-status — JSON (default) ---
+echo "--- rocky retention-status (JSON, default output) --------------------"
+rocky retention-status --models models > expected/retention_status.json
+jq '.' expected/retention_status.json
+echo
+
+# --- 5. --model <name> scope ---
+echo "--- rocky retention-status --model ledger_archive_1y -o table --------"
+rocky retention-status --models models --model ledger_archive_1y -o table \
+  | tee expected/retention_status_scoped.txt
+echo
+
+# --- 6. --drift is v2. Pair with -o table so the deferred-note lands
+#     on stderr. With JSON output the note is suppressed by design
+#     (retention_status.rs:65-67).
+echo "--- rocky retention-status --drift -o table (v2 probe deferred) ------"
+rocky retention-status --models models --drift -o table 2>&1 \
+  | tee expected/retention_status_drift.txt
+echo
+
+# --- Validation: page_views_30d should report 30, ledger_archive_1y
+#     should report 365, ephemeral_summary should report null. ---
+CFG_30=$(jq -r '.models[] | select(.model=="page_views_30d") | .configured_days' expected/retention_status.json)
+CFG_1Y=$(jq -r '.models[] | select(.model=="ledger_archive_1y") | .configured_days' expected/retention_status.json)
+CFG_NONE=$(jq -r '.models[] | select(.model=="ephemeral_summary") | .configured_days' expected/retention_status.json)
+
+if [[ "$CFG_30" != "30" ]]; then
+  echo "FAIL: page_views_30d expected configured_days=30 but got '$CFG_30'"
+  exit 1
+fi
+if [[ "$CFG_1Y" != "365" ]]; then
+  echo "FAIL: ledger_archive_1y expected configured_days=365 but got '$CFG_1Y'"
+  exit 1
+fi
+if [[ "$CFG_NONE" != "null" ]]; then
+  echo "FAIL: ephemeral_summary expected configured_days=null but got '$CFG_NONE'"
+  exit 1
+fi
+
+echo "===================================================================="
+echo " POC complete: 30d -> 30, 1y -> 365 (flat), no-key -> null."
+echo " Apply is a silent no-op on DuckDB; Databricks/Snowflake enforce"
+echo " it via TBLPROPERTIES / DATA_RETENTION_TIME_IN_DAYS. See README."
+echo "===================================================================="


### PR DESCRIPTION
## Summary

Closes the docs + POC gap for `engine-v1.16.0`'s governance waveplan (Waves A, B, C-1, C-2) plus a handful of uncovered surface from v1.14.0 / v1.15.0. The code shipped; the docs and walkthroughs didn't.

**Docs** (+~900 lines across 5 files)

- `guides/governance.md` — expanded from grants-only to the 5-pillar story: grants, classification+masking, `rocky compliance` rollup, role-graph reconciliation, data retention. Adds an audit-trail section (`rocky history --audit`, 8 `RunRecord` fields, redb v5→v6) and a CI-gate example using `rocky compliance --fail-on exception`.
- `reference/configuration.md` — new `[state.idempotency]`, `[mask]` / `[mask.<env>]`, `[classifications]`, `[role.<name>]` blocks.
- `reference/model-format.md` — `retention` sidecar key and `[classification]` block.
- `reference/cli.md` — `--cache-ttl`, `discover --with-schemas`, `run --idempotency-key`, `rocky state` as a subcommand group, `rocky compliance`, `rocky retention-status`.
- `reference/commands/administration.md` — `history --audit`, `state clear-schema-cache`, `compliance`, `retention-status`, plus the v1.16.0 state-path upgrade callout (canonical `<models>/.rocky-state.redb` vs legacy CWD).

**POCs** (2 new, DuckDB-primary, no creds for `./run.sh`)

- `04-governance/05-classification-masking-compliance/` — sidecar `[classification]` tags, project `[mask]` defaults + `[mask.prod]` tightening, and three `rocky compliance` invocations including `--fail-on exception` as a CI gate (exit code captured by the demo script). Databricks apply flow is narrative in the README.
- `04-governance/06-retention-policies/` — three models with `retention = "30d"` / `"1y"` / (unset) exercising the sidecar parser and `rocky retention-status` (text + JSON + `--model` + `--drift`). `jq` assertions guard the numbers. Documents the silent no-op on DuckDB (`NoopGovernanceAdapter`) vs real apply on Databricks / Snowflake.

### Two things worth flagging for review

1. The CHANGELOG says retention is "DuckDB default-unsupported," but on DuckDB the apply is actually a silent `Ok(())` via `NoopGovernanceAdapter`, not a warn. The POC README documents the real behavior.
2. The masking POC can't demonstrate "prod adds new exceptions" because `[mask.<env>]` merges *over* defaults — it can tighten strategies, not add gaps. The POC uses an unresolved tag (`audit_only`) to force a persistent exception that fires the CI gate identically across envs, which is the more honest demo.

## Test plan

- [ ] `astro build` on `docs/` produces no broken links
- [ ] `bash -n run.sh` passes on both POCs (already verified locally)
- [ ] `./run.sh` in `05-classification-masking-compliance/` walks the four `rocky compliance` modes and prints the captured exit code for `--fail-on exception`
- [ ] `./run.sh` in `06-retention-policies/` passes the `jq` assertions for 30 / 365 / null
- [ ] Manual read-through of `guides/governance.md` for flow
- [ ] Spot-check cross-links between guide and reference pages