### PR TITLE
docs: drop "Git-grade workflow" overclaim from engine README + intro

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -28,7 +28,7 @@ A Rust-based control plane for warehouse-side data work. Storage and compute sta
 
 ## The seven trust dimensions
 
-1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Git-grade workflow on a warehouse.
+1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
 2. **Cost attribution + budgets** — per-model cost on every run. `[budget]` block in `rocky.toml`; `budget_breach` hook event on exceed.
 3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
 4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).

--- a/engine/README.md
+++ b/engine/README.md
@@ -21,7 +21,7 @@ No Jinja. No manifest. No parse step.
 
 ## The seven trust dimensions
 
-1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Git-grade workflow on a warehouse.
+1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
 2. **Cost attribution + budgets** — per-model cost on every run; `[budget]` block in `rocky.toml`; `budget_breach` hook event.
 3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
 4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).


### PR DESCRIPTION
## Summary
- Drop the trailing "Git-grade workflow on a warehouse" sentence from the branches trust-dimension bullet in `engine/README.md` and `docs/src/content/docs/getting-started/introduction.md`.
- Replace with "Branch and replay workflow on top of your warehouse" — operational framing that matches how branches are described elsewhere (e.g. `reference/commands/core-pipeline.md` calls a branch "the persistent, named analogue of \`--shadow\` mode").

Branches in Rocky are scoped schema namespaces, not a commit graph — there is no \`rocky merge\` or rebase. The previous wording overclaimed git semantics; this tightens the marketing copy to match the implementation.

## Test plan
- [x] \`grep -rn -iE "git[- ]grade|git semantics|commit graph" engine/README.md docs/src/content/docs/getting-started/introduction.md\` returns zero matches
- [ ] Render the docs site locally (\`cd docs && npm run dev\`) and visually confirm the trust-dimensions bullet list still scans cleanly with the other six items