### PR TITLE
fix(engine): two latent BQ-adapter bugs surfaced by PR #309 live test

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -418,6 +418,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +788,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -1150,6 +1182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1359,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2004,6 +2048,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64",
  "getrandom 0.2.17",
  "js-sys",
@@ -3275,7 +3320,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3820,7 +3865,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4855,6 +4900,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -118,7 +118,12 @@ sha2 = "0.11"
 blake3 = "1"
 
 # JWT / RSA / Base64
-jsonwebtoken = "10"
+# `aws_lc_rs` matches reqwest's default crypto provider (rustls + aws-lc-rs).
+# `jsonwebtoken` 10.x requires picking a provider explicitly; without a
+# feature, the BigQuery service-account JWT signer panics at first use.
+# `pem` keeps `EncodingKey::from_rsa_pem` available for PEM-encoded
+# service-account keys.
+jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 rsa = { version = "0.9", features = ["pem"] }
 base64 = "0.22"
 

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -12,7 +12,7 @@ use rocky_core::ir::{ColumnInfo, TableRef};
 use rocky_core::traits::{
     AdapterError, AdapterResult, ExecutionStats, QueryResult, SqlDialect, WarehouseAdapter,
 };
-use rocky_sql::validation::validate_identifier;
+use rocky_sql::validation::{validate_gcp_project_id, validate_identifier};
 
 use crate::auth::BigQueryAuth;
 use crate::dialect::BigQueryDialect;
