### PR TITLE
fix(rocky-snowflake): set auth-token-type header per auth mode

### DIFF
--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -28,6 +28,40 @@ const JWT_TTL_SECS: u64 = 59 * 60;
 /// wasteful.
 const REFRESH_SLACK: Duration = Duration::from_secs(60);
 
+/// Snowflake auth token kind, used by the connector to set the
+/// `X-Snowflake-Authorization-Token-Type` header on REST API calls.
+///
+/// Snowflake's SQL API v2 documents three values today:
+/// - `KEYPAIR_JWT` for RS256 JWT signed with a private RSA key
+/// - `OAUTH` for OAuth access tokens (caller-supplied or IdP-issued)
+/// - no header at all when authenticating with a session token from
+///   the `/session/v1/login-request` endpoint — the server sniffs the
+///   token type from the token itself.
+///
+/// See <https://docs.snowflake.com/en/developer-guide/sql-api/authenticating>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenType {
+    /// RS256 key-pair JWT — sets `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT`.
+    KeypairJwt,
+    /// OAuth access token — sets `X-Snowflake-Authorization-Token-Type: OAUTH`.
+    OAuth,
+    /// Session token from username/password login — no token-type header.
+    SessionToken,
+}
+
+impl TokenType {
+    /// Returns the `X-Snowflake-Authorization-Token-Type` header value for
+    /// this token kind, or `None` if no token-type header should be sent.
+    #[must_use]
+    pub fn header_value(self) -> Option<&'static str> {
+        match self {
+            TokenType::KeypairJwt => Some("KEYPAIR_JWT"),
+            TokenType::OAuth => Some("OAUTH"),
+            TokenType::SessionToken => None,
+        }
+    }
+}
+
 /// Errors from Snowflake authentication.
 #[derive(Debug, Error)]
 pub enum AuthError {
@@ -176,6 +210,18 @@ impl Auth {
                 },
             }),
             _ => Err(AuthError::NoAuthConfigured),
+        }
+    }
+
+    /// Returns the [`TokenType`] for this auth handle, used by the
+    /// connector to set the `X-Snowflake-Authorization-Token-Type`
+    /// header per Snowflake's SQL API v2 spec.
+    #[must_use]
+    pub fn token_type(&self) -> TokenType {
+        match &self.inner {
+            AuthInner::OAuth { .. } => TokenType::OAuth,
+            AuthInner::KeyPair { .. } => TokenType::KeypairJwt,
+            AuthInner::Password { .. } => TokenType::SessionToken,
         }
     }
 
@@ -373,8 +419,14 @@ impl Auth {
         }
     }
 
