### PR TITLE
fix(engine): paper-cut cluster — BigQuery JWT cache, sql transpile, wasm UTF-8, explain TOML, partial-success exit code

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -21,5 +21,8 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/engine/crates/rocky-ai/src/explain.rs
+++ b/engine/crates/rocky-ai/src/explain.rs
@@ -68,6 +68,14 @@ pub async fn explain_model(
 }
 
 /// Write intent to a model's TOML sidecar config file.
+///
+/// If the sidecar already exists but cannot be parsed as TOML, this
+/// function returns an error rather than silently overwriting the file
+/// with a fresh `intent = "..."` document — the original behavior would
+/// erase whatever the user was editing (e.g. mid-keystroke during an
+/// editor flush, or a hand-rolled TOML with a typo). The caller can
+/// surface the message to the user, who is expected to fix or remove
+/// the file before retrying.
 pub fn save_intent_to_config(model: &Model, intent: &str) -> Result<(), std::io::Error> {
     let toml_path = if model.file_path.ends_with(".rocky") {
         format!("{}.toml", model.file_path)
@@ -79,10 +87,21 @@ pub fn save_intent_to_config(model: &Model, intent: &str) -> Result<(), std::io:
 
     let path = std::path::Path::new(&toml_path);
 
-    // Read existing config or start fresh
+    // Read existing config or start fresh. Refuse to clobber a sidecar
+    // that exists but doesn't parse — overwriting it would delete the
+    // user's in-flight edits.
     let mut config: toml::Value = if path.exists() {
         let content = std::fs::read_to_string(path)?;
-        toml::from_str(&content).unwrap_or(toml::Value::Table(toml::map::Map::new()))
+        match toml::from_str(&content) {
+            Ok(value) => value,
+            Err(err) => {
+                return Err(std::io::Error::other(format!(
+                    "refusing to overwrite unparseable TOML at {}: {err}; \
+                     please fix the file first or remove it and rerun",
+                    path.display()
+                )));
+            }
+        }
     } else {
         toml::Value::Table(toml::map::Map::new())
     };
@@ -104,4 +123,104 @@ pub fn save_intent_to_config(model: &Model, intent: &str) -> Result<(), std::io:
     let toml_str = toml::to_string_pretty(&config).map_err(std::io::Error::other)?;
 
     std::fs::write(path, toml_str)
+}
+
+#[cfg(test)]
+mod save_intent_tests {
+    use super::*;
+    use rocky_core::models::{Model, ModelConfig, StrategyConfig, TargetConfig};
+    use std::io::Write;
+
+    fn make_model(file_path: String) -> Model {
+        Model {
+            sql: String::new(),
+            file_path,
+            contract_path: None,
+            config: ModelConfig {
+                name: "test_model".to_string(),
+                depends_on: vec![],
+                strategy: StrategyConfig::default(),
+                target: TargetConfig {
+                    catalog: "c".into(),
+                    schema: "s".into(),
+                    table: "test_model".into(),
+                },
+                sources: vec![],
+                adapter: None,
+                intent: None,
+                freshness: None,
+                tests: vec![],
+                format: None,
+                format_options: None,
+                classification: Default::default(),
+                retention: None,
+            },
+        }
+    }
+
+    #[test]
+    fn save_intent_refuses_to_overwrite_unparseable_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let sql_path = dir.path().join("model.sql");
+        let toml_path = dir.path().join("model.toml");
+
+        // Pre-populate a broken TOML sidecar.
+        let broken = "name = \"unfinished string\nintent = \"old\"\n";
+        let mut f = std::fs::File::create(&toml_path).unwrap();
+        f.write_all(broken.as_bytes()).unwrap();
+        drop(f);
+
+        let model = make_model(sql_path.to_string_lossy().to_string());
+        let result = save_intent_to_config(&model, "the new intent");
+
+        // Must return an error, not silently overwrite.
+        let err = result.expect_err("save should refuse to overwrite unparseable TOML");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("refusing to overwrite unparseable TOML"),
+            "unexpected error message: {msg}"
+        );
+
+        // The original (broken) file must be untouched.
+        let on_disk = std::fs::read_to_string(&toml_path).unwrap();
+        assert_eq!(
+            on_disk, broken,
+            "save_intent_to_config clobbered an unparseable file"
+        );
+    }
+
+    #[test]
+    fn save_intent_creates_fresh_toml_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let sql_path = dir.path().join("model.sql");
+        let model = make_model(sql_path.to_string_lossy().to_string());
+
+        save_intent_to_config(&model, "some intent").unwrap();
+
+        let toml_path = dir.path().join("model.toml");
+        let content = std::fs::read_to_string(&toml_path).unwrap();
+        assert!(content.contains("intent"));
+        assert!(content.contains("some intent"));
+        assert!(content.contains("test_model"));
+    }
+
+    #[test]
+    fn save_intent_merges_into_valid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let sql_path = dir.path().join("model.sql");
+        let toml_path = dir.path().join("model.toml");
+
+        std::fs::write(&toml_path, "name = \"existing_name\"\nowner = \"team\"\n").unwrap();
+
+        let model = make_model(sql_path.to_string_lossy().to_string());
+        save_intent_to_config(&model, "updated").unwrap();
+
+        let content = std::fs::read_to_string(&toml_path).unwrap();
+        // Pre-existing fields preserved.
+        assert!(content.contains("existing_name"));
+        assert!(content.contains("owner"));
+        assert!(content.contains("team"));
+        // New intent added.
+        assert!(content.contains("updated"));
+    }
 }

