### PR TITLE
feat(engine/rocky-databricks): override clone_table_for_branch with SHALLOW CLONE

### DIFF
--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -28,6 +28,7 @@ name = "wiremock_tests"
 required-features = ["test-support"]
 
 [dev-dependencies]
+rocky-core = { path = "../rocky-core" }
 tokio = { workspace = true }
 wiremock = { workspace = true }
 serde_json = { workspace = true }

--- a/engine/crates/rocky-databricks/src/adapter.rs
+++ b/engine/crates/rocky-databricks/src/adapter.rs
@@ -92,6 +92,29 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
             .map(|tables| tables.into_iter().map(|t| t.to_lowercase()).collect())
             .map_err(AdapterError::new)
     }
+
+    /// Override: emit `SHALLOW CLONE` instead of CTAS. Branch table lands in
+    /// `<source.catalog>.<branch_schema>.<source.table>` — same catalog as the
+    /// source, since the trait surface scopes branches by schema only.
+    async fn clone_table_for_branch(
+        &self,
+        source: &TableRef,
+        branch_schema: &str,
+    ) -> AdapterResult<()> {
+        rocky_sql::validation::validate_identifier(&source.catalog).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(&source.schema).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(&source.table).map_err(AdapterError::new)?;
+        rocky_sql::validation::validate_identifier(branch_schema).map_err(AdapterError::new)?;
+
+        let catalog = &source.catalog;
+        let src_schema = &source.schema;
+        let table = &source.table;
+        let sql = format!(
+            "CREATE OR REPLACE TABLE {catalog}.{branch_schema}.{table} \
+             SHALLOW CLONE {catalog}.{src_schema}.{table}"
+        );
+        self.execute_statement(&sql).await
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-databricks/tests/integration.rs
+++ b/engine/crates/rocky-databricks/tests/integration.rs
@@ -7,8 +7,11 @@
 //!
 //! Run with: cargo test -p rocky-databricks --test integration -- --ignored
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use rocky_core::ir::TableRef;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
 use rocky_databricks::auth::{Auth, AuthConfig};
 use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
 
@@ -91,6 +94,93 @@ async fn test_execute_invalid_sql_fails() {
     let result = connector.execute_sql("SELECTT INVALID SYNTAX").await;
 
     assert!(result.is_err());
+}
+
+/// Verifies the Databricks `clone_table_for_branch` override emits a
+/// working `SHALLOW CLONE` statement: source schema + table created,
+/// clone produced in a sibling schema, row contents match. Both schemas
+/// are dropped (CASCADE) at the end regardless of test outcome.
+///
+/// Catalog is read from `DATABRICKS_TEST_CATALOG` (defaults to the value
+/// of `DATABRICKS_CATALOG_PREFIX`) so the test honors per-environment
+/// sandbox naming. Schemas use the `hc_phase5_` prefix.
+#[tokio::test]
+#[ignore]
+async fn test_clone_table_for_branch_shallow_clone() {
+    let connector = connector_from_env().expect("Databricks env vars not set");
+    let adapter = DatabricksWarehouseAdapter::new(connector);
+
+    let catalog = std::env::var("DATABRICKS_TEST_CATALOG")
+        .or_else(|_| std::env::var("DATABRICKS_CATALOG_PREFIX"))
+        .expect("DATABRICKS_TEST_CATALOG or DATABRICKS_CATALOG_PREFIX must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let src_schema = format!("hc_phase5_src_{suffix}");
+    let brn_schema = format!("hc_phase5_brn_{suffix}");
+    let table = "test_table";
+
+    // Setup: create the two schemas + a 2-row source table.
+    // The catalog is assumed to exist; operator is responsible for pre-creating it.
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS {catalog}.{src_schema}"
+        ))
+        .await
+        .expect("create source schema");
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS {catalog}.{brn_schema}"
+        ))
+        .await
+        .expect("create branch schema");
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {catalog}.{src_schema}.{table} AS \
+             SELECT * FROM (VALUES (1, 'a'), (2, 'b')) AS t(id, name)"
+        ))
+        .await
+        .expect("create source table");
+
+    // Run the unit under test, capture the result so cleanup runs first.
+    let source = TableRef {
+        catalog: catalog.clone(),
+        schema: src_schema.clone(),
+        table: table.to_string(),
+    };
+    let clone_result = adapter.clone_table_for_branch(&source, &brn_schema).await;
+
+    let row_count = if clone_result.is_ok() {
+        let q = adapter
+            .execute_query(&format!(
+                "SELECT COUNT(*) AS n FROM {catalog}.{brn_schema}.{table}"
+            ))
+            .await
+            .ok();
+        q.and_then(|r| r.rows.first().and_then(|row| row.first().cloned()))
+    } else {
+        None
+    };
+
+    // Unconditional cleanup (best-effort; ignored on failure).
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{src_schema} CASCADE"
+        ))
+        .await;
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {catalog}.{brn_schema} CASCADE"
+        ))
+        .await;
+
+    clone_result.expect("clone_table_for_branch should succeed");
+    let n = row_count.expect("clone target should be queryable");
+    let n_str = n.as_str().or_else(|| n.as_str()).unwrap_or_default();
+    let n_num: i64 = n.as_i64().unwrap_or_else(|| n_str.parse().unwrap_or(-1));
+    assert_eq!(n_num, 2, "cloned table should have 2 rows, got {n:?}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Databricks adapter now overrides `WarehouseAdapter::clone_table_for_branch` with a native `SHALLOW CLONE` statement, replacing the inherited CTAS default. Branch table lands in `<source.catalog>.<branch_schema>.<source.table>` — same catalog as the source, since the trait surface scopes branches by schema only.
- Identifiers (catalog, source schema, source table, branch schema) are validated through `rocky_sql::validation` before SQL generation, matching the guard pattern used by the default impl.
- Adds an `#[ignore]` integration test that creates two ephemeral schemas, materializes a 2-row source table, runs `clone_table_for_branch`, verifies row count on the cloned target, and drops both schemas `CASCADE` on success or failure. Test is gated on `DATABRICKS_HOST` + auth env vars + `DATABRICKS_TEST_CATALOG` (with `DATABRICKS_CATALOG_PREFIX` as fallback).

## Test plan
- [x] `cargo build -p rocky-databricks --tests` clean
- [x] `cargo clippy -p rocky-databricks --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rocky-databricks --features test-support` (36 wiremock-backed tests pass)
- [x] `cargo test -p rocky-databricks --test integration test_clone_table_for_branch_shallow_clone -- --ignored` verified end-to-end against a real Databricks workspace
- [x] `just codegen` no schema drift