### PR TITLE
chore: release engine-v1.17.1 + vscode-v1.9.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] — 2026-04-24
+
+Patch release. Fixes the "Show Lineage" command producing an error webview complaining about character `{` (#260). The extension now passes `-o table` alongside `--format dot` so it works against the already-shipped `rocky 1.17.0` binary without waiting for the engine patch (engine 1.17.1 fixes the same bug at the CLI layer for terminal users).
+
 ## [1.9.0] — 2026-04-24
 
 Tracks engine 1.17.0 (governance-waveplan polish wave). Regenerated TypeScript bindings for the expanded `PlanOutput` surface; no extension feature changes.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1] — 2026-04-24
+
+Patch release. `rocky lineage <model> --format dot` now actually emits DOT when the global `--output` is left at its `json` default (#260). Previously the CLI's `--output json` default took precedence over the lineage-local `--format dot`, so the flag was silently ignored and stdout was a JSON blob. `--format dot` now wins inside the lineage command; `rocky lineage foo` without `--format` is still JSON by default. The VS Code extension's "Show Lineage" webview was the primary casualty — it fed the JSON to viz.js and rendered as an error complaining about character `{`.
+
 ## [1.17.0] — 2026-04-24
 
 Governance waveplan polish wave. Five follow-ups on top of v1.16.0 plus one breaking data-integrity guardrail. Highlights: `rocky run --governance-override` now rejects `workspace_ids = []` without an explicit opt-in (breaking; set `allow_empty_workspace_ids: true` to keep the old "revoke everything" behaviour); `rocky run` + `rocky plan` accept `--env <name>` and plumb it into the masking resolver; `rocky plan` previews classification / mask / retention actions alongside SQL statements; `rocky compile` emits `W004` for classification tags that don't resolve to any masking strategy; Databricks role-graph reconciliation goes from log-only to real — SCIM group creation + per-catalog GRANT emission; `rocky retention-status --drift` now probes the warehouse (Databricks + Snowflake) instead of always returning `warehouse_days = null`.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "redis",
  "serde",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "logos",
  "miette",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "miette",
  "regex",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.17.0"
+version = "1.17.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.17.0"
+version = "1.17.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.17.0"
+version = "1.17.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.17.0"
+version = "1.17.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.17.0"
+version = "1.17.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.17.0"
+version = "1.17.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.17.0"
+version = "1.17.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.17.0"
+version = "1.17.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.17.0"
+version = "1.17.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.17.0"
+version = "1.17.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.17.0"
+version = "1.17.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.17.0"
+version = "1.17.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.17.0"
+version = "1.17.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.17.0"
+version = "1.17.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.17.0"
+version = "1.17.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.17.0"
+version = "1.17.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Patch release on top of 1.17.0 / 1.9.0. Ships the `--format dot` precedence fix from #260.

**Engine 1.17.1**
- `rocky lineage <model> --format dot` now actually emits DOT when the global `--output` is at its `json` default. Previously the global default won, the flag was silently ignored, and stdout was a JSON blob.
- `rocky lineage foo` without `--format` is still JSON by default — no breaking change.

**VS Code 1.9.1** (tracks engine 1.17.1)
- `Rocky: Show Lineage` passes `-o table` alongside `--format dot` so the extension works against the already-shipped `rocky 1.17.0` binary. Users don't have to wait to upgrade the engine.

**Dagster** — untouched. No CLI output shape changed, so no wheel release needed.

## Test plan

- [x] `cargo build --workspace` (refreshes `Cargo.lock`)
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace -- -D warnings`, `cargo fmt --all --check`
- [x] `just codegen` — no drift (no CLI output shape changes in this patch)
- [x] `editors/vscode`: `npm run compile && npm run lint && npm run test:unit` — 20 passing
- [x] `integrations/dagster`: `uv run pytest` — 427 passing, `uv run ruff check` clean
- [x] Manual: `rocky lineage revenue_summary --format dot` now emits DOT (was JSON); JSON + human modes unchanged; column-lineage DOT still works.
- [ ] Post-merge: tag `engine-v1.17.1` and `vscode-v1.9.1` on the merge commit; push to trigger `engine-release.yml` + `vscode-release.yml`.