### PR TITLE
fix(dagster): FR-014 failed_sources plumbing + argv/stderr redaction

### DIFF
--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -105,6 +105,7 @@ from .types import (
     DriftInfo,
     DriftTableResult,
     ExecutionSummary,
+    FailedSourceOutput,
     FreshnessConfig,
     HealthCheck,
     HealthStatus,
@@ -234,6 +235,7 @@ __all__ = [
     "DiscoverResult",
     "ChecksConfig",
     "FreshnessConfig",
+    "FailedSourceOutput",
     # Run
     "RunResult",
     "MaterializationInfo",

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -86,7 +86,72 @@ MIN_ROCKY_VERSION = "1.0.0"
 # tracing line or truncated blob without dumping potentially MB of noise.
 _JSON_ERROR_PREVIEW_BYTES = 500
 
+# Maximum bytes of stderr embedded into ``dg.Failure.metadata`` when a Rocky
+# subprocess fails. Rocky's tracing layer can emit megabytes of context for a
+# pathological run; the Dagster UI renders metadata inline and isn't designed
+# to host blobs that large, so we clip and append a marker advertising the
+# original byte count for operators who need the full payload.
+_STDERR_METADATA_CAP_BYTES = 8192
+
+# Argv flags whose immediately-following positional value is credential-bearing
+# or otherwise sensitive. When we log the constructed argv (e.g. for live
+# debugging in :meth:`_run_rocky_streaming`) we replace the value of any
+# matching flag with ``"***"`` so credentials don't leak into Dagster logs or
+# the operator's terminal. The subprocess itself still receives the real
+# value — only the *log line* is redacted.
+_REDACTED_ARGV_FLAGS = frozenset(
+    {
+        # `--governance-override <json>` carries a JSON blob with workspace IDs
+        # and grant tuples. Not strictly a "credential" but treated as
+        # sensitive so it never appears in shared logs or screenshots.
+        "--governance-override",
+        # `--idempotency-key <opaque>` is a caller-chosen token used to dedup
+        # runs. Treat as opaque secret material.
+        "--idempotency-key",
+    }
+)
+
 _TModel = TypeVar("_TModel", bound=BaseModel)
+
+
+def _redact_argv(argv: list[str]) -> list[str]:
+    """Return a copy of ``argv`` with credential-bearing flag values masked.
+
+    Walks the list left-to-right; whenever a token equals one of
+    :data:`_REDACTED_ARGV_FLAGS`, the *next* token (the value) is replaced
+    with ``"***"``. The flag itself is kept verbatim so log lines stay
+    diagnostic ("we passed ``--idempotency-key ***``"). Useful for log
+    output only — never for the argv handed to the subprocess.
+    """
+    out: list[str] = []
+    redact_next = False
+    for token in argv:
+        if redact_next:
+            out.append("***")
+            redact_next = False
+            continue
+        out.append(token)
+        if token in _REDACTED_ARGV_FLAGS:
+            redact_next = True
+    return out
+
+
+def _truncate_stderr_for_metadata(stderr: str) -> str:
+    """Cap ``stderr`` at :data:`_STDERR_METADATA_CAP_BYTES` for ``dg.Failure``.
+
+    The Dagster UI renders ``dg.Failure.metadata`` inline; a multi-megabyte
+    stderr blob would overwhelm both the renderer and the database row.
+    When the input exceeds the cap, the prefix is preserved and a single
+    marker line is appended advertising the original size so operators who
+    need the full payload know to look in the Dagster compute logs / their
+    own subprocess capture instead.
+    """
+    if len(stderr) <= _STDERR_METADATA_CAP_BYTES:
+        return stderr
+    original_bytes = len(stderr)
+    return stderr[:_STDERR_METADATA_CAP_BYTES] + (
+        f"\n... [truncated, original {original_bytes} bytes]"
+    )
 
 
 def _validate_governance_override(override: dict | None) -> None:
@@ -899,7 +964,9 @@ class RockyResource(dg.ConfigurableResource):
 
         raise dg.Failure(
             description=f"Rocky command failed (exit {result.returncode})",
-            metadata={"stderr": dg.MetadataValue.text(result.stderr)},
+            metadata={
+                "stderr": dg.MetadataValue.text(_truncate_stderr_for_metadata(result.stderr)),
+            },
         )
 
     def _build_cmd(self, args: list[str]) -> list[str]:
@@ -1019,7 +1086,11 @@ class RockyResource(dg.ConfigurableResource):
             "rocky subprocess started: pid=%s timeout_s=%s cmd=%s",
             proc.pid,
             self.timeout_seconds,
-            " ".join(cmd),
+            # Redact credential-bearing argv values before they hit the log.
+            # The subprocess itself was already spawned with the real ``cmd``;
+            # this only sanitises what gets written into Dagster logs / the
+            # operator's terminal. See :func:`_redact_argv`.
+            " ".join(_redact_argv(cmd)),
         )
 
         # Sole-reader threads for the two pipes. Must be started before
@@ -1112,7 +1183,9 @@ class RockyResource(dg.ConfigurableResource):
                     f"Rocky command timed out after {self.timeout_seconds}s (watchdog-killed)"
                 ),
                 metadata={
-                    "stderr_tail": dg.MetadataValue.text("\n".join(stderr_lines[-20:])),
+                    "stderr_tail": dg.MetadataValue.text(
+                        _truncate_stderr_for_metadata("\n".join(stderr_lines[-20:]))
+                    ),
                     "duration_ms": dg.MetadataValue.int(duration_ms),
                     "pid": dg.MetadataValue.int(proc.pid),
                 },
