### PR TITLE
fix: maintenance sweep cluster — hooks, HTTP timeouts, vscode-release env-var, branch HashSet

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -70,7 +70,15 @@ jobs:
           files: editors/vscode/*.vsix
 
       - name: Publish to VS Code Marketplace
-        if: env.VSCE_PAT != ''
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx @vscode/vsce publish --pat "$VSCE_PAT"
+        # `if: env.VSCE_PAT != ''` doesn't work — the `env` context isn't
+        # available in step-level `if:` evaluation. Guard inline instead so
+        # forks without the secret produce a soft no-op rather than a hard
+        # failure (matches the pattern documented in engine-wasm-release.yml).
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "VSCE_PAT not set — skipping marketplace publish (this is expected on forks)"
+            exit 0
+          fi
+          npx @vscode/vsce publish --pat "$VSCE_PAT"

--- a/engine/crates/rocky-airbyte/src/client.rs
+++ b/engine/crates/rocky-airbyte/src/client.rs
@@ -7,6 +7,17 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use reqwest::Client;
+
+/// Build the shared `reqwest::Client` used for every Airbyte API call.
+/// `Client::new()` left both connect and request timeouts unset — a
+/// stalled connection would block `rocky run` forever.
+fn build_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("reqwest client builder is infallible with these options")
+}
 use rocky_core::config::RetryConfig;
 use rocky_core::redacted::RedactedString;
 use serde::{Deserialize, Serialize};
@@ -122,7 +133,7 @@ impl AirbyteClient {
     pub fn with_retry(api_url: &str, auth_token: Option<String>, retry: RetryConfig) -> Self {
         let base_url = api_url.trim_end_matches('/').to_string();
         AirbyteClient {
-            client: Client::new(),
+            client: build_http_client(),
             base_url,
             auth_token: auth_token.map(RedactedString::new),
             retry,

--- a/engine/crates/rocky-core/src/hooks/mod.rs
+++ b/engine/crates/rocky-core/src/hooks/mod.rs
@@ -840,6 +840,11 @@ async fn execute_hook(hook: &HookConfig, json: &str) -> Result<(), HookError> {
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
+    // SIGKILL the child if our `Child` handle is dropped — including when
+    // `tokio::time::timeout` cancels the `wait_with_output` future on
+    // expiry. Without this, a hook that runs past `timeout_ms` keeps
+    // executing after Rocky returns `HookError::Timeout`.
+    cmd.kill_on_drop(true);
 
     // Set extra environment variables
     for (k, v) in &hook.env {
@@ -881,8 +886,9 @@ async fn execute_hook(hook: &HookConfig, json: &str) -> Result<(), HookError> {
         }
         Ok(Err(e)) => Err(HookError::Io(e)),
         Err(_) => {
-            // Timeout — the child process is already dropped (and killed) when
-            // `wait_with_output` future is cancelled by the timeout.
+            // Timeout — `kill_on_drop(true)` on the `Command` ensures the
+            // OS process is SIGKILL'd when `wait_with_output`'s `Child`
+            // handle is dropped by the timeout cancellation.
             Err(HookError::Timeout {
                 command: hook.command.clone(),
                 timeout_ms: hook.timeout_ms,

--- a/engine/crates/rocky-databricks/src/scim.rs
+++ b/engine/crates/rocky-databricks/src/scim.rs
@@ -37,11 +37,25 @@
 //! SQL Statement Execution API uses — [`crate::auth::Auth`] handles
 //! both transparently. No separate SCIM auth path.
 
+use std::time::Duration;
+
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::auth::Auth;
+
+/// Build the shared `reqwest::Client` used for every SCIM call.
+/// `Client::new()` left both connect and request timeouts unset — a
+/// stalled connection would block any SCIM-using path (group sync,
+/// principal lookups) forever.
+fn build_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("reqwest client builder is infallible with these options")
+}
 
 /// Errors from the Databricks SCIM API.
 #[derive(Debug, thiserror::Error)]
@@ -112,7 +126,7 @@ impl ScimClient {
         ScimClient {
             host,
             auth,
-            client: Client::new(),
+            client: build_http_client(),
             #[cfg(any(test, feature = "test-support"))]
             base_url_override: None,
         }

--- a/engine/crates/rocky-engine/src/branch.rs
+++ b/engine/crates/rocky-engine/src/branch.rs
@@ -3,7 +3,7 @@
 //! Creates isolated branches for testing model changes without
 //! affecting production data.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -61,14 +61,19 @@ pub fn diff_branch(
         let main_cols: Vec<String> = main_schemas.get(model).cloned().unwrap_or_default();
         let branch_cols: Vec<String> = branch_schemas.get(model).cloned().unwrap_or_default();
 
+        // Set membership probes are O(1) — replaces a quadratic
+        // `Vec::contains` scan that became measurable on wide tables.
+        let main_set: HashSet<&String> = main_cols.iter().collect();
+        let branch_set: HashSet<&String> = branch_cols.iter().collect();
+
         let added: Vec<String> = branch_cols
             .iter()
-            .filter(|c| !main_cols.contains(c))
+            .filter(|c| !main_set.contains(c))
             .cloned()
             .collect();
         let removed: Vec<String> = main_cols
             .iter()
-            .filter(|c| !branch_cols.contains(c))
+            .filter(|c| !branch_set.contains(c))
             .cloned()
             .collect();
 

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -1,6 +1,19 @@
 use std::time::Duration;
 
 use reqwest::Client;
+
+/// Build the shared `reqwest::Client` used for every Fivetran API call.
+/// `Client::new()` previously left both connect and request timeouts
+/// unset — a stalled connection would block `rocky run` forever. The
+/// 10s/120s pair matches the per-adapter `timeout_secs` default and the
+/// other engine adapters' bounds.
+fn build_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("reqwest client builder is infallible with these options")
+}
 use rocky_core::config::RetryConfig;
 use rocky_core::redacted::RedactedString;
 use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
@@ -62,7 +75,7 @@ impl FivetranClient {
         let retry_budget =
             rocky_core::retry_budget::RetryBudget::from_config(retry.max_retries_per_run);
         FivetranClient {
-            client: Client::new(),
+            client: build_http_client(),
             base_url: "https://api.fivetran.com".to_string(),
             api_key: RedactedString::new(api_key),
             api_secret: RedactedString::new(api_secret),
@@ -83,7 +96,7 @@ impl FivetranClient {
     #[cfg(any(test, feature = "test-support"))]
     pub fn with_base_url(api_key: String, api_secret: String, base_url: String) -> Self {
         FivetranClient {
-            client: Client::new(),
+            client: build_http_client(),
             base_url,
             api_key: RedactedString::new(api_key),
             api_secret: RedactedString::new(api_secret),

--- a/engine/crates/rocky-iceberg/src/client.rs
+++ b/engine/crates/rocky-iceberg/src/client.rs
@@ -7,6 +7,18 @@
 use std::time::Duration;
 
 use reqwest::Client;
+
+/// Build the shared `reqwest::Client` used for every Iceberg REST
+/// catalog call. `Client::new()` left both connect and request
+/// timeouts unset — a stalled connection would block `rocky run`
+/// forever.
+fn build_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("reqwest client builder is infallible with these options")
+}
 use rocky_core::config::RetryConfig;
 use rocky_core::redacted::RedactedString;
 use serde::{Deserialize, Serialize};
@@ -105,7 +117,7 @@ impl IcebergCatalogClient {
     pub fn with_retry(catalog_url: &str, auth_token: Option<String>, retry: RetryConfig) -> Self {
         let base_url = catalog_url.trim_end_matches('/').to_string();
         IcebergCatalogClient {
-            client: Client::new(),
+            client: build_http_client(),
             base_url,
             auth_token: auth_token.map(RedactedString::new),
             retry,


### PR DESCRIPTION
Five low-risk fixes from the post-launch maintenance audit, bundled because each is < 20 lines and they all trace back to subtle bugs.

## Changes

**`rocky-core` hooks — `kill_on_drop`.** A hook that ran past `timeout_ms` kept executing after Rocky returned `HookError::Timeout`: `tokio::time::timeout` cancels the wait future, but the spawned `sh -c` child wasn't configured to die when its `Child` handle dropped. Fix is `cmd.kill_on_drop(true)`. Inline comment used to claim the child was killed; corrected.

**Adapter HTTP clients — connect + request timeouts.** `rocky-fivetran`, `rocky-airbyte`, `rocky-iceberg`, and `rocky-databricks/scim` all built their `reqwest::Client` via `Client::new()` which leaves both `connect_timeout` and `timeout` unset. A stalled connection blocked `rocky run` indefinitely. Each now uses a small `build_http_client()` helper with `connect_timeout(10s)` + `timeout(120s)`.

**`vscode-release.yml` — VSCE_PAT guard.** Step-level `if: env.VSCE_PAT != ''` doesn't work because the `env` context isn't available in step `if:` evaluation; the publish step was silently skipped. Drop the `if:` and guard inline with a shell `[ -z ... ]` check, so forks without the secret get a soft no-op rather than a hard failure (matches the pattern documented in `engine-wasm-release.yml`).

**`rocky-engine/branch.rs` — HashSet column diff.** O(n*m) `Vec::contains` scan replaced with two `HashSet<&String>` membership probes. Measurable on wide tables.

## Test plan

- [x] `cargo test -p rocky-core -p rocky-fivetran -p rocky-airbyte -p rocky-iceberg -p rocky-databricks -p rocky-engine --lib` — passes
- [x] `cargo clippy -p ... --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] No JSON-output schema changes — no codegen-drift risk