@@ -300,7 +300,9 @@ impl WarehouseAdapter for BigQueryAdapter {
     async fn describe_table(&self, table: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
         // validate_identifier rejects `'` and other non-alphanumerics, so the
         // `table_name = '...'` literal cannot be broken out of by `table.table`.
-        validate_identifier(&table.catalog).map_err(AdapterError::new)?;
+        // The catalog (= GCP project) needs the looser project-ID validator
+        // because GCP allows hyphens in project IDs (e.g. `my-project-id`).
+        validate_gcp_project_id(&table.catalog).map_err(AdapterError::new)?;
         validate_identifier(&table.schema).map_err(AdapterError::new)?;
         validate_identifier(&table.table).map_err(AdapterError::new)?;
         let sql = format!(
@@ -331,8 +333,8 @@ impl WarehouseAdapter for BigQueryAdapter {
     }
 
     async fn list_tables(&self, catalog: &str, schema: &str) -> AdapterResult<Vec<String>> {
-        // BigQuery: catalog = project, schema = dataset
-        validate_identifier(catalog).map_err(AdapterError::new)?;
+        // BigQuery: catalog = project (allows hyphens), schema = dataset.
+        validate_gcp_project_id(catalog).map_err(AdapterError::new)?;
         validate_identifier(schema).map_err(AdapterError::new)?;
         let sql =
             format!("SELECT table_name FROM `{catalog}`.`{schema}`.INFORMATION_SCHEMA.TABLES");
@@ -362,7 +364,10 @@ impl WarehouseAdapter for BigQueryAdapter {
         source: &TableRef,
         branch_schema: &str,
     ) -> AdapterResult<()> {
-        validate_identifier(&source.catalog).map_err(AdapterError::new)?;
+        // GCP project IDs allow hyphens (`my-project-1`), so the catalog
+        // component takes the looser project-ID validator. Datasets and
+        // tables stay on the strict `[A-Za-z0-9_]+` rule.
+        validate_gcp_project_id(&source.catalog).map_err(AdapterError::new)?;
         validate_identifier(&source.schema).map_err(AdapterError::new)?;
         validate_identifier(&source.table).map_err(AdapterError::new)?;
         validate_identifier(branch_schema).map_err(AdapterError::new)?;

--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -10,8 +10,10 @@ pub struct BigQueryDialect;
 
 impl SqlDialect for BigQueryDialect {
     fn format_table_ref(&self, catalog: &str, schema: &str, table: &str) -> AdapterResult<String> {
-        // BigQuery uses project.dataset.table (three-part)
-        validation::validate_identifier(catalog).map_err(AdapterError::new)?;
+        // BigQuery uses project.dataset.table (three-part). The project
+        // (catalog) component allows hyphens; dataset + table stay on
+        // the stricter SQL-identifier rule.
+        validation::validate_gcp_project_id(catalog).map_err(AdapterError::new)?;
         validation::validate_identifier(schema).map_err(AdapterError::new)?;
         validation::validate_identifier(table).map_err(AdapterError::new)?;
         Ok(format!("`{catalog}`.`{schema}`.`{table}`"))
@@ -121,9 +123,10 @@ impl SqlDialect for BigQueryDialect {
     }
 
     fn create_schema_sql(&self, catalog: &str, schema: &str) -> Option<AdapterResult<String>> {
-        // BigQuery: CREATE SCHEMA = CREATE DATASET
+        // BigQuery: CREATE SCHEMA = CREATE DATASET. Project (catalog)
+        // allows hyphens; dataset stays on the strict identifier rule.
         let validate = || -> AdapterResult<String> {
-            validation::validate_identifier(catalog).map_err(AdapterError::new)?;
+            validation::validate_gcp_project_id(catalog).map_err(AdapterError::new)?;
             validation::validate_identifier(schema).map_err(AdapterError::new)?;
             Ok(format!(
                 "CREATE SCHEMA IF NOT EXISTS `{catalog}`.`{schema}`"
@@ -159,7 +162,8 @@ impl SqlDialect for BigQueryDialect {
         // BigQuery's INFORMATION_SCHEMA.TABLES lives per-dataset, so the
         // four-part `project.dataset.INFORMATION_SCHEMA.TABLES` form is
         // required. Backtick-quote project + dataset per BQ conventions.
-        rocky_sql::validation::validate_identifier(catalog)
+        // Project (catalog) allows hyphens; dataset stays strict.
+        rocky_sql::validation::validate_gcp_project_id(catalog)
             .map_err(rocky_core::traits::AdapterError::new)?;
         rocky_sql::validation::validate_identifier(schema)
             .map_err(rocky_core::traits::AdapterError::new)?;

--- a/engine/crates/rocky-sql/src/validation.rs
+++ b/engine/crates/rocky-sql/src/validation.rs
@@ -10,6 +10,15 @@ static SQL_IDENTIFIER_RE: LazyLock<Regex> =
 static PRINCIPAL_NAME_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_ \-\.@]+$").unwrap());
 
+/// Pattern for valid GCP project IDs.
+///
+/// GCP requires project IDs to be 6–30 chars, lowercase alphanumeric +
+/// hyphens, starting with a letter and not ending in a hyphen. The
+/// hyphen is what makes the stricter [`SQL_IDENTIFIER_RE`] reject them
+/// (e.g. `rocky-sandbox-hc-test-63874`).
+static GCP_PROJECT_ID_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z][a-z0-9\-]{4,28}[a-z0-9]$").unwrap());
+
 /// Errors from SQL identifier and principal name validation.
 #[derive(Debug, Error)]
 pub enum ValidationError {
@@ -18,6 +27,12 @@ pub enum ValidationError {
 
     #[error("invalid principal name '{value}': must match [a-zA-Z0-9_ \\-\\.@]+")]
     InvalidPrincipal { value: String },
+
+    #[error(
+        "invalid GCP project ID '{value}': must be 6-30 chars, start with a letter, \
+         contain only lowercase letters / digits / hyphens, and not end with a hyphen"
+    )]
+    InvalidGcpProjectId { value: String },
 
     #[error("SQL identifier cannot be empty")]
     EmptyIdentifier,
@@ -36,6 +51,25 @@ pub fn validate_identifier(value: &str) -> Result<&str, ValidationError> {
     }
     if !SQL_IDENTIFIER_RE.is_match(value) {
         return Err(ValidationError::InvalidIdentifier {
+            value: value.to_string(),
+        });
+    }
+    Ok(value)
+}
+
+/// Validates a GCP project ID for safe interpolation into BigQuery SQL.
+///
+/// GCP project IDs allow hyphens (`my-project-id-123`), which the
+/// stricter [`validate_identifier`] would reject. Use this for the
+/// catalog/project component on the BigQuery adapter; keep
+/// [`validate_identifier`] for dataset and table names, which still
+/// must match `[a-zA-Z0-9_]+`.
+pub fn validate_gcp_project_id(value: &str) -> Result<&str, ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::EmptyIdentifier);
+    }
+    if !GCP_PROJECT_ID_RE.is_match(value) {
+        return Err(ValidationError::InvalidGcpProjectId {
             value: value.to_string(),
         });
     }
@@ -130,6 +164,35 @@ mod tests {
     #[test]
     fn test_format_table_ref_rejects_injection() {
         assert!(format_table_ref("catalog; DROP TABLE", "schema", "table").is_err());
+    }
+
+    #[test]
+    fn test_valid_gcp_project_ids() {
+        assert!(validate_gcp_project_id("rocky-sandbox").is_ok());
+        assert!(validate_gcp_project_id("rocky-sandbox-hc-test-63874").is_ok());
+        assert!(validate_gcp_project_id("my-project-1").is_ok());
+        // Lower bound: 6 chars total (1 leading letter + 4 middle + 1 tail).
+        assert!(validate_gcp_project_id("abc12d").is_ok());
+    }
+
+    #[test]
+    fn test_invalid_gcp_project_ids() {
+        // Empty / too short.
+        assert!(validate_gcp_project_id("").is_err());
+        assert!(validate_gcp_project_id("abc12").is_err());
+        // Must start with a letter.
+        assert!(validate_gcp_project_id("1-project").is_err());
+        assert!(validate_gcp_project_id("-project").is_err());
+        // Cannot end with a hyphen.
+        assert!(validate_gcp_project_id("rocky-sandbox-").is_err());
+        // No uppercase, dots, underscores, spaces.
+        assert!(validate_gcp_project_id("Rocky-Sandbox").is_err());
+        assert!(validate_gcp_project_id("rocky.sandbox").is_err());
+        assert!(validate_gcp_project_id("rocky_sandbox").is_err());
+        assert!(validate_gcp_project_id("rocky sandbox").is_err());
+        // Injection attempts.
+        assert!(validate_gcp_project_id("'; DROP TABLE users; --").is_err());
+        assert!(validate_gcp_project_id("project`backtick").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fast-follow to PR [#309](https://github.com/rocky-data/rocky/pull/309). Two pre-existing bugs in the BigQuery adapter only surfaced when I ran the new `#[ignore]`d integration test against a real GCP sandbox after #309 merged. I had pushed this fix to the original branch but the merge of #309 had already squashed at the prior commit, so this slipped through.

### What's broken on `main` today

The BigQuery adapter (`is_experimental: true`) is unusable against any real GCP project until this lands. Both bugs trigger on the first call:

1. **`jsonwebtoken` 10.x panics on first JWT signing.** Workspace pin was `jsonwebtoken = "10"` with no features → no crypto provider selected → `CryptoProvider::install_default()` panic. Fixed by pinning `["aws_lc_rs", "use_pem"]` (matches reqwest's default rustls provider; keeps `EncodingKey::from_rsa_pem` available for service-account JSON keys).

2. **`validate_identifier` rejects GCP project IDs.** GCP project IDs match `^[a-z][a-z0-9-]{4,28}[a-z0-9]$` — the hyphen fails the strict `^[a-zA-Z0-9_]+$` SQL identifier check. Any real project ID like `rocky-sandbox-hc-test-63874` errored before SQL was ever issued. New `rocky_sql::validation::validate_gcp_project_id` honours GCP's actual rules; the BQ adapter (`describe_table`, `list_tables`, `clone_table_for_branch`) and dialect (`format_table_ref`, `create_schema_sql`, `list_tables_sql`) all switched to it for the project component. Dataset and table names stay on the strict identifier rule.

## Why this didn't go in with #309

I committed the fix to the same branch (`5e10c72`) but pushed *after* the squash-merge happened. Git accepted the push as a fresh ref of the same name — git's `[new branch]` output was the giveaway. Cherry-picked clean off main here.

## Test plan

- [x] `cargo test -p rocky-bigquery -p rocky-sql --tests` — 75 unit tests pass; 2 new validator tests for `validate_gcp_project_id` cover valid + injection-bearing inputs
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] **Live verified end-to-end** against `rocky-sandbox-hc-test-63874` (EU): `cargo test -p rocky-bigquery --test integration -- --ignored` passes; ephemeral `hc_phase5_*` datasets created and dropped cleanly. The live test was the only thing that surfaced these bugs in the first place.