### PR TITLE
feat(engine)!: surface failed sources in discover (FR-014) + Arc 2 wave 3 stats on transformation models

### DIFF
--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -19,6 +19,10 @@ export interface DiscoverOutput {
    */
   excluded_tables: ExcludedTableOutput[];
   /**
+   * Sources the discovery adapter attempted to fetch metadata for and failed (transient HTTP error, timeout, rate-limit budget exhausted, auth blip). Their absence from `sources` does NOT mean they were removed upstream — consumers diffing against a prior run must treat failed sources as "unknown state, do not delete." Empty when discovery completed cleanly. See FR-014.
+   */
+  failed_sources?: FailedSourceOutput[];
+  /**
    * Number of schema-cache entries written by this invocation.
    *
    * Populated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache (design doc §4.2 route B at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`). Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
@@ -66,6 +70,34 @@ export interface ExcludedTableOutput {
    * Bare table name as reported by the discovery adapter.
    */
   table_name: string;
+  [k: string]: unknown;
+}
+/**
+ * A source the discovery adapter attempted to fetch metadata for and failed.
+ *
+ * Surfaced on `DiscoverOutput.failed_sources` so downstream consumers can distinguish a transient fetch failure from a deletion when diffing successive discover snapshots (FR-014).
+ */
+export interface FailedSourceOutput {
+  /**
+   * Coarse error class so consumers can branch without parsing the `message`. One of `"transient"` / `"timeout"` / `"rate_limit"` / `"auth"` / `"unknown"`.
+   */
+  error_class: string;
+  /**
+   * Adapter-side identifier for the source (e.g. Fivetran connector_id).
+   */
+  id: string;
+  /**
+   * Human-readable error from the adapter — for logs / debugging only. Don't pattern-match on this; use `error_class` for branching.
+   */
+  message: string;
+  /**
+   * Source schema name the adapter would have written into.
+   */
+  schema: string;
+  /**
+   * Adapter type (`"fivetran"`, `"airbyte"`, `"iceberg"`, ...).
+   */
+  source_type: string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-adapter-sdk/src/lib.rs
+++ b/engine/crates/rocky-adapter-sdk/src/lib.rs
@@ -29,8 +29,8 @@ pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub use manifest::{AdapterCapabilities, AdapterManifest};
 pub use traits::{
     AdapterError, AdapterResult, BatchCheckAdapter, ColumnInfo, ColumnSelection,
-    DiscoveredConnector, DiscoveredTable, DiscoveryAdapter, FileFormat, FreshnessResult,
-    GovernanceAdapter, Grant, GrantTarget, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
-    MetadataColumn, Permission, QueryResult, RowCountResult, SqlDialect, TableRef, TagTarget,
-    TypeMapper, WarehouseAdapter, is_cloud_uri,
+    DiscoveredConnector, DiscoveredTable, DiscoveryAdapter, DiscoveryResult, FailedSource,
+    FailedSourceErrorClass, FileFormat, FreshnessResult, GovernanceAdapter, Grant, GrantTarget,
+    LoadOptions, LoadResult, LoadSource, LoaderAdapter, MetadataColumn, Permission, QueryResult,
+    RowCountResult, SqlDialect, TableRef, TagTarget, TypeMapper, WarehouseAdapter, is_cloud_uri,
 };

--- a/engine/crates/rocky-adapter-sdk/src/traits.rs
+++ b/engine/crates/rocky-adapter-sdk/src/traits.rs
@@ -141,6 +141,57 @@ pub struct DiscoveredTable {
     pub row_count: Option<u64>,
 }
 
+/// A source the discovery adapter attempted to fetch metadata for and failed.
+///
+/// Distinct from "removed upstream" — distinguishing the two is the contract
+/// that lets downstream consumers safely diff one discover result against
+/// the next without misinterpreting a transient fetch failure as a deletion
+/// (FR-014).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedSource {
+    pub id: String,
+    pub schema: String,
+    pub source_type: String,
+    pub error_class: FailedSourceErrorClass,
+    pub message: String,
+}
+
+/// Coarse classification of why a discovery fetch failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailedSourceErrorClass {
+    Transient,
+    Timeout,
+    RateLimit,
+    Auth,
+    Unknown,
+}
+
+/// Result of a discovery operation: successful connectors plus any sources
+/// the adapter attempted to fetch metadata for and failed on.
+///
+/// Implementors of [`DiscoveryAdapter`] MUST surface per-source failures via
+/// `failed` instead of silently dropping them — this is what lets downstream
+/// consumers distinguish "fetch failed transiently" from "removed upstream"
+/// when diffing snapshots.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryResult {
+    pub connectors: Vec<DiscoveredConnector>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<FailedSource>,
+}
+
+impl DiscoveryResult {
+    /// Build a clean result with no failures — convenience for adapters
+    /// whose discovery surface is single-shot (no per-source fan-out).
+    pub fn ok(connectors: Vec<DiscoveredConnector>) -> Self {
+        Self {
+            connectors,
+            failed: Vec::new(),
+        }
+    }
+}
+
 /// Target for a tag operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TagTarget {
