### PR TITLE
fix(engine): validate identifiers + reject injection-bearing SQL string-literal payloads

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3554,6 +3554,7 @@ dependencies = [
  "rocky-compiler",
  "rocky-core",
  "rocky-duckdb",
+ "rocky-sql",
  "serde",
  "serde_json",
  "thiserror",

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -12,6 +12,7 @@ use rocky_core::ir::{ColumnInfo, TableRef};
 use rocky_core::traits::{
     AdapterError, AdapterResult, ExecutionStats, QueryResult, SqlDialect, WarehouseAdapter,
 };
+use rocky_sql::validation::validate_identifier;
 
 use crate::auth::BigQueryAuth;
 use crate::dialect::BigQueryDialect;
@@ -297,6 +298,11 @@ impl WarehouseAdapter for BigQueryAdapter {
     }
 
     async fn describe_table(&self, table: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
+        // validate_identifier rejects `'` and other non-alphanumerics, so the
+        // `table_name = '...'` literal cannot be broken out of by `table.table`.
+        validate_identifier(&table.catalog).map_err(AdapterError::new)?;
+        validate_identifier(&table.schema).map_err(AdapterError::new)?;
+        validate_identifier(&table.table).map_err(AdapterError::new)?;
         let sql = format!(
             "SELECT column_name, data_type, is_nullable \
              FROM `{}`.`{}`.INFORMATION_SCHEMA.COLUMNS \
@@ -326,6 +332,8 @@ impl WarehouseAdapter for BigQueryAdapter {
 
     async fn list_tables(&self, catalog: &str, schema: &str) -> AdapterResult<Vec<String>> {
         // BigQuery: catalog = project, schema = dataset
+        validate_identifier(catalog).map_err(AdapterError::new)?;
+        validate_identifier(schema).map_err(AdapterError::new)?;
         let sql =
             format!("SELECT table_name FROM `{catalog}`.`{schema}`.INFORMATION_SCHEMA.TABLES");
         let result = self.execute_query(&sql).await?;

--- a/engine/crates/rocky-databricks/src/loader.rs
+++ b/engine/crates/rocky-databricks/src/loader.rs
@@ -24,6 +24,7 @@ use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
+use rocky_sql::validation::validate_identifier;
 
 use crate::connector::{DatabricksConnector, QueryResult};
 
@@ -58,12 +59,20 @@ fn resolve_format(source: &LoadSource, options: &LoadOptions) -> AdapterResult<F
     })
 }
 
-/// Render a Databricks target as `catalog.schema.table`.
-fn format_target(target: &TableRef) -> String {
+/// Render a Databricks target as `catalog.schema.table` after validating each
+/// identifier. Rejects anything that isn't `[A-Za-z0-9_]+` so the result is
+/// always safe to interpolate into SQL.
+fn format_target(target: &TableRef) -> AdapterResult<String> {
+    validate_identifier(&target.schema).map_err(AdapterError::new)?;
+    validate_identifier(&target.table).map_err(AdapterError::new)?;
     if target.catalog.is_empty() {
-        format!("{}.{}", target.schema, target.table)
+        Ok(format!("{}.{}", target.schema, target.table))
     } else {
-        format!("{}.{}.{}", target.catalog, target.schema, target.table)
+        validate_identifier(&target.catalog).map_err(AdapterError::new)?;
+        Ok(format!(
+            "{}.{}.{}",
+            target.catalog, target.schema, target.table
+        ))
     }
 }
 
@@ -77,7 +86,10 @@ fn file_format_clause(format: FileFormat) -> &'static str {
 }
 
 /// Render the FORMAT_OPTIONS clause (only CSV has tunables Databricks cares about).
-fn format_options_clause(format: FileFormat, options: &LoadOptions) -> Option<String> {
+fn format_options_clause(
+    format: FileFormat,
+    options: &LoadOptions,
+) -> AdapterResult<Option<String>> {
     match format {
         FileFormat::Csv => {
             let header = if options.csv_has_header {
@@ -85,13 +97,40 @@ fn format_options_clause(format: FileFormat, options: &LoadOptions) -> Option<St
             } else {
                 "false"
             };
-            let delim = options.csv_delimiter;
-            Some(format!(
+            let delim = validate_csv_delimiter(options.csv_delimiter)?;
+            Ok(Some(format!(
                 "FORMAT_OPTIONS ('header' = '{header}', 'delimiter' = '{delim}')"
-            ))
+            )))
         }
-        FileFormat::Parquet | FileFormat::JsonLines => None,
+        FileFormat::Parquet | FileFormat::JsonLines => Ok(None),
     }
+}
+
+/// Reject CSV delimiters that would break out of the `'...'` SQL string literal.
+/// Allows printable ASCII plus tab; rejects quotes, backslash, and newlines.
+fn validate_csv_delimiter(c: char) -> AdapterResult<char> {
+    let ok = c == '\t' || (c.is_ascii() && !c.is_ascii_control() && c != '\'' && c != '\\');
+    if ok {
+        Ok(c)
+    } else {
+        Err(AdapterError::msg(format!(
+            "invalid CSV delimiter {c:?}: must be a printable ASCII char (or tab), not a quote, backslash, or control character"
+        )))
+    }
+}
+
+/// Reject cloud URIs that would break out of the `'<uri>'` SQL string literal.
+/// Rocky never escapes embedded quotes — instead we refuse to build the SQL.
+fn validate_cloud_uri(uri: &str) -> AdapterResult<&str> {
+    if uri.is_empty() {
+        return Err(AdapterError::msg("cloud URI cannot be empty"));
+    }
+    if uri.contains(['\'', '\n', '\r', '\\']) {
+        return Err(AdapterError::msg(format!(
+            "invalid cloud URI {uri:?}: must not contain quotes, backslashes, or newlines"
+        )));
+    }
+    Ok(uri)
 }
 
 /// Extract the `num_affected_rows` count from a COPY INTO response.
@@ -122,14 +161,18 @@ fn extract_num_affected_rows(result: &QueryResult) -> Option<u64> {
 }
 
 /// Build the full `COPY INTO ... FROM '<uri>'` SQL statement.
+///
+/// The caller must pass a validated `target_ref` (use [`format_target`]) and a
+/// validated `uri` (use [`validate_cloud_uri`]) so the literal-context
+/// interpolation can't be broken out of.
 fn build_copy_into_sql(
     uri: &str,
     target_ref: &str,
     format: FileFormat,
     options: &LoadOptions,
-) -> String {
+) -> AdapterResult<String> {
     let fileformat = file_format_clause(format);
-    let format_opts = format_options_clause(format, options)
+    let format_opts = format_options_clause(format, options)?
         .map(|s| format!(" {s}"))
         .unwrap_or_default();
     // mergeSchema lets Databricks evolve the target schema when new columns
@@ -139,7 +182,9 @@ fn build_copy_into_sql(
     } else {
         ""
     };
-    format!("COPY INTO {target_ref} FROM '{uri}' FILEFORMAT = {fileformat}{format_opts}{copy_opts}")
+    Ok(format!(
+        "COPY INTO {target_ref} FROM '{uri}' FILEFORMAT = {fileformat}{format_opts}{copy_opts}"
+    ))
 }
 
 #[async_trait]
@@ -165,7 +210,8 @@ impl LoaderAdapter for DatabricksLoaderAdapter {
         };
 
         let format = resolve_format(source, options)?;
-        let target_ref = format_target(target);
+        let target_ref = format_target(target)?;
+        let uri = validate_cloud_uri(&uri)?.to_string();
 
         // `truncate_first` maps to a DELETE prior to COPY INTO. Databricks
         // supports DELETE FROM on managed tables.
@@ -178,7 +224,7 @@ impl LoaderAdapter for DatabricksLoaderAdapter {
                 .map_err(|e| AdapterError::msg(e.to_string()))?;
         }
 
-        let sql = build_copy_into_sql(&uri, &target_ref, format, options);
+        let sql = build_copy_into_sql(&uri, &target_ref, format, options)?;
         info!(sql = %sql, "databricks COPY INTO");
         let copy_result = self
             .connector
@@ -229,7 +275,9 @@ mod tests {
     #[test]
     fn test_format_options_csv_default() {
         let opts = LoadOptions::default();
-        let clause = format_options_clause(FileFormat::Csv, &opts).unwrap();
+        let clause = format_options_clause(FileFormat::Csv, &opts)
+            .unwrap()
+            .unwrap();
         assert!(clause.contains("'header' = 'true'"));
         assert!(clause.contains("'delimiter' = ','"));
     }
@@ -241,14 +289,29 @@ mod tests {
             csv_has_header: false,
             ..Default::default()
         };
-        let clause = format_options_clause(FileFormat::Csv, &opts).unwrap();
+        let clause = format_options_clause(FileFormat::Csv, &opts)
+            .unwrap()
+            .unwrap();
         assert!(clause.contains("'header' = 'false'"));
         assert!(clause.contains("'delimiter' = '\t'"));
     }
 
     #[test]
     fn test_format_options_parquet_none() {
-        assert!(format_options_clause(FileFormat::Parquet, &LoadOptions::default()).is_none());
+        assert!(
+            format_options_clause(FileFormat::Parquet, &LoadOptions::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_format_options_csv_rejects_quote_delimiter() {
+        let opts = LoadOptions {
+            csv_delimiter: '\'',
+            ..Default::default()
+        };
+        assert!(format_options_clause(FileFormat::Csv, &opts).is_err());
     }
 
     #[test]
@@ -258,7 +321,7 @@ mod tests {
             schema: "raw".into(),
             table: "orders".into(),
         };
-        assert_eq!(format_target(&t), "main.raw.orders");
+        assert_eq!(format_target(&t).unwrap(), "main.raw.orders");
     }
 
     #[test]
@@ -268,7 +331,25 @@ mod tests {
             schema: "raw".into(),
             table: "orders".into(),
         };
-        assert_eq!(format_target(&t), "raw.orders");
+        assert_eq!(format_target(&t).unwrap(), "raw.orders");
+    }
+
+    #[test]
+    fn test_format_target_rejects_injection() {
+        let t = TableRef {
+            catalog: "main; DROP TABLE x".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        };
+        assert!(format_target(&t).is_err());
+    }
+
+    #[test]
+    fn test_validate_cloud_uri_rejects_quote() {
+        assert!(validate_cloud_uri("s3://bucket/key").is_ok());
+        assert!(validate_cloud_uri("s3://bucket/key'; DROP --").is_err());
+        assert!(validate_cloud_uri("s3://bucket/\nfoo").is_err());
+        assert!(validate_cloud_uri("").is_err());
     }
 
     #[test]
@@ -279,7 +360,8 @@ mod tests {
             "main.raw.orders",
             FileFormat::Csv,
             &opts,
-        );
+        )
+        .unwrap();
         assert!(sql.starts_with("COPY INTO main.raw.orders"));
         assert!(sql.contains("FROM 's3://bucket/path/file.csv'"));
         assert!(sql.contains("FILEFORMAT = CSV"));
@@ -298,7 +380,8 @@ mod tests {
             "main.raw.orders",
             FileFormat::Parquet,
             &opts,
-        );
+        )
+        .unwrap();
         assert!(sql.contains("FILEFORMAT = PARQUET"));
         assert!(!sql.contains("mergeSchema"));
         assert!(!sql.contains("FORMAT_OPTIONS"));
@@ -312,7 +395,8 @@ mod tests {
             "main.raw.orders",
             FileFormat::JsonLines,
             &opts,
-        );
+        )
+        .unwrap();
         assert!(sql.contains("FILEFORMAT = JSON"));
         assert!(sql.contains("abfss://container@acct/data.jsonl"));
     }

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 rocky-compiler = { path = "../rocky-compiler" }
 rocky-core = { path = "../rocky-core" }
 rocky-duckdb = { path = "../rocky-duckdb", optional = true }
