### PR TITLE
docs: refresh playground catalog + serve auth + max_bytes_scanned; production preview POC

### DIFF
--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -138,7 +138,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 ## CLI Commands (38+)
 
 ### Core Pipeline
-`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch`
+`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch` · `preview create` · `preview diff` · `preview cost`
 
 ### Modeling & Compilation
 `compile` · `lineage` · `test` · `ci` · `ci-diff` · `export-schemas`
@@ -159,7 +159,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 - **`rocky replay <run_id|latest>`** — flat per-model dump of SQL hashes, row counts, bytes, and timings captured at execution time.
 - **Timed half-open circuit breaker** — three-state (`Closed` / `Open` / `HalfOpen`) breaker shared across Databricks + Snowflake adapters. Fires `circuit_breaker_tripped` / `circuit_breaker_recovered` events.
 - **OTLP metrics export** (feature-gated via `--features otel`) — `rocky run` exports in-process counters and histograms to any OTLP-compatible collector.
-- **Run-level budgets** — `[budget] max_usd` + `max_duration_ms` with `on_breach = "warn" | "error"`; fires `budget_breach` events. See [`[budget]`](/reference/configuration/#budget).
+- **Run-level budgets** — `[budget] max_usd` + `max_duration_ms` + `max_bytes_scanned` with `on_breach = "warn" | "error"`; any single dimension breach fires the `budget_breach` event. See [`[budget]`](/reference/configuration/#budget).
 - **Per-run cost attribution** — `RunOutput.cost_summary` carries per-run total cost; per-materialization `cost_usd` flows through `MaterializationMetadata`.
 - **`rocky cost <run_id|latest>`** — historical rollup over stored runs. Reads the same `RunRecord` as `replay` / `trace`; recomputes per-model cost via the adapter-appropriate formula (duration × DBU for Databricks/Snowflake; bytes × $/TB for BigQuery; zero for DuckDB).
 

--- a/docs/src/content/docs/guides/playground.md
+++ b/docs/src/content/docs/guides/playground.md
@@ -380,9 +380,9 @@ Exit code 0 means all checks passed. A non-zero exit code fails the CI job.
 
 ## 8. Explore the POC Catalog
 
-The playground includes a curated catalog of 28 POCs that showcase Rocky's distinctive capabilities. Each POC is self-contained with its own `rocky.toml`, `models/`, and `run.sh`. Most run on local DuckDB with zero credentials.
+The playground includes a curated catalog of 58 POCs that showcase Rocky's distinctive capabilities. Each POC is self-contained with its own `rocky.toml`, `models/`, and `run.sh`. Most run on local DuckDB with zero credentials.
 
-### Foundations (5 POCs)
+### Foundations (7 POCs)
 
 | POC | Feature |
 |---|---|
@@ -391,8 +391,10 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-null-safe-operators` | `!=` lowering to `IS DISTINCT FROM` |
 | `03-date-literals-and-match` | `@2025-01-01` date literals and `match { ... }` pattern matching |
 | `04-window-functions` | DSL window syntax with partition + sort + frame |
+| `05-generic-adapter-exercise` | Full generic-adapter trait surface against DuckDB |
+| `06-branches-replay-lineage` | Trust arc 1: branches + replay + column lineage end-to-end |
 
-### Quality (4 POCs)
+### Quality (6 POCs)
 
 | POC | Feature |
 |---|---|
@@ -400,8 +402,10 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-inline-checks` | Built-in checks (row_count, column_match, freshness, null_rate) |
 | `03-anomaly-detection` | `rocky history` + `rocky metrics --alerts` driven by row count anomalies |
 | `04-local-test-with-duckdb` | `rocky test` with passing and failing assertions |
+| `05-snapshot-scd2` | Snapshot pipeline with SCD Type 2 history |
+| `06-quality-pipeline-standalone` | Standalone `pipeline.type = "quality"` (checks-only run) |
 
-### Performance (6 POCs)
+### Performance (10 POCs)
 
 | POC | Feature |
 |---|---|
@@ -411,8 +415,12 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `04-column-propagation` | Column-level lineage pruning -- skip unchanged downstream models |
 | `05-optimize-recommendations` | `rocky optimize` + `profile-storage` + `compact --dry-run` |
 | `06-schema-drift-recover` | Drift detection, auto-widening, DROP+RECREATE |
+| `07-ephemeral-cte` | `materialization = "ephemeral"` CTE inlining |
+| `08-delete-insert-partitioned` | Partitioned `delete+insert` strategy |
+| `09-adaptive-concurrency` | AIMD dynamic parallelism via the throttle module |
+| `10-cost-budgets` | Trust arc 2: per-run cost summary + `[budget]` breach |
 
-### AI (4 POCs, `ANTHROPIC_API_KEY` required)
+### AI (5 POCs, `ANTHROPIC_API_KEY` required)
 
 | POC | Feature |
 |---|---|
@@ -420,8 +428,9 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-ai-explain-bootstrap` | `rocky ai-explain --all --save` reverse-engineers intent |
 | `03-ai-sync-schema-evolution` | `rocky ai-sync` proposes downstream updates |
 | `04-ai-test-generation` | `rocky ai-test --all --save` generates SQL assertions |
+| `05-schema-grounded-validation` | Trust arc 5: AI output is compiler-gated against the schema |
 
-### Governance (4 POCs, Databricks required)
+### Governance (6 POCs, Databricks required)
 
 | POC | Feature |
 |---|---|
@@ -429,8 +438,10 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-schema-patterns-multi-tenant` | Schema patterns with variadic `regions...` routing |
 | `03-workspace-isolation` | Workspace bindings + ISOLATED catalog mode |
 | `04-tagging-lifecycle` | Tags propagated via `ALTER ... SET TAGS` |
+| `05-classification-masking-compliance` | `[classification]` + `[mask]` + `rocky compliance` |
+| `06-retention-policies` | Declarative `retention = "<N>[dy]"` + `rocky retention-status --drift` |
 
-### Orchestration (4 POCs)
+### Orchestration (9 POCs)
 
 | POC | Feature |
 |---|---|
@@ -438,8 +449,13 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-webhook-slack-preset` | Webhook presets (Slack, PagerDuty, Datadog, Teams) |
 | `03-remote-state-s3` | S3 state backend via MinIO docker-compose |
 | `04-checkpoint-resume` | `rocky run --resume-latest` after mid-pipeline failure |
+| `05-webhook-presets-multi` | Multiple webhook presets composed on the same run |
+| `06-valkey-distributed-cache` | Distributed cache + tiered state via Valkey/Redis |
+| `07-dagster-dag-mode` | Full asset-graph rendering from Rocky's unified DAG |
+| `08-circuit-breaker` | Trust arc 3: retry policy + three-state circuit breaker |
+| `09-idempotency-key` | `rocky run --idempotency-key` dedup + skip semantics |
 
-### Developer Experience (5 POCs)
+### Developer Experience (10 POCs)
 
 | POC | Feature |
 |---|---|
@@ -448,8 +464,13 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `03-import-dbt-validate` | `rocky import-dbt` + `rocky validate-migration` |
 | `04-shadow-mode-compare` | `rocky compare` shadow vs production |
 | `05-doctor-and-ci` | `rocky doctor` + `rocky ci --output json` |
+| `06-hybrid-dbt-packages` | Rocky alongside dbt packages in the same repo |
+| `07-run-trace-gantt` | Trust arc 4: render a run as a Gantt timeline (`rocky trace`) |
+| `08-portability-lint` | Trust arc 6: compile-time portability gate via `[portability]` |
+| `09-sql-types-blast-radius` | Trust arc 7: SQL as first-class with typed blast-radius |
+| `10-pr-preview-and-data-diff` | `rocky preview create / diff / cost` end-to-end PR bundle |
 
-### Adapters (4 POCs)
+### Adapters (5 POCs)
 
 | POC | Feature |
 |---|---|
@@ -457,6 +478,7 @@ The playground includes a curated catalog of 28 POCs that showcase Rocky's disti
 | `02-databricks-materialized-view` | Materialized views on Databricks |
 | `03-fivetran-discover` | `rocky discover` against Fivetran REST API |
 | `04-custom-process-adapter` | Python adapter via JSON-RPC over stdio |
+| `05-bigquery-native-queries` | BigQuery adapter end-to-end with native query patterns |
 
 ### Running a POC
 
@@ -465,7 +487,7 @@ cd examples/playground
 ./pocs/02-performance/01-incremental-watermark/run.sh
 ```
 
-22 of 28 POCs run with no external credentials.
+Most POCs run with no external credentials. The exceptions: AI (`ANTHROPIC_API_KEY`), Governance (Databricks workspace), and the warehouse-specific adapter POCs (Snowflake / Databricks / Fivetran / BigQuery).
 
 ## 9. Benchmarks
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -153,20 +153,33 @@ Start an HTTP API server that exposes the compiler's semantic graph. Provides RE
 rocky serve [flags]
 ```
 
+### Security defaults
+
+`rocky serve` binds **`127.0.0.1` (loopback) by default**. Every endpoint except `/api/v1/health` requires a Bearer token. Two operating modes:
+
+- **Loopback only (default)** — bind stays on `127.0.0.1`. Authentication is still on, so external processes (LSP, dashboards) need the token, but a misconfigured network won't expose model SQL to the LAN.
+- **Non-loopback bind** — `--host 0.0.0.0` (or any non-loopback address) **requires `--token <secret>`** (or the `ROCKY_SERVE_TOKEN` env var). `rocky serve` refuses to start otherwise. This prevents the "I just wanted to try it from another machine" foot-gun shipping model SQL to the LAN unauthenticated.
+
+CORS is empty-by-default. Browser apps must declare every allowed origin via `--allowed-origin <ORIGIN>`. Permitted methods: `GET`, `POST`, `OPTIONS`. Permitted headers: `Authorization`, `Content-Type`.
+
 ### Flags
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing model files. |
 | `--contracts <PATH>` | `PathBuf` | | Directory containing data contract definitions. |
+| `--host <HOST>` | `String` | `127.0.0.1` | Bind host. Non-loopback (`0.0.0.0`, etc.) requires `--token`. |
 | `--port <PORT>` | `u16` | `8080` | Port to listen on. |
+| `--token <SECRET>` | `String` | | Bearer token required by every API request except `/api/v1/health`. Falls back to `ROCKY_SERVE_TOKEN` env var when omitted. **Required when `--host` is non-loopback.** |
+| `--allowed-origin <ORIGIN>` | `String` (repeatable) | `[]` | Add an origin to the CORS allowlist. Repeat for multiple origins (e.g. `--allowed-origin http://localhost:5173 --allowed-origin https://dashboard.example.com`). |
 | `--watch` | `bool` | `false` | Watch for file changes and auto-recompile. |
 
 ### Examples
 
-Start the server with defaults:
+Start the server with defaults (loopback, token via env var):
 
 ```bash
+export ROCKY_SERVE_TOKEN=$(openssl rand -hex 32)
 rocky serve
 ```
 
@@ -180,16 +193,34 @@ Endpoints:
   GET /api/dag             - Full dependency graph
 ```
 
+Call an authenticated endpoint:
+
+```bash
+curl -H "Authorization: Bearer $ROCKY_SERVE_TOKEN" http://127.0.0.1:8080/api/models
+```
+
+`/api/v1/health` is exempt and reachable without the token.
+
 Start with file watching on a custom port:
 
 ```bash
-rocky serve --port 3000 --watch
+rocky serve --port 3000 --watch --token "$ROCKY_SERVE_TOKEN"
 ```
 
 ```
 Compiled 14 models in 42ms
 Watching models/ for changes...
 Listening on http://127.0.0.1:3000
+```
+
+Expose to the LAN with explicit token + origin allowlist:
+
+```bash
+rocky serve \
+  --host 0.0.0.0 \
+  --token "$ROCKY_SERVE_TOKEN" \
+  --allowed-origin https://dashboard.internal \
+  --port 9090
 ```
 
 Start with contracts:

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
@@ -103,18 +103,15 @@ run` for both DSL and SQL surfaces.
 
 ## Status
 
-`rocky preview {create,diff,cost}` are scaffolded today; their
-implementations land in Phases 1–3 of the
-[`rocky-pr-preview-and-data-diff`](../../../../../) plan. This POC ships
-the integration-test baseline:
+Production path as of **engine-v1.18.0** (Phases 1, 1.5, 2, 3 all merged).
+Earlier revisions of `run.sh` wrapped each preview call in a
+stub-tolerating helper while the engine handlers were still scaffolding;
+that scaffolding is gone — the script now treats `preview create / diff /
+cost` like any other production CLI command (`set -e` enforces failure).
 
-- `run.sh` exits **0** today by capturing each preview-stub error and
-  surfacing it without sinking the run.
-- The `expected/preview_*.example.json` files are the **aspirational
-  target shapes** the Phase 1+ implementation must match — values are
-  illustrative, the keys / types / reason strings are the contract.
-- When Phase 1 lands, the stub `.err` sidecars disappear and the JSON
-  files in `expected/` become real golden fixtures.
+The `expected/preview_*.example.json` files remain as the shape contract
+that the live `expected/preview_*.json` outputs should match modulo
+non-deterministic fields (timestamps, branch suffixes, hashes).
 
 ## Prerequisites
 
@@ -130,19 +127,21 @@ cd examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff
 
 `run.sh`:
 
-1. Cleans `.rocky-state.redb` and `poc.duckdb`.
+1. Cleans `.rocky-state.redb` (root + `models/`) and `poc.duckdb`.
 2. Runs `rocky compile` against the 5-model DAG.
 3. Seeds the raw tables into DuckDB.
 4. Runs the pipeline on `main` state.
 5. Captures the current git HEAD as the `--base` ref (or a sentinel
    string when not in a git checkout).
-6. Swaps `models/fct_revenue.rocky` for `fct_revenue.rocky.changed` —
-   adds a `where amount > 25` filter that should produce a real
-   row-level diff.
-7. Runs `rocky preview create --base <ref> --name pr-preview-poc-10`.
-   Today: bails with a Phase 1 stub message; `run.sh` keeps going.
-8. Runs `rocky preview diff` against the branch. Same.
-9. Runs `rocky preview cost` against the branch. Same.
+6. Swaps `models/fct_revenue.sql` for `fct_revenue.sql.changed` — adds a
+   `WHERE s.amount > 25` filter that produces a real row-level diff.
+7. `rocky preview create --base <ref> --name pr-preview-poc-10` —
+   materializes the per-PR branch schema and copies unchanged upstream
+   from the base via DuckDB CTAS.
+8. `rocky preview diff --name pr-preview-poc-10` — structural + sampled
+   row diff between branch and base.
+9. `rocky preview cost --name pr-preview-poc-10` — per-model bytes /
+   duration / USD delta vs. the latest base run.
 10. Reverts the synthetic change (`trap`-protected, idempotent).
 
 ## Related
@@ -153,6 +152,6 @@ cd examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff
 - Sibling POC: [`06-developer-experience/04-shadow-mode-compare/`](../04-shadow-mode-compare/)
   — the precursor `rocky compare` kernel that Phase 2's `preview diff`
   extends.
-- Engine source: `engine/crates/rocky-cli/src/commands/preview.rs`
-  (Phase 0 stubs), `engine/crates/rocky-cli/src/output.rs`
+- Engine source: `engine/crates/rocky-cli/src/commands/preview.rs`,
+  `engine/crates/rocky-cli/src/output.rs`
   (`PreviewCreateOutput`, `PreviewDiffOutput`, `PreviewCostOutput`).

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/run.sh
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/run.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
-# 10-pr-preview-and-data-diff — PR preview workflow on a 5-model DAG.
+# 10-pr-preview-and-data-diff — `rocky preview create / diff / cost` on a
+# 5-model DAG. Production path as of engine-v1.18.0 (Phases 1, 1.5, 2, 3
+# all merged). Earlier revisions of this script wrapped each preview call
+# in a stub-tolerating helper; that scaffolding is gone.
 #
-# Today (Phase 0): the engine handlers for `rocky preview {create,diff,cost}`
-# bail with a "Phase N implementation" message — that's expected. This POC is
-# the integration-test baseline that Phase 1+ will populate.
-#
-# Each preview step below is wrapped so the stub error is captured and the
-# script keeps going; non-stub steps (compile, test, run on main) must
-# succeed, otherwise we exit non-zero.
+# Flow:
+#   1. Compile + seed DuckDB.
+#   2. Run the pipeline on the base ref (populates `poc.demo.*`).
+#   3. Capture HEAD as the preview's `--base`.
+#   4. Apply a synthetic edit to `fct_revenue.sql` so the preview has
+#      something real to diff.
+#   5. `rocky preview create` materializes a per-PR branch schema by
+#      copying unchanged upstream from base via DuckDB CTAS, then
+#      re-running only the prune set.
+#   6. `rocky preview diff` produces a structural + sampled-row diff
+#      between branch and base for every model in the prune set.
+#   7. `rocky preview cost` produces a per-model bytes/duration/USD
+#      delta versus the latest base-schema run.
+#   8. The synthetic change is reverted via `trap`, idempotent on re-run.
 
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-# Prefer an explicitly-set binary, then the local feature-branch build
-# (which has `preview` wired), then `rocky` on PATH.
+# Prefer an explicitly-set binary, then the local feature-branch build,
+# then `rocky` on PATH.
 ROCKY_BIN="${ROCKY_BIN:-}"
 if [[ -z "$ROCKY_BIN" ]]; then
     REPO_ROOT="$(cd "$HERE/../../../../.." && pwd)"
@@ -33,9 +43,8 @@ CHANGED_VARIANT="models/fct_revenue.sql.changed"
 LIVE_FILE="models/fct_revenue.sql"
 BACKUP_FILE="models/fct_revenue.sql.orig"
 
-# Always restore the original fct_revenue on exit, even if the script fails
-# halfway through. Idempotent: re-running the POC must leave the working tree
-# byte-identical to the starting state.
+# Always restore the original fct_revenue on exit, even if the script
+# fails halfway through. Idempotent on re-run.
 revert_change() {
     if [[ -f "$BACKUP_FILE" ]]; then
         mv -f "$BACKUP_FILE" "$LIVE_FILE"
@@ -44,7 +53,8 @@ revert_change() {
 }
 trap revert_change EXIT
 
-rm -f .rocky-state.redb poc.duckdb
+rm -f .rocky-state.redb .rocky-state.redb.lock .rocky_state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
 mkdir -p expected
 
 echo "==> 1. Compile the 5-model DAG (type-check, no warehouse)"
@@ -55,11 +65,9 @@ duckdb poc.duckdb < data/seed.sql
 
 echo "==> 3. Run the pipeline on 'main' state — populates poc.demo.*"
 "$ROCKY_BIN" -c rocky.toml -o json run > expected/run_main.json
-echo "    main run: ok"
 
-# Capture a 'before' marker. Prefer git HEAD; fall back to a sentinel string
-# when the POC is run outside of a git checkout (rare, but possible in CI
-# tarballs).
+# Capture a 'before' marker. Prefer git HEAD; fall back to a sentinel
+# string when the POC is run outside a git checkout.
 if BASE_REF=$(git rev-parse HEAD 2>/dev/null); then
     echo "==> 4. Captured base ref: $BASE_REF"
 else
@@ -71,59 +79,38 @@ echo "==> 5. Apply synthetic change to fct_revenue.sql (adds 'WHERE s.amount > 2
 cp "$LIVE_FILE" "$BACKUP_FILE"
 cp "$CHANGED_VARIANT" "$LIVE_FILE"
 
-# Helper: run a preview subcommand that is either a known Phase-N stub or
-# not yet wired in the binary on PATH. Capture stderr, surface a clear note,
-# and keep the script going. A real non-stub failure still aborts.
-run_stub() {
-    local label="$1"
-    local outfile="$2"
-    shift 2
-    echo "==> $label"
-    if "$@" > "$outfile" 2> "${outfile}.err"; then
-        echo "    $label: succeeded (Phase 1+ implementation has landed)"
-        return 0
-    fi
-    local exit_code=$?
-    local err_text
-    err_text="$(cat "${outfile}.err" 2>/dev/null || true)"
-    if grep -q "implementation lands in Phase" "${outfile}.err" 2>/dev/null; then
-        echo "    $label: stub (exit $exit_code) — Phase 1+ will populate this"
-        head -n 4 "${outfile}.err" | sed 's/^/      /'
-        return 0
-    fi
-    if echo "$err_text" | grep -qiE "unrecognized subcommand|invalid subcommand|unexpected argument|error:.*'preview'"; then
-        echo "    $label: 'preview' not wired in this rocky binary yet — Phase 0a engine PR not on PATH"
-        head -n 4 "${outfile}.err" | sed 's/^/      /'
-        return 0
-    fi
-    echo "    $label: FAILED with non-stub error (exit $exit_code)"
-    echo "$err_text" | sed 's/^/      /'
-    return $exit_code
-}
-
 PREVIEW_BRANCH="pr-preview-poc-10"
 
-run_stub "6. rocky preview create --base $BASE_REF" \
-    expected/preview_create.json \
-    "$ROCKY_BIN" -c rocky.toml -o json preview create \
-        --base "$BASE_REF" \
-        --name "$PREVIEW_BRANCH" \
-        --models models
+echo "==> 6. rocky preview create --base $BASE_REF"
+"$ROCKY_BIN" -c rocky.toml -o json preview create \
+    --base "$BASE_REF" \
+    --name "$PREVIEW_BRANCH" \
+    --models models \
+    > expected/preview_create.json
 
-run_stub "7. rocky preview diff --name $PREVIEW_BRANCH" \
-    expected/preview_diff.json \
-    "$ROCKY_BIN" -c rocky.toml -o json preview diff \
-        --name "$PREVIEW_BRANCH" \
-        --base "$BASE_REF"
+echo "==> 7. rocky preview diff --name $PREVIEW_BRANCH"
+"$ROCKY_BIN" -c rocky.toml -o json preview diff \
+    --name "$PREVIEW_BRANCH" \
+    --base "$BASE_REF" \
+    > expected/preview_diff.json
 
-run_stub "8. rocky preview cost --name $PREVIEW_BRANCH" \
-    expected/preview_cost.json \
-    "$ROCKY_BIN" -c rocky.toml -o json preview cost \
-        --name "$PREVIEW_BRANCH"
+echo "==> 8. rocky preview cost --name $PREVIEW_BRANCH"
+"$ROCKY_BIN" -c rocky.toml -o json preview cost \
+    --name "$PREVIEW_BRANCH" \
+    > expected/preview_cost.json
+
+# Quick non-empty sanity check; we don't pin the JSON shape here because
+# the example shapes already live in `expected/preview_*.example.json`.
+for f in expected/preview_create.json expected/preview_diff.json expected/preview_cost.json; do
+    if [[ ! -s "$f" ]]; then
+        echo "FAIL: $f is empty" >&2
+        exit 1
+    fi
+done
 
 # revert_change runs via trap.
 
 echo
-echo "POC complete: stubs exercised; expected/ holds Phase 1+ target shapes."
-echo "When Phase 1 lands, the .err sidecars disappear and the JSON files"
-echo "match expected/preview_*.example.json (the aspirational fixtures)."
+echo "POC complete: rocky preview create/diff/cost exercised end-to-end."
+echo "JSON output captured under expected/. Compare against the"
+echo "expected/preview_*.example.json fixtures for shape contract."


### PR DESCRIPTION
## Summary

Post-1.18.0 documentation + POC cleanup. Five gaps surfaced during the post-release audit, fixed in one bundle.

### Docs

- **`guides/playground.md`** — POC catalog was wildly stale: documented 36 POCs vs. 58 actual on disk. All eight section tables synced (Foundations 5→7, Quality 4→6, Performance 6→10, AI 4→5, Governance 4→6, Orchestration 4→9, DX 5→10, Adapters 4→5), lead-in count corrected (28 → 58), and the brittle "22 of 28 run with no external credentials" replaced with a credential-class summary.
- **`reference/commands/development.md`** — `rocky serve` section was missing the auth surface shipped in 1.18.0 (#291). New "Security defaults" subsection documents loopback bind, Bearer token (env: `ROCKY_SERVE_TOKEN`), empty-by-default CORS, and the non-loopback-requires-token rule. `--host` / `--token` / `--allowed-origin` added to the flags table; examples reworked to show the auth-aware invocations.
- **`features/all-features.md`** — budget bullet now lists `max_bytes_scanned` alongside `max_usd` / `max_duration_ms` (#288). CLI Core Pipeline list now includes `preview create` / `preview diff` / `preview cost`.

### POC

- **`examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/`** — `run.sh` was carrying the Phase-0 `run_stub` wrapper that swallowed "implementation lands in Phase N" stub errors while the engine handlers were still scaffolding. With Phases 1 / 1.5 / 2 / 3 all merged in 1.18.0, that wrapper is dead code that was hiding real failures (verified — running the rewritten POC immediately surfaced a state-store cleanup gap: branch state lives at `models/.rocky-state.redb` not just the root, so the cleanup line had to cover both). `set -e` now enforces failure; expected JSON outputs are captured each run; idempotent on re-run. README Status section rewritten to reflect post-1.18.0 reality.

## Test plan
- [x] POC runs end-to-end with the local 1.18.0 build (`bash run.sh` returns 0; produces non-empty `expected/preview_create.json` / `_diff.json` / `_cost.json`)
- [x] POC is idempotent — second run starts from clean state and succeeds (`pr-preview-poc-10` branch is recreated, not collided)
- [x] Doc edits render cleanly (no broken links to absent sections; `[budget]` link target intact)
- [x] No version-pin or codegen drift; this is docs + a single POC script, no Rust / Python / TS source touched