### PR TITLE
fix(dagster): propagate ValidationError, dev-suffix versions, sanitize pr_number, parallelize lineage

### DIFF
--- a/integrations/dagster/src/dagster_rocky/branch_deploy.py
+++ b/integrations/dagster/src/dagster_rocky/branch_deploy.py
@@ -117,6 +117,24 @@ def branch_deployment_info(env: dict[str, str] | None = None) -> BranchDeploymen
     )
 
 
+def _is_safe_pr_number(raw: str) -> bool:
+    """Return ``True`` when ``raw`` is a positive integer in string form.
+
+    The PR number is sourced from ``DAGSTER_CLOUD_PULL_REQUEST_ID`` and
+    flows verbatim into a SQL identifier suffix. Dagster+ controls the
+    env var in production, but mirroring or webhook-driven deployments
+    can place untrusted strings in front of it. Anything that isn't a
+    positive integer is rejected — the caller falls through to the
+    sanitized ``deployment_name`` branch instead, so a branch deployment
+    still gets a shadow suffix, just not one carrying the malformed
+    input.
+    """
+    if not raw or not raw.isdigit():
+        return False
+    # `isdigit()` guarantees ascii digits only; ``int`` parse won't raise.
+    return int(raw) > 0
+
+
 def branch_deploy_shadow_suffix(
     info: BranchDeploymentInfo | None = None,
 ) -> str | None:
