### PR TITLE
fix(engine): enable rustls in redis crate so rediss:// URLs work (release 1.17.3)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.3] — 2026-04-25
+
+Patch release. Fixes the `redis::Client::open("rediss://...")` → `valkey error: can't connect with TLS, the feature is not enabled - InvalidClientConfig` failure that hit any deployment pointing Rocky's Valkey/Redis state-sync or cache at a TLS-required endpoint (e.g. AWS ElastiCache with in-transit encryption). The prebuilt 1.17.2 binary's `redis` crate was compiled without any TLS feature — `rocky-core`'s sync state/idempotency client and `rocky-cache`'s async `ConnectionManager` both rejected the `rediss://` scheme at parse time.
+
+### Fixed
+
+- **TLS support enabled in the bundled `redis` crate.** `rocky-core` now pulls `redis` with `tls-rustls` + `tls-rustls-webpki-roots`, and `rocky-cache` adds `tokio-rustls-comp` + `tls-rustls-webpki-roots` on top of the existing `tokio-comp` + `connection-manager` features. Matches the workspace's existing rustls-only stance (`reqwest` already uses `rustls-tls`); no OpenSSL or system-cert dependency is introduced. `webpki-roots` bundles Mozilla's CA set so the static Linux binary works inside minimal containers without a populated `/etc/ssl/certs`. `redis://` URLs are unchanged. Both sync paths (`StateSync::Valkey` in `rocky-core/src/state_sync.rs`, idempotency keys in `rocky-core/src/idempotency.rs`) and the async `ValkeyCache::connect` in `rocky-cache/src/valkey.rs` now accept `rediss://`.
+
 ## [1.17.2] — 2026-04-25
 
 Patch release. Two LSP-vs-CLI concurrency fixes that surface as a better VS Code extension experience: the extension's commands no longer randomly fail with a raw `Database already open. Cannot acquire lock.` error from redb, and the LSP no longer briefly stalls on every keystroke when a CLI process is running against the same state file.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3091,12 +3091,16 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
  "ryu",
  "sha1_smol",
  "socket2",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "url",
+ "webpki-roots",
  "xxhash-rust",
 ]
 
@@ -3279,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3295,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3327,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "redis",
  "serde",
@@ -3373,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3416,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3441,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3478,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3497,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3514,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3530,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3549,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3564,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "logos",
  "miette",
@@ -3574,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3582,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3598,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3624,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -3647,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "miette",
  "regex",
@@ -3660,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.17.2"
+version = "1.17.3"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.17.2"
+version = "1.17.3"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.17.2"
+version = "1.17.3"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.17.2"
+version = "1.17.3"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.17.2"
+version = "1.17.3"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true
@@ -16,7 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-redis = { workspace = true, features = ["tokio-comp", "connection-manager"], optional = true }
+redis = { workspace = true, features = ["tokio-comp", "connection-manager", "tokio-rustls-comp", "tls-rustls-webpki-roots"], optional = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.17.2"
+version = "1.17.3"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.17.2"
+version = "1.17.3"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 redb = { workspace = true }
 fs4 = { workspace = true }
-redis = { workspace = true }
+redis = { workspace = true, features = ["tls-rustls", "tls-rustls-webpki-roots"] }
 regex = { workspace = true }
 csv = { workspace = true }
 tokio = { workspace = true }

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.17.2"
+version = "1.17.3"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.17.2"
+version = "1.17.3"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.17.2"
+version = "1.17.3"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.17.2"
+version = "1.17.3"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.17.2"
+version = "1.17.3"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.17.2"
+version = "1.17.3"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.17.2"
+version = "1.17.3"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.17.2"
+version = "1.17.3"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.17.2"
+version = "1.17.3"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Rocky 1.17.2's prebuilt binary was compiled without any TLS feature on the `redis` crate. Any deployment pointing `[state.valkey] url` (rocky-core sync path) or the rocky-cache `ConnectionManager` at a TLS-required endpoint (e.g. AWS ElastiCache with in-transit encryption) hits `valkey error: can't connect with TLS, the feature is not enabled - InvalidClientConfig` at parse time.
- Adds rustls TLS support to both call sites and bumps the workspace to **1.17.3**.

## Fix

| Crate | Existing features | Added |
|---|---|---|
| `rocky-core` (sync redis in `state_sync.rs` + `idempotency.rs`) | _(none — bare `redis = { workspace = true }`)_ | `tls-rustls`, `tls-rustls-webpki-roots` |
| `rocky-cache` (async `ConnectionManager` in `valkey.rs`) | `tokio-comp`, `connection-manager` | `tokio-rustls-comp`, `tls-rustls-webpki-roots` |

Matches the workspace's existing rustls-only stance — `reqwest` already uses `rustls-tls` (`engine/Cargo.toml:86`). No OpenSSL or system-cert dependency is introduced. `webpki-roots` bundles Mozilla's CA set so the static Linux release binary works inside minimal containers without `/etc/ssl/certs` populated. `redis://` URLs are unchanged.

## Test plan

- [x] `cargo check -p rocky-core -p rocky-cache --features rocky-cache/valkey` — clean
- [x] `cargo build --release --bin rocky` — clean (1m28s)
- [x] `target/release/rocky --version` reports `1.17.3`
- [x] `target/release/rocky doctor --output json` from the playground POC works
- [x] `just codegen` produces no diff
- [ ] CI green (engine-ci.yml + codegen-drift.yml)
- [ ] After merge: tag `engine-v1.17.3` → `engine-release.yml` ships 5-platform binaries
- [ ] Downstream: bump `ROCKY_VERSION=1.17.3` in the consumer Dockerfile and re-deploy against the `rediss://` ElastiCache endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)