### PR TITLE
feat(engine/rocky-bigquery): override clone_table_for_branch with CREATE TABLE COPY

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -344,6 +344,38 @@ impl WarehouseAdapter for BigQueryAdapter {
             .collect();
         Ok(tables)
     }
+
+    /// Override the trait default: emit BigQuery's native
+    /// `CREATE OR REPLACE TABLE ... COPY` instead of CTAS. The branch
+    /// table lands in `<source.catalog>.<branch_schema>.<source.table>` —
+    /// same project as the source, since BigQuery's `COPY` primitive is
+    /// scoped to a single project (cross-region multi-region datasets
+    /// are fine, but cross-project is not).
+    ///
+    /// `COPY` is a metadata-only operation: the new table references the
+    /// same physical storage as the source until either side mutates,
+    /// so the per-PR branch is effectively zero-cost at create time.
+    /// Strictly dominates the default CTAS implementation, which would
+    /// re-scan the source bytes.
+    async fn clone_table_for_branch(
+        &self,
+        source: &TableRef,
+        branch_schema: &str,
+    ) -> AdapterResult<()> {
+        validate_identifier(&source.catalog).map_err(AdapterError::new)?;
+        validate_identifier(&source.schema).map_err(AdapterError::new)?;
+        validate_identifier(&source.table).map_err(AdapterError::new)?;
+        validate_identifier(branch_schema).map_err(AdapterError::new)?;
+
+        let project = &source.catalog;
+        let src_dataset = &source.schema;
+        let table = &source.table;
+        let sql = format!(
+            "CREATE OR REPLACE TABLE `{project}`.`{branch_schema}`.`{table}` \
+             COPY `{project}`.`{src_dataset}`.`{table}`"
+        );
+        self.execute_statement(&sql).await
+    }
 }
 
 /// Extract [`ExecutionStats`] from a successful [`BigQueryResponse`].

--- a/engine/crates/rocky-bigquery/tests/integration.rs
+++ b/engine/crates/rocky-bigquery/tests/integration.rs
@@ -1,0 +1,126 @@
+//! Integration tests against a real BigQuery environment.
+//!
+//! These tests require:
+//! - `BIGQUERY_TEST_PROJECT` (the GCP project ID under which to create
+//!   the ephemeral test datasets)
+//! - one of:
+//!   - `GOOGLE_APPLICATION_CREDENTIALS` (path to a service-account JSON
+//!     file with `bigquery.dataEditor` + `bigquery.jobUser` on the
+//!     project), or
+//!   - `BIGQUERY_TOKEN` (a pre-exchanged OAuth bearer token; useful for
+//!     `gcloud auth print-access-token` flows in CI).
+//!
+//! Optional:
+//! - `BIGQUERY_TEST_LOCATION` — the dataset location (defaults to
+//!   `"EU"` to match the typical free-trial quota).
+//!
+//! Run with: `cargo test -p rocky-bigquery --test integration -- --ignored`
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rocky_bigquery::auth::BigQueryAuth;
+use rocky_bigquery::connector::BigQueryAdapter;
+use rocky_core::ir::TableRef;
+use rocky_core::traits::WarehouseAdapter;
+
+/// Build an adapter from env vars. Returns `None` when the required
+/// vars aren't present, so the `#[ignore]`d test silently skips on a
+/// developer machine without GCP creds plumbed in.
+fn adapter_from_env() -> Option<BigQueryAdapter> {
+    let project = std::env::var("BIGQUERY_TEST_PROJECT").ok()?;
+    let location = std::env::var("BIGQUERY_TEST_LOCATION").unwrap_or_else(|_| "EU".to_string());
+    // `BigQueryAuth::from_env()` honours `BIGQUERY_TOKEN` first, then
+    // falls back to `GOOGLE_APPLICATION_CREDENTIALS`.
+    let auth = BigQueryAuth::from_env().ok()?;
+    Some(BigQueryAdapter::new(project, location, auth))
+}
+
+/// Verifies the BigQuery `clone_table_for_branch` override emits a
+/// working `CREATE OR REPLACE TABLE ... COPY` statement: source dataset
+/// + table created, clone produced in a sibling dataset, row contents
+/// match. Both datasets are dropped (CASCADE-equivalent
+/// `DROP SCHEMA ... CASCADE`) at the end regardless of test outcome.
+///
+/// Project is read from `BIGQUERY_TEST_PROJECT`. Datasets use the
+/// `hc_phase5_` prefix to match Hugo's Databricks-side convention so
+/// sandbox housekeeping uses one regex across warehouses.
+#[tokio::test]
+#[ignore]
+async fn test_clone_table_for_branch_copy() {
+    let adapter = adapter_from_env().expect("BigQuery env vars not set");
+    let project =
+        std::env::var("BIGQUERY_TEST_PROJECT").expect("BIGQUERY_TEST_PROJECT must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let src_dataset = format!("hc_phase5_src_{suffix}");
+    let brn_dataset = format!("hc_phase5_brn_{suffix}");
+    let table = "test_table";
+
+    // Setup: create the two datasets + a 2-row source table. BigQuery
+    // calls them "datasets" rather than "schemas", but the
+    // `CREATE SCHEMA` DDL works either way (it's an alias).
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{project}`.`{src_dataset}`"
+        ))
+        .await
+        .expect("create source dataset");
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{project}`.`{brn_dataset}`"
+        ))
+        .await
+        .expect("create branch dataset");
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE `{project}`.`{src_dataset}`.`{table}` AS \
+             SELECT * FROM UNNEST([STRUCT(1 AS id, 'a' AS name), STRUCT(2, 'b')])"
+        ))
+        .await
+        .expect("create source table");
+
+    // Run the unit under test, capture the result so cleanup runs first.
+    let source = TableRef {
+        catalog: project.clone(),
+        schema: src_dataset.clone(),
+        table: table.to_string(),
+    };
+    let clone_result = adapter.clone_table_for_branch(&source, &brn_dataset).await;
+
+    let row_count = if clone_result.is_ok() {
+        let q = adapter
+            .execute_query(&format!(
+                "SELECT COUNT(*) AS n FROM `{project}`.`{brn_dataset}`.`{table}`"
+            ))
+            .await
+            .ok();
+        q.and_then(|r| r.rows.first().and_then(|row| row.first().cloned()))
+    } else {
+        None
+    };
+
+    // Unconditional cleanup (best-effort; ignored on failure).
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{src_dataset}` CASCADE"
+        ))
+        .await;
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{brn_dataset}` CASCADE"
+        ))
+        .await;
+
+    clone_result.expect("clone_table_for_branch should succeed");
+    let n = row_count.expect("clone target should be queryable");
+    // BigQuery returns COUNT(*) results as JSON strings (`{"v": "2"}`)
+    // rather than typed numbers, so handle both shapes defensively.
+    let n_num: i64 = n
+        .as_i64()
+        .or_else(|| n.as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(-1);
+    assert_eq!(n_num, 2, "cloned table should have 2 rows, got {n:?}");
+}