@@ -1128,7 +1201,9 @@ class RockyResource(dg.ConfigurableResource):
         raise dg.Failure(
             description=f"Rocky command failed (exit {proc.returncode})",
             metadata={
-                "stderr_tail": dg.MetadataValue.text("\n".join(stderr_lines[-20:])),
+                "stderr_tail": dg.MetadataValue.text(
+                    _truncate_stderr_for_metadata("\n".join(stderr_lines[-20:]))
+                ),
                 "duration_ms": dg.MetadataValue.int(duration_ms),
             },
         )

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -77,6 +77,16 @@ class DiscoverResult(BaseModel):
     #: (defined further down with the run-output classes) resolves
     #: without explicit string quotes.
     excluded_tables: list[ExcludedTable] = []
+    #: Sources the discovery adapter attempted to fetch metadata for and
+    #: failed (transient HTTP error, timeout, rate-limit budget exhausted,
+    #: auth blip). Their absence from :attr:`sources` does NOT mean they
+    #: were removed upstream — consumers diffing against a prior run must
+    #: treat failed sources as "unknown state, do not delete." Empty when
+    #: discovery completed cleanly. See FR-014. Forward-references the
+    #: codegen-generated :class:`FailedSourceOutput` re-exported in the
+    #: round 9 bridge block below — ``from __future__ import annotations``
+    #: defers evaluation so the forward reference resolves at runtime.
+    failed_sources: list[FailedSourceOutput] = []
 
 
 # ---------------------------------------------------------------------------