+rocky-sql = { path = "../rocky-sql" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/engine/crates/rocky-engine/src/executor.rs
+++ b/engine/crates/rocky-engine/src/executor.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use rocky_compiler::compile::{CompileResult, CompilerConfig};
 use rocky_duckdb::DuckDbConnector;
+use rocky_sql::validation::validate_identifier;
 use tracing::info;
 
 /// Result of local execution.
@@ -32,7 +33,12 @@ pub fn execute_locally(compile_result: &CompileResult, db: &DuckDbConnector) -> 
     for layer in &compile_result.project.layers {
         for model_name in layer {
             if let Some(model) = compile_result.project.model(model_name) {
-                // Wrap model SQL in CREATE TABLE AS for local execution
+                if let Err(e) = validate_identifier(model_name) {
+                    result.failed.push((model_name.clone(), e.to_string()));
+                    continue;
+                }
+                // Wrap model SQL in CREATE TABLE AS for local execution.
+                // `model_name` was validated above; `model.sql` is compiler-emitted SQL.
                 let exec_sql = format!("CREATE OR REPLACE TABLE {model_name} AS\n{}", model.sql);
 
                 match db.execute_statement(&exec_sql) {

--- a/engine/crates/rocky-engine/src/profile.rs
+++ b/engine/crates/rocky-engine/src/profile.rs
@@ -3,6 +3,7 @@
 //! Generates column-level statistics (null rates, cardinality, min/max, etc.)
 //! and diffs profiles between runs to detect data quality regressions.
 
+use rocky_sql::validation::{ValidationError, validate_identifier};
 use serde::{Deserialize, Serialize};
 
 /// Statistical profile for a single column.
@@ -215,16 +216,23 @@ pub fn diff_profiles(old: &ModelProfile, new: &ModelProfile) -> ProfileDiff {
 /// Generates profiling SQL for DuckDB.
 ///
 /// Produces a single query that computes column-level statistics for each
-/// column in the given table.
-pub fn generate_profile_sql(table_name: &str, columns: &[(String, String)]) -> String {
+/// column in the given table. The table name and every column name are
+/// validated as SQL identifiers; injection-bearing inputs are rejected
+/// rather than escaped.
+pub fn generate_profile_sql(
+    table_name: &str,
+    columns: &[(String, String)],
+) -> Result<String, ValidationError> {
+    validate_identifier(table_name)?;
     if columns.is_empty() {
-        return format!("SELECT COUNT(*) AS row_count FROM {table_name}");
+        return Ok(format!("SELECT COUNT(*) AS row_count FROM {table_name}"));
     }
 
     let mut parts = Vec::new();
     parts.push("SELECT COUNT(*) AS _row_count".to_string());
 
     for (col_name, col_type) in columns {
+        validate_identifier(col_name)?;
         let is_numeric = matches!(
             col_type.to_uppercase().as_str(),
             "INT"
@@ -263,7 +271,7 @@ pub fn generate_profile_sql(table_name: &str, columns: &[(String, String)]) -> S
         }
     }
 
-    format!("{}\nFROM {table_name}", parts.join(""))
+    Ok(format!("{}\nFROM {table_name}", parts.join("")))
 }
 
 #[cfg(test)]
@@ -416,7 +424,7 @@ mod tests {
             ("id".to_string(), "INTEGER".to_string()),
             ("name".to_string(), "VARCHAR".to_string()),
         ];
-        let sql = generate_profile_sql("orders", &cols);
+        let sql = generate_profile_sql("orders", &cols).unwrap();
         assert!(sql.contains("COUNT(*)"));
         assert!(sql.contains("COUNT(DISTINCT \"id\")"));
         assert!(sql.contains("\"id__distinct\""));
@@ -431,7 +439,14 @@ mod tests {
 
     #[test]
     fn test_generate_profile_sql_empty_columns() {
-        let sql = generate_profile_sql("empty_table", &[]);
+        let sql = generate_profile_sql("empty_table", &[]).unwrap();
         assert_eq!(sql, "SELECT COUNT(*) AS row_count FROM empty_table");
+    }
+
+    #[test]
+    fn test_generate_profile_sql_rejects_injection() {
+        assert!(generate_profile_sql("orders; DROP TABLE x", &[]).is_err());
+        let cols = vec![("col\"; DROP".to_string(), "INTEGER".to_string())];
+        assert!(generate_profile_sql("orders", &cols).is_err());
     }
 }

--- a/engine/crates/rocky-lang/src/lower.rs
+++ b/engine/crates/rocky-lang/src/lower.rs
@@ -2,6 +2,20 @@
 //!
 //! Compiles the DSL AST into standard SQL. The key semantic improvement:
 //! `!=` compiles to `IS DISTINCT FROM` (NULL-safe), not SQL's `!=`.
+//!
+//! ## SQL injection safety
+//!
+//! Identifier-positioned strings (column names, function names, model names,
+//! aliases) are interpolated raw via `format!`. They are safe by construction:
+//! every such string flows from `Token::Ident`, whose lexer regex
+//! `[a-zA-Z_][a-zA-Z0-9_]*` (see `token.rs`) is strictly tighter than
+//! [`rocky_sql::validation::validate_identifier`]. A `Token::Ident` cannot
+//! contain quotes, semicolons, dots, spaces, or any other SQL metacharacter.
+//!
+//! String literals are escaped (`'` → `''`) at the `Expr::StringLit` site;
+//! number and date literals are grammar-constrained. No `validate_*` call is
+//! threaded through this module because there is no reachable path from the
+//! parser to a `format!` here that admits an unsafe identifier.
 
 #[cfg(test)]
 use std::sync::Arc;

--- a/engine/crates/rocky-snowflake/src/loader.rs
+++ b/engine/crates/rocky-snowflake/src/loader.rs
@@ -20,6 +20,7 @@ use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
+use rocky_sql::validation::validate_identifier;
 
 use crate::connector::{QueryResult, SnowflakeConnector};
 use crate::stage::{
@@ -78,12 +79,19 @@ fn resolve_format(source: &LoadSource, options: &LoadOptions) -> AdapterResult<F
 }
 
 /// Render a Snowflake target as `db.schema.table` (Snowflake uses the same
-/// 3-part form as Databricks for fully-qualified references).
-fn format_target(target: &TableRef) -> String {
+/// 3-part form as Databricks for fully-qualified references). Each segment is
+/// validated as a SQL identifier so the result is safe to interpolate.
+fn format_target(target: &TableRef) -> AdapterResult<String> {
+    validate_identifier(&target.schema).map_err(AdapterError::new)?;
+    validate_identifier(&target.table).map_err(AdapterError::new)?;
     if target.catalog.is_empty() {
-        format!("{}.{}", target.schema, target.table)
+        Ok(format!("{}.{}", target.schema, target.table))
     } else {
-        format!("{}.{}.{}", target.catalog, target.schema, target.table)
+        validate_identifier(&target.catalog).map_err(AdapterError::new)?;
+        Ok(format!(
+            "{}.{}.{}",
+            target.catalog, target.schema, target.table
+        ))
     }
 }
 
@@ -97,7 +105,7 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
     ) -> AdapterResult<LoadResult> {
         let start = Instant::now();
         let format = resolve_format(source, options)?;
-        let target_ref = format_target(target);
+        let target_ref = format_target(target)?;
         let stage = generate_stage_name();
 
         // `truncate_first` → DELETE FROM before COPY INTO. Snowflake supports
@@ -113,7 +121,7 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
         let (rows_loaded, file_size) = match source {
             LoadSource::CloudUri(uri) => {
                 // External stage path: one CREATE, one COPY, one DROP.
-                let create_sql = create_external_stage_sql(&stage, uri, format, options);
+                let create_sql = create_external_stage_sql(&stage, uri, format, options)?;
                 debug!(sql = %create_sql, "creating external stage");
                 self.exec(&create_sql).await?;
 
@@ -132,12 +140,12 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
             }
             LoadSource::LocalFile(local_path) => {
                 // Internal stage path: CREATE, PUT, COPY, DROP.
-                let create_sql = create_temporary_stage_sql(&stage, format, options);
+                let create_sql = create_temporary_stage_sql(&stage, format, options)?;
                 debug!(sql = %create_sql, "creating internal stage");
                 self.exec(&create_sql).await?;
 
                 let local_str = local_path_str(local_path)?;
-                let put_sql = put_file_sql(&local_str, &stage);
+                let put_sql = put_file_sql(&local_str, &stage)?;
                 info!(sql = %put_sql, "snowflake PUT");
                 let put_result = self.exec(&put_sql).await;
 
@@ -256,7 +264,7 @@ mod tests {
             schema: "RAW".into(),
             table: "ORDERS".into(),
         };
-        assert_eq!(format_target(&t), "DB.RAW.ORDERS");
+        assert_eq!(format_target(&t).unwrap(), "DB.RAW.ORDERS");
     }
 
     #[test]
@@ -266,7 +274,17 @@ mod tests {
             schema: "RAW".into(),
             table: "ORDERS".into(),
         };
-        assert_eq!(format_target(&t), "RAW.ORDERS");
+        assert_eq!(format_target(&t).unwrap(), "RAW.ORDERS");
+    }
+
+    #[test]
+    fn test_format_target_rejects_injection() {
+        let t = TableRef {
+            catalog: "DB".into(),
+            schema: "RAW; DROP TABLE x; --".into(),
+            table: "ORDERS".into(),
+        };
+        assert!(format_target(&t).is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-snowflake/src/stage.rs
+++ b/engine/crates/rocky-snowflake/src/stage.rs
@@ -16,6 +16,22 @@
 
 use rocky_adapter_sdk::{AdapterError, AdapterResult, FileFormat, LoadOptions};
 
+/// Reject string-literal payloads (URIs, local paths) that would break out of
+/// the surrounding `'...'` SQL literal. Snowflake interpolates these raw, so
+/// any embedded quote, backslash, or newline is unsafe — refuse to build the
+/// SQL rather than try to escape.
+fn validate_sql_string_literal(label: &str, value: &str) -> AdapterResult<()> {
+    if value.is_empty() {
+        return Err(AdapterError::msg(format!("{label} cannot be empty")));
+    }
+    if value.contains(['\'', '\n', '\r', '\\']) {
+        return Err(AdapterError::msg(format!(
+            "invalid {label} {value:?}: must not contain quotes, backslashes, or newlines"
+        )));
+    }
+    Ok(())
+}
+
 /// Snowflake stage reference. Prefixed with `@` when rendered in SQL.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StageName(String);
@@ -60,36 +76,43 @@ pub fn create_temporary_stage_sql(
     name: &StageName,
     format: FileFormat,
     options: &LoadOptions,
-) -> String {
-    format!(
+) -> AdapterResult<String> {
+    Ok(format!(
         "CREATE TEMPORARY STAGE {name} FILE_FORMAT = ({})",
-        file_format_clause(format, options)
-    )
+        file_format_clause(format, options)?
+    ))
 }
 
 /// Build the `CREATE TEMPORARY STAGE ... URL = '<uri>'` SQL for an external
 /// stage backed by cloud storage.
+///
+/// `uri` is interpolated inside a `'...'` string literal; we refuse to build
+/// the SQL if it contains characters that could break out of that literal.
 pub fn create_external_stage_sql(
     name: &StageName,
     uri: &str,
     format: FileFormat,
     options: &LoadOptions,
-) -> String {
-    format!(
+) -> AdapterResult<String> {
+    validate_sql_string_literal("cloud URI", uri)?;
+    Ok(format!(
         "CREATE TEMPORARY STAGE {name} URL = '{uri}' FILE_FORMAT = ({})",
-        file_format_clause(format, options)
-    )
+        file_format_clause(format, options)?
+    ))
 }
 
 /// Build the `PUT file://<path> @<stage>` SQL for uploading a local file.
 ///
 /// Snowflake's PUT automatically compresses files with gzip unless we turn
-/// that off; we keep the default for smaller network transfer.
-pub fn put_file_sql(local_path: &str, stage: &StageName) -> String {
-    format!(
+/// that off; we keep the default for smaller network transfer. The local
+/// path is interpolated inside a `'...'` literal — refuse to build the SQL
+/// if it contains characters that could break out of that literal.
+pub fn put_file_sql(local_path: &str, stage: &StageName) -> AdapterResult<String> {
+    validate_sql_string_literal("local file path", local_path)?;
+    Ok(format!(
         "PUT 'file://{local_path}' {stage_ref} OVERWRITE = TRUE",
         stage_ref = stage.reference()
-    )
+    ))
 }
 
 /// Build the `DROP STAGE IF EXISTS` SQL (defensive cleanup).
@@ -105,15 +128,33 @@ pub fn drop_stage_sql(name: &StageName) -> String {
 /// Snowflake expects `(TYPE = 'CSV', FIELD_DELIMITER = ',', SKIP_HEADER = 1)`
 /// or similar. This function emits only the inner key-value pairs so callers
 /// can wrap in `FILE_FORMAT = (...)` as needed.
-pub fn file_format_clause(format: FileFormat, options: &LoadOptions) -> String {
+///
+/// CSV delimiters are validated to keep the `'<delim>'` literal safe.
+pub fn file_format_clause(format: FileFormat, options: &LoadOptions) -> AdapterResult<String> {
     match format {
         FileFormat::Csv => {
             let skip = if options.csv_has_header { 1 } else { 0 };
-            let delim = options.csv_delimiter;
-            format!("TYPE = 'CSV', FIELD_DELIMITER = '{delim}', SKIP_HEADER = {skip}")
+            let delim = validate_csv_delimiter(options.csv_delimiter)?;
+            Ok(format!(
+                "TYPE = 'CSV', FIELD_DELIMITER = '{delim}', SKIP_HEADER = {skip}"
+            ))
         }
-        FileFormat::Parquet => "TYPE = 'PARQUET'".into(),
-        FileFormat::JsonLines => "TYPE = 'JSON'".into(),
+        FileFormat::Parquet => Ok("TYPE = 'PARQUET'".into()),
+        FileFormat::JsonLines => Ok("TYPE = 'JSON'".into()),
+    }
+}
+
+/// Reject CSV delimiters that would break out of the `'...'` SQL string
+/// literal. Allows printable ASCII plus tab; rejects quotes, backslash, and
+/// control characters.
+fn validate_csv_delimiter(c: char) -> AdapterResult<char> {
+    let ok = c == '\t' || (c.is_ascii() && !c.is_ascii_control() && c != '\'' && c != '\\');
+    if ok {
+        Ok(c)
+    } else {
+        Err(AdapterError::msg(format!(
+            "invalid CSV delimiter {c:?}: must be a printable ASCII char (or tab), not a quote, backslash, or control character"
+        )))
     }
 }
 
@@ -168,7 +209,8 @@ mod tests {
     #[test]
     fn test_create_temporary_stage_csv() {
         let name = StageName::new("tmp").unwrap();
-        let sql = create_temporary_stage_sql(&name, FileFormat::Csv, &LoadOptions::default());
+        let sql =
+            create_temporary_stage_sql(&name, FileFormat::Csv, &LoadOptions::default()).unwrap();
         assert!(sql.starts_with("CREATE TEMPORARY STAGE tmp"));
         assert!(sql.contains("TYPE = 'CSV'"));
         assert!(sql.contains("SKIP_HEADER = 1"));
@@ -182,16 +224,37 @@ mod tests {
             "s3://bucket/path",
             FileFormat::Parquet,
             &LoadOptions::default(),
-        );
+        )
+        .unwrap();
         assert!(sql.contains("URL = 's3://bucket/path'"));
         assert!(sql.contains("TYPE = 'PARQUET'"));
     }
 
     #[test]
+    fn test_create_external_stage_rejects_quote_in_uri() {
+        let name = StageName::new("ext").unwrap();
+        assert!(
+            create_external_stage_sql(
+                &name,
+                "s3://bucket/x'); DROP TABLE y; --",
+                FileFormat::Parquet,
+                &LoadOptions::default(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn test_put_file_sql() {
         let stage = StageName::new("stg").unwrap();
-        let sql = put_file_sql("/tmp/data.csv", &stage);
+        let sql = put_file_sql("/tmp/data.csv", &stage).unwrap();
         assert_eq!(sql, "PUT 'file:///tmp/data.csv' @stg OVERWRITE = TRUE");
+    }
+
+    #[test]
+    fn test_put_file_sql_rejects_quote() {
+        let stage = StageName::new("stg").unwrap();
+        assert!(put_file_sql("/tmp/data'.csv", &stage).is_err());
     }
 
     #[test]
@@ -216,15 +279,24 @@ mod tests {
             csv_delimiter: '|',
             ..Default::default()
         };
-        let c = file_format_clause(FileFormat::Csv, &opts);
+        let c = file_format_clause(FileFormat::Csv, &opts).unwrap();
         assert!(c.contains("FIELD_DELIMITER = '|'"));
         assert!(c.contains("SKIP_HEADER = 0"));
     }
 
     #[test]
+    fn test_file_format_clause_csv_rejects_quote_delimiter() {
+        let opts = LoadOptions {
+            csv_delimiter: '\'',
+            ..Default::default()
+        };
+        assert!(file_format_clause(FileFormat::Csv, &opts).is_err());
+    }
+
+    #[test]
     fn test_file_format_clause_parquet() {
         assert_eq!(
-            file_format_clause(FileFormat::Parquet, &LoadOptions::default()),
+            file_format_clause(FileFormat::Parquet, &LoadOptions::default()).unwrap(),
             "TYPE = 'PARQUET'"
         );
     }
@@ -232,7 +304,7 @@ mod tests {
     #[test]
     fn test_file_format_clause_json() {
         assert_eq!(
-            file_format_clause(FileFormat::JsonLines, &LoadOptions::default()),
+            file_format_clause(FileFormat::JsonLines, &LoadOptions::default()).unwrap(),
             "TYPE = 'JSON'"
         );
     }


### PR DESCRIPTION
## Summary

Closes the SQL-injection audit sweep across the warehouse adapters and execution engine. Every untrusted-input `format!`-with-SQL site now refuses unsafe input rather than escaping it.

- **rocky-bigquery/connector.rs** — `validate_identifier` on catalog/schema/table in `describe_table` (the `WHERE table_name = '...'` literal is safe because the validator rejects single quotes), and on catalog/schema in `list_tables` (same class, found while there).
- **rocky-databricks/loader.rs** — `format_target` validates each segment and returns `AdapterResult`; the cloud URI passed to `COPY INTO` is checked against `validate_cloud_uri` (rejects `'`, `\`, `\n`, `\r`); the `csv_delimiter: char` is validated to keep the `'<delim>'` literal safe.
- **rocky-snowflake/stage.rs + loader.rs** — `create_external_stage_sql`, `put_file_sql`, `file_format_clause` refuse string-literal payloads with embedded quotes or backslashes; `format_target` validates target identifiers.
- **rocky-engine/executor.rs** — `validate_identifier` on `model_name` before the `CREATE OR REPLACE TABLE` `format!`; failed validation surfaces in the result's `failed` list.
- **rocky-engine/profile.rs** — `generate_profile_sql` returns `Result` and validates the table name and every column name.
- **rocky-lang/lower.rs** — unchanged. `Token::Ident`'s lexer regex `[a-zA-Z_][a-zA-Z0-9_]*` is strictly tighter than `validate_identifier`, so every `format!` site there is safe by construction. Documented in the module header so a future reader doesn't have to re-derive it.

Threads validation at the SQL boundary the same way `crates/rocky-databricks/src/{batch,dialect,permissions}.rs` already do — no `TableRef` shape change, no newtype.

## Test plan
- [x] `cargo test --workspace` — all 30 test groups green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Per-site rejection tests added (injection-bearing identifier, quote-in-URI, quote-in-CSV-delimiter, etc.)