### PR TITLE
ci(engine-release): install NASM on Windows for aws-lc-sys

### DIFF
--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -77,6 +77,16 @@ jobs:
           workspaces: engine
           key: release-${{ matrix.target }}
 
+      # Windows: install NASM. `aws-lc-sys` (transitive dep of `jsonwebtoken`
+      # via the `aws_lc_rs` feature flag enabled in the workspace toml)
+      # builds AWS-LC's optimized crypto kernels from `.asm` sources on
+      # Windows and panics with "NASM command not found" without it. The
+      # macOS / Linux toolchains fall back to a YASM-equivalent assembler
+      # that ships with the runner image.
+      - name: Install NASM (Windows only)
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
       # Linux: free disk space and add swap (DuckDB C++ is memory-hungry)
       - name: Free disk space and add swap
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

`engine-v1.19.1`'s 5-platform release matrix failed on `x86_64-pc-windows-msvc` because `aws-lc-sys` (transitive dep of `jsonwebtoken` via the `aws_lc_rs` feature flag enabled in [#310](https://github.com/rocky-data/rocky/pull/310)) needs NASM to assemble AWS-LC's optimized crypto kernels on Windows. The runner image doesn't ship NASM by default — the macOS / Linux toolchains fall back to a YASM-equivalent that does ship.

Specific failure from the v1.19.1 release run:

```
cargo:warning=NASM command not found or failed to execute.
thread 'main' panicked at aws-lc-sys-0.39.1/builder/nasm_builder.rs:138:13:
NASM command not found! Build cannot continue.
```

## Fix

Adds an `ilammy/setup-nasm@v1` step to `.github/workflows/engine-release.yml`, gated on `runner.os == 'Windows'`, placed before the cargo build. Trivial; well-trodden pattern for `aws-lc-sys` on Windows.

## After this merges

Force-update the `engine-v1.19.1` tag to point at the merge commit so the existing tag's release workflow re-runs from a CI configuration that knows how to build Windows. The macOS / Linux archives already on the `engine-v1.19.1` release stay byte-identical on the rebuild; only the missing Windows archives + SHA256SUMS get added.

The blast radius for force-updating the tag is essentially zero in this case — no consumer can have resolved `engine-v1.19.1` to a Windows install yet because the Windows archive doesn't exist; the install scripts (`engine/install.sh`, `install.ps1`) 404 today.

## Test plan

- [x] Workflow YAML lints clean
- [ ] After merge: re-tag `engine-v1.19.1` at the merge commit → workflow re-runs → all 5 platform archives + SHA256SUMS land on the existing GitHub Release