@@ -974,6 +984,7 @@ from .types_generated import (  # noqa: E402, F401
     DriftOutput,
     DriftSummary,
     EnvMaskingStatus,
+    FailedSourceOutput,
     FreshnessConfigOutput,
     HistoryOutput,
     LineageColumnDef,

--- a/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
@@ -84,6 +84,7 @@ from .compile_schema import (
 from .discover_schema import (
     ChecksConfigOutput,
     DiscoverOutput,
+    FailedSourceOutput,
     FreshnessConfigOutput,
     SourceOutput,
     TableOutput,
@@ -249,6 +250,7 @@ __all__ = [
     # discover
     "ChecksConfigOutput",
     "DiscoverOutput",
+    "FailedSourceOutput",
     "FreshnessConfigOutput",
     "SourceOutput",
     "TableOutput",

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -26,6 +26,8 @@ from dagster_rocky.resource import (
     DEFAULT_TIMEOUT_SECONDS,
     MIN_ROCKY_VERSION,
     RockyResource,
+    _redact_argv,
+    _truncate_stderr_for_metadata,
     _validate_governance_override,
 )
 
@@ -1505,3 +1507,145 @@ def test_retention_status_forwards_env_flag(retention_status_json: str):
         rocky.retention_status(env="prod")
 
     assert captured[0] == ["retention-status", "--output", "json", "--env", "prod"]
+
+
+# ---------------------------------------------------------------------------
+# Argv redaction + stderr truncation (security hardening)
+# ---------------------------------------------------------------------------
+
+
+class TestRedactArgv:
+    """``_redact_argv`` masks the value of credential-bearing flags only.
+
+    The subprocess still receives the unredacted argv — only the *log
+    line* changes. Tests pin both that the value is masked and that
+    nothing else gets touched.
+    """
+
+    def test_idempotency_key_value_is_masked(self):
+        argv = [
+            "rocky",
+            "--config",
+            "rocky.toml",
+            "run",
+            "--filter",
+            "tenant=acme",
+            "--idempotency-key",
+            "abcd-secret-token",
+        ]
+        redacted = _redact_argv(argv)
+
+        # The flag itself stays intact so the log line still says what
+        # was passed; only the *next* token is replaced.
+        assert "--idempotency-key" in redacted
+        assert "***" in redacted
+        # The actual key MUST NOT survive into the redacted form.
+        assert "abcd-secret-token" not in redacted
+        # The flag's index is preserved and the redacted token sits
+        # immediately after it, matching the original positional shape.
+        idx = redacted.index("--idempotency-key")
+        assert redacted[idx + 1] == "***"
+
+    def test_governance_override_json_payload_is_masked(self):
+        # The governance-override value carries a JSON blob containing
+        # workspace IDs and grant principals — sensitive payload.
+        argv = [
+            "rocky",
+            "run",
+            "--governance-override",
+            '{"workspace_ids":[42],"grants":[{"principal":"svc-acct"}]}',
+        ]
+        redacted = _redact_argv(argv)
+        assert "--governance-override" in redacted
+        assert "***" in redacted
+        # No fragment of the JSON payload may leak.
+        assert "workspace_ids" not in " ".join(redacted)
+        assert "svc-acct" not in " ".join(redacted)
+
+    def test_non_sensitive_flags_pass_through(self):
+        # Non-sensitive flags (filter, partition, etc.) keep their values
+        # so debugging ``--filter tenant=acme`` stays informative.
+        argv = ["rocky", "run", "--filter", "tenant=acme", "--parallel", "4"]
+        redacted = _redact_argv(argv)
+        assert redacted == argv  # no changes
+
+    def test_multiple_sensitive_flags_each_redacted(self):
+        argv = [
+            "rocky",
+            "run",
+            "--governance-override",
+            '{"workspace_ids":[1]}',
+            "--filter",
+            "tenant=acme",
+            "--idempotency-key",
+            "key-2026-04-29",
+        ]
+        redacted = _redact_argv(argv)
+        # Both sensitive values masked; non-sensitive filter survives.
+        assert redacted.count("***") == 2
+        assert "tenant=acme" in redacted
+        assert "key-2026-04-29" not in redacted
+
+    def test_redaction_does_not_mutate_input(self):
+        # The redacted form is a *copy* — the subprocess argv must stay
+        # untouched so the real values still reach rocky.
+        argv = ["rocky", "--idempotency-key", "real-key"]
+        original = list(argv)
+        _redact_argv(argv)
+        assert argv == original
+
+
+class TestTruncateStderrForMetadata:
+    """``_truncate_stderr_for_metadata`` caps ``dg.Failure.metadata`` size."""
+
+    def test_short_input_unchanged(self):
+        stderr = "short error message"
+        assert _truncate_stderr_for_metadata(stderr) == stderr
+
+    def test_input_at_cap_unchanged(self):
+        # Exactly 8192 bytes — boundary case, must NOT add the marker.
+        stderr = "x" * 8192
+        out = _truncate_stderr_for_metadata(stderr)
+        assert out == stderr
+        assert "truncated" not in out
+
+    def test_oversize_input_truncated_with_marker(self):
+        # 20KB of stderr — well above the 8KB cap.
+        stderr = "x" * 20_000
+        out = _truncate_stderr_for_metadata(stderr)
+
+        # The output is bounded — the prefix is exactly ``cap`` bytes
+        # plus a single ~40-byte marker advertising the original size.
+        # 8KB + a generous marker headroom keeps the cap operator-friendly.
+        assert len(out) <= 8300
+        assert "truncated" in out
+        assert "20000 bytes" in out
+
+    def test_marker_advertises_correct_original_size(self):
+        # The marker must report the *input* length so operators know
+        # how much was clipped, not just that clipping happened.
+        stderr = "y" * 50_000
+        out = _truncate_stderr_for_metadata(stderr)
+        assert "50000 bytes" in out
+
+
+def test_run_rocky_failure_truncates_oversize_stderr_in_metadata():
+    """End-to-end: a Rocky failure with multi-KB stderr surfaces a
+    truncated string in ``dg.Failure.metadata``, not the raw blob.
+
+    Pins both the SEC fix (no unbounded blob in the Dagster UI) and the
+    operator-debugging path (the marker tells them how much was clipped).
+    """
+    rocky = RockyResource()
+    huge_stderr = "ERR " * 5000  # 20KB of stderr noise
+    with (
+        _patched_run(return_value=_completed(stdout="", stderr=huge_stderr, returncode=2)),
+        pytest.raises(dg.Failure) as excinfo,
+    ):
+        rocky._run_rocky(["discover"])
+
+    metadata = excinfo.value.metadata
+    assert "stderr" in metadata
+    text = metadata["stderr"].text
+    assert len(text) <= 8300
+    assert "truncated" in text

--- a/integrations/dagster/tests/test_sensor.py
+++ b/integrations/dagster/tests/test_sensor.py
@@ -10,6 +10,7 @@ import dagster as dg
 
 from dagster_rocky import (
     DiscoverResult,
+    FailedSourceOutput,
     RockyResource,
     SourceInfo,
     TableInfo,
@@ -243,4 +244,86 @@ def test_cursor_handles_mixed_timezone_offsets():
         result = sensor(dg.build_sensor_context(cursor=cursor))
 
     # Sync (10:30 UTC) is later than cursor (10:00 UTC despite -02:00 offset)
+    assert len(result.run_requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# FR-014 — failed_sources plumbing through the codegen soft-swap
+# ---------------------------------------------------------------------------
+
+
+def _failed(source_id: str, *, error_class: str = "transient") -> FailedSourceOutput:
+    """Build a `FailedSourceOutput` matching the engine's wire shape.
+
+    The generated model uses ``schema_`` because ``schema`` collides with
+    pydantic's own attribute namespace; the alias ``"schema"`` is what
+    the engine actually emits over the wire. We construct via the alias
+    here for parity with the live JSON path the sensor exercises.
+    """
+    return FailedSourceOutput.model_validate(
+        {
+            "id": source_id,
+            "schema": f"{source_id}_schema",
+            "source_type": "fivetran",
+            "error_class": error_class,
+            "message": "fetch failed",
+        }
+    )
+
+
+def test_sensor_logs_failed_sources_warning_and_does_not_treat_as_deletion():
+    """FR-014: when discover surfaces ``failed_sources``, the sensor must
+    warn (so the operator notices) and must NOT advance / drop the cursor
+    entry for the failed id — a missing source on the next tick whose
+    prior fetch failed is "unknown state", not a deletion.
+    """
+    rocky = RockyResource()
+    # `s1` synced cleanly; `s2` failed. Cursor already knows about both
+    # so we can prove the failed-id cursor entry survives the tick.
+    cursor = json.dumps(
+        {
+            "s1": _ts(2026, 4, 8, 9).isoformat(),
+            "s2": _ts(2026, 4, 8, 9).isoformat(),
+        }
+    )
+    discover = DiscoverResult(
+        version="0.3.0",
+        command="discover",
+        sources=[_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10))],
+        failed_sources=[_failed("s2", error_class="timeout")],
+    )
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _build_sensor(rocky)
+        ctx = dg.build_sensor_context(cursor=cursor)
+        result = sensor(ctx)
+
+    # `s1` triggered as usual…
+    assert result.run_requests is not None
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].tags["rocky/source_id"] == "s1"
+
+    # …and the cursor entry for the failed `s2` is preserved untouched
+    # so the next tick can re-evaluate it without losing state.
+    new_cursor = json.loads(result.cursor)
+    assert "s2" in new_cursor
+    assert new_cursor["s2"] == _ts(2026, 4, 8, 9).isoformat()
+
+
+def test_sensor_handles_empty_failed_sources_cleanly():
+    """The default-empty branch of the new field — sanity-check that a
+    `DiscoverResult` without `failed_sources` (legacy or clean run)
+    behaves exactly like the pre-FR-014 path."""
+    rocky = RockyResource()
+    discover = _discover(
+        _source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)),
+    )
+    # No `failed_sources` provided — defaults to [].
+    assert discover.failed_sources == []
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _build_sensor(rocky)
+        result = sensor(dg.build_sensor_context(cursor=None))
+
+    assert result.run_requests is not None
     assert len(result.run_requests) == 1


### PR DESCRIPTION
## Summary

Part of the post-launch maintenance cluster — two HIGH-priority fixes for the Dagster integration.

**Bug #8 (HIGH/BUG) — FR-014 Python plumbing.** `rocky_source_sensor` guards with `getattr(result, "failed_sources", None) or []` (sensor.py:104), but the hand-written `DiscoverResult` never declared the field, so the engine fix shipped in engine-v1.17.4 was silently dropped on the Python side. Soft-swap pattern: add `failed_sources: list[FailedSourceOutput] = []` to `DiscoverResult`, forward-referencing the codegen-generated `FailedSourceOutput` via the existing types-generated bridge. Re-export `FailedSourceOutput` from the package and from `types_generated/__init__.py` for downstream consumers and tests. Pin the sensor's warn-and-keep-cursor behaviour with a focused test.

**Bug #9 (HIGH/SEC) — credential leak via argv + stderr.**
- `_run_rocky_streaming` (resource.py:1019) logged the full constructed argv via `_log.info(... " ".join(cmd))`, including `--governance-override <json>` and `--idempotency-key <opaque>` — both surface to operator terminals and Dagster compute logs.
- `_run_rocky`'s failure path (resource.py:902) embedded the entire stderr into `dg.Failure.metadata["stderr"]`, which the Dagster UI renders inline. A multi-MB stderr blob is both a UX problem and a footgun if rocky's tracing layer ever logs sensitive context.

Fix introduces two small helpers:
- `_redact_argv(argv)` — replaces the value of any token in `_REDACTED_ARGV_FLAGS = {"--governance-override", "--idempotency-key"}` with `"***"`. Returns a copy so the subprocess still receives the unredacted argv.
- `_truncate_stderr_for_metadata(stderr)` — caps at `_STDERR_METADATA_CAP_BYTES = 8192` and appends `\n... [truncated, original {N} bytes]` so operators know how much was clipped.

Applied at the two leaking sites and defensively at the streaming-failure path's `stderr_tail` metadata. New tests cover both the helpers and an end-to-end `dg.Failure` truncation case.

## Test plan

- [x] `uv run pytest` in `integrations/dagster/` — 470 passed (10 new sensor + resource tests)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [ ] CI green on the dagster + codegen-drift workflows