### PR TITLE
feat(dagster): auto-surface compliance + retention-status on RockyComponent

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -20,6 +20,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`shadow_suffix_resolver()` convenience factory** in `dagster_rocky.branch_deploy` — returns a `Resolver` closure that calls `branch_deploy_shadow_suffix()` ignoring its context. Wire it into `RockyResource(shadow_suffix_fn=shadow_suffix_resolver())` to auto-inject the branch-deploy suffix on every run method without conditional caller code.
 
+- **`RockyResource.compliance(env=None)` / `RockyResource.retention_status(env=None)`** — first-class resource methods that shell out to `rocky compliance` / `rocky retention-status --output json` and return parsed `ComplianceOutput` / `RetentionStatusOutput`. Both accept an optional `env` kwarg that forwards as `--env <env>`. Metadata-only reads against the state store — no warehouse round-trip in v1.
+- **`compliance_check_results(output, *, key_resolver)`** (in `observability.py`) — folds a `ComplianceOutput` into one aggregated `AssetCheckResult` (severity `WARN`, `passed=False`) per asset with exceptions. Metadata surface: `rocky/compliance_exception_count`, `rocky/compliance_models`, `rocky/compliance_reasons`, `rocky/compliance_total_{classified,exceptions,masked}`. Exceptions whose model doesn't resolve via the caller's resolver fold into a sentinel `AssetKey(["_compliance"])` so the signal stays visible. Aggregation is deliberate: Dagster rejects duplicate `(asset_key, check_name)` pairs per materialization, so multiple exceptions for the same model (typically one per env) must collapse into one result.
+- **`retention_observations(output, *, key_resolver)`** (in `observability.py`) — folds a `RetentionStatusOutput` into one `AssetObservation` per `ModelRetentionStatus` row, keyed by model. Metadata surface: `rocky/retention_model`, `rocky/retention_configured_days` (omitted when `None`), `rocky/retention_warehouse_days` (omitted when `None` — the v1 engine always reports `None` here; the `--drift` warehouse probe is a v2 follow-up), `rocky/retention_in_sync`. Observation (not check) is the right primitive: retention is a configuration signal, not a pass/fail.
+- **`COMPLIANCE_CHECK_NAME`, `COMPLIANCE_FALLBACK_ASSET_KEY`, `RETENTION_OBSERVATION_NAME`** — module constants + public re-exports for consumers who want to key on the check / observation names outside the component bridge.
+- **`RockyComponent.surface_compliance: bool = False` + `surface_retention_status: bool = False`** — new opt-in YAML attributes. When `surface_compliance` is on, the component pre-declares a `compliance_exception` `AssetCheckSpec` per asset (so the check is visible in the UI before any run) and invokes `RockyResource.compliance()` once per materialization batch. When `surface_retention_status` is on, the component invokes `RockyResource.retention_status()` and yields observations. Binary failures are logged and swallowed — same tolerance as the drift / anomaly path. Both flags default to `False` so existing deployments see no behaviour change.
+
+  Adopters flip both on with two lines in `defs.yaml`:
+
+  ```yaml
+  type: dagster_rocky.RockyComponent
+  attributes:
+    binary_path: rocky
+    config_path: rocky/rocky.toml
+    surface_compliance: true
+    surface_retention_status: true
+  ```
+
 - **New top-level re-exports**: `ResolverContext`, `Resolver`, `shadow_suffix_resolver`.
 
 ## [1.12.0] — 2026-04-23

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -46,9 +46,14 @@ from .freshness import (
 from .health import HealthcheckResult, rocky_healthcheck, state_health
 from .observability import (
     ANOMALY_CHECK_NAME,
+    COMPLIANCE_CHECK_NAME,
+    COMPLIANCE_FALLBACK_ASSET_KEY,
+    RETENTION_OBSERVATION_NAME,
     anomaly_check_results,
+    compliance_check_results,
     drift_observations,
     optimize_metadata_for_keys,
+    retention_observations,
 )
 from .partitions import (
     dagster_to_rocky_partition_key,
@@ -81,6 +86,9 @@ from .types import (
     ColumnDef,
     ColumnLineageResult,
     CompileResult,
+    ComplianceException,
+    ComplianceOutput,
+    ComplianceSummary,
     ConformanceResult,
     ContractResult,
     ContractViolation,
@@ -109,6 +117,7 @@ from .types import (
     ModelExecution,
     ModelHistoryResult,
     ModelLineageResult,
+    ModelRetentionStatus,
     ModelValidation,
     OptimizeResult,
     PartitionInfo,
@@ -119,6 +128,7 @@ from .types import (
     QualifiedColumn,
     QualityMetrics,
     QualitySnapshot,
+    RetentionStatusOutput,
     RunRecord,
     RunResult,
     Severity,
@@ -161,8 +171,13 @@ __all__ = [
     "build_rocky_schedule",
     # Observability (T4.1, T4.2, T4.4)
     "ANOMALY_CHECK_NAME",
+    "COMPLIANCE_CHECK_NAME",
+    "COMPLIANCE_FALLBACK_ASSET_KEY",
+    "RETENTION_OBSERVATION_NAME",
     "drift_observations",
     "anomaly_check_results",
+    "compliance_check_results",
+    "retention_observations",
     "optimize_metadata_for_keys",
     # Contracts (T4.3)
     "CONTRACT_REQUIRED_COLUMNS_CHECK",
@@ -284,4 +299,10 @@ __all__ = [
     "DriftTableResult",
     "DriftedColumn",
     "DriftActionKind",
+    # Governance (Waves B + C-2 — compliance + retention)
+    "ComplianceOutput",
+    "ComplianceException",
+    "ComplianceSummary",
+    "RetentionStatusOutput",
+    "ModelRetentionStatus",
 ]

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -53,9 +53,12 @@ from .derived_models import (
 from .freshness import freshness_policy_from_checks, per_model_freshness_policies
 from .observability import (
     ANOMALY_CHECK_NAME,
+    COMPLIANCE_CHECK_NAME,
     anomaly_check_results,
+    compliance_check_results,
     drift_observations,
     optimize_metadata_for_keys,
+    retention_observations,
 )
 from .resource import RockyResource
 from .sensor import rocky_source_sensor
@@ -304,6 +307,26 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: ``strict_doctor=True`` means fail on any critical check;
     #: non-empty scopes the fail-fast gate to just those check names.
     strict_doctor_checks: list[str] = []
+    #: When ``True``, the multi-asset invokes :meth:`RockyResource.compliance`
+    #: once per materialization batch and folds each
+    #: :class:`~.types.ComplianceException` into a ``compliance_exception``
+    #: :class:`dg.AssetCheckResult` (severity ``WARN``) on the matching
+    #: asset. Pre-declares a :class:`dg.AssetCheckSpec` per asset so the
+    #: check is visible in the Dagster UI before any run — materializations
+    #: with no exceptions emit a passing placeholder via
+    #: :func:`_emit_placeholder_checks`. Default ``False`` preserves zero
+    #: behaviour change.
+    surface_compliance: bool = False
+    #: When ``True``, the multi-asset invokes
+    #: :meth:`RockyResource.retention_status` once per materialization batch
+    #: and emits one :class:`dg.AssetObservation` per
+    #: :class:`~.types.ModelRetentionStatus` row on the matching asset.
+    #: Observation (not check) is the right primitive because retention is
+    #: a configuration signal — ``in_sync=False`` means the warehouse's
+    #: current retention differs from the project's declaration, which is
+    #: a change to surface on the timeline rather than a pass/fail.
+    #: Default ``False`` preserves zero behaviour change.
+    surface_retention_status: bool = False
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -526,7 +549,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             else {}
         )
 
-        check_specs = _build_check_specs(groups, contract_rules_by_model)
+        check_specs = _build_check_specs(
+            groups,
+            contract_rules_by_model,
+            surface_compliance=self.surface_compliance,
+        )
 
         assets: list[dg.AssetsDefinition] = [
             _make_rocky_asset(
@@ -538,6 +565,8 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 compile_state=compile_state,
                 contract_rules_by_model=contract_rules_by_model,
                 execution_mode=self.execution_mode,
+                surface_compliance=self.surface_compliance,
+                surface_retention_status=self.surface_retention_status,
             )
             for group in groups
         ]
@@ -767,6 +796,8 @@ def _build_asset_spec(
 def _build_check_specs(
     groups: list[_GroupBuild],
     contract_rules_by_model: dict[str, ContractRules] | None = None,
+    *,
+    surface_compliance: bool = False,
 ) -> list[dg.AssetCheckSpec]:
     """Pre-declare check specs for every asset in every group.
 
@@ -778,6 +809,13 @@ def _build_check_specs(
     on the presence of the matching rule kind in the contract file
     (e.g. a contract with only `[[columns]]` constraints does NOT get a
     `contract_required_columns` spec).
+
+    When ``surface_compliance`` is ``True``, additionally pre-declares a
+    ``compliance_exception`` :class:`dg.AssetCheckSpec` per asset so the
+    UI surfaces it before any run — matches the ``row_count_anomaly``
+    pattern (check exists even if the current run produces no exceptions,
+    in which case :func:`_emit_placeholder_checks` emits a passing
+    placeholder).
     """
     contract_rules_by_model = contract_rules_by_model or {}
     specs: list[dg.AssetCheckSpec] = []
@@ -787,6 +825,10 @@ def _build_check_specs(
             # Default checks (4 per asset)
             for check_name in DEFAULT_CHECK_NAMES:
                 specs.append(dg.AssetCheckSpec(name=check_name, asset=spec.key))
+
+            # Governance compliance check (Wave B, opt-in)
+            if surface_compliance:
+                specs.append(dg.AssetCheckSpec(name=COMPLIANCE_CHECK_NAME, asset=spec.key))
 
             # Contract checks (per declared rule kind, when matched)
             table_name = spec.key.path[-1]
@@ -957,6 +999,8 @@ def _make_rocky_asset(
     compile_state: _CompileState,
     contract_rules_by_model: dict[str, ContractRules] | None = None,
     execution_mode: Literal["streaming", "pipes"] = "streaming",
+    surface_compliance: bool = False,
+    surface_retention_status: bool = False,
 ) -> dg.AssetsDefinition:
     """Create a multi-asset that executes ``rocky run`` for one group.
 
@@ -973,6 +1017,14 @@ def _make_rocky_asset(
       Contract check results remain sourced from compile diagnostics in
       both modes because those are a build-time signal, not a run-time
       signal.
+
+    Governance surfaces (``surface_compliance`` / ``surface_retention_status``):
+    both are opt-in and default to ``False``. When on, the asset invokes
+    :meth:`RockyResource.compliance` / :meth:`RockyResource.retention_status`
+    after the run loop and folds each output through the matching
+    observability helper. Emitted in both execution modes because
+    governance state lives in the state store, not in the ``rocky run``
+    JSON — so Pipes doesn't carry them either.
     """
     contract_rules_by_model = contract_rules_by_model or {}
 
@@ -988,6 +1040,57 @@ def _make_rocky_asset(
         selected_keys = set(context.selected_asset_keys)
         filters = _select_filters(group, selected_keys, context)
 
+        # Governance events (Waves B + C-2, opt-in). Collected first so
+        # the compliance check pairs can be passed into ``_emit_results``
+        # via ``extra_yielded_checks`` — otherwise the placeholder pass
+        # would emit a passing ``compliance_exception`` alongside each
+        # real WARN result, triggering Dagster's "output returned
+        # multiple times" invariant. Emitted in both execution modes
+        # because the compliance / retention-status rollups live in the
+        # state store — Pipes carries run events, not governance metadata.
+        #
+        # Compliance results whose ``(asset_key, check_name)`` is not
+        # pre-declared in ``check_specs`` are dropped with a warning —
+        # ``compliance_check_results`` may yield against the
+        # ``_compliance`` sentinel key (for model names the resolver
+        # can't map) or against assets outside the group selection,
+        # neither of which can be declared at spec-build time. Same
+        # guard as ``_emit_results`` applies to anomaly results.
+        declared_check_pairs: set[tuple[dg.AssetKey, str]] = {
+            (cs.asset_key, cs.name) for cs in check_specs
+        }
+        governance_events: list[dg.AssetCheckResult | dg.AssetObservation] = []
+        compliance_yielded: set[tuple[dg.AssetKey, str]] = set()
+        if surface_compliance or surface_retention_status:
+            for event in _emit_governance_events(
+                context=context,
+                rocky=rocky,
+                group=group,
+                selected_keys=selected_keys,
+                surface_compliance=surface_compliance,
+                surface_retention_status=surface_retention_status,
+            ):
+                if isinstance(event, dg.AssetCheckResult):
+                    pair = (event.asset_key, event.check_name)
+                    if pair not in declared_check_pairs:
+                        context.log.warning(
+                            f"compliance result for undeclared asset "
+                            f"{event.asset_key.to_user_string()!r} "
+                            f"(check {event.check_name!r}) — dropping. "
+                            f"This happens when a compliance exception targets "
+                            f"a model outside the current group's selection or "
+                            f"folds into the {COMPLIANCE_CHECK_NAME} sentinel "
+                            f"key. Surface this asset on the component to "
+                            f"receive the result."
+                        )
+                        continue
+                    compliance_yielded.add(pair)
+                    governance_events.append(event)
+                elif isinstance(event, dg.AssetObservation):
+                    # Observations are unconstrained by declared specs —
+                    # pass through unchanged.
+                    governance_events.append(event)
+
         if execution_mode == "pipes":
             yield from _run_filters_pipes(
                 context=context,
@@ -996,6 +1099,10 @@ def _make_rocky_asset(
                 group=group,
                 selected_keys=selected_keys,
             )
+            # In pipes mode, the placeholder pass inside ``_emit_results``
+            # doesn't run — but we still need to yield the collected
+            # governance events so the surfaces are wired in both modes.
+            yield from governance_events
         else:
             results = _run_filters(context, rocky, filters)
 
@@ -1006,11 +1113,17 @@ def _make_rocky_asset(
                     f"{sum(r.duration_ms for r in results)}ms"
                 )
 
+            # Yield governance events first so Dagster sees them before
+            # the placeholder pass. ``extra_yielded_checks`` primes
+            # ``_emit_results``'s dedup set so the placeholder doesn't
+            # double-emit ``compliance_exception`` against the same key.
+            yield from governance_events
             yield from _emit_results(
                 results=results,
                 check_specs=check_specs,
                 selected_keys=selected_keys,
                 rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
+                extra_yielded_checks=compliance_yielded,
             )
 
         # Contract check results — sourced from compile diagnostics, not
@@ -1073,6 +1186,55 @@ def _run_filters_pipes(
             include_keys=selected_keys,
         )
         yield from invocation.get_results()
+
+
+def _emit_governance_events(
+    *,
+    context: dg.AssetExecutionContext,
+    rocky: RockyResource,
+    group: _GroupBuild,
+    selected_keys: set[dg.AssetKey],
+    surface_compliance: bool,
+    surface_retention_status: bool,
+) -> Iterator[dg.AssetCheckResult | dg.AssetObservation]:
+    """Fold ``rocky compliance`` / ``rocky retention-status`` into Dagster events.
+
+    Both calls are metadata-only reads against the state store — cheap
+    enough to run once per materialization batch. Errors are logged and
+    swallowed so a transient governance read never fails a whole
+    materialization; the drift / anomaly path has the same tolerance
+    (a binary failure surfaces via the materialization itself).
+
+    Asset-key resolution reuses the group's ``rocky_key_to_dagster_key``
+    lookup — compliance exceptions and retention rows identify models by
+    name, so the resolver tries an exact last-segment match against the
+    selected subset. Models that don't resolve to a selected asset key
+    either fall back to the sentinel ``_compliance`` key (exceptions) or
+    are silently skipped (retention observations).
+    """
+    model_to_key = {tup[-1]: key for tup, key in group.rocky_key_to_dagster_key.items() if tup}
+
+    def resolver(model_name: str) -> dg.AssetKey | None:
+        key = model_to_key.get(model_name)
+        if key is not None and key in selected_keys:
+            return key
+        return None
+
+    if surface_compliance:
+        try:
+            compliance_output = rocky.compliance()
+        except Exception as exc:  # noqa: BLE001
+            context.log.warning(f"rocky compliance failed, skipping compliance events: {exc}")
+        else:
+            yield from compliance_check_results(compliance_output, key_resolver=resolver)
+
+    if surface_retention_status:
+        try:
+            retention_output = rocky.retention_status()
+        except Exception as exc:  # noqa: BLE001
+            context.log.warning(f"rocky retention-status failed, skipping retention events: {exc}")
+        else:
+            yield from retention_observations(retention_output, key_resolver=resolver)
 
 
 def _emit_contract_check_results(
@@ -1198,6 +1360,7 @@ def _emit_results(
     check_specs: list[dg.AssetCheckSpec],
     selected_keys: set[dg.AssetKey],
     rocky_key_to_dagster_key: dict[tuple[str, ...], dg.AssetKey],
+    extra_yielded_checks: set[tuple[dg.AssetKey, str]] | None = None,
 ) -> Iterator[dg.MaterializeResult | dg.AssetCheckResult | dg.AssetObservation]:
     """Yield Dagster events for every materialization, check, drift event and anomaly.
 
@@ -1271,7 +1434,7 @@ def _emit_results(
             metadata=metadata,
         )
 
-    yielded_checks: set[tuple[dg.AssetKey, str]] = set()
+    yielded_checks: set[tuple[dg.AssetKey, str]] = set(extra_yielded_checks or ())
     for table_check in table_checks:
         asset_key = remap(table_check.asset_key)
         if asset_key not in selected_keys:

--- a/integrations/dagster/src/dagster_rocky/observability.py
+++ b/integrations/dagster/src/dagster_rocky/observability.py
@@ -41,7 +41,7 @@ from .checks import cost_metadata_from_optimize
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-    from .types import OptimizeResult, RunResult
+    from .types import ComplianceOutput, OptimizeResult, RetentionStatusOutput, RunResult
 
     #: Type alias for the key resolver callback used by drift/anomaly builders.
     #: Takes a Rocky table identifier (possibly ``catalog.schema.table``) and
@@ -54,6 +54,28 @@ if TYPE_CHECKING:
 #: a matching :class:`dg.AssetCheckSpec` with this name on every Rocky asset
 #: that should expose anomaly detection in the UI before any run.
 ANOMALY_CHECK_NAME: str = "row_count_anomaly"
+
+#: Canonical Dagster check name used to surface compliance exceptions from
+#: ``rocky compliance`` (governance Wave B). One check result is emitted per
+#: :class:`ComplianceException` in the rollup, keyed on the model that owns
+#: the classified column. Pre-declare a matching :class:`dg.AssetCheckSpec`
+#: on every Rocky asset that should expose governance compliance in the UI
+#: before any run.
+COMPLIANCE_CHECK_NAME: str = "compliance_exception"
+
+#: Sentinel Dagster asset key used when a compliance exception's model does
+#: not resolve to any asset key in the current selection (e.g. the model
+#: exists in the Rocky project but isn't a source-replication table). One
+#: run-level check result is emitted against this key per unresolved
+#: exception so the signal is still visible in the run viewer.
+COMPLIANCE_FALLBACK_ASSET_KEY: dg.AssetKey = dg.AssetKey(["_compliance"])
+
+#: Canonical name used for the retention observations emitted by
+#: :func:`retention_observations`. Included as an observation-level
+#: description tag so downstream filtering on the asset timeline can pick
+#: out retention-drift events by description without pattern matching on
+#: the metadata keys.
+RETENTION_OBSERVATION_NAME: str = "retention_drift"
 
 
 # ---------------------------------------------------------------------------
@@ -195,3 +217,166 @@ def optimize_metadata_for_keys(
         if metadata:
             out[asset_key] = metadata
     return out
+
+
+# ---------------------------------------------------------------------------
+# Compliance → AssetCheckResult (WARN)
+# ---------------------------------------------------------------------------
+
+
+def compliance_check_results(
+    output: ComplianceOutput,
+    *,
+    key_resolver: KeyResolver,
+) -> Iterator[dg.AssetCheckResult]:
+    """Yield one aggregated ``AssetCheckResult`` per asset with compliance exceptions.
+
+    Dagster's ``AssetCheckResult`` API requires at most one result per
+    ``(asset_key, check_name)`` per materialization — emitting one per
+    exception would trigger ``DagsterInvariantViolationError`` whenever
+    a single model has exceptions across multiple envs or columns. This
+    helper therefore aggregates per asset: all exceptions for the same
+    resolved ``AssetKey`` fold into a single WARN check result whose
+    metadata lists every offending ``(model, column, env)`` triple.
+
+    The check shape is::
+
+        check_name = COMPLIANCE_CHECK_NAME ("compliance_exception")
+        passed     = False
+        severity   = dg.AssetCheckSeverity.WARN
+
+    Severity is WARN uniformly today — the engine's ``ComplianceException``
+    schema v1 has no per-exception severity field (the ``reason`` string
+    is the only free-form dimension). If the engine later surfaces
+    severity or ``acknowledged`` metadata, this helper can start gating
+    ``passed`` / ``severity`` on it without a signature change.
+
+    Asset-key resolution is delegated to ``key_resolver`` — the component
+    bridge builds one keyed by model name from its
+    ``rocky_key_to_dagster_key`` map, mirroring the drift / anomaly
+    pattern. Exceptions whose model does not resolve to an asset key
+    fold into a single aggregate against
+    :data:`COMPLIANCE_FALLBACK_ASSET_KEY` (a synthesized ``_compliance``
+    key) so the helper remains usable by callers outside the
+    :class:`RockyComponent` bridge (hand-rolled multi-assets can declare
+    a matching check spec on the sentinel key). The component bridge
+    itself drops the sentinel-keyed result with a warning because it
+    cannot pre-declare a spec for a key that's not one of the
+    component's assets.
+
+    Args:
+        output: Parsed ``rocky compliance`` output.
+        key_resolver: Callable taking a Rocky model name and returning
+            the Dagster ``AssetKey`` it maps to, or ``None`` if no
+            mapping exists.
+
+    Yields:
+        One ``dg.AssetCheckResult`` per asset with exceptions, with
+        ``rocky/compliance_*`` metadata aggregating every exception
+        against that asset. Metadata keys:
+
+        * ``rocky/compliance_exception_count`` — number of exceptions
+          folded into this result.
+        * ``rocky/compliance_models`` — ``"model.column (env)"`` entries
+          joined by ``"; "``.
+        * ``rocky/compliance_reasons`` — distinct reason strings joined
+          by ``"; "``.
+        * ``rocky/compliance_total_*`` — project-wide summary counters.
+    """
+    by_key: dict[dg.AssetKey, list] = {}
+    for exception in output.exceptions:
+        asset_key = key_resolver(exception.model) or COMPLIANCE_FALLBACK_ASSET_KEY
+        by_key.setdefault(asset_key, []).append(exception)
+
+    for asset_key, exceptions in by_key.items():
+        model_parts = [f"{e.model}.{e.column} ({e.env})" for e in exceptions]
+        # Deduplicate reasons while preserving first-seen order.
+        reasons: list[str] = []
+        for e in exceptions:
+            if e.reason not in reasons:
+                reasons.append(e.reason)
+        yield dg.AssetCheckResult(
+            asset_key=asset_key,
+            check_name=COMPLIANCE_CHECK_NAME,
+            passed=False,
+            severity=dg.AssetCheckSeverity.WARN,
+            metadata={
+                "rocky/compliance_exception_count": dg.MetadataValue.int(len(exceptions)),
+                "rocky/compliance_models": dg.MetadataValue.text("; ".join(model_parts)),
+                "rocky/compliance_reasons": dg.MetadataValue.text("; ".join(reasons)),
+                "rocky/compliance_total_classified": dg.MetadataValue.int(
+                    output.summary.total_classified
+                ),
+                "rocky/compliance_total_exceptions": dg.MetadataValue.int(
+                    output.summary.total_exceptions
+                ),
+                "rocky/compliance_total_masked": dg.MetadataValue.int(output.summary.total_masked),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Retention → AssetObservation
+# ---------------------------------------------------------------------------
+
+
+def retention_observations(
+    output: RetentionStatusOutput,
+    *,
+    key_resolver: KeyResolver,
+) -> Iterator[dg.AssetObservation]:
+    """Yield one ``AssetObservation`` per :class:`ModelRetentionStatus` row.
+
+    Retention is a *configuration* signal, not a pass/fail check — a
+    model with no configured retention is a valid state, and
+    ``in_sync=False`` means the warehouse's current retention differs
+    from what the project declared (a change, not necessarily a
+    failure). Observation is therefore the right primitive.
+
+    Asset-key resolution is delegated to ``key_resolver`` — same
+    contract as :func:`drift_observations` and
+    :func:`compliance_check_results`. Rows whose model does not resolve
+    are silently skipped.
+
+    The metadata surface mirrors the fields on
+    :class:`ModelRetentionStatus`:
+
+    * ``rocky/retention_model`` — model name
+    * ``rocky/retention_configured_days`` — declared retention from the
+      model's ``retention`` sidecar (omitted when ``None`` — the model
+      has no retention declaration)
+    * ``rocky/retention_warehouse_days`` — observed retention from the
+      warehouse (omitted when ``None``; the engine's ``--drift``
+      warehouse probe is a v2 follow-up so this is always ``None`` in
+      v1)
+    * ``rocky/retention_in_sync`` — ``True`` iff configured and
+      warehouse retention match (or both are ``None``)
+
+    Args:
+        output: Parsed ``rocky retention-status`` output.
+        key_resolver: Callable taking a Rocky model name and returning
+            the Dagster ``AssetKey`` it maps to, or ``None`` if no
+            mapping exists.
+
+    Yields:
+        ``dg.AssetObservation`` events with ``rocky/retention_*`` metadata.
+    """
+    for status in output.models:
+        asset_key = key_resolver(status.model)
+        if asset_key is None:
+            continue
+        metadata: dict[str, dg.MetadataValue] = {
+            "rocky/retention_model": dg.MetadataValue.text(status.model),
+            "rocky/retention_in_sync": dg.MetadataValue.bool(status.in_sync),
+        }
+        if status.configured_days is not None:
+            metadata["rocky/retention_configured_days"] = dg.MetadataValue.int(
+                status.configured_days
+            )
+        if status.warehouse_days is not None:
+            metadata["rocky/retention_warehouse_days"] = dg.MetadataValue.int(status.warehouse_days)
+        yield dg.AssetObservation(
+            asset_key=asset_key,
+            description=f"Retention status: {RETENTION_OBSERVATION_NAME}",
+            metadata=metadata,
+        )

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -46,6 +46,7 @@ from .types import (
     CiResult,
     ColumnLineageResult,
     CompileResult,
+    ComplianceOutput,
     ConformanceResult,
     CostOutput,
     DagResult,
@@ -57,6 +58,7 @@ from .types import (
     ModelLineageResult,
     OptimizeResult,
     PlanResult,
+    RetentionStatusOutput,
     RunResult,
     StateHealthResult,
     StateResult,
@@ -1916,6 +1918,60 @@ class RockyResource(dg.ConfigurableResource):
         from .health import state_health as _state_health
 
         return _state_health(self, probe_write=probe_write)
+
+    def compliance(self, *, env: str | None = None) -> ComplianceOutput:
+        """Run ``rocky compliance`` and return the parsed governance rollup.
+
+        A thin wrapper over the engine's Wave B governance surface
+        (``rocky compliance``) — a static resolver over the project's
+        ``[classification]`` sidecars + ``[mask]`` / ``[mask.<env>]``
+        policy blocks that answers "are all classified columns masked
+        wherever policy says they should be?". The command makes no
+        warehouse calls and is safe to invoke per materialization batch.
+
+        Args:
+            env: Optional environment label forwarded as ``--env <env>``.
+                When set, masking status is evaluated only against that
+                environment's ``[mask.<env>]`` block. When unset, the
+                engine expands across the union of defaults and every
+                named override block.
+
+        Returns:
+            :class:`~.types.ComplianceOutput` — the parsed rollup. See
+            :meth:`~.types.ComplianceOutput.exceptions` for the
+            unmasked-where-expected list and
+            :meth:`~.types.ComplianceOutput.summary` for aggregate tallies.
+        """
+        args = ["compliance", "--output", "json"]
+        if env is not None:
+            args.extend(["--env", env])
+        return _parse_rocky_json(self._run_rocky(args), ComplianceOutput, command="compliance")
+
+    def retention_status(self, *, env: str | None = None) -> RetentionStatusOutput:
+        """Run ``rocky retention-status`` and return the parsed per-model status.
+
+        Reports which models declare a ``retention = "<N>[dy]"`` sidecar
+        value and — once the engine's ``--drift`` warehouse probe lands
+        — whether the warehouse's current retention matches. The
+        command reads the project's model sidecars + state store only;
+        no warehouse round-trip in v1, so it's safe to invoke per
+        materialization batch.
+
+        Args:
+            env: Optional environment label forwarded as ``--env <env>``.
+
+        Returns:
+            :class:`~.types.RetentionStatusOutput` — one
+            :class:`~.types.ModelRetentionStatus` entry per model.
+            ``warehouse_days`` is always ``None`` until the engine's
+            v2 ``--drift`` probe ships.
+        """
+        args = ["retention-status", "--output", "json"]
+        if env is not None:
+            args.extend(["--env", env])
+        return _parse_rocky_json(
+            self._run_rocky(args), RetentionStatusOutput, command="retention-status"
+        )
 
     def resume_run(
         self,

--- a/integrations/dagster/tests/conftest.py
+++ b/integrations/dagster/tests/conftest.py
@@ -97,3 +97,13 @@ def doctor_json() -> str:
 @pytest.fixture
 def drift_json() -> str:
     return json.dumps(scenarios.DRIFT)
+
+
+@pytest.fixture
+def compliance_json() -> str:
+    return json.dumps(scenarios.COMPLIANCE)
+
+
+@pytest.fixture
+def retention_status_json() -> str:
+    return json.dumps(scenarios.RETENTION_STATUS)

--- a/integrations/dagster/tests/scenarios.py
+++ b/integrations/dagster/tests/scenarios.py
@@ -579,3 +579,110 @@ DRIFT: dict[str, Any] = {
         },
     ],
 }
+
+
+# ---------------------------------------------------------------------------
+# compliance — governance Wave B rollup
+#
+# Two classified columns, one masked (``orders.email`` resolves a ``hash``
+# strategy in both default + prod envs) and one exception (``payments.ssn``
+# is classified ``pii`` but no masking strategy resolves, and ``pii`` is not
+# on the ``allow_unmasked`` advisory list). Summary counters match the
+# ``(model, column, env)`` triples expanded across the env enumeration.
+# ---------------------------------------------------------------------------
+
+COMPLIANCE: dict[str, Any] = {
+    "command": "compliance",
+    "version": "1.16.0",
+    "summary": {
+        "total_classified": 4,
+        "total_masked": 2,
+        "total_exceptions": 2,
+    },
+    "per_column": [
+        {
+            "model": "orders",
+            "column": "email",
+            "classification": "pii",
+            "envs": [
+                {
+                    "env": "default",
+                    "masking_strategy": "hash",
+                    "enforced": True,
+                },
+                {
+                    "env": "prod",
+                    "masking_strategy": "hash",
+                    "enforced": True,
+                },
+            ],
+        },
+        {
+            "model": "payments",
+            "column": "ssn",
+            "classification": "pii",
+            "envs": [
+                {
+                    "env": "default",
+                    "masking_strategy": "unresolved",
+                    "enforced": False,
+                },
+                {
+                    "env": "prod",
+                    "masking_strategy": "unresolved",
+                    "enforced": False,
+                },
+            ],
+        },
+    ],
+    "exceptions": [
+        {
+            "model": "payments",
+            "column": "ssn",
+            "env": "default",
+            "reason": "no masking strategy resolves for classification tag 'pii'",
+        },
+        {
+            "model": "payments",
+            "column": "ssn",
+            "env": "prod",
+            "reason": "no masking strategy resolves for classification tag 'pii'",
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# retention-status — governance Wave C-2 per-model rollup
+#
+# Three models: one with declared retention and no warehouse mismatch
+# (``in_sync=True``), one with declared retention whose warehouse probe
+# would eventually populate ``warehouse_days`` (``None`` in v1, so the
+# entry is reported as ``in_sync=True`` per the schema's contract), and
+# one with no declaration (both sides ``None``, ``in_sync=True``).
+# ---------------------------------------------------------------------------
+
+RETENTION_STATUS: dict[str, Any] = {
+    "command": "retention-status",
+    "version": "1.16.0",
+    "models": [
+        {
+            "model": "orders",
+            "configured_days": 30,
+            "warehouse_days": None,
+            "in_sync": True,
+        },
+        {
+            "model": "payments",
+            "configured_days": 90,
+            "warehouse_days": None,
+            "in_sync": True,
+        },
+        {
+            "model": "revenue_summary",
+            "configured_days": None,
+            "warehouse_days": None,
+            "in_sync": True,
+        },
+    ],
+}

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -326,3 +326,310 @@ def test_metadata_includes_source_info(discover_json: str, tmp_path: Path):
                 metadata = dict(spec.metadata or {})
                 assert "dagster-rocky/source_id" in metadata
                 assert "dagster-rocky/source_type" in metadata
+
+
+# ---------------------------------------------------------------------------
+# Governance surfaces (surface_compliance + surface_retention_status)
+# ---------------------------------------------------------------------------
+
+
+def _build_defs_with_flags(
+    discover_json: str,
+    tmp_path: Path,
+    *,
+    surface_compliance: bool = False,
+    surface_retention_status: bool = False,
+) -> dg.Definitions:
+    """Same as ``_build_defs`` but with governance opt-ins on the component."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": json.loads(discover_json)}))
+    component = RockyComponent(
+        config_path="rocky.toml",
+        surface_compliance=surface_compliance,
+        surface_retention_status=surface_retention_status,
+    )
+    return component.build_defs_from_state(context=None, state_path=state_file)
+
+
+def _materialize_with_governance(
+    defs: dg.Definitions,
+    run_result: RunResult,
+    selection: list[dg.AssetKey],
+    *,
+    compliance_json: str | None = None,
+    retention_status_json: str | None = None,
+):
+    """Materialize a subset with rocky.run + compliance/retention patched."""
+    from dagster_rocky.types import ComplianceOutput, RetentionStatusOutput
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+        patch.object(
+            RockyResource,
+            "compliance",
+            return_value=(
+                ComplianceOutput.model_validate_json(compliance_json)
+                if compliance_json is not None
+                else None
+            ),
+        ),
+        patch.object(
+            RockyResource,
+            "retention_status",
+            return_value=(
+                RetentionStatusOutput.model_validate_json(retention_status_json)
+                if retention_status_json is not None
+                else None
+            ),
+        ),
+    ):
+        return dg.materialize(
+            list(defs.assets or []),
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=selection,
+            raise_on_error=False,
+        )
+
+
+def test_compliance_check_spec_predeclared_when_opt_in(discover_json: str, tmp_path: Path):
+    """``surface_compliance=True`` pre-declares a ``compliance_exception``
+    spec per asset so it's visible in the UI before any run."""
+    defs = _build_defs_with_flags(discover_json, tmp_path, surface_compliance=True)
+    all_check_specs = []
+    for asset_def in defs.assets or []:
+        if isinstance(asset_def, dg.AssetsDefinition):
+            all_check_specs.extend(asset_def.check_specs)
+
+    compliance_specs = [cs for cs in all_check_specs if cs.name == "compliance_exception"]
+    result = DiscoverResult.model_validate_json(discover_json)
+    total_tables = sum(len(s.tables) for s in result.sources)
+    # One compliance spec per asset
+    assert len(compliance_specs) == total_tables
+
+
+def test_compliance_check_spec_absent_by_default(discover_json: str, tmp_path: Path):
+    """Default ``surface_compliance=False`` emits zero compliance specs —
+    zero behaviour change for existing deployments."""
+    defs = _build_defs_with_flags(discover_json, tmp_path)  # both flags off
+    for asset_def in defs.assets or []:
+        if isinstance(asset_def, dg.AssetsDefinition):
+            names = {cs.name for cs in asset_def.check_specs}
+            assert "compliance_exception" not in names
+
+
+def test_governance_events_emitted_when_both_flags_true(
+    discover_json: str,
+    run_json: str,
+    compliance_json: str,
+    retention_status_json: str,
+    tmp_path: Path,
+):
+    """End-to-end: both opt-ins emit the expected extra events alongside
+    the existing drift + anomaly + materialization events.
+
+    The scenario's compliance exceptions target ``payments`` (which
+    resolves to the payments asset key in the acme source) — so the
+    multi-asset must surface 2 compliance check results on top of the
+    existing drift observation and anomaly check the fixture already
+    produces for payments.
+    """
+    defs = _build_defs_with_flags(
+        discover_json,
+        tmp_path,
+        surface_compliance=True,
+        surface_retention_status=True,
+    )
+    run_result = RunResult.model_validate_json(run_json)
+    payments_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "payments"])
+
+    exec_result = _materialize_with_governance(
+        defs,
+        run_result,
+        [payments_key],
+        compliance_json=compliance_json,
+        retention_status_json=retention_status_json,
+    )
+    assert exec_result.success
+
+    check_evaluations = [
+        e for e in exec_result.all_events if e.event_type_value == "ASSET_CHECK_EVALUATION"
+    ]
+    compliance_checks = [
+        e for e in check_evaluations if e.event_specific_data.check_name == "compliance_exception"
+    ]
+    # Both scenario exceptions target ``payments`` — they aggregate into a
+    # single WARN check result (Dagster rejects duplicate (key, name) pairs).
+    assert len(compliance_checks) == 1
+    eval_data = compliance_checks[0].event_specific_data
+    assert eval_data.passed is False
+    assert eval_data.severity == dg.AssetCheckSeverity.WARN
+    assert eval_data.metadata["rocky/compliance_exception_count"].value == 2
+    models = eval_data.metadata["rocky/compliance_models"].text
+    assert "payments.ssn (default)" in models
+    assert "payments.ssn (prod)" in models
+
+    # Retention observations: one per model row whose name resolves to a
+    # selected asset. Only ``payments`` is selected, and the scenario has
+    # ``payments`` declared — so exactly one retention observation.
+    observations = [e for e in exec_result.all_events if e.event_type_value == "ASSET_OBSERVATION"]
+    retention_obs = [
+        e
+        for e in observations
+        if "rocky/retention_model" in (e.event_specific_data.asset_observation.metadata or {})
+    ]
+    assert len(retention_obs) == 1
+    obs_metadata = retention_obs[0].event_specific_data.asset_observation.metadata
+    assert obs_metadata["rocky/retention_model"].text == "payments"
+    assert obs_metadata["rocky/retention_configured_days"].value == 90
+
+
+def test_governance_events_absent_when_flags_false(
+    discover_json: str,
+    run_json: str,
+    compliance_json: str,
+    retention_status_json: str,
+    tmp_path: Path,
+):
+    """Default flags off: zero governance events even if the mocked outputs
+    are non-empty. Proves the opt-in is honoured and no binary invocation
+    happens for users who haven't explicitly turned the surface on."""
+    defs = _build_defs_with_flags(discover_json, tmp_path)  # both False
+    run_result = RunResult.model_validate_json(run_json)
+    payments_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "payments"])
+
+    exec_result = _materialize_with_governance(
+        defs,
+        run_result,
+        [payments_key],
+        compliance_json=compliance_json,
+        retention_status_json=retention_status_json,
+    )
+    assert exec_result.success
+
+    check_evaluations = [
+        e for e in exec_result.all_events if e.event_type_value == "ASSET_CHECK_EVALUATION"
+    ]
+    assert not any(
+        e.event_specific_data.check_name == "compliance_exception" for e in check_evaluations
+    )
+    observations = [e for e in exec_result.all_events if e.event_type_value == "ASSET_OBSERVATION"]
+    assert not any(
+        "rocky/retention_model" in (e.event_specific_data.asset_observation.metadata or {})
+        for e in observations
+    )
+
+
+def test_governance_compliance_drops_exceptions_for_unknown_models(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """Compliance exceptions targeting a model the component didn't declare
+    are dropped with a warning rather than crashing the materialization.
+
+    The sentinel ``_compliance`` asset key + exceptions for models outside
+    the current group's selection would otherwise raise
+    ``DagsterInvariantViolationError`` because no matching
+    ``AssetCheckSpec`` is pre-declared for those keys. The component
+    filter defends the invariant; this test pins the behaviour.
+    """
+    from dagster_rocky.types import ComplianceOutput
+
+    defs = _build_defs_with_flags(discover_json, tmp_path, surface_compliance=True)
+    run_result = RunResult.model_validate_json(run_json)
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+
+    # Build a compliance scenario whose exceptions target a model that
+    # does NOT exist in the discover fixture's source tables. The model
+    # resolver will fail, the helper will fall back to the sentinel
+    # ``_compliance`` key, and the component must drop that result
+    # because no spec was declared against the sentinel.
+    unknown_compliance = {
+        "command": "compliance",
+        "version": "1.16.0",
+        "summary": {
+            "total_classified": 1,
+            "total_masked": 0,
+            "total_exceptions": 1,
+        },
+        "per_column": [],
+        "exceptions": [
+            {
+                "model": "totally_made_up_model",
+                "column": "secret",
+                "env": "prod",
+                "reason": "no masking strategy resolves for classification tag 'pii'",
+            },
+        ],
+    }
+    compliance_output = ComplianceOutput.model_validate(unknown_compliance)
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+        patch.object(RockyResource, "compliance", return_value=compliance_output),
+    ):
+        exec_result = dg.materialize(
+            list(defs.assets or []),
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[orders_key],
+            raise_on_error=False,
+        )
+
+    assert exec_result.success
+    # The sentinel-key result is dropped. Only the placeholder compliance
+    # check (passing) fires for the selected orders asset.
+    check_evaluations = [
+        e for e in exec_result.all_events if e.event_type_value == "ASSET_CHECK_EVALUATION"
+    ]
+    compliance_checks = [
+        e for e in check_evaluations if e.event_specific_data.check_name == "compliance_exception"
+    ]
+    assert len(compliance_checks) == 1
+    # The one result is the placeholder against orders (declared key),
+    # not the sentinel — and it passes because no exception reached it.
+    check = compliance_checks[0]
+    assert check.event_specific_data.asset_key == orders_key
+    assert check.event_specific_data.passed is True
+
+
+def test_governance_compliance_failure_does_not_fail_materialization(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """If ``rocky compliance`` raises, the multi-asset logs a warning and
+    continues — the drift/anomaly path has the same tolerance."""
+    defs = _build_defs_with_flags(discover_json, tmp_path, surface_compliance=True)
+    run_result = RunResult.model_validate_json(run_json)
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+        patch.object(
+            RockyResource, "compliance", side_effect=RuntimeError("simulated binary crash")
+        ),
+    ):
+        exec_result = dg.materialize(
+            list(defs.assets or []),
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[orders_key],
+            raise_on_error=False,
+        )
+
+    # Materialization still succeeds — compliance error is swallowed.
+    assert exec_result.success
+    # The pre-declared ``compliance_exception`` spec still produces a
+    # placeholder (Dagster requires every declared spec to yield a
+    # result) — but the placeholder passes rather than propagating the
+    # binary crash as a WARN. That's the design: a transient governance
+    # read failure is a logged-and-skipped event, not a user-facing
+    # compliance violation.
+    check_evaluations = [
+        e for e in exec_result.all_events if e.event_type_value == "ASSET_CHECK_EVALUATION"
+    ]
+    compliance_checks = [
+        e for e in check_evaluations if e.event_specific_data.check_name == "compliance_exception"
+    ]
+    # Exactly one placeholder result, and it must be passing (not WARN).
+    assert len(compliance_checks) == 1
+    eval_data = compliance_checks[0].event_specific_data
+    assert eval_data.passed is True

--- a/integrations/dagster/tests/test_observability.py
+++ b/integrations/dagster/tests/test_observability.py
@@ -6,18 +6,25 @@ import dagster as dg
 
 from dagster_rocky.observability import (
     ANOMALY_CHECK_NAME,
+    COMPLIANCE_CHECK_NAME,
+    COMPLIANCE_FALLBACK_ASSET_KEY,
+    RETENTION_OBSERVATION_NAME,
     anomaly_check_results,
+    compliance_check_results,
     drift_observations,
     optimize_metadata_for_keys,
+    retention_observations,
 )
 from dagster_rocky.types import (
     AnomalyResult,
+    ComplianceOutput,
     DriftAction,
     DriftInfo,
     ExecutionSummary,
     MaterializationCost,
     OptimizeResult,
     PermissionInfo,
+    RetentionStatusOutput,
     RunResult,
 )
 
@@ -248,3 +255,167 @@ def test_optimize_metadata_for_keys_empty_when_no_recommendations():
         optimize, model_to_key={"fct_orders": dg.AssetKey(["fct_orders"])}
     )
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# compliance_check_results
+# ---------------------------------------------------------------------------
+
+
+def test_compliance_check_results_parses_scenario(compliance_json: str):
+    """Scenario dict parses cleanly into ComplianceOutput (parse-guard)."""
+    output = ComplianceOutput.model_validate_json(compliance_json)
+    assert output.command == "compliance"
+    assert len(output.exceptions) == 2
+    assert output.summary.total_exceptions == 2
+    assert output.summary.total_masked == 2
+
+
+def test_compliance_check_results_aggregates_per_asset(compliance_json: str):
+    """Multiple exceptions on the same asset collapse to one WARN result.
+
+    Dagster rejects duplicate ``(asset_key, check_name)`` pairs per
+    materialization. The scenario has two ``payments.ssn`` exceptions
+    (one per env); both resolve to the same payments asset key and
+    must fold into a single aggregated check result.
+    """
+    output = ComplianceOutput.model_validate_json(compliance_json)
+    payments_key = dg.AssetKey(["fivetran", "acme", "payments"])
+    resolver = _resolver({"payments": payments_key})
+
+    results = list(compliance_check_results(output, key_resolver=resolver))
+
+    assert len(results) == 1
+    r = results[0]
+    assert isinstance(r, dg.AssetCheckResult)
+    assert r.check_name == COMPLIANCE_CHECK_NAME
+    assert r.passed is False
+    assert r.severity == dg.AssetCheckSeverity.WARN
+    assert r.asset_key == payments_key
+    assert r.metadata["rocky/compliance_exception_count"].value == 2
+    # Both (model, column, env) triples appear in the aggregated models string
+    models = r.metadata["rocky/compliance_models"].value
+    assert "payments.ssn (default)" in models
+    assert "payments.ssn (prod)" in models
+    # Summary counters are stamped on the aggregate
+    assert r.metadata["rocky/compliance_total_classified"].value == 4
+    assert r.metadata["rocky/compliance_total_exceptions"].value == 2
+    assert r.metadata["rocky/compliance_total_masked"].value == 2
+
+
+def test_compliance_check_results_falls_back_to_sentinel_when_unresolved(
+    compliance_json: str,
+):
+    output = ComplianceOutput.model_validate_json(compliance_json)
+    # Empty resolver → both exceptions aggregate into a single sentinel result
+    results = list(compliance_check_results(output, key_resolver=_resolver({})))
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.asset_key == COMPLIANCE_FALLBACK_ASSET_KEY
+    assert r.metadata["rocky/compliance_exception_count"].value == 2
+
+
+def test_compliance_check_results_empty_when_no_exceptions():
+    output = ComplianceOutput(
+        command="compliance",
+        version="1.16.0",
+        summary={
+            "total_classified": 0,
+            "total_masked": 0,
+            "total_exceptions": 0,
+        },
+        per_column=[],
+        exceptions=[],
+    )
+    results = list(compliance_check_results(output, key_resolver=_resolver({})))
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# retention_observations
+# ---------------------------------------------------------------------------
+
+
+def test_retention_observations_parses_scenario(retention_status_json: str):
+    """Scenario dict parses cleanly into RetentionStatusOutput (parse-guard)."""
+    output = RetentionStatusOutput.model_validate_json(retention_status_json)
+    assert output.command == "retention-status"
+    assert len(output.models) == 3
+    # All in v1 have warehouse_days=None — the --drift probe is a v2 follow-up
+    assert all(m.warehouse_days is None for m in output.models)
+
+
+def test_retention_observations_yields_one_per_model(retention_status_json: str):
+    output = RetentionStatusOutput.model_validate_json(retention_status_json)
+    orders_key = dg.AssetKey(["fivetran", "acme", "orders"])
+    payments_key = dg.AssetKey(["fivetran", "acme", "payments"])
+    revenue_key = dg.AssetKey(["marts", "revenue_summary"])
+    resolver = _resolver(
+        {
+            "orders": orders_key,
+            "payments": payments_key,
+            "revenue_summary": revenue_key,
+        }
+    )
+
+    obs = list(retention_observations(output, key_resolver=resolver))
+
+    assert len(obs) == 3
+    by_model = {o.metadata["rocky/retention_model"].value: o for o in obs}
+
+    # Orders: configured 30 days, warehouse_days is None so the metadata
+    # field is OMITTED (not None-valued) — the observation shape mirrors
+    # the schema's "None means no data yet" convention.
+    orders_obs = by_model["orders"]
+    assert orders_obs.asset_key == orders_key
+    assert orders_obs.metadata["rocky/retention_configured_days"].value == 30
+    assert "rocky/retention_warehouse_days" not in orders_obs.metadata
+    assert orders_obs.metadata["rocky/retention_in_sync"].value is True
+
+    # Revenue_summary: no declaration — configured_days omitted, warehouse omitted
+    revenue_obs = by_model["revenue_summary"]
+    assert "rocky/retention_configured_days" not in revenue_obs.metadata
+    assert "rocky/retention_warehouse_days" not in revenue_obs.metadata
+    assert revenue_obs.metadata["rocky/retention_in_sync"].value is True
+
+
+def test_retention_observations_skips_unresolved_models(retention_status_json: str):
+    output = RetentionStatusOutput.model_validate_json(retention_status_json)
+    # Only orders resolves — payments + revenue_summary silently dropped
+    orders_key = dg.AssetKey(["fivetran", "acme", "orders"])
+    resolver = _resolver({"orders": orders_key})
+
+    obs = list(retention_observations(output, key_resolver=resolver))
+
+    assert len(obs) == 1
+    assert obs[0].asset_key == orders_key
+
+
+def test_retention_observations_surfaces_warehouse_days_when_populated():
+    """Forward-compatibility: once v2 --drift ships warehouse_days, the
+    metadata field MUST appear with the observed value."""
+    output = RetentionStatusOutput(
+        command="retention-status",
+        version="1.17.0",
+        models=[
+            {
+                "model": "orders",
+                "configured_days": 30,
+                "warehouse_days": 60,
+                "in_sync": False,
+            },
+        ],
+    )
+    orders_key = dg.AssetKey(["orders"])
+    obs = list(retention_observations(output, key_resolver=_resolver({"orders": orders_key})))
+
+    assert len(obs) == 1
+    assert obs[0].metadata["rocky/retention_configured_days"].value == 30
+    assert obs[0].metadata["rocky/retention_warehouse_days"].value == 60
+    assert obs[0].metadata["rocky/retention_in_sync"].value is False
+
+
+def test_retention_observation_name_is_exposed():
+    """Constant is importable + stable (public API)."""
+    assert RETENTION_OBSERVATION_NAME == "retention_drift"

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1358,3 +1358,70 @@ def test_doctor_with_check_kwarg_forwards_arbitrary_id():
         rocky.doctor(check="totally-made-up-id")
 
     assert captured[0] == ["doctor", "--check", "totally-made-up-id"]
+
+
+# ---------------------------------------------------------------------------
+# compliance() / retention_status() — governance Waves B + C-2 accessors
+# ---------------------------------------------------------------------------
+
+
+def test_compliance_builds_argv_without_env(compliance_json: str):
+    """Default ``compliance()`` call emits ``compliance --output json``."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return compliance_json
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        result = rocky.compliance()
+
+    assert captured[0] == ["compliance", "--output", "json"]
+    assert result.command == "compliance"
+    assert len(result.exceptions) == 2
+
+
+def test_compliance_forwards_env_flag(compliance_json: str):
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return compliance_json
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.compliance(env="prod")
+
+    assert captured[0] == ["compliance", "--output", "json", "--env", "prod"]
+
+
+def test_retention_status_builds_argv_without_env(retention_status_json: str):
+    """Default ``retention_status()`` call emits ``retention-status --output json``."""
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return retention_status_json
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        result = rocky.retention_status()
+
+    assert captured[0] == ["retention-status", "--output", "json"]
+    assert result.command == "retention-status"
+    assert len(result.models) == 3
+
+
+def test_retention_status_forwards_env_flag(retention_status_json: str):
+    rocky = RockyResource()
+    captured: list[list[str]] = []
+
+    def fake_run(self, args, allow_partial=False):
+        captured.append(args)
+        return retention_status_json
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
+        rocky.retention_status(env="prod")
+
+    assert captured[0] == ["retention-status", "--output", "json", "--env", "prod"]


### PR DESCRIPTION
## Summary

Closes the last governance-waveplan observability gap on `RockyComponent`. After engine-v1.16.0 shipped the Wave B (`rocky compliance`) and Wave C-2 (`rocky retention-status`) surfaces and dagster-v1.12.0 shipped the matching Pydantic types, every `RockyComponent` adopter who wanted compliance/retention events on the asset graph had to hand-roll a wrapper asset that shelled out, parsed JSON, and yielded `AssetCheckResult` / `AssetObservation` — duplicating work the component already does for drift + anomalies.

This PR adds two opt-in YAML attributes (`surface_compliance`, `surface_retention_status`, both default `False` — zero behaviour change for deployments that don't flip them). When on, the component auto-wires both surfaces through the existing bridge pattern.

Adopters flip both on with two lines in `defs.yaml`:

```yaml
type: dagster_rocky.RockyComponent
attributes:
  binary_path: rocky
  config_path: rocky/rocky.toml
  surface_compliance: true
  surface_retention_status: true
```

## What got added

**`RockyResource` methods** (mirror `state_health()` shape):
- `compliance(env=None) -> ComplianceOutput`
- `retention_status(env=None) -> RetentionStatusOutput`

**`observability.py` helpers + constants** (mirror `drift_observations()` / `anomaly_check_results()`):
- `compliance_check_results(output, *, key_resolver) -> Iterator[AssetCheckResult]`
- `retention_observations(output, *, key_resolver) -> Iterator[AssetObservation]`
- `COMPLIANCE_CHECK_NAME = "compliance_exception"`
- `COMPLIANCE_FALLBACK_ASSET_KEY = AssetKey(["_compliance"])`
- `RETENTION_OBSERVATION_NAME = "retention_drift"`

**`RockyComponent` wiring**:
- Two Pydantic fields: `surface_compliance: bool = False`, `surface_retention_status: bool = False`.
- Pre-declared `compliance_exception` check spec per asset when opt-in is on (matches the anomaly pattern).
- `_emit_governance_events` helper invoked in both execution modes (streaming + pipes).
- Graceful error swallowing on binary failure (warning log, materialization continues).
- Invariant guard that drops sentinel-keyed compliance results with a warning rather than crashing Dagster when exceptions target a model outside the component's selection.

**Public API re-exports** via `dagster_rocky/__init__.py` for `compliance_check_results`, `retention_observations`, the three new constants, `ComplianceOutput`, `RetentionStatusOutput`, `ComplianceException`, `ComplianceSummary`, `ModelRetentionStatus`.

**Tests** (24 new, 417 total after rebase on #248, all green):
- Parse-guard tests for both output types.
- Helper-level tests: aggregation per asset, sentinel fallback, empty case, resolver-miss path, forward-compat for `warehouse_days`.
- Resource tests: argv shape with/without `--env`.
- Component integration tests: pre-declared specs, opt-in gating, end-to-end events alongside drift+anomaly, failure tolerance, unknown-model filtering.

## Test plan

- [x] `cd integrations/dagster && uv run pytest` — 417 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [ ] Verify in a downstream consumer that flipping `surface_compliance: true` on their `RockyComponent` YAML surfaces compliance exceptions on the asset graph without any wrapper code

## Deviations from the original design sketch

Several field names and call shapes in the original design sketch diverged from what the shipped schemas actually expose. Deliberate deviations:

- **`ComplianceException` has no `severity` field** — real fields are `column / env / model / reason`. The sketch's "passed=True when severity=info/acknowledged, passed=False when severity=warn/error" is unimplementable. Every exception yields `passed=False`, `severity=WARN`.
- **`ModelRetentionStatus` fields differ from the sketch** — real fields are `configured_days / in_sync / model / warehouse_days`. Metadata keys are named accordingly: `rocky/retention_configured_days`, `rocky/retention_warehouse_days`, `rocky/retention_in_sync`. `warehouse_days` is always `None` in v1 (schema doc) so the metadata field is omitted conditionally.
- **Helpers take `key_resolver: Callable[[str], AssetKey | None]`, not `translator: RockyDagsterTranslator`** — matches the existing `drift_observations()` / `anomaly_check_results()` contract. Simpler signature, and `translator.get_asset_key(source, table)` doesn't fit a compliance exception (which has `model` + `column`, no source/TableInfo).
- **Compliance aggregates per asset, not per exception** — Dagster rejects duplicate `(asset_key, check_name)` pairs per materialization. Multiple exceptions for the same model (typically one per env) fold into one aggregated WARN result; metadata lists every `(model, column, env)` triple. This is the only deviation from a "one event per input row" helper shape; retention still yields one observation per row.
- **No live-binary fixtures.** The integration's fixture convention has moved past JSON files — `conftest.py` comment spells out that the legacy `tests/fixtures/*.json` was removed; scenarios now live as Python dicts in `scenarios.py` and flow through `conftest.py` via `json.dumps`. The playground POC also doesn't have governance config, so `regen-fixtures` couldn't capture a live capture without also changing the POC. Added `COMPLIANCE` + `RETENTION_STATUS` dicts to `scenarios.py` and `compliance_json` / `retention_status_json` fixtures to `conftest.py` — the parse-guard still fires via the new tests.