### PR TITLE
docs(dagster): document RockyComponent opt-in surfaces (1.13.0–1.14.1)

### DIFF
--- a/docs/src/content/docs/dagster/component.md
+++ b/docs/src/content/docs/dagster/component.md
@@ -26,6 +26,46 @@ attributes:
   state_path: .rocky-state.redb
 ```
 
+## Opt-in surfaces
+
+Five fields toggle additional behaviour on top of the basic discover/compile cache. All default to off — existing components see no behaviour change unless you flip them on.
+
+| Field | Since | YAML | What it does |
+|---|---|---|---|
+| `surface_compliance` | 1.13.0 | yes | Calls `rocky compliance` once per materialization batch and emits an aggregated `AssetCheckResult` per asset for any model with classification exceptions. |
+| `surface_retention_status` | 1.13.0 | yes | Calls `rocky retention-status` once per materialization batch and emits one `AssetObservation` per model row, keyed by model. |
+| `discover_on_missing_state` | 1.14.0 | yes | If the local state file is absent at code-server load, `build_defs` runs `write_state_to_path()` synchronously instead of returning an empty `Definitions`. Skipped under `dg dev` (which relies on the CLI workflow) and only applies when state management is local-filesystem. |
+| `surface_column_lineage` | 1.14.0 | yes | At code-server load, walks `models_dir/*.toml` (skipping `_*.toml` and `*.contract.toml`), calls `rocky lineage` per model, and merges the resulting `dagster.TableColumnLineage` into each matching `AssetSpec`'s `metadata["dagster/column_lineage"]`. |
+| `post_state_write_hook` | 1.14.0 | **no — Python only** | Callable invoked with the state-file path immediately after every successful `write_state_to_path()`. Typical use: push the freshly-written state to a durable store (S3, Valkey) so the next ephemeral pod boots with the cache pre-warmed. |
+
+```yaml
+type: dagster_rocky.RockyComponent
+attributes:
+  binary_path: rocky
+  config_path: rocky.toml
+  models_dir: models
+  surface_compliance: true
+  surface_retention_status: true
+  surface_column_lineage: true
+  discover_on_missing_state: true
+```
+
+`post_state_write_hook` cannot be set from YAML — arbitrary Python callables are not YAML-resolvable, and a non-null YAML value raises `ResolutionException` at component load. Set it programmatically in a subclass instead:
+
+```python
+from pathlib import Path
+from dagster_rocky import RockyComponent
+
+class MyRockyComponent(RockyComponent):
+    def __init__(self, **kwargs):
+        super().__init__(
+            **kwargs,
+            post_state_write_hook=lambda path: push_to_s3(path),
+        )
+```
+
+Hook exceptions are logged and swallowed so a failing side-effect (typically the S3/Valkey push) cannot block code-server boot.
+
 ## State storage
 
 By default, the component stores its state on the local filesystem. This is configurable via the `defs_state` mechanism in Dagster, allowing you to use alternative storage backends if needed.

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/README.md
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/README.md
@@ -3,7 +3,7 @@
 > **Category:** 05-orchestration
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 10s
-> **Rocky features:** rocky dag, dag_mode, dagster-rocky, lineage
+> **Rocky features:** rocky dag, dag_mode, dagster-rocky, lineage, surface_column_lineage
 
 ## What it shows
 
@@ -55,7 +55,8 @@ uv sync && uv run dg dev
 Open http://localhost:3000 and verify:
 1. Asset graph shows `source:ingest` → `load:ingest` → `stg_orders` → `fct_customer_revenue`
 2. Click any node to see upstream/downstream dependencies
-3. "Materialize all" executes the full pipeline
+3. Open `fct_customer_revenue` → the **Column lineage** tab shows per-column upstream edges back to `stg_orders` (surfaced via `surface_column_lineage: true` in `defs.yaml`)
+4. "Materialize all" executes the full pipeline
 
 ## Expected output
 
@@ -91,7 +92,7 @@ Open http://localhost:3000 and verify:
 2. `rocky run` replicates the source table via the `ingest` pipeline
 3. `rocky dag` produces the full unified DAG: 4 nodes, 3 edges, 4 execution layers
 4. `rocky compile` verifies model dependencies (`fct_customer_revenue` depends on `stg_orders`)
-5. `definitions.py` uses `RockyComponent(dag_mode=True)` — Dagster reads the cached DAG and builds a connected asset graph automatically
+5. `definitions.py` uses `RockyComponent(dag_mode=True, surface_column_lineage=True)` — Dagster reads the cached DAG and builds a connected asset graph automatically; at component-load time it also calls `rocky lineage` per derived model and merges `TableColumnLineage` into each `AssetSpec`'s `metadata["dagster/column_lineage"]` slot, so the Dagster UI's Column lineage tab renders without any hand-written wiring
 
 ## Related
 

--- a/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/src/rocky_dag_mode_poc/defs/rocky/defs.yaml
+++ b/examples/playground/pocs/05-orchestration/07-dagster-dag-mode/src/rocky_dag_mode_poc/defs/rocky/defs.yaml
@@ -4,5 +4,11 @@ attributes:
   config_path: rocky.toml
   models_dir: models
   dag_mode: true
+  # surface_column_lineage (dagster-rocky 1.14.0+) walks models/*.toml, calls
+  # `rocky lineage` per model, and merges TableColumnLineage into each
+  # AssetSpec's metadata["dagster/column_lineage"] slot. With two models
+  # in this POC (stg_orders, fct_customer_revenue) the Dagster asset graph
+  # surfaces per-column upstream/downstream edges, not just table-level ones.
+  surface_column_lineage: true
   defs_state:
     management_type: LOCAL_FILESYSTEM


### PR DESCRIPTION
## Summary

The dagster `component.md` page was one release behind. Five public opt-in fields shipped across **dagster-rocky 1.13.0**, **1.14.0**, and **1.14.1** with no narrative documentation beyond the CHANGELOG + source-code docstrings:

- `surface_compliance` (1.13.0)
- `surface_retention_status` (1.13.0)
- `discover_on_missing_state` (1.14.0)
- `surface_column_lineage` (1.14.0)
- `post_state_write_hook` (1.14.0; **Python kwarg only since 1.14.1** — #266 enforces it via `ResolutionException` on any non-null YAML value)

## Changes

**`docs/src/content/docs/dagster/component.md`** — new "Opt-in surfaces" section between "Configuration" and "State storage". Table lists each field with version, YAML/Python-only status, and one-line description. YAML example shows the four YAML-configurable fields together. Separate Python-only example covers `post_state_write_hook` with the subclass pattern.

**`examples/playground/pocs/05-orchestration/07-dagster-dag-mode/`** — light extension to demonstrate `surface_column_lineage: true` end-to-end:
- `defs.yaml` — added the toggle with a comment explaining the origin and what the user will see.
- `README.md` — added `surface_column_lineage` to the feature list, added a verification step pointing at the Dagster UI's Column lineage tab, and updated the "What happened" walkthrough.

This was a deliberate scope choice over creating a new dedicated POC. None of the other four new fields demo cleanly without external infrastructure (S3/Valkey for `post_state_write_hook`, classification/retention sidecars for the compliance/retention pair, a cold-start scenario for `discover_on_missing_state`). Extending the existing dag-mode POC keeps the demo zero-infrastructure and zero-new-files.

## Test plan

- [x] `cd docs && npm run build` — Astro build green, 69 pages built, zero errors/warnings
- [x] All three modified files lint cleanly under their respective conventions (markdown table syntax, YAML structure)
- [ ] Manual: open the rendered docs page and confirm the new section reads cleanly (no broken table rendering, code blocks render correctly)