### PR TITLE
feat(dagster): RockyComponent genericity wave (FR-010, FR-011, FR-012)

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+`RockyComponent` genericity wave — three behaviours that every adopter
+was reimplementing in a subclass move into the framework. All three
+default off so existing components see no change.
+
+### Added
+
+- **`RockyComponent.discover_on_missing_state: bool = False`** — when
+  on, `build_defs` runs `write_state_to_path()` synchronously if the
+  local state file is absent at code-server load. Skipped under
+  `using_dagster_dev()` (dev relies on the CLI workflow) and for
+  non-local-filesystem state management. Failures are logged and
+  swallowed so the code server still boots — the status quo for
+  missing state is "no Rocky assets" anyway, so the fallback is
+  strictly an improvement. Closes the cold-start window where a fresh
+  ephemeral pod with no pre-seeded state would yield an empty
+  `Definitions` until the next out-of-band sensor tick.
+
+- **`RockyComponent.post_state_write_hook: Callable[[Path], None] | None = None`**
+  — optional callback invoked with the state-file path immediately
+  after `write_state_to_path()` succeeds. Fires on every successful
+  write (cold-start fallback, `dg defs state refresh`, framework
+  state-refresh paths). Hook exceptions are logged and swallowed so
+  a failing side-effect (typically an S3 / Valkey push of the
+  freshly-written cache) cannot block code-server boot. Set
+  programmatically in a subclass; YAML resolution of arbitrary
+  callables is left to adopters.
+
+- **`RockyComponent.surface_column_lineage: bool = False`** — when on,
+  `build_defs` walks `models_dir/*.toml` (skipping `_*.toml` and
+  `*.contract.toml`), calls `rocky lineage` per model, and merges the
+  resulting `dagster.TableColumnLineage` into each matching
+  `AssetSpec`'s `metadata["dagster/column_lineage"]` slot. Match is by
+  leaf segment of the asset key — the stock translator and most
+  custom translators preserve the model name there. Per-model
+  failures (binary missing, lineage compile error, malformed SQL) log
+  and skip that entry; a missing `models_dir` is a no-op. Pairs with
+  the existing `build_column_lineage()` helper, which has been the
+  building block but had no automatic surfacing path.
+
+### Changed
+
+- **Per-slot exception scope in `write_state_to_path` widened from
+  `dg.Failure` to `Exception`.** `_compile_payload`, `_optimize_payload`,
+  `_dag_payload`, and the discover try/except now log via
+  `_log.warning(..., exc_info=True)` and omit the slot on any
+  exception. The narrower predicate let real production failures
+  (subprocess timeouts, `MemoryError` on large discover dumps,
+  transient state-store I/O errors, malformed JSON, future-engine
+  `pydantic.ValidationError`) abort the whole write *after* a
+  successful discover, throwing away usable state. Same slot-omit
+  semantics as before — just robust against the actual exception
+  surface.
+
+- **`write_state_to_path` materializes intermediate directories**
+  before writing. The framework's local-filesystem path
+  (`_store_local_filesystem_state`) `shutil.rmtree`s the state dir
+  before calling write, so a missing parent is the expected normal
+  case. Previously relied on the dir already existing.
+
 ## [1.13.0] — 2026-04-24
 
 Tracks engine 1.17.0 (governance-waveplan polish wave). Three new `RockyResource` / `RockyComponent` surfaces plus a breaking pre-flight validator on the `governance_override` payload:

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -23,22 +23,28 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import dagster as dg
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
+from dagster._utils.env import using_dagster_dev
 from dagster.components.component.state_backed_component import StateBackedComponent
 from dagster.components.utils.defs_state import (
     DefsStateConfig,
     DefsStateConfigArgs,
     ResolvedDefsStateConfig,
 )
+from dagster.components.utils.project_paths import get_local_state_path
 from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
+from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
 
 from .checks import check_metadata
