### PR TITLE
feat(engine): max_bytes_scanned threshold in [budget] block

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -670,22 +670,26 @@ warehouse_size = "Medium"
 
 ## `[budget]`
 
-Declarative run-level cost and duration limits. When a run exceeds a configured limit, Rocky emits a `budget_breach` pipeline event and fires the `HookEvent::BudgetBreach` hook. With `on_breach = "error"` the run also exits non-zero. Unknown fields are rejected.
+Declarative run-level cost, duration, and scan-volume limits. When a run exceeds a configured limit, Rocky emits a `budget_breach` pipeline event and fires the `HookEvent::BudgetBreach` hook. With `on_breach = "error"` the run also exits non-zero. Unknown fields are rejected.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_usd` | float | | Maximum allowed run cost in USD. Cost is computed from per-materialization `cost_usd` values on `RunOutput.cost_summary`. `None` on runs where no adapter produced cost data (e.g. a BigQuery job with no bytes billed). |
 | `max_duration_ms` | integer | | Maximum allowed run wall time in milliseconds. |
+| `max_bytes_scanned` | integer | | Maximum allowed total bytes scanned across every materialization in the run. Useful for CI gates on scan volume even when the dollar cost stays inside `max_usd` (e.g. a BigQuery query that stops pruning partitions). Aggregated from the per-model `bytes_scanned` figures the adapter reports — today that's BigQuery's `totalBytesBilled`; Databricks / Snowflake / DuckDB still inherit `None` and skip the dimension rather than treating "no data" as zero. |
 | `on_breach` | string | `"warn"` | Either `"warn"` (fire the event, keep the run successful) or `"error"` (also fail the run). |
 
 ```toml
 [budget]
 max_usd = 25.0
