### PR TITLE
fix(rocky-ai): credential redaction + testgen path canonicalization + token budget

### DIFF
--- a/docs/src/content/docs/guides/ai-features.md
+++ b/docs/src/content/docs/guides/ai-features.md
@@ -24,6 +24,17 @@ source ~/.zshrc
 
 Rocky uses `claude-sonnet-4-6` by default. No additional configuration is needed.
 
+### Token budget (optional)
+
+Each AI command runs a compile-verify retry loop (up to 3 attempts). To bound the worst-case spend when the LLM produces runaway responses, Rocky enforces a cumulative output-token budget across retries. Set the budget in `rocky.toml` if the default of `4096` is not enough for your project:
+
+```toml
+[ai]
+max_tokens = 8192
+```
+
+`max_tokens` doubles as the per-request cap on the Anthropic Messages API and as the cumulative output-token ceiling — when the running total of `output_tokens` across retry attempts exceeds this value, Rocky fail-stops with a `TokenBudgetExceeded` error instead of paying for another retry. See [`[ai]`](/reference/configuration/#ai) in the configuration reference.
+
 ### Verify the setup
 
 ```bash

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -618,6 +618,23 @@ Stamps live in the `IDEMPOTENCY_KEYS` redb table and replicate on tiered backend
 
 ---
 
+## `[ai]`
+
+Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`). Unknown fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_tokens` | integer | `4096` | Per-request `max_tokens` sent to the Anthropic Messages API **and** the cumulative output-token budget enforced across the compile-verify retry loop. When the running total of `output_tokens` returned by the LLM across attempts exceeds this value, Rocky fail-stops with a `TokenBudgetExceeded` error instead of issuing another retry. The default preserves Rocky's pre-1.x hard-coded behaviour. Increase only when generations legitimately need more headroom (large model surfaces, verbose tests). |
+
+```toml
+[ai]
+max_tokens = 8192
+```
+
+The `[ai]` block is read by every `rocky ai*` command. The API key itself is **not** read from `rocky.toml` — it must come from the `ANTHROPIC_API_KEY` environment variable so it never lands on disk in a project file.
+
+---
+
 ## `[cache]`
 
 Project-level cache configuration. Today this is the schema cache

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -328,6 +328,20 @@
         }
       ]
     },
+    "AiSection": {
+      "additionalProperties": false,
+      "description": "Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`).\n\n`max_tokens` doubles as: 1. The per-request `max_tokens` cap on the Anthropic Messages API. 2. The cumulative output-token budget across the compile-verify retry loop — when the running total exceeds this value, the loop fail-stops instead of issuing another retry. This bounds the worst-case spend when the LLM produces runaway responses that fail validation.\n\nThe default ([`DEFAULT_AI_MAX_TOKENS`]) preserves Rocky's pre-1.x hard-coded behaviour. Increase for projects that legitimately need longer generations (large model surfaces, verbose tests).\n\n```toml [ai] max_tokens = 8192 ```",
+      "properties": {
+        "max_tokens": {
+          "default": 4096,
+          "description": "Per-request `max_tokens` and cumulative output-token budget across retries. Default [`DEFAULT_AI_MAX_TOKENS`].",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "BindingType": {
       "description": "Workspace binding access level.",
       "enum": [
@@ -2763,6 +2777,17 @@
       ],
       "default": {},
       "description": "Named adapter configurations (keyed by adapter name)."
+    },
+    "ai": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AiSection"
+        }
+      ],
+      "default": {
+        "max_tokens": 4096
+      },
+      "description": "AI intent layer configuration. Currently scopes the per-request and cumulative-retry token budget for `rocky ai` / `ai-explain` / `ai-sync` / `ai-test`. See [`AiSection`]."
     },
     "budget": {
       "allOf": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -312,6 +312,10 @@ export interface RockyConfig {
    */
   adapter?: AdaptersFieldSchema;
   /**
+   * AI intent layer configuration. Currently scopes the per-request and cumulative-retry token budget for `rocky ai` / `ai-explain` / `ai-sync` / `ai-test`. See [`AiSection`].
+   */
+  ai?: AiSection;
+  /**
    * Declarative run-level budget. See [`BudgetConfig`] for the semantics of each limit and the breach action.
    */
   budget?: BudgetConfig;
@@ -490,6 +494,21 @@ export interface RetryConfig {
    * `None` (default) keeps legacy behaviour — per-statement [`RetryConfig::max_retries`] is the only bound. `Some(0)` means no retries are allowed for the whole run.
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`).
+ *
+ * `max_tokens` doubles as: 1. The per-request `max_tokens` cap on the Anthropic Messages API. 2. The cumulative output-token budget across the compile-verify retry loop — when the running total exceeds this value, the loop fail-stops instead of issuing another retry. This bounds the worst-case spend when the LLM produces runaway responses that fail validation.
+ *
+ * The default ([`DEFAULT_AI_MAX_TOKENS`]) preserves Rocky's pre-1.x hard-coded behaviour. Increase for projects that legitimately need longer generations (large model surfaces, verbose tests).
+ *
+ * ```toml [ai] max_tokens = 8192 ```
+ */
+export interface AiSection {
+  /**
+   * Per-request `max_tokens` and cumulative output-token budget across retries. Default [`DEFAULT_AI_MAX_TOKENS`].
+   */
+  max_tokens?: number;
 }
 /**
  * Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.

--- a/engine/crates/rocky-ai/src/client.rs
+++ b/engine/crates/rocky-ai/src/client.rs
@@ -3,24 +3,42 @@
 //! Supports Claude (Anthropic Messages API) as the primary provider.
 //! Uses reqwest for HTTP, serde for JSON.
 
+use rocky_core::redacted::RedactedString;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Default `max_tokens` for the Anthropic Messages API request body. Also
+/// serves as the default cumulative-output token budget enforced across the
+/// compile-verify retry loop in [`crate::generate::generate_model`]. Stays at
+/// 4096 to preserve pre-token-budget behaviour for users who don't set
+/// `[ai] max_tokens` in `rocky.toml`.
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+
 /// AI provider configuration.
+///
+/// `api_key` is wrapped in [`RedactedString`] so accidental `?config` /
+/// `{config:?}` formatting in logs prints `***` instead of the raw secret.
+/// Use [`RedactedString::expose`] only at the outbound HTTP boundary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiConfig {
     /// Provider: "anthropic" or "openai".
     pub provider: String,
     /// Model name (e.g., "claude-sonnet-4-6").
     pub model: String,
-    /// API key.
-    pub api_key: String,
+    /// API key. Wrapped in [`RedactedString`] to block accidental log leaks.
+    pub api_key: RedactedString,
     /// Default output format: "rocky" or "sql".
     #[serde(default = "default_format")]
     pub default_format: String,
     /// Max compile-verify retries.
     #[serde(default = "default_max_attempts")]
     pub max_attempts: usize,
+    /// Per-request `max_tokens` for the Anthropic Messages API and the
+    /// cumulative output-token budget enforced across retries by
+    /// [`crate::generate::generate_model`]. Default
+    /// [`DEFAULT_MAX_TOKENS`] preserves pre-knob behaviour.
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
 }
 
 fn default_format() -> String {
@@ -29,6 +47,10 @@ fn default_format() -> String {
 
 fn default_max_attempts() -> usize {
     3
+}
+
+fn default_max_tokens() -> u32 {
+    DEFAULT_MAX_TOKENS
 }
 
 /// Errors from AI operations.
@@ -45,6 +67,21 @@ pub enum AiError {
 
     #[error("no API key configured")]
     NoApiKey,
+
+    /// Cumulative output tokens consumed by the compile-verify retry loop
+    /// exceeded the configured `[ai] max_tokens` budget. Bounds the
+    /// worst-case cost when the LLM produces runaway responses across
+    /// retries.
+    #[error(
+        "AI token budget exceeded after {attempts} attempts: \
+         consumed {consumed_output_tokens} output tokens, budget is {budget}. \
+         Increase `[ai] max_tokens` in rocky.toml to allow longer generations."
+    )]
+    TokenBudgetExceeded {
+        attempts: usize,
+        consumed_output_tokens: u64,
+        budget: u32,
+    },
 }
 
 /// Response from the LLM.
@@ -68,13 +105,20 @@ pub struct LlmClient {
 impl LlmClient {
     /// Create a new LLM client.
     pub fn new(config: AiConfig) -> Result<Self, AiError> {
-        if config.api_key.is_empty() {
+        if config.api_key.expose().is_empty() {
             return Err(AiError::NoApiKey);
         }
         Ok(Self {
             config,
             http: reqwest::Client::new(),
         })
+    }
+
+    /// `max_tokens` configured for this client. Used as the per-request cap
+    /// on the Anthropic API call and as the cumulative output-token budget
+    /// across retries in the compile-verify loop.
+    pub fn max_tokens(&self) -> u32 {
+        self.config.max_tokens
     }
 
     /// Generate content from a system prompt and user message.
@@ -112,7 +156,7 @@ impl LlmClient {
 
         let body = serde_json::json!({
             "model": self.config.model,
-            "max_tokens": 4096,
+            "max_tokens": self.config.max_tokens,
             "system": system,
             "messages": messages,
         });
@@ -120,7 +164,7 @@ impl LlmClient {
         let response = self
             .http
             .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &self.config.api_key)
+            .header("x-api-key", self.config.api_key.expose())
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
             .json(&body)
@@ -165,6 +209,16 @@ mod tests {
         .unwrap();
         assert_eq!(config.default_format, "rocky");
         assert_eq!(config.max_attempts, 3);
+        assert_eq!(config.max_tokens, DEFAULT_MAX_TOKENS);
+    }
+
+    #[test]
+    fn test_config_max_tokens_override() {
+        let config: AiConfig = serde_json::from_str(
+            r#"{"provider": "anthropic", "model": "m", "api_key": "k", "max_tokens": 8192}"#,
+        )
+        .unwrap();
+        assert_eq!(config.max_tokens, 8192);
     }
 
     #[test]
@@ -172,10 +226,35 @@ mod tests {
         let config = AiConfig {
             provider: "anthropic".to_string(),
             model: "test".to_string(),
-            api_key: String::new(),
+            api_key: RedactedString::new(String::new()),
             default_format: "rocky".to_string(),
             max_attempts: 3,
+            max_tokens: DEFAULT_MAX_TOKENS,
         };
         assert!(LlmClient::new(config).is_err());
+    }
+
+    /// `Debug` on [`AiConfig`] must NOT leak the api_key. Defends against a
+    /// future `tracing::error!(?config)` accidentally exfiltrating the
+    /// credential into log files. Issue 6a.
+    #[test]
+    fn debug_does_not_leak_api_key() {
+        let config = AiConfig {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            api_key: RedactedString::new("sk-ant-supersecret".to_string()),
+            default_format: "rocky".to_string(),
+            max_attempts: 3,
+            max_tokens: DEFAULT_MAX_TOKENS,
+        };
+        let dbg = format!("{config:?}");
+        assert!(
+            !dbg.contains("sk-ant-supersecret"),
+            "AiConfig Debug leaked the api_key: {dbg}"
+        );
+        assert!(
+            dbg.contains("***"),
+            "AiConfig Debug should mask api_key with ***: {dbg}"
+        );
     }
 }

--- a/engine/crates/rocky-ai/src/generate.rs
+++ b/engine/crates/rocky-ai/src/generate.rs
@@ -48,6 +48,16 @@ pub struct ValidationContext<'a> {
 /// lenient on unresolved column references, so this is NOT a hard
 /// "no hallucinated columns" guarantee — the prompt grounding does most of
 /// that work, and warehouse execution catches the rest.
+///
+/// # Token budget
+///
+/// The retry loop tracks cumulative `output_tokens` returned by the LLM
+/// across attempts. When the running total exceeds the client's
+/// `max_tokens` (sourced from `[ai] max_tokens` in `rocky.toml`, default
+/// [`crate::client::DEFAULT_MAX_TOKENS`]), the loop fail-stops with
+/// [`AiError::TokenBudgetExceeded`] instead of issuing another retry.
+/// This bounds the worst-case spend when the LLM produces a runaway
+/// response that fails validation.
 pub async fn generate_model(
     intent: &str,
     model_schemas: &[(String, Vec<TypedColumn>)],
@@ -59,11 +69,19 @@ pub async fn generate_model(
 ) -> Result<GeneratedModel, AiError> {
     let system = prompt::build_system_prompt(model_schemas, source_tables, format);
     let mut error_context: Option<String> = None;
+    let token_budget: u64 = u64::from(client.max_tokens());
+    let mut consumed_output_tokens: u64 = 0;
 
     for attempt in 1..=max_attempts {
         let response = client
             .generate(&system, intent, error_context.as_deref())
             .await?;
+
+        // Track cumulative output tokens. The Anthropic API caps each
+        // individual response at `max_tokens`; this guard prevents a stuck
+        // retry loop from billing N × max_tokens before fail-stopping.
+        consumed_output_tokens =
+            consumed_output_tokens.saturating_add(response.output_tokens.unwrap_or(0));
 
         let source = extract_code(&response.content);
         let validation = validate_generated_code(&source, format, context);
@@ -79,6 +97,19 @@ pub async fn generate_model(
                 });
             }
             Err(errors) => {
+                if consumed_output_tokens > token_budget {
+                    tracing::warn!(
+                        attempt,
+                        consumed_output_tokens,
+                        budget = token_budget,
+                        "AI token budget exceeded; aborting compile-verify retry loop"
+                    );
+                    return Err(AiError::TokenBudgetExceeded {
+                        attempts: attempt,
+                        consumed_output_tokens,
+                        budget: client.max_tokens(),
+                    });
+                }
                 if attempt < max_attempts {
                     tracing::warn!(
                         attempt,

--- a/engine/crates/rocky-ai/src/testgen.rs
+++ b/engine/crates/rocky-ai/src/testgen.rs
@@ -98,20 +98,68 @@ pub async fn generate_tests(
     Ok(assertions)
 }
 
+/// Validate an assertion / model name component before it's interpolated
+/// into a filesystem path.
+///
+/// The LLM controls `assertion.name` end-to-end — left unvalidated, model
+/// output can write `tests/../../etc/passwd.sql` via path traversal.
+/// `model_name` flows from project config rather than the LLM, but the
+/// same allow-list applies for defence-in-depth.
+///
+/// Allow-list: ASCII alphanumeric, `_`, and `-`. Rejects `..`, `.`, `/`,
+/// `\\`, leading dots, empty strings, and any non-ASCII / control chars.
+fn is_safe_path_component(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with('.')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// Save test assertions to SQL files in a tests directory.
+///
+/// Validates `assertion.name` against [`is_safe_path_component`] before
+/// constructing the output path to prevent the LLM from steering writes
+/// outside `tests_dir` via path traversal (`../../etc/passwd`,
+/// absolute paths, etc.). Rejected names produce a
+/// [`std::io::ErrorKind::InvalidInput`] error.
 pub fn save_tests(
     model_name: &str,
     assertions: &[TestAssertion],
     tests_dir: &std::path::Path,
 ) -> Result<(), std::io::Error> {
+    if !is_safe_path_component(model_name) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to save tests: model name {model_name:?} contains \
+                 disallowed characters (allow-list: alphanumeric, _, -)"
+            ),
+        ));
+    }
+
     std::fs::create_dir_all(tests_dir)?;
 
     for assertion in assertions {
-        let file_name = format!(
-            "{}_{}.sql",
-            model_name,
-            assertion.name.replace(' ', "_").to_lowercase()
-        );
+        // The previous behaviour silently lower-cased + space-collapsed the
+        // raw `assertion.name` into the filename. That is unsafe when the
+        // string is LLM-controlled — `..` and `/` slip straight through.
+        // Validate the raw name against a strict allow-list and reject
+        // anything that doesn't match.
+        if !is_safe_path_component(&assertion.name) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "refusing to save test {model_name:?}/{:?}: \
+                     assertion name contains disallowed characters \
+                     (allow-list: alphanumeric, _, -). \
+                     This guards against LLM-driven path traversal.",
+                    assertion.name
+                ),
+            ));
+        }
+
+        let file_name = format!("{}_{}.sql", model_name, assertion.name.to_lowercase());
         let path = tests_dir.join(&file_name);
 
         let content = format!(
@@ -123,4 +171,121 @@ pub fn save_tests(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assertion(name: &str) -> TestAssertion {
+        TestAssertion {
+            name: name.to_string(),
+            sql: "SELECT 1 WHERE 0".to_string(),
+            description: "stub".to_string(),
+        }
+    }
+
+    fn unique_dir(label: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        let dir = std::env::temp_dir().join(format!("rocky-ai-testgen-{label}-{pid}-{nanos}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn safe_path_component_accepts_allow_list() {
+        assert!(is_safe_path_component("grain_uniqueness"));
+        assert!(is_safe_path_component("revenue-positive"));
+        assert!(is_safe_path_component("test123"));
+    }
+
+    #[test]
+    fn safe_path_component_rejects_traversal_and_separators() {
+        assert!(!is_safe_path_component(""));
+        assert!(!is_safe_path_component("."));
+        assert!(!is_safe_path_component(".."));
+        assert!(!is_safe_path_component("../etc/passwd"));
+        assert!(!is_safe_path_component("..\\windows"));
+        assert!(!is_safe_path_component("foo/bar"));
+        assert!(!is_safe_path_component("foo\\bar"));
+        assert!(!is_safe_path_component(".hidden"));
+        assert!(!is_safe_path_component("name with space"));
+        assert!(!is_safe_path_component("name\0null"));
+        // Absolute Unix path
+        assert!(!is_safe_path_component("/etc/passwd"));
+    }
+
+    /// Issue 6b — direct path traversal regression test. The LLM-controlled
+    /// `assertion.name` must never reach `Path::join` unvalidated.
+    #[test]
+    fn save_tests_rejects_path_traversal_in_assertion_name() {
+        let dir = unique_dir("traversal");
+        let assertions = vec![assertion("../../../etc/passwd")];
+
+        let result = save_tests("model", &assertions, &dir);
+
+        let err = result.expect_err("path traversal must be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("disallowed characters"),
+            "unexpected error message: {err}"
+        );
+
+        // The escaped target must NOT exist on disk.
+        assert!(
+            !std::path::Path::new("/etc/passwd_../../../etc/passwd.sql").exists(),
+            "writing to /etc/passwd via traversal would have succeeded"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_tests_rejects_absolute_path_in_assertion_name() {
+        let dir = unique_dir("absolute");
+        let assertions = vec![assertion("/tmp/evil")];
+
+        let result = save_tests("model", &assertions, &dir);
+
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_tests_rejects_dotted_name() {
+        let dir = unique_dir("dotted");
+        let assertions = vec![assertion(".hidden")];
+
+        assert!(save_tests("model", &assertions, &dir).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_tests_rejects_unsafe_model_name() {
+        let dir = unique_dir("unsafe-model");
+        let assertions = vec![assertion("ok_name")];
+
+        assert!(save_tests("../escaped", &assertions, &dir).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_tests_writes_safe_assertion() {
+        let dir = unique_dir("happy");
+        let assertions = vec![assertion("Grain_Uniqueness")];
+
+        save_tests("orders", &assertions, &dir).expect("safe write should succeed");
+
+        let expected = dir.join("orders_grain_uniqueness.sql");
+        assert!(
+            expected.exists(),
+            "expected file to be written at {}",
+            expected.display()
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
-use rocky_ai::client::{AiConfig, LlmClient};
+use rocky_ai::client::{AiConfig, DEFAULT_MAX_TOKENS, LlmClient};
 use rocky_ai::generate;
 use rocky_compiler::compile::{CompileResult, CompilerConfig, compile};
 use rocky_compiler::types::TypedColumn;
+use rocky_core::redacted::RedactedString;
 
 use crate::output::{
     AiExplainOutput, AiExplanation, AiGenerateOutput, AiSyncOutput, AiSyncProposal,
@@ -17,17 +18,30 @@ use crate::output::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ANTHROPIC_API_KEY_VAR: &str = "ANTHROPIC_API_KEY";
 
-/// Create an LLM client from environment.
-fn make_client() -> Result<LlmClient> {
+/// Create an LLM client from environment + project config.
+///
+/// Reads `[ai] max_tokens` from `rocky.toml` when the config loads cleanly;
+/// falls back to [`DEFAULT_MAX_TOKENS`] if the config is missing or
+/// malformed (so `rocky ai` keeps working in greenfield projects without
+/// any `rocky.toml`).
+///
+/// `api_key` is wrapped in [`RedactedString`] so any future `?config` /
+/// `{:?}` formatting in trace output prints `***` instead of the secret.
+fn make_client(config_path: &Path) -> Result<LlmClient> {
     let api_key = std::env::var(ANTHROPIC_API_KEY_VAR)
         .context("ANTHROPIC_API_KEY not set. Set it to use `rocky ai`.")?;
+
+    let max_tokens = rocky_core::config::load_rocky_config(config_path)
+        .map(|cfg| cfg.ai.max_tokens)
+        .unwrap_or(DEFAULT_MAX_TOKENS);
 
     let config = AiConfig {
         provider: "anthropic".to_string(),
         model: "claude-sonnet-4-6".to_string(),
-        api_key,
+        api_key: RedactedString::new(api_key),
         default_format: "rocky".to_string(),
         max_attempts: 3,
+        max_tokens,
     };
 
     LlmClient::new(config).map_err(|e| anyhow::anyhow!("{e}"))
@@ -111,7 +125,7 @@ pub async fn run_ai(
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    let client = make_client()?;
+    let client = make_client(config_path)?;
     let fmt = format.unwrap_or("rocky");
 
     // Best-effort compile of the project to ground the prompt.
@@ -186,7 +200,7 @@ pub async fn run_ai_sync(
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    let client = make_client()?;
+    let client = make_client(config_path)?;
     let result = compile_project(config_path, state_path, models_dir, cache_ttl_override)?;
 
     // For now, use the current compilation as both "previous" and "current".
@@ -289,7 +303,7 @@ pub async fn run_ai_explain(
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    let client = make_client()?;
+    let client = make_client(config_path)?;
     let result = compile_project(config_path, state_path, models_dir, cache_ttl_override)?;
 
     let models_to_explain: Vec<&rocky_core::models::Model> = result
@@ -359,7 +373,7 @@ pub async fn run_ai_test(
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    let client = make_client()?;
+    let client = make_client(config_path)?;
     let result = compile_project(config_path, state_path, models_dir, cache_ttl_override)?;
 
     let models_to_test: Vec<&rocky_core::models::Model> = result

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -310,6 +310,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1758,6 +1758,12 @@ pub struct RockyConfig {
     /// resolution semantics (DAG walk with cycle detection).
     #[serde(default, rename = "role", alias = "roles")]
     pub roles: std::collections::BTreeMap<String, RoleConfig>,
+
+    /// AI intent layer configuration. Currently scopes the per-request and
+    /// cumulative-retry token budget for `rocky ai` / `ai-explain` /
+    /// `ai-sync` / `ai-test`. See [`AiSection`].
+    #[serde(default)]
+    pub ai: AiSection,
 }
 
 impl RockyConfig {
@@ -1852,6 +1858,51 @@ pub struct RunRetryConfig {
     /// `retry.max_retries_per_run` still applies in isolation).
     #[serde(default)]
     pub max_retries_per_run: Option<u32>,
+}
+
+/// Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`,
+/// `rocky ai-sync`, `rocky ai-test`).
+///
+/// `max_tokens` doubles as:
+/// 1. The per-request `max_tokens` cap on the Anthropic Messages API.
+/// 2. The cumulative output-token budget across the compile-verify retry
+///    loop — when the running total exceeds this value, the loop fail-stops
+///    instead of issuing another retry. This bounds the worst-case spend
+///    when the LLM produces runaway responses that fail validation.
+///
+/// The default ([`DEFAULT_AI_MAX_TOKENS`]) preserves Rocky's pre-1.x
+/// hard-coded behaviour. Increase for projects that legitimately need
+/// longer generations (large model surfaces, verbose tests).
+///
+/// ```toml
+/// [ai]
+/// max_tokens = 8192
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AiSection {
+    /// Per-request `max_tokens` and cumulative output-token budget across
+    /// retries. Default [`DEFAULT_AI_MAX_TOKENS`].
+    #[serde(default = "default_ai_max_tokens")]
+    pub max_tokens: u32,
+}
+
+impl Default for AiSection {
+    fn default() -> Self {
+        Self {
+            max_tokens: DEFAULT_AI_MAX_TOKENS,
+        }
+    }
+}
+
+/// Default value for [`AiSection::max_tokens`]. Mirrors
+/// `rocky_ai::client::DEFAULT_MAX_TOKENS`; duplicated as a `const` here so
+/// the schema generator and TOML parser don't need to depend on the AI
+/// crate (which would invert the dependency graph).
+pub const DEFAULT_AI_MAX_TOKENS: u32 = 4096;
+
+fn default_ai_max_tokens() -> u32 {
+    DEFAULT_AI_MAX_TOKENS
 }
 
 /// Schema-only helper that mirrors the deserializer's acceptance of both

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -578,6 +578,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -714,6 +714,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         };
 
         let models = vec![
@@ -793,6 +794,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         };
 
         let models = vec![Model {
@@ -866,6 +868,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None);

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -930,6 +930,7 @@ mod tests {
             mask: Default::default(),
             classifications: Default::default(),
             roles: Default::default(),
+            ai: Default::default(),
         }
     }
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -83,6 +83,26 @@ class AggregateOp5(StrEnum):
     max = "max"
 
 
+class AiSection(BaseModel):
+    """
+    Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`).
+
+    `max_tokens` doubles as: 1. The per-request `max_tokens` cap on the Anthropic Messages API. 2. The cumulative output-token budget across the compile-verify retry loop — when the running total exceeds this value, the loop fail-stops instead of issuing another retry. This bounds the worst-case spend when the LLM produces runaway responses that fail validation.
+
+    The default ([`DEFAULT_AI_MAX_TOKENS`]) preserves Rocky's pre-1.x hard-coded behaviour. Increase for projects that legitimately need longer generations (large model surfaces, verbose tests).
+
+    ```toml [ai] max_tokens = 8192 ```
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    max_tokens: conint(ge=0) | None = 4096
+    """
+    Per-request `max_tokens` and cumulative output-token budget across retries. Default [`DEFAULT_AI_MAX_TOKENS`].
+    """
+
+
 class BindingType(StrEnum):
     """
     Workspace binding access level.
@@ -2296,6 +2316,10 @@ class RockyConfig(BaseModel):
     )
     """
     Named adapter configurations (keyed by adapter name).
+    """
+    ai: AiSection | None = Field({"max_tokens": 4096}, validate_default=True)
+    """
+    AI intent layer configuration. Currently scopes the per-request and cumulative-retry token budget for `rocky ai` / `ai-explain` / `ai-sync` / `ai-test`. See [`AiSection`].
     """
     budget: BudgetConfig | None = Field(
         {"max_duration_ms": None, "max_usd": None, "on_breach": "warn"},

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -327,6 +327,20 @@
         }
       ]
     },
