### PR TITLE
feat(ci): rocky preview GitHub Action + auto PR comment — Phase 4

### DIFF
--- a/.github/actions/rocky-preview/action.yml
+++ b/.github/actions/rocky-preview/action.yml
@@ -50,10 +50,10 @@ inputs:
     default: 'false'
   github_token:
     description: >-
-      Token used to read the PR and upsert the comment. Pass
-      `${{ github.token }}` (or a PAT for cross-repo permissions) from
-      the workflow. Required because composite actions cannot reference
-      `${{ github.token }}` in input defaults.
+      Token used to read the PR and upsert the comment. Pass the
+      workflow's github.token (or a PAT for cross-repo permissions).
+      Required because composite actions cannot reference the github
+      context in input defaults.
     required: true
 
 outputs:

--- a/.github/actions/rocky-preview/action.yml
+++ b/.github/actions/rocky-preview/action.yml
@@ -50,11 +50,11 @@ inputs:
     default: 'false'
   github_token:
     description: >-
-      Token used to read the PR and upsert the comment. Defaults to the
-      workflow's `${{ github.token }}`; override if you need cross-repo
-      permissions.
-    required: false
-    default: ${{ github.token }}
+      Token used to read the PR and upsert the comment. Pass
+      `${{ github.token }}` (or a PAT for cross-repo permissions) from
+      the workflow. Required because composite actions cannot reference
+      `${{ github.token }}` in input defaults.
+    required: true
 
 outputs:
   comment_url:

