### PR TITLE
feat(dagster): pluggable per-call kwarg resolvers on RockyResource

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pluggable per-call kwarg resolvers on `RockyResource`** — three optional callable fields (`shadow_suffix_fn`, `governance_override_fn`, `idempotency_key_fn`) that fire per `run` / `run_streaming` / `run_pipes` invocation to inject kwargs derived from the Dagster run context. Motivated by deployments that need to compute `shadow_suffix` / `governance_override` / `idempotency_key` from the Dagster run context on every call and were previously forced to hand-roll a composition wrapper around the resource.
+
+  Design points (pinned by tests):
+  - **Caller-wins.** A resolver fires only when the kwarg is absent from the call; caller-supplied values always win.
+  - **`None` is a no-op.** Resolvers can return `None` to opt out conditionally (e.g. outside a branch deploy).
+  - **`ResolverContext` is frozen.** Each resolver receives a frozen Pydantic snapshot of the Dagster context, the `filter`, the invoking method, and the caller-supplied kwargs.
+  - **`run()` passes `context=None`** (it has no context parameter); `run_streaming()` and `run_pipes()` pass the positional Dagster context.
+  - **Resolver exceptions surface as `dg.Failure`** with the resolver's `__qualname__` in the description. A resolver that raises `dg.Failure` directly has its original description preserved.
+
+- **`shadow_suffix_resolver()` convenience factory** in `dagster_rocky.branch_deploy` — returns a `Resolver` closure that calls `branch_deploy_shadow_suffix()` ignoring its context. Wire it into `RockyResource(shadow_suffix_fn=shadow_suffix_resolver())` to auto-inject the branch-deploy suffix on every run method without conditional caller code.
+
+- **New top-level re-exports**: `ResolverContext`, `Resolver`, `shadow_suffix_resolver`.
+
 ## [1.12.0] — 2026-04-23
 
 Tracks engine 1.16.0 (governance waveplan). New `ComplianceOutput` + `RetentionStatusOutput` Pydantic models, extended `RockyOutput` union, regenerated bindings for classification / masking / role-graph / retention config surfaces.

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -7,6 +7,7 @@ from .branch_deploy import (
     branch_deploy_shadow_suffix,
     branch_deployment_info,
     is_branch_deployment,
+    shadow_suffix_resolver,
 )
 from .checks import (
     check_metadata,
@@ -57,7 +58,7 @@ from .partitions import (
     partitions_def_for_time_interval,
     rocky_to_dagster_partition_key,
 )
-from .resource import MIN_ROCKY_VERSION, RockyResource
+from .resource import MIN_ROCKY_VERSION, Resolver, ResolverContext, RockyResource
 from .scaffold import init_rocky_project
 from .schedules import build_rocky_schedule
 from .sensor import rocky_source_sensor
@@ -140,6 +141,8 @@ __all__ = [
     "RockyTableProps",
     "RockyResource",
     "MIN_ROCKY_VERSION",
+    "Resolver",
+    "ResolverContext",
     "RockyDagsterTranslator",
     "load_rocky_assets",
     "emit_check_results",
@@ -206,6 +209,7 @@ __all__ = [
     "is_branch_deployment",
     "branch_deployment_info",
     "branch_deploy_shadow_suffix",
+    "shadow_suffix_resolver",
     # Discover
     "SourceInfo",
     "TableInfo",

--- a/integrations/dagster/src/dagster_rocky/branch_deploy.py
+++ b/integrations/dagster/src/dagster_rocky/branch_deploy.py
@@ -34,6 +34,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .resource import Resolver, ResolverContext  # noqa: F401 — used in annotations
 
 #: Standard Dagster+ env var that's ``"true"`` (string) inside a branch
 #: deployment, unset elsewhere.
@@ -146,3 +150,33 @@ def branch_deploy_shadow_suffix(
         safe = "".join(c if c.isalnum() else "_" for c in info.deployment_name)
         return f"_dagster_{safe}"
     return "_dagster_branch"
+
+
+def shadow_suffix_resolver() -> Resolver:
+    """Return a :class:`~.resource.Resolver` that injects the branch-deploy shadow suffix.
+
+    The returned closure calls :func:`branch_deploy_shadow_suffix` and
+    ignores its :class:`~.resource.ResolverContext` argument — the
+    suffix is derived purely from Dagster+ env vars, not from the
+    Dagster run context.
+
+    Wire it into :class:`~.resource.RockyResource` to make every run
+    method auto-inject the branch-deploy shadow suffix::
+
+        from dagster_rocky import RockyResource, shadow_suffix_resolver
+
+        resource = RockyResource(
+            binary_path="rocky",
+            config_path="rocky.toml",
+            shadow_suffix_fn=shadow_suffix_resolver(),
+        )
+
+    Outside a branch deployment the suffix resolves to ``None``, which
+    the resolver machinery treats as a no-op — so production runs are
+    unaffected.
+    """
+
+    def _resolve(_rc: ResolverContext) -> str | None:
+        return branch_deploy_shadow_suffix()
+
+    return _resolve

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -29,13 +29,14 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from typing import IO, TYPE_CHECKING, TypeVar
+from collections.abc import Callable
+from typing import IO, TYPE_CHECKING, Annotated, Any, Literal, TypeVar
 
 import dagster as dg
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
 from .types import (
     AiExplainResult,
@@ -390,6 +391,80 @@ def _kill_process_group(proc: subprocess.Popen[str]) -> None:
         pass
 
 
+def _collect_supplied_run_kwargs(
+    *,
+    filter: str,
+    shadow_suffix: str | None,
+    governance_override: dict | None,
+    idempotency_key: str | None,
+) -> dict[str, Any]:
+    """Build the ``kwargs`` dict handed to :meth:`RockyResource._apply_resolvers`.
+
+    The three resolver-eligible kwargs (``shadow_suffix``,
+    ``governance_override``, ``idempotency_key``) have typed signatures on
+    the public run methods, so at runtime we can't distinguish "caller
+    passed ``None``" from "caller didn't pass anything". We follow the
+    spec's caller-wins rule by treating **only non-``None`` values as
+    supplied** — explicit ``None`` and omission both let the resolver
+    fire. The tradeoff is documented on each public run method.
+
+    ``filter`` is always included because :class:`ResolverContext` exposes
+    it to resolvers for disambiguation (e.g. governance-override lookup
+    keyed on the filter value).
+    """
+    kwargs: dict[str, Any] = {"filter": filter}
+    if shadow_suffix is not None:
+        kwargs["shadow_suffix"] = shadow_suffix
+    if governance_override is not None:
+        kwargs["governance_override"] = governance_override
+    if idempotency_key is not None:
+        kwargs["idempotency_key"] = idempotency_key
+    return kwargs
+
+
+class ResolverContext(BaseModel):
+    """Read-only snapshot handed to each per-call kwarg resolver.
+
+    Resolvers are closures users register on :class:`RockyResource` to inject
+    kwargs derived from Dagster run context on every ``run`` / ``run_streaming``
+    / ``run_pipes`` call. The context is **frozen** — signature stability
+    matters because resolvers are user-authored closures imported across
+    module boundaries.
+
+    Attributes:
+        context: The Dagster execution context for the call. ``None`` when
+            the resolver fires from :meth:`RockyResource.run` (which doesn't
+            accept a context param). Resolvers that need a context must
+            handle ``None`` (typically by returning ``None`` to no-op).
+        filter: The positional ``filter`` kwarg passed to the run method.
+        method: Which run method triggered the resolver.
+        supplied_kwargs: Snapshot of the kwargs the caller explicitly
+            supplied. Lets resolvers bail early when the caller already set
+            a value (though ``_apply_resolvers`` already skips resolution
+            for present kwargs — this field is for resolvers that want to
+            branch on *other* caller-supplied kwargs).
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    # Typed as ``Any`` rather than ``AssetExecutionContext | OpExecutionContext``
+    # because Pydantic's is-instance validation would reject test doubles
+    # (MagicMock) — and because Dagster occasionally hands callers wrapper
+    # context objects that aren't instance-of the public classes. Resolvers
+    # should treat ``context`` as a duck-typed Dagster context and only reach
+    # for attributes the Dagster docs promise (run, tags, log, ...).
+    context: Any = None
+    filter: str | None = None
+    method: Literal["run", "run_streaming", "run_pipes"]
+    supplied_kwargs: dict[str, Any]
+
+
+#: Type alias for user-authored per-call kwarg resolvers. Each resolver is a
+#: callable taking a :class:`ResolverContext` and returning either a value
+#: for the target kwarg or ``None`` to leave it unset.
+Resolver = Callable[[ResolverContext], Any]
+
+
 class RockyResource(dg.ConfigurableResource):
     """Dagster resource that invokes the Rocky CLI binary.
 
@@ -404,6 +479,13 @@ class RockyResource(dg.ConfigurableResource):
             ``compile()``, ``lineage()`` and ``metrics()`` use the HTTP API instead
             of a subprocess.
         timeout_seconds: Subprocess timeout for any one CLI invocation.
+        shadow_suffix_fn: Optional resolver that produces ``shadow_suffix`` per
+            call when the caller doesn't supply one. See :class:`ResolverContext`
+            for the closure signature. Returning ``None`` is a no-op.
+        governance_override_fn: Optional resolver for ``governance_override``.
+            Same semantics as ``shadow_suffix_fn``.
+        idempotency_key_fn: Optional resolver for ``idempotency_key``.
+            Same semantics as ``shadow_suffix_fn``.
     """
 
     binary_path: str = "rocky"
@@ -435,8 +517,107 @@ class RockyResource(dg.ConfigurableResource):
     #: rather than producing a mid-run error.
     strict_doctor_checks: list[str] = []
 
+    #: Optional resolver that produces a ``shadow_suffix`` per ``run`` /
+    #: ``run_streaming`` / ``run_pipes`` call. Fires only when the caller
+    #: didn't supply ``shadow_suffix`` (or supplied ``None``). See
+    #: :class:`ResolverContext` for the closure signature. Returning ``None``
+    #: leaves the kwarg unset. Pair with
+    #: :func:`.branch_deploy.shadow_suffix_resolver` for the common branch-
+    #: deploy case.
+    # Callable fields aren't valid Dagster config schema entries, so we
+    # mark them as ``resource_dependency`` via ``typing.Annotated`` —
+    # Dagster's canonical escape hatch for non-config resource attrs
+    # (see ``_is_annotated_as_resource_type`` in
+    # ``dagster/_config/pythonic_config/resource.py``). Using the
+    # literal string marker instead of ``dg.ResourceDependency[...]``
+    # keeps the annotation robust under ``from __future__ import annotations``,
+    # where the generic-alias form fails Pydantic validation because
+    # the string annotation isn't resolved back to the marker type.
+    #
+    # This also ensures the resolver closures survive Dagster's resource
+    # lifecycle: at execution time Dagster rebuilds the resource via
+    # ``self.__class__(**public_field_values)`` (see
+    # ``ConfigurableResourceFactory._with_updated_values``). ``Annotated``
+    # resource-dependency fields participate in that rebuild as public
+    # fields, so the registered resolvers carry through to the per-asset
+    # call. ``PrivateAttr``-backed fields did *not* survive that rebuild
+    # and would silently drop resolvers mid-materialize — the end-to-end
+    # test ``test_resolvers_survive_dagster_materialize_lifecycle`` pins
+    # this regression.
+    shadow_suffix_fn: Annotated[Resolver | None, "resource_dependency"] = None
+    governance_override_fn: Annotated[Resolver | None, "resource_dependency"] = None
+    idempotency_key_fn: Annotated[Resolver | None, "resource_dependency"] = None
+
     # Instance-level cache for the version check (not a Dagster config field).
     _version_checked: bool = False
+
+    # ------------------------------------------------------------------ #
+    # Per-call kwarg resolvers                                           #
+    # ------------------------------------------------------------------ #
+
+    def _apply_resolvers(
+        self,
+        context: dg.AssetExecutionContext | dg.OpExecutionContext | None,
+        method: Literal["run", "run_streaming", "run_pipes"],
+        kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Inject resolver-produced values into ``kwargs`` in place.
+
+        For each ``(kwarg_name, resolver_fn)`` pair, fire the resolver only
+        when the caller didn't supply the kwarg (i.e. it's absent from
+        ``kwargs``). Caller-supplied values always win. Resolvers that
+        return ``None`` are treated as a no-op so they can conditionally
+        opt in (e.g. :func:`branch_deploy_shadow_suffix` returns ``None``
+        outside a branch deploy).
+
+        Exceptions raised by a resolver propagate as :class:`dg.Failure`
+        with the resolver's ``__qualname__`` in the description. A
+        ``dg.Failure`` raised directly by a resolver is preserved so the
+        resolver can surface its own operator-friendly error.
+
+        Args:
+            context: Dagster execution context for the call, or ``None``
+                for :meth:`run` (which has no context param).
+            method: Which run method triggered this resolver invocation.
+                Passed into the :class:`ResolverContext` so resolvers can
+                specialize behaviour per method.
+            kwargs: The mutable kwargs dict being assembled for
+                :meth:`_build_run_args`. This function mutates the dict
+                in place and also returns it for convenience.
+
+        Returns:
+            The same ``kwargs`` dict, with resolver-produced values added
+            for any absent keys whose resolver returned a non-``None``
+            value.
+        """
+        rc = ResolverContext(
+            context=context,
+            filter=kwargs.get("filter"),
+            method=method,
+            supplied_kwargs=dict(kwargs),
+        )
+        for kw, fn in (
+            ("shadow_suffix", self.shadow_suffix_fn),
+            ("governance_override", self.governance_override_fn),
+            ("idempotency_key", self.idempotency_key_fn),
+        ):
+            if fn is None or kw in kwargs:
+                continue
+            try:
+                value = fn(rc)
+            except dg.Failure:
+                # Preserve resolver-raised dg.Failure so the resolver can
+                # surface its own operator-friendly message (e.g.
+                # "Could not determine target client ...").
+                raise
+            except Exception as exc:
+                qualname = getattr(fn, "__qualname__", repr(fn))
+                raise dg.Failure(
+                    description=(f"resolver {qualname!r} for {kw!r} raised: {exc}"),
+                ) from exc
+            if value is not None:
+                kwargs[kw] = value
+        return kwargs
 
     # ------------------------------------------------------------------ #
     # Startup hook — opt-in strict rocky doctor gate                     #
@@ -989,10 +1170,29 @@ class RockyResource(dg.ConfigurableResource):
 
                 ⚠️ Keys are stored verbatim in the state store; do NOT put
                 secrets in idempotency keys.
+
+        Note on resolver interaction:
+            Per-call resolvers registered on the resource (``shadow_suffix_fn``,
+            ``governance_override_fn``, ``idempotency_key_fn``) fire for the
+            matching kwarg only when that kwarg is **absent** from the call.
+            Because Python can't distinguish "caller explicitly passed
+            ``None``" from "caller didn't pass anything", an explicit
+            ``None`` is treated as absent and resolvers fire. Pass the
+            non-``None`` value you want to win against the resolver.
         """
+        resolved = self._apply_resolvers(
+            context=None,
+            method="run",
+            kwargs=_collect_supplied_run_kwargs(
+                filter=filter,
+                shadow_suffix=shadow_suffix,
+                governance_override=governance_override,
+                idempotency_key=idempotency_key,
+            ),
+        )
         args = self._build_run_args(
             filter,
-            governance_override=governance_override,
+            governance_override=resolved.get("governance_override"),
             pipeline=pipeline,
             run_models=run_models,
             partition=partition,
@@ -1002,8 +1202,8 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
-            shadow_suffix=shadow_suffix,
-            idempotency_key=idempotency_key,
+            shadow_suffix=resolved.get("shadow_suffix"),
+            idempotency_key=resolved.get("idempotency_key"),
         )
         return _parse_rocky_json(
             self._run_rocky(args, allow_partial=True), RunResult, command="run"
@@ -1068,9 +1268,19 @@ class RockyResource(dg.ConfigurableResource):
             The parsed :class:`RunResult` from stdout after the
             subprocess exits.
         """
+        resolved = self._apply_resolvers(
+            context=context,
+            method="run_streaming",
+            kwargs=_collect_supplied_run_kwargs(
+                filter=filter,
+                shadow_suffix=shadow_suffix,
+                governance_override=governance_override,
+                idempotency_key=idempotency_key,
+            ),
+        )
         args = self._build_run_args(
             filter,
-            governance_override=governance_override,
+            governance_override=resolved.get("governance_override"),
             run_models=run_models,
             partition=partition,
             partition_from=partition_from,
@@ -1079,8 +1289,8 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
-            shadow_suffix=shadow_suffix,
-            idempotency_key=idempotency_key,
+            shadow_suffix=resolved.get("shadow_suffix"),
+            idempotency_key=resolved.get("idempotency_key"),
         )
         return _parse_rocky_json(
             self._run_rocky_streaming(args, context, allow_partial=True),
@@ -1235,9 +1445,19 @@ class RockyResource(dg.ConfigurableResource):
                 propagates a Failure when the subprocess crashes
                 without sending a Pipes ``closed`` message.
         """
+        resolved = self._apply_resolvers(
+            context=context,
+            method="run_pipes",
+            kwargs=_collect_supplied_run_kwargs(
+                filter=filter,
+                shadow_suffix=shadow_suffix,
+                governance_override=governance_override,
+                idempotency_key=idempotency_key,
+            ),
+        )
         args = self._build_run_args(
             filter,
-            governance_override=governance_override,
+            governance_override=resolved.get("governance_override"),
             run_models=run_models,
             partition=partition,
             partition_from=partition_from,
@@ -1246,8 +1466,8 @@ class RockyResource(dg.ConfigurableResource):
             missing=missing,
             lookback=lookback,
             parallel=parallel,
-            shadow_suffix=shadow_suffix,
-            idempotency_key=idempotency_key,
+            shadow_suffix=resolved.get("shadow_suffix"),
+            idempotency_key=resolved.get("idempotency_key"),
         )
         if pipes_client is not None:
             client = pipes_client

--- a/integrations/dagster/tests/test_resolvers.py
+++ b/integrations/dagster/tests/test_resolvers.py
@@ -1,0 +1,540 @@
+"""Tests for the per-call kwarg resolvers on :class:`RockyResource`.
+
+The resolvers (``shadow_suffix_fn``, ``governance_override_fn``,
+``idempotency_key_fn``) let deployments inject kwargs derived from the
+Dagster run context without hand-rolling a composition wrapper around
+the resource. These tests pin down the design contract:
+
+* Resolvers fire only when the caller didn't supply the kwarg.
+* A ``None`` return is a no-op.
+* ``run()`` passes ``context=None``; ``run_streaming()`` / ``run_pipes()``
+  pass the positional Dagster context.
+* Resolver exceptions surface as ``dg.Failure`` with the resolver's
+  ``__qualname__`` in the description — unless the resolver itself raised
+  ``dg.Failure``, in which case the original failure is preserved.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import dagster as dg
+import pytest
+
+from dagster_rocky import RockyResource
+from dagster_rocky.resource import ResolverContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _empty_run_json() -> str:
+    return (
+        '{"version":"0.3.0","command":"run","filter":"tenant=acme",'
+        '"duration_ms":0,"tables_copied":0,"materializations":[],'
+        '"check_results":[],"permissions":{"grants_added":0,"grants_revoked":0,'
+        '"catalogs_created":0,"schemas_created":0},"drift":{"tables_checked":0,'
+        '"tables_drifted":0,"actions_taken":[]}}'
+    )
+
+
+def _capture_run_args() -> tuple[list[list[str]], Any]:
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _empty_run_json()
+
+    return captured, fake_run
+
+
+def _streaming_popen_mock(stdout: str, returncode: int = 0):
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.stdout = iter([stdout]) if stdout else iter([])
+    proc.stderr = iter([])
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    proc.wait = MagicMock()
+    return proc
+
+
+def _captured_log_context() -> Any:
+    captured: list[str] = []
+    context = MagicMock()
+    context.log = MagicMock()
+    context.log.info = MagicMock(side_effect=lambda msg: captured.append(msg))
+    context.captured = captured  # type: ignore[attr-defined]
+    return context
+
+
+# ---------------------------------------------------------------------------
+# ResolverContext shape
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_context_is_frozen():
+    from pydantic import ValidationError
+
+    rc = ResolverContext(method="run", supplied_kwargs={"filter": "x=y"})
+    with pytest.raises(ValidationError):
+        rc.method = "run_streaming"  # type: ignore[misc]
+
+
+def test_resolver_context_defaults():
+    rc = ResolverContext(method="run", supplied_kwargs={"filter": "x=y"})
+    assert rc.context is None
+    assert rc.filter is None
+    assert rc.supplied_kwargs == {"filter": "x=y"}
+
+
+# ---------------------------------------------------------------------------
+# shadow_suffix_fn
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_suffix_resolver_fires_when_caller_omits_kwarg():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> str:
+        calls.append(rc)
+        return "_dagster_pr_42"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert len(calls) == 1
+    assert calls[0].method == "run"
+    assert calls[0].context is None  # run() has no context
+    assert calls[0].filter == "tenant=acme"
+    assert "--shadow-suffix" in captured[0]
+    idx = captured[0].index("--shadow-suffix")
+    assert captured[0][idx + 1] == "_dagster_pr_42"
+
+
+def test_shadow_suffix_resolver_skipped_when_caller_supplies_value():
+    """Caller-supplied kwarg wins — resolver must not fire."""
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> str:
+        calls.append(rc)
+        return "_resolver_set"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme", shadow_suffix="_caller_set")
+
+    assert calls == []  # resolver never fired
+    idx = captured[0].index("--shadow-suffix")
+    assert captured[0][idx + 1] == "_caller_set"
+
+
+def test_shadow_suffix_resolver_none_return_is_noop():
+    """A resolver returning ``None`` leaves the kwarg unset."""
+    rocky = RockyResource(shadow_suffix_fn=lambda _rc: None)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert "--shadow-suffix" not in captured[0]
+    assert "--shadow" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# governance_override_fn
+# ---------------------------------------------------------------------------
+
+
+def test_governance_override_resolver_fires_when_caller_omits_kwarg():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> dict:
+        calls.append(rc)
+        return {"workspace_ids": [1, 2]}
+
+    rocky = RockyResource(governance_override_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert len(calls) == 1
+    assert "--governance-override" in captured[0]
+    idx = captured[0].index("--governance-override")
+    assert '"workspace_ids"' in captured[0][idx + 1]
+
+
+def test_governance_override_resolver_skipped_when_caller_supplies_value():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> dict:
+        calls.append(rc)
+        return {"workspace_ids": [99]}
+
+    rocky = RockyResource(governance_override_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme", governance_override={"workspace_ids": [1, 2]})
+
+    assert calls == []
+    idx = captured[0].index("--governance-override")
+    assert '"workspace_ids": [1, 2]' in captured[0][idx + 1]
+
+
+def test_governance_override_resolver_none_return_is_noop():
+    rocky = RockyResource(governance_override_fn=lambda _rc: None)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert "--governance-override" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# idempotency_key_fn
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_key_resolver_fires_when_caller_omits_kwarg():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> str:
+        calls.append(rc)
+        return "run-abc123"
+
+    rocky = RockyResource(idempotency_key_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert len(calls) == 1
+    idx = captured[0].index("--idempotency-key")
+    assert captured[0][idx + 1] == "run-abc123"
+
+
+def test_idempotency_key_resolver_skipped_when_caller_supplies_value():
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> str:
+        calls.append(rc)
+        return "resolver-key"
+
+    rocky = RockyResource(idempotency_key_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme", idempotency_key="caller-key")
+
+    assert calls == []
+    idx = captured[0].index("--idempotency-key")
+    assert captured[0][idx + 1] == "caller-key"
+
+
+def test_idempotency_key_resolver_none_return_is_noop():
+    rocky = RockyResource(idempotency_key_fn=lambda _rc: None)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert "--idempotency-key" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# Context threading across all three run methods
+# ---------------------------------------------------------------------------
+
+
+def test_run_passes_none_context_to_resolver():
+    captured_contexts: list[Any] = []
+
+    def fn(rc: ResolverContext) -> str:
+        captured_contexts.append(rc.context)
+        return "_suffix"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert captured_contexts == [None]
+
+
+def test_run_streaming_passes_context_to_resolver():
+    captured_contexts: list[Any] = []
+    captured_methods: list[str] = []
+
+    def fn(rc: ResolverContext) -> str:
+        captured_contexts.append(rc.context)
+        captured_methods.append(rc.method)
+        return "_suffix"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    context = _captured_log_context()
+    proc = _streaming_popen_mock(_empty_run_json())
+
+    with (
+        patch.object(RockyResource, "_verify_engine_version"),
+        patch("dagster_rocky.resource.subprocess.Popen", return_value=proc),
+    ):
+        rocky.run_streaming(context, filter="tenant=acme")
+
+    assert captured_contexts == [context]
+    assert captured_methods == ["run_streaming"]
+
+
+def test_run_pipes_passes_context_to_resolver():
+    captured_contexts: list[Any] = []
+    captured_methods: list[str] = []
+
+    def fn(rc: ResolverContext) -> str:
+        captured_contexts.append(rc.context)
+        captured_methods.append(rc.method)
+        return "_suffix"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    context = MagicMock()
+    pipes_client = MagicMock()
+    pipes_client.run = MagicMock(return_value=MagicMock())
+
+    rocky.run_pipes(context, filter="tenant=acme", pipes_client=pipes_client)
+
+    assert captured_contexts == [context]
+    assert captured_methods == ["run_pipes"]
+
+
+# ---------------------------------------------------------------------------
+# Resolver failure propagation
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_exception_surfaces_as_dg_failure_with_qualname():
+    def my_named_resolver(_rc: ResolverContext) -> str:
+        raise RuntimeError("something went wrong in the resolver")
+
+    rocky = RockyResource(shadow_suffix_fn=my_named_resolver)
+
+    with (
+        patch.object(RockyResource, "_run_rocky", autospec=True),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.run(filter="tenant=acme")
+
+    description = excinfo.value.description or ""
+    assert "my_named_resolver" in description
+    assert "shadow_suffix" in description
+    assert "something went wrong" in description
+
+
+def test_resolver_raising_dg_failure_is_preserved():
+    """A resolver that raises dg.Failure directly keeps its own description
+    rather than getting wrapped under a generic 'resolver raised' message.
+    """
+    original = dg.Failure(description="could not determine target client for tenant=acme")
+
+    def fn(_rc: ResolverContext) -> str:
+        raise original
+
+    rocky = RockyResource(governance_override_fn=fn)
+
+    with (
+        patch.object(RockyResource, "_run_rocky", autospec=True),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky.run(filter="tenant=acme")
+
+    description = excinfo.value.description or ""
+    assert "could not determine target client" in description
+    assert "resolver" not in description.lower() or "could not determine" in description
+
+
+def test_resolver_exception_fires_on_run_streaming():
+    def fn(_rc: ResolverContext) -> str:
+        raise ValueError("boom")
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    context = _captured_log_context()
+
+    with pytest.raises(dg.Failure, match="boom"):
+        rocky.run_streaming(context, filter="tenant=acme")
+
+
+# ---------------------------------------------------------------------------
+# supplied_kwargs snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_supplied_kwargs_includes_filter_and_caller_values():
+    snapshots: list[dict[str, Any]] = []
+
+    def fn(rc: ResolverContext) -> str:
+        snapshots.append(dict(rc.supplied_kwargs))
+        return "_suffix"
+
+    rocky = RockyResource(shadow_suffix_fn=fn)
+    _, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(
+            filter="tenant=acme",
+            governance_override={"workspace_ids": [1]},
+            idempotency_key="k-1",
+        )
+
+    assert snapshots == [
+        {
+            "filter": "tenant=acme",
+            "governance_override": {"workspace_ids": [1]},
+            "idempotency_key": "k-1",
+        },
+    ]
+
+
+def test_each_resolver_wired_independently():
+    """Registering only one resolver must not affect the other two kwargs."""
+    rocky = RockyResource(idempotency_key_fn=lambda _rc: "only-idem")
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    assert "--idempotency-key" in captured[0]
+    assert "--shadow-suffix" not in captured[0]
+    assert "--governance-override" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# shadow_suffix_resolver() factory
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_suffix_resolver_returns_branch_deploy_value(monkeypatch):
+    from dagster_rocky import branch_deploy as branch_deploy_mod
+    from dagster_rocky import shadow_suffix_resolver
+
+    monkeypatch.setattr(
+        branch_deploy_mod,
+        "branch_deploy_shadow_suffix",
+        lambda: "_dagster_pr_99",
+    )
+
+    resolver = shadow_suffix_resolver()
+    rc = ResolverContext(method="run", supplied_kwargs={"filter": "x=y"})
+    assert resolver(rc) == "_dagster_pr_99"
+
+
+def test_shadow_suffix_resolver_returns_none_outside_branch_deploy(monkeypatch):
+    from dagster_rocky import branch_deploy as branch_deploy_mod
+    from dagster_rocky import shadow_suffix_resolver
+
+    monkeypatch.setattr(
+        branch_deploy_mod,
+        "branch_deploy_shadow_suffix",
+        lambda: None,
+    )
+
+    resolver = shadow_suffix_resolver()
+    rc = ResolverContext(method="run", supplied_kwargs={"filter": "x=y"})
+    assert resolver(rc) is None
+
+
+def test_shadow_suffix_resolver_wired_into_resource(monkeypatch):
+    """End-to-end: the factory's return value auto-injects when bound to the field."""
+    from dagster_rocky import branch_deploy as branch_deploy_mod
+    from dagster_rocky import shadow_suffix_resolver
+
+    monkeypatch.setattr(
+        branch_deploy_mod,
+        "branch_deploy_shadow_suffix",
+        lambda: "_dagster_pr_7",
+    )
+
+    rocky = RockyResource(shadow_suffix_fn=shadow_suffix_resolver())
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme")
+
+    idx = captured[0].index("--shadow-suffix")
+    assert captured[0][idx + 1] == "_dagster_pr_7"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — empty-dict caller value, Dagster lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_governance_override_empty_dict_from_caller_skips_resolver():
+    """Regression: legacy ``governance_override={}`` from the caller skips
+    the resolver (caller-wins). The empty dict is treated as "supplied",
+    and the pre-existing :meth:`_build_run_args` truthiness check then
+    drops the flag — so no ``--governance-override`` is emitted, exactly
+    as before resolvers existed.
+    """
+    calls: list[ResolverContext] = []
+
+    def fn(rc: ResolverContext) -> dict:
+        calls.append(rc)
+        return {"workspace_ids": [1]}
+
+    rocky = RockyResource(governance_override_fn=fn)
+    captured, fake_run = _capture_run_args()
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.run(filter="tenant=acme", governance_override={})
+
+    assert calls == []  # resolver skipped — caller supplied {}
+    assert "--governance-override" not in captured[0]
+
+
+def test_resolvers_survive_dagster_materialize_lifecycle():
+    """End-to-end: resolvers registered on a ``RockyResource`` fire correctly
+    when the resource is exercised through ``dg.materialize``.
+
+    This guards against Dagster's resource lifecycle (which may rebuild
+    the resource instance at execution time) dropping the PrivateAttr-
+    backed resolver fields. If that ever regressed, this test would fail
+    loudly rather than the silent-no-resolver mode.
+    """
+    calls: list[str] = []
+
+    def my_suffix_resolver(_rc: ResolverContext) -> str:
+        calls.append("fired")
+        return "_dagster_pr_xyz"
+
+    rocky = RockyResource(
+        binary_path="rocky",
+        config_path="rocky.toml",
+        shadow_suffix_fn=my_suffix_resolver,
+    )
+
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return _empty_run_json()
+
+    @dg.asset
+    def my_asset(rocky: RockyResource) -> None:
+        rocky.run(filter="tenant=acme")
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        result = dg.materialize([my_asset], resources={"rocky": rocky})
+
+    assert result.success
+    assert calls == ["fired"]
+    assert "--shadow-suffix" in captured[0]
+    idx = captured[0].index("--shadow-suffix")
+    assert captured[0][idx + 1] == "_dagster_pr_xyz"


### PR DESCRIPTION
## Summary

Add three optional callable fields on `RockyResource` that fire per `run` / `run_streaming` / `run_pipes` invocation to inject kwargs derived from the Dagster run context. Deployments that need to compute `shadow_suffix`, `governance_override`, or `idempotency_key` per call (branch-deploy detection, per-client governance lookup, run-key fallback idempotency) can now register a resolver closure on the resource instead of hand-rolling a composition wrapper around every run method.

New resource-level resolvers set at construction:

- `shadow_suffix_fn`
- `governance_override_fn`
- `idempotency_key_fn`

## Design choices (pinned by tests)

- **Caller-wins.** A resolver fires only when its target kwarg is absent from the call; caller-supplied values always win.
- **`None` is a no-op.** Resolvers can return `None` to opt out conditionally (e.g. outside a branch deploy).
- **`ResolverContext` is frozen.** A Pydantic model with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` — signature stability matters because resolvers are user-authored closures imported across module boundaries. Fields: `context`, `filter`, `method` (`Literal["run", "run_streaming", "run_pipes"]`), `supplied_kwargs`.
- **`run()` passes `context=None`** (it has no context parameter); `run_streaming()` and `run_pipes()` pass the positional context.
- **Resolver exceptions surface as `dg.Failure`** with the resolver's `__qualname__` in the description. A resolver that raises `dg.Failure` directly has its original description preserved (no double-wrap).

## Resolver signature

```python
Resolver = Callable[[ResolverContext], Any]
```

```python
class ResolverContext(BaseModel):
    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)

    context: Any = None  # AssetExecutionContext | OpExecutionContext | None
    filter: str | None = None
    method: Literal["run", "run_streaming", "run_pipes"]
    supplied_kwargs: dict[str, Any]
```

## Usage

```python
from dagster_rocky import RockyResource, shadow_suffix_resolver, ResolverContext

def _resolve_governance(rc: ResolverContext) -> dict | None:
    client = _client_from_context_or_filter(rc.context, rc.filter)
    if not client:
        raise dg.Failure(description=f"Could not determine target client (filter={rc.filter!r})")
    return {"workspace_ids": lookup_bindings(client)}

def _resolve_idempotency(rc: ResolverContext) -> str | None:
    if rc.context is None:
        return None
    return (rc.context.run.tags or {}).get("dagster/run_key")

resource = RockyResource(
    binary_path="rocky",
    config_path="rocky.toml",
    shadow_suffix_fn=shadow_suffix_resolver(),        # built-in
    governance_override_fn=_resolve_governance,        # user-authored
    idempotency_key_fn=_resolve_idempotency,           # user-authored
)
```

`shadow_suffix_resolver()` in `dagster_rocky.branch_deploy` is a convenience factory for the common branch-deploy case — it returns a resolver that calls `branch_deploy_shadow_suffix()` and ignores its context. Outside a branch deploy it returns `None`, which the resolver machinery treats as a no-op.

## Implementation note

Resolver fields are declared as `Annotated[Resolver | None, "resource_dependency"]` — Dagster's canonical escape hatch for non-config resource attrs. This preserves them through Dagster's resource-lifecycle rebuild (`ConfigurableResourceFactory._with_updated_values` in `dagster/_config/pythonic_config/resource.py`). A `PrivateAttr`-backed alternative was tried first but silently dropped the resolvers mid-materialize; `test_resolvers_survive_dagster_materialize_lifecycle` pins the regression.

## Tests added (`tests/test_resolvers.py`, 24 tests)

- `ResolverContext` is frozen and has the right defaults.
- Each resolver field (`shadow_suffix_fn` / `governance_override_fn` / `idempotency_key_fn`) fires when caller omits the kwarg, is skipped when caller supplies it, and treats `None` return as a no-op.
- `run()` passes `context=None`; `run_streaming()` and `run_pipes()` pass the positional context; each threads the correct `method` literal into `ResolverContext`.
- Resolver exceptions surface as `dg.Failure` with the resolver's `__qualname__` in the description; `dg.Failure` raised directly by a resolver is preserved.
- `supplied_kwargs` snapshot includes the filter and only non-`None` caller-supplied kwargs.
- Each resolver wires independently (registering one doesn't affect the others).
- `shadow_suffix_resolver()` returns the right value (branch-deploy-aware), returns `None` outside a branch deploy, and auto-injects when bound to `shadow_suffix_fn`.
- Caller-supplied `governance_override={}` skips the resolver and (preserving the existing `_build_run_args` truthiness check) drops the flag — matches prior behaviour.
- **`test_resolvers_survive_dagster_materialize_lifecycle`** — end-to-end `dg.materialize` verifies resolvers fire through Dagster's resource-rebuild pipeline.

## Deliberate skip

`idempotency_key_from_run_key_resolver()` (mentioned as a nice-to-have in the FR) is **not** shipped — the FR author notes the prefix source is deployment-specific. `governance_override_fn` stays user-authored for the same reason, and symmetry here keeps the built-in surface focused on the one resolver (`shadow_suffix_resolver`) where 99% of users will want the same thing.

## Test plan

- [x] `uv run pytest tests/` — 398 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] End-to-end `dg.materialize` test proves resolvers survive Dagster lifecycle.

## Reference

Feature request: `/Users/hugocorreia/Developer/rocky-plans/feature-requests/gold-fr-008-rocky-resource-kwarg-resolvers.md`