+    "AiSection": {
+      "additionalProperties": false,
+      "description": "Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`).\n\n`max_tokens` doubles as: 1. The per-request `max_tokens` cap on the Anthropic Messages API. 2. The cumulative output-token budget across the compile-verify retry loop — when the running total exceeds this value, the loop fail-stops instead of issuing another retry. This bounds the worst-case spend when the LLM produces runaway responses that fail validation.\n\nThe default ([`DEFAULT_AI_MAX_TOKENS`]) preserves Rocky's pre-1.x hard-coded behaviour. Increase for projects that legitimately need longer generations (large model surfaces, verbose tests).\n\n```toml [ai] max_tokens = 8192 ```",
+      "properties": {
+        "max_tokens": {
+          "default": 4096,
+          "description": "Per-request `max_tokens` and cumulative output-token budget across retries. Default [`DEFAULT_AI_MAX_TOKENS`].",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "BindingType": {
       "description": "Workspace binding access level.",
       "enum": [
@@ -2762,6 +2776,17 @@
       ],
       "default": {},
       "description": "Named adapter configurations (keyed by adapter name)."
+    },
+    "ai": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AiSection"
+        }
+      ],
+      "default": {
+        "max_tokens": 4096
+      },
+      "description": "AI intent layer configuration. Currently scopes the per-request and cumulative-retry token budget for `rocky ai` / `ai-explain` / `ai-sync` / `ai-test`. See [`AiSection`]."
     },
     "budget": {
       "allOf": [


### PR DESCRIPTION
Three issues from the rocky-ai maintenance sweep, landed together since they all touch the same crate and the third one cascades into `rocky-core` and the schema codegen.

## Issue 6a — credential redaction (HIGH/SEC)

`AiConfig` stored `api_key: String` while deriving `Debug + Serialize`. Any future `tracing::error!(?config)` (or `tracing::debug!(?self.config)` inside `LlmClient`) would write the raw API key straight into log files.

Fix: wrap `api_key` in `rocky_core::redacted::RedactedString`, which masks `Debug` and `Display` to `***` by design. The raw value is exposed only at the outbound HTTP boundary in `call_anthropic` via `RedactedString::expose()`. Added a `debug_does_not_leak_api_key` regression test that asserts `format!("{config:?}")` never contains the secret and always contains `***`.

## Issue 6b — testgen path traversal (HIGH/SEC)

`testgen::save_tests` built file paths by joining `tests_dir` with `format!("{model}_{name}.sql", name = assertion.name.replace(' ', "_").to_lowercase())`. The LLM controls `assertion.name` end-to-end, and `..` / `/` / `\` slipped straight through `replace(' ', "_")` — direct path traversal from model output to the filesystem.

Fix: introduced a strict allow-list (`is_safe_path_component`) — ASCII alphanumeric, `_`, `-`, non-empty, no leading dot — and validated both the model name and every assertion name before any `Path::join`. Unsafe input rejects with `io::ErrorKind::InvalidInput`. Added the requested `assertion.name = "../../../etc/passwd"` regression test plus four siblings covering absolute paths, dotted names, unsafe model names, and the happy path.

## Issue 6c — max_tokens hardcoded + unbounded retry budget (MED/PERF + cost)

`call_anthropic` hard-coded `max_tokens: 4096` and `generate_model` retried 3× with no aggregate token / cost / time ceiling. A pathological run could pay for `3 × 4096` output tokens before fail-stopping.

Fix:
- New `[ai] max_tokens = N` config block in `rocky.toml` (default `4096`, preserving prior behaviour) — backed by a new `AiSection` struct wired into `RockyConfig`.
- `AiConfig::max_tokens` is sourced from that config block in `make_client` and used both as the per-request cap on the Anthropic Messages API and as the cumulative output-token budget across retries.
- The compile-verify retry loop in `generate_model` now sums `response.output_tokens` across attempts; when the running total exceeds the budget, it fail-stops with a new `AiError::TokenBudgetExceeded` variant instead of issuing another retry.
- Documented the knob in `docs/src/content/docs/reference/configuration.md` (new `## [ai]` section) and the `docs/src/content/docs/guides/ai-features.md` setup guide.

The Anthropic API caps each individual response at the per-request `max_tokens`, so attempt 1 alone can never trip the budget. The fail-stop kicks in only on attempt ≥ 2 with runaway accumulation — preserving typical-case behaviour while bounding the worst case.

## Codegen cascade

Adding `AiSection` to `RockyConfig` updates the autogenerated `rocky_project.schema.json`, the VS Code project schema and TypeScript types, and the Dagster Pydantic model. All regenerated via `just codegen` and committed in this PR so `codegen-drift.yml` stays green.

## Test plan

- [x] `cd engine && cargo test -p rocky-ai` — 26 passed (includes new Debug-leak + path-traversal regression tests)
- [x] `cd engine && cargo test -p rocky-core` — 1122 passed (covers new `AiSection` field on `RockyConfig`)
- [x] `cd engine && cargo test -p rocky-cli` — 296 passed
- [x] `cd engine && cargo clippy -p rocky-ai --all-targets -- -D warnings` — clean
- [x] `cd engine && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cd engine && cargo fmt --check` — clean
- [x] `just codegen` — regenerated `rocky_project.schema.json`, `editors/vscode/schemas/rocky-project.schema.json`, `editors/vscode/src/types/generated/rocky_project.ts`, `integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py`
- [x] `cd integrations/dagster && uv run pytest` — 458 passed