### PR TITLE
fix(rocky-server): require auth + restrict CORS + spawn_blocking on sync redb opens

### DIFF
--- a/engine/crates/rocky-cli/src/commands/serve.rs
+++ b/engine/crates/rocky-cli/src/commands/serve.rs
@@ -1,21 +1,45 @@
 //! `rocky serve` — HTTP API server exposing the compiler's semantic graph.
+//!
+//! # Security defaults
+//!
+//! The server binds `127.0.0.1:8080` by default. Binding a non-loopback
+//! host (e.g. `--host 0.0.0.0`) requires a Bearer token — otherwise the
+//! server refuses to start so model SQL, file paths, and run history
+//! don't leak to the LAN. Token sources, in priority order:
+//!
+//! 1. `--token <secret>` flag
+//! 2. `ROCKY_SERVE_TOKEN` env var
+//!
+//! Cross-origin clients must be enumerated via `--allowed-origin`. The
+//! default allowlist is empty (same-origin only); the dashboard at `/`
+//! is server-rendered HTML and doesn't need cross-origin XHR.
 
 use std::path::Path;
 
 use anyhow::Result;
 
 /// Execute `rocky serve`.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_serve(
     models_dir: &Path,
     contracts_dir: Option<&Path>,
     config_path: Option<&Path>,
+    host: String,
     port: u16,
     watch: bool,