-    #[cfg(test)]
-    async fn prime_cache_with(&self, token: &str, ttl: Duration) {
+    /// Test-only helper: pre-populate the session/JWT cache with a
+    /// caller-supplied token. Lets integration tests (under
+    /// `feature = "test-support"`) skip the (expensive, fixture-heavy)
+    /// JWT-mint or login-request roundtrips and still exercise the
+    /// connector's per-mode header logic. No-op for OAuth, which has
+    /// no cache.
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn prime_cache_with(&self, token: &str, ttl: Duration) {
         let new_cached = CachedToken {
             token: RedactedString::new(token.to_string()),
             expires_at: Instant::now() + ttl,

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use reqwest::Client;
+use reqwest::{Client, RequestBuilder};
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
 use rocky_core::config::RetryConfig;
 use rocky_core::retry::compute_backoff;
@@ -189,6 +189,20 @@ impl SnowflakeConnector {
         self
     }
 
+    /// Applies Snowflake auth headers to a request: the `Authorization:
+    /// Bearer <token>` header and, for OAuth and key-pair JWT modes,
+    /// the matching `X-Snowflake-Authorization-Token-Type` header.
+    /// Password / session-token mode emits no token-type header per
+    /// Snowflake's SQL API v2 spec — the server sniffs the token kind
+    /// from the token itself.
+    fn apply_auth_headers(&self, builder: RequestBuilder, token: &str) -> RequestBuilder {
+        let builder = builder.bearer_auth(token);
+        match self.auth.token_type().header_value() {
+            Some(value) => builder.header("X-Snowflake-Authorization-Token-Type", value),
+            None => builder,
+        }
+    }
+
     /// Base URL for the Snowflake SQL REST API.
     fn base_url(&self) -> String {
         #[cfg(any(test, feature = "test-support"))]
@@ -335,16 +349,13 @@ impl SnowflakeConnector {
             timeout: self.config.timeout.as_secs(),
         };
 
-        let resp = self
+        let request = self
             .client
             .post(&url)
-            .bearer_auth(&token)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
-            .json(&body)
-            .send()
-            .await?;
+            .json(&body);
+        let resp = self.apply_auth_headers(request, &token).send().await?;
 
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
@@ -387,13 +398,11 @@ impl SnowflakeConnector {
             );
 
             let token = self.auth.get_token().await?;
-            let poll_resp = self
+            let poll_request = self
                 .client
                 .get(&poll_url)
-                .bearer_auth(&token)
-                .header("Accept", "application/json")
-                .send()
-                .await?;
+                .header("Accept", "application/json");
+            let poll_resp = self.apply_auth_headers(poll_request, &token).send().await?;
 
             if !poll_resp.status().is_success() {
                 let status = poll_resp.status().as_u16();
@@ -417,10 +426,8 @@ impl SnowflakeConnector {
         let token = self.auth.get_token().await?;
         let url = format!("{}/{}/cancel", self.base_url(), handle);
 
-        self.client
-            .post(&url)
-            .bearer_auth(&token)
-            .header("Accept", "application/json")
+        let request = self.client.post(&url).header("Accept", "application/json");
+        self.apply_auth_headers(request, &token)
             .send()
             .await?
             .error_for_status()

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -576,20 +576,19 @@ async fn test_loader_missing_rows_loaded_column() {
     assert_eq!(result.rows_loaded, 0);
 }
 
-/// Bearer token is sent correctly in the Authorization header.
+/// Bearer token is sent correctly in the Authorization header for OAuth
+/// auth, and the matching `X-Snowflake-Authorization-Token-Type: OAUTH`
+/// header rides alongside it.
 #[tokio::test]
-async fn test_bearer_token_sent() {
+async fn test_oauth_auth_headers() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
         .and(path("/api/v2/statements"))
         .and(header("Authorization", "Bearer test-sf-token"))
-        .and(header(
-            "X-Snowflake-Authorization-Token-Type",
-            "KEYPAIR_JWT",
-        ))
+        .and(header("X-Snowflake-Authorization-Token-Type", "OAUTH"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "statementHandle": "sf-auth",
+            "statementHandle": "sf-auth-oauth",
             "code": "00000",
             "message": "ok",
             "statementStatusUrl": "",
@@ -603,6 +602,149 @@ async fn test_bearer_token_sent() {
     let connector = test_connector(&server);
     connector.execute_statement("SELECT 1").await.unwrap();
     // If the headers didn't match, the mock would not have responded with 200
+}
+
+/// Key-pair auth sets `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT`
+/// alongside the JWT in the Authorization header. Uses the `test-support`
+/// `prime_cache_with` to skip the (expensive, fixture-heavy) RS256 JWT
+/// minting path while still exercising the connector's header logic.
+#[tokio::test]
+async fn test_keypair_auth_headers() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header("Authorization", "Bearer fake-jwt-token"))
+        .and(header(
+            "X-Snowflake-Authorization-Token-Type",
+            "KEYPAIR_JWT",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-auth-keypair",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: "test_account".into(),
+        username: Some("test_user".into()),
+        password: None,
+        oauth_token: None,
+        private_key_path: Some("/unused-because-cache-primed.pem".into()),
+    })
+    .unwrap();
+    auth.prime_cache_with("fake-jwt-token", Duration::from_secs(3540))
+        .await;
+
+    let config = ConnectorConfig {
+        account: "test_account".into(),
+        warehouse: "COMPUTE_WH".into(),
+        database: Some("TEST_DB".into()),
+        schema: Some("PUBLIC".into()),
+        role: Some("SYSADMIN".into()),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            ..Default::default()
+        },
+    };
+    let connector = SnowflakeConnector::new(config, auth).with_base_url(server.uri());
+    connector.execute_statement("SELECT 1").await.unwrap();
+}
+
+/// Password / session-token auth sends the bearer token but **no**
+/// `X-Snowflake-Authorization-Token-Type` header — Snowflake's SQL API
+/// v2 spec lets the server sniff the token kind from the token itself,
+/// and emitting `KEYPAIR_JWT` here is what triggered the original
+/// 401-loop bug for non-keypair users.
+#[tokio::test]
+async fn test_password_auth_omits_token_type_header() {
+    let server = MockServer::start().await;
+
+    // Reject any request that *does* carry the token-type header — the
+    // mock only matches when the header is absent. Wiremock has no
+    // built-in "header-absent" matcher, so we set up a 500 fallback for
+    // any request carrying the header and assert it never fires.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header(
+            "X-Snowflake-Authorization-Token-Type",
+            "KEYPAIR_JWT",
+        ))
+        .respond_with(ResponseTemplate::new(500).set_body_string(
+            "should not be reached: password auth must not emit token-type header",
+        ))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header("X-Snowflake-Authorization-Token-Type", "OAUTH"))
+        .respond_with(ResponseTemplate::new(500).set_body_string(
+            "should not be reached: password auth must not emit token-type header",
+        ))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(header("Authorization", "Bearer cached-session-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-auth-password",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: "test_account".into(),
+        username: Some("test_user".into()),
+        password: Some("test_pass".into()),
+        oauth_token: None,
+        private_key_path: None,
+    })
+    .unwrap();
+    // Skip the live login-request hit by priming the session-token cache.
+    auth.prime_cache_with("cached-session-token", Duration::from_secs(3600))
+        .await;
+
+    let config = ConnectorConfig {
+        account: "test_account".into(),
+        warehouse: "COMPUTE_WH".into(),
+        database: Some("TEST_DB".into()),
+        schema: Some("PUBLIC".into()),
+        role: Some("SYSADMIN".into()),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            ..Default::default()
+        },
+    };
+    let connector = SnowflakeConnector::new(config, auth).with_base_url(server.uri());
+    connector.execute_statement("SELECT 1").await.unwrap();
+}
+
+/// Direct unit-style assertion on the [`TokenType`] -> header value
+/// mapping, kept alongside the wiremock cases so a regression in the
+/// mapping table surfaces with a sharper error than a 500 response.
+#[test]
+fn test_token_type_header_mapping() {
+    use rocky_snowflake::auth::TokenType;
+    assert_eq!(TokenType::OAuth.header_value(), Some("OAUTH"));
+    assert_eq!(TokenType::KeypairJwt.header_value(), Some("KEYPAIR_JWT"));
+    assert_eq!(TokenType::SessionToken.header_value(), None);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Snowflake's SQL REST API v2 connector hard-coded `X-Snowflake-Authorization-Token-Type: KEYPAIR_JWT` on every request, even when the resolved auth mode was OAuth or password / session-token. For non-keypair users the warehouse rejected the request as an invalid JWT, the 401 retry path dropped the cache and re-minted the same wrong-typed token, and the loop kept failing — what looked like an auth/refresh problem was a header bug.

## Bug

`engine/crates/rocky-snowflake/src/connector.rs:344` (pre-fix) attached `KEYPAIR_JWT` unconditionally on submit. Poll and cancel paths sent no token-type header at all. Tests at `tests/wiremock_tests.rs::test_bearer_token_sent` encoded the broken assertion against an OAuth-configured connector — it passed only because the test mock never validated the token shape.

## Fix

Per [Snowflake's SQL API v2 auth docs](https://docs.snowflake.com/en/developer-guide/sql-api/authenticating):

| Auth mode             | `X-Snowflake-Authorization-Token-Type` |
|-----------------------|----------------------------------------|
| Key-pair JWT (RS256)  | `KEYPAIR_JWT`                          |
| OAuth                 | `OAUTH`                                |
| Password / session    | (omit — server sniffs from token)      |

Changes:

- New `pub enum auth::TokenType { KeypairJwt, OAuth, SessionToken }` with a `header_value() -> Option<&'static str>` mapping.
- New `Auth::token_type()` returning the resolved mode.
- New `SnowflakeConnector::apply_auth_headers()` helper used by `submit_and_wait_once`, the polling loop, and `cancel_statement` — header logic now lives in one place and applies to every auth-bearing call site, not just submit.
- `prime_cache_with` test helper on `Auth` is now `pub` under `feature = "test-support"` so integration tests can skip the JWT/login roundtrip.

## Test plan

- [x] `cargo test -p rocky-snowflake` (107 unit tests pass)
- [x] `cargo test -p rocky-snowflake --features test-support --test wiremock_tests` (22/22 pass, including 3 new cases: `test_oauth_auth_headers`, `test_keypair_auth_headers`, `test_password_auth_omits_token_type_header`, plus `test_token_type_header_mapping`)
- [x] `cargo clippy -p rocky-snowflake --all-targets --features test-support -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Known follow-up (out of scope)

Snowflake's SQL API docs document the `Authorization: Bearer <token>` format for OAuth and key-pair, but session tokens minted via `/session/v1/login-request` are typically passed as `Authorization: Snowflake Token="<token>"`. The connector still uses `Bearer` for all three modes — that is unchanged by this PR. Password mode was already broken before this change; tracking a follow-up.