### PR TITLE
fix: ProcessAdapter concurrency + percent-encode URL path components in source adapters

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3362,6 +3362,7 @@ version = "1.17.4"
 dependencies = [
  "async-trait",
  "chrono",
+ "percent-encoding",
  "reqwest",
  "rocky-core",
  "serde",
@@ -3567,6 +3568,7 @@ dependencies = [
  "chrono",
  "futures",
  "indexmap",
+ "percent-encoding",
  "reqwest",
  "rocky-core",
  "rocky-observe",
@@ -3584,6 +3586,7 @@ version = "1.17.4"
 dependencies = [
  "async-trait",
  "chrono",
+ "percent-encoding",
  "reqwest",
  "rocky-core",
  "serde",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -96,6 +96,11 @@ object_store = { version = "0.11", features = ["aws", "gcp", "azure"] }
 bytes = "1"
 url = "2"
 
+# Percent-encoding for URL path components in source adapter HTTP clients
+# (Fivetran, Airbyte, Iceberg). Used to defend against path injection /
+# traversal when interpolating user-supplied IDs / namespaces.
+percent-encoding = "2"
+
 # DuckDB
 duckdb = { version = "1", features = ["bundled"] }
 

--- a/engine/crates/rocky-adapter-sdk/src/process.rs
+++ b/engine/crates/rocky-adapter-sdk/src/process.rs
@@ -102,6 +102,14 @@ pub struct ProcessAdapter {
     stdin: Mutex<BufWriter<ChildStdin>>,
     /// Buffered reader from the child's stdout.
     stdout: Mutex<BufReader<ChildStdout>>,
+    /// Serializes the request/response pair in [`ProcessAdapter::call`].
+    ///
+    /// The wire protocol is request-id-keyed in theory but the underlying
+    /// child process is single-threaded — it reads one request, writes one
+    /// response, then loops. Concurrent callers that interleave writes/reads
+    /// can therefore swap responses (caller A reads B's reply). Holding this
+    /// lock across the entire write→read pair makes `call` linearizable.
+    call_lock: Mutex<()>,
     /// Monotonically increasing request ID.
     next_id: AtomicU64,
     /// The adapter's manifest, received during initialization.
@@ -212,6 +220,7 @@ impl ProcessAdapter {
             child: Mutex::new(child),
             stdin,
             stdout,
+            call_lock: Mutex::new(()),
             next_id,
             manifest,
             dialect,
@@ -224,6 +233,15 @@ impl ProcessAdapter {
     }
 
     /// Send a JSON-RPC request and wait for the response.
+    ///
+    /// **Concurrency:** this method serializes concurrent callers. The
+    /// underlying child process is single-threaded — it reads one request
+    /// and writes one response per loop iteration — so two concurrent
+    /// `call`s would otherwise interleave on stdin/stdout and could swap
+    /// responses (caller A reads B's reply). [`Self::call_lock`] is held
+    /// across the entire write→read pair to keep the protocol
+    /// linearizable. If you need parallel adapter calls, spawn multiple
+    /// [`ProcessAdapter`] instances rather than sharing one.
     pub async fn call(
         &self,
         method: &str,
@@ -233,6 +251,13 @@ impl ProcessAdapter {
         let request = RpcRequest::new(id, method, params);
 
         let request_json = serde_json::to_string(&request).map_err(AdapterError::new)?;
+
+        // Hold `call_lock` across the entire write→read pair so concurrent
+        // callers cannot interleave on stdin/stdout. Without this, two
+        // overlapping calls can swap responses: caller A writes id=N,
+        // caller B writes id=M, then A reads M's reply and the existing
+        // id mismatch surfaces as a hard error rather than corruption.
+        let _guard = self.call_lock.lock().await;
 
         // Write request.
         {
@@ -270,7 +295,9 @@ impl ProcessAdapter {
         let response: RpcResponse = serde_json::from_str(line.trim())
             .map_err(|e| AdapterError::msg(format!("failed to parse adapter response: {e}")))?;
 
-        // Verify response ID matches request ID.
+        // Verify response ID matches request ID. With `call_lock` held this
+        // should be impossible to violate; the check stays as a defence
+        // against an adapter that emits a response with a wrong id.
         if response.id != id {
             return Err(AdapterError::msg(format!(
                 "response ID mismatch: expected {id}, got {}",
@@ -584,5 +611,91 @@ mod tests {
         let expr = d.row_hash_expr(&["col1".into(), "col2".into()]);
         assert!(expr.contains("MD5"));
         assert!(expr.contains("col1, col2"));
+    }
+
+    /// Spawn a tiny Python-based JSON-RPC echo adapter and fire two
+    /// `call`s concurrently. Without [`ProcessAdapter::call_lock`] the two
+    /// requests/responses can interleave on stdin/stdout and the per-call
+    /// id-mismatch guard turns the race into a hard error. With the lock
+    /// in place each caller deterministically reads its own response, so
+    /// both ids match.
+    ///
+    /// Unix-only because the test relies on `python3` being on `PATH`,
+    /// which is true for the engine CI matrix (ubuntu) but not Windows.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_concurrent_calls_do_not_swap_ids() {
+        // The adapter:
+        //   1. on `initialize`, writes back a manifest.
+        //   2. on `echo`, sleeps to widen the race window, then echoes the
+        //      caller's `id` + a marker copied from `params.tag`.
+        let script = r#"
+import json, sys, time
+def emit(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+manifest = {
+    "name": "echo", "version": "0.0.0", "sdk_version": "0.0.0",
+    "dialect": "echo",
+    "capabilities": {
+        "warehouse": True, "discovery": False, "governance": False,
+        "batch_checks": False, "create_catalog": False, "create_schema": False,
+        "merge": False, "tablesample": False, "file_load": False,
+    },
+    "auth_methods": [], "config_schema": {},
+}
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    method = req.get("method")
+    rid = req.get("id")
+    if method == "initialize":
+        emit({"jsonrpc": "2.0", "id": rid, "result": {"manifest": manifest}})
+    elif method == "echo":
+        # Sleep to widen the race window so an unsynchronized
+        # implementation will reliably interleave.
+        time.sleep(0.05)
+        tag = req.get("params", {}).get("tag")
+        emit({"jsonrpc": "2.0", "id": rid, "result": {"id_seen": rid, "tag": tag}})
+    elif method == "shutdown":
+        emit({"jsonrpc": "2.0", "id": rid, "result": {}})
+        break
+    else:
+        emit({"jsonrpc": "2.0", "id": rid,
+              "error": {"code": "UNKNOWN_METHOD", "message": method or ""}})
+"#;
+        let adapter =
+            match ProcessAdapter::spawn("python3", &["-c", script], &serde_json::json!({})).await {
+                Ok(a) => a,
+                Err(e) => {
+                    // Skip silently if python3 isn't installed in this
+                    // environment — we don't want to fail CI on a missing
+                    // tool the test only uses to emulate an adapter.
+                    eprintln!("skipping: spawn failed (python3 unavailable?): {e}");
+                    return;
+                }
+            };
+
+        // Fire two calls concurrently. Each carries a distinct `tag` so we
+        // can assert each result was returned to the right caller.
+        let a = adapter.call("echo", serde_json::json!({"tag": "alpha"}));
+        let b = adapter.call("echo", serde_json::json!({"tag": "beta"}));
+        let (ra, rb) = tokio::join!(a, b);
+
+        let ra = ra.expect("call A succeeded");
+        let rb = rb.expect("call B succeeded");
+
+        assert_eq!(ra["tag"], "alpha", "call A must receive its own tag");
+        assert_eq!(rb["tag"], "beta", "call B must receive its own tag");
+
+        // The id_seen field round-trips the request id; assert each
+        // caller's response carries its own id, not the other caller's.
+        let ida = ra["id_seen"].as_u64().expect("id_seen on A");
+        let idb = rb["id_seen"].as_u64().expect("id_seen on B");
+        assert_ne!(ida, idb, "request ids must be distinct");
+
+        let _ = adapter.close().await;
     }
 }

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+percent-encoding = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-airbyte/src/client.rs
+++ b/engine/crates/rocky-airbyte/src/client.rs
@@ -6,7 +6,20 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::Client;
+
+/// Percent-encode a user-supplied URL path component.
+///
+/// Uses RFC 3986 unreserved chars minus `.` — `-`, `_`, `~`, and ASCII
+/// alphanumerics pass through; `.` stays encoded so `..` cannot traverse
+/// out of the parent path. Every other byte (`/`, `?`, `#`, `%`, spaces,
+/// etc.) is percent-encoded. Apply at every interpolation site that takes
+/// caller-controlled input (connection IDs, etc.).
+fn encode_path_segment(segment: &str) -> String {
+    const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
+    utf8_percent_encode(segment, PATH_SAFE).to_string()
+}
 
 /// Build the shared `reqwest::Client` used for every Airbyte API call.
 /// `Client::new()` left both connect and request timeouts unset — a
@@ -164,8 +177,16 @@ impl AirbyteClient {
     }
 
     /// Fetch a single connection by ID.
+    ///
+    /// `id` is percent-encoded before being interpolated into the URL path,
+    /// so caller-supplied IDs containing `/`, `?`, `#`, `..`, or `%` cannot
+    /// escape the `/v1/connections/` prefix.
     pub async fn get_connection(&self, id: &str) -> Result<Connection, AirbyteError> {
-        let url = format!("{}/v1/connections/{}", self.base_url, id);
+        let url = format!(
+            "{}/v1/connections/{}",
+            self.base_url,
+            encode_path_segment(id)
+        );
         self.get(&url).await
     }
 
@@ -287,6 +308,50 @@ mod tests {
     fn test_base_url_trailing_slash_stripped() {
         let client = AirbyteClient::new("https://api.airbyte.com/", None);
         assert_eq!(client.base_url, "https://api.airbyte.com");
+    }
+
+    #[test]
+    fn test_encode_path_segment_alphanumeric_passthrough() {
+        // Plain IDs are unchanged.
+        assert_eq!(encode_path_segment("conn_abc123"), "conn_abc123");
+    }
+
+    #[test]
+    fn test_encode_path_segment_unsafe_chars() {
+        // `.` is encoded so `..` cannot traverse out of `/v1/connections/`.
+        assert_eq!(encode_path_segment(".."), "%2E%2E");
+        // `/` is encoded so callers cannot forge a different path.
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+        // Query-injection vectors (`?`, `#`) are encoded.
+        assert_eq!(encode_path_segment("a?b"), "a%3Fb");
+        assert_eq!(encode_path_segment("a#b"), "a%23b");
+        // Pre-encoded payloads have their literal `%` re-encoded so the
+        // server sees the original byte stream.
+        assert_eq!(encode_path_segment("%2F"), "%252F");
+    }
+
+    /// Regression guard: the URL `get_connection` builds for a hostile
+    /// `id` must percent-encode every metacharacter so the server sees a
+    /// single path segment under `/v1/connections/` rather than a forged
+    /// path or a query-string injection.
+    #[test]
+    fn test_get_connection_url_encodes_id() {
+        let raw_id = "conn/../admin?x=1#frag%2F";
+        let encoded = encode_path_segment(raw_id);
+        let url = format!("https://api.airbyte.com/v1/connections/{encoded}");
+
+        let suffix = url
+            .strip_prefix("https://api.airbyte.com/v1/connections/")
+            .unwrap();
+
+        // The encoded segment is what the server actually receives.
+        assert_eq!(suffix, "conn%2F%2E%2E%2Fadmin%3Fx%3D1%23frag%252F");
+
+        // Defensive: ensure no raw metacharacter survived the encoding.
+        for c in ['/', '?', '#'] {
+            assert!(!suffix.contains(c), "raw {c:?} leaked into URL: {suffix}");
+        }
+        assert!(!suffix.contains(".."), "raw `..` leaked into URL: {suffix}");
     }
 
     #[test]

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+percent-encoding = { workspace = true }
 
 [features]
 test-support = []

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -1,6 +1,21 @@
 use std::time::Duration;
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::Client;
+
+/// Percent-encode a single user-supplied URL path component.
+///
+/// Uses RFC 3986 unreserved chars minus `.` — `-`, `_`, `~`, and ASCII
+/// alphanumerics pass through; `.` stays encoded so a hostile `..` cannot
+/// climb out of the parent path. Every other byte (`/`, `?`, `#`, `%`,
+/// spaces, etc.) is percent-encoded. Always apply this when interpolating
+/// caller-controlled values (connector IDs, group IDs, table names) into a
+/// URL path; path-traversal and query-injection bugs in source-adapter
+/// HTTP clients begin and end here.
+pub(crate) fn encode_path_segment(segment: &str) -> String {
+    const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
+    utf8_percent_encode(segment, PATH_SAFE).to_string()
+}
 
 /// Build the shared `reqwest::Client` used for every Fivetran API call.
 /// `Client::new()` previously left both connect and request timeouts
@@ -420,6 +435,38 @@ mod tests {
         let data = resp.data.unwrap();
         assert_eq!(data.items.len(), 2);
         assert_eq!(data.next_cursor, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_encode_path_segment_alphanumeric_passthrough() {
+        // Plain alphanumeric IDs are unchanged.
+        assert_eq!(encode_path_segment("conn_abc123"), "conn_abc123");
+        assert_eq!(encode_path_segment("group_xyz"), "group_xyz");
+    }
+
+    #[test]
+    fn test_encode_path_segment_unsafe_chars() {
+        // Path-traversal: `..` is fully encoded so the path component cannot
+        // climb out of `/v1/connectors/`.
+        assert_eq!(encode_path_segment(".."), "%2E%2E");
+        // Path separator must not survive — otherwise `attacker/admin` could
+        // forge `/v1/connectors/attacker/admin` and hit a different endpoint.
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+        // Query-string injection: `?` and `#` are encoded.
+        assert_eq!(encode_path_segment("a?b"), "a%3Fb");
+        assert_eq!(encode_path_segment("a#b"), "a%23b");
+        // Pre-encoded payloads round-trip the literal `%` so the server sees
+        // the original byte rather than a re-decoded escape.
+        assert_eq!(encode_path_segment("%2F"), "%252F");
+        // Spaces and other ASCII whitespace must be encoded.
+        assert_eq!(encode_path_segment("a b"), "a%20b");
+    }
+
+    #[test]
+    fn test_encode_path_segment_unreserved_passthrough() {
+        // RFC 3986 unreserved chars (minus `.`) survive untouched so that
+        // ordinary identifiers (`my_id-1~v2`) don't become noise URLs.
+        assert_eq!(encode_path_segment("my_id-1~v2"), "my_id-1~v2");
     }
 
     #[test]

--- a/engine/crates/rocky-fivetran/src/connector.rs
+++ b/engine/crates/rocky-fivetran/src/connector.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use tracing::debug;
 
-use crate::client::{FivetranClient, FivetranError};
+use crate::client::{FivetranClient, FivetranError, encode_path_segment};
 
 /// A Fivetran connector as returned by the API.
 ///
@@ -53,7 +53,7 @@ pub async fn list_connectors(
     client: &FivetranClient,
     group_id: &str,
 ) -> Result<Vec<Connector>, FivetranError> {
-    let path = format!("/v1/groups/{group_id}/connectors");
+    let path = format!("/v1/groups/{}/connectors", encode_path_segment(group_id));
     let connectors: Vec<Connector> = client.get_all_pages(&path).await?;
     debug!(group_id, count = connectors.len(), "discovered connectors");
     Ok(connectors)
@@ -84,7 +84,7 @@ pub async fn get_connector(
     client: &FivetranClient,
     connector_id: &str,
 ) -> Result<Connector, FivetranError> {
-    let path = format!("/v1/connectors/{connector_id}");
+    let path = format!("/v1/connectors/{}", encode_path_segment(connector_id));
     client.get(&path).await
 }
 

--- a/engine/crates/rocky-fivetran/src/schema.rs
+++ b/engine/crates/rocky-fivetran/src/schema.rs
@@ -124,7 +124,10 @@ pub async fn get_schema_config(
     client: &crate::client::FivetranClient,
     connector_id: &str,
 ) -> Result<SchemaConfig, crate::client::FivetranError> {
-    let path = format!("/v1/connectors/{connector_id}/schemas");
+    let path = format!(
+        "/v1/connectors/{}/schemas",
+        crate::client::encode_path_segment(connector_id)
+    );
     client.get(&path).await
 }
 

--- a/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
@@ -639,3 +639,95 @@ async fn test_discover_classifies_401_as_auth() {
         rocky_core::source::FailedSourceErrorClass::Auth
     );
 }
+
+/// Path-injection guard: user-supplied IDs must be percent-encoded before
+/// being interpolated into the URL path. The mock server is configured to
+/// match only on the encoded path, so a regression that drops encoding
+/// would surface as a 404-shaped error instead of the expected success.
+#[tokio::test]
+async fn test_list_connectors_percent_encodes_group_id() {
+    let server = MockServer::start().await;
+
+    // Caller passes a group_id that contains every metacharacter we care
+    // about: `/`, `?`, `#`, `..`, and `%`. The wire format must encode
+    // each of them so the server sees a single path segment.
+    let raw_group_id = "../evil/group?x=1#frag%2F";
+    let encoded = "%2E%2E%2Fevil%2Fgroup%3Fx%3D1%23frag%252F";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/groups/{encoded}/connectors")))
+        .and(query_param("limit", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": { "items": [], "next_cursor": null }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server);
+    let result = connector::list_connectors(&client, raw_group_id)
+        .await
+        .expect("encoded request should succeed");
+    assert!(result.is_empty());
+}
+
+/// Same guard for `GET /v1/connectors/{id}` — single-connector lookups
+/// are the most exposed path because `connector_id` is the most common
+/// caller-controlled value in the discovery flow.
+#[tokio::test]
+async fn test_get_connector_percent_encodes_connector_id() {
+    let server = MockServer::start().await;
+
+    let raw_id = "conn/../admin?token=x";
+    let encoded = "conn%2F%2E%2E%2Fadmin%3Ftoken%3Dx";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/connectors/{encoded}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "id": "conn_safe",
+                "group_id": "g",
+                "service": "stripe",
+                "schema": "src__a__b__stripe",
+                "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                "succeeded_at": null,
+                "failed_at": null
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server);
+    let conn = connector::get_connector(&client, raw_id)
+        .await
+        .expect("encoded request should succeed");
+    assert_eq!(conn.id, "conn_safe");
+}
+
+/// Same guard for `GET /v1/connectors/{id}/schemas`.
+#[tokio::test]
+async fn test_get_schema_config_percent_encodes_connector_id() {
+    let server = MockServer::start().await;
+
+    let raw_id = "id with space/and?slash";
+    let encoded = "id%20with%20space%2Fand%3Fslash";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/connectors/{encoded}/schemas")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": { "schemas": {} }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server);
+    let cfg = schema::get_schema_config(&client, raw_id)
+        .await
+        .expect("encoded request should succeed");
+    assert!(cfg.schemas.is_empty());
+}

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+percent-encoding = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-iceberg/src/client.rs
+++ b/engine/crates/rocky-iceberg/src/client.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::Client;
 
 /// Build the shared `reqwest::Client` used for every Iceberg REST
@@ -244,11 +245,23 @@ impl IcebergCatalogClient {
 
 /// Encode a dot-separated namespace for the URL path.
 ///
-/// The Iceberg REST spec uses `%1F` (unit separator) to encode
-/// multi-level namespaces in URL paths. Single-level namespaces
-/// are passed through as-is.
+/// The Iceberg REST spec uses `%1F` (unit separator) to encode multi-level
+/// namespaces in URL paths. Each level is also percent-encoded so
+/// caller-supplied namespace parts cannot inject `/`, `?`, `#`, `..`, or
+/// other path-altering bytes into the URL. The encoding allows RFC 3986
+/// unreserved chars (`-`, `_`, `~`, alphanumerics) but explicitly encodes
+/// `.` so `..` traversal cannot escape the catalog prefix.
+///
+/// Order matters: split on `.`, percent-encode each part, then join with
+/// the literal `%1F` separator. Encoding after the join would re-encode
+/// the `%` of `%1F` to `%25` and break the spec-required separator.
 fn encode_namespace(namespace: &str) -> String {
-    namespace.replace('.', "%1F")
+    const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
+    namespace
+        .split('.')
+        .map(|part| utf8_percent_encode(part, PATH_SAFE).to_string())
+        .collect::<Vec<_>>()
+        .join("%1F")
 }
 
 /// Computes exponential backoff from RetryConfig.
@@ -308,6 +321,58 @@ mod tests {
     #[test]
     fn test_encode_namespace_multi_level() {
         assert_eq!(encode_namespace("a.b.c"), "a%1Fb%1Fc");
+    }
+
+    #[test]
+    fn test_encode_namespace_unsafe_chars_in_part() {
+        // Each namespace part is percent-encoded so a hostile caller cannot
+        // inject `/`, `?`, `#`, or other path-altering bytes via a name.
+        // (Path-traversal via `..` is defused at the split: the input `..`
+        // becomes two empty parts joined by the `%1F` separator, so the
+        // server sees an empty-namespace-segment, not a parent traversal.)
+        assert_eq!(
+            encode_namespace("a/b"),
+            "a%2Fb",
+            "raw `/` would forge a different REST endpoint"
+        );
+        assert_eq!(
+            encode_namespace("ns?x=1"),
+            "ns%3Fx%3D1",
+            "`?` would graft a query string onto the URL"
+        );
+        assert_eq!(
+            encode_namespace("ns#frag"),
+            "ns%23frag",
+            "`#` would terminate the path on the server side"
+        );
+        assert_eq!(
+            encode_namespace("a%2F"),
+            "a%252F",
+            "literal `%` round-trips so the server sees the original byte"
+        );
+    }
+
+    #[test]
+    fn test_encode_namespace_dot_split_neutralises_traversal() {
+        // `.` is the spec-defined level separator. Splitting on `.` first
+        // means `..` decomposes into empty parts joined by `%1F`, so the
+        // result cannot represent a parent-directory traversal at the URL
+        // path level — `/v1/namespaces/%1F%1Fns/tables` is just an
+        // invalid namespace, not `/v1/namespaces/../ns/tables`.
+        assert_eq!(encode_namespace(".."), "%1F%1F");
+        assert_eq!(encode_namespace("..ns"), "%1F%1Fns");
+    }
+
+    #[test]
+    fn test_encode_namespace_multi_level_unsafe_each_part_encoded() {
+        // Order matters: each part is encoded individually before joining
+        // with the literal `%1F` separator. Encoding after the join would
+        // re-encode the `%` and break the Iceberg spec separator.
+        assert_eq!(
+            encode_namespace("a/x.b?y"),
+            "a%2Fx%1Fb%3Fy",
+            "each part must be encoded; `%1F` separator must remain literal"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related defensive fixes to source-adapter / SPI infrastructure.

**`ProcessAdapter::call` is not safe for concurrent use.** It acquires the stdin `Mutex` to write the request, releases it, then acquires stdout to read the response. Two concurrent callers can therefore interleave on the JSON-RPC pipe; the per-call `id`-mismatch check turns the race into a hard error rather than silent corruption, but the entire process-adapter SPI is effectively single-threaded per instance — undocumented. Adds a `call_lock: Mutex<()>` held across the entire write→read pair so calls serialize cleanly, and documents the constraint on the function. The id-mismatch check stays as a defence against a misbehaving adapter.

**Source-adapter HTTP clients leaked user-supplied IDs into URL paths via `format!()`** without percent-encoding. Affects:

- `rocky-fivetran` — `group_id` and `connector_id` in `/v1/groups/{}/connectors`, `/v1/connectors/{}`, `/v1/connectors/{}/schemas` (interpolated in `connector.rs` / `schema.rs`; the `client.rs` GET helper just stitches the path onto `base_url`).
- `rocky-airbyte` — `id` in `GET /v1/connections/{}`.
- `rocky-iceberg` — namespace parts in `GET /v1/namespaces/{}/tables`. The existing `replace('.', "%1F")` is the spec separator, not encoding; the parts themselves were unencoded.

Fix: a small percent-encoding helper in each crate using RFC 3986 unreserved chars minus `.` (so `..` cannot traverse, while ordinary identifiers like `my_id-v2` round-trip cleanly). For Iceberg the order is split → encode each part → join with `%1F`; encoding after the join would re-encode the separator's `%`.

Adds `percent-encoding` to `[workspace.dependencies]` and to each of the three source-adapter crates.

## Test plan

- [x] `cd engine && cargo test -p rocky-adapter-sdk -p rocky-fivetran -p rocky-airbyte -p rocky-iceberg --features rocky-fivetran/test-support` — green
- [x] `cd engine && cargo clippy -p rocky-adapter-sdk -p rocky-fivetran -p rocky-airbyte -p rocky-iceberg --all-targets --features rocky-fivetran/test-support -- -D warnings` — clean
- [x] `cd engine && cargo fmt --check` — clean
- [x] `cd engine && cargo build --workspace` — clean

New tests:
- `process::tests::test_concurrent_calls_do_not_swap_ids` (`cfg(unix)`) spawns a Python-based JSON-RPC echo adapter and `tokio::join!`s two `call`s with distinct tags; asserts each caller receives its own tag/id back. Skips silently if `python3` is unavailable.
- `wiremock_tests::test_list_connectors_percent_encodes_group_id`, `test_get_connector_percent_encodes_connector_id`, `test_get_schema_config_percent_encodes_connector_id` — wire-level Fivetran tests where the mock matches only on the encoded path.
- Airbyte unit test asserting `get_connection`'s URL escapes `/`, `?`, `#`, `..`, and `%`.
- Iceberg unit tests covering each metacharacter per part, the `..`-via-split case, and the multi-level "encode-then-join" ordering invariant.