### PR TITLE
docs(preview): reflect Phase 5 warehouse-native clones shipped in v1.19.1

### DIFF
--- a/docs/src/content/docs/concepts/preview-internals.md
+++ b/docs/src/content/docs/concepts/preview-internals.md
@@ -21,9 +21,16 @@ sidebar:
 
 The final output ([`PreviewCreateOutput`](#output-shapes)) records `prune_set`, `copy_set`, and `skipped_set` so the decision is auditable from the JSON alone.
 
-### Copy substrate today and tomorrow
+### Copy substrate
 
-The Phase 1 copy substrate is `CREATE TABLE … AS SELECT *` (CTAS). It works on every Rocky-supported adapter without any adapter-specific work, but it copies bytes. Warehouse-native clones — Delta `SHALLOW CLONE` on Databricks, zero-copy `CLONE TABLE` on Snowflake, BigQuery's metadata-only `CREATE TABLE … COPY` — are a follow-up phase. They lift the copy step from a bytes-bearing CTAS to a metadata operation, which makes preview cheap enough to run on tables that would be uneconomic to CTAS today. The output's `copy_strategy` field is `"ctas"` until that phase lands.
+The copy substrate dispatches per-adapter via the `WarehouseAdapter::clone_table_for_branch` trait method:
+
+- **Databricks** — `CREATE OR REPLACE TABLE … SHALLOW CLONE …`. Metadata-only; the branch table references the source's underlying files until either side mutates.
+- **BigQuery** — `CREATE OR REPLACE TABLE … COPY …`. Metadata-only; same single-project scope as the source dataset.
+- **DuckDB** — `CREATE OR REPLACE TABLE … AS SELECT *` (CTAS). Bytes-copying but trivially portable; matches the trait's default impl, so the same code path works on any future adapter that doesn't override.
+- **Snowflake** — falls through to the CTAS default. Native zero-copy `CLONE TABLE` is a planned override; it'll switch in once a Snowflake consumer drives the integration test against a workspace.
+
+For the warehouses with native overrides (Databricks, BigQuery), `clone_table_for_branch` lifts the copy step from bytes-bearing CTAS to a metadata operation, which makes preview cheap enough to run on tables that would be uneconomic to CTAS today.
 
 ## Comparison to Fivetran's Smart Run
 
@@ -33,13 +40,12 @@ The closest published commercial analogue is Fivetran's [Smart Run for dbt Core]
 |---|---|---|
 | Change detection | "Manifest-independent" — mechanism not specified in the article | git-diff plus compiler-IR type-equivalence (the compiler can tell that two textually different models produce identical column types and lineage) |
 | Pruning granularity | Model-level (per the article's red / I-node / R-node example) | Column-level — derived from the compiler IR; a column added to an unused tail of a wide table prunes to zero downstream |
-| Copy substrate (today) | `COPY` ("the COPY command is free" per article) | CTAS — feature-parity in Phase 1 |
-| Copy substrate (planned) | — | Delta `SHALLOW CLONE` / Snowflake zero-copy `CLONE` (metadata-only) |
+| Copy substrate | `COPY` ("the COPY command is free" per article) | Per-adapter dispatch: Databricks `SHALLOW CLONE`, BigQuery `CREATE TABLE … COPY` (both metadata-only), DuckDB CTAS, Snowflake CTAS pending native `CLONE` override |
 | Cost delta | Not surfaced in the article | First-class output ([`PreviewCostOutput`](#output-shapes)) |
 | Data diff | Not surfaced in the article | First-class output ([`PreviewDiffOutput`](#output-shapes)) |
 | PR comment | Not described in the article | Pre-rendered Markdown in every output |
 
-The article does not document Smart Run's internal mechanism beyond the conceptual diagram and the "manifest-independent" claim, so the rows above hedge accordingly. The structural advantages — column-level pruning, compile-time type-equivalence detection, native clones at the next phase — are reachable because Rocky has its own compiler. They are unreachable from inside dbt without rewriting dbt's compiler.
+The article does not document Smart Run's internal mechanism beyond the conceptual diagram and the "manifest-independent" claim, so the rows above hedge accordingly. The structural advantages — column-level pruning, compile-time type-equivalence detection, warehouse-native clones — are reachable because Rocky has its own compiler. They are unreachable from inside dbt without rewriting dbt's compiler.
 
 ## Sampling correctness ceiling
 

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -131,7 +131,7 @@ A clean sample with `coverage_warning: true` is **not** evidence the PR is no-op
 
 **`preview cost` reports `null` for the branch.** The cost rollup uses the same adapter telemetry as [`rocky cost`](/reference/commands/administration/#rocky-cost). DuckDB and unconfigured adapters report `null` USD by design; duration and bytes still surface. Configure `[cost]` in `rocky.toml` to get dollar amounts on Databricks / Snowflake.
 
-**Copy step is slow.** Phase 1 uses CTAS, which physically copies bytes for every copy-set table. On large tables this is the dominant cost of `preview create`. Warehouse-native clones (`SHALLOW CLONE` on Databricks, zero-copy `CLONE` on Snowflake) lift this to a metadata operation; they're a planned follow-up but not yet shipped.
+**Copy step is slow.** The copy substrate dispatches per adapter via `WarehouseAdapter::clone_table_for_branch`. Databricks (`SHALLOW CLONE`) and BigQuery (`CREATE TABLE … COPY`) both ship metadata-only overrides as of `engine-v1.19.1` — the per-PR branch table is effectively zero-cost at create time. DuckDB and Snowflake fall through to the portable CTAS default, which physically copies bytes; on large tables this is the dominant cost of `preview create`. Snowflake's native zero-copy `CLONE` will land once a Snowflake consumer drives the integration test against a workspace.
 
 **The diff finds no changes but the model definitely changed.** Check `summary.any_coverage_warning` in the JSON output. If it's `true`, the sampling window missed the changed rows — see the section above.
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -527,7 +527,7 @@ rocky preview create --base main
 }
 ```
 
-`copy_strategy` is `"ctas"` in Phase 1. Warehouse-native clones (`"shallow_clone"` on Databricks, `"zero_copy_clone"` on Snowflake) are a planned follow-up.
+`copy_strategy` reports `"ctas"` for every successful copy regardless of which SQL primitive the adapter actually emitted. As of `engine-v1.19.1`, Databricks uses `SHALLOW CLONE` and BigQuery uses `CREATE TABLE … COPY` (both metadata-only) under the hood; DuckDB and Snowflake fall through to the portable CTAS default. Surfacing the per-adapter strategy in the wire output is a follow-up.
 
 ### `rocky preview diff`
 

--- a/editors/vscode/src/types/generated/preview_create.ts
+++ b/editors/vscode/src/types/generated/preview_create.ts
@@ -55,7 +55,7 @@ export interface PreviewCreateOutput {
 /**
  * One entry in [`PreviewCreateOutput::copy_set`].
  *
- * `copy_strategy` is `"ctas"` in Phase 1 (DuckDB CTAS or generic `CREATE TABLE AS SELECT *`); Phase 5 lifts this to `"shallow_clone"` (Databricks Delta) and `"zero_copy_clone"` (Snowflake) per the adapter's clone capability.
+ * `copy_strategy` reports `"ctas"` for every successful copy regardless of which SQL primitive the adapter emitted under the hood. Databricks uses `SHALLOW CLONE` and BigQuery uses `CREATE TABLE ... COPY` (both metadata-only); DuckDB and Snowflake fall through to the portable CTAS default. Surfacing the per-adapter strategy in the wire output is a follow-up.
  */
 export interface PreviewCopiedModel {
   copy_strategy: string;

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -29,17 +29,20 @@ use crate::output::{
 /// Orchestrate pruned planning on a per-PR branch with copy-from-base for
 /// unchanged upstream.
 ///
-/// **Phase 1.5 scope.** Plans the prune-and-copy decision against the working
-/// DAG, registers the branch in the state store, and **executes** the
-/// copy-from-base step via `CREATE OR REPLACE TABLE ... AS SELECT *` against
-/// the configured warehouse adapter. Per-model `copy_strategy = "ctas"` on
-/// success, `"failed"` on a per-model error (the rest of the copy set still
-/// runs — partial-success surfaces in the output).
+/// Plans the prune-and-copy decision against the working DAG, registers
+/// the branch in the state store, and **executes** the copy-from-base
+/// step via the adapter's `clone_table_for_branch` trait method. The
+/// trait dispatches per adapter: Databricks uses `SHALLOW CLONE`,
+/// BigQuery uses `CREATE TABLE ... COPY` (both metadata-only); DuckDB
+/// and Snowflake fall through to the portable CTAS default. Per-model
+/// `copy_strategy = "ctas"` on success regardless of which underlying
+/// primitive ran, `"failed"` on a per-model error (the rest of the copy
+/// set still runs — partial-success surfaces in the output).
 ///
-/// Auto-invoking the actual run for the prune set is intentionally still
-/// deferred (the GitHub Action in Phase 4 orchestrates). `run_status` is
-/// `"planned"` for the prune set; `"copied"` is implicit for the copy set
-/// via `copy_strategy = "ctas"`.
+/// Auto-invoking the actual run for the prune set is intentionally
+/// still deferred (the GitHub Action orchestrates). `run_status` is
+/// `"planned"` for the prune set; `"copied"` is implicit for the copy
+/// set via `copy_strategy = "ctas"`.
 ///
 /// Steps:
 ///

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3629,10 +3629,12 @@ pub struct PreviewPrunedModel {
 
 /// One entry in [`PreviewCreateOutput::copy_set`].
 ///
-/// `copy_strategy` is `"ctas"` in Phase 1 (DuckDB CTAS or generic
-/// `CREATE TABLE AS SELECT *`); Phase 5 lifts this to `"shallow_clone"`
-/// (Databricks Delta) and `"zero_copy_clone"` (Snowflake) per the
-/// adapter's clone capability.
+/// `copy_strategy` reports `"ctas"` for every successful copy regardless
+/// of which SQL primitive the adapter emitted under the hood. Databricks
+/// uses `SHALLOW CLONE` and BigQuery uses `CREATE TABLE ... COPY` (both
+/// metadata-only); DuckDB and Snowflake fall through to the portable
+/// CTAS default. Surfacing the per-adapter strategy in the wire output
+/// is a follow-up.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PreviewCopiedModel {
     pub model_name: String,

--- a/examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md
+++ b/examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md
@@ -17,7 +17,10 @@ on a single 3-model DuckDB pipeline:
    land in a prefixed schema, leaving `main` untouched.
 2. **Branch-scoped runs** — `rocky run --branch fix-revenue` is the
    persistent analogue of `--shadow`. Warehouse-native zero-copy clones
-   (Delta `SHALLOW CLONE`, Snowflake `CLONE`) slot into the same API.
+   slot into the same API: Databricks emits `SHALLOW CLONE` and BigQuery
+   emits `CREATE TABLE … COPY` (both metadata-only) via the
+   `WarehouseAdapter::clone_table_for_branch` trait method. DuckDB and
+   Snowflake fall through to the portable CTAS default.
 3. **Replay** — `rocky replay latest` reads `RunRecord`s back from the
    state store: every model, SQL hash, row count, timings, per-model
    status. The reproducibility artefact for *"what exactly ran?"*.

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
@@ -42,9 +42,13 @@ without rewriting dbt's compiler:
 - **Column-level pruning > model-level.** Compiler IR knows column-level
   dependencies. A column added to an unused tail of a wide table prunes
   to zero downstream — Smart Run has to re-run the whole subtree.
-- **Branches are the substrate.** Today schema-prefix branches; tomorrow
-  Delta `SHALLOW CLONE` / Snowflake zero-copy `CLONE` slot into the same
-  API at Phase 5 (strict dominance over `COPY` once that lands).
+- **Branches are the substrate.** Schema-prefix branches everywhere;
+  warehouse-native clones slot into the same API via the
+  `WarehouseAdapter::clone_table_for_branch` trait method — Databricks
+  `SHALLOW CLONE` and BigQuery `CREATE TABLE … COPY` (both metadata-only)
+  are live as of `engine-v1.19.1`. DuckDB and Snowflake use the portable
+  CTAS default; Snowflake's native `CLONE` lands when a Snowflake
+  consumer drives the integration test.
 - **Compile-time change detection > git-diff alone.** `rocky ci-diff`
   already does git-diff between refs and produces a structural diff;
   the next step — *"this textual change is type-equivalent and produces
@@ -61,11 +65,10 @@ Compare:
 | Property | Fivetran Smart Run | `rocky preview` |
 |---|---|---|
 | Pruning granularity | Model-level | Column-level (compiler IR) |
-| Copy substrate (Phase 1) | `COPY` | CTAS / `COPY` |
-| Copy substrate (Phase 5) | — | `SHALLOW CLONE` / zero-copy `CLONE` |
+| Copy substrate | `COPY` | Per-adapter dispatch: Databricks `SHALLOW CLONE`, BigQuery `CREATE TABLE … COPY` (metadata-only); DuckDB / Snowflake CTAS |
 | Cost delta | Not surfaced | First-class output |
 | Data diff | Not surfaced | First-class output |
-| PR comment | Not described | First-class output (Phase 4) |
+| PR comment | Not described | First-class output |
 
 ## Layout
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_create_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_create_schema.py
@@ -10,7 +10,7 @@ class PreviewCopiedModel(BaseModel):
     """
     One entry in [`PreviewCreateOutput::copy_set`].
 
-    `copy_strategy` is `"ctas"` in Phase 1 (DuckDB CTAS or generic `CREATE TABLE AS SELECT *`); Phase 5 lifts this to `"shallow_clone"` (Databricks Delta) and `"zero_copy_clone"` (Snowflake) per the adapter's clone capability.
+    `copy_strategy` reports `"ctas"` for every successful copy regardless of which SQL primitive the adapter emitted under the hood. Databricks uses `SHALLOW CLONE` and BigQuery uses `CREATE TABLE ... COPY` (both metadata-only); DuckDB and Snowflake fall through to the portable CTAS default. Surfacing the per-adapter strategy in the wire output is a follow-up.
     """
 
     copy_strategy: str

--- a/schemas/preview_create.schema.json
+++ b/schemas/preview_create.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "PreviewCopiedModel": {
-      "description": "One entry in [`PreviewCreateOutput::copy_set`].\n\n`copy_strategy` is `\"ctas\"` in Phase 1 (DuckDB CTAS or generic `CREATE TABLE AS SELECT *`); Phase 5 lifts this to `\"shallow_clone\"` (Databricks Delta) and `\"zero_copy_clone\"` (Snowflake) per the adapter's clone capability.",
+      "description": "One entry in [`PreviewCreateOutput::copy_set`].\n\n`copy_strategy` reports `\"ctas\"` for every successful copy regardless of which SQL primitive the adapter emitted under the hood. Databricks uses `SHALLOW CLONE` and BigQuery uses `CREATE TABLE ... COPY` (both metadata-only); DuckDB and Snowflake fall through to the portable CTAS default. Surfacing the per-adapter strategy in the wire output is a follow-up.",
       "properties": {
         "copy_strategy": {
           "type": "string"


### PR DESCRIPTION
## Summary

Three doc surfaces had stale "planned follow-up / not yet shipped" language for warehouse-native clones, which actually shipped in `engine-v1.19.1` (Databricks `SHALLOW CLONE` + BigQuery `CREATE TABLE … COPY`, both metadata-only). Snowflake stays on the CTAS default until a Snowflake consumer drives the integration test.

### Changed

- **`docs/src/content/docs/concepts/preview-internals.md`** — rewrote "Copy substrate today and tomorrow" as "Copy substrate" with per-adapter dispatch list; updated the Smart Run comparison table (single "Copy substrate" row instead of "today / planned" split).
- **`docs/src/content/docs/guides/preview-a-pr.md`** — "Copy step is slow" troubleshooting entry now says native clones ship in v1.19.1 for Databricks + BigQuery; flags the per-adapter behaviour explicitly.
- **`docs/src/content/docs/reference/commands/modeling.md`** — clarified that `copy_strategy` reports `"ctas"` for every successful copy regardless of which SQL primitive the adapter emitted under the hood. Surfacing the per-adapter strategy in the wire output is a follow-up.
- **`engine/crates/rocky-cli/src/output.rs`** — matched doc-comment on `PreviewCopiedModel` to the docs (this is the `JsonSchema`-deriving struct; description rides through codegen).
- **`engine/crates/rocky-cli/src/commands/preview.rs`** — function-level doc-comment on `run_preview_create` updated for the same reason.
- **`examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md`** — branches-as-substrate bullet now describes the per-adapter dispatch.
- **`examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md`** — branches bullet + Smart Run comparison table updated.

### Codegen-driven schema changes (description-text only)

- `schemas/preview_create.schema.json`
- `editors/vscode/src/types/generated/preview_create.ts`
- `integrations/dagster/src/dagster_rocky/types_generated/preview_create_schema.py`

Pure description drift; no field added / removed / renamed.

## Test plan

- [x] `just codegen` clean
- [x] No version bump needed (engine release just shipped; docs ride along)
- [ ] Reviewer eyeball on the doc text (tone consistent with the rest of `preview-internals.md`)