+from .column_lineage import build_column_lineage
 from .contracts import (
     ContractRules,
     contract_check_results_from_diagnostics,
@@ -68,6 +74,7 @@ from .types import (
     DagResult,
     Diagnostic,
     DiscoverResult,
+    ModelLineageResult,
     OptimizeResult,
     RunResult,
     Severity,
@@ -75,8 +82,10 @@ from .types import (
     TableInfo,
 )
 
+_log = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
 
 #: Built-in Rocky check names. Pre-declared as ``AssetCheckSpec`` so the
 #: Dagster UI knows about them before any execution happens. The
@@ -327,6 +336,41 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: a change to surface on the timeline rather than a pass/fail.
     #: Default ``False`` preserves zero behaviour change.
     surface_retention_status: bool = False
+    #: When ``True``, ``build_defs`` runs :meth:`write_state_to_path`
+    #: synchronously if the local state file is missing at code-server
+    #: load. Skipped under :func:`using_dagster_dev` because dev relies
+    #: on the local CLI workflow (``dg dev`` + sensor-driven refresh)
+    #: rather than cold-start behaviour. Only applies when state
+    #: management is local-filesystem (versioned / code-server modes
+    #: handle missing state through their own paths). Failures are
+    #: logged and swallowed so the code server still boots — the
+    #: status quo for missing state is "no Rocky assets" anyway, so
+    #: the fallback is strictly an improvement.
+    discover_on_missing_state: bool = False
+    #: Optional callable invoked with the state-file path immediately
+    #: after :meth:`write_state_to_path` succeeds (whether triggered
+    #: by the cold-start fallback, an explicit ``dg defs state refresh``,
+    #: or the framework's own state-refresh paths). Hook exceptions
+    #: are logged and swallowed — the hook must not block code-server
+    #: boot. Typical use: push the freshly-written state to a durable
+    #: store (S3, Valkey, etc.) so the next ephemeral pod boots with
+    #: the cache pre-warmed. Set programmatically in a subclass — YAML
+    #: resolution of arbitrary callables is left to adopters
+    #: (a Jinja ``{{ load_module_attr('pkg.mod:fn') }}`` template
+    #: works for components that ship one).
+    post_state_write_hook: Callable[[Path], None] | None = None
+    #: When ``True``, ``build_defs`` calls ``rocky lineage`` per derived
+    #: model at component-load time and merges the resulting
+    #: :class:`dagster.TableColumnLineage` into each matching
+    #: ``AssetSpec``'s ``metadata["dagster/column_lineage"]`` slot.
+    #: Per-model failures (binary missing, lineage compile error,
+    #: malformed SQL) are logged and the lineage entry is skipped —
+    #: never blocks the component load. Match is by leaf segment of
+    #: the asset key, so it works with the stock translator and any
+    #: translator that preserves the model name as the last key
+    #: segment. Default ``False`` because N derived models = N CLI
+    #: invocations on every code-server load.
+    surface_column_lineage: bool = False
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -375,16 +419,30 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         diagnostics as asset checks and merge optimize recommendations into
         ``AssetSpec.metadata``. Compile and optimize are best-effort: if either
         fails, discovery state is still written and the slot is left empty.
+
+        Per-slot exception handling catches :class:`Exception` (not just
+        :class:`dg.Failure`). The resource methods raise ``dg.Failure`` for
+        expected failures, but subprocess timeouts, ``MemoryError`` from
+        large discover dumps, transient state-store I/O errors, malformed
+        JSON, and Pydantic validation errors against future engine versions
+        all surface as non-``Failure`` exceptions. Without the broader
+        catch any of these would abort the write *after* a successful
+        discover, throwing away usable state.
         """
         rocky = self._get_rocky_resource()
 
         try:
             discover_payload = json.loads(rocky.discover().model_dump_json())
-        except dg.Failure:
+        except Exception:
             # Discover can fail on multi-pipeline configs without a pipeline
             # arg, or when no replication pipeline exists. In dag_mode the
             # DAG output is the primary data source, so an empty discover
-            # envelope is acceptable.
+            # envelope is acceptable. Log so operators can triage the
+            # underlying cause.
+            _log.warning(
+                "rocky discover failed during state write — writing empty discover envelope",
+                exc_info=True,
+            )
             discover_payload = {
                 "version": "0.0.0",
                 "command": "discover",
@@ -410,7 +468,20 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             if dag_payload is not None:
                 state["dag"] = dag_payload
 
+        state_path.parent.mkdir(parents=True, exist_ok=True)
         state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+        if self.post_state_write_hook is not None:
+            try:
+                self.post_state_write_hook(state_path)
+            except Exception:
+                # Hook is a side-effect channel (typically pushing the
+                # written state to a durable store). A failing hook must
+                # not abort the write — the file is already on disk.
+                _log.warning(
+                    "post_state_write_hook failed — state on disk is intact",
+                    exc_info=True,
+                )
 
     def _compile_payload(self, rocky: RockyResource) -> dict | None:
         """Return compile JSON, or ``None`` if compile cannot/should not run."""
@@ -418,11 +489,16 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             return None
         try:
             return json.loads(rocky.compile().model_dump_json())
-        except dg.Failure:
-            # Compile is best-effort: missing binary, partial errors and
-            # config issues should not block discovery state from being
-            # written. The diagnostics surfaced through `rocky compile`
-            # already cover the user-facing errors when it does run.
+        except Exception:
+            # Compile is best-effort: missing binary, partial errors,
+            # subprocess timeouts, OOM during large dumps, and malformed
+            # JSON should not block discovery state from being written.
+            # The diagnostics surfaced through `rocky compile` already
+            # cover the user-facing errors when it does run.
+            _log.warning(
+                "rocky compile failed during state write — slot omitted",
+                exc_info=True,
+            )
             return None
 
     def _optimize_payload(self, rocky: RockyResource) -> dict | None:
@@ -434,7 +510,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         """
         try:
             return json.loads(rocky.optimize().model_dump_json())
-        except dg.Failure:
+        except Exception:
+            _log.warning(
+                "rocky optimize failed during state write — slot omitted",
+                exc_info=True,
+            )
             return None
 
     def _dag_payload(self, rocky: RockyResource) -> dict | None:
@@ -445,7 +525,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         """
         try:
             return json.loads(rocky.dag(column_lineage=True).model_dump_json(by_alias=True))
-        except dg.Failure:
+        except Exception:
+            _log.warning(
+                "rocky dag failed during state write — slot omitted",
+                exc_info=True,
+            )
             return None
 
     def _build_defs_from_dag(
@@ -488,6 +572,122 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     # ------------------------------------------------------------------ #
     # Definition building                                                #
     # ------------------------------------------------------------------ #
+
+    def build_defs(self, context: dg.ComponentLoadContext) -> dg.Definitions:
+        """Override to add cold-start fallback discover and column-lineage surfacing.
+
+        Both behaviours are opt-in (``discover_on_missing_state`` and
+        ``surface_column_lineage``) and default to off, so the fast path
+        is unchanged from :meth:`StateBackedComponent.build_defs`.
+        """
+        self._maybe_cold_start_discover(context)
+        defs = super().build_defs(context)
+        if self.surface_column_lineage:
+            defs = self._attach_column_lineage(defs)
+        return defs
+
+    def _maybe_cold_start_discover(self, context: dg.ComponentLoadContext) -> None:
+        """Run :meth:`write_state_to_path` synchronously when state is absent.
+
+        Skipped when ``discover_on_missing_state`` is off, under
+        :func:`using_dagster_dev` (dev relies on the CLI workflow), and
+        for non-local-filesystem state management (those modes own
+        missing-state recovery through their own paths). Failures are
+        logged and swallowed — the component falls through to its normal
+        empty-state behaviour, same as if the fallback had not been
+        configured.
+        """
+        if not self.discover_on_missing_state:
+            return
+        if using_dagster_dev():
+            return
+        if self.defs_state_config.management_type != DefsStateManagementType.LOCAL_FILESYSTEM:
+            return
+        state_path = get_local_state_path(self.defs_state_config.key, context.project_root)
+        if state_path.exists():
+            return
+        try:
+            self.write_state_to_path(state_path)
+        except Exception:
+            _log.warning(
+                "RockyComponent fallback discover failed — component will load with no assets",
+                exc_info=True,
+            )
+
+    def _attach_column_lineage(self, defs: dg.Definitions) -> dg.Definitions:
+        """Walk ``models_dir``, run ``rocky lineage`` per model, attach to specs.
+
+        Best-effort: a missing ``models_dir`` is a no-op, per-model
+        failures are logged and skipped, and an empty result returns
+        ``defs`` unchanged. Match is by leaf segment of the asset key,
+        which lines up with the stock translator's
+        ``[source_type, *components, table]`` shape.
+        """
+        models_dir = Path(self.models_dir)
+        if not models_dir.is_dir():
+            return defs
+
+        rocky = self._get_rocky_resource()
+        lineage_by_model = self._collect_lineage(rocky, models_dir)
+        if not lineage_by_model:
+            return defs
+
+        def _merge(spec: dg.AssetSpec) -> dg.AssetSpec:
+            leaf = spec.key.path[-1] if spec.key.path else ""
+            lineage = lineage_by_model.get(leaf)
+            if lineage is None:
+                return spec
+            merged = dict(spec.metadata or {})
+            merged["dagster/column_lineage"] = lineage
+            return spec.replace_attributes(metadata=merged)
+
+        return defs.map_asset_specs(func=_merge)
+
+    @staticmethod
+    def _collect_lineage(
+        rocky: RockyResource,
+        models_dir: Path,
+    ) -> dict[str, dg.TableColumnLineage]:
+        """Return ``{model_name: TableColumnLineage}`` for every model in ``models_dir``.
+
+        Walks ``models_dir/*.toml``, skipping ``_*.toml`` (directory-level
+        defaults) and ``*.contract.toml`` (contract files) — same predicate
+        the framework uses elsewhere to decide "what's a model." Calls
+        ``rocky lineage --target <model>`` once per model; failures (binary
+        missing, lineage compile error, malformed SQL) log and skip that
+        entry.
+        """
+        model_names = sorted(
+            p.stem
+            for p in models_dir.rglob("*.toml")
+            if not p.name.startswith("_") and not p.name.endswith(".contract.toml")
+        )
+
+        out: dict[str, dg.TableColumnLineage] = {}
+        for model_name in model_names:
+            try:
+                lineage = rocky.lineage(target=model_name)
+            except Exception:
+                _log.warning(
+                    "rocky lineage %s failed during column-lineage attach — skipping",
+                    model_name,
+                    exc_info=True,
+                )
+                continue
+            if not isinstance(lineage, ModelLineageResult):
+                # Defensive: ``lineage(target=...)`` without a column always
+                # returns ``ModelLineageResult``; the column-level shape
+                # would not fit ``TableColumnLineage`` anyway.
+                continue
+            try:
+                out[model_name] = build_column_lineage(lineage)
+            except Exception:
+                _log.warning(
+                    "build_column_lineage(%s) failed — skipping",
+                    model_name,
+                    exc_info=True,
+                )
+        return out
 
     def build_defs_from_state(
         self,

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -3,13 +3,24 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
+import dagster as dg
+import pydantic
 import pytest
 
+from dagster_rocky import component as component_module
 from dagster_rocky.component import RockyComponent, _load_state
 from dagster_rocky.translator import RockyDagsterTranslator
-from dagster_rocky.types import DiscoverResult
+from dagster_rocky.types import (
+    DiscoverResult,
+    LineageEdge,
+    ModelLineageResult,
+    QualifiedColumn,
+)
 
 
 def _write_state(discover_json: str, tmp_path: Path, compile_json: str | None = None) -> Path:
@@ -226,3 +237,621 @@ def test_get_translator_invalid_dotted_path():
     component = RockyComponent(config_path="rocky.toml", translator_class="NoModule")
     with pytest.raises(ValueError, match="dotted module path"):
         component._get_translator()
+
+
+# ---------------------------------------------------------------------------
+# FR-012: write_state_to_path tolerates non-Failure exceptions per slot.
+# ---------------------------------------------------------------------------
+
+
+class _StubResource:
+    """Minimal RockyResource stub. Each method either returns a Pydantic
+    output or raises a configured exception."""
+
+    def __init__(
+        self,
+        *,
+        discover_result: Any | Exception,
+        compile_result: Any | Exception | None = None,
+        optimize_result: Any | Exception | None = None,
+        dag_result: Any | Exception | None = None,
+        lineage_results: dict[str, Any | Exception] | None = None,
+    ):
+        self._discover = discover_result
+        self._compile = compile_result
+        self._optimize = optimize_result
+        self._dag = dag_result
+        self._lineage = lineage_results or {}
+
+    def _ret(self, value: Any | Exception):
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    def discover(self):
+        return self._ret(self._discover)
+
+    def compile(self):
+        return self._ret(self._compile)
+
+    def optimize(self):
+        return self._ret(self._optimize)
+
+    def dag(self, *, column_lineage: bool = False):
+        return self._ret(self._dag)
+
+    def lineage(self, target: str, column: str | None = None):
+        if target not in self._lineage:
+            raise RuntimeError(f"unknown model: {target}")
+        return self._ret(self._lineage[target])
+
+
+def _install_stub_resource(monkeypatch: pytest.MonkeyPatch, stub: _StubResource) -> None:
+    monkeypatch.setattr(RockyComponent, "_get_rocky_resource", lambda self: stub)
+
+
+def _discover_payload() -> dict:
+    return {
+        "version": "0.0.0",
+        "command": "discover",
+        "sources": [],
+        "checks": {"freshness": None},
+    }
+
+
+def _make_discover_result() -> DiscoverResult:
+    return DiscoverResult.model_validate(_discover_payload())
+
+
+def _existing_models_dir(tmp_path: Path) -> str:
+    """Real on-disk models directory so ``_compile_payload`` reaches the
+    ``rocky.compile()`` call. Use the stub's compile_result to control
+    success / failure."""
+    d = tmp_path / "models-real"
+    d.mkdir(exist_ok=True)
+    return str(d)
+
+
+def _missing_models_dir(tmp_path: Path) -> str:
+    """Path that doesn't exist — ``_compile_payload`` short-circuits before
+    touching the resource."""
+    return str(tmp_path / "no-models-here")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.TimeoutExpired(cmd="rocky", timeout=1),
+        MemoryError("oom on dump"),
+        json.JSONDecodeError("bad", "doc", 0),
+        pydantic.ValidationError.from_exception_data("X", []),
+        RuntimeError("transient state-store error"),
+    ],
+)
+def test_write_state_compile_slot_tolerates_non_failure_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exc: BaseException,
+):
+    """``_compile_payload`` must swallow non-``dg.Failure`` exceptions and omit
+    the slot rather than aborting the whole write."""
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover, compile_result=exc)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_existing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)  # must not raise
+
+    state = json.loads(state_path.read_text())
+    assert "discover" in state
+    assert "compile" not in state  # slot omitted, write succeeded
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.TimeoutExpired(cmd="rocky", timeout=1),
+        MemoryError("oom on dump"),
+        json.JSONDecodeError("bad", "doc", 0),
+        RuntimeError("S3 outage"),
+    ],
+)
+def test_write_state_optimize_slot_tolerates_non_failure_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exc: BaseException,
+):
+    """Same widening for ``_optimize_payload`` — slot omitted on failure."""
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover, optimize_result=exc)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),  # skip compile
+        surface_optimize_metadata=True,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)
+
+    state = json.loads(state_path.read_text())
+    assert "discover" in state
+    assert "optimize" not in state
+
+
+def test_write_state_discover_failure_writes_empty_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """A non-``Failure`` exception out of discover falls back to the empty envelope."""
+    stub = _StubResource(discover_result=RuntimeError("binary missing"))
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)
+
+    state = json.loads(state_path.read_text())
+    assert state["discover"]["sources"] == []
+    assert state["discover"]["command"] == "discover"
+
+
+def test_write_state_creates_parent_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """``write_state_to_path`` materializes intermediate directories.
+
+    Local-filesystem state management writes under ``{project_root}/.dagster/...``
+    which may not exist on a fresh pod — the framework's
+    ``_store_local_filesystem_state`` shutil-rmtrees the dir before
+    calling write, so a missing parent is the expected normal case.
+    """
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "nested" / "deeper" / "state"
+
+    component.write_state_to_path(state_path)
+    assert state_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# FR-011: surface_column_lineage walks models_dir and attaches metadata.
+# ---------------------------------------------------------------------------
+
+
+def _model_lineage(model: str, *upstream: tuple[str, str, str]) -> ModelLineageResult:
+    """Build a tiny ``ModelLineageResult`` with one edge per upstream tuple
+    ``(source_model, source_column, target_column)``."""
+    return ModelLineageResult(
+        version="0.0.0",
+        command="lineage",
+        model=model,
+        columns=[],
+        upstream=[],
+        downstream=[],
+        edges=[
+            LineageEdge(
+                source=QualifiedColumn(model=src_model, column=src_col),
+                target=QualifiedColumn(model=model, column=tgt_col),
+                transform="direct",
+            )
+            for (src_model, src_col, tgt_col) in upstream
+        ],
+    )
+
+
+def _make_models_dir(tmp_path: Path, model_names: list[str]) -> Path:
+    """Create a tmp models_dir with one .toml per name. Adds a noise
+    ``_defaults.toml`` and a ``foo.contract.toml`` to verify the skip
+    predicate."""
+    d = tmp_path / "models"
+    d.mkdir()
+    (d / "_defaults.toml").write_text("# defaults — should be skipped\n")
+    (d / "foo.contract.toml").write_text("# contract — should be skipped\n")
+    for name in model_names:
+        (d / f"{name}.toml").write_text(f"name = '{name}'\n")
+    return d
+
+
+def test_surface_column_lineage_off_passes_defs_through_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Flag off → ``build_defs`` skips the attach branch entirely.
+
+    Verified by stubbing super().build_defs to return a known
+    ``Definitions`` and asserting the returned object passes through
+    without ``dagster/column_lineage`` metadata, even though
+    ``models_dir`` would yield a matching model name.
+    """
+    models_dir = _make_models_dir(tmp_path, ["orders"])
+    sentinel_lineage_calls: list[str] = []
+
+    class _Trace(_StubResource):
+        def lineage(self, target: str, column: str | None = None):
+            sentinel_lineage_calls.append(target)
+            return _model_lineage(target, ("u", "c", "c"))
+
+    stub = _Trace(discover_result=_make_discover_result())
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(models_dir),
+        # flag defaults to False
+    )
+
+    expected_defs = dg.Definitions(assets=[dg.AssetSpec(key=dg.AssetKey(["raw", "orders"]))])
+    monkeypatch.setattr(
+        "dagster.components.component.state_backed_component.StateBackedComponent.build_defs",
+        lambda self_, ctx: expected_defs,
+    )
+
+    out = component.build_defs(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert sentinel_lineage_calls == []  # _attach_column_lineage not called
+    out_spec = next(iter(out.assets or []))
+    assert "dagster/column_lineage" not in out_spec.metadata
+
+
+def test_surface_column_lineage_attaches_metadata_for_matching_specs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """With the flag on and a matching leaf, ``dagster/column_lineage`` lands in
+    spec metadata."""
+    models_dir = _make_models_dir(tmp_path, ["orders", "customers"])
+    stub = _StubResource(
+        discover_result=_make_discover_result(),
+        lineage_results={
+            "orders": _model_lineage("orders", ("raw_orders", "id", "id")),
+            "customers": _model_lineage("customers", ("raw_customers", "email", "email")),
+        },
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(models_dir),
+        surface_column_lineage=True,
+    )
+    defs = dg.Definitions(
+        assets=[
+            dg.AssetSpec(key=dg.AssetKey(["raw", "orders"])),
+            dg.AssetSpec(key=dg.AssetKey(["raw", "customers"])),
+            dg.AssetSpec(key=dg.AssetKey(["raw", "untouched"])),
+        ]
+    )
+
+    out = component._attach_column_lineage(defs)
+
+    by_key = {tuple(spec.key.path): spec for spec in (out.assets or [])}
+    assert "dagster/column_lineage" in by_key[("raw", "orders")].metadata
+    assert "dagster/column_lineage" in by_key[("raw", "customers")].metadata
+    assert "dagster/column_lineage" not in by_key[("raw", "untouched")].metadata
+
+
+def test_surface_column_lineage_per_model_failure_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """One failing model is skipped; others land."""
+    models_dir = _make_models_dir(tmp_path, ["good", "bad"])
+    stub = _StubResource(
+        discover_result=_make_discover_result(),
+        lineage_results={
+            "good": _model_lineage("good", ("upstream", "x", "x")),
+            "bad": RuntimeError("compile error"),
+        },
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(models_dir),
+        surface_column_lineage=True,
+    )
+    defs = dg.Definitions(
+        assets=[
+            dg.AssetSpec(key=dg.AssetKey(["raw", "good"])),
+            dg.AssetSpec(key=dg.AssetKey(["raw", "bad"])),
+        ]
+    )
+
+    out = component._attach_column_lineage(defs)
+
+    by_key = {tuple(spec.key.path): spec for spec in (out.assets or [])}
+    assert "dagster/column_lineage" in by_key[("raw", "good")].metadata
+    assert "dagster/column_lineage" not in by_key[("raw", "bad")].metadata
+
+
+def test_surface_column_lineage_missing_models_dir_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """No ``models_dir`` on disk → returns ``defs`` unchanged."""
+    stub = _StubResource(discover_result=_make_discover_result())
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(tmp_path / "does-not-exist"),
+        surface_column_lineage=True,
+    )
+    spec = dg.AssetSpec(key=dg.AssetKey(["raw", "orders"]))
+    defs = dg.Definitions(assets=[spec])
+
+    out = component._attach_column_lineage(defs)
+
+    out_spec = next(iter(out.assets or []))
+    assert "dagster/column_lineage" not in out_spec.metadata
+
+
+def test_surface_column_lineage_skips_underscore_and_contract_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """``_*.toml`` and ``*.contract.toml`` must not be considered models."""
+    models_dir = _make_models_dir(tmp_path, ["only_model"])
+    targets_seen: list[str] = []
+
+    class _Capture(_StubResource):
+        def lineage(self, target: str, column: str | None = None):
+            targets_seen.append(target)
+            return _model_lineage(target, ("u", "c", "c"))
+
+    stub = _Capture(discover_result=_make_discover_result())
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(models_dir),
+        surface_column_lineage=True,
+    )
+    component._attach_column_lineage(dg.Definitions(assets=[]))
+
+    assert targets_seen == ["only_model"]
+
+
+# ---------------------------------------------------------------------------
+# FR-010: cold-start fallback discover.
+# ---------------------------------------------------------------------------
+
+
+def _patch_state_path(
+    monkeypatch: pytest.MonkeyPatch,
+    state_path: Path,
+    *,
+    is_dev: bool = False,
+) -> None:
+    monkeypatch.setattr(
+        component_module,
+        "get_local_state_path",
+        lambda key, project_root: state_path,
+    )
+    monkeypatch.setattr(component_module, "using_dagster_dev", lambda: is_dev)
+
+
+def test_cold_start_fallback_fires_when_state_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Missing state + flag on + non-dev → ``write_state_to_path`` is called."""
+    state_path = tmp_path / "missing-state"
+    assert not state_path.exists()
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+    )
+
+    calls: list[Path] = []
+
+    def fake_write(self_, p: Path) -> None:
+        calls.append(p)
+        p.write_text("{}")
+
+    monkeypatch.setattr(RockyComponent, "write_state_to_path", fake_write)
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    fake_context = SimpleNamespace(project_root=tmp_path)
+    component._maybe_cold_start_discover(fake_context)  # type: ignore[arg-type]
+
+    assert calls == [state_path]
+    assert state_path.exists()
+
+
+def test_cold_start_fallback_skipped_under_dev(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Dev mode short-circuits the fallback even with flag on + missing state."""
+    state_path = tmp_path / "missing-state"
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+    )
+
+    calls: list[Path] = []
+    monkeypatch.setattr(
+        RockyComponent,
+        "write_state_to_path",
+        lambda self_, p: calls.append(p),
+    )
+    _patch_state_path(monkeypatch, state_path, is_dev=True)
+
+    component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert calls == []
+
+
+def test_cold_start_fallback_skipped_when_flag_off(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Default behaviour (flag off): never fires."""
+    state_path = tmp_path / "missing-state"
+
+    component = RockyComponent(config_path="rocky.toml")  # flag defaults to False
+
+    calls: list[Path] = []
+    monkeypatch.setattr(
+        RockyComponent,
+        "write_state_to_path",
+        lambda self_, p: calls.append(p),
+    )
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert calls == []
+
+
+def test_cold_start_fallback_skipped_when_state_already_exists(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Existing state file → fallback is a no-op even with flag on."""
+    state_path = tmp_path / "state"
+    state_path.write_text("{}")  # pre-existing
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+    )
+
+    calls: list[Path] = []
+    monkeypatch.setattr(
+        RockyComponent,
+        "write_state_to_path",
+        lambda self_, p: calls.append(p),
+    )
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert calls == []
+
+
+def test_cold_start_fallback_swallows_write_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A failing ``write_state_to_path`` must not raise out of ``build_defs``."""
+    state_path = tmp_path / "missing-state"
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+    )
+
+    def raises(self_, p):
+        raise RuntimeError("S3 + state-store both down")
+
+    monkeypatch.setattr(RockyComponent, "write_state_to_path", raises)
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    with caplog.at_level("WARNING", logger="dagster_rocky.component"):
+        # Must not raise.
+        component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert any("fallback discover failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# FR-010: post_state_write_hook fires after every successful write.
+# ---------------------------------------------------------------------------
+
+
+def test_post_state_write_hook_fires_after_successful_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """The hook is invoked with the state-file path after a successful write."""
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    hook_calls: list[Path] = []
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+        post_state_write_hook=hook_calls.append,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)
+
+    assert hook_calls == [state_path]
+    assert state_path.exists()
+
+
+def test_post_state_write_hook_exception_is_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A failing hook must not raise out of ``write_state_to_path`` —
+    the file is already on disk by the time the hook fires."""
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    def boom(p: Path) -> None:
+        raise RuntimeError("S3 upload failed")
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+        post_state_write_hook=boom,
+    )
+    state_path = tmp_path / "state"
+
+    with caplog.at_level("WARNING", logger="dagster_rocky.component"):
+        component.write_state_to_path(state_path)  # must not raise
+
+    assert state_path.exists()
+    assert any("post_state_write_hook failed" in r.message for r in caplog.records)
+
+
+def test_post_state_write_hook_default_none_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """No hook configured → write completes normally with no extra side-effects."""
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    assert component.post_state_write_hook is None
+
+    state_path = tmp_path / "state"
+    component.write_state_to_path(state_path)
+    assert state_path.exists()


### PR DESCRIPTION
## Summary

Three behaviours that every adopter was reimplementing in a subclass move into the framework. All four new flags / fields default to off so existing components see no change.

- **FR-010 — cold-start fallback discover.** New `discover_on_missing_state: bool` runs `write_state_to_path()` synchronously when the local state file is absent at code-server load (skipped under `using_dagster_dev()`). New `post_state_write_hook: Callable[[Path], None] | None` fires after every successful write so adopters can push the freshly-written state to a durable store. Hook + write failures are logged and swallowed.
- **FR-011 — `surface_column_lineage`.** Walks `models_dir/*.toml` (skipping `_*.toml` and `*.contract.toml`), calls `rocky lineage` per model, merges `dagster.TableColumnLineage` into each matching `AssetSpec`'s `metadata["dagster/column_lineage"]`. Match is by leaf segment of the asset key. Per-model failures log + skip.
- **FR-012 — widened per-slot exception scope in `write_state_to_path`.** `_compile_payload` / `_optimize_payload` / `_dag_payload` and the discover try/except go from `except dg.Failure:` to `except Exception:` with `_log.warning(..., exc_info=True)`. Closes a real prod hole where `subprocess.TimeoutExpired` / `MemoryError` / `json.JSONDecodeError` / `pydantic.ValidationError` aborted the whole write *after* a successful discover, throwing away usable state. Same slot-omit semantics as before — just robust against the actual exception surface. `state_path.parent.mkdir(parents=True, exist_ok=True)` added before write to match the framework's `_store_local_filesystem_state` shutil.rmtree contract.

Backwards-compatible: every new field defaults to off / `None`. The widened `Exception` catch is strictly broader than `dg.Failure` (which inherits from it).

## Test plan

- [x] `uv run pytest` — 451 passed (24 new tests covering the three FRs)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [ ] Hand-check an adopter codebase (e.g. Gold) compiles against the new fields