-max_duration_ms = 900000   # 15 minutes
+max_duration_ms = 900000          # 15 minutes
+max_bytes_scanned = 1099511627776 # 1 TiB
 on_breach = "error"
 ```
 
-The limits are evaluated once per run against observed totals; per-model budgets are a follow-up. Subscribe to `on_budget_breach` under `[hook.*]` to route breaches into a notification system.
+All three limits are independent and composed with all-OR — any single dimension breach trips the `budget_breach` event (and, with `on_breach = "error"`, fails the run). They evaluate once per run against observed totals; per-model budgets are a follow-up. Subscribe to `on_budget_breach` under `[hook.*]` to route breaches into a notification system.
+
+Each [`BudgetBreachOutput`](./json-output) carries a `limit_type` tag — `"max_usd"`, `"max_duration_ms"`, or `"max_bytes_scanned"` — so consumers can branch on the breached dimension without string-matching the human message.
 
 ---
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -214,7 +214,7 @@ Returns a complete summary of the pipeline execution.
 | `anomalies` | array | Row count anomalies detected by historical baseline comparison. |
 | `partition_summaries` | array | Per-model partition execution summaries (present for `time_interval` models). |
 | `cost_summary` | object or absent | Per-run cost rollup: `total_usd` (float or null), `by_adapter` (map of adapter → USD). Present when at least one adapter reports cost data. See [`[budget]`](/reference/configuration/#budget) for how cost limits are enforced. |
-| `budget_breaches` | array | Populated when `[budget]` limits tripped. Each entry has `limit_type` (`"max_usd"` / `"max_duration_ms"`), `limit`, and `actual` (both floats). Empty array when within budget or no limits configured. |
+| `budget_breaches` | array | Populated when `[budget]` limits tripped. Each entry has `limit_type` (`"max_usd"` / `"max_duration_ms"` / `"max_bytes_scanned"`), `limit`, and `actual` (both floats). Empty array when within budget or no limits configured. |
 
 **`materializations[]`:**
 

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -346,8 +346,18 @@
     },
     "BudgetConfig": {
       "additionalProperties": false,
-      "description": "Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.",
+      "description": "Declarative run-level budget for cost, duration, and data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total, the run wall clock, and the aggregate `bytes_scanned` summed across every materialization. Limits are independent and composed with all-OR — any single dimension breach trips the `budget_breach` event. Per-model budgets are deferred to a later wave; the first iteration enforces run-level totals only.",
       "properties": {
+        "max_bytes_scanned": {
+          "default": null,
+          "description": "Maximum allowed total bytes scanned across every materialization in the run. Useful for CI gates that want to fail when a regression bloats scan volume even if the dollar cost stays within `max_usd` (e.g. a BigQuery query that suddenly stops pruning partitions).\n\nAggregated from per-model `bytes_scanned` figures the adapter reports — today that's BigQuery's `totalBytesBilled`; Databricks / Snowflake / DuckDB still inherit `None`, in which case the dimension is skipped rather than treated as zero (matching `max_usd`).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "max_duration_ms": {
           "default": null,
           "description": "Maximum allowed run wall-clock duration in milliseconds.",
@@ -2771,6 +2781,7 @@
         }
       ],
       "default": {
+        "max_bytes_scanned": null,
         "max_duration_ms": null,
         "max_usd": null,
         "on_breach": "warn"

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -492,11 +492,17 @@ export interface RetryConfig {
   max_retries_per_run?: number | null;
 }
 /**
- * Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.
+ * Declarative run-level budget for cost, duration, and data volume. All limits are optional; when unset the dimension is not enforced.
  *
- * A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.
+ * A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total, the run wall clock, and the aggregate `bytes_scanned` summed across every materialization. Limits are independent and composed with all-OR — any single dimension breach trips the `budget_breach` event. Per-model budgets are deferred to a later wave; the first iteration enforces run-level totals only.
  */
 export interface BudgetConfig {
+  /**
+   * Maximum allowed total bytes scanned across every materialization in the run. Useful for CI gates that want to fail when a regression bloats scan volume even if the dollar cost stays within `max_usd` (e.g. a BigQuery query that suddenly stops pruning partitions).
+   *
+   * Aggregated from per-model `bytes_scanned` figures the adapter reports — today that's BigQuery's `totalBytesBilled`; Databricks / Snowflake / DuckDB still inherit `None`, in which case the dimension is skipped rather than treated as zero (matching `max_usd`).
+   */
+  max_bytes_scanned?: number | null;
   /**
    * Maximum allowed run wall-clock duration in milliseconds.
    */

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -157,7 +157,7 @@ export interface BudgetBreachOutput {
   actual: number;
   limit: number;
   /**
-   * Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+   * Which limit was breached: `"max_usd"`, `"max_duration_ms"`, or `"max_bytes_scanned"`.
    */
   limit_type: string;
   [k: string]: unknown;
@@ -181,6 +181,10 @@ export interface RunCostSummary {
    * Per-model cost attribution, ordered as in [`RunOutput::materializations`].
    */
   per_model: ModelCostEntry[];
+  /**
+   * Sum of every per-model `bytes_scanned` that produced a number. `None` when no materialization reported a byte count (the non-BigQuery adapters today, which still inherit the default stub on `WarehouseAdapter::execute_statement_with_stats`). Surfaced so consumers — and the `[budget]` `max_bytes_scanned` gate — can read scan volume without re-walking [`RunOutput::materializations`].
+   */
+  total_bytes_scanned?: number | null;
   /**
    * Sum of every per-model `cost_usd` that produced a number. `None` when no materialization produced a cost.
    */

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`max_bytes_scanned` threshold on the `[budget]` block.** New optional `u64` field alongside `max_usd` and `max_duration_ms` that gates a run on the aggregate `bytes_scanned` summed across every materialization in `RunCostSummary`. Closes the post-launch user-feedback gap that "fail CI when this run scanned more than N TB" wasn't expressible — `max_usd` is correlated with scan volume but a regression that stops pruning partitions on a flat-rate warehouse can blow scan up without changing the dollar figure. Composes with the existing thresholds: any single dimension breach trips the `budget_breach` event, and (with `on_breach = "error"`) fails the run. New `BudgetLimitType::MaxBytesScanned` variant; the limit_type tag on each `BudgetBreach` / `BudgetBreachOutput` is `"max_bytes_scanned"`. `RunCostSummary` now carries `total_bytes_scanned: Option<u64>` so consumers can read the aggregate without re-walking `materializations`. Skipped (rather than treated as zero) when no adapter reports a byte count, matching `max_usd`.
+
 ## [1.17.4] — 2026-04-26
 
 Trust-system patch + minor data-cost fix. Closes a data-integrity hazard in `rocky discover` where a transient Fivetran 5xx or rate-limit window on a single connector could silently drop that connector from output, indistinguishable from "removed upstream" to downstream diff-based reconcilers (the asset-graph-shrinkage failure mode that took down a Dagster sensor in production with `DagsterInvalidSubsetError`). Same shape of bug Gold patched on the dbt path in commit `c43394d`. Bundled with an Arc 2 wave 3 residual: derived transformation models now report real `bytes_scanned` / `bytes_written` to `rocky cost` instead of dropping the warehouse-reported `ExecutionStats` on the floor.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2803,7 +2803,9 @@ mod cost_finalize_tests {
         out.materializations.push(m2);
         out.populate_cost_summary("bigquery", &CostSection::default());
         assert_eq!(
-            out.cost_summary.as_ref().and_then(|s| s.total_bytes_scanned),
+            out.cost_summary
+                .as_ref()
+                .and_then(|s| s.total_bytes_scanned),
             Some(2_000_000),
         );
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -276,6 +276,15 @@ pub struct RunCostSummary {
     /// governance overhead) so budget enforcement can target
     /// model-compute time specifically.
     pub total_duration_ms: u64,
+    /// Sum of every per-model `bytes_scanned` that produced a number.
+    /// `None` when no materialization reported a byte count (the
+    /// non-BigQuery adapters today, which still inherit the default
+    /// stub on `WarehouseAdapter::execute_statement_with_stats`).
+    /// Surfaced so consumers — and the `[budget]` `max_bytes_scanned`
+    /// gate — can read scan volume without re-walking
+    /// [`RunOutput::materializations`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_bytes_scanned: Option<u64>,
     /// Per-model cost attribution, ordered as in
     /// [`RunOutput::materializations`].
     pub per_model: Vec<ModelCostEntry>,
@@ -293,7 +302,8 @@ pub struct RunCostSummary {
 /// `BudgetBreach` one-to-one.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct BudgetBreachOutput {
-    /// Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+    /// Which limit was breached: `"max_usd"`, `"max_duration_ms"`, or
+    /// `"max_bytes_scanned"`.
     pub limit_type: String,
     pub limit: f64,
     pub actual: f64,
@@ -2195,6 +2205,8 @@ impl RunOutput {
         let mut any_cost_computed = false;
         let mut total_cost = 0.0;
         let mut total_duration_ms: u64 = 0;
+        let mut any_bytes_reported = false;
+        let mut total_bytes: u64 = 0;
 
         for mat in &mut self.materializations {
             // BigQuery: `mat.bytes_scanned` is populated by the adapter
@@ -2218,6 +2230,10 @@ impl RunOutput {
                 total_cost += c;
             }
             total_duration_ms = total_duration_ms.saturating_add(mat.duration_ms);
+            if let Some(b) = mat.bytes_scanned {
+                any_bytes_reported = true;
+                total_bytes = total_bytes.saturating_add(b);
+            }
             per_model.push(ModelCostEntry {
                 asset_key: mat.asset_key.clone(),
                 duration_ms: mat.duration_ms,
@@ -2230,10 +2246,16 @@ impl RunOutput {
         } else {
             None
         };
+        let total_bytes_scanned = if any_bytes_reported {
+            Some(total_bytes)
+        } else {
+            None
+        };
 
         self.cost_summary = Some(RunCostSummary {
             total_cost_usd,
             total_duration_ms,
+            total_bytes_scanned,
             per_model,
             adapter_type: adapter_type.to_string(),
         });
@@ -2264,7 +2286,11 @@ impl RunOutput {
         }
 
         let observed_cost = self.cost_summary.as_ref().and_then(|s| s.total_cost_usd);
-        let breaches = budget_cfg.check_breaches(observed_cost, self.duration_ms);
+        let observed_bytes = self
+            .cost_summary
+            .as_ref()
+            .and_then(|s| s.total_bytes_scanned);
+        let breaches = budget_cfg.check_breaches(observed_cost, self.duration_ms, observed_bytes);
         if breaches.is_empty() {
             return Ok(());
         }
@@ -2737,6 +2763,7 @@ mod cost_finalize_tests {
         let budget = BudgetConfig {
             max_usd: Some(5.0),
             max_duration_ms: Some(60_000),
+            max_bytes_scanned: None,
             on_breach: BudgetBreachAction::Warn,
         };
         assert!(out.check_and_record_budget(&budget, Some("run-1")).is_ok());
@@ -2751,12 +2778,62 @@ mod cost_finalize_tests {
         let budget = BudgetConfig {
             max_usd: None,
             max_duration_ms: Some(60_000),
+            max_bytes_scanned: None,
             on_breach: BudgetBreachAction::Error,
         };
         let result = out.check_and_record_budget(&budget, None);
         assert!(result.is_err(), "error mode must return Err on breach");
         assert_eq!(out.budget_breaches.len(), 1);
         assert_eq!(out.budget_breaches[0].limit_type, "max_duration_ms");
+    }
+
+    #[test]
+    fn check_and_record_budget_trips_on_max_bytes_scanned() {
+        // Synthetic run: two BigQuery-style materializations each
+        // reporting 1_000_000 bytes scanned. With
+        // `max_bytes_scanned = 1_000_000`, total of 2_000_000 must
+        // trip the breach and (because `on_breach = "error"`) return
+        // `Err`.
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        let mut m1 = mat(&["a"], 500);
+        m1.bytes_scanned = Some(1_000_000);
+        let mut m2 = mat(&["b"], 500);
+        m2.bytes_scanned = Some(1_000_000);
+        out.materializations.push(m1);
+        out.materializations.push(m2);
+        out.populate_cost_summary("bigquery", &CostSection::default());
+        assert_eq!(
+            out.cost_summary.as_ref().and_then(|s| s.total_bytes_scanned),
+            Some(2_000_000),
+        );
+
+        let budget = BudgetConfig {
+            max_usd: None,
+            max_duration_ms: None,
+            max_bytes_scanned: Some(1_000_000),
+            on_breach: BudgetBreachAction::Error,
+        };
+        let result = out.check_and_record_budget(&budget, Some("run-bytes"));
+        assert!(result.is_err(), "scan-volume breach must return Err");
+        assert_eq!(out.budget_breaches.len(), 1);
+        assert_eq!(out.budget_breaches[0].limit_type, "max_bytes_scanned");
+        assert!((out.budget_breaches[0].limit - 1_000_000.0).abs() < f64::EPSILON);
+        assert!((out.budget_breaches[0].actual - 2_000_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn check_and_record_budget_no_breach_when_max_bytes_scanned_unset() {
+        // Same synthetic 2 MB run, but `max_bytes_scanned` defaults to
+        // `None` — no breach regardless of scan total.
+        let mut out = RunOutput::new(String::new(), 1_000, 1);
+        let mut m = mat(&["a"], 500);
+        m.bytes_scanned = Some(2_000_000);
+        out.materializations.push(m);
+        out.populate_cost_summary("bigquery", &CostSection::default());
+
+        let budget = BudgetConfig::default();
+        assert!(out.check_and_record_budget(&budget, None).is_ok());
+        assert!(out.budget_breaches.is_empty());
     }
 }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1316,14 +1316,16 @@ pub enum BudgetBreachAction {
     Error,
 }
 
-/// Declarative run-level budget for cost, duration, and (future) data
-/// volume. All limits are optional; when unset the dimension is not
-/// enforced.
+/// Declarative run-level budget for cost, duration, and data volume.
+/// All limits are optional; when unset the dimension is not enforced.
 ///
 /// A breach is detected at end of run by comparing [`BudgetConfig`]
-/// against the observed [`crate::cost::compute_observed_cost_usd`] total
-/// and the run wall clock. Per-model budgets are deferred to a later
-/// wave — the first iteration enforces run-level totals only.
+/// against the observed [`crate::cost::compute_observed_cost_usd`]
+/// total, the run wall clock, and the aggregate `bytes_scanned` summed
+/// across every materialization. Limits are independent and composed
+/// with all-OR — any single dimension breach trips the
+/// `budget_breach` event. Per-model budgets are deferred to a later
+/// wave; the first iteration enforces run-level totals only.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BudgetConfig {
@@ -1337,6 +1339,20 @@ pub struct BudgetConfig {
     #[serde(default)]
     pub max_duration_ms: Option<u64>,
 
+    /// Maximum allowed total bytes scanned across every materialization
+    /// in the run. Useful for CI gates that want to fail when a
+    /// regression bloats scan volume even if the dollar cost stays
+    /// within `max_usd` (e.g. a BigQuery query that suddenly stops
+    /// pruning partitions).
+    ///
+    /// Aggregated from per-model `bytes_scanned` figures the adapter
+    /// reports — today that's BigQuery's `totalBytesBilled`; Databricks
+    /// / Snowflake / DuckDB still inherit `None`, in which case the
+    /// dimension is skipped rather than treated as zero (matching
+    /// `max_usd`).
+    #[serde(default)]
+    pub max_bytes_scanned: Option<u64>,
+
     /// What to do when a limit is breached. Defaults to `warn` — fire the
     /// event, keep the run successful. Set to `error` to fail the run.
     #[serde(default)]
@@ -1347,7 +1363,9 @@ impl BudgetConfig {
     /// True when no limit is configured — skip budget checking entirely.
     #[must_use]
     pub fn is_unset(&self) -> bool {
-        self.max_usd.is_none() && self.max_duration_ms.is_none()
+        self.max_usd.is_none()
+            && self.max_duration_ms.is_none()
+            && self.max_bytes_scanned.is_none()
     }
 
     /// Compare observed totals against each configured limit.
@@ -1357,12 +1375,14 @@ impl BudgetConfig {
     /// `observed_cost_usd` is `None` when the adapters didn't produce
     /// enough data to compute a cost (e.g. BigQuery with no bytes
     /// reported); in that case the cost dimension is skipped rather
-    /// than treated as zero.
+    /// than treated as zero. `observed_bytes_scanned` follows the same
+    /// rule — `None` when no materialization reported a byte count.
     #[must_use]
     pub fn check_breaches(
         &self,
         observed_cost_usd: Option<f64>,
         observed_duration_ms: u64,
+        observed_bytes_scanned: Option<u64>,
     ) -> Vec<BudgetBreach> {
         let mut breaches = Vec::new();
 
@@ -1386,6 +1406,16 @@ impl BudgetConfig {
             });
         }
 
+        if let (Some(limit), Some(actual)) = (self.max_bytes_scanned, observed_bytes_scanned)
+            && actual > limit
+        {
+            breaches.push(BudgetBreach {
+                limit_type: BudgetLimitType::MaxBytesScanned,
+                limit: limit as f64,
+                actual: actual as f64,
+            });
+        }
+
         breaches
     }
 }
@@ -1397,6 +1427,7 @@ impl BudgetConfig {
 pub enum BudgetLimitType {
     MaxUsd,
     MaxDurationMs,
+    MaxBytesScanned,
 }
 
 impl BudgetLimitType {
@@ -1407,6 +1438,7 @@ impl BudgetLimitType {
         match self {
             BudgetLimitType::MaxUsd => "max_usd",
             BudgetLimitType::MaxDurationMs => "max_duration_ms",
+            BudgetLimitType::MaxBytesScanned => "max_bytes_scanned",
         }
     }
 }
@@ -5468,11 +5500,13 @@ concurrency = "turbo"
         let toml_str = r#"
 max_usd = 25.0
 max_duration_ms = 900000
+max_bytes_scanned = 1099511627776
 on_breach = "error"
 "#;
         let cfg: BudgetConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(cfg.max_usd, Some(25.0));
         assert_eq!(cfg.max_duration_ms, Some(900_000));
+        assert_eq!(cfg.max_bytes_scanned, Some(1_099_511_627_776));
         assert_eq!(cfg.on_breach, BudgetBreachAction::Error);
     }
 
@@ -5491,9 +5525,13 @@ max_rows = 1000000
         let cfg = BudgetConfig {
             max_usd: Some(10.0),
             max_duration_ms: Some(60_000),
+            max_bytes_scanned: Some(1_000_000),
             on_breach: BudgetBreachAction::Warn,
         };
-        assert!(cfg.check_breaches(Some(9.0), 30_000).is_empty());
+        assert!(
+            cfg.check_breaches(Some(9.0), 30_000, Some(500_000))
+                .is_empty()
+        );
     }
 
     #[test]
@@ -5501,9 +5539,10 @@ max_rows = 1000000
         let cfg = BudgetConfig {
             max_usd: Some(10.0),
             max_duration_ms: None,
+            max_bytes_scanned: None,
             on_breach: BudgetBreachAction::Error,
         };
-        let breaches = cfg.check_breaches(Some(15.0), 0);
+        let breaches = cfg.check_breaches(Some(15.0), 0, None);
         assert_eq!(breaches.len(), 1);
         assert_eq!(breaches[0].limit_type, BudgetLimitType::MaxUsd);
         assert_eq!(breaches[0].limit, 10.0);
@@ -5515,9 +5554,10 @@ max_rows = 1000000
         let cfg = BudgetConfig {
             max_usd: None,
             max_duration_ms: Some(60_000),
+            max_bytes_scanned: None,
             on_breach: BudgetBreachAction::Warn,
         };
-        let breaches = cfg.check_breaches(None, 120_000);
+        let breaches = cfg.check_breaches(None, 120_000, None);
         assert_eq!(breaches.len(), 1);
         assert_eq!(breaches[0].limit_type, BudgetLimitType::MaxDurationMs);
     }
@@ -5529,20 +5569,62 @@ max_rows = 1000000
         let cfg = BudgetConfig {
             max_usd: Some(10.0),
             max_duration_ms: None,
+            max_bytes_scanned: None,
             on_breach: BudgetBreachAction::Warn,
         };
-        assert!(cfg.check_breaches(None, 0).is_empty());
+        assert!(cfg.check_breaches(None, 0, None).is_empty());
     }
 
     #[test]
-    fn budget_check_breaches_handles_both_limits() {
+    fn budget_check_breaches_handles_all_limits() {
         let cfg = BudgetConfig {
             max_usd: Some(5.0),
             max_duration_ms: Some(60_000),
+            max_bytes_scanned: Some(1_000_000),
             on_breach: BudgetBreachAction::Warn,
         };
-        let breaches = cfg.check_breaches(Some(12.0), 90_000);
-        assert_eq!(breaches.len(), 2);
+        let breaches = cfg.check_breaches(Some(12.0), 90_000, Some(2_000_000));
+        assert_eq!(breaches.len(), 3);
+    }
+
+    #[test]
+    fn budget_check_breaches_flags_bytes_over() {
+        // HackerNews-driven feature: a CI gate that fails the run when
+        // total scan volume crosses a threshold (e.g. 1 TB).
+        let cfg = BudgetConfig {
+            max_usd: None,
+            max_duration_ms: None,
+            max_bytes_scanned: Some(1_000_000),
+            on_breach: BudgetBreachAction::Error,
+        };
+        let breaches = cfg.check_breaches(None, 0, Some(2_000_000));
+        assert_eq!(breaches.len(), 1);
+        assert_eq!(breaches[0].limit_type, BudgetLimitType::MaxBytesScanned);
+        assert!((breaches[0].limit - 1_000_000.0).abs() < f64::EPSILON);
+        assert!((breaches[0].actual - 2_000_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn budget_check_breaches_skips_bytes_when_unknown() {
+        // Adapters that don't report `bytes_scanned` (Databricks /
+        // Snowflake / DuckDB today) skip the dimension rather than
+        // treating "no data" as zero.
+        let cfg = BudgetConfig {
+            max_usd: None,
+            max_duration_ms: None,
+            max_bytes_scanned: Some(1_000_000),
+            on_breach: BudgetBreachAction::Warn,
+        };
+        assert!(cfg.check_breaches(None, 0, None).is_empty());
+    }
+
+    #[test]
+    fn budget_check_breaches_no_breach_when_bytes_unset_default() {
+        // Default `BudgetConfig` (no `max_bytes_scanned`) never trips a
+        // bytes breach regardless of the observed scan volume.
+        let cfg = BudgetConfig::default();
+        let breaches = cfg.check_breaches(None, 0, Some(u64::MAX));
+        assert!(breaches.is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1363,9 +1363,7 @@ impl BudgetConfig {
     /// True when no limit is configured — skip budget checking entirely.
     #[must_use]
     pub fn is_unset(&self) -> bool {
-        self.max_usd.is_none()
-            && self.max_duration_ms.is_none()
-            && self.max_bytes_scanned.is_none()
+        self.max_usd.is_none() && self.max_duration_ms.is_none() && self.max_bytes_scanned.is_none()
     }
 
     /// Compare observed totals against each configured limit.

--- a/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
@@ -84,6 +84,7 @@ from .compile_schema import (
 from .discover_schema import (
     ChecksConfigOutput,
     DiscoverOutput,
+    FailedSourceOutput,
     FreshnessConfigOutput,
     SourceOutput,
     TableOutput,
@@ -249,6 +250,7 @@ __all__ = [
     # discover
     "ChecksConfigOutput",
     "DiscoverOutput",
+    "FailedSourceOutput",
     "FreshnessConfigOutput",
     "SourceOutput",
     "TableOutput",

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -105,14 +105,20 @@ class BudgetBreachAction(StrEnum):
 
 class BudgetConfig(BaseModel):
     """
-    Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.
+    Declarative run-level budget for cost, duration, and data volume. All limits are optional; when unset the dimension is not enforced.
 
-    A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.
+    A breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total, the run wall clock, and the aggregate `bytes_scanned` summed across every materialization. Limits are independent and composed with all-OR — any single dimension breach trips the `budget_breach` event. Per-model budgets are deferred to a later wave; the first iteration enforces run-level totals only.
     """
 
     model_config = ConfigDict(
         extra="forbid",
     )
+    max_bytes_scanned: conint(ge=0) | None = None
+    """
+    Maximum allowed total bytes scanned across every materialization in the run. Useful for CI gates that want to fail when a regression bloats scan volume even if the dollar cost stays within `max_usd` (e.g. a BigQuery query that suddenly stops pruning partitions).
+
+    Aggregated from per-model `bytes_scanned` figures the adapter reports — today that's BigQuery's `totalBytesBilled`; Databricks / Snowflake / DuckDB still inherit `None`, in which case the dimension is skipped rather than treated as zero (matching `max_usd`).
+    """
     max_duration_ms: conint(ge=0) | None = None
     """
     Maximum allowed run wall-clock duration in milliseconds.
@@ -2298,7 +2304,12 @@ class RockyConfig(BaseModel):
     Named adapter configurations (keyed by adapter name).
     """
     budget: BudgetConfig | None = Field(
-        {"max_duration_ms": None, "max_usd": None, "on_breach": "warn"},
+        {
+            "max_bytes_scanned": None,
+            "max_duration_ms": None,
+            "max_usd": None,
+            "on_breach": "warn",
+        },
         validate_default=True,
     )
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -31,7 +31,7 @@ class BudgetBreachOutput(BaseModel):
     limit: float
     limit_type: str
     """
-    Which limit was breached: `"max_usd"` or `"max_duration_ms"`.
+    Which limit was breached: `"max_usd"`, `"max_duration_ms"`, or `"max_bytes_scanned"`.
     """
 
 
@@ -241,6 +241,10 @@ class RunCostSummary(BaseModel):
     per_model: list[ModelCostEntry]
     """
     Per-model cost attribution, ordered as in [`RunOutput::materializations`].
+    """
+    total_bytes_scanned: conint(ge=0) | None = None
+    """
+    Sum of every per-model `bytes_scanned` that produced a number. `None` when no materialization reported a byte count (the non-BigQuery adapters today, which still inherit the default stub on `WarehouseAdapter::execute_statement_with_stats`). Surfaced so consumers — and the `[budget]` `max_bytes_scanned` gate — can read scan volume without re-walking [`RunOutput::materializations`].
     """
     total_cost_usd: float | None = None
     """

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -345,8 +345,18 @@
     },
     "BudgetConfig": {
       "additionalProperties": false,
-      "description": "Declarative run-level budget for cost, duration, and (future) data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total and the run wall clock. Per-model budgets are deferred to a later wave — the first iteration enforces run-level totals only.",
+      "description": "Declarative run-level budget for cost, duration, and data volume. All limits are optional; when unset the dimension is not enforced.\n\nA breach is detected at end of run by comparing [`BudgetConfig`] against the observed [`crate::cost::compute_observed_cost_usd`] total, the run wall clock, and the aggregate `bytes_scanned` summed across every materialization. Limits are independent and composed with all-OR — any single dimension breach trips the `budget_breach` event. Per-model budgets are deferred to a later wave; the first iteration enforces run-level totals only.",
       "properties": {
+        "max_bytes_scanned": {
+          "default": null,
+          "description": "Maximum allowed total bytes scanned across every materialization in the run. Useful for CI gates that want to fail when a regression bloats scan volume even if the dollar cost stays within `max_usd` (e.g. a BigQuery query that suddenly stops pruning partitions).\n\nAggregated from per-model `bytes_scanned` figures the adapter reports — today that's BigQuery's `totalBytesBilled`; Databricks / Snowflake / DuckDB still inherit `None`, in which case the dimension is skipped rather than treated as zero (matching `max_usd`).",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "max_duration_ms": {
           "default": null,
           "description": "Maximum allowed run wall-clock duration in milliseconds.",
@@ -2770,6 +2780,7 @@
         }
       ],
       "default": {
+        "max_bytes_scanned": null,
         "max_duration_ms": null,
         "max_usd": null,
         "on_breach": "warn"

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -45,7 +45,7 @@
           "type": "number"
         },
         "limit_type": {
-          "description": "Which limit was breached: `\"max_usd\"` or `\"max_duration_ms\"`.",
+          "description": "Which limit was breached: `\"max_usd\"`, `\"max_duration_ms\"`, or `\"max_bytes_scanned\"`.",
           "type": "string"
         }
       },