@@ -333,7 +384,13 @@ pub trait SqlDialect: Send + Sync {
 #[async_trait]
 pub trait DiscoveryAdapter: Send + Sync {
     /// Discover connectors/schemas matching the given prefix.
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>>;
+    ///
+    /// Returns a [`DiscoveryResult`] with both successfully fetched
+    /// `connectors` and any `failed` sources. Adapters MUST NOT silently
+    /// drop a source on transient per-source failure — the distinction
+    /// between "removed upstream" and "tried and failed" is the contract
+    /// downstream consumers depend on (FR-014).
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult>;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-airbyte/src/adapter.rs
+++ b/engine/crates/rocky-airbyte/src/adapter.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 use tracing::{debug, warn};
 
-use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+use rocky_core::source::{DiscoveredConnector, DiscoveredTable, DiscoveryResult};
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
 use crate::client::{AirbyteClient, Connection, ConnectionStatus};
@@ -29,14 +29,14 @@ impl AirbyteDiscoveryAdapter {
 
 #[async_trait]
 impl DiscoveryAdapter for AirbyteDiscoveryAdapter {
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>> {
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
         let connections = self
             .client
             .list_connections()
             .await
             .map_err(AdapterError::new)?;
 
-        let result: Vec<DiscoveredConnector> = connections
+        let connectors: Vec<DiscoveredConnector> = connections
             .into_iter()
             .filter(|c| c.status == ConnectionStatus::Active)
             .filter(|c| matches_prefix(c, schema_prefix))
@@ -45,11 +45,15 @@ impl DiscoveryAdapter for AirbyteDiscoveryAdapter {
 
         debug!(
             prefix = schema_prefix,
-            count = result.len(),
+            count = connectors.len(),
             "discovered Airbyte connections"
         );
 
-        Ok(result)
+        // Airbyte's discovery surface is a single `list_connections` call —
+        // there is no per-source metadata fetch that could partially fail
+        // the way Fivetran's per-connector schema fetch can. Either the list
+        // call succeeds (no `failed`) or the whole call errors out.
+        Ok(DiscoveryResult::ok(connectors))
     }
 
     async fn ping(&self) -> AdapterResult<()> {

--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -497,7 +497,8 @@ async fn resolve_replication_managed_tables(
     let connectors = discovery_adapter
         .discover(&pattern.prefix)
         .await
-        .map_err(|e| anyhow!("discovery failed: {e}"))?;
+        .map_err(|e| anyhow!("discovery failed: {e}"))?
+        .connectors;
 
     let target_sep = repl
         .target

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -47,6 +47,7 @@ pub async fn compare(
             .discover(&pattern.prefix)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?
+            .connectors
     } else {
         anyhow::bail!("no discovery adapter configured — compare requires source discovery");
     };

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -44,7 +44,7 @@ pub async fn discover(
 
     let adapter_registry = registry::AdapterRegistry::from_config(&rocky_cfg)?;
 
-    let connectors = if let Some(ref disc) = pipeline.source.discovery {
+    let discovery_result = if let Some(ref disc) = pipeline.source.discovery {
         let discovery_adapter = adapter_registry.discovery_adapter(&disc.adapter)?;
         discovery_adapter
             .discover(&pattern.prefix)
@@ -54,16 +54,31 @@ pub async fn discover(
         anyhow::bail!("no discovery adapter configured for this pipeline")
     };
 
+    let connectors = &discovery_result.connectors;
+    let failed_sources: Vec<FailedSourceOutput> = discovery_result
+        .failed
+        .iter()
+        .cloned()
+        .map(FailedSourceOutput::from_engine)
+        .collect();
+    if !failed_sources.is_empty() {
+        warn!(
+            count = failed_sources.len(),
+            "discover: source(s) failed metadata fetch — surfacing in `failed_sources`; \
+             downstream consumers must NOT treat them as deletions"
+        );
+    }
+
     // Source-existence filter: exclude tables that the discovery adapter
     // reports (e.g. Fivetran "enabled") but that don't actually exist in
     // the source warehouse. This keeps the discover output accurate so
     // downstream orchestrators (Dagster) don't plan assets for ghost tables.
     let source_table_sets =
-        build_source_table_sets(&adapter_registry, &pipeline.source, &connectors).await;
+        build_source_table_sets(&adapter_registry, &pipeline.source, connectors).await;
 
     let mut output_sources = Vec::new();
     let mut excluded_tables: Vec<ExcludedTableOutput> = Vec::new();
-    for conn in &connectors {
+    for conn in connectors {
         let parsed = match pattern.parse(&conn.schema) {
             Ok(p) => p,
             Err(e) => {
@@ -151,7 +166,7 @@ pub async fn discover(
     // at the top of this function. Errors inside the warm-up are logged and
     // counted as misses — a bad source shouldn't abort the whole discovery.
     let schemas_cached = if with_schemas {
-        warm_schema_cache(&adapter_registry, &pipeline.source, &connectors, state_path).await?
+        warm_schema_cache(&adapter_registry, &pipeline.source, connectors, state_path).await?
     } else {
         0
     };
@@ -160,6 +175,7 @@ pub async fn discover(
     let output = DiscoverOutput::new(output_sources)
         .with_checks(checks_output)
         .with_excluded_tables(excluded_tables)
+        .with_failed_sources(failed_sources)
         .with_schemas_cached(schemas_cached);
     if output_json {
         print_json(&output)?;

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -512,8 +512,7 @@ mod tests {
         async fn discover(
             &self,
             _schema_prefix: &str,
-        ) -> rocky_core::traits::AdapterResult<Vec<rocky_core::source::DiscoveredConnector>>
-        {
+        ) -> rocky_core::traits::AdapterResult<rocky_core::source::DiscoveryResult> {
             Err(rocky_core::traits::AdapterError::msg("unauthorized"))
         }
     }

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -43,6 +43,7 @@ pub async fn plan(
             .discover(&pattern.prefix)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))?
+            .connectors
     } else {
         anyhow::bail!("no discovery adapter configured for this pipeline")
     };

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1036,7 +1036,7 @@ pub async fn run(
     ))?;
 
     // Discover sources
-    let connectors = async {
+    let discovery_result = async {
         if let Some(ref disc) = pipeline.source.discovery {
             let discovery_adapter = adapter_registry.discovery_adapter(&disc.adapter)?;
             discovery_adapter
@@ -1049,6 +1049,17 @@ pub async fn run(
     }
     .instrument(info_span!("discover_sources"))
     .await?;
+    if !discovery_result.failed.is_empty() {
+        // FR-014: a failed-source list at run time means the run will
+        // execute the healthy subset, but the consumer should know that
+        // missing materializations are not the same as deletions.
+        warn!(
+            count = discovery_result.failed.len(),
+            "run: source(s) failed metadata fetch — these will be absent from \
+             materializations but were NOT removed upstream"
+        );
+    }
+    let connectors = discovery_result.connectors;
 
     let concurrency = pipeline.execution.concurrency.max_concurrency();
     let mut output = RunOutput::new(filter.unwrap_or("").to_string(), 0, concurrency);
@@ -3438,11 +3449,28 @@ pub(crate) async fn execute_models(
                 statements = exec_stmts.len(),
                 "executing model"
             );
+            // Capture per-statement stats so derived models report the
+            // same `bytes_scanned` / `bytes_written` shape that replication
+            // tables already have (Arc 2 wave 3 residual: plain
+            // transformation models were calling `execute_statement` and
+            // dropping the `ExecutionStats` reported by stats-aware
+            // adapters like BigQuery).
+            let model_started_at = Utc::now();
             let mut exec_error: Option<anyhow::Error> = None;
+            let mut bytes_scanned_acc: Option<u64> = None;
+            let mut bytes_written_acc: Option<u64> = None;
             for exec_sql in &exec_stmts {
-                if let Err(e) = warehouse.execute_statement(exec_sql).await {
-                    exec_error = Some(anyhow::anyhow!("model '{model_name}' failed: {e}"));
-                    break;
+                match warehouse.execute_statement_with_stats(exec_sql).await {
+                    Ok(stats) => {
+                        bytes_scanned_acc =
+                            accumulate_bytes(bytes_scanned_acc, stats.bytes_scanned);
+                        bytes_written_acc =
+                            accumulate_bytes(bytes_written_acc, stats.bytes_written);
+                    }
+                    Err(e) => {
+                        exec_error = Some(anyhow::anyhow!("model '{model_name}' failed: {e}"));
+                        break;
+                    }
                 }
             }
             if let Some(e) = exec_error {
@@ -3458,13 +3486,45 @@ pub(crate) async fn execute_models(
                 }
                 return Err(e);
             }
+            // Push a MaterializationOutput so `rocky cost` and downstream
+            // consumers see derived models in the run output instead of
+            // having to infer them from check / drift records. Mirrors
+            // the time_interval and replication paths.
+            let model_duration_ms = model_start.elapsed().as_millis() as u64;
+            let target_table_full_name = format!(
+                "{}.{}.{}",
+                plan.target.catalog, plan.target.schema, plan.target.table
+            );
+            let asset_key = vec![
+                plan.target.catalog.clone(),
+                plan.target.schema.clone(),
+                plan.target.table.clone(),
+            ];
+            output.materializations.push(MaterializationOutput {
+                asset_key,
+                rows_copied: None,
+                duration_ms: model_duration_ms,
+                started_at: model_started_at,
+                metadata: MaterializationMetadata {
+                    strategy: transformation_strategy_name(&plan.strategy).to_string(),
+                    watermark: None,
+                    target_table_full_name: Some(target_table_full_name),
+                    sql_hash: Some(crate::output::sql_fingerprint(&exec_stmts)),
+                    column_count: exec_ctx.column_count_for(model_name),
+                    compile_time_ms: exec_ctx.compile_time_ms_for(model_name),
+                },
+                partition: None,
+                cost_usd: None,
+                bytes_scanned: bytes_scanned_acc,
+                bytes_written: bytes_written_acc,
+            });
             if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
                 let _ = reg
                     .fire(&HookContext::after_model_run(
                         run_id,
                         pipe,
                         model_name,
-                        model_start.elapsed().as_millis() as u64,
+                        model_duration_ms,
                     ))
                     .await;
             }
@@ -3474,6 +3534,23 @@ pub(crate) async fn execute_models(
 
     info!(models = models_executed, "model execution complete");
     Ok(())
+}
+
+/// Map a `MaterializationStrategy` (post-`to_plan()`) onto the string used
+/// in `MaterializationMetadata.strategy`. Mirrors the names used elsewhere
+/// in `run.rs` (replication path lines ~4024-4076).
+fn transformation_strategy_name(strategy: &MaterializationStrategy) -> &'static str {
+    match strategy {
+        MaterializationStrategy::FullRefresh => "full_refresh",
+        MaterializationStrategy::Incremental { .. } => "incremental",
+        MaterializationStrategy::Merge { .. } => "merge",
+        MaterializationStrategy::MaterializedView => "materialized_view",
+        MaterializationStrategy::DynamicTable { .. } => "dynamic_table",
+        MaterializationStrategy::TimeInterval { .. } => "time_interval",
+        MaterializationStrategy::Ephemeral => "ephemeral",
+        MaterializationStrategy::DeleteInsert { .. } => "delete_insert",
+        MaterializationStrategy::Microbatch { .. } => "microbatch",
+    }
 }
 
 /// Execute a `time_interval` model: plan partitions, execute each, record

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -86,6 +86,14 @@ pub struct DiscoverOutput {
     /// parser. Empty when nothing was filtered.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub excluded_tables: Vec<ExcludedTableOutput>,
+    /// Sources the discovery adapter attempted to fetch metadata for and
+    /// failed (transient HTTP error, timeout, rate-limit budget exhausted,
+    /// auth blip). Their absence from `sources` does NOT mean they were
+    /// removed upstream — consumers diffing against a prior run must treat
+    /// failed sources as "unknown state, do not delete." Empty when
+    /// discovery completed cleanly. See FR-014.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_sources: Vec<FailedSourceOutput>,
     /// Number of schema-cache entries written by this invocation.
     ///
     /// Populated by `rocky discover --with-schemas` — the explicit
@@ -353,6 +361,41 @@ pub struct ExcludedTableOutput {
     /// causes (disabled, sync_paused, ...) can be added without a
     /// schema break.
     pub reason: String,
+}
+
+/// A source the discovery adapter attempted to fetch metadata for and failed.
+///
+/// Surfaced on `DiscoverOutput.failed_sources` so downstream consumers can
+/// distinguish a transient fetch failure from a deletion when diffing
+/// successive discover snapshots (FR-014).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct FailedSourceOutput {
+    /// Adapter-side identifier for the source (e.g. Fivetran connector_id).
+    pub id: String,
+    /// Source schema name the adapter would have written into.
+    pub schema: String,
+    /// Adapter type (`"fivetran"`, `"airbyte"`, `"iceberg"`, ...).
+    pub source_type: String,
+    /// Coarse error class so consumers can branch without parsing the
+    /// `message`. One of `"transient"` / `"timeout"` / `"rate_limit"` /
+    /// `"auth"` / `"unknown"`.
+    pub error_class: String,
+    /// Human-readable error from the adapter — for logs / debugging only.
+    /// Don't pattern-match on this; use `error_class` for branching.
+    pub message: String,
+}
+
+impl FailedSourceOutput {
+    /// Project a `rocky_core` `FailedSource` into the wire shape.
+    pub fn from_engine(failed: rocky_core::source::FailedSource) -> Self {
+        Self {
+            id: failed.id,
+            schema: failed.schema,
+            source_type: failed.source_type,
+            error_class: failed.error_class.to_string(),
+            message: failed.message,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1984,6 +2027,7 @@ impl DiscoverOutput {
             sources,
             checks: None,
             excluded_tables: vec![],
+            failed_sources: vec![],
             schemas_cached: 0,
         }
     }
@@ -1999,6 +2043,13 @@ impl DiscoverOutput {
     #[must_use]
     pub fn with_excluded_tables(mut self, excluded: Vec<ExcludedTableOutput>) -> Self {
         self.excluded_tables = excluded;
+        self
+    }
+
+    /// Attach the list of sources whose discovery fetch failed and return self.
+    #[must_use]
+    pub fn with_failed_sources(mut self, failed: Vec<FailedSourceOutput>) -> Self {
+        self.failed_sources = failed;
         self
     }
 

--- a/engine/crates/rocky-core/src/source.rs
+++ b/engine/crates/rocky-core/src/source.rs
@@ -36,6 +36,85 @@ pub struct DiscoveredTable {
     pub row_count: Option<u64>,
 }
 
+/// A source the discovery adapter attempted to fetch metadata for and failed.
+///
+/// Distinct from "removed upstream" — distinguishing the two is the contract
+/// that lets downstream consumers safely diff one discover result against the
+/// next without misinterpreting a transient fetch failure as a deletion.
+///
+/// A connector that is **absent from `connectors`** AND **absent from `failed`**
+/// was removed upstream. **Absent from `connectors`** but **present in `failed`**
+/// is unknown state — consumers must not delete derived assets for it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedSource {
+    pub id: String,
+    pub schema: String,
+    pub source_type: String,
+    pub error_class: FailedSourceErrorClass,
+    pub message: String,
+}
+
+/// Coarse classification of why a discovery fetch failed.
+///
+/// Adapters that wrap an HTTP-shaped API map their concrete errors onto this
+/// enum so downstream consumers can branch on operating-mode without knowing
+/// the adapter's own error type. A `Transient` or `Timeout` outcome is
+/// expected to clear on the next discover tick; `RateLimit` clears once
+/// upstream throttling expires; `Auth` requires a credentials rotation;
+/// `Unknown` is the catch-all for anything else (malformed response, JSON
+/// decode failure, adapter-specific shapes that don't fit the other
+/// classes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailedSourceErrorClass {
+    Transient,
+    Timeout,
+    RateLimit,
+    Auth,
+    Unknown,
+}
+
+impl std::fmt::Display for FailedSourceErrorClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FailedSourceErrorClass::Transient => "transient",
+            FailedSourceErrorClass::Timeout => "timeout",
+            FailedSourceErrorClass::RateLimit => "rate_limit",
+            FailedSourceErrorClass::Auth => "auth",
+            FailedSourceErrorClass::Unknown => "unknown",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Result of a discovery operation: successful connectors plus any sources
+/// the adapter attempted to fetch metadata for and failed on.
+///
+/// `failed` is empty when discovery completed cleanly. A non-empty `failed`
+/// list signals "degraded but useful" — the consumer may still act on
+/// `connectors`, but must NOT treat sources missing from this snapshot
+/// (relative to a prior one) as deletions until they're absent from both
+/// fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryResult {
+    pub connectors: Vec<DiscoveredConnector>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<FailedSource>,
+}
+
+impl DiscoveryResult {
+    /// Build a clean result with no failures — convenience for adapters
+    /// whose discovery surface is single-shot (Airbyte's `list_connections`,
+    /// DuckDB's `information_schema` query) and therefore can't surface a
+    /// per-source failure on top of an overall success.
+    pub fn ok(connectors: Vec<DiscoveredConnector>) -> Self {
+        Self {
+            connectors,
+            failed: Vec::new(),
+        }
+    }
+}
+
 /// Source configuration that can be deserialized from rocky.toml.
 ///
 /// The `type` field determines which adapter to use:

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -20,7 +20,7 @@ use schemars::JsonSchema;
 
 use crate::ir::{ColumnInfo, ColumnSelection, Grant, GrantTarget, MetadataColumn, TableRef};
 use crate::retention::RetentionPolicy;
-use crate::source::DiscoveredConnector;
+use crate::source::DiscoveryResult;
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -154,7 +154,15 @@ pub struct ExecutionStats {
 #[async_trait]
 pub trait DiscoveryAdapter: Send + Sync {
     /// Discover connectors/schemas matching the given prefix.
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>>;
+    ///
+    /// Returns a [`DiscoveryResult`] with both successfully fetched
+    /// `connectors` and any `failed` sources (transient API errors,
+    /// rate-limit budget exhausted, auth blip). Adapters MUST NOT silently
+    /// drop a source on transient per-source failure — the distinction
+    /// between "removed upstream" and "tried and failed" is the contract
+    /// downstream consumers depend on to avoid mistaking a fetch failure
+    /// for a deletion (FR-014).
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult>;
 
     /// Cheap connectivity check for the discovery API.
     ///

--- a/engine/crates/rocky-duckdb/src/discovery.rs
+++ b/engine/crates/rocky-duckdb/src/discovery.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+use rocky_core::source::{DiscoveredConnector, DiscoveredTable, DiscoveryResult};
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
 use crate::DuckDbConnector;
@@ -29,7 +29,7 @@ impl DuckDbDiscoveryAdapter {
 
 #[async_trait]
 impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>> {
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
         let conn = self
             .connector
             .lock()
@@ -81,7 +81,9 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
             });
         }
 
-        Ok(connectors)
+        // DuckDB discovery is a single-shot information_schema query — there
+        // is no per-source metadata fetch that could partially fail.
+        Ok(DiscoveryResult::ok(connectors))
     }
 }
 
@@ -94,7 +96,8 @@ mod tests {
         let connector = Arc::new(Mutex::new(DuckDbConnector::in_memory().unwrap()));
         let adapter = DuckDbDiscoveryAdapter::new(connector);
         let result = adapter.discover("raw__").await.unwrap();
-        assert_eq!(result.len(), 0);
+        assert_eq!(result.connectors.len(), 0);
+        assert!(result.failed.is_empty());
     }
 
     #[tokio::test]
@@ -118,14 +121,20 @@ mod tests {
 
         let adapter = DuckDbDiscoveryAdapter::new(connector);
         let result = adapter.discover("raw__").await.unwrap();
-        assert_eq!(result.len(), 2, "expected 2 raw__ schemas");
+        assert_eq!(result.connectors.len(), 2, "expected 2 raw__ schemas");
+        assert!(result.failed.is_empty());
 
-        let orders = result.iter().find(|c| c.schema == "raw__orders").unwrap();
+        let orders = result
+            .connectors
+            .iter()
+            .find(|c| c.schema == "raw__orders")
+            .unwrap();
         assert_eq!(orders.tables.len(), 2);
         assert!(orders.tables.iter().any(|t| t.name == "orders"));
         assert!(orders.tables.iter().any(|t| t.name == "line_items"));
 
         let customers = result
+            .connectors
             .iter()
             .find(|c| c.schema == "raw__customers")
             .unwrap();

--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -8,10 +8,12 @@ use futures::stream::{self, StreamExt};
 use indexmap::IndexMap;
 use tracing::warn;
 
-use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+use rocky_core::source::{
+    DiscoveredConnector, DiscoveredTable, DiscoveryResult, FailedSource, FailedSourceErrorClass,
+};
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
-use crate::client::FivetranClient;
+use crate::client::{FivetranClient, FivetranError};
 use crate::connector::{self as ft_connector, Connector};
 use crate::schema as ft_schema;
 
@@ -35,7 +37,7 @@ impl FivetranDiscoveryAdapter {
 
 #[async_trait]
 impl DiscoveryAdapter for FivetranDiscoveryAdapter {
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>> {
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
         let connectors =
             ft_connector::discover_connectors(&self.client, &self.destination_id, schema_prefix)
                 .await
@@ -43,50 +45,123 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
 
         let discover_concurrency = 10;
 
-        let result: Vec<DiscoveredConnector> = stream::iter(connectors)
-            .map(|conn| {
-                let client = &self.client;
-                async move {
-                    let schema_result = ft_schema::get_schema_config(client, &conn.id).await;
-                    (conn, schema_result)
-                }
-            })
-            .buffer_unordered(discover_concurrency)
-            .filter_map(|(conn, schema_result)| async move {
-                match schema_result {
-                    Ok(schema_config) => {
-                        let tables = schema_config
-                            .enabled_tables()
-                            .iter()
-                            .map(|t| DiscoveredTable {
-                                name: t.table_name.clone(),
-                                row_count: None,
-                            })
-                            .collect();
-                        let metadata = metadata_from_connector(&conn);
-                        Some(DiscoveredConnector {
-                            id: conn.id,
-                            schema: conn.schema,
-                            source_type: conn.service,
-                            last_sync_at: conn.succeeded_at,
-                            tables,
-                            metadata,
-                        })
+        let fetched: Vec<(Connector, Result<ft_schema::SchemaConfig, FivetranError>)> =
+            stream::iter(connectors)
+                .map(|conn| {
+                    let client = &self.client;
+                    async move {
+                        let schema_result = ft_schema::get_schema_config(client, &conn.id).await;
+                        (conn, schema_result)
                     }
-                    Err(e) => {
-                        warn!(
-                            connector = conn.id,
-                            error = %e,
-                            "failed to fetch schema config, skipping"
-                        );
-                        None
-                    }
-                }
-            })
-            .collect()
-            .await;
+                })
+                .buffer_unordered(discover_concurrency)
+                .collect()
+                .await;
 
-        Ok(result)
+        let mut connectors = Vec::new();
+        let mut failed = Vec::new();
+        for (conn, schema_result) in fetched {
+            match schema_result {
+                Ok(schema_config) => {
+                    let tables = schema_config
+                        .enabled_tables()
+                        .iter()
+                        .map(|t| DiscoveredTable {
+                            name: t.table_name.clone(),
+                            row_count: None,
+                        })
+                        .collect();
+                    let metadata = metadata_from_connector(&conn);
+                    connectors.push(DiscoveredConnector {
+                        id: conn.id,
+                        schema: conn.schema,
+                        source_type: conn.service,
+                        last_sync_at: conn.succeeded_at,
+                        tables,
+                        metadata,
+                    });
+                }
+                Err(e) => {
+                    let error_class = classify_fivetran_error(&e);
+                    warn!(
+                        connector = conn.id.as_str(),
+                        error = %e,
+                        error_class = %error_class,
+                        "schema fetch failed, surfacing as failed source"
+                    );
+                    failed.push(FailedSource {
+                        id: conn.id,
+                        schema: conn.schema,
+                        source_type: conn.service,
+                        error_class,
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
+
+        Ok(DiscoveryResult { connectors, failed })
+    }
+}
+
+/// Map a [`FivetranError`] onto the coarse [`FailedSourceErrorClass`].
+///
+/// The classes are operating-mode signals for downstream consumers, not a
+/// faithful taxonomy of the underlying transport. The `RetryBudgetExhausted`
+/// variant maps to `Transient` because the budget is per-run — a fresh
+/// discover invocation gets a new budget.
+fn classify_fivetran_error(err: &FivetranError) -> FailedSourceErrorClass {
+    match err {
+        FivetranError::RateLimited => FailedSourceErrorClass::RateLimit,
+        FivetranError::RetryBudgetExhausted { .. } => FailedSourceErrorClass::Transient,
+        FivetranError::UnexpectedResponse(_) => FailedSourceErrorClass::Unknown,
+        // `code` here is either the raw HTTP status display (e.g. "503
+        // Service Unavailable") from `client::get`, or the API envelope's
+        // `code` field (e.g. "Unauthorized"). Lead-digit + canonical-reason
+        // matching covers both.
+        FivetranError::Api { code, .. } => classify_api_code(code),
+        FivetranError::Http(reqwest_err) => {
+            if reqwest_err.is_timeout() {
+                FailedSourceErrorClass::Timeout
+            } else if reqwest_err.is_connect() {
+                FailedSourceErrorClass::Transient
+            } else if let Some(status) = reqwest_err.status() {
+                classify_status_code(status.as_u16())
+            } else {
+                FailedSourceErrorClass::Unknown
+            }
+        }
+    }
+}
+
+fn classify_api_code(code: &str) -> FailedSourceErrorClass {
+    let trimmed = code.trim();
+    // Lead numeric prefix: "503 Service Unavailable" → 503.
+    if let Some(num) = trimmed
+        .split_whitespace()
+        .next()
+        .and_then(|s| s.parse::<u16>().ok())
+    {
+        return classify_status_code(num);
+    }
+    // Envelope codes are alphanumeric tokens like "Unauthorized" or
+    // "RateLimited" — the upstream Fivetran API sends these for non-success
+    // envelopes wrapped in HTTP 200. Match the documented vocabulary and
+    // leave anything else as Unknown.
+    match trimmed {
+        "Unauthorized" | "Forbidden" | "AuthFailed" => FailedSourceErrorClass::Auth,
+        "RateLimited" | "TooManyRequests" => FailedSourceErrorClass::RateLimit,
+        _ => FailedSourceErrorClass::Unknown,
+    }
+}
+
+fn classify_status_code(status: u16) -> FailedSourceErrorClass {
+    match status {
+        401 | 403 => FailedSourceErrorClass::Auth,
+        408 => FailedSourceErrorClass::Timeout,
+        429 => FailedSourceErrorClass::RateLimit,
+        500..=599 => FailedSourceErrorClass::Transient,
+        _ => FailedSourceErrorClass::Unknown,
     }
 }
 

--- a/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
@@ -409,10 +409,11 @@ async fn test_discover_projects_namespaced_metadata() {
 
     let client = test_client(&server);
     let adapter = FivetranDiscoveryAdapter::new(client, "dest_meta".into());
-    let connectors = adapter.discover("src__").await.unwrap();
+    let result = adapter.discover("src__").await.unwrap();
 
-    assert_eq!(connectors.len(), 1);
-    let conn = &connectors[0];
+    assert_eq!(result.connectors.len(), 1);
+    assert!(result.failed.is_empty());
+    let conn = &result.connectors[0];
     assert_eq!(conn.id, "conn_ads");
     assert_eq!(conn.source_type, "facebook_ads");
     // Core identity is always stamped.
@@ -473,13 +474,168 @@ async fn test_discover_without_config_still_stamps_identity() {
 
     let client = test_client(&server);
     let adapter = FivetranDiscoveryAdapter::new(client, "dest_noconfig".into());
-    let connectors = adapter.discover("src__").await.unwrap();
+    let result = adapter.discover("src__").await.unwrap();
 
-    assert_eq!(connectors.len(), 1);
-    let conn = &connectors[0];
+    assert_eq!(result.connectors.len(), 1);
+    assert!(result.failed.is_empty());
+    let conn = &result.connectors[0];
     assert_eq!(conn.metadata["fivetran.service"], "stripe");
     assert_eq!(conn.metadata["fivetran.connector_id"], "conn_bare");
     // No service-specific keys since `config` was absent.
     assert!(!conn.metadata.contains_key("fivetran.custom_reports"));
     assert!(!conn.metadata.contains_key("fivetran.schema_prefix"));
+}
+
+/// FR-014 — when one connector's schema fetch returns a sustained 503,
+/// the connector must surface in `result.failed` (classified `Transient`)
+/// rather than being silently dropped from `result.connectors`. This is
+/// the exact failure mode that caused the asset-graph-shrinkage bug Gold
+/// patched on the dbt path (Gold commit `c43394d`).
+#[tokio::test]
+async fn test_discover_surfaces_transient_503_in_failed_sources() {
+    let server = MockServer::start().await;
+
+    // Two connectors, both pass the connectors list step.
+    Mock::given(method("GET"))
+        .and(path("/v1/groups/dest_partial/connectors"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": "conn_ok",
+                        "group_id": "dest_partial",
+                        "service": "shopify",
+                        "schema": "src__acme__na__shopify",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "succeeded_at": "2026-04-25T10:00:00Z",
+                        "failed_at": null
+                    },
+                    {
+                        "id": "conn_flaky",
+                        "group_id": "dest_partial",
+                        "service": "stripe",
+                        "schema": "src__acme__na__stripe",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "succeeded_at": "2026-04-25T10:00:00Z",
+                        "failed_at": null
+                    }
+                ],
+                "next_cursor": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // conn_ok's schema fetch succeeds.
+    Mock::given(method("GET"))
+        .and(path("/v1/connectors/conn_ok/schemas"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "schemas": {
+                    "src__acme__na__shopify": {
+                        "enabled": true,
+                        "tables": {
+                            "orders": {
+                                "enabled": true,
+                                "sync_mode": "SOFT_DELETE",
+                                "columns": {}
+                            }
+                        }
+                    }
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // conn_flaky's schema fetch returns 503 (server-error). Test client
+    // has `max_retries = 0`, so this surfaces immediately to the adapter.
+    Mock::given(method("GET"))
+        .and(path("/v1/connectors/conn_flaky/schemas"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("Service Unavailable"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server);
+    let adapter = FivetranDiscoveryAdapter::new(client, "dest_partial".into());
+    let result = adapter.discover("src__").await.unwrap();
+
+    // The healthy connector still came through.
+    assert_eq!(result.connectors.len(), 1, "expected conn_ok in connectors");
+    assert_eq!(result.connectors[0].id, "conn_ok");
+
+    // The flaky connector is NOT silently dropped — it's reported as a
+    // failed source so downstream consumers can distinguish "tried and
+    // failed" from "removed upstream."
+    assert_eq!(
+        result.failed.len(),
+        1,
+        "expected conn_flaky in failed_sources, not silently dropped"
+    );
+    let failed = &result.failed[0];
+    assert_eq!(failed.id, "conn_flaky");
+    assert_eq!(failed.schema, "src__acme__na__stripe");
+    assert_eq!(failed.source_type, "stripe");
+    assert_eq!(
+        failed.error_class,
+        rocky_core::source::FailedSourceErrorClass::Transient,
+        "503 should classify as Transient"
+    );
+    assert!(
+        !failed.message.is_empty(),
+        "failed source must carry a non-empty message for debugging"
+    );
+}
+
+/// FR-014 — auth failures classify as `Auth` so consumers can route them
+/// to alerting / credentials-rotation paths instead of silently retrying.
+#[tokio::test]
+async fn test_discover_classifies_401_as_auth() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/groups/dest_auth/connectors"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": "conn_no_auth",
+                        "group_id": "dest_auth",
+                        "service": "stripe",
+                        "schema": "src__acme__na__stripe",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "succeeded_at": null,
+                        "failed_at": null
+                    }
+                ],
+                "next_cursor": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/connectors/conn_no_auth/schemas"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server);
+    let adapter = FivetranDiscoveryAdapter::new(client, "dest_auth".into());
+    let result = adapter.discover("src__").await.unwrap();
+
+    assert!(result.connectors.is_empty());
+    assert_eq!(result.failed.len(), 1);
+    assert_eq!(
+        result.failed[0].error_class,
+        rocky_core::source::FailedSourceErrorClass::Auth
+    );
 }

--- a/engine/crates/rocky-iceberg/src/adapter.rs
+++ b/engine/crates/rocky-iceberg/src/adapter.rs
@@ -7,7 +7,9 @@
 use async_trait::async_trait;
 use tracing::{debug, warn};
 
-use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+use rocky_core::source::{
+    DiscoveredConnector, DiscoveredTable, DiscoveryResult, FailedSource, FailedSourceErrorClass,
+};
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
 use crate::client::IcebergCatalogClient;
@@ -33,7 +35,7 @@ impl IcebergDiscoveryAdapter {
 
 #[async_trait]
 impl DiscoveryAdapter for IcebergDiscoveryAdapter {
-    async fn discover(&self, schema_prefix: &str) -> AdapterResult<Vec<DiscoveredConnector>> {
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
         let namespaces = self
             .client
             .list_namespaces()
@@ -53,6 +55,7 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
         );
 
         let mut connectors = Vec::with_capacity(matching.len());
+        let mut failed = Vec::new();
 
         for ns in matching {
             match self.client.list_tables(ns).await {
@@ -78,8 +81,19 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
                     warn!(
                         namespace = ns.as_str(),
                         error = %e,
-                        "failed to list tables in namespace, skipping"
+                        "list_tables failed, surfacing as failed source"
                     );
+                    failed.push(FailedSource {
+                        id: ns.clone(),
+                        schema: ns.clone(),
+                        source_type: "iceberg".to_string(),
+                        // The Iceberg REST client doesn't differentiate
+                        // transport-shape errors today; treat everything as
+                        // Unknown until it does. Future: classify on
+                        // `IcebergError` variants.
+                        error_class: FailedSourceErrorClass::Unknown,
+                        message: e.to_string(),
+                    });
                 }
             }
         }
@@ -87,10 +101,11 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
         debug!(
             prefix = schema_prefix,
             count = connectors.len(),
+            failed = failed.len(),
             "discovered Iceberg connectors"
         );
 
-        Ok(connectors)
+        Ok(DiscoveryResult { connectors, failed })
     }
 
     async fn ping(&self) -> AdapterResult<()> {

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -96,6 +96,20 @@ def rocky_source_sensor(
         cursor_data: dict[str, str] = json.loads(context.cursor) if context.cursor else {}
         result = rocky_resource.discover()
 
+        # FR-014: distinguish "tried-and-failed" from "removed upstream."
+        # If discover surfaced any `failed_sources`, log them so the
+        # consumer can investigate, and leave the cursor entries for those
+        # ids untouched — a missing entry on the next tick MUST NOT be
+        # treated as a deletion when its prior fetch failed transiently.
+        failed_sources = getattr(result, "failed_sources", None) or []
+        if failed_sources:
+            failed_ids = [fs.id for fs in failed_sources]
+            context.log.warning(
+                f"rocky_source_sensor: rocky discover reported {len(failed_sources)} "
+                f"failed source(s) — these are NOT deletions, do not reconcile "
+                f"missing-asset state for them: {failed_ids}"
+            )
+
         triggered: list[SourceInfo] = []
         new_cursor = dict(cursor_data)
         for source in result.sources:

--- a/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import AwareDatetime, BaseModel, conint
+from pydantic import AwareDatetime, BaseModel, Field, conint
 
 
 class ExcludedTableOutput(BaseModel):
@@ -28,6 +28,35 @@ class ExcludedTableOutput(BaseModel):
     table_name: str
     """
     Bare table name as reported by the discovery adapter.
+    """
+
+
+class FailedSourceOutput(BaseModel):
+    """
+    A source the discovery adapter attempted to fetch metadata for and failed.
+
+    Surfaced on `DiscoverOutput.failed_sources` so downstream consumers can distinguish a transient fetch failure from a deletion when diffing successive discover snapshots (FR-014).
+    """
+
+    error_class: str
+    """
+    Coarse error class so consumers can branch without parsing the `message`. One of `"transient"` / `"timeout"` / `"rate_limit"` / `"auth"` / `"unknown"`.
+    """
+    id: str
+    """
+    Adapter-side identifier for the source (e.g. Fivetran connector_id).
+    """
+    message: str
+    """
+    Human-readable error from the adapter — for logs / debugging only. Don't pattern-match on this; use `error_class` for branching.
+    """
+    schema_: str = Field(..., alias="schema")
+    """
+    Source schema name the adapter would have written into.
+    """
+    source_type: str
+    """
+    Adapter type (`"fivetran"`, `"airbyte"`, `"iceberg"`, ...).
     """
 
 
@@ -92,6 +121,10 @@ class DiscoverOutput(BaseModel):
     excluded_tables: list[ExcludedTableOutput]
     """
     Tables filtered out of `sources` because they were reported by the discovery adapter but do not exist in the source warehouse. Same shape as `RunOutput.excluded_tables` so consumers can use one parser. Empty when nothing was filtered.
+    """
+    failed_sources: list[FailedSourceOutput] | None = None
+    """
+    Sources the discovery adapter attempted to fetch metadata for and failed (transient HTTP error, timeout, rate-limit budget exhausted, auth blip). Their absence from `sources` does NOT mean they were removed upstream — consumers diffing against a prior run must treat failed sources as "unknown state, do not delete." Empty when discovery completed cleanly. See FR-014.
     """
     schemas_cached: conint(ge=0) | None = None
     """

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -48,6 +48,39 @@
       ],
       "type": "object"
     },
+    "FailedSourceOutput": {
+      "description": "A source the discovery adapter attempted to fetch metadata for and failed.\n\nSurfaced on `DiscoverOutput.failed_sources` so downstream consumers can distinguish a transient fetch failure from a deletion when diffing successive discover snapshots (FR-014).",
+      "properties": {
+        "error_class": {
+          "description": "Coarse error class so consumers can branch without parsing the `message`. One of `\"transient\"` / `\"timeout\"` / `\"rate_limit\"` / `\"auth\"` / `\"unknown\"`.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Adapter-side identifier for the source (e.g. Fivetran connector_id).",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable error from the adapter — for logs / debugging only. Don't pattern-match on this; use `error_class` for branching.",
+          "type": "string"
+        },
+        "schema": {
+          "description": "Source schema name the adapter would have written into.",
+          "type": "string"
+        },
+        "source_type": {
+          "description": "Adapter type (`\"fivetran\"`, `\"airbyte\"`, `\"iceberg\"`, ...).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error_class",
+        "id",
+        "message",
+        "schema",
+        "source_type"
+      ],
+      "type": "object"
+    },
     "FreshnessConfigOutput": {
       "description": "Freshness check configuration projected into the discover output.\n\nPer-schema `overrides` from `rocky_core::config::FreshnessConfig` are intentionally not exposed yet — the override-key semantics need to be nailed down before integrations can rely on them.",
       "properties": {
@@ -143,6 +176,13 @@
       "description": "Tables filtered out of `sources` because they were reported by the discovery adapter but do not exist in the source warehouse. Same shape as `RunOutput.excluded_tables` so consumers can use one parser. Empty when nothing was filtered.",
       "items": {
         "$ref": "#/definitions/ExcludedTableOutput"
+      },
+      "type": "array"
+    },
+    "failed_sources": {
+      "description": "Sources the discovery adapter attempted to fetch metadata for and failed (transient HTTP error, timeout, rate-limit budget exhausted, auth blip). Their absence from `sources` does NOT mean they were removed upstream — consumers diffing against a prior run must treat failed sources as \"unknown state, do not delete.\" Empty when discovery completed cleanly. See FR-014.",
+      "items": {
+        "$ref": "#/definitions/FailedSourceOutput"
       },
       "type": "array"
     },


### PR DESCRIPTION
## Summary

- **FR-014: discover no longer silently drops connectors on transient adapter failure.** `DiscoveryAdapter::discover` now returns `DiscoveryResult { connectors, failed }`; per-source fetch failures land in `failed` with a coarse `error_class` (`transient` / `timeout` / `rate_limit` / `auth` / `unknown`) instead of being filtered out. Patches the same asset-graph-shrinkage bug shape Gold just fixed on the dbt path (Gold commit `c43394d`).
- **Bundled Arc 2 wave 3 residual:** plain transformation models in `execute_models` now call `execute_statement_with_stats` and push a `MaterializationOutput`. Derived BigQuery models via full_refresh / incremental / merge will now report real `bytes_scanned`, feeding `rocky cost` on the BQ on-demand pricing path.
- **Wire-shape changes:**
  - `DiscoverOutput` gains `failed_sources: Vec<FailedSourceOutput>` (additive, `skip_serializing_if = "Vec::is_empty"`).
  - `RunOutput.materializations` now contains entries for plain transformation models that previously emitted nothing — consumers iterating blindly will see new entries; `dagster-rocky`'s `_emit_results` already filters to declared assets, so it's unaffected.
  - Sensor in `dagster-rocky` logs a warning on `failed_sources` and leaves cursor entries for failed ids untouched.

## Breaking changes

⚠️ Two trait surfaces changed return type. Both bumped via crate version, but external implementors need to update:

1. **`rocky_core::traits::DiscoveryAdapter::discover`**  — `AdapterResult<Vec<DiscoveredConnector>>` → `AdapterResult<DiscoveryResult>`.
2. **`rocky_adapter_sdk::DiscoveryAdapter::discover`**  — same shape change. This is the public SDK trait for external adapter authors; updating in lockstep keeps the FR-014 contract uniform.

Migration: return `DiscoveryResult::ok(connectors)` for adapters whose discovery surface is single-shot (no per-source fan-out); use `DiscoveryResult { connectors, failed }` when partial-failure classification is meaningful (per-connector parallel fetch, per-namespace listings).

The wire format change (`failed_sources` on `DiscoverOutput`) is additive — existing JSON consumers that ignore unknown fields are unaffected.

## Adapter coverage

| Adapter | Bug present? | Fix |
|---|---|---|
| `rocky-fivetran` | ✅ — silent drop on `get_schema_config` failure (`adapter.rs:55-83`) | Partition + classify `FivetranError` onto 5 classes, surface via `failed`. |
| `rocky-iceberg` | ✅ — silent drop on per-namespace `list_tables` failure (`adapter.rs:77-83`) | Surface via `failed`; classifier hard-coded to `Unknown` pending an `IcebergError` taxonomy. |
| `rocky-airbyte` | ❌ single-shot `list_connections`; either succeeds or whole call errors | `DiscoveryResult::ok(connectors)`. |
| `rocky-duckdb` | ❌ single-shot `information_schema` query | `DiscoveryResult::ok(connectors)`. |

## Test plan

- [x] New wiremock test `test_discover_surfaces_transient_503_in_failed_sources` — the exact bug reproducer: 503 on one connector's schema fetch surfaces in `result.failed` with class `Transient`, not silently dropped from `result.connectors`.
- [x] New wiremock test `test_discover_classifies_401_as_auth` — 401 classifies as `Auth`, distinct from server-error `Transient`.
- [x] All 13 fivetran wiremock tests pass.
- [x] `cargo test --workspace --all-targets` — green modulo the pre-existing `state_sync_timeout_test` parallel-load flake (passes when run sequentially; unrelated to this change).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `just codegen` regenerated `schemas/discover.schema.json`, `discover_schema.py` (Pydantic), `discover.ts` (TypeScript).
- [x] `just regen-fixtures` — no fixture diff (playground POC doesn't exercise the partial-failure path; that's expected).
- [x] All 458 dagster tests pass; `ruff check` + `ruff format --check` clean.

## Known follow-ups (not blockers)

- **Iceberg integration test**: the silent-drop fix is mechanical but doesn't have a dedicated wiremock test the way Fivetran does. Low-priority follow-up — the trait contract is exercised end-to-end via fivetran.
- **e2e assertion on `materializations`**: the playground POC is replication-only (`pipeline.type = "replication"`), so `regen-fixtures` doesn't pin the new transformation-path `MaterializationOutput`. Existing rocky-core e2e tests cover SQL generation but not the full `execute_models` flow. If transformation-path materializations ever drift, downstream `rocky cost` on derived BQ models will be the canary.
- **`RunOutput.failed_sources`**: not added in this PR. The FR explicitly scopes Layer 2 to `DiscoverOutput`; for `rocky run`, missing materializations are already a strong "did not happen" signal. Add later if user demand surfaces.

## References

- FR plan: `~/Developer/rocky-plans/feature-requests/gold-fr-014-discover-fetch-failure-resilience.md`
- Backlog item: `~/Developer/rocky-plans/TODO.md` §5 Arc 2 wave 3 residuals (the bundled `bytes_scanned` plumbing for plain transformation models)
- Gold dbt-path precedent: commit `c43394d` ("don't drop on transient errors" + consumer-side manifest verification)