### PR TITLE
fix(dagster): hide post_state_write_hook from YAML schema (FR-013)

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`RockyComponent` YAML schema derivation regression (FR-013).** The
+  `post_state_write_hook` field added in 1.14.0 had a bare
+  `Callable[[Path], None] | None` annotation, which made
+  `derive_model_type(RockyComponent)` raise `ResolutionException`
+  with no resolver registered. Any YAML-driven load
+  (`load_from_defs_folder`, `dg dev`, anything that resolves a
+  `defs.yaml` whose `type:` points at `RockyComponent` or a subclass)
+  crashed during model derivation regardless of whether the project
+  set the hook field. The field now carries a `dg.Resolver` with
+  `model_field_type=type(None)`: callables remain settable from
+  Python kwargs, but YAML cannot configure the hook (attempting to do
+  so raises `ResolutionException` instead of silently dropping the
+  value). Pre-existing dagster-rocky tests instantiated the component
+  programmatically and bypassed the schema resolver, so the regression
+  slipped through 1.14.0 — `tests/test_component.py` now pins
+  `derive_model_type` directly and parametrizes over the bool toggles
+  released in the same wave.
+
 ## [1.14.0] — 2026-04-25
 
 `RockyComponent` genericity wave ([#264](https://github.com/rocky-data/rocky/pull/264)) — three behaviours that every adopter was reimplementing in a subclass move into the framework. All three default off so existing components see no change.

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -199,6 +199,17 @@ class _CompileState:
 # ---------------------------------------------------------------------------
 
 
+def _reject_post_state_write_hook_in_yaml(value: object) -> None:
+    if value is not None:
+        raise dg.DagsterInvalidConfigError(
+            "post_state_write_hook cannot be set from YAML — set it programmatically "
+            "on a RockyComponent subclass instead.",
+            errors=[],
+            config_value=value,
+        )
+    return None
+
+
 class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     """Loads Rocky-managed tables as materializable Dagster assets.
 
@@ -354,11 +365,22 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: are logged and swallowed — the hook must not block code-server
     #: boot. Typical use: push the freshly-written state to a durable
     #: store (S3, Valkey, etc.) so the next ephemeral pod boots with
-    #: the cache pre-warmed. Set programmatically in a subclass — YAML
-    #: resolution of arbitrary callables is left to adopters
-    #: (a Jinja ``{{ load_module_attr('pkg.mod:fn') }}`` template
-    #: works for components that ship one).
-    post_state_write_hook: Callable[[Path], None] | None = None
+    #: the cache pre-warmed. Set programmatically in a subclass —
+    #: callables are not YAML-resolvable, so the YAML schema for this
+    #: field accepts only ``null`` and any non-null YAML value raises
+    #: ``ResolutionException`` (see ``_reject_post_state_write_hook_in_yaml``).
+    post_state_write_hook: Annotated[
+        Callable[[Path], None] | None,
+        dg.Resolver(
+            lambda _ctx, _val: _reject_post_state_write_hook_in_yaml(_val),
+            model_field_type=type(None),
+            description=(
+                "Reserved — set programmatically in a subclass. Cannot be "
+                "configured from YAML; arbitrary callables are not "
+                "YAML-resolvable."
+            ),
+        ),
+    ] = None
     #: When ``True``, ``build_defs`` calls ``rocky lineage`` per derived
     #: model at component-load time and merges the resulting
     #: :class:`dagster.TableColumnLineage` into each matching

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -855,3 +855,94 @@ def test_post_state_write_hook_default_none_is_noop(
     state_path = tmp_path / "state"
     component.write_state_to_path(state_path)
     assert state_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# YAML schema derivation regression (FR-013)
+# ---------------------------------------------------------------------------
+#
+# `post_state_write_hook: Callable[[Path], None] | None` was added in 1.14.0
+# without a Resolver, which made `derive_model_type(RockyComponent)` crash with
+# `ResolutionException` on `_get_resolver`. Any YAML-driven load
+# (`load_from_defs_folder`, `dg dev`, …) walks every component's MRO through
+# `derive_model_type`, so the parent class crashing took down every subclass too
+# — even subclasses that only set the hook in `__init__`.
+#
+# These tests pin the schema-derivation path directly so the regression can't
+# recur, parametrized over the bool toggles released in the same PR (#264) to
+# also catch any future Callable-typed field that lands without a Resolver.
+
+
+@pytest.mark.parametrize("surface_column_lineage", [False, True])
+@pytest.mark.parametrize("discover_on_missing_state", [False, True])
+def test_rocky_component_yaml_schema_derives_without_callable_field_crash(
+    surface_column_lineage: bool,
+    discover_on_missing_state: bool,
+):
+    """Regression: derive_model_type must not crash on the Callable hook field.
+
+    Reproduces the 1.14.0 crash filed in FR-013. Toggles do not change the
+    schema-derivation path but are parametrized to retroactively cover any new
+    Callable-typed field added without a Resolver.
+    """
+    from dagster.components.resolved.base import derive_model_type
+
+    model = derive_model_type(RockyComponent)
+    # The hook field exists on the derived model but with a YAML-safe field
+    # type (None | str after dagster's str-injection wrapping); the actual
+    # callable annotation is hidden from the YAML schema.
+    assert "post_state_write_hook" in model.model_fields
+
+    # Subclasses must derive too — the original crash fired on the *parent*
+    # schema even when subclasses overrode behavior in `__init__`.
+    class _Sub(RockyComponent):
+        def __init__(self, **kwargs: Any) -> None:
+            kwargs.setdefault("surface_column_lineage", surface_column_lineage)
+            kwargs.setdefault("discover_on_missing_state", discover_on_missing_state)
+            super().__init__(**kwargs)
+
+    derive_model_type(_Sub)
+
+
+def test_rocky_component_yaml_resolves_without_post_state_write_hook(tmp_path: Path):
+    """YAML payloads that omit `post_state_write_hook` resolve cleanly to None.
+
+    This is the path `load_from_defs_folder` exercises when a `defs.yaml`
+    points at `RockyComponent`. The pre-fix crash was upstream of YAML parsing
+    (in `derive_model_type`), so this confirms the post-fix YAML round trip.
+    """
+    yaml_payload = "config_path: rocky.toml\nbinary_path: rocky\n"
+    component = RockyComponent.resolve_from_yaml(yaml_payload)
+    assert component.post_state_write_hook is None
+    assert component.config_path == "rocky.toml"
+
+
+def test_rocky_component_yaml_rejects_post_state_write_hook_value():
+    """Setting `post_state_write_hook` from YAML is rejected, not silently dropped.
+
+    The Resolver's `model_field_type=type(None)` plus dagster's str-injection
+    wrapping means YAML technically accepts a string here, but the resolver
+    raises so misuse surfaces loudly instead of silently leaving the hook unset.
+    """
+    from dagster.components.resolved.errors import ResolutionException
+
+    with pytest.raises(ResolutionException):
+        RockyComponent.resolve_from_yaml(
+            "config_path: rocky.toml\npost_state_write_hook: some_value\n"
+        )
+
+
+def test_rocky_component_python_kwarg_post_state_write_hook_preserved(tmp_path: Path):
+    """The Python kwarg API still accepts a callable — only the YAML path is gated."""
+    calls: list[Path] = []
+
+    def hook(p: Path) -> None:
+        calls.append(p)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        post_state_write_hook=hook,
+    )
+    assert callable(component.post_state_write_hook)
+    component.post_state_write_hook(tmp_path)
+    assert calls == [tmp_path]


### PR DESCRIPTION
## Summary

- `RockyComponent.post_state_write_hook` (added in 1.14.0) had a bare `Callable[[Path], None] | None` annotation — no Resolver — so any YAML-driven load (`load_from_defs_folder`, `dg dev`, anything resolving a `defs.yaml` whose `type:` points at `RockyComponent` or a subclass) crashed with `ResolutionException` during `derive_model_type` whether or not the project set the hook.
- Wrap the annotation in `Annotated[..., dg.Resolver(...)]` with `model_field_type=type(None)`. Python kwarg API unchanged (callables still accepted); YAML can no longer configure the hook — non-null YAML values raise `ResolutionException` instead of silently dropping.
- Pre-existing tests instantiated the component programmatically and bypassed the schema resolver. Add `derive_model_type`-direct regression tests parametrized over the `surface_column_lineage` × `discover_on_missing_state` toggles released in the same wave (#264) to catch any future Callable-typed field landing without a Resolver.

## Why the original FR proposal didn't ship

FR-013 proposed `Annotated[..., "resource_dependency"]` — "same marker FR-008 used for the resolver fields on `RockyResource`." That marker is consumed by `ConfigurableResource._is_annotated_as_resource_type`, **not** by `derive_model_type`. `RockyResource` is not a `Resolvable` and never goes through that code path; the marker there is unrelated to YAML schema derivation. Empirical reproduction (`derive_model_type(T)` on a trivial `dg.Model + dg.Resolvable` class with the marker) raises `ResolutionException` regardless. The Resolver-with-`type(None)` approach in this PR is the working alternative.

## Changelog

- Adds an entry under `[Unreleased]` in `integrations/dagster/CHANGELOG.md` to be cut as 1.14.1.

## Test plan

- [x] `uv run pytest -q` — 458 passed
- [x] `uv run ruff check src/dagster_rocky/component.py tests/test_component.py` — clean
- [x] `uv run ruff format --check src/dagster_rocky/component.py tests/test_component.py` — formatted
- [x] New regression tests:
  - `test_rocky_component_yaml_schema_derives_without_callable_field_crash[*]` — `derive_model_type` on `RockyComponent` and a trivial subclass, parametrized over the two bool toggles
  - `test_rocky_component_yaml_resolves_without_post_state_write_hook` — YAML omitting the field round-trips with `hook is None`
  - `test_rocky_component_yaml_rejects_post_state_write_hook_value` — YAML setting the field raises `ResolutionException`
  - `test_rocky_component_python_kwarg_post_state_write_hook_preserved` — Python kwarg API still accepts a callable

## Follow-ups (not in this PR)

- Defensive `getattr(annotation, "__name__", repr(annotation))` upstream in `dagster/components/resolved/base.py:429` so future `Callable | None`-style regressions surface a usable "no resolver" error instead of `AttributeError: 'types.UnionType' object has no attribute '__name__'`. Worth a separate PR against dagster.