### PR TITLE
feat(dagster): rocky_source_sensor backlog cap, lifecycle hooks, resource key

### DIFF
--- a/docs/src/content/docs/dagster/sensors.md
+++ b/docs/src/content/docs/dagster/sensors.md
@@ -26,9 +26,12 @@ from dagster_rocky import (
 rocky = RockyResource(config_path="rocky.toml")
 rocky_assets = load_rocky_assets(rocky)
 
-# Build a sensor that targets every Rocky asset
+# Build a sensor that targets every Rocky asset.
+# `rocky_resource` defaults to the resource key "rocky" — the sensor
+# resolves it through Dagster's required-resource injection at evaluation
+# time, so per-deployment overrides applied via `Definitions` reach the
+# sensor without needing to rebuild it.
 fivetran_sync_sensor = rocky_source_sensor(
-    rocky_resource=rocky,
     target=dg.AssetSelection.assets(*[s.key for s in rocky_assets]),
     minimum_interval_seconds=300,  # poll every 5 minutes
 )
@@ -109,6 +112,84 @@ Every `RunRequest` is tagged with:
 
 These show up in the Dagster run history view so you can audit which Fivetran
 sync triggered which materialization.
+
+## Resource injection
+
+`rocky_resource` accepts either form:
+
+- **String key** (default `"rocky"`) — Dagster resolves the resource from `context.resources` at evaluation time. Per-deployment overrides apply, mock substitution via `dg.build_sensor_context(resources={...})` works without wrapping, and the resource doesn't need to exist before the sensor is built.
+- **`RockyResource` instance** — the legacy form, closure-captured at sensor-build time. Still supported indefinitely so existing call sites don't break, but the keyed form is recommended for new code.
+
+```python
+# String-key form (recommended) — resolves "rocky" from context.resources
+sensor = rocky_source_sensor(target=...)
+
+# Custom resource key
+sensor = rocky_source_sensor(rocky_resource="my_rocky", target=...)
+
+# Instance form (legacy, still supported)
+sensor = rocky_source_sensor(rocky_resource=rocky, target=...)
+```
+
+## Backlog cap
+
+Pass `backlog_cap=BacklogCap(...)` to suppress emits when too many in-flight Dagster runs already share a tag value. Useful when a hung downstream amplifies into a runaway queue — without back-pressure, a stuck run can pile up dozens of fresh `RunRequest`s tagged for the same client/tenant before anyone notices.
+
+```python
+from dagster_rocky import BacklogCap, rocky_source_sensor
+
+sensor = rocky_source_sensor(
+    target=...,
+    backlog_cap=BacklogCap(
+        tag_key="rocky/group",  # or "rocky/source_id" for per_source granularity
+        max_in_flight=5,
+    ),
+)
+```
+
+Before each emit, the sensor counts in-flight runs matching `tag_key=<value>` in the non-terminal statuses (`QUEUED`, `NOT_STARTED`, `STARTING`, `STARTED` by default — override via `BacklogCap.statuses`). If the count is at or above `max_in_flight`, the `RunRequest` is suppressed.
+
+**The cursor still advances on suppression** — the in-flight run picks up the latest data via Rocky's per-source state. Freezing the cursor would compound the failure: the next tick would re-detect the same sync, retry the same suppressed emit, and never recover until the queue drains below cap.
+
+`BacklogCap` is opt-in. Default behavior (no cap) is unchanged.
+
+## Lifecycle hooks
+
+Three optional best-effort callbacks let you attach metrics, alerts, or audit logs without subclassing or wrapping the sensor:
+
+```python
+from dagster_rocky import (
+    EmitContext,
+    FailedSourcesContext,
+    SkipContext,
+    rocky_source_sensor,
+)
+
+def record_emit(ec: EmitContext) -> None:
+    # ec.run_request, ec.sources, ec.granularity, ec.sensor_context
+    ...
+
+def alert_failed(fc: FailedSourcesContext) -> None:
+    # fc.failed_sources, fc.sensor_context
+    ...
+
+def gauge_idle(sc: SkipContext) -> None:
+    # sc.reason, sc.cursor_size, sc.sensor_context
+    ...
+
+sensor = rocky_source_sensor(
+    target=...,
+    on_run_request_emitted=record_emit,
+    on_failed_sources=alert_failed,
+    on_skip=gauge_idle,
+)
+```
+
+Hook contract:
+
+- **Best-effort.** Raised exceptions are caught and logged at WARN. A misbehaving hook never blocks an emit.
+- **Observability, not policy.** Hooks fire after the sensor decides what to do. Use `backlog_cap` (above) for emit-time policy.
+- **`on_run_request_emitted` fires per emit, after suppression.** It sees only the requests Dagster will be asked to launch.
 
 ## Defaults
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky_source_sensor` per-tag-key backlog cap (FR-015).** New opt-in `backlog_cap=BacklogCap(tag_key=..., max_in_flight=..., statuses=...)` argument that consults `context.instance.get_runs(...)` before each emit and suppresses the `RunRequest` when the in-flight count for the matched tag value is at or above the cap. The cursor still advances on suppression so the in-flight run picks up the latest data via Rocky's per-source state — avoiding the stuck-tick failure mode where freezing the cursor would re-detect the same sync forever. Default off; existing call sites unchanged. New `BacklogCap` NamedTuple is exported from the package root.
+- **`rocky_source_sensor` lifecycle hooks (FR-016).** Three new optional best-effort callbacks — `on_run_request_emitted`, `on_failed_sources`, `on_skip` — each receiving a frozen-dataclass context (`EmitContext` / `FailedSourcesContext` / `SkipContext`). Hooks fire after the sensor decides what to do and never block emits; raised exceptions are caught and logged at WARN. Lets consumers attach OTel metrics, alert webhooks, or audit logs without wrapping the sensor. The four new public types (`EmitContext`, `FailedSourcesContext`, `SkipContext`, plus the existing FR-015 `BacklogCap`) are exported from the package root.
+- **`rocky_source_sensor` resource-key injection (FR-017).** The `rocky_resource` argument now accepts either a `RockyResource` instance (legacy form, closure-captured) or a string key (new default `"rocky"`) that the sensor resolves through Dagster's required-resource injection at evaluation time. The keyed form is swap-safe (per-deployment overrides actually apply to the sensor), mock-friendly (`dg.build_sensor_context(resources={"rocky": ...})` works without monkeypatching), and removes the build-order coupling that previously forced the resource to exist before sensor construction. Existing instance-form call sites keep working with no change.
+
 ## [1.16.0] — 2026-04-30
 
 Companion release to engine `v1.19.0`. Picks up the regenerated Pydantic model for the new `rocky lineage-diff` command surface and wires it into the dispatch table.

--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -66,7 +66,13 @@ from .partitions import (
 from .resource import MIN_ROCKY_VERSION, Resolver, ResolverContext, RockyResource
 from .scaffold import init_rocky_project
 from .schedules import build_rocky_schedule
-from .sensor import rocky_source_sensor
+from .sensor import (
+    BacklogCap,
+    EmitContext,
+    FailedSourcesContext,
+    SkipContext,
+    rocky_source_sensor,
+)
 from .translator import RockyDagsterTranslator
 from .types import (
     AdapterTestResult,
@@ -172,6 +178,10 @@ __all__ = [
     "rocky_cron_automation",
     # Sensor + schedule (T1.3, T1.5)
     "rocky_source_sensor",
+    "BacklogCap",
+    "EmitContext",
+    "FailedSourcesContext",
+    "SkipContext",
     "build_rocky_schedule",
     # Observability (T4.1, T4.2, T4.4)
     "ANOMALY_CHECK_NAME",

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import dagster as dg
 
@@ -30,25 +31,91 @@ from .resource import RockyResource
 from .translator import RockyDagsterTranslator
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Callable, Iterator, Sequence
 
     from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 
-    from .types import SourceInfo
+    from .types import FailedSourceOutput, SourceInfo
 
 
 Granularity = Literal["per_source", "per_group"]
 
 
+# ---------------------------------------------------------------------------
+# FR-015: backlog-cap configuration
+# ---------------------------------------------------------------------------
+
+
+class BacklogCap(NamedTuple):
+    """Per-tag-key in-flight cap on emitted RunRequests.
+
+    Before emitting each RunRequest, the sensor counts in-flight Dagster
+    runs matching ``tag_key=<value>`` in any of the non-terminal statuses
+    listed in ``statuses``. If the count is at or above ``max_in_flight``,
+    the RunRequest is suppressed — but the cursor still advances, so the
+    sync is not re-detected on the next tick.
+
+    The cursor-advance behavior is intentional: the existing in-flight run
+    will pick up the latest data via Rocky's per-source state. Suppressing
+    the emit *and* freezing the cursor would create a stuck-tick where
+    nothing progresses until the in-flight queue drains below cap.
+    """
+
+    tag_key: str
+    max_in_flight: int
+    statuses: tuple[dg.DagsterRunStatus, ...] = (
+        dg.DagsterRunStatus.QUEUED,
+        dg.DagsterRunStatus.NOT_STARTED,
+        dg.DagsterRunStatus.STARTING,
+        dg.DagsterRunStatus.STARTED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FR-016: lifecycle-hook contexts (frozen dataclasses → additive evolution)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmitContext:
+    """Args passed to ``on_run_request_emitted`` once per emitted RunRequest."""
+
+    run_request: dg.RunRequest
+    sources: tuple[SourceInfo, ...]
+    granularity: Granularity
+    sensor_context: dg.SensorEvaluationContext
+
+
+@dataclass(frozen=True)
+class FailedSourcesContext:
+    """Args passed to ``on_failed_sources`` when discover reports failures."""
+
+    failed_sources: tuple[FailedSourceOutput, ...]
+    sensor_context: dg.SensorEvaluationContext
+
+
+@dataclass(frozen=True)
+class SkipContext:
+    """Args passed to ``on_skip`` when no sources advanced."""
+
+    reason: str
+    cursor_size: int
+    sensor_context: dg.SensorEvaluationContext
+
+
 def rocky_source_sensor(
     *,
-    rocky_resource: RockyResource,
+    rocky_resource: RockyResource | str = "rocky",
     target: CoercibleToAssetSelection | dg.AssetsDefinition,
     granularity: Granularity = "per_source",
     translator: RockyDagsterTranslator | None = None,
     name: str = "rocky_source_sensor",
     minimum_interval_seconds: int = 300,
     default_status: dg.DefaultSensorStatus = dg.DefaultSensorStatus.STOPPED,
+    backlog_cap: BacklogCap | None = None,
+    on_run_request_emitted: Callable[[EmitContext], None] | None = None,
+    on_failed_sources: Callable[[FailedSourcesContext], None] | None = None,
+    on_skip: Callable[[SkipContext], None] | None = None,
 ) -> dg.SensorDefinition:
     """Build a Dagster sensor that watches Rocky sources for new syncs.
 
@@ -62,7 +129,16 @@ def rocky_source_sensor(
     so adding a new source doesn't replay history for existing ones.
 
     Args:
-        rocky_resource: The :class:`RockyResource` used to call ``discover``.
+        rocky_resource: Either the :class:`RockyResource` instance the
+            sensor should call ``discover`` on (legacy form, closure-
+            captured at build time) **or** the resource key (string,
+            default ``"rocky"``) under which the resource is registered
+            in :class:`dagster.Definitions`. The string form is the
+            recommended path: it lets Dagster resolve the resource at
+            evaluation time, supports per-deployment overrides, and
+            makes mock-substitution via
+            ``dg.build_sensor_context(resources={...})`` work without
+            wrapping.
         target: The asset selection (or AssetsDefinition) the sensor is
             allowed to materialize. Typically the result of
             ``load_rocky_assets()`` wrapped in ``dg.AssetSelection.assets(...)``,
@@ -78,11 +154,29 @@ def rocky_source_sensor(
             Defaults to 300 (5 minutes).
         default_status: Whether the sensor is enabled on deployment.
             Defaults to ``STOPPED`` so users opt in explicitly.
+        backlog_cap: Opt-in :class:`BacklogCap` config to suppress emits
+            when too many in-flight runs already share a tag value.
+            Defaults to ``None`` (no suppression). The cursor still
+            advances when an emit is suppressed so the in-flight run
+            picks up the latest data via Rocky's per-source state.
+        on_run_request_emitted: Optional best-effort callback fired once
+            per RunRequest the sensor will return (after suppression
+            decisions). Exceptions are caught and logged at WARN — a
+            misbehaving hook never blocks an emit.
+        on_failed_sources: Optional best-effort callback fired when
+            ``rocky discover`` surfaces ``failed_sources``. Same
+            exception-swallowing contract as ``on_run_request_emitted``.
+        on_skip: Optional best-effort callback fired when the tick has
+            no advancing sources. Same exception-swallowing contract as
+            ``on_run_request_emitted``.
 
     Returns:
         A :class:`dagster.SensorDefinition` ready to add to a ``Definitions``
         object.
     """
+    is_keyed = isinstance(rocky_resource, str)
+    resource_keys: set[str] = {rocky_resource} if is_keyed else set()  # type: ignore[arg-type]
+
     if translator is None:
         translator = RockyDagsterTranslator()
 
@@ -91,10 +185,24 @@ def rocky_source_sensor(
         target=target,
         minimum_interval_seconds=minimum_interval_seconds,
         default_status=default_status,
+        required_resource_keys=resource_keys,
     )
-    def _sensor(context: dg.SensorEvaluationContext) -> dg.SensorResult:
+    # NOTE on the **injected kwargs:
+    # Dagster's @dg.sensor passes required resources by name as keyword
+    # arguments to the decorated function. Annotating ``**injected`` with
+    # a concrete type (``**injected: RockyResource``) would make Dagster's
+    # resource detector pick up "injected" as a *second* required resource
+    # key — which collides with the explicit ``required_resource_keys``
+    # arg above. The annotation is omitted on purpose.
+    def _sensor(context: dg.SensorEvaluationContext, **injected) -> dg.SensorResult:  # noqa: ANN003
+        # FR-017: late-bind the resource through Dagster's required-resource
+        # injection (resources arrive by key as keyword arguments) when a
+        # key was passed; fall back to the closure-captured instance for
+        # the legacy form.
+        resource = injected[rocky_resource] if is_keyed else rocky_resource  # type: ignore[assignment,index]
+
         cursor_data: dict[str, str] = json.loads(context.cursor) if context.cursor else {}
-        result = rocky_resource.discover()
+        result = resource.discover()
 
         # FR-014: distinguish "tried-and-failed" from "removed upstream."
         # If discover surfaced any `failed_sources`, log them so the
@@ -109,6 +217,17 @@ def rocky_source_sensor(
                 f"failed source(s) — these are NOT deletions, do not reconcile "
                 f"missing-asset state for them: {failed_ids}"
             )
+            # FR-016: best-effort observability hook for the failed-sources event.
+            if on_failed_sources is not None:
+                try:
+                    on_failed_sources(
+                        FailedSourcesContext(
+                            failed_sources=tuple(failed_sources),
+                            sensor_context=context,
+                        )
+                    )
+                except Exception:
+                    context.log.warning("on_failed_sources hook raised", exc_info=True)
 
         triggered: list[SourceInfo] = []
         new_cursor = dict(cursor_data)
@@ -122,15 +241,82 @@ def rocky_source_sensor(
                 new_cursor[source.id] = sync_iso
 
         if not triggered:
+            skip_reason = "No Rocky sources have synced since the last tick"
+            # FR-016: best-effort observability hook for the no-advance skip.
+            if on_skip is not None:
+                try:
+                    on_skip(
+                        SkipContext(
+                            reason=skip_reason,
+                            cursor_size=len(new_cursor),
+                            sensor_context=context,
+                        )
+                    )
+                except Exception:
+                    context.log.warning("on_skip hook raised", exc_info=True)
             return dg.SensorResult(
                 cursor=json.dumps(new_cursor),
-                skip_reason=dg.SkipReason("No Rocky sources have synced since the last tick"),
+                skip_reason=dg.SkipReason(skip_reason),
             )
 
         if granularity == "per_source":
-            run_requests = [_per_source_request(source, translator) for source in triggered]
+            request_pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = [
+                (_per_source_request(source, translator), (source,)) for source in triggered
+            ]
         else:
-            run_requests = list(_per_group_requests(triggered, translator))
+            request_pairs = list(_per_group_request_pairs(triggered, translator))
+
+        # FR-015: opt-in per-tag-key in-flight backlog cap. Suppresses the
+        # emit but advances the cursor — the in-flight run will pick up
+        # the data via Rocky's per-source state.
+        if backlog_cap is not None:
+            accepted_pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = []
+            suppressed_keys: list[str] = []
+            for rr, sources in request_pairs:
+                tag_value = rr.tags.get(backlog_cap.tag_key)
+                if tag_value is None:
+                    accepted_pairs.append((rr, sources))
+                    continue
+                in_flight = len(
+                    context.instance.get_runs(
+                        filters=dg.RunsFilter(
+                            tags={backlog_cap.tag_key: tag_value},
+                            statuses=list(backlog_cap.statuses),
+                        ),
+                        limit=backlog_cap.max_in_flight + 1,
+                    )
+                )
+                if in_flight >= backlog_cap.max_in_flight:
+                    suppressed_keys.append(tag_value)
+                    continue
+                accepted_pairs.append((rr, sources))
+            if suppressed_keys:
+                context.log.warning(
+                    f"rocky_source_sensor: suppressed {len(suppressed_keys)} RunRequest(s) "
+                    f"due to backlog cap (max_in_flight={backlog_cap.max_in_flight}, "
+                    f"tag_key={backlog_cap.tag_key}): {sorted(set(suppressed_keys))}. "
+                    f"Cursor still advances; in-flight runs will pick up latest data."
+                )
+            request_pairs = accepted_pairs
+
+        run_requests = [rr for rr, _ in request_pairs]
+
+        # FR-016: best-effort per-emit observability hook fires after all
+        # suppression decisions, so it sees only what Dagster will be asked
+        # to launch (matches the "emitted" semantics).
+        if on_run_request_emitted is not None:
+            for rr, sources in request_pairs:
+                try:
+                    on_run_request_emitted(
+                        EmitContext(
+                            run_request=rr,
+                            sources=sources,
+                            granularity=granularity,
+                            sensor_context=context,
+                        )
+                    )
+                except Exception:
+                    context.log.warning("on_run_request_emitted hook raised", exc_info=True)
 
         context.log.info(
             f"rocky_source_sensor: {len(triggered)} source(s) triggered, "
@@ -177,11 +363,11 @@ def _per_source_request(
     )
 
 
-def _per_group_requests(
+def _per_group_request_pairs(
     triggered: Sequence[SourceInfo],
     translator: RockyDagsterTranslator,
-) -> Iterator[dg.RunRequest]:
-    """Group triggered sources by their translator group and yield one RunRequest each."""
+) -> Iterator[tuple[dg.RunRequest, tuple[SourceInfo, ...]]]:
+    """Group triggered sources by translator group; yield ``(RunRequest, sources)`` pairs."""
     by_group: dict[str, list[SourceInfo]] = defaultdict(list)
     for source in triggered:
         by_group[translator.get_group_name(source)].append(source)
@@ -196,7 +382,7 @@ def _per_group_requests(
             source.last_sync_at for source in sources if source.last_sync_at is not None
         )
         sync_iso = latest_sync.isoformat()
-        yield dg.RunRequest(
+        rr = dg.RunRequest(
             run_key=f"{group_name}-{sync_iso}",
             asset_selection=asset_keys,
             tags={
@@ -204,3 +390,4 @@ def _per_group_requests(
                 "rocky/sync_at": sync_iso,
             },
         )
+        yield rr, tuple(sources)

--- a/integrations/dagster/tests/test_sensor.py
+++ b/integrations/dagster/tests/test_sensor.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import dagster as dg
 
 from dagster_rocky import (
+    BacklogCap,
     DiscoverResult,
+    EmitContext,
     FailedSourceOutput,
+    FailedSourcesContext,
     RockyResource,
+    SkipContext,
     SourceInfo,
     TableInfo,
     rocky_source_sensor,
@@ -326,4 +330,288 @@ def test_sensor_handles_empty_failed_sources_cleanly():
         result = sensor(dg.build_sensor_context(cursor=None))
 
     assert result.run_requests is not None
+    assert len(result.run_requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# FR-015 — per-tag-key backlog cap
+# ---------------------------------------------------------------------------
+
+
+def _mock_instance_with_run_count(count: int) -> MagicMock:
+    """Build a mock Dagster instance whose ``get_runs`` returns ``count`` rows.
+
+    The sensor calls ``len(context.instance.get_runs(...))``; the backlog-cap
+    branch only cares about how many rows come back, so the row contents
+    don't matter. ``MagicMock()`` placeholders satisfy ``len()``.
+
+    ``spec=DagsterInstance`` is required because ``build_sensor_context``
+    runs ``check.opt_inst_param(instance, "instance", DagsterInstance)``
+    on the argument and rejects raw ``MagicMock``.
+    """
+    instance = MagicMock(spec=dg.DagsterInstance)
+    instance.get_runs.return_value = [MagicMock() for _ in range(count)]
+    return instance
+
+
+def test_backlog_cap_none_is_unchanged_emit_path():
+    """No backlog_cap → emit path stays exactly as before (regression guard
+    against accidentally calling ``context.instance.get_runs`` when the
+    feature is opt-in)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    instance = _mock_instance_with_run_count(99)  # would suppress everything if consulted
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            # no backlog_cap
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    assert len(result.run_requests) == 1
+    instance.get_runs.assert_not_called()
+
+
+def test_backlog_cap_suppresses_when_in_flight_at_or_above_max():
+    """Two in-flight runs already share the tag value → cap=2 → suppress
+    the emit but advance the cursor so the in-flight run picks up the
+    fresh data on its own (no stuck-tick)."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    instance = _mock_instance_with_run_count(2)
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(tag_key="rocky/source_id", max_in_flight=2),
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # Emit suppressed
+    assert result.run_requests == []
+    # …but cursor still advances so we don't re-detect on the next tick
+    assert json.loads(result.cursor)["s1"] == "2026-04-08T10:00:00+00:00"
+    # And the cap was actually consulted with the correct filter shape
+    instance.get_runs.assert_called_once()
+    call = instance.get_runs.call_args
+    assert call.kwargs["filters"].tags == {"rocky/source_id": "s1"}
+    assert call.kwargs["limit"] == 3  # max_in_flight + 1
+
+
+def test_backlog_cap_below_max_emits_normally():
+    """Zero in-flight runs → emit normally even when a cap is set."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    instance = _mock_instance_with_run_count(0)
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            backlog_cap=BacklogCap(tag_key="rocky/source_id", max_in_flight=5),
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].tags["rocky/source_id"] == "s1"
+
+
+def test_backlog_cap_passes_through_when_tag_key_missing():
+    """RunRequests that don't carry the configured ``tag_key`` are not
+    counted by ``get_runs`` and pass through. Cap configured for a tag
+    that this sensor never sets → all emits accepted, ``get_runs``
+    never called."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    instance = _mock_instance_with_run_count(99)
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            # `per_source` granularity emits `rocky/source_id` and
+            # `rocky/sync_at` tags — `rocky/group` is only set in
+            # `per_group`, so this RunRequest has no value to count by.
+            backlog_cap=BacklogCap(tag_key="rocky/group", max_in_flight=1),
+        )
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    assert len(result.run_requests) == 1
+    instance.get_runs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# FR-016 — lifecycle hooks (on_run_request_emitted / on_failed_sources / on_skip)
+# ---------------------------------------------------------------------------
+
+
+def test_on_run_request_emitted_fires_per_emitted_request():
+    rocky = RockyResource()
+    discover = _discover(
+        _source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)),
+        _source("s2", "acme", ["invoices"], _ts(2026, 4, 8, 11)),
+    )
+
+    seen: list[EmitContext] = []
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            on_run_request_emitted=seen.append,
+        )
+        sensor(dg.build_sensor_context(cursor=None))
+
+    assert len(seen) == 2
+    # Each EmitContext carries the matching RunRequest + the source(s)
+    # that backed it (1 source per emit at per_source granularity).
+    for ec in seen:
+        assert ec.granularity == "per_source"
+        assert len(ec.sources) == 1
+        assert ec.run_request.tags["rocky/source_id"] == ec.sources[0].id
+
+
+def test_on_failed_sources_fires_when_discover_reports_failures():
+    rocky = RockyResource()
+    discover = DiscoverResult(
+        version="0.3.0",
+        command="discover",
+        sources=[_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10))],
+        failed_sources=[_failed("s2", error_class="timeout")],
+    )
+
+    seen: list[FailedSourcesContext] = []
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            on_failed_sources=seen.append,
+        )
+        sensor(dg.build_sensor_context(cursor=None))
+
+    assert len(seen) == 1
+    fc = seen[0]
+    assert len(fc.failed_sources) == 1
+    assert fc.failed_sources[0].id == "s2"
+
+
+def test_on_skip_fires_when_no_sources_advanced():
+    rocky = RockyResource()
+    # Source already at the cursor's last-seen timestamp → no advance.
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+    starting_cursor = json.dumps({"s1": "2026-04-08T10:00:00+00:00"})
+
+    seen: list[SkipContext] = []
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            on_skip=seen.append,
+        )
+        sensor(dg.build_sensor_context(cursor=starting_cursor))
+
+    assert len(seen) == 1
+    sc = seen[0]
+    assert "No Rocky sources have synced" in sc.reason
+    assert sc.cursor_size == 1
+
+
+def test_hook_exceptions_are_caught_and_do_not_block_emit():
+    """A hook that raises must not break the sensor — exception is
+    caught + logged at WARN, emit goes through unchanged."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    def _boom(_ec: EmitContext) -> None:
+        raise RuntimeError("hook is broken")
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            on_run_request_emitted=_boom,
+        )
+        result = sensor(dg.build_sensor_context(cursor=None))
+
+    # Emit still happens despite the hook raising
+    assert len(result.run_requests) == 1
+
+
+# ---------------------------------------------------------------------------
+# FR-017 — resource injection via string key (alongside the legacy instance form)
+# ---------------------------------------------------------------------------
+
+
+def test_keyed_resource_form_resolves_via_context_resources():
+    """Default ``rocky_resource="rocky"`` → sensor declares the resource
+    key as required and reads the resource off ``context.resources`` at
+    evaluation time, not closure-captured at build time."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+            # rocky_resource defaults to "rocky"
+        )
+        # Sensor declares the key as required — late-bound, swap-safe.
+        assert sensor.required_resource_keys == {"rocky"}
+
+        # ConfigurableResource lifecycle requires the build_sensor_context
+        # context-manager scope when resources are provided.
+        with dg.build_sensor_context(cursor=None, resources={"rocky": rocky}) as ctx:
+            result = sensor(ctx)
+
+    assert result.run_requests is not None
+    assert len(result.run_requests) == 1
+
+
+def test_keyed_resource_form_supports_custom_key_name():
+    """Consumer using a non-conventional resource key passes the string
+    through; the sensor resolves it under the provided name."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource="my_custom_rocky",
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+        )
+        assert sensor.required_resource_keys == {"my_custom_rocky"}
+
+        with dg.build_sensor_context(cursor=None, resources={"my_custom_rocky": rocky}) as ctx:
+            result = sensor(ctx)
+
+    assert len(result.run_requests) == 1
+
+
+def test_instance_resource_form_still_works_for_back_compat():
+    """Passing a ``RockyResource`` instance directly keeps the legacy
+    closure-capture path. No resource key is registered as required."""
+    rocky = RockyResource()
+    discover = _discover(_source("s1", "acme", ["orders"], _ts(2026, 4, 8, 10)))
+
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = rocky_source_sensor(
+            rocky_resource=rocky,
+            target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "acme"])),
+            minimum_interval_seconds=60,
+        )
+        assert sensor.required_resource_keys == set()
+
+        # No `resources={}` needed — closure-captured.
+        result = sensor(dg.build_sensor_context(cursor=None))
+
     assert len(result.run_requests) == 1


### PR DESCRIPTION
## Summary

Three additive enhancements to `rocky_source_sensor`, driven by downstream-consumer operational learnings. All three touch only `integrations/dagster/src/dagster_rocky/sensor.py`, `__init__.py`, the test file, the CHANGELOG, and the sensor doc page.

### `backlog_cap=BacklogCap(...)` — per-tag-key in-flight cap

Opt-in back-pressure on the emit loop. Before emitting each `RunRequest`, the sensor counts in-flight Dagster runs matching `tag_key=<value>` in the configured non-terminal statuses; if the count is at or above `max_in_flight`, the emit is suppressed.

Cursor-advance behavior is intentional: the in-flight run picks up the latest data via Rocky's per-source state. Freezing the cursor on suppression would create a stuck-tick where nothing progresses until the queue drains below cap.

```python
sensor = rocky_source_sensor(
    target=...,
    backlog_cap=BacklogCap(tag_key="rocky/group", max_in_flight=5),
)
```

Default off; existing call sites unchanged.

### Lifecycle hooks — `on_run_request_emitted` / `on_failed_sources` / `on_skip`

Three optional best-effort callbacks, each receiving a frozen-dataclass context (`EmitContext` / `FailedSourcesContext` / `SkipContext`). Lets consumers attach OTel metrics, alert webhooks, or audit logs without subclassing or wrapping the sensor.

Hook contract: raised exceptions are caught and logged at WARN; hooks never block emits. Hooks fire after the sensor decides what to do — observability, not policy. `on_run_request_emitted` fires per emit *after* `backlog_cap` suppression, so it sees only what Dagster will be asked to launch.

### `rocky_resource: RockyResource | str = "rocky"` — resource-key injection

`rocky_resource` now accepts either a `RockyResource` instance (legacy form, closure-captured at sensor-build time) or a string resource key (new default `"rocky"`) that the sensor resolves through Dagster's required-resource injection at evaluation time. The keyed form is:

- Swap-safe — per-deployment overrides applied via `Definitions(resources=...)` actually reach the sensor.
- Mock-friendly — `dg.build_sensor_context(resources={"rocky": MockRocky()})` works without monkeypatching the closure-captured instance.
- Build-order independent — the resource doesn't have to exist before the sensor is constructed.

Instance form stays first-class. Existing call sites passing `rocky_resource=<instance>` continue to work with no change.

### Implementation note for reviewers

The sensor body uses an **untyped** `**injected` kwargs catch-all on purpose. Annotating it with a concrete type (`**injected: RockyResource`) trips Dagster's required-resource detector — it would auto-add `"injected"` to `required_resource_keys` and collide with the explicit set passed to `@dg.sensor`. The required keys are declared explicitly on the decorator; resources arrive by their declared key name as keyword arguments. Don't "improve" the signature by adding a type hint to `**injected` — it will silently break the keyed-resource path. (Same caveat is captured in an in-code comment.)

## Test plan

- [x] 21 unit tests in `tests/test_sensor.py` covering all three new code paths plus the unchanged baseline (498 in the wider dagster suite, all passing)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [ ] Reviewer eyeball on the doc page (`docs/src/content/docs/dagster/sensors.md`)