--- a/engine/crates/rocky-bigquery/src/auth.rs
+++ b/engine/crates/rocky-bigquery/src/auth.rs
@@ -3,10 +3,21 @@
 //! Credential fields (`private_key`, bearer tokens) are wrapped in
 //! [`RedactedString`] so that `Debug` output never leaks secrets.
 
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use rocky_core::redacted::RedactedString;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::sync::RwLock;
+
+/// Serve a cached OAuth access token only if it still has at least this
+/// much time left. Mirrors the Databricks adapter so a request in flight
+/// when the token crosses the server-side expiry doesn't 401 right
+/// before the call finishes. Google access tokens are typically valid
+/// for 3600s, so a 60s slack is well below the TTL.
+const REFRESH_SLACK: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Error)]
 pub enum AuthError {
@@ -66,14 +77,38 @@ struct Claims {
     iat: u64,
 }
 
+/// Cached exchanged OAuth access token. Mirrors the Databricks pattern
+/// (`rocky-databricks/src/auth.rs`). `pub` only because it appears in
+/// the public `BigQueryAuth::ServiceAccount` variant; consumers should
+/// treat it as opaque.
+#[derive(Clone)]
+pub struct CachedToken {
+    access_token: RedactedString,
+    expires_at: Instant,
+}
+
+impl CachedToken {
+    fn is_fresh(&self) -> bool {
+        self.expires_at > Instant::now() + REFRESH_SLACK
+    }
+}
+
 /// BigQuery authentication provider.
 ///
 /// Credential fields are wrapped in [`RedactedString`]; the custom `Debug`
 /// impl prints `***` instead of raw secrets.
+///
+/// The `ServiceAccount` variant carries an in-memory access-token cache
+/// so each `get_token` call doesn't mint + exchange a fresh JWT (~100ms
+/// of latency per call). The cache is keyed by the auth instance — clones
+/// of the same `BigQueryAuth` share the same cache via `Arc`.
 #[derive(Clone)]
 pub enum BigQueryAuth {
-    /// Service Account JSON key.
-    ServiceAccount(ServiceAccountKey),
+    /// Service Account JSON key with cached exchanged access token.
+    ServiceAccount {
+        key: ServiceAccountKey,
+        cached_token: Arc<RwLock<Option<CachedToken>>>,
+    },
     /// Pre-supplied Bearer token (e.g., from ADC or gcloud).
     Bearer(RedactedString),
 }
@@ -81,7 +116,7 @@ pub enum BigQueryAuth {
 impl std::fmt::Debug for BigQueryAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BigQueryAuth::ServiceAccount(key) => f
+            BigQueryAuth::ServiceAccount { key, .. } => f
                 .debug_tuple("BigQueryAuth::ServiceAccount")
                 .field(key)
                 .finish(),
@@ -93,7 +128,25 @@ impl std::fmt::Debug for BigQueryAuth {
     }
 }
 
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    /// Lifetime of the access token in seconds. Used to populate the
+    /// local cache so subsequent `get_token` calls within the window
+    /// skip the JWT mint + exchange roundtrip.
+    expires_in: u64,
+}
+
 impl BigQueryAuth {
+    /// Construct a `ServiceAccount` variant from a parsed key. Initializes
+    /// an empty access-token cache.
+    pub fn service_account(key: ServiceAccountKey) -> Self {
+        BigQueryAuth::ServiceAccount {
+            key,
+            cached_token: Arc::new(RwLock::new(None)),
+        }
+    }
+
     /// Auto-detect authentication from environment.
     pub fn from_env() -> Result<Self, AuthError> {
         // 1. Check for explicit bearer token
@@ -106,17 +159,35 @@ impl BigQueryAuth {
             let content = std::fs::read_to_string(&path)?;
             let key: ServiceAccountKey =
                 serde_json::from_str(&content).map_err(AuthError::ParseKey)?;
-            return Ok(BigQueryAuth::ServiceAccount(key));
+            return Ok(BigQueryAuth::service_account(key));
         }
 
         Err(AuthError::NoAuth)
     }
 
     /// Get a bearer token for API calls.
+    ///
+    /// For `ServiceAccount`, returns the cached exchanged access token if
+    /// it still has at least [`REFRESH_SLACK`] left; otherwise mints a
+    /// fresh JWT, exchanges it at Google's token endpoint, caches the
+    /// result with the server-supplied `expires_in`, and returns it.
     pub async fn get_token(&self, client: &reqwest::Client) -> Result<String, AuthError> {
         match self {
             BigQueryAuth::Bearer(token) => Ok(token.expose().to_string()),
-            BigQueryAuth::ServiceAccount(key) => {
+            BigQueryAuth::ServiceAccount { key, cached_token } => {
+                // Fast path: cache hit under a read lock.
+                if let Some(token) = read_fresh_token(cached_token).await {
+                    return Ok(token);
+                }
+
+                // Slow path: take the write lock, double-check (someone
+                // else may have refreshed while we were waiting), then
+                // mint + exchange.
+                let mut cache = cached_token.write().await;
+                if let Some(ct) = cache.as_ref().filter(|ct| ct.is_fresh()) {
+                    return Ok(ct.access_token.expose().to_string());
+                }
+
                 let now = chrono::Utc::now().timestamp() as u64;
                 let claims = Claims {
                     iss: key.client_email.clone(),
@@ -130,7 +201,7 @@ impl BigQueryAuth {
                 let encoding_key = EncodingKey::from_rsa_pem(key.private_key.expose().as_bytes())?;
                 let jwt = encode(&header, &claims, &encoding_key)?;
 
-                // Exchange JWT for access token
+                // Exchange JWT for access token.
                 let resp = client
                     .post(&key.token_uri)
                     .form(&[
@@ -149,24 +220,59 @@ impl BigQueryAuth {
                     return Err(AuthError::TokenExchange(body));
                 }
 
-                #[derive(Deserialize)]
-                struct TokenResponse {
-                    access_token: String,
-                }
-
                 let token: TokenResponse = resp
                     .json()
                     .await
                     .map_err(|e| AuthError::TokenExchange(e.to_string()))?;
+
+                *cache = Some(CachedToken {
+                    access_token: RedactedString::new(token.access_token.clone()),
+                    expires_at: Instant::now() + Duration::from_secs(token.expires_in),
+                });
+
                 Ok(token.access_token)
             }
         }
     }
+
+    /// Invalidate any cached access token so the next `get_token` call
+    /// forces a fresh JWT exchange. Bearer auth has no cache and is a
+    /// no-op. Useful after a server 401 — long pipelines can otherwise
+    /// keep replaying a server-expired token from the local cache.
+    pub async fn invalidate_cache(&self) {
+        if let BigQueryAuth::ServiceAccount { cached_token, .. } = self {
+            *cached_token.write().await = None;
+        }
+    }
+}
+
+/// Fast-path cache read: returns the cached access token if it still has
+/// at least [`REFRESH_SLACK`] left, otherwise `None`.
+async fn read_fresh_token(cache: &RwLock<Option<CachedToken>>) -> Option<String> {
+    cache
+        .read()
+        .await
+        .as_ref()
+        .filter(|ct| ct.is_fresh())
+        .map(|ct| ct.access_token.expose().to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fake_key() -> ServiceAccountKey {
+        ServiceAccountKey {
+            key_type: "service_account".into(),
+            project_id: "my-project".into(),
+            private_key_id: "key-id-123".into(),
+            private_key: RedactedString::new(
+                "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----".into(),
+            ),
+            client_email: "test@project.iam.gserviceaccount.com".into(),
+            token_uri: "https://oauth2.googleapis.com/token".into(),
+        }
+    }
 
     #[test]
     fn debug_bearer_hides_token() {
@@ -181,17 +287,7 @@ mod tests {
 
     #[test]
     fn debug_service_account_hides_private_key() {
-        let key = ServiceAccountKey {
-            key_type: "service_account".into(),
-            project_id: "my-project".into(),
-            private_key_id: "key-id-123".into(),
-            private_key: RedactedString::new(
-                "-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----".into(),
-            ),
-            client_email: "test@project.iam.gserviceaccount.com".into(),
-            token_uri: "https://oauth2.googleapis.com/token".into(),
-        };
-        let auth = BigQueryAuth::ServiceAccount(key);
+        let auth = BigQueryAuth::service_account(fake_key());
         let debug = format!("{auth:?}");
         assert!(
             !debug.contains("SECRET"),
@@ -223,5 +319,74 @@ mod tests {
             "private key leaked: {debug}"
         );
         assert!(debug.contains("***"));
+    }
+
+    #[tokio::test]
+    async fn cache_starts_empty() {
+        let auth = BigQueryAuth::service_account(fake_key());
+        if let BigQueryAuth::ServiceAccount { cached_token, .. } = &auth {
+            assert!(cached_token.read().await.is_none());
+        } else {
+            panic!("expected ServiceAccount variant");
+        }
+    }
+
+    #[tokio::test]
+    async fn invalidate_cache_clears_token() {
+        let auth = BigQueryAuth::service_account(fake_key());
+        if let BigQueryAuth::ServiceAccount { cached_token, .. } = &auth {
+            *cached_token.write().await = Some(CachedToken {
+                access_token: RedactedString::new("primed_token".into()),
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            });
+            assert!(cached_token.read().await.is_some());
+        }
+        auth.invalidate_cache().await;
+        if let BigQueryAuth::ServiceAccount { cached_token, .. } = &auth {
+            assert!(cached_token.read().await.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn invalidate_cache_noop_on_bearer() {
+        let auth = BigQueryAuth::Bearer(RedactedString::new("bearer_tok".into()));
+        // Should not panic.
+        auth.invalidate_cache().await;
+        let client = reqwest::Client::new();
+        assert_eq!(auth.get_token(&client).await.unwrap(), "bearer_tok");
+    }
+
+    #[tokio::test]
+    async fn fresh_cached_token_is_returned() {
+        let auth = BigQueryAuth::service_account(fake_key());
+        if let BigQueryAuth::ServiceAccount { cached_token, .. } = &auth {
+            *cached_token.write().await = Some(CachedToken {
+                access_token: RedactedString::new("cached_access_token".into()),
+                expires_at: Instant::now() + Duration::from_secs(3600),
+            });
+        }
+        let client = reqwest::Client::new();
+        // No network call should happen — the cache is still fresh.
+        let token = auth.get_token(&client).await.unwrap();
+        assert_eq!(token, "cached_access_token");
+    }
+
+    #[tokio::test]
+    async fn expired_cached_token_is_not_used() {
+        // We can't easily mock the token endpoint here, but we can prove
+        // the cache freshness check rejects an expired entry by inspecting
+        // `read_fresh_token` directly.
+        let cache: RwLock<Option<CachedToken>> = RwLock::new(Some(CachedToken {
+            access_token: RedactedString::new("expired".into()),
+            // Already past the slack window.
+            expires_at: Instant::now() + Duration::from_secs(1),
+        }));
+        assert!(read_fresh_token(&cache).await.is_none());
+
+        let cache_fresh: RwLock<Option<CachedToken>> = RwLock::new(Some(CachedToken {
+            access_token: RedactedString::new("ok".into()),
+            expires_at: Instant::now() + Duration::from_secs(3600),
+        }));
+        assert_eq!(read_fresh_token(&cache_fresh).await.as_deref(), Some("ok"));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -97,7 +97,7 @@ pub use retention_status::run_retention_status;
 // Re-exported so the `rocky` bin can build a clap ValueEnum for
 // `--target-dialect` without taking a direct dep on rocky-sql.
 pub use rocky_sql::transpile::Dialect;
-pub use run::{Interrupted, PartitionRunOptions, run};
+pub use run::{Interrupted, PartialFailure, PartitionRunOptions, run};
 pub use run_dag_exec::run_with_dag;
 pub use seed::run_seed;
 pub use serve::run_serve;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -90,6 +90,23 @@ struct TableError {
 #[error("run was interrupted by a shutdown signal")]
 pub struct Interrupted;
 
+/// Sentinel error signalling that `rocky run` completed with at least
+/// one successful materialization *and* at least one table failure
+/// (`RunStatus::PartialFailure`). The outer binary
+/// (`rocky/src/main.rs`) downcasts this off the `anyhow::Error` chain
+/// and maps it to exit code 2 so dagster's `allow_partial=True` can
+/// distinguish partial success from a total failure (exit 1) or an
+/// interrupt (exit 130). The full JSON `RunOutput` has already been
+/// emitted on stdout by the time this is returned.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "{count} table(s) failed during parallel execution (run_id: {run_id}, use --resume {run_id} to retry)"
+)]
+pub struct PartialFailure {
+    pub count: usize,
+    pub run_id: String,
+}
+
 /// Arm a background watcher that hard-exits with code 130 on a *second*
 /// SIGINT. The first signal (SIGINT or SIGTERM) is handled by the outer
 /// `tokio::select!` branch — this watcher gives the user an out when
@@ -3103,6 +3120,25 @@ pub async fn run(
             .fire(&HookContext::pipeline_error(&run_id, pipeline_name, &msg))
             .await;
         let _ = hook_registry.wait_async_webhooks().await;
+
+        // Branch the exit-code contract: a *partial* failure (at least
+        // one table copied + at least one failed) returns the
+        // `PartialFailure` sentinel so `rocky/src/main.rs` can map it
+        // to exit code 2. A total failure (no tables copied) keeps the
+        // existing exit-code-1 path. The valid JSON `RunOutput` has
+        // already been written to stdout above; dagster
+        // (`allow_partial=True`) reads stdout regardless of exit code
+        // for code 2.
+        if matches!(
+            output.derive_run_status(),
+            rocky_core::state::RunStatus::PartialFailure
+        ) {
+            return Err(PartialFailure {
+                count,
+                run_id: run_id.clone(),
+            }
+            .into());
+        }
         anyhow::bail!(
             "{count} table(s) failed during parallel execution (run_id: {run_id}, use --resume {run_id} to retry)"
         );

--- a/engine/crates/rocky-sql/src/transpile.rs
+++ b/engine/crates/rocky-sql/src/transpile.rs
@@ -92,22 +92,39 @@ pub fn transpile(sql: &str, from: Dialect, to: Dialect) -> TranspileResult {
     let mut warnings = Vec::new();
     let mut replacements = 0;
 
-    // Apply function name mappings
+    // Apply function name mappings.
+    //
+    // Function tokens already end in `(` (e.g. `NVL(`), so they're
+    // self-delimiting in code. The text-walk still skips inside string
+    // literals and comments to avoid corrupting `'NVL(...)'` or
+    // `-- NVL(...)` substrings.
     let mappings = get_function_mappings(from, to);
     for (from_fn, to_fn) in &mappings {
-        let count = result.matches(from_fn.as_str()).count();
+        let (next, count) = replace_outside_strings(&result, from_fn, to_fn, MatchKind::Literal);
         if count > 0 {
-            result = result.replace(from_fn.as_str(), to_fn.as_str());
+            result = next;
             replacements += count;
         }
     }
 
-    // Apply type name mappings
+    // Apply type name mappings.
+    //
+    // Type tokens are bare words (e.g. `INT`, `BIGINT`), so a naïve
+    // `replace` corrupts substrings (`INT` matches inside `BIGINT`) and
+    // string literals. Walk the body, skip strings/comments, and require
+    // ASCII word boundaries on either side of the match.
     let type_mappings = get_type_mappings(from, to);
     for (from_type, to_type) in &type_mappings {
-        let count = case_insensitive_count(&result, from_type);
+        let (next, count) = replace_outside_strings(
+            &result,
+            from_type,
+            to_type,
+            MatchKind::WordBoundary {
+                case_sensitive: false,
+            },
+        );
         if count > 0 {
-            result = case_insensitive_replace(&result, from_type, to_type);
+            result = next;
             replacements += count;
         }
     }
@@ -305,6 +322,179 @@ fn get_type_mappings(from: Dialect, to: Dialect) -> Vec<(String, String)> {
     mappings
 }
 
+/// How a candidate match must align with surrounding text to be replaced.
+#[derive(Debug, Clone, Copy)]
+enum MatchKind {
+    /// Exact, case-sensitive substring match. Used for function tokens
+    /// (`NVL(`) which end in `(` and are therefore self-delimiting.
+    Literal,
+    /// Case-insensitive match that requires an ASCII word boundary on
+    /// either side. Used for type tokens (`INT`, `BIGINT`) where a
+    /// naïve substring replace would corrupt `BIGINT` while looking for
+    /// `INT`.
+    WordBoundary { case_sensitive: bool },
+}
+
+/// Replace occurrences of `pattern` with `replacement` while skipping
+/// SQL string literals (`'...'`, `"..."`, `` `...` ``), line comments
+/// (`-- ...`), and block comments (`/* ... */`). Returns the rewritten
+/// string and the count of replacements applied.
+///
+/// This is *not* a full SQL parser — it only tracks quote/comment state
+/// well enough to avoid the most obvious corruptions a naïve
+/// `String::replace` causes:
+///
+/// - replacing inside string literals (`'NVL(a,b)'` mustn't change),
+/// - replacing inside comments (`-- LEN(x)`),
+/// - replacing identifier substrings (`INT` matching inside `BIGINT`).
+fn replace_outside_strings(
+    input: &str,
+    pattern: &str,
+    replacement: &str,
+    kind: MatchKind,
+) -> (String, usize) {
+    if pattern.is_empty() {
+        return (input.to_string(), 0);
+    }
+
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0usize;
+    let mut count = 0usize;
+
+    // Helper: advance `i` by one UTF-8 char starting at `start`,
+    // appending the raw byte slice to `out`. Keeps multi-byte chars
+    // intact (e.g. accented identifiers, emoji in comments).
+    let copy_one_char = |i: &mut usize, out: &mut String| {
+        let start = *i;
+        let step = utf8_char_len(bytes[start]);
+        let end = (start + step).min(bytes.len());
+        out.push_str(std::str::from_utf8(&bytes[start..end]).unwrap_or(""));
+        *i = end;
+    };
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        // -- line comment
+        if b == b'-' && bytes.get(i + 1) == Some(&b'-') {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                copy_one_char(&mut i, &mut out);
+            }
+            continue;
+        }
+
+        // /* block comment */
+        if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            out.push_str("/*");
+            i += 2;
+            while i < bytes.len() {
+                if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                    out.push_str("*/");
+                    i += 2;
+                    break;
+                }
+                copy_one_char(&mut i, &mut out);
+            }
+            continue;
+        }
+
+        // String literals / quoted identifiers.
+        if b == b'\'' || b == b'"' || b == b'`' {
+            let quote = b;
+            out.push(quote as char);
+            i += 1;
+            while i < bytes.len() {
+                let c = bytes[i];
+                // SQL standard: doubled quote escapes the quote inside
+                // a literal/identifier. Pass both bytes through.
+                if c == quote && bytes.get(i + 1) == Some(&quote) {
+                    out.push(quote as char);
+                    out.push(quote as char);
+                    i += 2;
+                    continue;
+                }
+                if c == quote {
+                    out.push(quote as char);
+                    i += 1;
+                    break;
+                }
+                copy_one_char(&mut i, &mut out);
+            }
+            continue;
+        }
+
+        // Code region: try to match the pattern at `i`.
+        if pattern_matches_at(input, i, pattern, kind) {
+            out.push_str(replacement);
+            i += pattern.len();
+            count += 1;
+            continue;
+        }
+
+        copy_one_char(&mut i, &mut out);
+    }
+
+    (out, count)
+}
+
+/// Length (in bytes) of the UTF-8 character whose first byte is `b`.
+/// Falls back to 1 for invalid leading bytes so the walk always makes
+/// progress.
+fn utf8_char_len(b: u8) -> usize {
+    if b < 0x80 {
+        1
+    } else if b < 0xC0 {
+        // continuation byte — shouldn't be a leading byte; advance by 1
+        // to avoid getting stuck.
+        1
+    } else if b < 0xE0 {
+        2
+    } else if b < 0xF0 {
+        3
+    } else {
+        4
+    }
+}
+
+/// Tests whether `pattern` matches the input at byte offset `start`
+/// under the rules of `kind`.
+fn pattern_matches_at(input: &str, start: usize, pattern: &str, kind: MatchKind) -> bool {
+    let bytes = input.as_bytes();
+    let p = pattern.as_bytes();
+    let end = start + p.len();
+    if end > bytes.len() {
+        return false;
+    }
+
+    let region = &bytes[start..end];
+
+    match kind {
+        MatchKind::Literal => region == p,
+        MatchKind::WordBoundary { case_sensitive } => {
+            let body_match = if case_sensitive {
+                region == p
+            } else {
+                region.eq_ignore_ascii_case(p)
+            };
+            if !body_match {
+                return false;
+            }
+            let left_ok = start == 0 || !is_word_byte(bytes[start - 1]);
+            let right_ok = end == bytes.len() || !is_word_byte(bytes[end]);
+            left_ok && right_ok
+        }
+    }
+}
+
+/// ASCII word byte: `[A-Za-z0-9_]`. Multi-byte UTF-8 leading bytes
+/// (>= 0x80) are intentionally treated as non-word here — type tokens
+/// in SQL are ASCII, and treating high bytes as boundaries avoids
+/// false negatives without enabling false positives.
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
 /// Case-insensitive string replacement.
 fn case_insensitive_replace(input: &str, from: &str, to: &str) -> String {
     let lower_input = input.to_lowercase();
@@ -401,5 +591,103 @@ mod tests {
     fn test_display_dialect() {
         assert_eq!(format!("{}", Dialect::BigQuery), "BigQuery");
         assert_eq!(format!("{}", Dialect::Snowflake), "Snowflake");
+    }
+
+    // ---- replace_outside_strings + transpile correctness ----
+
+    #[test]
+    fn type_replace_respects_word_boundaries() {
+        // BigQuery → Databricks maps INT64 → BIGINT. Going the other way
+        // (Databricks → BigQuery) maps BIGINT → INT64; we need to ensure
+        // we don't hit `INT` matches inside `BIGINT` if any rule were to
+        // map `INT` independently.
+        //
+        // Here we exercise the helper directly to prove `INT` does not
+        // eat into `BIGINT`.
+        let (out, count) = replace_outside_strings(
+            "CAST(x AS INT), CAST(y AS BIGINT)",
+            "INT",
+            "INTEGER",
+            MatchKind::WordBoundary {
+                case_sensitive: false,
+            },
+        );
+        assert_eq!(count, 1, "expected exactly one replacement, got: {out}");
+        assert!(out.contains("AS INTEGER)"));
+        assert!(
+            out.contains("BIGINT"),
+            "BIGINT must be preserved, got: {out}"
+        );
+        assert!(
+            !out.contains("BIGINTEGER"),
+            "BIGINT was corrupted into BIGINTEGER, got: {out}"
+        );
+    }
+
+    #[test]
+    fn function_replace_skips_string_literals() {
+        // `NVL(` inside a string literal must not be rewritten to `IFNULL(`.
+        let sql = "SELECT NVL(a, b), '-- example NVL(a,b)' AS doc FROM t";
+        let result = transpile(sql, Dialect::Snowflake, Dialect::BigQuery);
+        // Real call site got transpiled.
+        assert!(
+            result.sql.contains("IFNULL(a, b)"),
+            "real call should be rewritten: {}",
+            result.sql
+        );
+        // String literal stayed verbatim.
+        assert!(
+            result.sql.contains("'-- example NVL(a,b)'"),
+            "string literal corrupted: {}",
+            result.sql
+        );
+    }
+
+    #[test]
+    fn function_replace_skips_line_comments() {
+        let sql = "SELECT NVL(a, b) -- legacy NVL(...) reference\nFROM t";
+        let result = transpile(sql, Dialect::Snowflake, Dialect::BigQuery);
+        assert!(result.sql.contains("IFNULL(a, b)"));
+        assert!(
+            result.sql.contains("-- legacy NVL(...) reference"),
+            "comment was rewritten: {}",
+            result.sql
+        );
+    }
+
+    #[test]
+    fn function_replace_skips_block_comments() {
+        let sql = "SELECT NVL(a, b) /* inline NVL(x) note */ FROM t";
+        let result = transpile(sql, Dialect::Snowflake, Dialect::BigQuery);
+        assert!(result.sql.contains("IFNULL(a, b)"));
+        assert!(
+            result.sql.contains("/* inline NVL(x) note */"),
+            "block comment was rewritten: {}",
+            result.sql
+        );
+    }
+
+    #[test]
+    fn type_replace_skips_string_literals() {
+        // `INT64` inside a quoted string must not be rewritten.
+        let sql = "SELECT CAST(x AS INT64), 'INT64 lives here' FROM t";
+        let result = transpile(sql, Dialect::BigQuery, Dialect::Snowflake);
+        assert!(result.sql.contains("AS BIGINT"));
+        assert!(
+            result.sql.contains("'INT64 lives here'"),
+            "INT64 in literal corrupted: {}",
+            result.sql
+        );
+    }
+
+    #[test]
+    fn doubled_quote_escape_in_literal_handled() {
+        // `'it''s NVL'` is a valid SQL string literal containing a quote.
+        // The inner `NVL` must not be rewritten and the literal must
+        // round-trip unchanged.
+        let sql = "SELECT 'it''s NVL', NVL(a, b) FROM t";
+        let result = transpile(sql, Dialect::Snowflake, Dialect::BigQuery);
+        assert!(result.sql.contains("'it''s NVL'"), "{}", result.sql);
+        assert!(result.sql.contains("IFNULL(a, b)"));
     }
 }

--- a/engine/crates/rocky-wasm/src/lib.rs
+++ b/engine/crates/rocky-wasm/src/lib.rs
@@ -313,10 +313,19 @@ pub fn compile_rocky_model(source: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// Convert a byte offset to 1-based line and column numbers.
+///
+/// The offset is clamped to `source.len()` and walked back to the
+/// nearest preceding char boundary so a multi-byte UTF-8 character at
+/// the end of the buffer (or a deliberately mid-char offset from
+/// adversarial LSP/WASM input) cannot panic the slice in `&source[..n]`.
 fn byte_offset_to_line_col(source: &str, offset: usize) -> (usize, usize) {
-    let before = &source[..offset.min(source.len())];
-    let line = before.chars().filter(|c| *c == '\n').count() + 1;
-    let col = before.rfind('\n').map_or(offset, |pos| offset - pos - 1) + 1;
+    let mut clamped = offset.min(source.len());
+    while clamped > 0 && !source.is_char_boundary(clamped) {
+        clamped -= 1;
+    }
+    let before = &source[..clamped];
+    let line = before.bytes().filter(|b| *b == b'\n').count() + 1;
+    let col = before.rfind('\n').map_or(clamped, |pos| clamped - pos - 1) + 1;
     (line, col)
 }
 
@@ -579,5 +588,39 @@ mod tests {
         assert!(parse_dialect("postgres").is_none());
         assert!(parse_dialect("mysql").is_none());
         assert!(parse_dialect("").is_none());
+    }
+
+    // ---- byte_offset_to_line_col regression coverage ----
+
+    #[test]
+    fn byte_offset_to_line_col_handles_offset_past_end() {
+        // Empty source, large offset: no panic, returns (1, 1).
+        assert_eq!(byte_offset_to_line_col("", 999), (1, 1));
+        // Non-empty source, offset past end: clamped to len, no panic.
+        let (line, _) = byte_offset_to_line_col("abc", 999);
+        assert_eq!(line, 1);
+    }
+
+    #[test]
+    fn byte_offset_to_line_col_handles_multibyte_at_eof() {
+        // `é` is two bytes in UTF-8. An offset that lands one byte past
+        // the end (or in the middle of the multi-byte char) used to
+        // panic via `&source[..offset]`. The clamped + char-boundary
+        // walk must keep this safe.
+        let src = "let a = \"é\""; // 12 bytes total
+        for offset in 0..=src.len() + 4 {
+            // Should never panic.
+            let _ = byte_offset_to_line_col(src, offset);
+        }
+    }
+
+    #[test]
+    fn byte_offset_to_line_col_handles_midchar_offset() {
+        // `日本語` = 9 bytes; an offset of 1 lands inside the first
+        // codepoint. We expect graceful walk-back to byte 0.
+        let src = "日本語";
+        let (line, col) = byte_offset_to_line_col(src, 1);
+        assert_eq!(line, 1);
+        assert_eq!(col, 1, "expected column 1 after walk-back to boundary");
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1880,6 +1880,22 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         }
     }
 
+    // Partial-success: map `commands::PartialFailure` to exit code 2.
+    // The valid `RunOutput` JSON has already been written to stdout in
+    // `run.rs` before the sentinel was returned, so dagster's
+    // `allow_partial=True` path can parse it and surface per-table
+    // results rather than treating the whole run as a hard failure.
+    // Total failure (no tables copied) keeps exit code 1 — that branch
+    // doesn't produce the partial-success sentinel.
+    if let Err(ref err) = result {
+        if err
+            .downcast_ref::<rocky_cli::commands::PartialFailure>()
+            .is_some()
+        {
+            std::process::exit(2);
+        }
+    }
+
     // In text mode, try to upgrade config errors to rich miette diagnostics
     // with source spans and suggestions. JSON mode returns structured errors
     // unchanged for orchestrators (e.g., Dagster).


### PR DESCRIPTION
## Summary

Five small, isolated bug fixes from the maintenance sweep — each fixes a subtle bug in already-shipped code. Bundled because they all share that shape and don't interact.

- **P1.1 BigQuery JWT not cached** (`rocky-bigquery/src/auth.rs`)
  Service Account auth was minting + exchanging a fresh JWT on every API call (~100ms/call). Added an `Arc<RwLock<Option<CachedToken>>>` keyed by the `BigQueryAuth` instance, mirroring the Databricks pattern (60s `REFRESH_SLACK`). The cache uses Google's `expires_in` from the token-exchange response. New `invalidate_cache()` for post-401 retries. The `ServiceAccount` enum variant is now struct-form `{ key, cached_token }`.

- **P1.2 `rocky-sql` transpile corruption** (`rocky-sql/src/transpile.rs`)
  `String::replace` walked the whole SQL body, corrupting string literals, line/block comments, and identifier substrings (e.g. mapping `INT64 → BIGINT` incorrectly hit inside `INT`-prefixed words). Added a single-pass walker that tracks `LineComment` / `BlockComment` / `'…'` / `"…"` / `` `…` `` state (with doubled-quote escape handling), and requires ASCII word boundaries on type tokens. Function tokens (e.g. `NVL(`) are still literal but skip strings/comments.

- **P1.3 WASM `byte_offset_to_line_col` panic** (`rocky-wasm/src/lib.rs`)
  An offset past `source.len()` *or* mid-char into a multi-byte UTF-8 character would panic the slice. Clamp to `text.len()` and walk back to the nearest char boundary via `is_char_boundary`.

- **P1.4 `explain.save_intent_to_config` clobber** (`rocky-ai/src/explain.rs`)
  When the existing TOML sidecar failed to parse, the prior `unwrap_or(empty)` silently overwrote the file with a fresh `intent = "..."` document, deleting the user's in-flight edits. Now returns `Err(io::Error::other("refusing to overwrite unparseable TOML at <path>: …"))`.

- **P1.5 Partial-success exit code 2** (`rocky-cli/src/commands/run.rs`, `rocky/src/main.rs`)
  Documented contract said partial failures exit 2, but the post-JSON `bail!` always returned exit 1, so dagster `allow_partial=True` couldn't distinguish partial from total failure. Defined a `PartialFailure` sentinel next to `Interrupted`, branched the `bail!` site on `derive_run_status()`, and added the downcast in `main.rs` (`PartialFailure → exit 2`, mirroring `Interrupted → exit 130`). Total failure (no tables copied) still exits 1.

## Test plan

- [x] `cd engine && cargo test -p rocky-bigquery -p rocky-sql -p rocky-wasm -p rocky-ai -p rocky-cli` — all green (incl. new tests for each fix).
- [x] `cd engine && cargo clippy --all-targets -- -D warnings` clean.
- [x] `cd engine && cargo fmt --check` clean.
- [x] Full `cargo test` workspace-wide — no regressions.

New regression tests:
- BigQuery: cache-hit returns cached token, expired token rejected by `read_fresh_token`, `invalidate_cache` clears the entry, `invalidate_cache` is a no-op on `Bearer`.
- rocky-sql: word boundaries (`INT` vs `BIGINT`), function/type replacement skips string literals + line + block comments, doubled-quote escape inside literals round-trips.
- rocky-wasm: offset past end, multi-byte char at EOF (`é`), mid-char offset (`日本語`).
- rocky-ai: refuses to clobber unparseable TOML *and* asserts the file is byte-identical after the failed call; merges into valid TOML; creates fresh sidecar when missing.

No `*Output` structs touched, so no `just codegen` cascade. No DSL change.