### PR DESCRIPTION
## Summary

Phase 5 sub-step 3 — overrides the in-tree `WarehouseAdapter` default (portable CTAS) on `BigQueryAdapter` with BigQuery's native `CREATE OR REPLACE TABLE ... COPY` primitive. `COPY` is a metadata-only operation, so the per-PR branch table is effectively zero-cost at create time. Strictly dominates the CTAS default (which would re-scan the source bytes).

Mirrors PR [#305](https://github.com/rocky-data/rocky/pull/305) (Databricks `SHALLOW CLONE`) and slots into the trait surface added in PR [#303](https://github.com/rocky-data/rocky/pull/303). The `Phase 5 — Adapter parity` section in `docs/.../guides/preview-internals.md` already names BigQuery `CREATE TABLE ... COPY` as the planned override; this PR fulfils it.

### What's in the diff

- **`engine/crates/rocky-bigquery/src/connector.rs`** — adds the override on `BigQueryAdapter`'s `WarehouseAdapter` impl.
  - Three-part backtick quoting (`` `project`.`dataset`.`table` ``) — BigQuery convention, vs the unquoted form Databricks uses.
  - Four identifier validations (`project`, `src_dataset`, `table`, `branch_dataset`) via `rocky_sql::validation::validate_identifier`. The validator only allows `[A-Za-z0-9_]+`, closing the SQL-injection vector through the schema prefix.
  - Branch table lands in the same GCP project as the source, since `COPY` is single-project-scoped (cross-region multi-region datasets are fine; cross-project is not).

- **`engine/crates/rocky-bigquery/tests/integration.rs`** *(new)* — one `#[ignore]`d test `test_clone_table_for_branch_copy` end-to-end against a real BigQuery project. Gated on:
  - `BIGQUERY_TEST_PROJECT`
  - one of `GOOGLE_APPLICATION_CREDENTIALS` (service-account JSON path) or `BIGQUERY_TOKEN` (pre-exchanged bearer)
  - optional `BIGQUERY_TEST_LOCATION` (defaults to `"EU"` to match the typical free-trial quota)

  Test creates ephemeral `hc_phase5_src_<timestamp>` + `hc_phase5_brn_<timestamp>` datasets, populates a 2-row source table, calls `clone_table_for_branch`, and asserts the copied table is queryable with 2 rows. Datasets are dropped (`CASCADE`) unconditionally on test exit.

  ```bash
  cargo test -p rocky-bigquery --test integration -- --ignored
  ```

### Test plan

- [x] `cargo test -p rocky-bigquery --tests` — 55 unit tests pass; integration test correctly `#[ignore]`d (skipped without env vars)
- [x] `cargo clippy -p rocky-bigquery --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean (the wider workspace fmt failure on PR #307 fixed in `be5944b`)
- [ ] **Live BQ verification deferred** — sandbox project + service account not wired locally yet. Matches PR #305's first-iteration pattern: land `#[ignore]`-gated, verify separately once the sandbox is plumbed.