@@ -754,6 +754,15 @@
             "$ref": "#/definitions/ModelCostEntry"
           },
           "type": "array"
+        },
+        "total_bytes_scanned": {
+          "description": "Sum of every per-model `bytes_scanned` that produced a number. `None` when no materialization reported a byte count (the non-BigQuery adapters today, which still inherit the default stub on `WarehouseAdapter::execute_statement_with_stats`). Surfaced so consumers — and the `[budget]` `max_bytes_scanned` gate — can read scan volume without re-walking [`RunOutput::materializations`].",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "total_cost_usd": {
           "description": "Sum of every per-model `cost_usd` that produced a number. `None` when no materialization produced a cost.",


### PR DESCRIPTION
## Summary

Adds `max_bytes_scanned: Option<u64>` to the `[budget]` block, gating a run on aggregate `bytes_scanned` summed across every materialization.

- New variant `BudgetLimitType::MaxBytesScanned` with `"max_bytes_scanned"` `limit_type` tag on `BudgetBreach` / `BudgetBreachOutput`.
- `RunCostSummary.total_bytes_scanned: Option<u64>` so consumers can read the aggregate without re-walking `materializations`.
- Skipped (rather than treated as zero) when no adapter reports a byte count, matching `max_usd`.

### Composition with the existing thresholds

`max_usd`, `max_duration_ms`, and the new `max_bytes_scanned` are independent and composed with all-OR — any single dimension breach trips the `budget_breach` PipelineEvent + `HookEvent::BudgetBreach` hook, and (with `on_breach = \"error\"`) fails the run. They evaluate once per run against observed totals; per-model budgets remain a follow-up wave.

### Why

Post-launch user feedback that \"fail CI when this run scanned more than N TB\" wasn't expressible. `max_usd` correlates with scan volume on per-byte warehouses but a regression that stops pruning partitions can blow scan up without changing the dollar figure (or on flat-rate warehouses, change neither).

## Test plan

- [x] `cd engine && cargo test -p rocky-cli -p rocky-core` (all green; new tests added below)
- [x] `cd engine && cargo clippy -p rocky-cli -p rocky-core --all-targets -- -D warnings`
- [x] `cd engine && cargo fmt --check`
- [x] `just codegen` is idempotent on second run (committed bindings match generator)

New unit tests:

- `rocky-core::config::budget_check_breaches_flags_bytes_over` — `max_bytes_scanned = 1_000_000`, observed 2_000_000 trips one breach with `MaxBytesScanned` and the right limit/actual values.
- `rocky-core::config::budget_check_breaches_skips_bytes_when_unknown` — `max_bytes_scanned = 1_000_000` but no observed bytes returns no breach (skipped, not zero).
- `rocky-core::config::budget_check_breaches_no_breach_when_bytes_unset_default` — `BudgetConfig::default()` never trips even with `u64::MAX` observed.
- `rocky-core::config::budget_check_breaches_handles_all_limits` — three thresholds set, three breaches when all overshoot.
- `rocky-core::config::budget_parses_from_toml` — extended to round-trip `max_bytes_scanned`.
- `rocky-cli::output::check_and_record_budget_trips_on_max_bytes_scanned` — synthetic 2-mat BigQuery run summing to 2 MB trips the breach via `RunOutput::check_and_record_budget` with `on_breach = \"error\"`, returns `Err` and records one `BudgetBreachOutput { limit_type = \"max_bytes_scanned\" }`.
- `rocky-cli::output::check_and_record_budget_no_breach_when_max_bytes_scanned_unset` — same input shape with default `BudgetConfig` (all `None`) returns `Ok(())` and an empty breaches list regardless of scan total.

Also extended the existing `budget_check_breaches_*` tests to the new 3-arg `check_breaches` signature.

## Docs

- `docs/src/content/docs/reference/configuration.md` — `[budget]` table now lists `max_bytes_scanned` with the same warehouse-coverage caveat as the other dimensions; example `rocky.toml` includes the new field; \"all three limits are independent and composed with all-OR\" framing added.
- `docs/src/content/docs/reference/json-output.md` — `budget_breaches` row now lists the third valid `limit_type`.
- `engine/CHANGELOG.md` — Unreleased / Added entry.