--- a/.github/actions/rocky-preview/action.yml
+++ b/.github/actions/rocky-preview/action.yml
@@ -1,0 +1,378 @@
+name: 'Rocky Preview'
+description: >-
+  Run rocky preview create + diff + cost against a pull request and post a
+  single Markdown comment summarising the prune set, structural diff, and
+  cost delta. Idempotent across pushes via comment upsert.
+
+inputs:
+  base_ref:
+    description: 'Git ref to compare against (e.g. main, the PR base branch).'
+    required: true
+  branch_name:
+    description: >-
+      Preview branch name passed to `rocky preview` as `--name`. Defaults to
+      the PR head ref slugged for warehouse-schema safety. Pre-slug if you
+      pass it explicitly: only `[A-Za-z0-9_-]` are preserved, everything else
+      becomes `_`.
+    required: false
+    default: ''
+  models_dir:
+    description: 'Directory containing the model files. Passed to `rocky preview create --models`.'
+    required: false
+    default: 'models'
+  working_directory:
+    description: >-
+      Directory containing `rocky.toml`. The action cd's here before invoking
+      every rocky subcommand, so users with a non-root pipeline can point at
+      a subpath without restructuring the repo.
+    required: false
+    default: '.'
+  rocky_version:
+    description: >-
+      Engine version to install. `latest` (default) resolves the highest
+      `engine-v*` tag; otherwise pass a bare version like `1.17.4` or a full
+      tag like `engine-v1.17.4`.
+    required: false
+    default: 'latest'
+  comment_marker:
+    description: >-
+      HTML-comment magic string used to find and edit the existing PR
+      comment. Override only if you run multiple Rocky preview workflows on
+      the same PR and need to disambiguate them.
+    required: false
+    default: '<!-- rocky-preview -->'
+  fail_on_preview_error:
+    description: >-
+      When `true`, exit non-zero if any `rocky preview` subcommand fails. The
+      default (`false`) posts a failure section in the PR comment but lets
+      the PR check pass — preview is advisory.
+    required: false
+    default: 'false'
+  github_token:
+    description: >-
+      Token used to read the PR and upsert the comment. Defaults to the
+      workflow's `${{ github.token }}`; override if you need cross-repo
+      permissions.
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  comment_url:
+    description: 'HTML URL of the upserted PR comment.'
+    value: ${{ steps.upsert-comment.outputs.comment_url }}
+  prune_set_size:
+    description: 'Number of models in the prune set (changed + downstream-of-changed).'
+    value: ${{ steps.run-preview.outputs.prune_set_size }}
+  delta_usd:
+    description: >-
+      Total branch-vs-base USD cost delta. Empty string when no paired runs
+      exist in the state store yet (e.g. before Phase 1.5 lands actual
+      branch-run execution, or on first preview against an unpopulated
+      base).
+    value: ${{ steps.run-preview.outputs.delta_usd }}
+
+runs:
+  using: 'composite'
+  steps:
+    # --- Step 1: install rocky ----------------------------------------------
+    #
+    # Use the engine's official install.sh on Linux/macOS and install.ps1 on
+    # Windows. Both scripts already filter to the `engine-v*` tag prefix and
+    # verify the SHA256 against the published checksums.txt — no caching is
+    # added because the scripts are fast (≈3-5s) and caching adds a failure
+    # mode (stale binary, key churn) that doesn't pay for itself yet.
+    - name: Install rocky (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        export ROCKY_INSTALL_DIR="$HOME/.local/bin"
+        mkdir -p "$ROCKY_INSTALL_DIR"
+        if [ "${{ inputs.rocky_version }}" = "latest" ]; then
+          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
+        else
+          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- "${{ inputs.rocky_version }}"
+        fi
+        echo "$ROCKY_INSTALL_DIR" >> "$GITHUB_PATH"
+
+    - name: Install rocky (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if ('${{ inputs.rocky_version }}' -ne 'latest') {
+          $env:ROCKY_VERSION = '${{ inputs.rocky_version }}'
+        }
+        irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
+        Add-Content -Path $env:GITHUB_PATH -Value "$env:LOCALAPPDATA\rocky\bin"
+
+    # --- Step 2: run the three preview commands -----------------------------
+    #
+    # Each subcommand runs with `set +e` so a non-zero exit doesn't abort
+    # the script — the action always wants to post something to the PR even
+    # if one stage failed. Failures are collected into `_err` files that the
+    # comment-rendering step reads to compose a failure section.
+    #
+    # The `markdown` field lives inside the JSON output for diff and cost
+    # (no `--output markdown` flag exists). Create has no markdown field, so
+    # the action synthesises a one-liner from the structured prune/copy/run
+    # fields below.
+    - name: Run rocky preview
+      id: run-preview
+      shell: bash
+      env:
+        ROCKY_PREVIEW_BASE_REF: ${{ inputs.base_ref }}
+        ROCKY_PREVIEW_BRANCH_RAW: ${{ inputs.branch_name }}
+        ROCKY_PREVIEW_MODELS_DIR: ${{ inputs.models_dir }}
+      run: |
+        set -euo pipefail
+        cd "${{ inputs.working_directory }}"
+
+        # Resolve the branch name. If the caller passed one, slug it for
+        # warehouse-schema safety (only [A-Za-z0-9_-]). Otherwise default
+        # from the PR head ref or git HEAD.
+        slug() {
+          printf '%s' "$1" | tr -c 'A-Za-z0-9-' '_' | sed 's/__*/_/g; s/^_//; s/_$//'
+        }
+        if [ -n "${ROCKY_PREVIEW_BRANCH_RAW}" ]; then
+          BRANCH_NAME="$(slug "${ROCKY_PREVIEW_BRANCH_RAW}")"
+        else
+          # Fallback: the head ref env var GitHub sets on pull_request
+          # events, slugged. Detached-HEAD safety is delegated to the CLI.
+          if [ -n "${GITHUB_HEAD_REF:-}" ]; then
+            BRANCH_NAME="pr-preview-$(slug "$GITHUB_HEAD_REF")"
+          else
+            BRANCH_NAME=""
+          fi
+        fi
+
+        WORK="$RUNNER_TEMP/rocky-preview"
+        mkdir -p "$WORK"
+
+        # ---- preview create ----
+        CREATE_ARGS=(preview create --base "$ROCKY_PREVIEW_BASE_REF" --models "$ROCKY_PREVIEW_MODELS_DIR")
+        if [ -n "$BRANCH_NAME" ]; then
+          CREATE_ARGS+=(--name "$BRANCH_NAME")
+        fi
+        if rocky "${CREATE_ARGS[@]}" > "$WORK/create.json" 2> "$WORK/create.err"; then
+          : > "$WORK/create_failed"
+        else
+          echo failed > "$WORK/create_failed"
+        fi
+
+        # If `branch_name` was empty and the CLI defaulted, recover the
+        # actual name from the create output so diff/cost target the right
+        # branch. Empty fallback covers the unlikely case where create
+        # failed before emitting JSON.
+        if [ -z "$BRANCH_NAME" ] && [ -s "$WORK/create.json" ]; then
+          BRANCH_NAME="$(jq -r '.branch_name // ""' "$WORK/create.json" 2>/dev/null || true)"
+        fi
+
+        # ---- preview diff ----
+        : > "$WORK/diff.json"
+        if [ -n "$BRANCH_NAME" ]; then
+          if rocky preview diff --name "$BRANCH_NAME" --base "$ROCKY_PREVIEW_BASE_REF" \
+              > "$WORK/diff.json" 2> "$WORK/diff.err"; then
+            : > "$WORK/diff_failed"
+          else
+            echo failed > "$WORK/diff_failed"
+          fi
+        else
+          echo failed > "$WORK/diff_failed"
+          echo "branch name unresolved (preview create did not emit one)" > "$WORK/diff.err"
+        fi
+
+        # ---- preview cost ----
+        : > "$WORK/cost.json"
+        if [ -n "$BRANCH_NAME" ]; then
+          if rocky preview cost --name "$BRANCH_NAME" \
+              > "$WORK/cost.json" 2> "$WORK/cost.err"; then
+            : > "$WORK/cost_failed"
+          else
+            echo failed > "$WORK/cost_failed"
+          fi
+        else
+          echo failed > "$WORK/cost_failed"
+          echo "branch name unresolved (preview create did not emit one)" > "$WORK/cost.err"
+        fi
+
+        # ---- expose downstream outputs ----
+        PRUNE_SIZE="$(jq -r '.prune_set | length' "$WORK/create.json" 2>/dev/null || echo 0)"
+        DELTA_USD="$(jq -r '.summary.delta_usd // empty' "$WORK/cost.json" 2>/dev/null || true)"
+        echo "prune_set_size=$PRUNE_SIZE" >> "$GITHUB_OUTPUT"
+        echo "delta_usd=$DELTA_USD" >> "$GITHUB_OUTPUT"
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+        echo "work_dir=$WORK" >> "$GITHUB_OUTPUT"
+
+    # --- Step 3: assemble the Markdown comment body -------------------------
+    #
+    # Concatenates a synthesised Create section with the diff and cost
+    # `markdown` fields, plus a fenced failure section per failed stage.
+    # No HTML escaping needed — diff/cost markdown is engine-rendered and
+    # deterministic; failure sections quote stderr in a fenced block.
+    - name: Render PR comment body
+      id: render
+      shell: bash
+      env:
+        WORK_DIR: ${{ steps.run-preview.outputs.work_dir }}
+        BRANCH_NAME: ${{ steps.run-preview.outputs.branch_name }}
+        BASE_REF: ${{ inputs.base_ref }}
+        COMMENT_MARKER: ${{ inputs.comment_marker }}
+      run: |
+        set -euo pipefail
+        BODY="$RUNNER_TEMP/rocky-preview-body.md"
+        : > "$BODY"
+
+        printf '%s\n' "$COMMENT_MARKER" >> "$BODY"
+        printf '## Rocky preview — `%s` vs `%s`\n\n' "${BRANCH_NAME:-?}" "$BASE_REF" >> "$BODY"
+
+        # ---- create section ----
+        if [ ! -s "$WORK_DIR/create_failed" ] && [ -s "$WORK_DIR/create.json" ]; then
+          PRUNE="$(jq -r '.prune_set | length' "$WORK_DIR/create.json")"
+          COPY="$(jq -r '.copy_set | length' "$WORK_DIR/create.json")"
+          SKIPPED="$(jq -r '.skipped_set | length' "$WORK_DIR/create.json")"
+          STATUS="$(jq -r '.run_status' "$WORK_DIR/create.json")"
+          RUN_ID="$(jq -r '.run_id // ""' "$WORK_DIR/create.json")"
+          # An empty prune set means no model files actually changed in
+          # this PR (whitespace-only edits, doc tweaks under models/, etc).
+          # Copy set is the inverse — all N working-DAG models. Use prune
+          # alone as the no-op signal; copy will be non-zero whenever the
+          # project has any models at all.
+          if [ "$PRUNE" = "0" ]; then
+            printf '_This PR does not change any pipeline models._\n\n' >> "$BODY"
+          else
+            printf '**Plan** — pruned: %s • copied: %s • skipped: %s • status: `%s`%s\n\n' \
+              "$PRUNE" "$COPY" "$SKIPPED" "$STATUS" \
+              "$([ -n "$RUN_ID" ] && printf ' • run_id: `%s`' "$RUN_ID" || true)" \
+              >> "$BODY"
+          fi
+        else
+          printf '### :x: `rocky preview create` failed\n\n```\n' >> "$BODY"
+          if [ -s "$WORK_DIR/create.err" ]; then
+            head -c 8192 "$WORK_DIR/create.err" >> "$BODY"
+          else
+            printf '(no stderr captured)' >> "$BODY"
+          fi
+          printf '\n```\n\n' >> "$BODY"
+          if grep -q 'unknown revision\|bad revision\|not found' "$WORK_DIR/create.err" 2>/dev/null; then
+            printf "> :information_source: Couldn't compute base — was the base branch fetched? Set \`fetch-depth: 0\` on \`actions/checkout\`.\n\n" >> "$BODY"
+          fi
+        fi
+
+        # ---- diff section ----
+        printf -- '---\n\n' >> "$BODY"
+        if [ ! -s "$WORK_DIR/diff_failed" ] && [ -s "$WORK_DIR/diff.json" ]; then
+          MD="$(jq -r '.markdown // ""' "$WORK_DIR/diff.json")"
+          if [ -n "$MD" ]; then
+            printf '%s\n\n' "$MD" >> "$BODY"
+          else
+            printf '_No diff payload._\n\n' >> "$BODY"
+          fi
+        else
+          printf '### :x: `rocky preview diff` failed\n\n```\n' >> "$BODY"
+          if [ -s "$WORK_DIR/diff.err" ]; then
+            head -c 8192 "$WORK_DIR/diff.err" >> "$BODY"
+          else
+            printf '(no stderr captured)' >> "$BODY"
+          fi
+          printf '\n```\n\n' >> "$BODY"
+        fi
+
+        # ---- cost section ----
+        printf -- '---\n\n' >> "$BODY"
+        if [ ! -s "$WORK_DIR/cost_failed" ] && [ -s "$WORK_DIR/cost.json" ]; then
+          MD="$(jq -r '.markdown // ""' "$WORK_DIR/cost.json")"
+          if [ -n "$MD" ]; then
+            printf '%s\n\n' "$MD" >> "$BODY"
+          else
+            printf '_No cost payload._\n\n' >> "$BODY"
+          fi
+        else
+          printf '### :x: `rocky preview cost` failed\n\n```\n' >> "$BODY"
+          if [ -s "$WORK_DIR/cost.err" ]; then
+            head -c 8192 "$WORK_DIR/cost.err" >> "$BODY"
+          else
+            printf '(no stderr captured)' >> "$BODY"
+          fi
+          printf '\n```\n\n' >> "$BODY"
+        fi
+
+        printf -- '---\n\n_Posted by `.github/actions/rocky-preview`._\n' >> "$BODY"
+
+        echo "body_path=$BODY" >> "$GITHUB_OUTPUT"
+
+    # --- Step 4: upsert the PR comment --------------------------------------
+    #
+    # Skipped on non-PR triggers (the action gracefully no-ops when there's
+    # no PR context). Uses actions/github-script — already a transitive
+    # dependency of the GitHub-hosted runner image, no marketplace
+    # dependency added. Body is read from disk so multi-kilobyte payloads
+    # don't blow the env-var size limit.
+    - name: Upsert PR comment
+      id: upsert-comment
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        BODY_PATH: ${{ steps.render.outputs.body_path }}
+        COMMENT_MARKER: ${{ inputs.comment_marker }}
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const fs = require('fs');
+          const body = fs.readFileSync(process.env.BODY_PATH, 'utf8');
+          const marker = process.env.COMMENT_MARKER;
+          const issue_number = context.payload.pull_request.number;
+          const { owner, repo } = context.repo;
+
+          // Find an existing comment carrying our marker. Iterate via the
+          // paginate helper so PRs with hundreds of comments still land on
+          // the right one.
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner,
+            repo,
+            issue_number,
+            per_page: 100,
+          });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+          let url;
+          if (existing) {
+            const { data } = await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: existing.id,
+              body,
+            });
+            url = data.html_url;
+          } else {
+            const { data } = await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+            url = data.html_url;
+          }
+          core.setOutput('comment_url', url);
+
+    # --- Step 5: optional fail-the-check propagation ------------------------
+    - name: Propagate preview failure
+      if: ${{ inputs.fail_on_preview_error == 'true' }}
+      shell: bash
+      env:
+        WORK_DIR: ${{ steps.run-preview.outputs.work_dir }}
+      run: |
+        set -e
+        FAILED=0
+        for f in create_failed diff_failed cost_failed; do
+          if [ -s "$WORK_DIR/$f" ]; then
+            echo "::error::rocky preview ${f%_failed} failed"
+            FAILED=1
+          fi
+        done
+        if [ "$FAILED" = "1" ]; then
+          exit 1
+        fi
+
+branding:
+  icon: 'git-pull-request'
+  color: 'blue'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,3 +48,4 @@ jobs:
           # on what lives at `working_directory/models_dir`.
           working_directory: examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff
           models_dir: models
