### PR TITLE
fix(vscode,engine): lineage --format dot was silently producing JSON

### DIFF
--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -39,7 +39,10 @@ export async function showLineage(arg?: unknown): Promise<void> {
 
   panel.webview.html = renderLoadingHtml(panel.webview, modelName);
 
-  const args = ["lineage", modelName, "--format", "dot"];
+  // `-o table` opts out of the CLI's default `--output json`, so the lineage
+  // handler honours `--format dot`. Without this, stdout is a JSON blob and
+  // viz.js rejects the leading `{` as invalid DOT.
+  const args = ["-o", "table", "lineage", modelName, "--format", "dot"];
   if (workspaceFolder) {
     args.unshift("--config", `${workspaceFolder}/rocky.toml`);
   }

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -84,7 +84,12 @@ pub fn run_lineage(
 
     let direction = if downstream { "downstream" } else { "upstream" };
 
-    if output_json {
+    // `--format dot` is lineage-specific and only produces DOT, so it wins
+    // over the global `--output json` (which defaults to `json`). Without
+    // this, `rocky lineage <m> --format dot` silently emits JSON.
+    let emit_dot = matches!(format, Some("dot"));
+
+    if output_json && !emit_dot {
         if let Some(col) = col_name {
             let trace_edges = if downstream {
                 result
@@ -130,7 +135,7 @@ pub fn run_lineage(
             };
             print_json(&output)?;
         }
-    } else if matches!(format, Some("dot")) {
+    } else if emit_dot {
         // Graphviz DOT output
         println!("digraph lineage {{");
         println!("  rankdir=LR;");


### PR DESCRIPTION
## Summary

- Clicking the Lineage command on an open `.rocky`/`.sql` file in VS Code produced a broken webview with viz.js complaining about character `{`.
- Root cause: the top-level `rocky --output` flag defaults to `json`, and the lineage handler (`engine/crates/rocky-cli/src/commands/lineage.rs:87`) checked `output_json` before `--format dot`. So `rocky lineage <m> --format dot` silently emitted JSON. The extension fed that JSON to viz.js, which rejected the leading `{`.
- **engine**: `--format dot` now wins over the default `--output json` in the lineage command — matches user expectation for a format flag and makes `rocky lineage foo --format dot` work from the terminal without needing `-o table`.
- **vscode**: passes `-o table` alongside `--format dot` so the extension keeps working against the already-shipped `rocky 1.17.0` binary, without waiting for a new engine release.

## Test plan

- [x] `cargo test -p rocky-cli` — 270 passed
- [x] `cargo clippy -p rocky-cli -- -D warnings`, `cargo fmt --check`
- [x] `npm run compile && npm run lint && npm run test:unit` in `editors/vscode/`
- [x] Manual: `rocky lineage revenue_summary --format dot` now emits DOT (was JSON); JSON mode (`rocky lineage revenue_summary`) unchanged; human mode (`-o table lineage revenue_summary`) unchanged; column-lineage (`--column --format dot`) emits DOT.
- [ ] Manual: F5 Extension Development Host, run `Rocky: Show Lineage` on a model — webview renders the graph.