### PR TITLE
chore: release engine-v1.19.1 + dagster-v1.17.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.1] — 2026-04-30
+
+Patch release. Headline: **`clone_table_for_branch` warehouse-native overrides on Databricks (`SHALLOW CLONE`) and BigQuery (`CREATE TABLE … COPY`)** turn the per-PR branch substrate from a portable CTAS that re-scans bytes into a metadata-only operation that's effectively zero-cost at create time. Snowflake stays on the CTAS default (still correct, just slower) until a Snowflake consumer asks for the native `CLONE` path.
+
+### Added
+
+- **`WarehouseAdapter::clone_table_for_branch` trait method + DuckDB CTAS default** ([#303](https://github.com/rocky-data/rocky/pull/303)). New trait surface that `rocky preview create` uses to populate the per-PR branch schema for every model not in the prune set. Default impl is a portable `CREATE OR REPLACE TABLE "{branch}"."{table}" AS SELECT * FROM "{src_schema}"."{table}"` that works on DuckDB and any warehouse whose CTAS accepts the two-part `schema.table` form without a catalog prefix. Adapters with native zero-copy primitives override. Identifier-validation guard on every component via `rocky_sql::validation`.
+- **Databricks `SHALLOW CLONE` override of `clone_table_for_branch`** ([#305](https://github.com/rocky-data/rocky/pull/305)). Replaces the portable CTAS with `CREATE OR REPLACE TABLE … SHALLOW CLONE …` so the per-PR branch lands in `<source.catalog>.<branch_schema>.<source.table>` as a metadata-only reference to the source's underlying files. Live-verified end-to-end against a real Databricks workspace (~12s wall clock for the integration test).
+- **BigQuery `CREATE TABLE … COPY` override of `clone_table_for_branch`** ([#309](https://github.com/rocky-data/rocky/pull/309)). BigQuery's native metadata-only table copy primitive — strictly dominates the CTAS default, which would re-scan the source bytes. Three-part backtick quoting (`` `project`.`dataset`.`table` ``); branch table lands in the same GCP project as the source (BigQuery's `COPY` is single-project-scoped). Live-verified end-to-end against a real BigQuery sandbox (~12s wall clock).
+- **`rocky run --idempotency-key` env-var fallback** ([#307](https://github.com/rocky-data/rocky/pull/307)). The CLI flag now falls back to `ROCKY_IDEMPOTENCY_KEY` when not given. Useful for orchestrators that already plumb an idempotency key through env (cron wrappers, pod templates, ad-hoc CI scripts). Workspace `clap` features grew `["env"]`.
+- **`IcebergError` taxonomy on the discovery adapter's `failed_sources` classifier** ([#307](https://github.com/rocky-data/rocky/pull/307)). The classifier was hard-coded to `Unknown` pending wire-error classification; now mirrors the Fivetran taxonomy (`Transient | Timeout | RateLimit | Auth | Unknown`) keyed on `IcebergError` variants and HTTP status codes. Downstream consumers of `failed_sources` get the same back-pressure / alerting signals from Iceberg as they do from Fivetran. Three new wiremock integration tests cover `401 → Auth`, `403 → Auth`, and `404 → Unknown` paths.
+- **`rocky_sql::validation::validate_gcp_project_id`** ([#310](https://github.com/rocky-data/rocky/pull/310)). New validator honouring GCP's actual project-ID rules (`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`). The strict `validate_identifier` rejected hyphens, which made the BigQuery adapter unusable against any real GCP project.
+
+### Fixed
+
+- **`jsonwebtoken` 10.x crypto-provider panic on first JWT signing** ([#310](https://github.com/rocky-data/rocky/pull/310)). Workspace pin grew `["aws_lc_rs", "use_pem"]` features so the BigQuery service-account auth path doesn't panic with `CryptoProvider::install_default()` on its first call.
+- **BigQuery adapter rejects real GCP project IDs containing hyphens** ([#310](https://github.com/rocky-data/rocky/pull/310)). `BigQueryAdapter::{describe_table, list_tables, clone_table_for_branch}` and `BigQueryDialect::{format_table_ref, create_schema_sql, list_tables_sql}` now use `validate_gcp_project_id` for the project component. Dataset and table names stay on the strict identifier rule.
+
+### Changed
+
+- **Schema-cache doc-comment cleanup** ([#307](https://github.com/rocky-data/rocky/pull/307)). Internal task-tracking labels stripped from ~25 doc-comments and inline comments across the schema-cache codebase. Surrounding descriptive prose preserved. Description text on a few `JsonSchema`-deriving structs (`SchemaCacheConfig`, `CacheConfig`, `schemas_cached`) propagated through the codegen cascade — pure description-text drift, no field added / removed / renamed.
+
 ## [1.19.0] — 2026-04-30
 
 Feature release. Headline: **`rocky lineage-diff`** — a new top-level CLI verb that combines `rocky ci-diff`'s structural per-column diff with `rocky lineage --downstream`'s blast-radius walk, emitting a PR-comment-ready Markdown summary of which downstream columns each PR change reaches. Closes the launch-thread commitment to `xiaoher-c` ([HN item 47935246](https://news.ycombinator.com/item?id=47935246)).

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "redis",
  "serde",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "logos",
  "miette",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "miette",
  "regex",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.19.0"
+version = "1.19.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.19.0"
+version = "1.19.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.19.0"
+version = "1.19.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.19.0"
+version = "1.19.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.19.0"
+version = "1.19.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.19.0"
+version = "1.19.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.19.0"
+version = "1.19.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.19.0"
+version = "1.19.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.19.0"
+version = "1.19.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.19.0"
+version = "1.19.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.19.0"
+version = "1.19.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.19.0"
+version = "1.19.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.19.0"
+version = "1.19.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.19.0"
+version = "1.19.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.19.0"
+version = "1.19.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] — 2026-04-30
+
+Minor release. Headline: **three additive enhancements to `rocky_source_sensor`** driven by downstream-consumer operational learnings — backlog cap, lifecycle hooks, and resource-key injection. Companion to engine `v1.19.1` but doesn't require it; works against any engine `≥ 1.17.4`.
+
 ### Added
 
 - **`rocky_source_sensor` per-tag-key backlog cap (FR-015).** New opt-in `backlog_cap=BacklogCap(tag_key=..., max_in_flight=..., statuses=...)` argument that consults `context.instance.get_runs(...)` before each emit and suppresses the `RunRequest` when the in-flight count for the matched tag value is at or above the cap. The cursor still advances on suppression so the in-flight run picks up the latest data via Rocky's per-source state — avoiding the stuck-tick failure mode where freezing the cursor would re-detect the same sync forever. Default off; existing call sites unchanged. New `BacklogCap` NamedTuple is exported from the package root.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.16.0"
+version = "1.17.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Coordinated release covering the five engine PRs and one dagster PR that landed on 2026-04-30. VS Code unaffected — no consumer-visible changes since v1.11.0.

### Engine v1.19.1 (patch)

| PR | What |
|---|---|
| [#303](https://github.com/rocky-data/rocky/pull/303) | `WarehouseAdapter::clone_table_for_branch` trait + DuckDB CTAS default + identifier-validation guard |
| [#305](https://github.com/rocky-data/rocky/pull/305) | Databricks `SHALLOW CLONE` override (live-verified against a real workspace) |
| [#309](https://github.com/rocky-data/rocky/pull/309) | BigQuery `CREATE TABLE … COPY` override (live-verified against a real GCP sandbox) |
| [#307](https://github.com/rocky-data/rocky/pull/307) | Schema-cache doc-comment cleanup + Iceberg `IcebergError` taxonomy with three new wiremock tests + `rocky run --idempotency-key` env-var fallback (`ROCKY_IDEMPOTENCY_KEY`) |
| [#310](https://github.com/rocky-data/rocky/pull/310) | Two latent BQ-adapter fixes surfaced by #309's live integration test: `validate_gcp_project_id` (hyphenated GCP project IDs) + `jsonwebtoken = ["aws_lc_rs", "use_pem"]` (avoids the JWT signing panic) |

### Dagster v1.17.0 (minor — new optional public surface)

| PR | What |
|---|---|
| [#306](https://github.com/rocky-data/rocky/pull/306) | `rocky_source_sensor` gains `BacklogCap` per-tag-key in-flight cap (suppress + advance cursor), three lifecycle hooks (`on_run_request_emitted` / `on_failed_sources` / `on_skip` with frozen-dataclass contexts), and `rocky_resource: RockyResource \| str = "rocky"` resource-key injection alongside the legacy instance form |

### Bumps in this PR

- 20 engine `Cargo.toml` files: `1.19.0 → 1.19.1` (`rocky-bigquery` stays on its own track at `0.1.0`)
- `integrations/dagster/pyproject.toml`: `1.16.0 → 1.17.0`
- `integrations/dagster/uv.lock` regen
- `engine/Cargo.lock` regen
- Engine + dagster `CHANGELOG.md` entries

## Test plan

- [x] `just codegen` — clean, no schema drift
- [x] `just lint` — clean across cargo clippy + cargo fmt + ruff + eslint
- [x] `just test` — green except a pre-existing timing-sensitive flake on `state_sync_probe_test::probe_state_backend_s3_roundtrip_succeeds` that exceeds its 2-second wall-clock budget under heavy local CPU load. The same test passed on CI for all four constituent PRs and is not affected by this release's version-bump diff.
- [ ] After merge: tag `engine-v1.19.1` + `dagster-v1.17.0` against the merge commit. `engine-release.yml` produces the 5-platform binary release; `dagster-release.yml` builds the wheel + publishes to PyPI via OIDC.

## Notes

- VS Code stays at `1.11.0`. Schema description text changes from #307 made it through the codegen cascade into `editors/vscode/src/types/generated/`, but consumers don't see those — the strings are doc-comments on type aliases that vscode never renders. No release needed.
- BigQuery integration test (`#[ignore]`d in `engine/crates/rocky-bigquery/tests/integration.rs`) is live-runnable from any developer machine wired with `BIGQUERY_TEST_PROJECT` + `GOOGLE_APPLICATION_CREDENTIALS`. Sandbox project, SA, and key path are tracked in the team reference.