### PR TITLE
feat(rocky-cli): add --verbose flag to rocky doctor

### DIFF
--- a/editors/vscode/src/types/generated/doctor.ts
+++ b/editors/vscode/src/types/generated/doctor.ts
@@ -24,6 +24,7 @@ export interface DoctorOutput {
  * A single health check result.
  */
 export interface HealthCheck {
+  details?: [string, string][];
   duration_ms: number;
   message: string;
   name: string;

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -21,6 +21,8 @@ pub struct HealthCheck {
     pub status: HealthStatus,
     pub message: String,
     pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub details: Vec<(String, String)>,
 }
 
 /// Doctor output structure.
@@ -38,6 +40,7 @@ pub async fn doctor(
     state_path: &Path,
     output_json: bool,
     check_filter: Option<&str>,
+    verbose: bool,
 ) -> Result<()> {
     let mut checks: Vec<HealthCheck> = Vec::new();
     let mut suggestions: Vec<String> = Vec::new();
@@ -45,6 +48,11 @@ pub async fn doctor(
     // 1. Config validation
     if should_run("config", check_filter) {
         let start = Instant::now();
+        let details = if verbose {
+            vec![("path".into(), config_path.display().to_string())]
+        } else {
+            Vec::new()
+        };
         match rocky_core::config::load_rocky_config(config_path) {
             Ok(_) => {
                 checks.push(HealthCheck {
@@ -52,6 +60,7 @@ pub async fn doctor(
                     status: HealthStatus::Healthy,
                     message: "Config syntax valid".into(),
                     duration_ms: start.elapsed().as_millis() as u64,
+                    details,
                 });
             }
             Err(e) => {
@@ -60,6 +69,7 @@ pub async fn doctor(
                     status: HealthStatus::Critical,
                     message: format!("Config invalid: {e}"),
                     duration_ms: start.elapsed().as_millis() as u64,
+                    details,
                 });
                 suggestions.push(format!("Fix config file at {}", config_path.display()));
             }
@@ -69,6 +79,20 @@ pub async fn doctor(
     // 2. State store
     if should_run("state", check_filter) {
         let start = Instant::now();
+        let details = if verbose {
+            let mut details = vec![("path".into(), state_path.display().to_string())];
+            if state_path.exists() {
+                details.push((
+                    "size_bytes".into(),
+                    std::fs::metadata(state_path)
+                        .map(|metadata| metadata.len().to_string())
+                        .unwrap_or_else(|_| "n/a".into()),
+                ));
+            }
+            details
+        } else {
+            Vec::new()
+        };
         match rocky_core::state::StateStore::open_read_only(state_path) {
             Ok(store) => {
                 // Try reading watermarks to verify the DB is healthy
@@ -79,6 +103,7 @@ pub async fn doctor(
                             status: HealthStatus::Healthy,
                             message: format!("State store healthy ({} watermarks)", wms.len()),
                             duration_ms: start.elapsed().as_millis() as u64,
+                            details,
                         });
                     }
                     Err(e) => {
@@ -87,6 +112,7 @@ pub async fn doctor(
                             status: HealthStatus::Warning,
                             message: format!("State store read error: {e}"),
                             duration_ms: start.elapsed().as_millis() as u64,
+                            details,
                         });
                         suggestions.push(
                             "State store may be corrupted — try deleting and re-running".into(),
@@ -100,6 +126,7 @@ pub async fn doctor(
                     status: HealthStatus::Warning,
                     message: format!("Cannot open state store: {e}"),
                     duration_ms: start.elapsed().as_millis() as u64,
+                    details,
                 });
             }
         }
@@ -110,7 +137,21 @@ pub async fn doctor(
         let start = Instant::now();
         if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
             let mut adapter_ok = true;
+            let mut details = Vec::new();
             for (name, adapter) in &cfg.adapters {
+                if verbose {
+                    details.push((format!("{name}.type"), adapter.adapter_type.clone()));
+                    let credential = if adapter.token.is_some() {
+                        "token"
+                    } else if adapter.client_id.is_some() {
+                        "oauth_client"
+                    } else if adapter.api_key.is_some() {
+                        "api_key"
+                    } else {
+                        "none"
+                    };
+                    details.push((format!("{name}.credential"), credential.into()));
+                }
                 match adapter.adapter_type.as_str() {
                     "databricks" => {
                         if adapter.host.is_none() || adapter.host.as_deref() == Some("") {
@@ -145,6 +186,7 @@ pub async fn doctor(
                     "Some adapters have missing configuration".into()
                 },
                 duration_ms: start.elapsed().as_millis() as u64,
+                details,
             });
         }
     }
@@ -153,9 +195,12 @@ pub async fn doctor(
     if should_run("pipelines", check_filter) {
         let start = Instant::now();
         if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
-            let pipeline_count = cfg.pipelines.len();
             let mut issues = Vec::new();
+            let mut details = Vec::new();
             for (name, pipeline) in &cfg.pipelines {
+                if verbose {
+                    details.push((format!("pipeline.{name}"), "configured".into()));
+                }
                 // Check schema pattern is parseable (replication pipelines only)
                 if let Some(repl) = pipeline.as_replication() {
                     if let Err(e) = repl.schema_pattern() {
@@ -163,6 +208,7 @@ pub async fn doctor(
                     }
                 }
             }
+            let pipeline_count = cfg.pipelines.len();
             checks.push(HealthCheck {
                 name: "pipelines".into(),
                 status: if issues.is_empty() {
@@ -176,6 +222,7 @@ pub async fn doctor(
                     format!("{} issue(s) found", issues.len())
                 },
                 duration_ms: start.elapsed().as_millis() as u64,
+                details,
             });
             suggestions.extend(issues);
         }
@@ -187,6 +234,11 @@ pub async fn doctor(
         if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
             let backend = &cfg.state.backend;
             let has_remote = *backend != rocky_core::config::StateBackend::Local;
+            let details = if verbose {
+                vec![("backend".into(), backend.to_string())]
+            } else {
+                Vec::new()
+            };
             checks.push(HealthCheck {
                 name: "state_sync".into(),
                 status: if has_remote {
@@ -196,6 +248,7 @@ pub async fn doctor(
                 },
                 message: format!("State backend: {backend}"),
                 duration_ms: start.elapsed().as_millis() as u64,
+                details,
             });
             if !has_remote {
                 suggestions
@@ -213,12 +266,18 @@ pub async fn doctor(
         let start = Instant::now();
         if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
             let backend = &cfg.state.backend;
+            let details = if verbose {
+                vec![("backend".into(), backend.to_string())]
+            } else {
+                Vec::new()
+            };
             if *backend == rocky_core::config::StateBackend::Local {
                 checks.push(HealthCheck {
                     name: "state_rw".into(),
                     status: HealthStatus::Healthy,
                     message: "Local backend — no remote probe needed".into(),
                     duration_ms: start.elapsed().as_millis() as u64,
+                    details,
                 });
             } else {
                 match rocky_core::state_sync::probe_state_backend(&cfg.state).await {
@@ -228,6 +287,7 @@ pub async fn doctor(
                             status: HealthStatus::Healthy,
                             message: format!("State backend RW probe succeeded ({backend})"),
                             duration_ms: start.elapsed().as_millis() as u64,
+                            details,
                         });
                     }
                     Err(e) => {
@@ -236,6 +296,7 @@ pub async fn doctor(
                             status: HealthStatus::Critical,
                             message: format!("State backend RW probe failed: {e}"),
                             duration_ms: start.elapsed().as_millis() as u64,
+                            details,
                         });
                         suggestions.push(format!(
                             "state_rw: verify the '{backend}' backend has read+write access \
@@ -262,6 +323,7 @@ pub async fn doctor(
                                 status: HealthStatus::Warning,
                                 message: "No warehouse adapters registered".into(),
                                 duration_ms: start.elapsed().as_millis() as u64,
+                                details: Vec::new(),
                             });
                         } else {
                             let mut all_ok = true;
@@ -275,6 +337,7 @@ pub async fn doctor(
                                             status: HealthStatus::Healthy,
                                             message: format!("Authenticated to {name}"),
                                             duration_ms: ping_start.elapsed().as_millis() as u64,
+                                            details: Vec::new(),
                                         });
                                     }
                                     Err(e) => {
@@ -284,6 +347,7 @@ pub async fn doctor(
                                             status: HealthStatus::Critical,
                                             message: format!("Ping failed: {e}"),
                                             duration_ms: ping_start.elapsed().as_millis() as u64,
+                                            details: Vec::new(),
                                         });
                                         suggestions.push(format!(
                                             "Adapter '{name}': verify credentials and network access"
@@ -292,6 +356,11 @@ pub async fn doctor(
                                 }
                             }
                             if all_ok {
+                                let details = if verbose {
+                                    vec![("warehouse_count".into(), names.len().to_string())]
+                                } else {
+                                    Vec::new()
+                                };
                                 checks.push(HealthCheck {
                                     name: "auth".into(),
                                     status: HealthStatus::Healthy,
@@ -300,6 +369,7 @@ pub async fn doctor(
                                         names.len()
                                     ),
                                     duration_ms: start.elapsed().as_millis() as u64,
+                                    details,
                                 });
                             }
                         }
@@ -316,6 +386,7 @@ pub async fn doctor(
                                         status: HealthStatus::Healthy,
                                         message: format!("Discovery adapter {name} reachable"),
                                         duration_ms: ping_start.elapsed().as_millis() as u64,
+                                        details: Vec::new(),
                                     });
                                 }
                                 Err(e) => {
@@ -324,6 +395,7 @@ pub async fn doctor(
                                         status: HealthStatus::Critical,
                                         message: format!("Discovery ping failed: {e}"),
                                         duration_ms: ping_start.elapsed().as_millis() as u64,
+                                        details: Vec::new(),
                                     });
                                     suggestions.push(format!(
                                         "Discovery adapter '{name}': verify API credentials"
@@ -338,6 +410,7 @@ pub async fn doctor(
                             status: HealthStatus::Critical,
                             message: format!("Adapter construction failed: {e}"),
                             duration_ms: start.elapsed().as_millis() as u64,
+                            details: Vec::new(),
                         });
                         suggestions.push(
                             "Fix adapter configuration — see `rocky doctor --check adapters` for details".into(),
@@ -351,6 +424,7 @@ pub async fn doctor(
                     status: HealthStatus::Critical,
                     message: format!("Cannot load config: {e}"),
                     duration_ms: start.elapsed().as_millis() as u64,
+                    details: Vec::new(),
                 });
             }
         }
@@ -393,6 +467,11 @@ pub async fn doctor(
                 "{} {} — {} ({}ms)",
                 icon, check.name, check.message, check.duration_ms
             );
+            if !check.details.is_empty() {
+                for (label, value) in &check.details {
+                    println!("        {label}: {value}");
+                }
+            }
         }
         println!("\nOverall: {}\n", doctor_output.overall);
         if !doctor_output.suggestions.is_empty() {
@@ -530,6 +609,7 @@ mod tests {
             status: HealthStatus::Critical,
             message: format!("Ping failed: {err}"),
             duration_ms: 0,
+            details: Vec::new(),
         };
 
         assert!(matches!(check.status, HealthStatus::Critical));
@@ -548,6 +628,7 @@ mod tests {
             status: HealthStatus::Critical,
             message: format!("Discovery ping failed: {err}"),
             duration_ms: 0,
+            details: Vec::new(),
         };
 
         assert!(matches!(check.status, HealthStatus::Critical));

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -141,16 +141,10 @@ pub async fn doctor(
             for (name, adapter) in &cfg.adapters {
                 if verbose {
                     details.push((format!("{name}.type"), adapter.adapter_type.clone()));
-                    let credential = if adapter.token.is_some() {
-                        "token"
-                    } else if adapter.client_id.is_some() {
-                        "oauth_client"
-                    } else if adapter.api_key.is_some() {
-                        "api_key"
-                    } else {
-                        "none"
-                    };
-                    details.push((format!("{name}.credential"), credential.into()));
+                    details.push((
+                        format!("{name}.credential"),
+                        credential_kind(adapter).into(),
+                    ));
                 }
                 match adapter.adapter_type.as_str() {
                     "databricks" => {
@@ -199,7 +193,10 @@ pub async fn doctor(
             let mut details = Vec::new();
             for (name, pipeline) in &cfg.pipelines {
                 if verbose {
-                    details.push((format!("pipeline.{name}"), "configured".into()));
+                    details.push((
+                        format!("pipeline.{name}"),
+                        pipeline.pipeline_type_str().into(),
+                    ));
                 }
                 // Check schema pattern is parseable (replication pipelines only)
                 if let Some(repl) = pipeline.as_replication() {
@@ -494,6 +491,29 @@ fn should_run(name: &str, filter: Option<&str>) -> bool {
     filter.is_none_or(|f| f == name)
 }
 
+/// Best-effort label for the credential shape an adapter is configured to use.
+///
+/// Surfaced in `rocky doctor --verbose` to help diagnose adapters that look
+/// healthy on a structural check but are wired to the wrong auth path. Order
+/// matches the auth precedence each adapter actually applies at connect time.
+fn credential_kind(adapter: &rocky_core::config::AdapterConfig) -> &'static str {
+    if adapter.token.is_some() {
+        "token"
+    } else if adapter.oauth_token.is_some() {
+        "oauth_token"
+    } else if adapter.private_key_path.is_some() {
+        "key_pair"
+    } else if adapter.client_id.is_some() {
+        "oauth_client"
+    } else if adapter.api_key.is_some() {
+        "api_key"
+    } else if adapter.password.is_some() {
+        "password"
+    } else {
+        "implicit"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -633,5 +653,138 @@ mod tests {
 
         assert!(matches!(check.status, HealthStatus::Critical));
         assert!(check.message.contains("unauthorized"));
+    }
+
+    // -----------------------------------------------------------------------
+    // credential_kind — verbose adapter detail heuristic
+    // -----------------------------------------------------------------------
+
+    fn empty_adapter(adapter_type: &str) -> rocky_core::config::AdapterConfig {
+        rocky_core::config::AdapterConfig {
+            adapter_type: adapter_type.into(),
+            kind: None,
+            host: None,
+            http_path: None,
+            token: None,
+            client_id: None,
+            client_secret: None,
+            timeout_secs: None,
+            destination_id: None,
+            api_key: None,
+            api_secret: None,
+            account: None,
+            warehouse: None,
+            username: None,
+            password: None,
+            oauth_token: None,
+            private_key_path: None,
+            role: None,
+            database: None,
+            project_id: None,
+            location: None,
+            path: None,
+            retry: rocky_core::config::RetryConfig::default(),
+        }
+    }
+
+    #[test]
+    fn credential_kind_databricks_pat() {
+        let mut a = empty_adapter("databricks");
+        a.token = Some(rocky_core::redacted::RedactedString::new("dapi_x".into()));
+        assert_eq!(credential_kind(&a), "token");
+    }
+
+    #[test]
+    fn credential_kind_databricks_oauth_m2m() {
+        let mut a = empty_adapter("databricks");
+        a.client_id = Some("client_123".into());
+        a.client_secret = Some(rocky_core::redacted::RedactedString::new("secret".into()));
+        assert_eq!(credential_kind(&a), "oauth_client");
+    }
+
+    #[test]
+    fn credential_kind_snowflake_oauth() {
+        let mut a = empty_adapter("snowflake");
+        a.oauth_token = Some(rocky_core::redacted::RedactedString::new("oauth_x".into()));
+        assert_eq!(credential_kind(&a), "oauth_token");
+    }
+
+    #[test]
+    fn credential_kind_snowflake_keypair() {
+        let mut a = empty_adapter("snowflake");
+        a.private_key_path = Some("/etc/rocky/snowflake.pem".into());
+        assert_eq!(credential_kind(&a), "key_pair");
+    }
+
+    #[test]
+    fn credential_kind_snowflake_password() {
+        let mut a = empty_adapter("snowflake");
+        a.password = Some(rocky_core::redacted::RedactedString::new("pw".into()));
+        assert_eq!(credential_kind(&a), "password");
+    }
+
+    #[test]
+    fn credential_kind_fivetran_api_key() {
+        let mut a = empty_adapter("fivetran");
+        a.api_key = Some(rocky_core::redacted::RedactedString::new("key".into()));
+        assert_eq!(credential_kind(&a), "api_key");
+    }
+
+    /// BigQuery and DuckDB don't carry credentials in [adapter.*] — auth is
+    /// resolved from the environment (ADC, in-memory). "implicit" (rather
+    /// than "none") signals "not misconfigured, just env-based" and avoids
+    /// alarming a user whose adapter is actually fine.
+    #[test]
+    fn credential_kind_bigquery_implicit() {
+        let mut a = empty_adapter("bigquery");
+        a.project_id = Some("my-gcp-project".into());
+        a.location = Some("US".into());
+        assert_eq!(credential_kind(&a), "implicit");
+    }
+
+    /// Token wins when more than one credential field is set — matches the
+    /// auth precedence the Databricks adapter applies at connect time.
+    #[test]
+    fn credential_kind_token_precedence() {
+        let mut a = empty_adapter("databricks");
+        a.token = Some(rocky_core::redacted::RedactedString::new("t".into()));
+        a.client_id = Some("c".into());
+        a.password = Some(rocky_core::redacted::RedactedString::new("p".into()));
+        assert_eq!(credential_kind(&a), "token");
+    }
+
+    // -----------------------------------------------------------------------
+    // HealthCheck JSON contract — empty `details` must not appear in payloads
+    // (existing dagster fixtures depend on this; the field only materializes
+    // under `--verbose`).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn health_check_json_omits_empty_details() {
+        let check = HealthCheck {
+            name: "config".into(),
+            status: HealthStatus::Healthy,
+            message: "ok".into(),
+            duration_ms: 0,
+            details: Vec::new(),
+        };
+        let json = serde_json::to_string(&check).unwrap();
+        assert!(!json.contains("details"), "empty details leaked: {json}");
+    }
+
+    #[test]
+    fn health_check_json_emits_populated_details() {
+        let check = HealthCheck {
+            name: "config".into(),
+            status: HealthStatus::Healthy,
+            message: "ok".into(),
+            duration_ms: 0,
+            details: vec![("path".into(), "/etc/rocky.toml".into())],
+        };
+        let json = serde_json::to_string(&check).unwrap();
+        assert!(
+            json.contains("\"details\":[[\"path\",\"/etc/rocky.toml\"]]"),
+            "{json}"
+        );
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -905,6 +905,9 @@ enum Command {
         /// Run only a specific check (config, state, adapters, pipelines, state_sync)
         #[arg(long)]
         check: Option<String>,
+        /// Print extra context for each check (config path, state file size, adapter type, credential type).
+        #[arg(long)]
+        verbose: bool,
     },
 
     /// Governance compliance rollup: classification tags + `[mask]`
@@ -1879,8 +1882,9 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 rocky_cli::commands::list_consumers(&model, &models, json)
             }
         },
-        Command::Doctor { check } => {
-            rocky_cli::commands::doctor(&cli.config, &state_path, json, check.as_deref()).await
+        Command::Doctor { check, verbose } => {
+            rocky_cli::commands::doctor(&cli.config, &state_path, json, check.as_deref(), verbose)
+                .await
         }
         Command::Compliance {
             env,

--- a/integrations/dagster/src/dagster_rocky/types_generated/doctor_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/doctor_schema.py
@@ -23,6 +23,7 @@ class HealthCheck(BaseModel):
     A single health check result.
     """
 
+    details: list[list[str]] | None = None
     duration_ms: conint(ge=0)
     message: str
     name: str

--- a/schemas/doctor.schema.json
+++ b/schemas/doctor.schema.json
@@ -4,6 +4,22 @@
     "HealthCheck": {
       "description": "A single health check result.",
       "properties": {
+        "details": {
+          "items": {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "type": "array"
+        },
         "duration_ms": {
           "format": "uint64",
           "minimum": 0.0,


### PR DESCRIPTION
## Summary

Adds a `--verbose` flag to `rocky doctor` (per #21). When passed, the human-readable output prints additional per-check context (config path, state DB path and size, adapter type and credential signal, pipeline names, and the configured state backend) on indented lines beneath each check. The default (non-verbose) output is unchanged, and the JSON output stays backwards-compatible because the new `HealthCheck.details` field is `#[serde(skip_serializing_if = "Vec::is_empty", default)]` and only ever populated when `--verbose` is set.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [x] `integrations/dagster/` (Python package, codegen only)
- [x] `editors/vscode/` (TypeScript extension, codegen only)
- [ ] `examples/playground/` (sample project / benchmarks)
- [x] `schemas/` (canonical CLI JSON schema)
- [ ] Cross-project (CI, scripts, root docs)

## Changes

In the engine, the `Doctor` command variant in `engine/rocky/src/main.rs` gains a `verbose: bool` field that's plumbed through to `commands::doctor`. The `doctor` function in `engine/crates/rocky-cli/src/commands/doctor.rs` takes that `verbose` flag as a new last parameter, and `HealthCheck` grows an optional `details: Vec<(String, String)>` field that each check populates when verbose is true. The human-readable rendering prints the details inline under each check; the JSON branch is unaffected because the new field serde-skips empty vectors. Each check populates the kind of detail the reporter cares about for that check: the `config` check adds the resolved config path, `state` adds the DB path and on-disk size in bytes, `adapters` adds an entry per adapter for type and credential signal (one of token, oauth_client, api_key, or none), `pipelines` lists each configured pipeline name, and the `state_sync` and `state_rw` checks add the backend identifier.

The schema and binding regen comes from running `just codegen` after the engine change. That updates `schemas/doctor.schema.json`, `editors/vscode/src/types/generated/doctor.ts`, and `integrations/dagster/src/dagster_rocky/types_generated/doctor_schema.py` to declare the new optional `details` field. Without that step the codegen-drift CI check would fire because the rocky JSON contract is the source of truth for the dagster and VS Code consumers; with it, both consumers see the new field as optional and existing payloads stay valid. The `npm install` step that ran during codegen also bumped `editors/vscode/package-lock.json` from 1.9.1 to 1.11.0, which is unrelated to this PR; I reverted that file so the only diff here is the doctor surface area.

## Test Plan

From `engine/`:

- `cargo build --package rocky-cli --package rocky` — clean.
- `cargo clippy --package rocky-cli --package rocky --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test --package rocky-cli` — 304 passed, 0 failed.

Codegen (from repo root): `just codegen` ran cleanly. The three regenerated files in this PR are the only meaningful diff.

The change is additive. Existing scripts that read `rocky doctor --output json` continue to work because `HealthCheck.details` only appears in the payload when `--verbose` is also set, and the field is optional in the regenerated TS/Pydantic types.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR

### Engine (`engine/`)
- [x] `cargo test --all-targets` passes
- [x] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [x] Codegen-only change. The regenerated `doctor_schema.py` adds an optional `details: list[list[str]] | None = None` field.

### VS Code (`editors/vscode/`)
- [x] Codegen-only change. The regenerated `doctor.ts` adds an optional `details?: [string, string][]` field.

Closes #21