+    auth_token: Option<String>,
+    allowed_origins: Vec<String>,
 ) -> Result<()> {
-    let state = rocky_server::state::ServerState::new(
+    // Token resolution: --token takes precedence over the env var so
+    // CI / scripts can override an inherited environment.
+    let token = auth_token.or_else(|| std::env::var("ROCKY_SERVE_TOKEN").ok());
+
+    let state = rocky_server::state::ServerState::with_auth(
         models_dir.to_path_buf(),
         contracts_dir.map(std::path::Path::to_path_buf),
         config_path.map(std::path::Path::to_path_buf),
+        token,
+        allowed_origins,
     );
 
     // Start filesystem watcher if requested
@@ -31,5 +55,5 @@ pub async fn run_serve(
     // Wait for initial compilation
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    rocky_server::api::serve(state, port).await
+    rocky_server::api::serve(state, rocky_server::api::ServeConfig { host, port }).await
 }

--- a/engine/crates/rocky-server/src/api.rs
+++ b/engine/crates/rocky-server/src/api.rs
@@ -13,21 +13,50 @@
 //! GET  /api/v1/dag/status                      → latest DAG run status
 //! POST /api/v1/compile                         → trigger recompilation
 //! ```
+//!
+//! All routes except `/api/v1/health` require a Bearer token when one is
+//! configured on [`ServerState`]; see [`crate::auth`].
 
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use axum::middleware;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use tower_http::cors::CorsLayer;
 
+use crate::auth::{build_cors_layer, require_bearer_token};
 use crate::dashboard;
 use crate::state::ServerState;
 
+/// Bind config for [`serve`].
+///
+/// Defaults bind to `127.0.0.1:8080` (loopback only) — the LAN-leak class
+/// of bug doesn't reproduce unless the operator opts into a non-loopback
+/// host *and* configures a Bearer token.
+#[derive(Debug, Clone)]
+pub struct ServeConfig {
+    /// Bind host. Defaults to `127.0.0.1`. A non-loopback host (e.g.
+    /// `0.0.0.0`) requires `auth_token` to be `Some`.
+    pub host: String,
+    /// Listen port.
+    pub port: u16,
+}
+
+impl Default for ServeConfig {
+    fn default() -> Self {
+        Self {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+        }
+    }
+}
+
 /// Build the axum router with all API routes.
 pub fn router(state: Arc<ServerState>) -> Router {
+    let cors = build_cors_layer(&state.allowed_origins);
+
     Router::new()
         .route("/", get(dashboard::dashboard))
         .route("/dashboard", get(dashboard::dashboard))
@@ -44,7 +73,11 @@ pub fn router(state: Arc<ServerState>) -> Router {
         .route("/api/v1/dag", get(full_dag))
         .route("/api/v1/dag/layers", get(dag_layers))
         .route("/api/v1/dag/status", get(dag_status))
-        .layer(CorsLayer::permissive())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer_token,
+        ))
+        .layer(cors)
         .with_state(state)
 }
 
@@ -63,12 +96,40 @@ async fn dag_status(
 }
 
 /// Start the HTTP server.
-pub async fn serve(state: Arc<ServerState>, port: u16) -> anyhow::Result<()> {
+///
+/// # Errors
+///
+/// Returns an error when:
+/// - the bind host is non-loopback (e.g. `0.0.0.0`) and no Bearer token
+///   is configured on `state` — exposing the API on the LAN without
+///   auth would leak model SQL, file paths, and run history;
+/// - the listener fails to bind (port in use, permissions, etc.);
+/// - the axum runtime returns an error.
+pub async fn serve(state: Arc<ServerState>, config: ServeConfig) -> anyhow::Result<()> {
+    if !is_loopback(&config.host) && state.auth_token.is_none() {
+        anyhow::bail!(
+            "rocky serve refuses to bind {host} without a Bearer token. \
+             Pass --token <secret> (or set ROCKY_SERVE_TOKEN), or bind to \
+             127.0.0.1 (the default).",
+            host = config.host,
+        );
+    }
+
     let app = router(state);
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}")).await?;
-    tracing::info!(port, "rocky serve listening");
+    let bind_addr = format!("{}:{}", config.host, config.port);
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    tracing::info!(addr = %bind_addr, "rocky serve listening");
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+/// Returns `true` when `host` resolves to loopback only.
+///
+/// Accepts the textual forms we actually emit / accept on the CLI:
+/// `127.0.0.1`, `::1`, `localhost`. Anything else (including `0.0.0.0`
+/// and external addresses) is treated as non-loopback.
+fn is_loopback(host: &str) -> bool {
+    matches!(host, "127.0.0.1" | "::1" | "localhost")
 }
 
 // --- Route handlers ---
@@ -231,12 +292,18 @@ async fn full_dag(
 async fn list_runs(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
+    // The redb open + scan are sync work that can sleep on the state
+    // flock (see `StateStore::open_redb_with_retry`); move it off the
+    // async runtime. Mirrors the pattern at `lsp.rs:468` (PR #263).
     let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
-    let store = rocky_core::state::StateStore::open_read_only(&state_path)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let runs = store
-        .list_runs(50)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let runs = tokio::task::spawn_blocking(move || {
+        let store = rocky_core::state::StateStore::open_read_only(&state_path)
+            .map_err(|e| e.to_string())?;
+        store.list_runs(50).map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let run_entries: Vec<serde_json::Value> = runs
         .iter()
@@ -263,11 +330,17 @@ async fn model_history(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
-    let store = rocky_core::state::StateStore::open_read_only(&state_path)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let history = store
-        .get_model_history(&name, 50)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let history_name = name.clone();
+    let history = tokio::task::spawn_blocking(move || {
+        let store = rocky_core::state::StateStore::open_read_only(&state_path)
+            .map_err(|e| e.to_string())?;
+        store
+            .get_model_history(&history_name, 50)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let entries: Vec<serde_json::Value> = history
         .iter()
@@ -296,11 +369,17 @@ async fn model_metrics(
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let state_path = rocky_core::state::resolve_state_path(None, &state.models_dir).path;
-    let store = rocky_core::state::StateStore::open_read_only(&state_path)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let snapshots = store
-        .get_quality_trend(&name, 20)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let trend_name = name.clone();
+    let snapshots = tokio::task::spawn_blocking(move || {
+        let store = rocky_core::state::StateStore::open_read_only(&state_path)
+            .map_err(|e| e.to_string())?;
+        store
+            .get_quality_trend(&trend_name, 20)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let entries: Vec<serde_json::Value> = snapshots
         .iter()
@@ -456,5 +535,135 @@ mod tests {
         let body: serde_json::Value = resp.json().await.unwrap();
         assert_eq!(body["total_models"], 3);
         assert_eq!(body["layers"].as_array().unwrap().len(), 3);
+    }
+
+    fn test_state_with_token(token: &str) -> Arc<ServerState> {
+        let models_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../rocky-compiler/tests/fixtures/simple_project/models");
+        ServerState::with_auth(models_dir, None, None, Some(token.to_string()), Vec::new())
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_request_without_token() {
+        let state = test_state_with_token("s3cret");
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp = reqwest::get(format!("http://{addr}/api/v1/models"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_request_with_wrong_token() {
+        let state = test_state_with_token("s3cret");
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://{addr}/api/v1/models"))
+            .bearer_auth("wrong")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn auth_accepts_request_with_correct_token() {
+        let state = test_state_with_token("s3cret");
+        state.recompile().await;
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("http://{addr}/api/v1/models"))
+            .bearer_auth("s3cret")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_is_auth_exempt() {
+        let state = test_state_with_token("s3cret");
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // No bearer token — health must still respond 200 so liveness
+        // probes work without provisioning the secret to the prober.
+        let resp = reqwest::get(format!("http://{addr}/api/v1/health"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn serve_refuses_non_loopback_without_token() {
+        let models_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../rocky-compiler/tests/fixtures/simple_project/models");
+        let state = ServerState::with_auth(models_dir, None, None, None, Vec::new());
+        let result = serve(
+            state,
+            ServeConfig {
+                host: "0.0.0.0".to_string(),
+                port: 0,
+            },
+        )
+        .await;
+        let err = result.expect_err("expected 0.0.0.0 without token to be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("Bearer token"), "unexpected error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn serve_allows_loopback_without_token() {
+        // Sanity check: the historical default (loopback, no token)
+        // must keep working — refusal applies only to non-loopback.
+        let models_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../rocky-compiler/tests/fixtures/simple_project/models");
+        let state = ServerState::with_auth(models_dir, None, None, None, Vec::new());
+        // Bind on a random port; serve runs forever, so race a short
+        // timeout against it. We only need to confirm it didn't bail
+        // immediately on the loopback check.
+        let task = tokio::spawn(async move {
+            serve(
+                state,
+                ServeConfig {
+                    host: "127.0.0.1".to_string(),
+                    port: 0,
+                },
+            )
+            .await
+        });
+        let early =
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut Box::pin(task)).await;
+        // Timeout = serve is happily running. An immediate Ok/Err would
+        // mean the loopback check fired; that would be the bug.
+        assert!(early.is_err(), "serve exited too quickly: {early:?}");
     }
 }

--- a/engine/crates/rocky-server/src/auth.rs
+++ b/engine/crates/rocky-server/src/auth.rs
@@ -1,0 +1,162 @@
+//! Authentication and CORS configuration for the HTTP API.
+//!
+//! `rocky serve` ships behind a Bearer-token auth middleware and a
+//! configurable CORS allowlist. The defaults are deliberately tight:
+//!
+//! - When `auth_token` is `Some`, every request to `/api/v1/*`, `/`, or
+//!   `/dashboard` must carry an `Authorization: Bearer <token>` header
+//!   that matches via constant-time comparison. `/api/v1/health` is
+//!   always auth-exempt so liveness probes work.
+//! - When `auth_token` is `None`, the server refuses to start unless the
+//!   bind host is `127.0.0.1` / `localhost` (loopback only). This keeps
+//!   the LAN-leak class of bug from regressing on a forgotten `--host`
+//!   override.
+//!
+//! CORS defaults mirror the auth posture: an empty allowlist means
+//! same-origin only (no `Access-Control-Allow-Origin` header). Origins
+//! are configured via `--allowed-origin` on the CLI or `[serve]
+//! allowed_origins = [...]` in `rocky.toml` (Phase 2 — the CLI flag is
+//! the source of truth today).
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderName, HeaderValue, Method, StatusCode, header};
+use axum::middleware::Next;
+use axum::response::Response;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+use crate::state::ServerState;
+
+/// Path prefixes that bypass the auth middleware. `/api/v1/health` is
+/// the canonical liveness probe — orchestrators and load balancers need
+/// to hit it without a token.
+const AUTH_EXEMPT_PATHS: &[&str] = &["/api/v1/health"];
+
+/// Bearer-token auth middleware.
+///
+/// Extracts the configured token from [`ServerState`] and requires every
+/// non-exempt request to carry `Authorization: Bearer <token>`. Token
+/// comparison is constant-time so timing oracles can't be used to leak
+/// the token byte-by-byte.
+///
+/// When no token is configured (loopback-only deployments) the middleware
+/// is a no-op — but [`api::serve`][crate::api::serve] refuses to bind a
+/// non-loopback host without one, so the no-op path is safe.
+pub async fn require_bearer_token(
+    State(state): State<Arc<ServerState>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if AUTH_EXEMPT_PATHS.contains(&request.uri().path()) {
+        return Ok(next.run(request).await);
+    }
+
+    let Some(expected) = state.auth_token.as_deref() else {
+        // No token configured → loopback-only mode (see `api::serve`).
+        return Ok(next.run(request).await);
+    };
+
+    let header_value = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let provided = header_value
+        .strip_prefix("Bearer ")
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if !constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(header::WWW_AUTHENTICATE, "Bearer")
+            .body(Body::empty())
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    Ok(next.run(request).await)
+}
+
+/// Constant-time byte comparison. Returns `true` only if both slices have
+/// the same length *and* every byte matches; runtime is independent of
+/// the position of the first mismatch.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Build the CORS layer from a configured allowlist.
+///
+/// - Empty allowlist → no `Access-Control-Allow-Origin` header is sent
+///   (same-origin only). The dashboard at `/` is server-rendered HTML
+///   and doesn't need cross-origin XHR, so this is the safe default.
+/// - Non-empty allowlist → only the listed origins are accepted. We
+///   restrict methods to `GET, POST, OPTIONS` and headers to
+///   `Authorization, Content-Type` so the surface stays minimal.
+///
+/// Origins must be valid `Origin`-header values (e.g.
+/// `http://localhost:5173`). Invalid entries are dropped with a
+/// `tracing::warn`.
+pub fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
+    if allowed_origins.is_empty() {
+        return CorsLayer::new();
+    }
+
+    let parsed: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .filter_map(|o| match HeaderValue::from_str(o) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                tracing::warn!(origin = %o, error = %e, "invalid CORS origin, ignoring");
+                None
+            }
+        })
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(parsed))
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([
+            HeaderName::from_static("authorization"),
+            HeaderName::from_static("content-type"),
+        ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_strings() {
+        assert!(constant_time_eq(b"hello", b"hello"));
+        assert!(!constant_time_eq(b"hello", b"world"));
+        assert!(!constant_time_eq(b"hello", b"hello!"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn cors_layer_empty_allowlist_is_minimal() {
+        // Doesn't panic; the layer rejects cross-origin without an
+        // explicit allow_origin call.
+        let _layer = build_cors_layer(&[]);
+    }
+
+    #[test]
+    fn cors_layer_drops_invalid_origins() {
+        // Invalid origin strings (those containing control chars) should
+        // be filtered out without panicking.
+        let _layer = build_cors_layer(&[
+            "http://localhost:5173".to_string(),
+            "bad\norigin".to_string(),
+        ]);
+    }
+}

--- a/engine/crates/rocky-server/src/lib.rs
+++ b/engine/crates/rocky-server/src/lib.rs
@@ -3,8 +3,21 @@
 //! Two components:
 //! - **`rocky serve`** — HTTP API exposing compilation, lineage, and model metadata
 //! - **`rocky lsp`** — Language Server Protocol for `.rocky` and `.sql` IDE support
+//!
+//! # Security expectations
+//!
+//! `rocky serve` exposes model SQL, file paths, the DAG, and run history.
+//! Treat the bind address as production-sensitive — the server defaults
+//! to loopback (`127.0.0.1`) and refuses to bind a non-loopback host
+//! without a Bearer token configured via [`api::ServeConfig::auth_token`]
+//! (CLI: `--token` / env `ROCKY_SERVE_TOKEN`). The CORS allowlist is
+//! empty by default (same-origin only); cross-origin clients must be
+//! enumerated via `--allowed-origin`.
+//!
+//! See [`auth`] for the middleware and CORS helpers.
 
 pub mod api;
+pub mod auth;
 pub mod dag_viz;
 pub mod dashboard;
 pub mod lsp;

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -23,6 +23,13 @@ pub struct ServerState {
     pub compile_result: RwLock<Option<CompileResult>>,
     /// Latest DAG execution status, exposed at `GET /api/v1/dag/status`.
     pub dag_status: DagStatusStore,
+    /// Bearer token required by the HTTP API auth middleware. `None`
+    /// means "no auth"; in that mode [`crate::api::serve`] refuses to
+    /// bind a non-loopback host. See [`crate::auth::require_bearer_token`].
+    pub auth_token: Option<String>,
+    /// CORS allowlist passed to [`crate::auth::build_cors_layer`]. An
+    /// empty list means same-origin only.
+    pub allowed_origins: Vec<String>,
     /// Arc 7 wave 2 wave-2: per-session throttle for the "N sources hit"
     /// info log so it emits once per server start, not once per recompile.
     /// PR 2 will key it on `(document_uri, cache_version)` — the only LSP
@@ -32,10 +39,25 @@ pub struct ServerState {
 
 impl ServerState {
     /// Create new server state and perform initial compilation.
+    ///
+    /// Defaults to the LSP-style configuration (no token, empty CORS
+    /// allowlist). Use [`ServerState::with_auth`] to attach a Bearer
+    /// token + CORS allowlist before starting the HTTP server.
     pub fn new(
         models_dir: PathBuf,
         contracts_dir: Option<PathBuf>,
         config_path: Option<PathBuf>,
+    ) -> Arc<Self> {
+        Self::with_auth(models_dir, contracts_dir, config_path, None, Vec::new())
+    }
+
+    /// Create new server state with explicit auth + CORS configuration.
+    pub fn with_auth(
+        models_dir: PathBuf,
+        contracts_dir: Option<PathBuf>,
+        config_path: Option<PathBuf>,
+        auth_token: Option<String>,
+        allowed_origins: Vec<String>,
     ) -> Arc<Self> {
         let state = Arc::new(Self {
             models_dir,
@@ -43,6 +65,8 @@ impl ServerState {
             config_path,
             compile_result: RwLock::new(None),
             dag_status: DagStatusStore::new(),
+            auth_token,
+            allowed_origins,
             schema_cache_throttle: SchemaCacheThrottle::new(),
         });
 
@@ -79,7 +103,25 @@ impl ServerState {
             ..Default::default()
         };
 
-        match rocky_compiler::compile::compile(&config) {
+        // The compile pass walks the model directory, parses every
+        // `.rocky` / `.sql` file, and runs type-checking. On a non-trivial
+        // project this is hundreds of milliseconds of CPU-bound work; if
+        // we run it directly on the async runtime it stalls every other
+        // task on this worker thread (HTTP handlers, the file watcher,
+        // the LSP). Move it to the blocking pool. Mirrors the pattern at
+        // `lsp.rs:468` (PR #263).
+        let compile_result =
+            match tokio::task::spawn_blocking(move || rocky_compiler::compile::compile(&config))
+                .await
+            {
+                Ok(r) => r,
+                Err(join_err) => {
+                    warn!(error = %join_err, "compile task join failed");
+                    return;
+                }
+            };
+
+        match compile_result {
             Ok(result) => {
                 let model_count = result.project.model_count();
                 let diag_count = result.diagnostics.len();
@@ -130,22 +172,32 @@ impl ServerState {
             return HashMap::new();
         }
 
-        let store = match rocky_core::state::StateStore::open_read_only(&state_path) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!(error = %e, "schema cache: state open failed in server path");
+        // Mirror the LSP path at `lsp.rs:468` (PR #263): the redb open +
+        // scan are sync work that can sleep up to ~250ms when contending
+        // with a CLI process for the state-file flock (see
+        // `StateStore::open_redb_with_retry`). Doing that on a Tokio
+        // worker would intermittently starve HTTP handlers; move it to
+        // the blocking pool.
+        let ttl = schema_cache_config.ttl();
+        let map = match tokio::task::spawn_blocking(move || {
+            let store = rocky_core::state::StateStore::open_read_only(&state_path)
+                .map_err(|e| ("state open", e.to_string()))?;
+            rocky_compiler::schema_cache::load_source_schemas_from_cache(
+                &store,
+                chrono::Utc::now(),
+                ttl,
+            )
+            .map_err(|e| ("scan", e.to_string()))
+        })
+        .await
+        {
+            Ok(Ok(m)) => m,
+            Ok(Err((stage, e))) => {
+                debug!(error = %e, stage, "schema cache: {stage} failed in server path");
                 return HashMap::new();
             }
-        };
-
-        let map = match rocky_compiler::schema_cache::load_source_schemas_from_cache(
-            &store,
-            chrono::Utc::now(),
-            schema_cache_config.ttl(),
-        ) {
-            Ok(m) => m,
-            Err(e) => {
-                debug!(error = %e, "schema cache: scan failed in server path");
+            Err(join_err) => {
+                debug!(error = %join_err, "schema cache: blocking task join failed");
                 return HashMap::new();
             }
         };

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -585,12 +585,27 @@ enum Command {
         /// Contracts directory
         #[arg(long)]
         contracts: Option<PathBuf>,
+        /// Bind host. Defaults to loopback. Binding a non-loopback host
+        /// (e.g. `0.0.0.0`) requires `--token` so model SQL and run
+        /// history don't leak on the LAN.
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
         /// Port to listen on
         #[arg(long, default_value = "8080")]
         port: u16,
         /// Watch for file changes and auto-recompile
         #[arg(long)]
         watch: bool,
+        /// Bearer token required by every API request (except
+        /// `/api/v1/health`). Falls back to the `ROCKY_SERVE_TOKEN` env
+        /// var when omitted. Required when `--host` is non-loopback.
+        #[arg(long)]
+        token: Option<String>,
+        /// CORS allowlist. Repeat for each origin (e.g.
+        /// `--allowed-origin http://localhost:5173`). The default
+        /// allowlist is empty (same-origin only).
+        #[arg(long = "allowed-origin", value_name = "ORIGIN")]
+        allowed_origins: Vec<String>,
     },
 
     /// Start Language Server Protocol server for IDE integration
@@ -1589,15 +1604,28 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         Command::Serve {
             models,
             contracts,
+            host,
             port,
             watch,
+            token,
+            allowed_origins,
         } => {
             let config = if cli.config.exists() {
                 Some(cli.config.as_path())
             } else {
                 None
             };
-            rocky_cli::commands::run_serve(&models, contracts.as_deref(), config, port, watch).await
+            rocky_cli::commands::run_serve(
+                &models,
+                contracts.as_deref(),
+                config,
+                host,
+                port,
+                watch,
+                token,
+                allowed_origins,
+            )
+            .await
         }
         Command::Lsp { stdio: _ } => rocky_cli::commands::run_lsp().await,
         #[cfg(feature = "duckdb")]


### PR DESCRIPTION
## Summary

`rocky serve` previously bound `0.0.0.0` with `CorsLayer::permissive()` and zero auth — model SQL, file paths, the DAG, and run history all leaked to anyone on the same network, and `POST /api/v1/compile` was CSRFable. The HTTP runtime also ran sync `redb` opens directly on the async executor, so heavy state reads could stall HTTP handlers.

This PR closes both classes of issue:

**Auth + bind hardening**
- Default bind moves to `127.0.0.1:8080`. New `--host` flag opts into a non-loopback bind.
- Non-loopback bind requires a Bearer token; `serve()` refuses to start otherwise.
- New Bearer-token middleware on every route except `/api/v1/health` (kept exempt so liveness probes don't need the secret). Token sources, in priority order: `--token <secret>` flag, then `ROCKY_SERVE_TOKEN` env var. Token comparison is constant-time.
- `CorsLayer::permissive()` is replaced by an explicit allowlist: empty by default (same-origin only), populated via `--allowed-origin <ORIGIN>` (repeatable). Methods restricted to GET/POST/OPTIONS; headers to Authorization/Content-Type.

**Async runtime hygiene**
- Wraps four sync sites in `tokio::task::spawn_blocking` so they don't starve the executor:
  - `state::recompile` — the CPU-heavy compile pass
  - `state::load_cached_source_schemas` — redb open + scan
  - `api::list_runs`, `api::model_history`, `api::model_metrics` — three handlers that opened redb on the async runtime
- Mirrors the LSP pattern landed in #263.

**Notes for reviewers**
- The dashboard at `/` and `/dashboard` is inside the auth middleware. With a token configured, browser navigation returns 401 — that's intentional (the dashboard renders model SQL). For browser usability stick to the loopback default, which is exactly what's now shipped by default.
- TOML `[serve] allowed_origins = [...]` is deliberately deferred. The CLI flag + env-var pair is sufficient for closing the launch-blocker class of bug; a future PR can fold these into `RockyConfig` if multi-machine deployments demand persistent config.

## Test plan
- [x] `cd engine && cargo test -p rocky-server` (47 tests pass — six new ones cover the auth happy path, missing/wrong-token rejection, the health-endpoint exemption, the non-loopback refusal, and the loopback-without-token sanity case)
- [x] `cd engine && cargo clippy -p rocky-server --all-targets -- -D warnings`
- [x] `cd engine && cargo fmt --check`
- [x] `cd engine && cargo build -p rocky-lsp` (the slim adapter-free LSP binary that links rocky-server still compiles)
- [x] `cd engine && cargo clippy -p rocky-cli -p rocky --all-targets -- -D warnings` (CLI + main binary integrate with the new `serve()` signature)