### PR TITLE
fix(engine/rocky-server): move LSP schema-cache redb work onto blocking pool

### DIFF
--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -458,22 +458,32 @@ impl RockyLsp {
             return HashMap::new();
         }
 
-        let store = match rocky_core::state::StateStore::open_read_only(&state_path) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::debug!(error = %e, "LSP schema cache: state open failed");
+        // The redb open + scan are sync work that can sleep up to ~250ms
+        // when contending with a CLI process for the state-file flock
+        // (see `StateStore::open_redb_with_retry`). Doing that on a Tokio
+        // worker would intermittently starve the LSP under heavy typing.
+        // Move it onto the blocking pool. The throttle log below stays on
+        // the async runtime because it awaits a tokio mutex.
+        let ttl = schema_cache_config.ttl();
+        let map = match tokio::task::spawn_blocking(move || {
+            let store = rocky_core::state::StateStore::open_read_only(&state_path)
+                .map_err(|e| ("state open", e.to_string()))?;
+            rocky_compiler::schema_cache::load_source_schemas_from_cache(
+                &store,
+                chrono::Utc::now(),
+                ttl,
+            )
+            .map_err(|e| ("scan", e.to_string()))
+        })
+        .await
+        {
+            Ok(Ok(m)) => m,
+            Ok(Err((stage, e))) => {
+                tracing::debug!(error = %e, stage, "LSP schema cache: {stage} failed");
                 return HashMap::new();
             }
-        };
-
-        let map = match rocky_compiler::schema_cache::load_source_schemas_from_cache(
-            &store,
-            chrono::Utc::now(),
-            schema_cache_config.ttl(),
-        ) {
-            Ok(m) => m,
-            Err(e) => {
-                tracing::debug!(error = %e, "LSP schema cache: scan failed");
+            Err(join_err) => {
+                tracing::debug!(error = %join_err, "LSP schema cache: blocking task join failed");
                 return HashMap::new();
             }
         };


### PR DESCRIPTION
## Summary

Follow-up to #262. The retry helper that #262 adds to \`StateStore::open_read_only\` can now sleep up to ~250ms when contending with a CLI process for the redb flock. The LSP calls into that open from a \`tokio::spawn\`'d task on every debounced keystroke (\`Server::did_change\` → \`load_cached_source_schemas\`). Sleeping on a Tokio worker intermittently starves the LSP under heavy typing — exactly when the user is most likely to notice.

This PR wraps the sync redb work (\`StateStore::open_read_only\` + \`load_source_schemas_from_cache\`) in \`tokio::task::spawn_blocking\` so the blocking sleep lands on the dedicated blocking pool. The throttled info log stays on the async runtime because it awaits a tokio mutex.

Independently useful even without #262 — \`Database::create\` already does file I/O that shouldn't run on the runtime — but the motivation is bounding the worst-case LSP responsiveness regression #262 would otherwise carry into a release.

Error reporting is preserved: state-open and scan failures still surface as \`tracing::debug!\` and degrade to an empty schema cache, same as before.

## Test plan

- [x] \`cargo check -p rocky-server\` — green
- [x] \`cargo test -p rocky-server\` — 38 tests pass
- [x] \`cargo clippy -p rocky-server --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt -- --check\` — clean
- [ ] Land after #262 (this PR is independent but the user-visible benefit only kicks in once retry-induced sleeps exist)