### PR TITLE
chore: release engine-v1.19.0 + dagster-v1.16.0 + vscode-v1.11.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] — 2026-04-30
+
+Tracks engine `v1.19.0`. Regenerated TypeScript bindings for the new `rocky lineage-diff` command surface. No extension feature changes.
+
+### Added
+
+- **TS interface for `rocky lineage-diff`** ([#298](https://github.com/rocky-data/rocky/pull/298)). Regenerated `src/types/generated/lineage_diff.ts` from engine v1.19.0 schemas — full typed surface (`LineageDiffOutput`, `LineageDiffResult`, `LineageColumnChange`) for any future webview / command that wants to consume `rocky lineage-diff`. Barrel `index.ts` updated.
+
 ## [1.10.0] — 2026-04-29
 
 Tracks engine `v1.18.0`. Regenerated TypeScript bindings for the new `rocky preview` command surface plus the additive `[budget].max_bytes_scanned` field on `RunOutput`. No extension feature changes.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0] — 2026-04-30
+
+Feature release. Headline: **`rocky lineage-diff`** — a new top-level CLI verb that combines `rocky ci-diff`'s structural per-column diff with `rocky lineage --downstream`'s blast-radius walk, emitting a PR-comment-ready Markdown summary of which downstream columns each PR change reaches. Closes the launch-thread commitment to `xiaoher-c` ([HN item 47935246](https://news.ycombinator.com/item?id=47935246)).
+
+Bundled with the public adapter SDK guide + Rust-native skeleton POC that close the launch-thread commitment to `hasyimibhar` (community-driven adapter contributions are now genuinely *"tractable through the Adapter SDK without engine patching"*).
+
+### Added
+
+- **`rocky lineage-diff [<base_ref>]`** ([#298](https://github.com/rocky-data/rocky/pull/298)). New top-level CLI verb. Internally factors a `pub(crate) compute_ci_diff` out of `commands/ci_diff.rs::run_ci_diff` returning `CiDiffData { summary, results, head_compile, changed_file_count }` so both `ci-diff` and `lineage-diff` run git + compile once and share the diff result. `commands/lineage_diff.rs::run_lineage_diff` enriches each `ColumnDiff` via `semantic_graph::trace_column_downstream(model, col)` and dedupes consumers by `(target.model, target.column)`. New `LineageDiffOutput` schema in `output.rs` with sibling `LineageDiffResult` + `LineageColumnChange`; reuses `LineageQualifiedColumn`. Pre-rendered Markdown lives on `LineageDiffOutput.markdown` so a CI-side caller posts the PR comment without re-parsing. v1 trace direction is downstream-from-HEAD only — removed columns report empty consumer sets and the Markdown row reads `_(removed; not traceable on HEAD)_`. Codegen cascade clean (1 new schema → 1 Pydantic file → 1 TypeScript file).
+- **Adapter SDK guide + Rust-native skeleton POC** ([#300](https://github.com/rocky-data/rocky/pull/300)). New `docs/src/content/docs/guides/adapter-sdk.md` (eight sections: when-to-use, full trait surface table, worked example, auth + connection, testing, distribution, gotchas, next steps) + standalone POC at `examples/playground/pocs/07-adapters/05-rust-native-adapter-skeleton/`. POC is intentionally NOT a workspace member — models the out-of-tree consumer experience. ClickHouse-shaped: backtick quoting, two-part names, no `MERGE`, partition replace via `ALTER TABLE ... DELETE` + `INSERT`. 11 unit tests; `cargo run --example demo` prints generated SQL end-to-end against an in-memory `MockBackend`. The guide is honestly upfront about three current SDK gaps (two-trait-surface confusion between `rocky-adapter-sdk` and `rocky-core`; static adapter registry; `conformance::run_conformance` is a checklist, not a runner) — tracked as backlog items for future SDK work.
+- **3 new demo GIFs + lineage-diff POC** ([#301](https://github.com/rocky-data/rocky/pull/301)). VHS-rendered `demo-classification-masking.gif` (governance), `demo-incremental-watermark.gif`, `demo-lineage-diff.gif` embedded in the top-level README + relevant POC READMEs. New POC at `examples/playground/pocs/06-developer-experience/11-lineage-diff/` sets up a self-contained scratch git repo with baseline + feature branch and runs `rocky lineage-diff main` to surface 5 column changes across 2 modified models.
+
+### Changed
+
+- **`commands/ci_diff.rs::run_ci_diff` refactored to share its body via `compute_ci_diff`** ([#298](https://github.com/rocky-data/rocky/pull/298)). Pure refactor — JSON output and human-readable messaging are byte-identical to v1.18.0 (the "no changed model files detected" vs "X file(s) changed, but no model files affected" distinction is preserved via the new `changed_file_count` field on `CiDiffData`). `lineage-diff` is the second consumer.
+
 ## [1.18.0] — 2026-04-29
 
 Feature + audit-sweep release. Headline: **`rocky preview`** ships end-to-end — a new top-level command that builds a per-PR branch pre-populated from the base ref, computes a structural + sampled-data diff against base, runs a cost-delta projection, and a companion GitHub Action posts the result as a single PR comment. Also bundles a security audit closeout (#285–#287, #290–#293), a `[budget].max_bytes_scanned` gate, and Snowflake / BigQuery auth fixes.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "redis",
  "serde",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "logos",
  "miette",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "miette",
  "regex",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.18.0"
+version = "1.19.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.18.0"
+version = "1.19.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.18.0"
+version = "1.19.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.18.0"
+version = "1.19.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.18.0"
+version = "1.19.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.18.0"
+version = "1.19.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.18.0"
+version = "1.19.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.18.0"
+version = "1.19.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.18.0"
+version = "1.19.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.18.0"
+version = "1.19.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.18.0"
+version = "1.19.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.18.0"
+version = "1.19.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.18.0"
+version = "1.19.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.18.0"
+version = "1.19.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.18.0"
+version = "1.19.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] — 2026-04-30
+
+Companion release to engine `v1.19.0`. Picks up the regenerated Pydantic model for the new `rocky lineage-diff` command surface and wires it into the dispatch table.
+
+### Added
+
+- **`LineageDiffOutput` Pydantic model + `parse_rocky_output` route** ([#298](https://github.com/rocky-data/rocky/pull/298)). Regenerated from engine v1.19.0's `lineage_diff.schema.json`. New `lineage_diff_schema.py` in `types_generated/`; barrel + curated `types.py` re-exports `LineageDiffOutput`, `LineageDiffResult`, `LineageColumnChange`. `parse_rocky_output` dispatch table grew a `"lineage-diff" → LineageDiffOutput` entry so PyPI consumers decode `lineage-diff` envelopes via the existing facade. Round-tripped end-to-end before merge.
+
 ## [1.15.0] — 2026-04-29
 
 Companion release to engine `v1.18.0`. Picks up regenerated Pydantic models for the `rocky preview` command surface (`PreviewCreateOutput` / `PreviewDiffOutput` / `PreviewCostOutput`) and ships a P1 hardening cluster in the resource + component layer.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.15.0"
+version = "1.16.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Coordinated minor release on top of v1.18.0. Bundles three feature/doc PRs:

| PR | Headline |
|---|---|
| [#298](https://github.com/rocky-data/rocky/pull/298) | `rocky lineage-diff` — new top-level CLI verb. Combines `ci-diff`'s structural diff with `lineage --downstream`'s blast-radius walk; emits PR-comment-ready Markdown. Closes HN commitment to `xiaoher-c`. |
| [#300](https://github.com/rocky-data/rocky/pull/300) | Adapter SDK guide + Rust-native skeleton POC. Closes HN commitment to `hasyimibhar` (community adapter contributions are now genuinely *tractable*). |
| [#301](https://github.com/rocky-data/rocky/pull/301) | 3 new demo GIFs (governance / incremental / lineage-diff) + lineage-diff POC at `06-developer-experience/11-lineage-diff/`. |

## Why minor (not patch)

- Engine: new top-level CLI verb (`lineage-diff`) + new `LineageDiffOutput` JSON schema — feature-grade.
- Dagster: new Pydantic types + `parse_rocky_output` route — feature-grade additive.
- vscode: regenerated TS bindings for the new schema — additive only, but tracking engine.

## Pre-flight

- `cargo build --workspace` ✓
- `cargo test --workspace` ✓ (2668 tests pass)
- `cargo clippy --workspace -- -D warnings` ✓
- `cargo fmt --check` ✓
- `just codegen` ✓ (zero drift)
- `uv run pytest` (dagster) ✓ (487 pass)
- `npm run compile` (vscode) ✓

## Files touched (27)

- 20 × `engine/**/Cargo.toml` (1.18.0 → 1.19.0; `rocky-bigquery` held at 0.1.0 per its own track)
- 1 × `engine/Cargo.lock` (auto-rebuilt)
- 1 × `engine/CHANGELOG.md` (1.19.0 entry)
- 1 × `integrations/dagster/pyproject.toml` (1.15.0 → 1.16.0)
- 1 × `integrations/dagster/uv.lock` (auto)
- 1 × `integrations/dagster/CHANGELOG.md` (1.16.0 entry)
- 1 × `editors/vscode/package.json` (1.10.0 → 1.11.0)
- 1 × `editors/vscode/CHANGELOG.md` (1.11.0 entry)

## Test plan

- [x] `cargo build --workspace` from `engine/`
- [x] `cargo test --workspace` from `engine/` — 2668 pass
- [x] `cargo clippy --workspace -- -D warnings` from `engine/`
- [x] `cargo fmt --check` from `engine/`
- [x] `just codegen` from monorepo root — zero drift
- [x] `uv run pytest` from `integrations/dagster/` — 487 pass
- [x] `npm run compile` from `editors/vscode/` — clean

## After merge

Tag the merged commit and push (one tag at a time triggers each `*-release.yml` workflow):

```bash
git tag -a engine-v1.19.0 -m "Release engine-v1.19.0"
git tag -a dagster-v1.16.0 -m "Release dagster-v1.16.0"
git tag -a vscode-v1.11.0 -m "Release vscode-v1.11.0"
git push origin engine-v1.19.0 dagster-v1.16.0 vscode-v1.11.0
```