### PR TITLE
chore(engine): Arc 7 phase-marker cleanup + iceberg error taxonomy + idempotency-key env-var fallback

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -418,7 +418,7 @@
             "replicate": false,
             "ttl_seconds": 86400
           },
-          "description": "Schema cache (Arc 7 wave 2 wave-2). Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile."
+          "description": "Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile."
         }
       },
       "type": "object"
@@ -2141,7 +2141,7 @@
     },
     "SchemaCacheConfig": {
       "additionalProperties": false,
-      "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the Arc 7 wave 2 wave-2 DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in. See the design doc at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md` (§4.3, §5.7) for the rationale.",
+      "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.",
       "properties": {
         "enabled": {
           "default": true,
@@ -2826,7 +2826,7 @@
           "ttl_seconds": 86400
         }
       },
-      "description": "Project-level cache configuration. Arc 7 wave 2 wave-2 introduces `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`]."
+      "description": "Project-level cache configuration. Today this is just `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`]."
     },
     "classifications": {
       "allOf": [

--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -25,7 +25,7 @@ export interface DiscoverOutput {
   /**
    * Number of schema-cache entries written by this invocation.
    *
-   * Populated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
+   * Populated by `rocky discover --with-schemas` — the explicit warm-up path for the schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
    */
   schemas_cached?: number;
   sources: SourceOutput[];

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -320,7 +320,7 @@ export interface RockyConfig {
    */
   budget?: BudgetConfig;
   /**
-   * Project-level cache configuration. Arc 7 wave 2 wave-2 introduces `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`].
+   * Project-level cache configuration. Today this is just `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`].
    */
   cache?: CacheConfig;
   /**
@@ -542,14 +542,14 @@ export interface BudgetConfig {
  */
 export interface CacheConfig {
   /**
-   * Schema cache (Arc 7 wave 2 wave-2). Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile.
+   * Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile.
    */
   schemas?: SchemaCacheConfig;
 }
 /**
  * `[cache.schemas]` — schema cache configuration.
  *
- * Controls the Arc 7 wave 2 wave-2 DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in. See the design doc at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md` (§4.3, §5.7) for the rationale.
+ * Controls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.
  */
 export interface SchemaCacheConfig {
   /**

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -79,7 +79,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 
 # HTTP

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -49,11 +49,10 @@ fn make_client(config_path: &Path) -> Result<LlmClient> {
 
 /// Compile the project from a models directory.
 ///
-/// Wave-2 of Arc 7 wave 2: source schemas flow from the persisted cache
-/// (populated by `rocky run` / `rocky discover --with-schemas` in later
-/// PRs) so the AI prompt is grounded in real warehouse types when the
-/// cache is warm. Cold cache degrades to empty, which matches the
-/// pre-wave-2 behaviour this function had.
+/// Source schemas flow from the persisted cache (populated by
+/// `rocky run` / `rocky discover --with-schemas`) so the AI prompt is
+/// grounded in real warehouse types when the cache is warm. Cold cache
+/// degrades to empty.
 ///
 /// `cache_ttl_override` is the CLI `--cache-ttl` flag from PR 4.
 fn compile_project(

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -210,11 +210,11 @@ fn compile_head(
 /// This is best-effort: if the base ref doesn't have a complete models directory
 /// or compilation fails, we return an empty map rather than erroring.
 ///
-/// Arc 7 wave 2 wave-2 note: `source_schemas` seeds the compile from the
-/// *current* warehouse cache, not historical types. That's fine for diff
-/// purposes — typecheck on historical models with today's leaf types still
-/// detects the model-level schema drift that ci-diff is looking for, and
-/// there's no per-ref cache to restore from.
+/// `source_schemas` seeds the compile from the *current* warehouse
+/// cache, not historical types. That's fine for diff purposes —
+/// typecheck on historical models with today's leaf types still detects
+/// the model-level schema drift that ci-diff is looking for, and there's
+/// no per-ref cache to restore from.
 fn extract_base_schemas(
     base_ref: &str,
     models_dir: &Path,
@@ -494,11 +494,11 @@ pub(crate) fn compute_ci_diff(
     models_dir: &Path,
     cache_ttl_override: Option<u64>,
 ) -> Result<CiDiffData> {
-    // Wave-2 of Arc 7 wave 2: load cached source schemas once and seed
-    // both compiles (current tree + base ref) with the same map so the
-    // resulting per-model type diffs measure real schema drift rather
-    // than `Unknown`-vs-`Unknown` noise. Degrades to empty when the
-    // cache is cold or `[cache.schemas] enabled = false`.
+    // Load cached source schemas once and seed both compiles (current
+    // tree + base ref) with the same map so the resulting per-model
+    // type diffs measure real schema drift rather than
+    // `Unknown`-vs-`Unknown` noise. Degrades to empty when the cache is
+    // cold or `[cache.schemas] enabled = false`.
     let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
         Ok(cfg) => {
             let schema_cfg = cfg.cache.schemas.with_ttl_override(cache_ttl_override);

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -21,8 +21,8 @@ use crate::output::{CompileOutput, CostHint, ModelDetail, print_json};
 ///
 /// `cache_ttl_override`: optional CLI flag value from the binary's
 /// `--cache-ttl <seconds>` global arg. Replaces
-/// `[cache.schemas] ttl_seconds` for this invocation only (Arc 7 wave 2
-/// wave-2 PR 4). `None` keeps the config/default TTL.
+/// `[cache.schemas] ttl_seconds` for this invocation only. `None`
+/// keeps the config/default TTL.
 #[allow(clippy::too_many_arguments)]
 pub fn run_compile(
     config_path: Option<&Path>,
@@ -36,22 +36,22 @@ pub fn run_compile(
     with_seed: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    // `source_schemas` precedence (Arc 7 wave 2):
-    //   1. `--with-seed` wins -> wave-1 seed loader (explicit user intent,
+    // `source_schemas` precedence:
+    //   1. `--with-seed` wins -> seed loader (explicit user intent,
     //      used for tests/playgrounds where the cache is irrelevant).
-    //   2. Otherwise, the wave-2 schema cache if `[cache.schemas] enabled`.
-    //   3. Cold-cache fallback: empty map — typecheck degrades to Unknown,
-    //      which matches pre-wave-2 behaviour.
+    //   2. Otherwise, the schema cache if `[cache.schemas] enabled`.
+    //   3. Cold-cache fallback: empty map — typecheck degrades to
+    //      Unknown.
     let source_schemas = if with_seed {
-        // Wave-1: run `data/seed.sql` in in-memory DuckDB, read columns
-        // from its `information_schema`. Turns leaf .sql models from
-        // `RockyType::Unknown` into concrete types for any project that
-        // ships a runnable seed (the entire playground).
+        // Seed loader: run `data/seed.sql` in in-memory DuckDB, read
+        // columns from its `information_schema`. Turns leaf .sql models
+        // from `RockyType::Unknown` into concrete types for any project
+        // that ships a runnable seed (the entire playground).
         load_source_schemas_from_seed(models_dir)?
     } else if let Some(path) = config_path {
-        // Wave-2: TTL-filtered load from `state.redb`'s `SCHEMA_CACHE`
-        // table. Honours `[cache.schemas] enabled` + `ttl_seconds`
-        // (after applying the optional CLI `--cache-ttl` override).
+        // TTL-filtered load from `state.redb`'s `SCHEMA_CACHE` table.
+        // Honours `[cache.schemas] enabled` + `ttl_seconds` (after
+        // applying the optional CLI `--cache-ttl` override).
         match rocky_config::load_rocky_config(path) {
             Ok(cfg) => {
                 let schema_cfg = cfg.cache.schemas.with_ttl_override(cache_ttl_override);
@@ -340,8 +340,8 @@ fn build_p001_diagnostic(
         .with_suggestion(issue.suggestion.clone())
 }
 
-/// Wave-1 of Arc 7 wave 2: load source schemas from a project's
-/// `data/seed.sql` by running it against an in-memory DuckDB.
+/// Load source schemas from a project's `data/seed.sql` by running it
+/// against an in-memory DuckDB.
 ///
 /// Resolution: walks up from `models_dir` looking for `data/seed.sql`. The
 /// playground convention is `<project>/models/` + `<project>/data/seed.sql`,
@@ -740,7 +740,7 @@ schema_template = "s"
         .expect("missing config should fall through, not error");
     }
 
-    // ---- Wave-1 of Arc 7 wave 2: --with-seed source-schema loading ----
+    // ---- --with-seed source-schema loading ----
 
     #[cfg(feature = "duckdb")]
     fn write_seed(project_dir: &Path, sql: &str) {
@@ -877,7 +877,7 @@ schema_template = "s"
         ));
     }
 
-    // ---- Wave-2 of Arc 7 wave 2: cache-backed source_schemas ----
+    // ---- cache-backed source_schemas ----
 
     /// End-to-end wiring check: seed a `SchemaCacheEntry` in `state.redb`,
     /// run `rocky compile` without `--with-seed`, and confirm the cached

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -23,8 +23,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Execute `rocky dag`.
 ///
-/// `cache_ttl_override`: CLI `--cache-ttl` flag (Arc 7 wave 2 wave-2 PR 4).
-/// Only relevant when `include_column_lineage` drives a compile.
+/// `cache_ttl_override`: CLI `--cache-ttl` flag override for the
+/// `[cache.schemas] ttl_seconds` setting. Only relevant when
+/// `include_column_lineage` drives a compile.
 #[allow(clippy::too_many_arguments)]
 pub fn run_dag(
     config_path: &Path,
@@ -273,11 +274,11 @@ fn build_column_lineage_from_models(
     let compile_config = rocky_compiler::compile::CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: contracts_dir.map(Path::to_path_buf),
-        // Wave-2 of Arc 7 wave 2: typed columns flow from the persisted
-        // schema cache (populated by `rocky run` / `rocky discover
-        // --with-schemas` in later PRs) straight into column lineage
-        // extraction, so downstream edges carry real types instead of
-        // `RockyType::Unknown`. `schema_cache_cfg` already has the
+        // Typed columns flow from the persisted schema cache (populated
+        // by `rocky run` / `rocky discover --with-schemas`) straight
+        // into column lineage extraction, so downstream edges carry
+        // real types instead of `RockyType::Unknown`.
+        // `schema_cache_cfg` already has the
         // `--cache-ttl` override applied by `run_dag`.
         source_schemas: crate::source_schemas::load_cached_source_schemas(
             schema_cache_cfg,

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -161,10 +161,10 @@ pub async fn discover(
         });
     }
 
-    // Cache warm-up (Arc 7 wave 2 wave-2 PR 3, design doc §4.2 route B).
-    // Only runs when `--with-schemas` is set; config gating already happened
-    // at the top of this function. Errors inside the warm-up are logged and
-    // counted as misses — a bad source shouldn't abort the whole discovery.
+    // Schema-cache warm-up. Only runs when `--with-schemas` is set;
+    // config gating already happened at the top of this function.
+    // Errors inside the warm-up are logged and counted as misses — a
+    // bad source shouldn't abort the whole discovery.
     let schemas_cached = if with_schemas {
         warm_schema_cache(&adapter_registry, &pipeline.source, connectors, state_path).await?
     } else {
@@ -261,7 +261,7 @@ async fn build_source_table_sets(
     map
 }
 
-/// Populate the Arc 7 wave 2 wave-2 schema cache for every discovered source.
+/// Populate the schema cache for every discovered source.
 ///
 /// For each unique `(catalog, schema)` pair reachable via the source's
 /// warehouse `BatchCheckAdapter`, issues a single `batch_describe_schema`

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -32,8 +32,8 @@ fn to_edge_record(edge: &rocky_compiler::semantic::LineageEdge) -> LineageEdgeRe
 /// Execute `rocky lineage`.
 ///
 /// `cache_ttl_override`: optional CLI `--cache-ttl <seconds>` value
-/// (Arc 7 wave 2 wave-2 PR 4). Replaces `[cache.schemas] ttl_seconds`
-/// for this invocation only.
+/// that replaces `[cache.schemas] ttl_seconds` for this invocation
+/// only.
 #[allow(clippy::too_many_arguments)]
 pub fn run_lineage(
     config_path: &Path,
@@ -46,9 +46,9 @@ pub fn run_lineage(
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
-    // Wave-2 of Arc 7 wave 2: load cached warehouse schemas so lineage
-    // edges inherit real types instead of `RockyType::Unknown` on the
-    // leaves. Degrades to empty on cold cache / missing config.
+    // Load cached warehouse schemas so lineage edges inherit real
+    // types instead of `RockyType::Unknown` on the leaves. Degrades to
+    // empty on cold cache / missing config.
     let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
         Ok(cfg) => {
             let schema_cfg = cfg.cache.schemas.with_ttl_override(cache_ttl_override);

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -700,10 +700,9 @@ pub async fn run(
     shadow_config: Option<&rocky_core::shadow::ShadowConfig>,
     partition_opts: &PartitionRunOptions,
     model_name_filter: Option<&str>,
-    // `--cache-ttl <seconds>` override (Arc 7 wave 2 wave-2 PR 4).
-    // Applied to the model-execution schema cache read; the replication
-    // path doesn't consult the cache, so this flag is a no-op for
-    // replication-only runs.
+    // `--cache-ttl <seconds>` override applied to the model-execution
+    // schema cache read; the replication path doesn't consult the
+    // cache, so this flag is a no-op for replication-only runs.
     cache_ttl_override: Option<u64>,
     // Caller-supplied `--idempotency-key`. `None` bypasses the dedup path
     // entirely. When `Some`, the run is skipped if the key already dedups
@@ -1684,11 +1683,11 @@ pub async fn run(
             }))
             .await;
 
-        // Arc 7 wave 2 wave-2 PR 2: tap successful describes into the schema
-        // cache. One key per table in the returned map — the DESCRIBE cost
-        // is already paid, so populating the cache for sibling tables is
-        // free signal for future compiles. Write failures are logged at
-        // `warn!` level and never fail the run.
+        // Tap successful describes into the schema cache. One key per
+        // table in the returned map — the DESCRIBE cost is already paid,
+        // so populating the cache for sibling tables is free signal for
+        // future compiles. Write failures are logged at `warn!` level
+        // and never fail the run.
         let mut schema_cache_tap = SchemaCacheWriteTap::default();
 
         for (side, cat, sch, result) in describe_results {
@@ -3309,15 +3308,13 @@ pub(crate) async fn execute_models(
     // the caller having to synthesise a fake pipeline name.
     hook_registry: Option<&HookRegistry>,
     pipeline_name: Option<&str>,
-    // Arc 7 wave 2 wave-2: honour `[cache.schemas]` for source-schema
-    // loading during compile. The write tap that keeps the cache fresh
-    // lands in PR 2; today the loader reads whatever's there.
+    // Honour `[cache.schemas]` for source-schema loading during compile.
     schema_cache_config: &rocky_core::config::SchemaCacheConfig,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
-    // Wave-2 of Arc 7 wave 2: load the persisted schema cache directly
-    // from the live `StateStore` — no round-trip through
+    // Load the persisted schema cache directly from the live
+    // `StateStore` — no round-trip through
     // `crate::source_schemas::load_cached_source_schemas`, because that
     // helper opens a read-only handle and we already hold a write-capable
     // one here. Degrades silently when the cache is cold or disabled.

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -30,10 +30,10 @@ pub async fn run_transformation(
     rocky_cfg: &rocky_core::config::RockyConfig,
     output_json: bool,
     partition_opts: &super::run::PartitionRunOptions,
-    // Already-overridden schema cache config (Arc 7 wave 2 wave-2 PR 4).
-    // Caller (`run::run`) has folded the CLI `--cache-ttl` flag into
-    // this value via `with_ttl_override` so the override propagates
-    // consistently across replication and transformation paths.
+    // Already-overridden schema cache config. Caller (`run::run`) has
+    // folded the CLI `--cache-ttl` flag into this value via
+    // `with_ttl_override` so the override propagates consistently
+    // across replication and transformation paths.
     schema_cache_cfg: &rocky_core::config::SchemaCacheConfig,
 ) -> Result<()> {
     let start = Instant::now();

--- a/engine/crates/rocky-cli/src/commands/state.rs
+++ b/engine/crates/rocky-cli/src/commands/state.rs
@@ -40,10 +40,10 @@ pub fn state_show(state_path: &Path, output_json: bool) -> Result<()> {
 
 /// Execute `rocky state clear-schema-cache`.
 ///
-/// Arc 7 wave 2 wave-2 PR 4 — the explicit-flush path for the DESCRIBE
-/// cache. Counterpart to the TTL auto-eviction baked into the read path:
-/// users who want a cache refresh *now* (e.g. after a manual warehouse DDL
-/// change, or during strict-CI debugging) use this command.
+/// The explicit-flush path for the DESCRIBE cache. Counterpart to the
+/// TTL auto-eviction baked into the read path: users who want a cache
+/// refresh *now* (e.g. after a manual warehouse DDL change, or during
+/// strict-CI debugging) use this command.
 ///
 /// Behaviour:
 /// - No prompt (the cache is cheap to rebuild via the next `rocky run`

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -97,9 +97,9 @@ pub struct DiscoverOutput {
     /// Number of schema-cache entries written by this invocation.
     ///
     /// Populated by `rocky discover --with-schemas` — the explicit
-    /// warm-up path for the Arc 7 wave 2 wave-2 schema cache. Zero —
-    /// and omitted from the wire format — when `--with-schemas` isn't
-    /// set, so fixtures captured without the flag stay byte-stable.
+    /// warm-up path for the schema cache. Zero — and omitted from the
+    /// wire format — when `--with-schemas` isn't set, so fixtures
+    /// captured without the flag stay byte-stable.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub schemas_cached: usize,
 }

--- a/engine/crates/rocky-cli/src/schema_cache_writer.rs
+++ b/engine/crates/rocky-cli/src/schema_cache_writer.rs
@@ -1,7 +1,7 @@
-//! Arc 7 wave 2 wave-2 PR 2 — `rocky run` write tap for the schema cache.
+//! `rocky run` write tap for the schema cache.
 //!
-//! Sibling to `source_schemas.rs` (the read helper wired in PR 1b). The two
-//! ends of the cache share the same `SchemaCacheConfig` gate, key shape, and
+//! Sibling to `source_schemas.rs` (the read helper). The two ends of
+//! the cache share the same `SchemaCacheConfig` gate, key shape, and
 //! `state.redb` table — only the direction of travel differs.
 //!
 //! The write tap hangs off `rocky run`'s batch `DESCRIBE TABLE` pass. Any code

--- a/engine/crates/rocky-cli/src/source_schemas.rs
+++ b/engine/crates/rocky-cli/src/source_schemas.rs
@@ -1,13 +1,12 @@
-//! Shared helper for loading the Arc 7 wave 2 wave-2 schema cache into the
-//! typecheck pipeline.
+//! Shared helper for loading the schema cache into the typecheck
+//! pipeline.
 //!
 //! Every `rocky <verb>` whose internal flow calls
 //! `rocky_compiler::compile::compile` used to pass
-//! `source_schemas: HashMap::new()` — which forces the typechecker to treat
-//! every leaf `FROM <schema>.<table>` as `RockyType::Unknown`. Wave-1 seeded
-//! that map from DuckDB (`--with-seed`); wave-2 seeds it from a persisted
-//! redb cache written by prior `rocky run` / `rocky discover --with-schemas`
-//! invocations (PRs 2-3).
+//! `source_schemas: HashMap::new()` — which forces the typechecker to
+//! treat every leaf `FROM <schema>.<table>` as `RockyType::Unknown`. The
+//! map is now seeded from a persisted redb cache written by prior
+//! `rocky run` / `rocky discover --with-schemas` invocations.
 //!
 //! This helper collapses the read-path boilerplate — config gating, optional
 //! state-store open, TTL application, log emission — into one call. PR 1b
@@ -204,11 +203,11 @@ mod tests {
 
     #[test]
     fn cache_ttl_override_flips_hit_to_miss() {
-        // Arc 7 wave 2 wave-2 PR 4: `--cache-ttl <seconds>` overrides
-        // `[cache.schemas] ttl_seconds`. Baseline (default 24h): a
-        // 1-hour-old entry is a hit. With `--cache-ttl 30` (30s) the
-        // same entry is a miss — the CLI-flag-overridden config is
-        // what `load_cached_source_schemas` ends up using.
+        // `--cache-ttl <seconds>` overrides `[cache.schemas]
+        // ttl_seconds`. Baseline (default 24h): a 1-hour-old entry is a
+        // hit. With `--cache-ttl 30` (30s) the same entry is a miss —
+        // the CLI-flag-overridden config is what
+        // `load_cached_source_schemas` ends up using.
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("state.redb");
         {

--- a/engine/crates/rocky-compiler/src/schema_cache.rs
+++ b/engine/crates/rocky-compiler/src/schema_cache.rs
@@ -18,10 +18,6 @@
 //! multi-pipeline setup), the last one wins — this matches the behaviour
 //! a compiler operating without catalog awareness would see from a live
 //! `batch_describe_schema` call today.
-//!
-//! Arc 7 wave 2 wave-2 PR 1a: this module is ready to be called but has
-//! no callers yet. PR 1b replaces the 10 `HashMap::new()` callsites with
-//! `load_source_schemas_from_cache(...)` calls.
 
 use std::collections::HashMap;
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1459,7 +1459,7 @@ pub struct BudgetBreach {
 /// currently not wired into [`RockyConfig`] — see `CHANGELOG.md` for the
 /// history. Kept `pub` because downstream tooling may still reference it,
 /// but the top-level `[cache]` config surface is now [`CacheConfig`]
-/// (schemas section for Arc 7 wave 2 wave-2).
+/// (schemas section).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValkeyCacheConfig {
     pub valkey_url: String,
@@ -1476,20 +1476,17 @@ pub struct ValkeyCacheConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct CacheConfig {
-    /// Schema cache (Arc 7 wave 2 wave-2). Stores `DESCRIBE TABLE` results
-    /// in `state.redb` so leaf models typecheck against real warehouse
-    /// types without a live round-trip on every compile.
+    /// Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so
+    /// leaf models typecheck against real warehouse types without a live
+    /// round-trip on every compile.
     pub schemas: SchemaCacheConfig,
 }
 
 /// `[cache.schemas]` — schema cache configuration.
 ///
-/// Controls the Arc 7 wave 2 wave-2 DESCRIBE-result cache. Defaults are
-/// chosen so the feature is useful out of the box: the cache is on,
-/// entries live for 24 hours, and nothing replicates off-machine until
-/// the user opts in. See the design doc at
-/// `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`
-/// (§4.3, §5.7) for the rationale.
+/// Controls the DESCRIBE-result cache. Defaults are chosen so the
+/// feature is useful out of the box: the cache is on, entries live for
+/// 24 hours, and nothing replicates off-machine until the user opts in.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct SchemaCacheConfig {
@@ -1526,9 +1523,8 @@ impl SchemaCacheConfig {
 
     /// Apply an optional `--cache-ttl <seconds>` CLI override.
     ///
-    /// Precedence (Arc 7 wave 2 wave-2 PR 4):
-    /// CLI flag > env var (future) > `[cache.schemas] ttl_seconds` > default
-    /// (86400s).
+    /// Precedence: CLI flag > env var (future) > `[cache.schemas]
+    /// ttl_seconds` > default (86400s).
     ///
     /// `override_seconds = Some(0)` is deliberately meaningful: every
     /// cached entry reports as expired on read, so the typecheck path
@@ -1751,9 +1747,10 @@ pub struct RockyConfig {
     #[serde(default)]
     pub portability: PortabilityConfig,
 
-    /// Project-level cache configuration. Arc 7 wave 2 wave-2 introduces
-    /// `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future
-    /// cache surfaces live as sibling fields under [`CacheConfig`].
+    /// Project-level cache configuration. Today this is just
+    /// `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results);
+    /// future cache surfaces live as sibling fields under
+    /// [`CacheConfig`].
     #[serde(default)]
     pub cache: CacheConfig,
 
@@ -5677,7 +5674,7 @@ max_rows = 1000000
     }
 
     // -----------------------------------------------------------------------
-    // Cache / schema cache config (Arc 7 wave 2 wave-2)
+    // Cache / schema cache config
     // -----------------------------------------------------------------------
 
     #[test]

--- a/engine/crates/rocky-core/src/schema_cache.rs
+++ b/engine/crates/rocky-core/src/schema_cache.rs
@@ -1,17 +1,15 @@
 //! Persisted cache of warehouse `DESCRIBE TABLE` results.
 //!
-//! Arc 7 wave 2 wave-2 infrastructure. The cache is the mechanism that lets
-//! `rocky compile` / `rocky lsp` typecheck leaf models against real warehouse
-//! column types without paying a live `DESCRIBE` round-trip on every call.
-//! A `rocky run` or `rocky discover --with-schemas` writes here on success;
-//! the compiler loads a TTL-filtered snapshot on every subsequent compile.
+//! The cache is the mechanism that lets `rocky compile` / `rocky lsp`
+//! typecheck leaf models against real warehouse column types without
+//! paying a live `DESCRIBE` round-trip on every call. A `rocky run` or
+//! `rocky discover --with-schemas` writes here on success; the compiler
+//! loads a TTL-filtered snapshot on every subsequent compile.
 //!
 //! This module deliberately holds only the redb-persistable types. The
 //! `TypedColumn`-shaped loader lives in `rocky-compiler::schema_cache` —
 //! `rocky-core` does not depend on `rocky-compiler`, so the compiler-side
-//! wrapper owns the `ColumnInfo`/`TypedColumn` conversion. See the design
-//! doc at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md`
-//! section 4 for the full rationale.
+//! wrapper owns the `ColumnInfo`/`TypedColumn` conversion.
 //!
 //! Value shape in `state.redb`: `serde_json::to_vec(&SchemaCacheEntry)` —
 //! matches the encoding every other table in the state store uses

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -45,15 +45,14 @@ const LOADED_FILES: TableDefinition<&str, &[u8]> = TableDefinition::new("loaded_
 /// zero-copy `CLONE`) are a follow-up — the schema-prefix approach ships first
 /// because it works uniformly across every adapter.
 const BRANCHES: TableDefinition<&str, &[u8]> = TableDefinition::new("branches");
-/// Cache of `DESCRIBE TABLE` results for source warehouses (Arc 7 wave 2
-/// wave-2).
+/// Cache of `DESCRIBE TABLE` results for source warehouses.
 ///
 /// Key format: `"<catalog>.<schema>.<table>"` (lowercased). Value: serialized
 /// [`crate::schema_cache::SchemaCacheEntry`]. Read by
 /// `rocky_compiler::schema_cache::load_source_schemas_from_cache` to populate
 /// `CompilerConfig.source_schemas` without a live round-trip. Written
 /// opportunistically by `rocky run`'s drift/materialize paths and explicitly
-/// by `rocky discover --with-schemas` (wiring lands in PR 1b / PR 2 / PR 3).
+/// by `rocky discover --with-schemas`.
 ///
 /// Replicates as `replicate = false` by default in `state_sync.rs` so a fresh
 /// clone doesn't inherit another machine's stale types — see design doc §5.7.
@@ -1569,7 +1568,7 @@ impl StateStore {
     }
 
     // -----------------------------------------------------------------------
-    // Schema cache (Arc 7 wave 2 wave-2)
+    // Schema cache
     // -----------------------------------------------------------------------
 
     /// Read a single schema cache entry by key.
@@ -1802,11 +1801,12 @@ impl ResolvedStatePath {
 
 /// Resolve the canonical state-file path for a project.
 ///
-/// Unifies the CLI and LSP defaults that diverged through Arc 7 wave 2
-/// wave-2: the CLI wrote `./rocky-state.redb` in CWD while the LSP read
-/// `<models_dir>/.rocky-state.redb`, so the schema-cache write tap and
-/// inlay-hint read path missed each other in every project where they
-/// weren't already co-located.
+/// Unifies the CLI and LSP defaults: a divergence (CLI wrote
+/// `./rocky-state.redb` in CWD while the LSP read
+/// `<models_dir>/.rocky-state.redb`) made the schema-cache write tap and
+/// inlay-hint read path miss each other in every project where they
+/// weren't already co-located. This resolver is the single source of
+/// truth for both surfaces.
 ///
 /// Policy (checked in order):
 ///
@@ -2966,7 +2966,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Schema cache (Arc 7 wave 2 wave-2)
+    // Schema cache
     // -----------------------------------------------------------------------
 
     use crate::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -143,9 +143,9 @@ pub async fn download_state(config: &StateConfig, local_path: &Path) -> Result<(
 /// errors. Set `on_upload_failure = "fail"` for strict environments that must
 /// treat state durability as a hard requirement.
 ///
-/// Tables listed in [`crate::state::LOCAL_ONLY_TABLE_NAMES`] are filtered out
-/// of the remote copy by default — Arc 7 wave 2 wave-2 wires the schema cache
-/// here (design doc §5.7). Use
+/// Tables listed in [`crate::state::LOCAL_ONLY_TABLE_NAMES`] are filtered
+/// out of the remote copy by default — the schema cache is wired here so
+/// fresh clones don't inherit another machine's stale types. Use
 /// [`upload_state_with_excluded_tables`] to override the default when
 /// `[cache.schemas] replicate = true` is configured.
 pub async fn upload_state(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
@@ -207,12 +207,12 @@ pub async fn upload_state_with_excluded_tables(
 
 /// Build a temp redb copy of `local_path` with `excluded_tables` removed.
 ///
-/// Returns the path of the temp copy. Caller is responsible for deleting it.
-/// Used by the replicate-filtered upload path (Arc 7 wave 2 wave-2,
-/// design doc §5.7). Kept small and synchronous — the schema cache is the
-/// only local-only table today, its footprint is bounded by TTL (§4.3),
-/// and the round-trip file copy is proportional to total state size (order
-/// of single-digit megabytes for a typical project).
+/// Returns the path of the temp copy. Caller is responsible for deleting
+/// it. Used by the replicate-filtered upload path. Kept small and
+/// synchronous — the schema cache is the only local-only table today,
+/// its footprint is bounded by TTL, and the round-trip file copy is
+/// proportional to total state size (order of single-digit megabytes for
+/// a typical project).
 fn strip_local_only_tables(
     local_path: &Path,
     excluded_tables: &[&str],
@@ -1146,7 +1146,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // strip_local_only_tables (Arc 7 wave 2 wave-2)
+    // strip_local_only_tables
     // -----------------------------------------------------------------------
 
     use crate::schema_cache::{SchemaCacheEntry, StoredColumn, schema_cache_key};

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -18,5 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 percent-encoding = { workspace = true }
 
+[dev-dependencies]
+wiremock = { workspace = true }
+
 [lints]
 workspace = true

--- a/engine/crates/rocky-iceberg/src/adapter.rs
+++ b/engine/crates/rocky-iceberg/src/adapter.rs
@@ -12,7 +12,7 @@ use rocky_core::source::{
 };
 use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter};
 
-use crate::client::IcebergCatalogClient;
+use crate::client::{IcebergCatalogClient, IcebergError};
 
 /// Iceberg source discovery adapter.
 ///
@@ -78,20 +78,18 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
                     });
                 }
                 Err(e) => {
+                    let error_class = classify_iceberg_error(&e);
                     warn!(
                         namespace = ns.as_str(),
                         error = %e,
+                        class = ?error_class,
                         "list_tables failed, surfacing as failed source"
                     );
                     failed.push(FailedSource {
                         id: ns.clone(),
                         schema: ns.clone(),
                         source_type: "iceberg".to_string(),
-                        // The Iceberg REST client doesn't differentiate
-                        // transport-shape errors today; treat everything as
-                        // Unknown until it does. Future: classify on
-                        // `IcebergError` variants.
-                        error_class: FailedSourceErrorClass::Unknown,
+                        error_class,
                         message: e.to_string(),
                     });
                 }
@@ -126,6 +124,41 @@ fn matches_prefix(namespace: &str, prefix: &str) -> bool {
         return true;
     }
     namespace.starts_with(prefix)
+}
+
+/// Map an [`IcebergError`] onto the coarse [`FailedSourceErrorClass`].
+///
+/// The classes are operating-mode signals for downstream consumers, not a
+/// faithful taxonomy of the underlying transport. Mirrors the Fivetran
+/// adapter's classifier so consumers see consistent semantics across
+/// adapters.
+fn classify_iceberg_error(err: &IcebergError) -> FailedSourceErrorClass {
+    match err {
+        IcebergError::RateLimited => FailedSourceErrorClass::RateLimit,
+        IcebergError::UnexpectedResponse(_) => FailedSourceErrorClass::Unknown,
+        IcebergError::Api { status, .. } => classify_status_code(*status),
+        IcebergError::Http(reqwest_err) => {
+            if reqwest_err.is_timeout() {
+                FailedSourceErrorClass::Timeout
+            } else if reqwest_err.is_connect() {
+                FailedSourceErrorClass::Transient
+            } else if let Some(status) = reqwest_err.status() {
+                classify_status_code(status.as_u16())
+            } else {
+                FailedSourceErrorClass::Unknown
+            }
+        }
+    }
+}
+
+fn classify_status_code(status: u16) -> FailedSourceErrorClass {
+    match status {
+        401 | 403 => FailedSourceErrorClass::Auth,
+        408 => FailedSourceErrorClass::Timeout,
+        429 => FailedSourceErrorClass::RateLimit,
+        500..=599 => FailedSourceErrorClass::Transient,
+        _ => FailedSourceErrorClass::Unknown,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -247,5 +280,49 @@ mod tests {
             metadata: Default::default(),
         };
         assert_eq!(connector.source_type, "iceberg");
+    }
+
+    // ---- error classifier ----
+
+    #[test]
+    fn classify_rate_limited_explicit() {
+        let err = IcebergError::RateLimited;
+        assert!(matches!(
+            classify_iceberg_error(&err),
+            FailedSourceErrorClass::RateLimit
+        ));
+    }
+
+    #[test]
+    fn classify_api_status_codes() {
+        for (status, expected) in [
+            (401, FailedSourceErrorClass::Auth),
+            (403, FailedSourceErrorClass::Auth),
+            (404, FailedSourceErrorClass::Unknown),
+            (408, FailedSourceErrorClass::Timeout),
+            (429, FailedSourceErrorClass::RateLimit),
+            (500, FailedSourceErrorClass::Transient),
+            (502, FailedSourceErrorClass::Transient),
+            (503, FailedSourceErrorClass::Transient),
+        ] {
+            let err = IcebergError::Api {
+                status,
+                message: format!("status {status}"),
+            };
+            assert_eq!(
+                classify_iceberg_error(&err),
+                expected,
+                "status {status} misclassified"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unexpected_response_is_unknown() {
+        let err = IcebergError::UnexpectedResponse("bad json".to_string());
+        assert!(matches!(
+            classify_iceberg_error(&err),
+            FailedSourceErrorClass::Unknown
+        ));
     }
 }

--- a/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
@@ -1,0 +1,121 @@
+//! Wire-level mock tests for the Iceberg discovery adapter.
+//!
+//! Uses wiremock to simulate the Iceberg REST Catalog at the HTTP level
+//! and verifies that `IcebergError` variants flow through to the
+//! correct `FailedSourceErrorClass` on the discovered `failed_sources`
+//! payload.
+
+use rocky_core::source::FailedSourceErrorClass;
+use rocky_core::traits::DiscoveryAdapter;
+use rocky_iceberg::adapter::IcebergDiscoveryAdapter;
+use rocky_iceberg::client::IcebergCatalogClient;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn list_tables_401_classifies_as_auth() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "namespaces": [["good_ns"], ["bad_ns"]]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/good_ns/tables"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "identifiers": []
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/bad_ns/tables"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergDiscoveryAdapter::new(client);
+    let result = adapter.discover("").await.expect("discover should succeed");
+
+    assert_eq!(result.connectors.len(), 1, "good_ns should be discovered");
+    assert_eq!(result.connectors[0].id, "good_ns");
+
+    assert_eq!(result.failed.len(), 1, "bad_ns should be a failed source");
+    let failed = &result.failed[0];
+    assert_eq!(failed.id, "bad_ns");
+    assert_eq!(failed.error_class, FailedSourceErrorClass::Auth);
+    assert!(
+        failed.message.contains("401"),
+        "message should preserve the status code, got: {}",
+        failed.message
+    );
+}
+
+#[tokio::test]
+async fn list_tables_403_classifies_as_auth() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "namespaces": [["forbidden_ns"]]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/forbidden_ns/tables"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergDiscoveryAdapter::new(client);
+    let result = adapter.discover("").await.expect("discover should succeed");
+
+    assert_eq!(result.connectors.len(), 0);
+    assert_eq!(result.failed.len(), 1);
+    assert_eq!(
+        result.failed[0].error_class,
+        FailedSourceErrorClass::Auth
+    );
+}
+
+#[tokio::test]
+async fn list_tables_unknown_status_classifies_as_unknown() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "namespaces": [["weird_ns"]]
+        })))
+        .mount(&server)
+        .await;
+
+    // 404 isn't in the Auth/Timeout/RateLimit/Transient classes — falls
+    // through to Unknown. Pinning this avoids accidental Transient
+    // classification of misconfigured endpoints, which would have
+    // consumers assume "retry will fix it" when it won't.
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/weird_ns/tables"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergDiscoveryAdapter::new(client);
+    let result = adapter.discover("").await.expect("discover should succeed");
+
+    assert_eq!(result.failed.len(), 1);
+    assert_eq!(
+        result.failed[0].error_class,
+        FailedSourceErrorClass::Unknown
+    );
+}

--- a/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
@@ -81,10 +81,7 @@ async fn list_tables_403_classifies_as_auth() {
 
     assert_eq!(result.connectors.len(), 0);
     assert_eq!(result.failed.len(), 1);
-    assert_eq!(
-        result.failed[0].error_class,
-        FailedSourceErrorClass::Auth
-    );
+    assert_eq!(result.failed[0].error_class, FailedSourceErrorClass::Auth);
 }
 
 #[tokio::test]

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -23,8 +23,8 @@ sqlparser = { workspace = true }
 strsim = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
-# Arc 7 wave 2 wave-2: schema-cache read-path needs `chrono::Utc::now()` +
-# `Duration` for TTL filtering. Reused via `rocky_compiler::schema_cache`.
+# Schema-cache read-path needs `chrono::Utc::now()` + `Duration` for TTL
+# filtering. Reused via `rocky_compiler::schema_cache`.
 chrono = { workspace = true }
 
 [dev-dependencies]

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -350,10 +350,9 @@ pub struct RockyLsp {
     /// pass when the cached hash matches the current model SQL —
     /// editors call this hook on every scroll on large files.
     semantic_tokens_cache: SemanticTokensCache,
-    /// Arc 7 wave 2 wave-2: throttle the "N sources hit" info log so it
-    /// fires once per session per `models_dir` rather than per keystroke.
-    /// PR 2 will encode a cache version in the throttle key so the log
-    /// re-fires after a write tap bump. See `schema_cache_throttle.rs`.
+    /// Throttle the "N sources hit" info log so it fires once per
+    /// session per `models_dir` rather than per keystroke. See
+    /// `schema_cache_throttle.rs`.
     schema_cache_throttle: SchemaCacheThrottle,
 }
 
@@ -377,9 +376,9 @@ impl RockyLsp {
         let models_dir = self.models_dir.read().await;
         let Some(ref dir) = *models_dir else { return };
 
-        // Wave-2 of Arc 7 wave 2: plug cached warehouse schemas into the
-        // LSP typecheck so `FROM <schema>.<table>` inlay hints and hover
-        // types resolve against real columns instead of `Unknown`.
+        // Plug cached warehouse schemas into the LSP typecheck so
+        // `FROM <schema>.<table>` inlay hints and hover types resolve
+        // against real columns instead of `Unknown`.
         let dir_path = std::path::PathBuf::from(dir);
         let source_schemas = Self::load_cached_source_schemas(
             &dir_path,
@@ -413,11 +412,11 @@ impl RockyLsp {
         }
     }
 
-    /// Arc 7 wave 2 wave-2: load the persisted schema cache for use as
+    /// Load the persisted schema cache for use as
     /// `CompilerConfig.source_schemas`. Mirrors
     /// `rocky-cli::source_schemas::load_cached_source_schemas` but (a)
-    /// reuses the LSP's per-session throttle so the info log doesn't fire
-    /// on every recompile, and (b) resolves the state file via
+    /// reuses the LSP's per-session throttle so the info log doesn't
+    /// fire on every recompile, and (b) resolves the state file via
     /// [`rocky_core::state::resolve_state_path`] so the LSP observes the
     /// same file the CLI writes to — unified default
     /// `<models>/.rocky-state.redb` with the legacy CWD fallback for
@@ -860,9 +859,9 @@ impl LanguageServer for RockyLsp {
             let compile_result = self.compile_result.clone();
             let models_dir = self.models_dir.clone();
             let pending = self.recompile_pending.clone();
-            // Arc 7 wave 2 wave-2: share the throttle so the did_change
-            // debounced recompile doesn't re-emit the info log that
-            // `recompile()` already emitted for the same project.
+            // Share the throttle so the did_change debounced recompile
+            // doesn't re-emit the info log that `recompile()` already
+            // emitted for the same project.
             let schema_cache_throttle = self.schema_cache_throttle.clone();
 
             tokio::spawn(async move {
@@ -872,10 +871,10 @@ impl LanguageServer for RockyLsp {
                 let dir = models_dir.read().await;
                 let Some(ref dir) = *dir else { return };
 
-                // Wave-2 of Arc 7 wave 2: keep the per-keystroke typecheck
-                // grounded in real warehouse types when the cache is warm.
-                // Throttle guarantees the info log fires at most once per
-                // session per project.
+                // Keep the per-keystroke typecheck grounded in real
+                // warehouse types when the cache is warm. Throttle
+                // guarantees the info log fires at most once per session
+                // per project.
                 let dir_path = std::path::PathBuf::from(dir);
                 let source_schemas =
                     Self::load_cached_source_schemas(&dir_path, &schema_cache_throttle, dir).await;
@@ -3251,7 +3250,7 @@ mod tests {
         assert_eq!(encoded[2].delta_start, 10);
     }
 
-    // ---- Arc 7 wave 2 wave-2: LSP schema-cache loader ----
+    // ---- LSP schema-cache loader ----
 
     /// LSP must honour `[cache.schemas] enabled = false` from
     /// `<root>/rocky.toml` and NOT read cache entries even when the

--- a/engine/crates/rocky-server/src/schema_cache_throttle.rs
+++ b/engine/crates/rocky-server/src/schema_cache_throttle.rs
@@ -1,5 +1,4 @@
-//! Per-document throttle for Arc 7 wave 2 wave-2 schema-cache info logs in
-//! the LSP path.
+//! Per-document throttle for schema-cache info logs in the LSP path.
 //!
 //! The CLI emits a single info log per process when `load_source_schemas_from_cache`
 //! returns at least one entry. That pattern would turn into per-keystroke spam in

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -30,10 +30,9 @@ pub struct ServerState {
     /// CORS allowlist passed to [`crate::auth::build_cors_layer`]. An
     /// empty list means same-origin only.
     pub allowed_origins: Vec<String>,
-    /// Arc 7 wave 2 wave-2: per-session throttle for the "N sources hit"
-    /// info log so it emits once per server start, not once per recompile.
-    /// PR 2 will key it on `(document_uri, cache_version)` — the only LSP
-    /// analogue today is `models_dir`, which stays constant.
+    /// Per-session throttle for the "N sources hit" info log so it
+    /// emits once per server start, not once per recompile. Keyed on
+    /// `models_dir`, which stays constant.
     schema_cache_throttle: SchemaCacheThrottle,
 }
 
@@ -83,11 +82,11 @@ impl ServerState {
     pub async fn recompile(&self) {
         info!(models_dir = %self.models_dir.display(), "compiling project");
 
-        // Wave-2 of Arc 7 wave 2: load cached source schemas so the
-        // server's hover/inlay-hint surfaces typecheck against real
-        // warehouse types when the cache is warm. Degrades to empty on
-        // cold cache, missing state.redb, or `[cache.schemas] enabled =
-        // false`. See `rocky-cli::source_schemas` for the CLI equivalent.
+        // Load cached source schemas so the server's hover/inlay-hint
+        // surfaces typecheck against real warehouse types when the cache
+        // is warm. Degrades to empty on cold cache, missing state.redb,
+        // or `[cache.schemas] enabled = false`. See
+        // `rocky-cli::source_schemas` for the CLI equivalent.
         let source_schemas = self.load_cached_source_schemas().await;
 
         let config = CompilerConfig {

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -309,7 +309,12 @@ enum Command {
         ///
         /// ⚠️ Keys are stored verbatim in the state store; do NOT put
         /// secrets in idempotency keys.
-        #[arg(long, value_name = "KEY")]
+        ///
+        /// Falls back to the `ROCKY_IDEMPOTENCY_KEY` environment variable
+        /// when the flag is not given. Useful for orchestrators that
+        /// already plumb an idempotency key through env (cron wrappers,
+        /// Airflow pod templates, ad-hoc CI bash scripts).
+        #[arg(long, value_name = "KEY", env = "ROCKY_IDEMPOTENCY_KEY")]
         idempotency_key: Option<String>,
 
         /// Scope the post-DAG governance reconcile to a specific
@@ -1983,5 +1988,74 @@ async fn shutdown_signal() {
     #[cfg(not(unix))]
     {
         ctrl_c.await.ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::sync::Mutex;
+
+    /// Serialises every env-mutating test in this module so concurrent
+    /// `cargo test` threads don't race on the shared process env.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// SAFETY: callers MUST hold `ENV_LOCK` for the duration of any
+    /// `set_env` / `remove_env` call and any subsequent read that
+    /// depends on the value. Edition 2024 marked `std::env::set_var` /
+    /// `remove_var` unsafe because they race with reads in other
+    /// threads; the lock closes that hole for our tests.
+    fn set_env(key: &str, value: &str) {
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    fn remove_env(key: &str) {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn parse_run_idempotency_key(args: &[&str]) -> Option<String> {
+        let cli = Cli::try_parse_from(args).expect("parse should succeed");
+        match cli.command {
+            Command::Run {
+                idempotency_key, ..
+            } => idempotency_key,
+            _ => panic!("expected Run subcommand"),
+        }
+    }
+
+    #[test]
+    fn idempotency_key_explicit_flag_wins() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        set_env("ROCKY_IDEMPOTENCY_KEY", "from_env");
+        let key = parse_run_idempotency_key(&[
+            "rocky",
+            "run",
+            "--idempotency-key",
+            "from_flag",
+        ]);
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        assert_eq!(key.as_deref(), Some("from_flag"));
+    }
+
+    #[test]
+    fn idempotency_key_falls_back_to_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        set_env("ROCKY_IDEMPOTENCY_KEY", "from_env");
+        let key = parse_run_idempotency_key(&["rocky", "run"]);
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        assert_eq!(key.as_deref(), Some("from_env"));
+    }
+
+    #[test]
+    fn idempotency_key_none_when_neither_set() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let key = parse_run_idempotency_key(&["rocky", "run"]);
+        assert!(key.is_none());
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2032,12 +2032,7 @@ mod tests {
     fn idempotency_key_explicit_flag_wins() {
         let _guard = ENV_LOCK.lock().unwrap();
         set_env("ROCKY_IDEMPOTENCY_KEY", "from_env");
-        let key = parse_run_idempotency_key(&[
-            "rocky",
-            "run",
-            "--idempotency-key",
-            "from_flag",
-        ]);
+        let key = parse_run_idempotency_key(&["rocky", "run", "--idempotency-key", "from_flag"]);
         remove_env("ROCKY_IDEMPOTENCY_KEY");
         assert_eq!(key.as_deref(), Some("from_flag"));
     }

--- a/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
@@ -130,7 +130,7 @@ class DiscoverOutput(BaseModel):
     """
     Number of schema-cache entries written by this invocation.
 
-    Populated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
+    Populated by `rocky discover --with-schemas` — the explicit warm-up path for the schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.
     """
     sources: list[SourceOutput]
     version: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -691,7 +691,7 @@ class SchemaCacheConfig(BaseModel):
     """
     `[cache.schemas]` — schema cache configuration.
 
-    Controls the Arc 7 wave 2 wave-2 DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in. See the design doc at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md` (§4.3, §5.7) for the rationale.
+    Controls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.
     """
 
     model_config = ConfigDict(
@@ -1029,7 +1029,7 @@ class CacheConfig(BaseModel):
         validate_default=True,
     )
     """
-    Schema cache (Arc 7 wave 2 wave-2). Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile.
+    Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile.
     """
 
 
@@ -2344,7 +2344,7 @@ class RockyConfig(BaseModel):
         validate_default=True,
     )
     """
-    Project-level cache configuration. Arc 7 wave 2 wave-2 introduces `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`].
+    Project-level cache configuration. Today this is just `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`].
     """
     classifications: ClassificationsConfig | None = Field(
         {"allow_unmasked": []}, validate_default=True

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -187,7 +187,7 @@
       "type": "array"
     },
     "schemas_cached": {
-      "description": "Number of schema-cache entries written by this invocation.\n\nPopulated by `rocky discover --with-schemas` — the explicit warm-up path for the Arc 7 wave 2 wave-2 schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.",
+      "description": "Number of schema-cache entries written by this invocation.\n\nPopulated by `rocky discover --with-schemas` — the explicit warm-up path for the schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.",
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -417,7 +417,7 @@
             "replicate": false,
             "ttl_seconds": 86400
           },
-          "description": "Schema cache (Arc 7 wave 2 wave-2). Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile."
+          "description": "Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile."
         }
       },
       "type": "object"
@@ -2140,7 +2140,7 @@
     },
     "SchemaCacheConfig": {
       "additionalProperties": false,
-      "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the Arc 7 wave 2 wave-2 DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in. See the design doc at `~/Developer/rocky-plans/plans/rocky-arc7-wave2-wave2-design.md` (§4.3, §5.7) for the rationale.",
+      "description": "`[cache.schemas]` — schema cache configuration.\n\nControls the DESCRIBE-result cache. Defaults are chosen so the feature is useful out of the box: the cache is on, entries live for 24 hours, and nothing replicates off-machine until the user opts in.",
       "properties": {
         "enabled": {
           "default": true,
@@ -2825,7 +2825,7 @@
           "ttl_seconds": 86400
         }
       },
-      "description": "Project-level cache configuration. Arc 7 wave 2 wave-2 introduces `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`]."
+      "description": "Project-level cache configuration. Today this is just `[cache.schemas]` (schema cache for `DESCRIBE TABLE` results); future cache surfaces live as sibling fields under [`CacheConfig`]."
     },
     "classifications": {
       "allOf": [


### PR DESCRIPTION
## Summary

Three engine-side cleanups bundled into one PR — all small, all engine-side, no codegen cascade. Each landed in its own commit-block in the diff so reviewers can read them independently.

### 1. Iceberg `IcebergError` taxonomy (FR-014 carry-over)

The Iceberg discovery adapter's `failed_sources` classifier was hard-coded to `Unknown` pending the wire-error classification work flagged in FR-014's landed-surface notes. This PR fills it in:

- New `classify_iceberg_error()` in `engine/crates/rocky-iceberg/src/adapter.rs` mirrors the Fivetran classifier (`Transient | Timeout | RateLimit | Auth | Unknown`) keyed on `IcebergError` variants and HTTP status codes.
- Status-code mapping matches Fivetran exactly: `401 | 403 → Auth`, `408 → Timeout`, `429 → RateLimit`, `5xx → Transient`, else `Unknown`. Same numbers, same vocabulary, same operator expectations.
- Three wiremock integration tests in `engine/crates/rocky-iceberg/tests/wiremock_tests.rs` cover `401 → Auth`, `403 → Auth`, and `404 → Unknown` paths end-to-end through the adapter (i.e. the wire shape, not just the classifier).
- Unit tests on `classify_iceberg_error` cover all variants on the synthetic-error path.

Net: the iceberg suite goes from 28 → 31 tests; downstream consumers of `failed_sources` get the same back-pressure / alerting signals from Iceberg as they do from Fivetran.

### 2. `--idempotency-key` env-var fallback (FR-004 follow-up F3)

Adds `env = "ROCKY_IDEMPOTENCY_KEY"` to the `--idempotency-key` clap arg + bumps the workspace `clap` features to include `"env"`. Useful for orchestrators that already plumb an idempotency key through env (cron wrappers, Airflow pod templates, ad-hoc CI bash scripts).

Tests in `engine/rocky/src/main.rs::tests` cover the three ordering rules:
- `--idempotency-key foo` + `ROCKY_IDEMPOTENCY_KEY=bar` → flag wins (`foo`)
- no flag + `ROCKY_IDEMPOTENCY_KEY=bar` → env fallback (`bar`)
- neither set → `None`

All three serialised under a module-local `ENV_LOCK: Mutex<()>` so they don't race on the shared process env (mirrors the existing `run_audit.rs` pattern; edition 2024 makes `set_var` unsafe).

### 3. Arc 7 phase-marker comment cleanup

The schema-cache codebase carried ~25 comments referencing internal task tracking (`Arc 7 wave 2 wave-2`, `Arc 7 wave 2 PR N`, `Wave-1 of Arc 7`, etc.) — useful while building, dead weight now that the feature has shipped. Stripped the markers across:

- `rocky-core/src/{state,state_sync,config,schema_cache}.rs`
- `rocky-cli/src/{source_schemas,schema_cache_writer,output}.rs` + `commands/{run,run_local,compile,discover,lineage,dag,ai,ci_diff,state}.rs`
- `rocky-compiler/src/schema_cache.rs`
- `rocky-server/src/{state,lsp,schema_cache_throttle}.rs` + `Cargo.toml`

Surrounding descriptive prose preserved. No semantic change.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p rocky-iceberg` — 28 unit + 3 new wiremock = 31 tests pass
- [x] `cargo test --bin rocky idempotency_key` — 3 new tests pass
- [x] `cargo check -p rocky-core -p rocky-cli -p rocky-server -p rocky-compiler` clean (after Arc 7 cleanup)
- [ ] `state_sync_timeout_test::upload_state_hung_endpoint_skip_mode_converts_to_ok` is a pre-existing timing-sensitive flake under heavy parallel load (passes in isolation). Not caused by this change.