### PR TITLE
docs: document FR-014 failed_sources across discover, sensor, and adapter SDK

### DIFF
--- a/docs/src/content/docs/concepts/adapters.md
+++ b/docs/src/content/docs/concepts/adapters.md
@@ -58,10 +58,12 @@ pub trait SqlDialect {
 
 | Trait | Capability | Methods |
 |-------|-----------|---------|
-| `DiscoveryAdapter` | Discover connectors/tables | `discover()` |
+| `DiscoveryAdapter` | Discover connectors/tables | `discover() -> DiscoveryResult` |
 | `GovernanceAdapter` | Tags, grants, bindings | `set_tags()`, `get_grants()`, `apply_grants()`, `revoke_grants()` |
 | `BatchCheckAdapter` | Batched quality checks | `batch_row_counts()`, `batch_freshness()` |
 | `TypeMapper` | Type normalization | `normalize_type()`, `types_compatible()` |
+
+`DiscoveryAdapter::discover` returns `DiscoveryResult { connectors, failed }` so adapters that fan out per-source metadata fetches (per-connector REST calls, per-namespace `list_tables`) can surface partial failures instead of silently dropping them — protecting downstream diff-based reconcilers from misreading a transient fetch failure as "removed upstream". Adapters that complete in a single shot return `DiscoveryResult::ok(connectors)`. Each `FailedSource` carries an `error_class` (`transient` / `timeout` / `rate_limit` / `auth` / `unknown`) so consumers can branch on operating-mode without parsing free-form messages.
 
 ## AdapterManifest
 

--- a/docs/src/content/docs/dagster/sensors.md
+++ b/docs/src/content/docs/dagster/sensors.md
@@ -45,7 +45,18 @@ The sensor:
 1. Calls `rocky.discover()` on each tick.
 2. Compares each source's `last_sync_at` timestamp to a per-source cursor.
 3. Emits a `RunRequest` for any source whose latest sync is newer than the cursor.
-4. Advances the cursor.
+4. Advances the cursor for the sources it processed.
+5. Logs a warning naming any ids the engine reported in `failed_sources`, and **does not** advance their cursor — so the next tick re-evaluates them.
+
+## Transient discover failures
+
+Source adapters can partially fail — a Fivetran 5xx or rate-limit window on a single connector, an Iceberg `list_tables` error on one namespace. From engine `1.17.4` onward, `rocky discover` surfaces these as `failed_sources` rather than silently dropping the connector from the output.
+
+The sensor relies on this signal to avoid the asset-graph-shrinkage failure mode where a transient adapter error looks indistinguishable from "removed upstream" to a diff-based reconciler. By skipping cursor advance for failed ids, the sensor guarantees that a flapping connector keeps reappearing for evaluation until it either succeeds (cursor advances normally) or is genuinely removed upstream (drops out of both `sources` and `failed_sources`).
+
+Healthy sources in the same tick still produce `RunRequest`s — partial failure does not block the run.
+
+Requires engine `≥ 1.17.4`. Older engines omit the field; the sensor treats absence as "no failures reported".
 
 ## Granularity
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -63,6 +63,15 @@ Returns all discovered sources and their tables.
       ]
     }
   ],
+  "failed_sources": [
+    {
+      "id": "connector_flaky456",
+      "schema": "src__acme__us_west__hubspot",
+      "source_type": "fivetran",
+      "error_class": "transient",
+      "message": "schema fetch failed: 503 Service Unavailable"
+    }
+  ],
   "checks": {
     "freshness": { "threshold_seconds": 86400 }
   }
@@ -80,8 +89,16 @@ Returns all discovered sources and their tables.
 | `sources[].tables` | array | List of tables in this source. |
 | `sources[].tables[].name` | string | Table name. |
 | `sources[].tables[].row_count` | integer or null | Row count if available, otherwise null. |
+| `failed_sources` | array or absent | Sources the adapter attempted to fetch metadata for and failed on. Absent when empty. Distinct from `sources` (succeeded) and `excluded_tables` (filtered post-success). |
+| `failed_sources[].id` | string | Connector or namespace identifier. |
+| `failed_sources[].schema` | string | Source schema string (when known). |
+| `failed_sources[].source_type` | string | Source type (`"fivetran"`, `"iceberg"`, etc.). |
+| `failed_sources[].error_class` | string | One of `"transient"`, `"timeout"`, `"rate_limit"`, `"auth"`, `"unknown"`. Lets consumers branch on operating-mode without parsing `message`. |
+| `failed_sources[].message` | string | Free-form error detail for human inspection. |
 | `checks` | object or absent | Pipeline-level check configuration, when `[checks]` is declared in `rocky.toml`. |
 | `checks.freshness.threshold_seconds` | integer | Freshness threshold in seconds. |
+
+Consumers diffing successive discover snapshots **must** treat ids that appear in `failed_sources` but not in `sources` as "unknown state, do not delete" — that's the contract that distinguishes a fetch failure from a deletion. Available since engine `1.17.4`.
 
 ---
 


### PR DESCRIPTION
## Summary
The 1.17.4 / 1.14.2 release surfaced `DiscoverOutput.failed_sources`, changed `rocky_source_sensor` to warn + skip cursor advance for failed ids, and flipped `DiscoveryAdapter::discover` to return `DiscoveryResult`. The docs site still described the pre-FR-014 contract — this PR brings the three affected pages into line.

- **`reference/json-output.md`** — `rocky discover` example gains a `failed_sources` block; field table documents `id` / `schema` / `source_type` / `error_class` / `message` and the consumer contract: ids that appear in `failed_sources` but not `sources` are unknown-state, do not delete.
- **`dagster/sensors.md`** — sensor flow extended with the warn + skip-cursor step, plus a new "Transient discover failures" subsection explaining the asset-graph-shrinkage protection and the engine `≥ 1.17.4` floor.
- **`concepts/adapters.md`** — `DiscoveryAdapter` row in the optional-traits table now shows the `DiscoveryResult` return type, with a paragraph on `DiscoveryResult::ok(connectors)` for clean cases and the 5-class `error_class` enum for partial-failure adapters.

Docs-only — no schema, codegen, or behavior changes.

## Test plan
- [ ] `engine-docs.yml` Astro build passes (no broken links / MDX errors)
- [ ] Spot-check rendered pages on the GitHub Pages deploy after merge:
  - [ ] `/reference/json-output/#rocky-discover` shows `failed_sources` example + field rows
  - [ ] `/dagster/sensors/` shows the new step 5 and "Transient discover failures" section
  - [ ] `/concepts/adapters/` shows `DiscoveryResult` in the trait table