@@ -130,8 +148,13 @@ def branch_deploy_shadow_suffix(
     The suffix is namespaced to keep parallel PRs isolated and to avoid
     collisions with manual ``rocky run --shadow`` invocations:
 
-      - PR-driven branch deploy: ``"_dagster_pr_<pr_number>"``
+      - PR-driven branch deploy with a *valid* numeric PR id:
+        ``"_dagster_pr_<pr_number>"``
+      - PR-driven branch deploy with an unparseable / non-numeric PR id:
+        falls through to the deployment-name branch (rejected: never
+        interpolated raw)
       - API-driven branch deploy: ``"_dagster_<deployment_name>"``
+        (with non-alphanumeric chars collapsed to underscores)
       - Anything else (production / non-Dagster+): ``None``
 
     Args:
@@ -141,7 +164,7 @@ def branch_deploy_shadow_suffix(
     info = info if info is not None else branch_deployment_info()
     if not info.is_branch_deployment:
         return None
-    if info.pr_number:
+    if info.pr_number and _is_safe_pr_number(info.pr_number):
         return f"_dagster_pr_{info.pr_number}"
     if info.deployment_name:
         # Sanitize: replace any character that isn't safe in a SQL

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -26,6 +26,7 @@ import json
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
@@ -42,6 +43,7 @@ from dagster.components.utils.defs_state import (
 from dagster.components.utils.project_paths import get_local_state_path
 from dagster.components.utils.translation import TranslationFn, TranslationFnResolver
 from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManagementType
+from pydantic import ValidationError
 
 from .checks import check_metadata
 from .column_lineage import build_column_lineage
@@ -83,6 +85,48 @@ from .types import (
 )
 
 _log = logging.getLogger(__name__)
+
+#: Maximum bytes of the Pydantic ``ValidationError`` payload surfaced in the
+#: schema-mismatch ``dg.Failure``. Engine schema breaks can produce hundreds of
+#: nested validation paths; a hard cap keeps the run-viewer message scannable
+#: without losing the leading errors that pinpoint the drifted field.
+_VALIDATION_ERROR_PREVIEW_BYTES: int = 1500
+
+#: Worker cap for the parallel ``rocky lineage`` fan-out in
+#: :meth:`RockyComponent._collect_lineage`. Each worker spawns a full
+#: ``rocky lineage`` subprocess that compiles every model in
+#: ``models_dir``, so memory grows linearly with worker count. Eight
+#: keeps cold-start fast (~Nx speedup vs. serial) without OOM-ing the
+#: code-server pod on large model trees.
+_COLUMN_LINEAGE_MAX_WORKERS: int = 8
+
+
+def _engine_schema_mismatch_failure(command: str, exc: ValidationError) -> dg.Failure:
+    """Build a ``dg.Failure`` for a Pydantic schema-mismatch on ``rocky <command>``.
+
+    A ``ValidationError`` from a CLI output parse almost always means the
+    installed ``rocky`` binary emits a JSON shape that ``dagster-rocky``
+    does not recognise — typically because the two were built from
+    different versions. Surface that as a structured failure so the
+    operator sees an actionable message instead of a missing
+    checks/freshness slot.
+    """
+    detail = str(exc)
+    if len(detail) > _VALIDATION_ERROR_PREVIEW_BYTES:
+        detail = detail[:_VALIDATION_ERROR_PREVIEW_BYTES] + " …(truncated)"
+    return dg.Failure(
+        description=(
+            f"Engine output schema mismatch on `rocky {command}` — `dagster-rocky` "
+            f"was built against a different `rocky` binary version. "
+            f"Run `rocky --version` to confirm the installed engine, then either "
+            f"upgrade the binary or pin `dagster-rocky` to the matching release."
+        ),
+        metadata={
+            "command": dg.MetadataValue.text(command),
+            "validation_error": dg.MetadataValue.text(detail),
+        },
+    )
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -506,11 +550,30 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 )
 
     def _compile_payload(self, rocky: RockyResource) -> dict | None:
-        """Return compile JSON, or ``None`` if compile cannot/should not run."""
+        """Return compile JSON, or ``None`` if compile cannot/should not run.
+
+        Schema-validation failures (Pydantic ``ValidationError``) are *not*
+        swallowed: they almost always mean ``dagster-rocky`` was built
+        against a different ``rocky`` binary version, and silently dropping
+        the compile slot would make checks/freshness vanish without any
+        operator-visible signal. Those re-raise as ``dg.Failure``. All
+        other failures (missing binary, subprocess timeout, malformed
+        JSON, OOM) remain best-effort: they log and omit the slot.
+        """
         if not Path(self.models_dir).is_dir():
             return None
         try:
             return json.loads(rocky.compile().model_dump_json())
+        except ValidationError as exc:
+            raise _engine_schema_mismatch_failure("compile", exc) from exc
+        except dg.Failure as exc:
+            if isinstance(exc.__cause__, ValidationError):
+                raise
+            _log.warning(
+                "rocky compile failed during state write — slot omitted",
+                exc_info=True,
+            )
+            return None
         except Exception:
             # Compile is best-effort: missing binary, partial errors,
             # subprocess timeouts, OOM during large dumps, and malformed
@@ -526,12 +589,23 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     def _optimize_payload(self, rocky: RockyResource) -> dict | None:
         """Return optimize JSON, or ``None`` if optimize cannot run.
 
-        Same best-effort semantics as ``_compile_payload``: a missing binary
-        or empty run history (no recommendations) does not block state
-        persistence.
+        Same best-effort semantics as ``_compile_payload`` for transport
+        errors (missing binary, empty run history, subprocess failure).
+        Schema-validation failures (``ValidationError``) propagate as
+        ``dg.Failure`` — see ``_compile_payload`` for the rationale.
         """
         try:
             return json.loads(rocky.optimize().model_dump_json())
+        except ValidationError as exc:
+            raise _engine_schema_mismatch_failure("optimize", exc) from exc
+        except dg.Failure as exc:
+            if isinstance(exc.__cause__, ValidationError):
+                raise
+            _log.warning(
+                "rocky optimize failed during state write — slot omitted",
+                exc_info=True,
+            )
+            return None
         except Exception:
             _log.warning(
                 "rocky optimize failed during state write — slot omitted",
@@ -678,15 +752,23 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         ``rocky lineage --target <model>`` once per model; failures (binary
         missing, lineage compile error, malformed SQL) log and skip that
         entry.
+
+        The per-model ``rocky lineage`` invocations are dispatched via a
+        bounded :class:`ThreadPoolExecutor` so a project with N models
+        does not pay N times the cold-start latency. Worker count is
+        capped at :data:`_COLUMN_LINEAGE_MAX_WORKERS` to avoid OOM-ing
+        the code-server pod — each worker spawns a full subprocess that
+        compiles ``models_dir``.
         """
         model_names = sorted(
             p.stem
             for p in models_dir.rglob("*.toml")
             if not p.name.startswith("_") and not p.name.endswith(".contract.toml")
         )
+        if not model_names:
+            return {}
 
-        out: dict[str, dg.TableColumnLineage] = {}
-        for model_name in model_names:
+        def _one(model_name: str) -> tuple[str, dg.TableColumnLineage | None]:
             try:
                 lineage = rocky.lineage(target=model_name)
             except Exception:
@@ -695,20 +777,31 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                     model_name,
                     exc_info=True,
                 )
-                continue
+                return model_name, None
             if not isinstance(lineage, ModelLineageResult):
                 # Defensive: ``lineage(target=...)`` without a column always
                 # returns ``ModelLineageResult``; the column-level shape
                 # would not fit ``TableColumnLineage`` anyway.
-                continue
+                return model_name, None
             try:
-                out[model_name] = build_column_lineage(lineage)
+                return model_name, build_column_lineage(lineage)
             except Exception:
                 _log.warning(
                     "build_column_lineage(%s) failed — skipping",
                     model_name,
                     exc_info=True,
                 )
+                return model_name, None
+
+        max_workers = min(_COLUMN_LINEAGE_MAX_WORKERS, len(model_names))
+        out: dict[str, dg.TableColumnLineage] = {}
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="rocky-lineage",
+        ) as pool:
+            for model_name, lineage in pool.map(_one, model_names):
+                if lineage is not None:
+                    out[model_name] = lineage
         return out
 
     def build_defs_from_state(

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -894,8 +894,16 @@ class RockyResource(dg.ConfigurableResource):
             object.__setattr__(self, "_version_checked", True)
             return
 
+        # Strip pre-release / build suffix before semver compare so dev
+        # builds like ``1.17.4-dev``, ``1.17.4-pre``, ``1.17.4-rc.2`` and
+        # ``1.17.4+sha.abc`` all gate against the matching release. Without
+        # this, ``int("4-dev")`` fails the parse and the version check
+        # silently skips — which is exactly how a too-old dev build slips
+        # past the gate.
+        core_version = version_str.split("-", 1)[0].split("+", 1)[0]
+
         try:
-            detected = tuple(int(p) for p in version_str.split(".")[:3])
+            detected = tuple(int(p) for p in core_version.split(".")[:3])
             required = tuple(int(p) for p in MIN_ROCKY_VERSION.split(".")[:3])
         except ValueError:
             # Non-semver output — skip check

--- a/integrations/dagster/tests/test_branch_deploy.py
+++ b/integrations/dagster/tests/test_branch_deploy.py
@@ -135,3 +135,95 @@ def test_shadow_suffix_fallback_when_no_pr_no_name():
         git_sha=None,
     )
     assert branch_deploy_shadow_suffix(info) == "_dagster_branch"
+
+
+# ---------------------------------------------------------------------------
+# pr_number sanitization (P1.3)
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_suffix_rejects_non_numeric_pr_number_falls_back_to_deployment_name():
+    """A non-numeric ``pr_number`` (the env var is webhook-controlled in
+    some setups) must never be interpolated raw into a SQL identifier
+    suffix. Instead, fall through to the sanitized ``deployment_name``
+    branch so the branch deployment still gets a stable shadow suffix."""
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="branch-deploy",
+        pr_number="42; DROP TABLE users",
+        git_sha=None,
+    )
+    suffix = branch_deploy_shadow_suffix(info)
+    # Falls through to deployment_name (sanitized), not the raw pr_number
+    assert suffix == "_dagster_branch_deploy"
+    assert "DROP" not in (suffix or "")
+    assert ";" not in (suffix or "")
+
+
+def test_shadow_suffix_rejects_pr_number_with_quotes():
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="x",
+        pr_number="42'--",
+        git_sha=None,
+    )
+    suffix = branch_deploy_shadow_suffix(info)
+    assert suffix == "_dagster_x"
+
+
+def test_shadow_suffix_rejects_negative_pr_number():
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="x",
+        pr_number="-1",
+        git_sha=None,
+    )
+    suffix = branch_deploy_shadow_suffix(info)
+    assert suffix == "_dagster_x"
+
+
+def test_shadow_suffix_rejects_zero_pr_number():
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="x",
+        pr_number="0",
+        git_sha=None,
+    )
+    suffix = branch_deploy_shadow_suffix(info)
+    assert suffix == "_dagster_x"
+
+
+def test_shadow_suffix_rejects_pr_number_with_whitespace():
+    """Leading/trailing spaces should be rejected — `isdigit()` already
+    handles this, but pin it as an explicit case."""
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="x",
+        pr_number=" 42 ",
+        git_sha=None,
+    )
+    suffix = branch_deploy_shadow_suffix(info)
+    assert suffix == "_dagster_x"
+
+
+def test_shadow_suffix_rejects_non_numeric_pr_number_no_deployment_name():
+    """When the pr_number is rejected and there's no deployment_name to
+    fall through to, the generic branch suffix wins."""
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name=None,
+        pr_number="not-a-number",
+        git_sha=None,
+    )
+    assert branch_deploy_shadow_suffix(info) == "_dagster_branch"
+
+
+def test_shadow_suffix_accepts_large_numeric_pr_number():
+    """Large but valid PR numbers still work."""
+    info = BranchDeploymentInfo(
+        is_branch_deployment=True,
+        deployment_name="x",
+        pr_number="999999",
+        git_sha=None,
+    )
+    assert branch_deploy_shadow_suffix(info) == "_dagster_pr_999999"

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -324,7 +324,6 @@ def _missing_models_dir(tmp_path: Path) -> str:
         subprocess.TimeoutExpired(cmd="rocky", timeout=1),
         MemoryError("oom on dump"),
         json.JSONDecodeError("bad", "doc", 0),
-        pydantic.ValidationError.from_exception_data("X", []),
         RuntimeError("transient state-store error"),
     ],
 )
@@ -334,7 +333,12 @@ def test_write_state_compile_slot_tolerates_non_failure_exception(
     exc: BaseException,
 ):
     """``_compile_payload`` must swallow non-``dg.Failure`` exceptions and omit
-    the slot rather than aborting the whole write."""
+    the slot rather than aborting the whole write.
+
+    ``ValidationError`` is excluded — it signals an engine/dagster-rocky
+    version mismatch that must surface loudly. See
+    :func:`test_write_state_compile_slot_propagates_validation_error`.
+    """
     discover = _make_discover_result()
     stub = _StubResource(discover_result=discover, compile_result=exc)
     _install_stub_resource(monkeypatch, stub)
@@ -351,6 +355,60 @@ def test_write_state_compile_slot_tolerates_non_failure_exception(
     state = json.loads(state_path.read_text())
     assert "discover" in state
     assert "compile" not in state  # slot omitted, write succeeded
+
+
+def test_write_state_compile_slot_propagates_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """``_compile_payload`` must re-raise a Pydantic ``ValidationError`` as
+    ``dg.Failure`` so an engine schema break does not silently drop checks
+    and freshness from the cached state."""
+    discover = _make_discover_result()
+    stub = _StubResource(
+        discover_result=discover,
+        compile_result=pydantic.ValidationError.from_exception_data("X", []),
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_existing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state"
+
+    with pytest.raises(dg.Failure) as excinfo:
+        component.write_state_to_path(state_path)
+
+    assert "schema mismatch" in (excinfo.value.description or "").lower()
+    assert "rocky --version" in (excinfo.value.description or "")
+    assert excinfo.value.metadata is not None
+    assert excinfo.value.metadata["command"].text == "compile"
+
+
+def test_write_state_compile_slot_propagates_dg_failure_caused_by_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """When ``rocky.compile()`` raises ``dg.Failure`` whose ``__cause__`` is
+    a ``ValidationError`` (i.e. ``_parse_rocky_json`` already wrapped it),
+    the slot helper still propagates rather than swallowing."""
+    discover = _make_discover_result()
+    inner = pydantic.ValidationError.from_exception_data("X", [])
+    wrapped = dg.Failure(description="rocky compile schema check failed")
+    wrapped.__cause__ = inner
+    stub = _StubResource(discover_result=discover, compile_result=wrapped)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_existing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+
+    with pytest.raises(dg.Failure):
+        component.write_state_to_path(tmp_path / "state")
 
 
 @pytest.mark.parametrize(
@@ -384,6 +442,33 @@ def test_write_state_optimize_slot_tolerates_non_failure_exception(
     state = json.loads(state_path.read_text())
     assert "discover" in state
     assert "optimize" not in state
+
+
+def test_write_state_optimize_slot_propagates_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """``_optimize_payload`` must re-raise a Pydantic ``ValidationError``
+    as ``dg.Failure`` — same engine/dagster-rocky version-mismatch
+    rationale as ``_compile_payload``."""
+    discover = _make_discover_result()
+    stub = _StubResource(
+        discover_result=discover,
+        optimize_result=pydantic.ValidationError.from_exception_data("X", []),
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),  # skip compile
+        surface_optimize_metadata=True,
+    )
+
+    with pytest.raises(dg.Failure) as excinfo:
+        component.write_state_to_path(tmp_path / "state")
+
+    assert excinfo.value.metadata is not None
+    assert excinfo.value.metadata["command"].text == "optimize"
 
 
 def test_write_state_discover_failure_writes_empty_envelope(
@@ -609,12 +694,16 @@ def test_surface_column_lineage_skips_underscore_and_contract_files(
     tmp_path: Path,
 ):
     """``_*.toml`` and ``*.contract.toml`` must not be considered models."""
+    import threading
+
     models_dir = _make_models_dir(tmp_path, ["only_model"])
     targets_seen: list[str] = []
+    targets_lock = threading.Lock()
 
     class _Capture(_StubResource):
         def lineage(self, target: str, column: str | None = None):
-            targets_seen.append(target)
+            with targets_lock:
+                targets_seen.append(target)
             return _model_lineage(target, ("u", "c", "c"))
 
     stub = _Capture(discover_result=_make_discover_result())
@@ -628,6 +717,55 @@ def test_surface_column_lineage_skips_underscore_and_contract_files(
     component._attach_column_lineage(dg.Definitions(assets=[]))
 
     assert targets_seen == ["only_model"]
+
+
+def test_surface_column_lineage_runs_in_parallel(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """``_collect_lineage`` fans out across a thread pool — two slow
+    lineage calls must overlap rather than running serially. This pins
+    the perf fix from P1.4: a code-server with N models pays roughly
+    one wall-clock latency, not N times it."""
+    import threading
+    import time
+
+    model_names = ["a", "b", "c", "d"]
+    models_dir = _make_models_dir(tmp_path, model_names)
+
+    inflight = 0
+    max_inflight = 0
+    inflight_lock = threading.Lock()
+
+    class _SlowResource(_StubResource):
+        def lineage(self, target: str, column: str | None = None):
+            nonlocal inflight, max_inflight
+            with inflight_lock:
+                inflight += 1
+                max_inflight = max(max_inflight, inflight)
+            try:
+                # Tiny sleep — long enough to guarantee overlap if the
+                # pool is parallel, short enough to keep the test fast.
+                time.sleep(0.05)
+                return _model_lineage(target, ("u", "c", "c"))
+            finally:
+                with inflight_lock:
+                    inflight -= 1
+
+    stub = _SlowResource(discover_result=_make_discover_result())
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=str(models_dir),
+        surface_column_lineage=True,
+    )
+    component._attach_column_lineage(dg.Definitions(assets=[]))
+
+    # Serial would mean max_inflight == 1. Parallel must observe overlap.
+    assert max_inflight > 1, (
+        f"expected parallel lineage fan-out, but observed max concurrent = {max_inflight}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1302,6 +1302,39 @@ def test_verify_version_skips_on_unparseable_output():
         rocky._verify_engine_version()
 
 
+@pytest.mark.parametrize(
+    "version_stdout",
+    [
+        f"rocky {MIN_ROCKY_VERSION}-dev",
+        f"rocky {MIN_ROCKY_VERSION}-pre",
+        f"rocky {MIN_ROCKY_VERSION}-rc.1",
+        f"rocky {MIN_ROCKY_VERSION}-alpha.2",
+        f"rocky {MIN_ROCKY_VERSION}+sha.abc123",
+        f"{MIN_ROCKY_VERSION}-dev",  # also handle the no-prefix case
+    ],
+)
+def test_verify_version_strips_pre_release_suffix(version_stdout: str):
+    """Pre-release / build suffixes (``-dev``, ``-pre``, ``-rc.N``,
+    ``+sha.<hash>``) must be stripped before comparison so a dev build
+    that matches the minimum version on the core triple is treated as
+    eligible. Without this, ``int("4-dev")`` fails the parse and the
+    check silently skips — which is exactly how a too-old dev build
+    used to slip past the gate."""
+    rocky = RockyResource()
+    with _patched_run(return_value=_version_completed(version_stdout)):
+        rocky._verify_engine_version()  # must not raise + must not silently skip
+
+
+def test_verify_version_dev_suffix_below_minimum_fails():
+    """A dev build whose core version is below the minimum still fails."""
+    rocky = RockyResource()
+    with (
+        _patched_run(return_value=_version_completed("rocky 0.99.99-dev")),
+        pytest.raises(dg.Failure, match="below the minimum"),
+    ):
+        rocky._verify_engine_version()
+
+
 def test_verify_version_caches_result():
     """After a successful check, subsequent calls don't invoke subprocess."""
     rocky = RockyResource()


### PR DESCRIPTION
## Summary

Four independent P1 fixes from the dagster-rocky maintenance sweep, landed as a single PR (no shared surface, but all small).

- **P1.1 — Schema-mismatch propagation.** `_compile_payload` / `_optimize_payload` re-raise Pydantic `ValidationError` as a structured `dg.Failure` (\"Engine output schema mismatch — built against a different rocky binary version\"). Previously swallowed silently, which made checks/freshness vanish without a signal whenever the engine and dagster-rocky drifted in lockstep cadence. *Note: these helpers live in `component.py`, not `resource.py` as the audit's pointer suggested.*
- **P1.2 — Dev-suffix version parsing.** `_verify_engine_version` strips `-dev`, `-pre`, `-rc.N`, `+sha.<hash>` before the semver tuple compare. Without this, `int(\"4-dev\")` fails the parse and the gate silently skips — the exact failure mode the audit flagged for `1.17.4-dev`.
- **P1.3 — `pr_number` injection hardening.** `branch_deploy_shadow_suffix` now validates `pr_number` is a positive integer string before interpolating into a SQL identifier suffix. Untrusted input (e.g. `\"42; DROP TABLE\"`) falls through to the (already-sanitized) deployment-name branch instead of being inlined raw.
- **P1.4 — Parallel column-lineage attach.** `_collect_lineage` fans per-model `rocky lineage` subprocesses across a bounded `ThreadPoolExecutor` (max 8 workers). The CLI takes a single `--target` so batching into one call isn't viable; thread-pool fan-out is the smaller refactor and gives ~Nx cold-start speedup with a memory cap.

## Out of scope (follow-up)

`_dag_payload` in `component.py` has the same `except Exception → return None` shape as the slot helpers and would swallow a `ValidationError` the same way. Audit only asked for compile/optimize, so leaving as a known follow-up.

## Test plan

- [x] `cd integrations/dagster && uv run pytest` — 487 passed
- [x] `cd integrations/dagster && uv run ruff check` — All checks passed
- [x] `cd integrations/dagster && uv run ruff format --check` — 47 files already formatted
- [x] New test: `test_write_state_compile_slot_propagates_validation_error` (P1.1)
- [x] New test: `test_write_state_compile_slot_propagates_dg_failure_caused_by_validation_error` (P1.1, transitive case)
- [x] New test: `test_write_state_optimize_slot_propagates_validation_error` (P1.1)
- [x] Updated parametrize lists to drop `ValidationError` from the swallowed-exceptions matrix (P1.1)
- [x] New parametrized test: `test_verify_version_strips_pre_release_suffix` covering `-dev`, `-pre`, `-rc.N`, `-alpha.2`, `+sha.<hash>` (P1.2)
- [x] New test: `test_verify_version_dev_suffix_below_minimum_fails` — dev builds below MIN still gate (P1.2)
- [x] New tests for `pr_number=\"42; DROP TABLE users\"`, `pr_number=\"42'--\"`, `pr_number=\"-1\"`, `pr_number=\"0\"`, `pr_number=\" 42 \"`, non-numeric without deployment fallback, large valid (P1.3)
- [x] New test: `test_surface_column_lineage_runs_in_parallel` — observes overlapping in-flight lineage calls via instrumented stub (P1.4)