+          github_token: ${{ github.token }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,50 @@
+name: rocky-preview
+
+# Self-test for the `.github/actions/rocky-preview` composite action.
+#
+# Triggers on PRs that touch any model under the playground POCs so the
+# action is exercised end-to-end on real (toy) pipelines without paying for
+# warehouse credits — the playground POCs run on DuckDB.
+#
+# This is also the canonical reference for users wiring the action into
+# their own repos: copy the snippet under `Setting up the GitHub Action` in
+# `docs/src/content/docs/guides/preview-a-pr.md` and adjust the path filter
+# to match where your `models/` directory lives.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      # Narrow to the specific POC the action targets — broader POC paths
+      # would still trigger the workflow but have nothing to diff at the
+      # configured `working_directory`. Widen in lockstep with the action's
+      # working_directory if the self-test ever points at another POC.
+      - 'examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/models/**'
+      - '.github/actions/rocky-preview/**'
+      - '.github/workflows/preview.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Rocky preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Required for `git diff <base_ref>...HEAD` inside the action.
+          fetch-depth: 0
+
+      - name: Run rocky preview
+        uses: ./.github/actions/rocky-preview
+        with:
+          base_ref: ${{ github.event.pull_request.base.ref }}
+          branch_name: ${{ github.event.pull_request.head.ref }}
+          # The playground POC at `06-developer-experience/10-pr-preview-and-data-diff`
+          # is the canonical Phase-4 self-test fixture. Other POCs are
+          # path-filtered into the trigger but the action itself only acts
+          # on what lives at `working_directory/models_dir`.
+          working_directory: examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff
+          models_dir: models

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -137,6 +137,69 @@ A clean sample with `coverage_warning: true` is **not** evidence the PR is no-op
 
 ## Posting to a PR
 
-For now, `rocky preview` is a local CLI workflow. You run the three commands, copy the Markdown into your PR description by hand (or pipe it via your shell), and the reviewer sees the same artifacts you do.
+`rocky preview` ships a composite GitHub Action that runs all three commands on every push to a pull request and upserts a single Markdown comment with the prune/copy/skip plan, the structural diff, and the cost delta. The action lives at `.github/actions/rocky-preview/` in the [rocky-data repo](https://github.com/rocky-data/rocky/tree/main/.github/actions/rocky-preview) and is drop-in for any repo with a `rocky.toml` and a `models/` directory.
 
-A composite GitHub Action that runs all three and upserts a single PR comment is on the roadmap as a follow-up. When it lands, it will live at `.github/actions/rocky-preview/` and be drop-in for any repo. Until then, the [CI/CD Integration guide](/guides/ci-cd/) covers the existing patterns for posting Rocky output to PR comments — `rocky preview` plugs into the same `gh pr comment --body-file` pattern.
+### Setting up the GitHub Action
+
+Add the workflow below to `.github/workflows/preview.yml` in your own repo:
+
+```yaml
+name: rocky-preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # required for git diff against the base branch
+
+      - uses: rocky-data/rocky/.github/actions/rocky-preview@main
+        with:
+          base_ref: ${{ github.event.pull_request.base.ref }}
+          branch_name: ${{ github.event.pull_request.head.ref }}
+          # working_directory: my-pipeline   # if rocky.toml lives in a subdir
+          # models_dir: models               # default
+          # rocky_version: latest            # or 1.17.4 / engine-v1.17.4
+```
+
+The first PR after wiring this in will install Rocky and post a comment with the plan, the diff, and the cost delta. Subsequent pushes update that same comment in place via the `<!-- rocky-preview -->` marker — no PR-comment spam.
+
+### Action inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `base_ref` | (required) | Git ref to compare against. Typically `${{ github.event.pull_request.base.ref }}`. |
+| `branch_name` | PR head ref, slugged | Preview branch name passed to `rocky preview --name`. Pre-slug if you pass it explicitly: only `[A-Za-z0-9_-]` are preserved. |
+| `models_dir` | `models` | Directory containing model files. Passed to `rocky preview create --models`. |
+| `working_directory` | `.` | Directory containing `rocky.toml`. The action `cd`s here before each subcommand. |
+| `rocky_version` | `latest` | Engine version. `latest` resolves the highest `engine-v*` tag; otherwise pass `1.17.4` or `engine-v1.17.4`. |
+| `comment_marker` | `<!-- rocky-preview -->` | Magic-string marker used for comment upsert. Override only if you run multiple preview workflows on the same PR. |
+| `fail_on_preview_error` | `false` | When `true`, fail the PR check if any `rocky preview` subcommand errors. The default keeps preview advisory — failures still post a section in the comment. |
+| `github_token` | `${{ github.token }}` | Token used to read the PR and upsert the comment. Override for cross-repo permissions. |
+
+### Action outputs
+
+| Output | Description |
+|---|---|
+| `comment_url` | HTML URL of the upserted PR comment. |
+| `prune_set_size` | Number of models in the prune set (changed + downstream-of-changed). |
+| `delta_usd` | Total branch-vs-base USD cost delta. Empty when no paired runs exist yet (e.g. first preview against an unpopulated base). |
+
+### Failure modes
+
+The action is designed to never block a PR by default:
+
+- A `rocky preview <subcommand>` failure surfaces as an `:x:` section in the comment with the captured stderr.
+- A missing or unfetched base ref produces a hint to add `fetch-depth: 0` to `actions/checkout`.
+- A PR that touches no model files renders a tight one-liner (`This PR does not change any pipeline models.`) instead of empty diff/cost tables.
+
+Set `fail_on_preview_error: true` to turn any of those into a hard PR-check failure.

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -166,6 +166,7 @@ jobs:
         with:
           base_ref: ${{ github.event.pull_request.base.ref }}
           branch_name: ${{ github.event.pull_request.head.ref }}
+          github_token: ${{ github.token }}
           # working_directory: my-pipeline   # if rocky.toml lives in a subdir
           # models_dir: models               # default
           # rocky_version: latest            # or 1.17.4 / engine-v1.17.4
@@ -184,7 +185,7 @@ The first PR after wiring this in will install Rocky and post a comment with the
 | `rocky_version` | `latest` | Engine version. `latest` resolves the highest `engine-v*` tag; otherwise pass `1.17.4` or `engine-v1.17.4`. |
 | `comment_marker` | `<!-- rocky-preview -->` | Magic-string marker used for comment upsert. Override only if you run multiple preview workflows on the same PR. |
 | `fail_on_preview_error` | `false` | When `true`, fail the PR check if any `rocky preview` subcommand errors. The default keeps preview advisory — failures still post a section in the comment. |
-| `github_token` | `${{ github.token }}` | Token used to read the PR and upsert the comment. Override for cross-repo permissions. |
+| `github_token` | (required) | Token used to read the PR and upsert the comment. Pass `${{ github.token }}` from the workflow (or a PAT for cross-repo permissions). Required because composite actions cannot reference `${{ github.token }}` in input defaults. |
 
 ### Action outputs
 


### PR DESCRIPTION
## Summary

- Adds a composite GitHub Action at `.github/actions/rocky-preview/` that runs `rocky preview create + diff + cost` on every pull request and upserts a single Markdown comment with the prune/copy/skip plan, the structural diff, and the cost delta.
- Adds `.github/workflows/preview.yml` as a self-test against the playground POC at `examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/` — this PR's own check, when it runs, becomes the integration test for the action.
- Updates `docs/src/content/docs/guides/preview-a-pr.md` with the ready-to-paste workflow snippet and the input/output reference; drops the "GitHub Action is a follow-up" disclaimer.

## What the action does

1. Installs `rocky` via the existing `install.sh` / `install.ps1` scripts (filtered to the `engine-v*` tag prefix; no caching — install is fast).
2. Runs `rocky preview create --base <ref> --name <branch> --models <dir>` and captures the JSON.
3. Runs `rocky preview diff --name <branch> --base <ref>` and `rocky preview cost --name <branch>` — extracts the engine-rendered `markdown` field from each.
4. Synthesises a one-liner Create section from the structured prune/copy/skip counts (Create has no `markdown` field) and concatenates the three sections.
5. Upserts a PR comment carrying the `<!-- rocky-preview -->` marker via `actions/github-script`.

Failures in any subcommand surface as fenced `:x:` sections in the comment without aborting the PR by default (`fail_on_preview_error: true` flips this). Missing-base-ref errors emit a hint about `fetch-depth: 0`. PRs that don't change any models render `_This PR does not change any pipeline models._`.

## Workflow snippet users paste

```yaml
name: rocky-preview

on:
  pull_request:
    types: [opened, synchronize, reopened]

permissions:
  contents: read
  pull-requests: write

jobs:
  preview:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v6
        with:
          fetch-depth: 0

      - uses: rocky-data/rocky/.github/actions/rocky-preview@main
        with:
          base_ref: \${{ github.event.pull_request.base.ref }}
          branch_name: \${{ github.event.pull_request.head.ref }}
```

## What's NOT in this PR

Tracked separately in the preview plan:

- **Phase 1.5** — actual copy-step execution (DuckDB CTAS through the adapter trait). Until that lands, `preview create` plans only, so on the self-test the diff/cost sections render the engine's "No paired runs" hint. That's the correct shape against today's CLI; the action structure works against either today's planning-only output or Phase 1.5's executed output.
- **Phase 2.5** — checksum-bisection sampling for exhaustive row-content diff (datafold-style). Until then, every `preview diff` output already carries `coverage_warning: true` from the engine.
- **Phase 5** — adapter-parity clones (Databricks `SHALLOW CLONE`, Snowflake zero-copy `CLONE`, BigQuery table copy).

## Test plan

- [ ] CI green on this PR (`engine-ci`, `codegen-drift`, `dagster-ci`, `vscode-ci` should all be `not run` since no engine/dagster/vscode source touched).
- [ ] The new `rocky-preview` workflow does **not** trigger on this PR (path filter is scoped to the POC's `models/**` and the action/workflow files themselves — this PR touches the latter, so it will trigger).
- [ ] If it does trigger: the action runs end-to-end, posts a PR comment carrying the `<!-- rocky-preview -->` marker. With state-store empty (Phase 1.5 not shipped), the diff/cost sections render the engine's "No paired runs" hint; the Create section renders the prune/copy/skip plan from the structured fields.
- [ ] A second push to this branch updates the existing comment in place rather than creating a new one (idempotency test).
- [ ] No private path leaks (`~/Developer/...`, plan-doc references) in `action.yml`, `preview.yml`, or the docs update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)