### PR TITLE
feat(engine): add clone_table_for_branch trait method for preview branches

### DIFF
--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -1081,16 +1081,13 @@ pub fn empty_cost_summary() -> PreviewCostSummary {
 /// copy set still runs so the PR-comment surface is informative.
 ///
 /// **DuckDB note.** DuckDB CTAS doesn't accept the catalog prefix on
-/// every dialect path; the SQL is written without catalog qualifier
-/// (just `schema.table`) which works for DuckDB and the cloud
-/// warehouses. Phase 5 lifts to native clones with adapter-aware DDL.
-///
-/// **Why this isn't a new trait method.** `WarehouseAdapter::execute_statement`
-/// already covers what we need; introducing `clone_table` on the trait
-/// today would block the Phase 5 native-clone landing on a wider
-/// refactor. When Phase 5 ships native clones, that's the moment to
-/// introduce a `clone_table_from(&self, src, dst)` adapter method with
-/// the CTAS as the default impl.
+/// every dialect path; the default trait impl writes the SQL without a
+/// catalog qualifier (just `schema.table`), which works for DuckDB and
+/// the cloud warehouses. Adapters that ship native warehouse clones
+/// (Databricks `SHALLOW CLONE`, Snowflake `CLONE`, BigQuery
+/// `CREATE TABLE ... COPY`) override
+/// [`WarehouseAdapter::clone_table_for_branch`] in their own crates;
+/// this function only calls the trait method.
 async fn execute_copy_from_base(
     config_path: &Path,
     models_dir: &Path,
@@ -1159,12 +1156,17 @@ async fn execute_copy_from_base(
         };
         let source_schema = model.config.target.schema.clone();
         let table = model.config.target.table.clone();
+        let source_catalog = model.config.target.catalog.clone();
+        let source_ref = rocky_core::ir::TableRef {
+            catalog: source_catalog,
+            schema: source_schema.clone(),
+            table: table.clone(),
+        };
 
-        let ctas = format!(
-            "CREATE OR REPLACE TABLE \"{branch_schema}\".\"{table}\" AS \
-             SELECT * FROM \"{source_schema}\".\"{table}\""
-        );
-        match adapter.execute_statement(&ctas).await {
+        match adapter
+            .clone_table_for_branch(&source_ref, branch_schema)
+            .await
+        {
             Ok(()) => results.push(PreviewCopiedModel {
                 model_name: model_name.clone(),
                 source_schema,

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -261,6 +261,54 @@ pub trait WarehouseAdapter: Send + Sync {
             "list_tables not supported by this adapter",
         ))
     }
+
+    /// Materialize `source` into `branch_schema` under the same table name.
+    ///
+    /// Used by `rocky preview create` to populate the per-PR branch schema
+    /// for every model not in the prune set, so the branch run only needs
+    /// to re-execute the changed-and-downstream slice. The default impl
+    /// is a portable `CREATE OR REPLACE TABLE "{branch}"."{table}" AS
+    /// SELECT * FROM "{src_schema}"."{table}"` that works on DuckDB and
+    /// any warehouse whose CTAS accepts the two-part `schema.table` form
+    /// without a catalog prefix. Adapters with native zero-copy primitives
+    /// (Databricks `SHALLOW CLONE`, Snowflake `CLONE`, BigQuery
+    /// `CREATE TABLE ... COPY`) override to swap CTAS for the cheaper
+    /// metadata-only operation.
+    ///
+    /// Lives on the in-tree `rocky-core` trait only — the SDK
+    /// `WarehouseAdapter` does not yet expose a clone primitive, and
+    /// `preview create` is already coupled to in-tree adapters via the
+    /// registry.
+    ///
+    /// `branch_schema` and `source.{schema,table}` are validated as SQL
+    /// identifiers before being interpolated into DDL; `source.catalog`
+    /// is ignored by the default impl so it stays portable to DuckDB
+    /// (which doesn't take a catalog prefix on CTAS in this shape).
+    /// Adapters that override are responsible for their own validation
+    /// and quoting.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any [`AdapterError`] from the underlying `execute_statement`
+    /// — most commonly "source table does not exist in base schema",
+    /// which `preview create` records as `copy_strategy = "failed"` so the
+    /// rest of the copy set still runs.
+    async fn clone_table_for_branch(
+        &self,
+        source: &TableRef,
+        branch_schema: &str,
+    ) -> AdapterResult<()> {
+        rocky_sql::validation::validate_identifier(branch_schema).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(&source.schema).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(&source.table).map_err(AdapterError::new)?;
+        let table = &source.table;
+        let src_schema = &source.schema;
+        let sql = format!(
+            "CREATE OR REPLACE TABLE \"{branch_schema}\".\"{table}\" AS \
+             SELECT * FROM \"{src_schema}\".\"{table}\""
+        );
+        self.execute_statement(&sql).await
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-duckdb/src/adapter.rs
+++ b/engine/crates/rocky-duckdb/src/adapter.rs
@@ -250,4 +250,60 @@ mod tests {
         let sql = adapter.dialect().create_table_as("t", "SELECT 1");
         assert!(sql.contains("CREATE OR REPLACE TABLE t"));
     }
+
+    /// Conformance test for the default `clone_table_for_branch` impl.
+    ///
+    /// DuckDB doesn't override the trait method, so this case proves the
+    /// portable CTAS default actually clones rows from the source schema
+    /// into the branch schema. Future native-clone adapters
+    /// (Databricks SHALLOW CLONE, Snowflake CLONE, BigQuery COPY) will
+    /// add their own per-adapter cases; the DuckDB path stays the
+    /// canonical regression test for the default implementation.
+    #[tokio::test]
+    async fn clone_table_for_branch_default_path() {
+        let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+
+        // Stand up a base schema with one row in it.
+        adapter
+            .execute_statement("CREATE SCHEMA IF NOT EXISTS demo")
+            .await
+            .unwrap();
+        adapter
+            .execute_statement("CREATE TABLE demo.orders AS SELECT 1 AS id, 'a' AS name")
+            .await
+            .unwrap();
+
+        // Create the branch schema and clone the table into it.
+        adapter
+            .execute_statement("CREATE SCHEMA IF NOT EXISTS branch__pr1")
+            .await
+            .unwrap();
+
+        let source = TableRef {
+            catalog: String::new(),
+            schema: "demo".into(),
+            table: "orders".into(),
+        };
+        adapter
+            .clone_table_for_branch(&source, "branch__pr1")
+            .await
+            .expect("default CTAS clone must succeed on DuckDB");
+
+        // Verify the cloned table contains the original row.
+        let result = adapter
+            .execute_query("SELECT id FROM branch__pr1.orders")
+            .await
+            .unwrap();
+        assert_eq!(result.rows.len(), 1, "cloned table should carry the row");
+
+        // Validation guard: rejects identifiers that would otherwise enable
+        // SQL injection through the branch / source / table names.
+        assert!(
+            adapter
+                .clone_table_for_branch(&source, "branch; DROP TABLE demo.orders; --")
+                .await
+                .is_err(),
+            "branch_schema must be validated as a SQL identifier"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `WarehouseAdapter::clone_table_for_branch` to the in-tree adapter trait, with a portable `CREATE OR REPLACE TABLE ... AS SELECT *` default impl that works on DuckDB and any warehouse whose CTAS accepts the two-part `schema.table` form.
- Wires `rocky preview create`'s copy-from-base step to call the new trait method instead of building the SQL inline. Behavior on DuckDB is unchanged.
- Adapters with native zero-copy clone primitives can override the method in their own crates without touching the call site.

## Test plan

- [x] `cargo test -p rocky-duckdb` passes, including the new `clone_table_for_branch_default_path` regression that covers the default impl + SQL-identifier validation guard.
- [x] `cargo test -p rocky-cli` passes, including the existing `copy_from_base_executes_ctas_on_duckdb` end-to-end test that now drives the trait path.
- [x] `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.
- [x] `just codegen` is idempotent — no schema drift.