### PR TITLE
feat(engine): add --catalog scope to rocky compact and rocky archive

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.9.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.9.1",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/types/generated/archive.ts
+++ b/editors/vscode/src/types/generated/archive.ts
@@ -7,14 +7,28 @@
 
 /**
  * JSON output for `rocky archive`.
+ *
+ * Mirrors [`CompactOutput`]: single-model invocations populate `model` and leave the catalog-scope fields absent; `--catalog` invocations populate `catalog`, `scope = "catalog"`, `tables`, and `totals`. The flat `statements` list carries every statement across every table.
  */
 export interface ArchiveOutput {
+  /**
+   * Set when invoked as `rocky archive --catalog <name>`.
+   */
+  catalog?: string | null;
   command: string;
   dry_run: boolean;
   model?: string | null;
   older_than: string;
   older_than_days: number;
+  /**
+   * `"catalog"` for the catalog-scoped path; absent for single-model invocations.
+   */
+  scope?: string | null;
   statements: NamedStatement[];
+  tables?: {
+    [k: string]: ArchiveTableEntry;
+  } | null;
+  totals?: ArchiveTotals | null;
   version: string;
   [k: string]: unknown;
 }
@@ -24,5 +38,20 @@ export interface ArchiveOutput {
 export interface NamedStatement {
   purpose: string;
   sql: string;
+  [k: string]: unknown;
+}
+/**
+ * Per-table archive plan inside a `--catalog` envelope.
+ */
+export interface ArchiveTableEntry {
+  statements: NamedStatement[];
+  [k: string]: unknown;
+}
+/**
+ * Aggregate counts over a `rocky archive --catalog` invocation.
+ */
+export interface ArchiveTotals {
+  statement_count: number;
+  table_count: number;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/types/generated/compact.ts
+++ b/editors/vscode/src/types/generated/compact.ts
@@ -7,13 +7,41 @@
 
 /**
  * JSON output for `rocky compact`.
+ *
+ * Two shapes share this struct:
+ *
+ * - **Single-model (`rocky compact <fqn>`)**: `model` is set; `scope`, `catalog`, `tables`, and `totals` are absent. Byte-stable with envelopes that predate the catalog-scope flag. - **Catalog scope (`rocky compact --catalog <name>`)**: `model` is absent, `scope = "catalog"`, `catalog` is set, `tables` keys per-FQN statement bundles, and `totals` carries aggregate counts. The flat `statements` field still carries every SQL statement across all tables for consumers that just iterate it.
  */
 export interface CompactOutput {
+  /**
+   * Set when invoked as `rocky compact --catalog <name>`. Stores the catalog identifier as resolved (lowercased to match the managed-table resolver's normalization).
+   */
+  catalog?: string | null;
   command: string;
   dry_run: boolean;
-  model: string;
+  /**
+   * Set when invoked as `rocky compact <fqn>`.
+   */
+  model?: string | null;
+  /**
+   * `"catalog"` for the catalog-scoped path; absent for single-model invocations to keep their envelope byte-stable.
+   */
+  scope?: string | null;
+  /**
+   * Flat list of every SQL statement across every table. Single-model invocations have one bundle here; `--catalog` invocations have the concatenation of every per-table bundle (in the same order as `tables`'s key iteration order).
+   */
   statements: NamedStatement[];
+  /**
+   * Per-table breakdown, keyed by fully-qualified table name. Present only on `--catalog` invocations.
+   */
+  tables?: {
+    [k: string]: CompactTableEntry;
+  } | null;
   target_size_mb: number;
+  /**
+   * Aggregate counts across the catalog. Present only on `--catalog` invocations.
+   */
+  totals?: CompactTotals | null;
   version: string;
   [k: string]: unknown;
 }
@@ -23,5 +51,20 @@ export interface CompactOutput {
 export interface NamedStatement {
   purpose: string;
   sql: string;
+  [k: string]: unknown;
+}
+/**
+ * Per-table compaction plan inside a `--catalog` envelope.
+ */
+export interface CompactTableEntry {
+  statements: NamedStatement[];
+  [k: string]: unknown;
+}
+/**
+ * Aggregate counts over a `rocky compact --catalog` invocation.
+ */
+export interface CompactTotals {
+  statement_count: number;
+  table_count: number;
   [k: string]: unknown;
 }

--- a/engine/.claude/skills/rocky/SKILL.md
+++ b/engine/.claude/skills/rocky/SKILL.md
@@ -35,8 +35,8 @@ Concise cheat sheet for the `rocky` binary. For full detail:
 | `rocky drift -c rocky.toml` | Schema drift report |
 | `rocky optimize -c rocky.toml` | Cost model + materialization-strategy recommendations |
 | `rocky compare` | Shadow vs production comparison |
-| `rocky compact` | Generate OPTIMIZE/VACUUM SQL plan |
-| `rocky archive` | DELETE + VACUUM SQL plan |
+| `rocky compact <fqn>` / `rocky compact --catalog <name>` | OPTIMIZE/VACUUM SQL plan (single table or every Rocky-managed table in a catalog) |
+| `rocky archive --older-than <span>` (`<fqn>` / `--catalog <name>`) | DELETE + VACUUM SQL plan (single table or catalog-wide) |
 | `rocky profile-storage` | Column encoding recommendations |
 | `rocky import-dbt <path>` | dbt → Rocky migration |
 | `rocky validate-migration` | Validate a dbt → Rocky migration |

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky compact --catalog <name>` and `rocky archive --catalog <name>`**. New scope flag that resolves the set of Rocky-managed tables in a single catalog from the pipeline config (replication discovery or transformation model files — no warehouse round trip) and aggregates per-table OPTIMIZE/VACUUM (compact) or DELETE/VACUUM (archive) SQL into one JSON envelope. Replaces the consumer-side `SHOW SCHEMAS`/`SHOW TABLES` enumeration that multi-catalog deployments otherwise have to reimplement to drive a weekly maintenance sweep — one subprocess call per catalog instead of one per table. Mutually exclusive with `--model` (and, for compact, `--measure-dedup`). Empty matches error with the available catalogs listed so consumer typos don't silently turn into no-ops.
+- **`CompactOutput` / `ArchiveOutput` carry per-catalog aggregation fields**. New optional `catalog`, `scope`, `tables` (per-FQN statement bundles), and `totals` (`table_count` + `statement_count`) fields populated only on `--catalog` invocations. Single-model envelopes are unchanged (the new fields are `skip_serializing_if = "Option::is_none"`); the flat top-level `statements` list still carries every SQL statement across every table for consumers that just iterate it.
+
+### Changed
+
+- **`CompactOutput.model` is now optional**. Was required (`String`); now `Option<String>` so the catalog-scope path can omit it. JSON schema relaxes from required to optional; existing single-model JSON output is byte-stable. Pydantic + TypeScript bindings regenerated accordingly.
+- **`rocky-cli/src/scope.rs`**. The managed-table resolver previously private to `commands/compact.rs` (`resolve_managed_tables`, `resolve_replication_managed_tables`, `resolve_transformation_managed_tables`, `managed_catalog_set`) lifted into a shared module so both `compact` (`--measure-dedup`, `--catalog`) and `archive` (`--catalog`) reuse one implementation. Pure refactor for the dedup path — its tests come along.
+
 ## [1.19.2] — 2026-04-30
 
 CI-only re-cut of `1.19.1`. Source code is identical to `1.19.1`; binary semantics unchanged. Adds the missing Windows archive (and the `SHA256SUMS` checksums file gated on it) that the `1.19.1` matrix run failed to produce because `aws-lc-sys` (transitive dep of `jsonwebtoken` via the `aws_lc_rs` feature flag) needs NASM on the Windows runner to assemble AWS-LC's optimized crypto kernels — the macOS / Linux toolchains fall back to a YASM-equivalent that ships by default. The release workflow now installs NASM on the Windows job before `cargo build`. macOS / Linux v1.19.1 binaries are correct and stay valid; this release just fills in the cross-platform set.

--- a/engine/crates/rocky-cli/src/commands/archive.rs
+++ b/engine/crates/rocky-cli/src/commands/archive.rs
@@ -1,8 +1,12 @@
 //! `rocky archive` — archive old data partitions.
 
+use std::collections::BTreeMap;
+use std::path::Path;
+
 use anyhow::Result;
 
-use crate::output::{ArchiveOutput, NamedStatement, print_json};
+use crate::output::{ArchiveOutput, ArchiveTableEntry, ArchiveTotals, NamedStatement, print_json};
+use crate::scope::resolve_managed_tables_in_catalog;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -29,10 +33,14 @@ pub fn run_archive(
             version: VERSION.to_string(),
             command: "archive".to_string(),
             model: model.map(String::from),
+            catalog: None,
+            scope: None,
             older_than: older_than.to_string(),
             older_than_days: days,
             dry_run,
             statements: typed_statements,
+            tables: None,
+            totals: None,
         };
         print_json(&output)?;
     } else {
@@ -48,6 +56,84 @@ pub fn run_archive(
         for (purpose, sql) in &statements {
             println!("-- {purpose}");
             println!("{sql};");
+            println!();
+        }
+
+        if dry_run {
+            println!("(dry run: no statements executed)");
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `rocky archive --catalog <name>` — generate archive SQL for
+/// every Rocky-managed table in the catalog.
+///
+/// Mirrors `rocky compact --catalog`: resolves the managed-table set via
+/// [`resolve_managed_tables_in_catalog`] (config-only, no warehouse round
+/// trip), then templates `DELETE` / `VACUUM` per table and aggregates
+/// into a single envelope.
+pub async fn run_archive_catalog(
+    config_path: &Path,
+    catalog: &str,
+    older_than: &str,
+    dry_run: bool,
+    output_json: bool,
+) -> Result<()> {
+    let days = parse_duration_days(older_than)?;
+    let scope = resolve_managed_tables_in_catalog(config_path, catalog).await?;
+
+    let mut flat_statements: Vec<NamedStatement> = Vec::new();
+    let mut per_table: BTreeMap<String, ArchiveTableEntry> = BTreeMap::new();
+
+    for fqn in &scope.tables {
+        let stmts = generate_archive_sql(Some(fqn), days);
+        let typed: Vec<NamedStatement> = stmts
+            .into_iter()
+            .map(|(purpose, sql)| NamedStatement { purpose, sql })
+            .collect();
+        flat_statements.extend(typed.iter().cloned());
+        per_table.insert(fqn.clone(), ArchiveTableEntry { statements: typed });
+    }
+
+    let totals = ArchiveTotals {
+        table_count: scope.tables.len(),
+        statement_count: flat_statements.len(),
+    };
+
+    if output_json {
+        let output = ArchiveOutput {
+            version: VERSION.to_string(),
+            command: "archive".to_string(),
+            model: None,
+            catalog: Some(scope.catalog.clone()),
+            scope: Some("catalog".to_string()),
+            older_than: older_than.to_string(),
+            older_than_days: days,
+            dry_run,
+            statements: flat_statements,
+            tables: Some(per_table),
+            totals: Some(totals),
+        };
+        print_json(&output)?;
+    } else {
+        println!(
+            "Archive plan for catalog '{}' ({} tables, older than {} = {} days){}",
+            scope.catalog,
+            scope.tables.len(),
+            older_than,
+            days,
+            if dry_run { " [DRY RUN]" } else { "" }
+        );
+        println!();
+
+        for (fqn, entry) in &per_table {
+            println!("-- {fqn}");
+            for s in &entry.statements {
+                println!("-- {}", s.purpose);
+                println!("{};", s.sql);
+            }
             println!();
         }
 

--- a/engine/crates/rocky-cli/src/commands/compact.rs
+++ b/engine/crates/rocky-cli/src/commands/compact.rs
@@ -4,7 +4,7 @@
 //! dedup-measurement experiment (`run_measure_dedup`). See
 //! `plans/rocky-storage-layer-0.md` for the scope + decision gate.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Instant;
 
@@ -17,10 +17,13 @@ use rocky_core::ir::TableRef;
 use rocky_core::traits::{QueryResult, WarehouseAdapter};
 
 use crate::output::{
-    ByteCalibration, CompactDedupOutput, CompactOutput, DedupPair, DedupSummary, NamedStatement,
-    TableDedupContribution, print_json,
+    ByteCalibration, CompactDedupOutput, CompactOutput, CompactTableEntry, CompactTotals,
+    DedupPair, DedupSummary, NamedStatement, TableDedupContribution, print_json,
 };
 use crate::registry::{AdapterRegistry, resolve_pipeline};
+use crate::scope::{
+    managed_catalog_set, resolve_managed_tables, resolve_managed_tables_in_catalog,
+};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -54,10 +57,14 @@ pub fn run_compact(
         let output = CompactOutput {
             version: VERSION.to_string(),
             command: "compact".to_string(),
-            model: model.to_string(),
+            model: Some(model.to_string()),
+            catalog: None,
+            scope: None,
             dry_run,
             target_size_mb: target_mb,
             statements: typed_statements,
+            tables: None,
+            totals: None,
         };
         print_json(&output)?;
     } else {
@@ -70,6 +77,99 @@ pub fn run_compact(
         for (purpose, sql) in &statements {
             println!("-- {purpose}");
             println!("{sql};");
+            println!();
+        }
+
+        if dry_run {
+            println!("(dry run: no statements executed)");
+        }
+    }
+
+    Ok(())
+}
+
+/// Execute `rocky compact --catalog <name>` — generate compaction SQL
+/// for every Rocky-managed table in the catalog.
+///
+/// Resolves the managed-table set via [`resolve_managed_tables_in_catalog`]
+/// (config-only — no warehouse round trip), then templates `OPTIMIZE` /
+/// `VACUUM` per table via [`generate_compact_sql`], aggregating into a
+/// single envelope. Per-table failures aren't a concern here: the SQL
+/// generator is pure, so the only failure paths are pre-loop (config
+/// load, pipeline resolution, empty catalog) and surface as a hard
+/// error rather than a partial run.
+///
+/// The flat `statements` list and the per-table `tables` map carry the
+/// same information in two shapes — consumers that just iterate SQL
+/// keep working; consumers that want per-table attribution read `tables`.
+pub async fn run_compact_catalog(
+    config_path: &Path,
+    catalog: &str,
+    target_size: Option<&str>,
+    dry_run: bool,
+    output_json: bool,
+) -> Result<()> {
+    let target_mb = target_size
+        .map(|s| {
+            s.trim_end_matches("MB")
+                .trim_end_matches("mb")
+                .parse::<u64>()
+        })
+        .transpose()
+        .map_err(|e| anyhow!("invalid --target-size: {e}"))?
+        .unwrap_or(256);
+
+    let scope = resolve_managed_tables_in_catalog(config_path, catalog).await?;
+
+    let mut flat_statements: Vec<NamedStatement> = Vec::new();
+    let mut per_table: std::collections::BTreeMap<String, CompactTableEntry> =
+        std::collections::BTreeMap::new();
+
+    for fqn in &scope.tables {
+        let stmts = generate_compact_sql(fqn, target_mb);
+        let typed: Vec<NamedStatement> = stmts
+            .into_iter()
+            .map(|(purpose, sql)| NamedStatement { purpose, sql })
+            .collect();
+        flat_statements.extend(typed.iter().cloned());
+        per_table.insert(fqn.clone(), CompactTableEntry { statements: typed });
+    }
+
+    let totals = CompactTotals {
+        table_count: scope.tables.len(),
+        statement_count: flat_statements.len(),
+    };
+
+    if output_json {
+        let output = CompactOutput {
+            version: VERSION.to_string(),
+            command: "compact".to_string(),
+            model: None,
+            catalog: Some(scope.catalog.clone()),
+            scope: Some("catalog".to_string()),
+            dry_run,
+            target_size_mb: target_mb,
+            statements: flat_statements,
+            tables: Some(per_table),
+            totals: Some(totals),
+        };
+        print_json(&output)?;
+    } else {
+        println!(
+            "Compaction plan for catalog '{}' ({} tables, target {}MB){}",
+            scope.catalog,
+            scope.tables.len(),
+            target_mb,
+            if dry_run { " [DRY RUN]" } else { "" }
+        );
+        println!();
+
+        for (fqn, entry) in &per_table {
+            println!("-- {fqn}");
+            for s in &entry.statements {
+                println!("-- {}", s.purpose);
+                println!("{};", s.sql);
+            }
             println!();
         }
 
@@ -425,169 +525,6 @@ pub(crate) async fn compute_measure_dedup(
     Ok(output)
 }
 
-/// Resolve the set of table names that Rocky manages for a given pipeline.
-///
-/// Returns `Ok(Some(set))` with lowercase fully-qualified table names
-/// (`catalog.schema.table`) when the pipeline type supports resolution,
-/// or `Ok(None)` when resolution is not possible (unsupported pipeline
-/// type, no discovery adapter configured, etc.). Callers should fall
-/// back to scanning all warehouse tables when `None` is returned.
-///
-/// ## Pipeline types
-///
-/// - **Replication**: discovers connectors via the discovery adapter,
-///   parses each schema through the source `schema_pattern`, resolves
-///   target catalog/schema from the target templates, and collects
-///   `catalog.schema.table` for every discovered table.
-/// - **Transformation**: loads model files from the models directory
-///   (same walk as `rocky list models`) and extracts the `target`
-///   coordinates from each model's TOML sidecar.
-/// - **Other types** (quality, snapshot, load): not yet supported —
-///   returns `Ok(None)`.
-async fn resolve_managed_tables(
-    config: &rocky_core::config::RockyConfig,
-    pipeline_name: &str,
-    pipeline: &rocky_core::config::PipelineConfig,
-    registry: &AdapterRegistry,
-    config_path: &Path,
-) -> Result<Option<HashSet<String>>> {
-    match pipeline {
-        rocky_core::config::PipelineConfig::Replication(repl) => {
-            resolve_replication_managed_tables(repl, registry, config).await
-        }
-        rocky_core::config::PipelineConfig::Transformation(tx) => {
-            resolve_transformation_managed_tables(tx, config_path)
-        }
-        _ => {
-            tracing::info!(
-                pipeline = pipeline_name,
-                pipeline_type = pipeline.pipeline_type_str(),
-                "managed-table resolution not supported for this pipeline type"
-            );
-            Ok(None)
-        }
-    }
-}
-
-/// Resolve managed tables for a replication pipeline by discovering
-/// connectors and resolving each table through the schema pattern
-/// templates.
-async fn resolve_replication_managed_tables(
-    repl: &rocky_core::config::ReplicationPipelineConfig,
-    registry: &AdapterRegistry,
-    _config: &rocky_core::config::RockyConfig,
-) -> Result<Option<HashSet<String>>> {
-    let pattern = repl
-        .schema_pattern()
-        .map_err(|e| anyhow!("failed to parse schema pattern: {e}"))?;
-
-    // Discovery adapter is required to enumerate source connectors.
-    let disc_config = match repl.source.discovery.as_ref() {
-        Some(d) => d,
-        None => {
-            tracing::warn!(
-                "no discovery adapter configured for this replication pipeline; \
-                 cannot resolve managed tables"
-            );
-            return Ok(None);
-        }
-    };
-    let discovery_adapter = registry.discovery_adapter(&disc_config.adapter)?;
-
-    let connectors = discovery_adapter
-        .discover(&pattern.prefix)
-        .await
-        .map_err(|e| anyhow!("discovery failed: {e}"))?
-        .connectors;
-
-    let target_sep = repl
-        .target
-        .separator
-        .as_deref()
-        .unwrap_or(&pattern.separator);
-
-    let mut managed = HashSet::new();
-    for conn in &connectors {
-        let parsed = match pattern.parse(&conn.schema) {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-
-        let target_catalog = parsed.resolve_template(&repl.target.catalog_template, target_sep);
-        let target_schema = parsed.resolve_template(&repl.target.schema_template, target_sep);
-
-        for table in &conn.tables {
-            let full_name = format!("{}.{}.{}", target_catalog, target_schema, table.name);
-            managed.insert(full_name.to_lowercase());
-        }
-    }
-
-    tracing::info!(
-        managed_count = managed.len(),
-        "resolved managed tables from replication pipeline"
-    );
-    Ok(Some(managed))
-}
-
-/// Resolve managed tables for a transformation pipeline by loading
-/// model files and extracting their target coordinates.
-fn resolve_transformation_managed_tables(
-    tx: &rocky_core::config::TransformationPipelineConfig,
-    config_path: &Path,
-) -> Result<Option<HashSet<String>>> {
-    // Models directory is relative to the config file's parent.
-    let project_root = config_path.parent().unwrap_or(Path::new("."));
-
-    // The `models` field is a glob like "models/**" — extract the base
-    // directory (everything before any glob wildcard).
-    let models_base = tx
-        .models
-        .split(&['*', '?', '['][..])
-        .next()
-        .unwrap_or("models");
-    let models_dir = project_root.join(models_base.trim_end_matches('/'));
-
-    if !models_dir.exists() {
-        tracing::warn!(
-            models_dir = %models_dir.display(),
-            "models directory does not exist; cannot resolve managed tables"
-        );
-        return Ok(None);
-    }
-
-    // Load models the same way `rocky list models` does: top-level +
-    // immediate subdirectories.
-    let mut all_models = rocky_core::models::load_models_from_dir(&models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(&models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all_models.extend(sub);
-                }
-            }
-        }
-    }
-
-    let mut managed = HashSet::new();
-    for model in &all_models {
-        let full_name = format!(
-            "{}.{}.{}",
-            model.config.target.catalog, model.config.target.schema, model.config.target.table
-        );
-        managed.insert(full_name.to_lowercase());
-    }
-
-    tracing::info!(
-        managed_count = managed.len(),
-        "resolved managed tables from transformation pipeline"
-    );
-    Ok(Some(managed))
-}
-
 /// Enumerate non-system tables visible to the warehouse adapter via
 /// `information_schema.tables`.
 ///
@@ -701,27 +638,6 @@ fn collect_table_rows(
         });
     }
     Ok(())
-}
-
-/// Extract the distinct set of catalog identifiers from a managed-table
-/// set built by `resolve_managed_tables`.
-///
-/// The set is keyed on fully-qualified lowercase names (`catalog.schema.table`)
-/// assembled via `format!("{}.{}.{}", ...)` in the resolver, so splitting
-/// on the first `.` yields the catalog component. Names without a dot
-/// are skipped (defensive — the resolver always emits three components).
-fn managed_catalog_set(managed: &HashSet<String>) -> Vec<String> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut out: Vec<String> = Vec::new();
-    for full in managed {
-        if let Some((catalog, _rest)) = full.split_once('.') {
-            if seen.insert(catalog.to_string()) {
-                out.push(catalog.to_string());
-            }
-        }
-    }
-    out.sort();
-    out
 }
 
 /// Execute one whole-table checksum SQL against the warehouse and parse
@@ -1233,28 +1149,6 @@ mod tests {
         assert!(stmts[0].1.contains("512MB"));
     }
 
-    #[test]
-    fn managed_catalog_set_extracts_distinct_catalogs() {
-        let mut managed = HashSet::new();
-        managed.insert("acme.raw__shopify.orders".to_string());
-        managed.insert("acme.raw__shopify.events".to_string());
-        managed.insert("beta.raw__stripe.charges".to_string());
-        managed.insert("acme.raw__stripe.customers".to_string());
-
-        let catalogs = managed_catalog_set(&managed);
-        assert_eq!(catalogs, vec!["acme".to_string(), "beta".to_string()]);
-    }
-
-    #[test]
-    fn managed_catalog_set_skips_names_without_catalog_prefix() {
-        let mut managed = HashSet::new();
-        managed.insert("acme.schema.table".to_string());
-        managed.insert("schema_only".to_string()); // defensive: no `.`
-
-        let catalogs = managed_catalog_set(&managed);
-        assert_eq!(catalogs, vec!["acme".to_string()]);
-    }
-
     /// E2E test for `compute_measure_dedup` against an ephemeral DuckDB.
     ///
     /// Sets up a temp database with three tables — two identical
@@ -1517,62 +1411,6 @@ schema_template = "staging__{{source}}"
         assert_eq!(output_all.tables_scanned, 4);
 
         Ok(())
-    }
-
-    /// Test that `resolve_transformation_managed_tables` correctly
-    /// extracts target table names from model sidecar files.
-    #[test]
-    fn resolve_transformation_managed_tables_extracts_targets() {
-        let dir = tempfile::tempdir().unwrap();
-        let models_dir = dir.path().join("models");
-        std::fs::create_dir(&models_dir).unwrap();
-
-        // Model A: target = warehouse.staging.orders
-        std::fs::write(
-            models_dir.join("orders.toml"),
-            r#"
-name = "orders"
-[target]
-catalog = "warehouse"
-schema = "staging"
-table = "orders"
-"#,
-        )
-        .unwrap();
-        std::fs::write(models_dir.join("orders.sql"), "SELECT 1").unwrap();
-
-        // Model B: target = warehouse.marts.customers
-        std::fs::write(
-            models_dir.join("customers.toml"),
-            r#"
-name = "customers"
-[target]
-catalog = "warehouse"
-schema = "marts"
-table = "customers"
-"#,
-        )
-        .unwrap();
-        std::fs::write(models_dir.join("customers.sql"), "SELECT 1").unwrap();
-
-        let tx = rocky_core::config::TransformationPipelineConfig {
-            models: "models/**".to_string(),
-            target: rocky_core::config::TransformationTargetConfig {
-                adapter: "default".to_string(),
-                governance: Default::default(),
-            },
-            checks: Default::default(),
-            execution: Default::default(),
-            depends_on: vec![],
-        };
-
-        let config_path = dir.path().join("rocky.toml");
-        let result = resolve_transformation_managed_tables(&tx, &config_path).unwrap();
-        let managed = result.expect("should resolve some managed tables");
-
-        assert_eq!(managed.len(), 2);
-        assert!(managed.contains("warehouse.staging.orders"));
-        assert!(managed.contains("warehouse.marts.customers"));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -55,7 +55,7 @@ mod validate_migration;
 mod watch;
 
 pub use ai::{run_ai, run_ai_explain, run_ai_sync, run_ai_test};
-pub use archive::run_archive;
+pub use archive::{run_archive, run_archive_catalog};
 #[cfg(feature = "duckdb")]
 pub use bench::run_bench;
 pub use branch::{
@@ -64,7 +64,7 @@ pub use branch::{
 #[cfg(feature = "duckdb")]
 pub use ci::run_ci;
 pub use ci_diff::run_ci_diff;
-pub use compact::{run_compact, run_measure_dedup};
+pub use compact::{run_compact, run_compact_catalog, run_measure_dedup};
 pub use compare::compare;
 pub use compile::run_compile;
 pub use compliance::run_compliance;

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -5,4 +5,5 @@ pub mod output;
 pub mod pipes;
 pub mod registry;
 pub(crate) mod schema_cache_writer;
+pub(crate) mod scope;
 pub(crate) mod source_schemas;

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1598,34 +1598,110 @@ pub struct TableCompareResult {
 }
 
 /// JSON output for `rocky compact`.
+///
+/// Two shapes share this struct:
+///
+/// - **Single-model (`rocky compact <fqn>`)**: `model` is set; `scope`,
+///   `catalog`, `tables`, and `totals` are absent. Byte-stable with
+///   envelopes that predate the catalog-scope flag.
+/// - **Catalog scope (`rocky compact --catalog <name>`)**: `model` is
+///   absent, `scope = "catalog"`, `catalog` is set, `tables` keys per-FQN
+///   statement bundles, and `totals` carries aggregate counts. The flat
+///   `statements` field still carries every SQL statement across all
+///   tables for consumers that just iterate it.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct CompactOutput {
     pub version: String,
     pub command: String,
-    pub model: String,
+    /// Set when invoked as `rocky compact <fqn>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Set when invoked as `rocky compact --catalog <name>`. Stores the
+    /// catalog identifier as resolved (lowercased to match the
+    /// managed-table resolver's normalization).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<String>,
+    /// `"catalog"` for the catalog-scoped path; absent for single-model
+    /// invocations to keep their envelope byte-stable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
     pub dry_run: bool,
     pub target_size_mb: u64,
+    /// Flat list of every SQL statement across every table. Single-model
+    /// invocations have one bundle here; `--catalog` invocations have
+    /// the concatenation of every per-table bundle (in the same order
+    /// as `tables`'s key iteration order).
+    pub statements: Vec<NamedStatement>,
+    /// Per-table breakdown, keyed by fully-qualified table name. Present
+    /// only on `--catalog` invocations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tables: Option<BTreeMap<String, CompactTableEntry>>,
+    /// Aggregate counts across the catalog. Present only on `--catalog`
+    /// invocations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub totals: Option<CompactTotals>,
+}
+
+/// Per-table compaction plan inside a `--catalog` envelope.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CompactTableEntry {
     pub statements: Vec<NamedStatement>,
 }
 
-/// Named SQL statement (purpose + sql), reused by compact and archive.
+/// Aggregate counts over a `rocky compact --catalog` invocation.
 #[derive(Debug, Serialize, JsonSchema)]
+pub struct CompactTotals {
+    pub table_count: usize,
+    pub statement_count: usize,
+}
+
+/// Named SQL statement (purpose + sql), reused by compact and archive.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct NamedStatement {
     pub purpose: String,
     pub sql: String,
 }
 
 /// JSON output for `rocky archive`.
+///
+/// Mirrors [`CompactOutput`]: single-model invocations populate `model`
+/// and leave the catalog-scope fields absent; `--catalog` invocations
+/// populate `catalog`, `scope = "catalog"`, `tables`, and `totals`. The
+/// flat `statements` list carries every statement across every table.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ArchiveOutput {
     pub version: String,
     pub command: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Set when invoked as `rocky archive --catalog <name>`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<String>,
+    /// `"catalog"` for the catalog-scoped path; absent for single-model
+    /// invocations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
     pub older_than: String,
     pub older_than_days: u64,
     pub dry_run: bool,
     pub statements: Vec<NamedStatement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tables: Option<BTreeMap<String, ArchiveTableEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub totals: Option<ArchiveTotals>,
+}
+
+/// Per-table archive plan inside a `--catalog` envelope.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ArchiveTableEntry {
+    pub statements: Vec<NamedStatement>,
+}
+
+/// Aggregate counts over a `rocky archive --catalog` invocation.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ArchiveTotals {
+    pub table_count: usize,
+    pub statement_count: usize,
 }
 
 /// JSON output for `rocky compact --measure-dedup` (Layer 0 storage experiment).

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -1,0 +1,438 @@
+//! Scope resolution for catalog/project-aware Rocky CLI commands.
+//!
+//! Shared by `rocky compact --measure-dedup`, `rocky compact --catalog`,
+//! and `rocky archive --catalog`. The resolvers walk the pipeline config
+//! (replication source discovery or transformation model files) to
+//! produce the set of fully-qualified `catalog.schema.table` names
+//! Rocky manages — without touching the warehouse.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::registry::{AdapterRegistry, resolve_pipeline};
+
+/// Resolve the set of table names that Rocky manages for a given pipeline.
+///
+/// Returns `Ok(Some(set))` with lowercase fully-qualified table names
+/// (`catalog.schema.table`) when the pipeline type supports resolution,
+/// or `Ok(None)` when resolution is not possible (unsupported pipeline
+/// type, no discovery adapter configured, etc.). Callers should fall
+/// back to scanning all warehouse tables when `None` is returned.
+///
+/// ## Pipeline types
+///
+/// - **Replication**: discovers connectors via the discovery adapter,
+///   parses each schema through the source `schema_pattern`, resolves
+///   target catalog/schema from the target templates, and collects
+///   `catalog.schema.table` for every discovered table.
+/// - **Transformation**: loads model files from the models directory
+///   (same walk as `rocky list models`) and extracts the `target`
+///   coordinates from each model's TOML sidecar.
+/// - **Other types** (quality, snapshot, load): not yet supported —
+///   returns `Ok(None)`.
+pub(crate) async fn resolve_managed_tables(
+    config: &rocky_core::config::RockyConfig,
+    pipeline_name: &str,
+    pipeline: &rocky_core::config::PipelineConfig,
+    registry: &AdapterRegistry,
+    config_path: &Path,
+) -> Result<Option<HashSet<String>>> {
+    match pipeline {
+        rocky_core::config::PipelineConfig::Replication(repl) => {
+            resolve_replication_managed_tables(repl, registry, config).await
+        }
+        rocky_core::config::PipelineConfig::Transformation(tx) => {
+            resolve_transformation_managed_tables(tx, config_path)
+        }
+        _ => {
+            tracing::info!(
+                pipeline = pipeline_name,
+                pipeline_type = pipeline.pipeline_type_str(),
+                "managed-table resolution not supported for this pipeline type"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Resolve managed tables for a replication pipeline by discovering
+/// connectors and resolving each table through the schema pattern
+/// templates.
+pub(crate) async fn resolve_replication_managed_tables(
+    repl: &rocky_core::config::ReplicationPipelineConfig,
+    registry: &AdapterRegistry,
+    _config: &rocky_core::config::RockyConfig,
+) -> Result<Option<HashSet<String>>> {
+    let pattern = repl
+        .schema_pattern()
+        .map_err(|e| anyhow!("failed to parse schema pattern: {e}"))?;
+
+    // Discovery adapter is required to enumerate source connectors.
+    let disc_config = match repl.source.discovery.as_ref() {
+        Some(d) => d,
+        None => {
+            tracing::warn!(
+                "no discovery adapter configured for this replication pipeline; \
+                 cannot resolve managed tables"
+            );
+            return Ok(None);
+        }
+    };
+    let discovery_adapter = registry.discovery_adapter(&disc_config.adapter)?;
+
+    let connectors = discovery_adapter
+        .discover(&pattern.prefix)
+        .await
+        .map_err(|e| anyhow!("discovery failed: {e}"))?
+        .connectors;
+
+    let target_sep = repl
+        .target
+        .separator
+        .as_deref()
+        .unwrap_or(&pattern.separator);
+
+    let mut managed = HashSet::new();
+    for conn in &connectors {
+        let parsed = match pattern.parse(&conn.schema) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let target_catalog = parsed.resolve_template(&repl.target.catalog_template, target_sep);
+        let target_schema = parsed.resolve_template(&repl.target.schema_template, target_sep);
+
+        for table in &conn.tables {
+            let full_name = format!("{}.{}.{}", target_catalog, target_schema, table.name);
+            managed.insert(full_name.to_lowercase());
+        }
+    }
+
+    tracing::info!(
+        managed_count = managed.len(),
+        "resolved managed tables from replication pipeline"
+    );
+    Ok(Some(managed))
+}
+
+/// Resolve managed tables for a transformation pipeline by loading
+/// model files and extracting their target coordinates.
+pub(crate) fn resolve_transformation_managed_tables(
+    tx: &rocky_core::config::TransformationPipelineConfig,
+    config_path: &Path,
+) -> Result<Option<HashSet<String>>> {
+    // Models directory is relative to the config file's parent.
+    let project_root = config_path.parent().unwrap_or(Path::new("."));
+
+    // The `models` field is a glob like "models/**" — extract the base
+    // directory (everything before any glob wildcard).
+    let models_base = tx
+        .models
+        .split(&['*', '?', '['][..])
+        .next()
+        .unwrap_or("models");
+    let models_dir = project_root.join(models_base.trim_end_matches('/'));
+
+    if !models_dir.exists() {
+        tracing::warn!(
+            models_dir = %models_dir.display(),
+            "models directory does not exist; cannot resolve managed tables"
+        );
+        return Ok(None);
+    }
+
+    // Load models the same way `rocky list models` does: top-level +
+    // immediate subdirectories.
+    let mut all_models = rocky_core::models::load_models_from_dir(&models_dir).context(format!(
+        "failed to load models from {}",
+        models_dir.display()
+    ))?;
+
+    if let Ok(entries) = std::fs::read_dir(&models_dir) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir() {
+                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
+                    all_models.extend(sub);
+                }
+            }
+        }
+    }
+
+    let mut managed = HashSet::new();
+    for model in &all_models {
+        let full_name = format!(
+            "{}.{}.{}",
+            model.config.target.catalog, model.config.target.schema, model.config.target.table
+        );
+        managed.insert(full_name.to_lowercase());
+    }
+
+    tracing::info!(
+        managed_count = managed.len(),
+        "resolved managed tables from transformation pipeline"
+    );
+    Ok(Some(managed))
+}
+
+/// Extract the distinct set of catalog identifiers from a managed-table
+/// set built by `resolve_managed_tables`.
+///
+/// The set is keyed on fully-qualified lowercase names (`catalog.schema.table`)
+/// assembled via `format!("{}.{}.{}", ...)` in the resolver, so splitting
+/// on the first `.` yields the catalog component. Names without a dot
+/// are skipped (defensive — the resolver always emits three components).
+pub(crate) fn managed_catalog_set(managed: &HashSet<String>) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for full in managed {
+        if let Some((catalog, _rest)) = full.split_once('.') {
+            if seen.insert(catalog.to_string()) {
+                out.push(catalog.to_string());
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Result of resolving the set of Rocky-managed tables in a single catalog.
+pub(crate) struct CatalogScope {
+    /// Catalog identifier as supplied to `--catalog`, lowercased to match
+    /// the resolver's output.
+    pub catalog: String,
+    /// Sorted list of fully-qualified `catalog.schema.table` names.
+    pub tables: Vec<String>,
+}
+
+/// Resolve the list of Rocky-managed tables in `catalog`.
+///
+/// Loads `rocky.toml`, picks the single pipeline (or first), runs the
+/// managed-table resolver, and filters to entries whose catalog component
+/// matches `catalog` (case-insensitive). Errors helpfully when:
+///
+/// - The pipeline type doesn't support managed-table resolution
+///   (quality, snapshot, load).
+/// - Resolution succeeded but no managed tables matched the catalog —
+///   the error lists every catalog Rocky knows about so the user can
+///   spot a typo.
+///
+/// This helper backs `rocky compact --catalog` and `rocky archive
+/// --catalog`. It does not touch the warehouse — both commands generate
+/// SQL only, so the resolver's config-derived view of managed tables is
+/// authoritative.
+pub(crate) async fn resolve_managed_tables_in_catalog(
+    config_path: &Path,
+    catalog: &str,
+) -> Result<CatalogScope> {
+    let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
+        "failed to load config from {}",
+        config_path.display()
+    ))?;
+    let registry = AdapterRegistry::from_config(&rocky_cfg)?;
+
+    let (pipeline_name, pipeline) = resolve_pipeline(&rocky_cfg, None)
+        .context("failed to resolve pipeline for catalog-scoped command")?;
+
+    let managed =
+        match resolve_managed_tables(&rocky_cfg, pipeline_name, pipeline, &registry, config_path)
+            .await?
+        {
+            Some(set) if !set.is_empty() => set,
+            Some(_) => {
+                bail!(
+                    "pipeline '{pipeline_name}' resolved zero managed tables; \
+                     `--catalog` requires at least one declared model or discovered source"
+                );
+            }
+            None => {
+                bail!(
+                    "pipeline '{pipeline_name}' (type: {}) does not support `--catalog` scope. \
+                     Supported pipeline types: replication, transformation.",
+                    pipeline.pipeline_type_str()
+                );
+            }
+        };
+
+    let (needle, tables) = filter_managed_to_catalog(&managed, catalog)?;
+
+    Ok(CatalogScope {
+        catalog: needle,
+        tables,
+    })
+}
+
+/// Filter a managed-table set to only entries in `catalog` (case-insensitive).
+///
+/// Returns `(lowercased_catalog, sorted_fqns)` on hit. Errors with a
+/// helpful "available catalogs: …" listing on miss so consumer typos
+/// don't silently turn into no-ops. Pure — no warehouse or filesystem
+/// access — so it's the easy unit-test target for the catalog filter.
+pub(crate) fn filter_managed_to_catalog(
+    managed: &HashSet<String>,
+    catalog: &str,
+) -> Result<(String, Vec<String>)> {
+    let needle = catalog.to_lowercase();
+    let mut tables: Vec<String> = managed
+        .iter()
+        .filter(|fqn| {
+            fqn.split_once('.')
+                .map(|(cat, _)| cat == needle)
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+
+    if tables.is_empty() {
+        let catalogs = managed_catalog_set(managed);
+        let available = if catalogs.is_empty() {
+            "(none)".to_string()
+        } else {
+            catalogs.join(", ")
+        };
+        bail!(
+            "no Rocky-managed tables found in catalog '{catalog}'. \
+             Available catalogs: {available}"
+        );
+    }
+    tables.sort();
+    Ok((needle, tables))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn managed_catalog_set_extracts_distinct_catalogs() {
+        let mut managed = HashSet::new();
+        managed.insert("acme.raw__shopify.orders".to_string());
+        managed.insert("acme.raw__shopify.events".to_string());
+        managed.insert("beta.raw__stripe.charges".to_string());
+        managed.insert("acme.raw__stripe.customers".to_string());
+
+        let catalogs = managed_catalog_set(&managed);
+        assert_eq!(catalogs, vec!["acme".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn managed_catalog_set_skips_names_without_catalog_prefix() {
+        let mut managed = HashSet::new();
+        managed.insert("acme.schema.table".to_string());
+        managed.insert("schema_only".to_string()); // defensive: no `.`
+
+        let catalogs = managed_catalog_set(&managed);
+        assert_eq!(catalogs, vec!["acme".to_string()]);
+    }
+
+    #[test]
+    fn filter_managed_to_catalog_filters_to_catalog() {
+        let mut managed = HashSet::new();
+        managed.insert("acme.raw__shopify.orders".to_string());
+        managed.insert("acme.raw__stripe.events".to_string());
+        managed.insert("beta.raw__shopify.orders".to_string());
+
+        let (needle, tables) = filter_managed_to_catalog(&managed, "acme").unwrap();
+        assert_eq!(needle, "acme");
+        assert_eq!(
+            tables,
+            vec![
+                "acme.raw__shopify.orders".to_string(),
+                "acme.raw__stripe.events".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn filter_managed_to_catalog_is_case_insensitive() {
+        // Resolver always lowercases; user input may not. The filter
+        // must match regardless of input case.
+        let mut managed = HashSet::new();
+        managed.insert("warehouse.staging.orders".to_string());
+        managed.insert("warehouse.marts.customers".to_string());
+
+        let (needle, tables) = filter_managed_to_catalog(&managed, "WAREHOUSE").unwrap();
+        assert_eq!(needle, "warehouse");
+        assert_eq!(tables.len(), 2);
+    }
+
+    #[test]
+    fn filter_managed_to_catalog_lists_available_on_miss() {
+        // Empty match must not silently succeed — the consumer would
+        // ship a nightly job that quietly does nothing. Error must list
+        // available catalogs so a typo is obvious.
+        let mut managed = HashSet::new();
+        managed.insert("acme.raw__shopify.orders".to_string());
+        managed.insert("beta.raw__shopify.orders".to_string());
+
+        let err = filter_managed_to_catalog(&managed, "gamma").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'gamma'"), "error mentions the input: {msg}");
+        assert!(msg.contains("acme"), "error lists acme: {msg}");
+        assert!(msg.contains("beta"), "error lists beta: {msg}");
+    }
+
+    #[test]
+    fn filter_managed_to_catalog_handles_empty_managed_set() {
+        let managed = HashSet::new();
+        let err = filter_managed_to_catalog(&managed, "acme").unwrap_err();
+        assert!(err.to_string().contains("(none)"));
+    }
+
+    /// Test that `resolve_transformation_managed_tables` correctly
+    /// extracts target table names from model sidecar files.
+    #[test]
+    fn resolve_transformation_managed_tables_extracts_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+
+        // Model A: target = warehouse.staging.orders
+        std::fs::write(
+            models_dir.join("orders.toml"),
+            r#"
+name = "orders"
+[target]
+catalog = "warehouse"
+schema = "staging"
+table = "orders"
+"#,
+        )
+        .unwrap();
+        std::fs::write(models_dir.join("orders.sql"), "SELECT 1").unwrap();
+
+        // Model B: target = warehouse.marts.customers
+        std::fs::write(
+            models_dir.join("customers.toml"),
+            r#"
+name = "customers"
+[target]
+catalog = "warehouse"
+schema = "marts"
+table = "customers"
+"#,
+        )
+        .unwrap();
+        std::fs::write(models_dir.join("customers.sql"), "SELECT 1").unwrap();
+
+        let tx = rocky_core::config::TransformationPipelineConfig {
+            models: "models/**".to_string(),
+            target: rocky_core::config::TransformationTargetConfig {
+                adapter: "default".to_string(),
+                governance: Default::default(),
+            },
+            checks: Default::default(),
+            execution: Default::default(),
+            depends_on: vec![],
+        };
+
+        let config_path = dir.path().join("rocky.toml");
+        let result = resolve_transformation_managed_tables(&tx, &config_path).unwrap();
+        let managed = result.expect("should resolve some managed tables");
+
+        assert_eq!(managed.len(), 2);
+        assert!(managed.contains("warehouse.staging.orders"));
+        assert!(managed.contains("warehouse.marts.customers"));
+    }
+}

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -761,8 +761,9 @@ enum Command {
 
     /// Generate OPTIMIZE/VACUUM SQL for storage compaction
     Compact {
-        /// Target table (catalog.schema.table) — required unless --measure-dedup is set
-        #[arg(required_unless_present = "measure_dedup")]
+        /// Target table (catalog.schema.table). Required unless one of
+        /// --catalog or --measure-dedup is set.
+        #[arg(required_unless_present_any = ["measure_dedup", "catalog"])]
         model: Option<String>,
         /// Target file size (e.g., "256MB")
         #[arg(long)]
@@ -770,6 +771,13 @@ enum Command {
         /// Show SQL without executing
         #[arg(long)]
         dry_run: bool,
+        /// Scope compaction to every Rocky-managed table in this catalog.
+        /// Resolves the managed-table set from the pipeline config (no
+        /// warehouse round trip) and aggregates per-table OPTIMIZE/VACUUM
+        /// SQL into one envelope. Mutually exclusive with --model and
+        /// --measure-dedup.
+        #[arg(long, conflicts_with_all = ["model", "measure_dedup"])]
+        catalog: Option<String>,
         /// Measure cross-table dedup ratio across all Rocky-managed tables
         /// in the project (Layer 0 storage experiment). Project-wide; does
         /// not take a model argument.
@@ -963,9 +971,15 @@ enum Command {
         /// Age threshold (e.g., "90d", "6m", "1y")
         #[arg(long)]
         older_than: String,
-        /// Filter to a specific model
-        #[arg(long)]
+        /// Filter to a specific model. Mutually exclusive with --catalog.
+        #[arg(long, conflicts_with = "catalog")]
         model: Option<String>,
+        /// Scope archive to every Rocky-managed table in this catalog.
+        /// Resolves the managed-table set from the pipeline config (no
+        /// warehouse round trip) and aggregates per-table DELETE/VACUUM
+        /// SQL into one envelope. Mutually exclusive with --model.
+        #[arg(long)]
+        catalog: Option<String>,
         /// Show SQL without executing
         #[arg(long)]
         dry_run: bool,
@@ -1761,6 +1775,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             model,
             target_size,
             dry_run,
+            catalog,
             measure_dedup,
             exclude_columns,
             calibrate_bytes,
@@ -1781,10 +1796,20 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     json,
                 )
                 .await
+            } else if let Some(catalog) = catalog {
+                rocky_cli::commands::run_compact_catalog(
+                    &cli.config,
+                    &catalog,
+                    target_size.as_deref(),
+                    dry_run,
+                    json,
+                )
+                .await
             } else {
-                // `required_unless_present = "measure_dedup"` on `model`
+                // clap's `required_unless_present_any` on `model`
                 // guarantees this branch always has a model.
-                let model = model.expect("clap enforces model is present unless --measure-dedup");
+                let model = model
+                    .expect("clap enforces model is present unless --measure-dedup or --catalog");
                 rocky_cli::commands::run_compact(&model, target_size.as_deref(), dry_run, json)
             }
         }
@@ -1921,8 +1946,21 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         Command::Archive {
             older_than,
             model,
+            catalog,
             dry_run,
-        } => rocky_cli::commands::run_archive(model.as_deref(), &older_than, dry_run, json),
+        } => match catalog {
+            Some(catalog) => {
+                rocky_cli::commands::run_archive_catalog(
+                    &cli.config,
+                    &catalog,
+                    &older_than,
+                    dry_run,
+                    json,
+                )
+                .await
+            }
+            None => rocky_cli::commands::run_archive(model.as_deref(), &older_than, dry_run, json),
+        },
         Command::Watch { models, contracts } => {
             rocky_cli::commands::run_watch(&models, contracts.as_deref(), json).await
         }

--- a/integrations/dagster/src/dagster_rocky/types_generated/archive_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/archive_schema.py
@@ -3,7 +3,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, conint
+
+
+class ArchiveTotals(BaseModel):
+    """
+    Aggregate counts over a `rocky archive --catalog` invocation.
+    """
+
+    statement_count: conint(ge=0)
+    table_count: conint(ge=0)
 
 
 class NamedStatement(BaseModel):
@@ -18,12 +29,32 @@ class NamedStatement(BaseModel):
 class ArchiveOutput(BaseModel):
     """
     JSON output for `rocky archive`.
+
+    Mirrors [`CompactOutput`]: single-model invocations populate `model` and leave the catalog-scope fields absent; `--catalog` invocations populate `catalog`, `scope = "catalog"`, `tables`, and `totals`. The flat `statements` list carries every statement across every table.
     """
 
+    catalog: str | None = None
+    """
+    Set when invoked as `rocky archive --catalog <name>`.
+    """
     command: str
     dry_run: bool
     model: str | None = None
     older_than: str
     older_than_days: conint(ge=0)
+    scope: str | None = None
+    """
+    `"catalog"` for the catalog-scoped path; absent for single-model invocations.
+    """
     statements: list[NamedStatement]
+    tables: dict[str, Any] | None = None
+    totals: ArchiveTotals | None = None
     version: str
+
+
+class ArchiveTableEntry(BaseModel):
+    """
+    Per-table archive plan inside a `--catalog` envelope.
+    """
+
+    statements: list[NamedStatement]

--- a/integrations/dagster/src/dagster_rocky/types_generated/compact_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/compact_schema.py
@@ -3,7 +3,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, conint
+
+
+class CompactTotals(BaseModel):
+    """
+    Aggregate counts over a `rocky compact --catalog` invocation.
+    """
+
+    statement_count: conint(ge=0)
+    table_count: conint(ge=0)
 
 
 class NamedStatement(BaseModel):
@@ -18,11 +29,45 @@ class NamedStatement(BaseModel):
 class CompactOutput(BaseModel):
     """
     JSON output for `rocky compact`.
+
+    Two shapes share this struct:
+
+    - **Single-model (`rocky compact <fqn>`)**: `model` is set; `scope`, `catalog`, `tables`, and `totals` are absent. Byte-stable with envelopes that predate the catalog-scope flag. - **Catalog scope (`rocky compact --catalog <name>`)**: `model` is absent, `scope = "catalog"`, `catalog` is set, `tables` keys per-FQN statement bundles, and `totals` carries aggregate counts. The flat `statements` field still carries every SQL statement across all tables for consumers that just iterate it.
     """
 
+    catalog: str | None = None
+    """
+    Set when invoked as `rocky compact --catalog <name>`. Stores the catalog identifier as resolved (lowercased to match the managed-table resolver's normalization).
+    """
     command: str
     dry_run: bool
-    model: str
+    model: str | None = None
+    """
+    Set when invoked as `rocky compact <fqn>`.
+    """
+    scope: str | None = None
+    """
+    `"catalog"` for the catalog-scoped path; absent for single-model invocations to keep their envelope byte-stable.
+    """
     statements: list[NamedStatement]
+    """
+    Flat list of every SQL statement across every table. Single-model invocations have one bundle here; `--catalog` invocations have the concatenation of every per-table bundle (in the same order as `tables`'s key iteration order).
+    """
+    tables: dict[str, Any] | None = None
+    """
+    Per-table breakdown, keyed by fully-qualified table name. Present only on `--catalog` invocations.
+    """
     target_size_mb: conint(ge=0)
+    totals: CompactTotals | None = None
+    """
+    Aggregate counts across the catalog. Present only on `--catalog` invocations.
+    """
     version: str
+
+
+class CompactTableEntry(BaseModel):
+    """
+    Per-table compaction plan inside a `--catalog` envelope.
+    """
+
+    statements: list[NamedStatement]

--- a/schemas/archive.schema.json
+++ b/schemas/archive.schema.json
@@ -1,6 +1,41 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "ArchiveTableEntry": {
+      "description": "Per-table archive plan inside a `--catalog` envelope.",
+      "properties": {
+        "statements": {
+          "items": {
+            "$ref": "#/definitions/NamedStatement"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "statements"
+      ],
+      "type": "object"
+    },
+    "ArchiveTotals": {
+      "description": "Aggregate counts over a `rocky archive --catalog` invocation.",
+      "properties": {
+        "statement_count": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "table_count": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "statement_count",
+        "table_count"
+      ],
+      "type": "object"
+    },
     "NamedStatement": {
       "description": "Named SQL statement (purpose + sql), reused by compact and archive.",
       "properties": {
@@ -18,8 +53,15 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky archive`.",
+  "description": "JSON output for `rocky archive`.\n\nMirrors [`CompactOutput`]: single-model invocations populate `model` and leave the catalog-scope fields absent; `--catalog` invocations populate `catalog`, `scope = \"catalog\"`, `tables`, and `totals`. The flat `statements` list carries every statement across every table.",
   "properties": {
+    "catalog": {
+      "description": "Set when invoked as `rocky archive --catalog <name>`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "command": {
       "type": "string"
     },
@@ -40,11 +82,37 @@
       "minimum": 0.0,
       "type": "integer"
     },
+    "scope": {
+      "description": "`\"catalog\"` for the catalog-scoped path; absent for single-model invocations.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "statements": {
       "items": {
         "$ref": "#/definitions/NamedStatement"
       },
       "type": "array"
+    },
+    "tables": {
+      "additionalProperties": {
+        "$ref": "#/definitions/ArchiveTableEntry"
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "totals": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ArchiveTotals"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "version": {
       "type": "string"

--- a/schemas/compact.schema.json
+++ b/schemas/compact.schema.json
@@ -1,6 +1,41 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "CompactTableEntry": {
+      "description": "Per-table compaction plan inside a `--catalog` envelope.",
+      "properties": {
+        "statements": {
+          "items": {
+            "$ref": "#/definitions/NamedStatement"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "statements"
+      ],
+      "type": "object"
+    },
+    "CompactTotals": {
+      "description": "Aggregate counts over a `rocky compact --catalog` invocation.",
+      "properties": {
+        "statement_count": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "table_count": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "statement_count",
+        "table_count"
+      ],
+      "type": "object"
+    },
     "NamedStatement": {
       "description": "Named SQL statement (purpose + sql), reused by compact and archive.",
       "properties": {
@@ -18,8 +53,15 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky compact`.",
+  "description": "JSON output for `rocky compact`.\n\nTwo shapes share this struct:\n\n- **Single-model (`rocky compact <fqn>`)**: `model` is set; `scope`, `catalog`, `tables`, and `totals` are absent. Byte-stable with envelopes that predate the catalog-scope flag. - **Catalog scope (`rocky compact --catalog <name>`)**: `model` is absent, `scope = \"catalog\"`, `catalog` is set, `tables` keys per-FQN statement bundles, and `totals` carries aggregate counts. The flat `statements` field still carries every SQL statement across all tables for consumers that just iterate it.",
   "properties": {
+    "catalog": {
+      "description": "Set when invoked as `rocky compact --catalog <name>`. Stores the catalog identifier as resolved (lowercased to match the managed-table resolver's normalization).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "command": {
       "type": "string"
     },
@@ -27,18 +69,51 @@
       "type": "boolean"
     },
     "model": {
-      "type": "string"
+      "description": "Set when invoked as `rocky compact <fqn>`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "scope": {
+      "description": "`\"catalog\"` for the catalog-scoped path; absent for single-model invocations to keep their envelope byte-stable.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "statements": {
+      "description": "Flat list of every SQL statement across every table. Single-model invocations have one bundle here; `--catalog` invocations have the concatenation of every per-table bundle (in the same order as `tables`'s key iteration order).",
       "items": {
         "$ref": "#/definitions/NamedStatement"
       },
       "type": "array"
     },
+    "tables": {
+      "additionalProperties": {
+        "$ref": "#/definitions/CompactTableEntry"
+      },
+      "description": "Per-table breakdown, keyed by fully-qualified table name. Present only on `--catalog` invocations.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
     "target_size_mb": {
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"
+    },
+    "totals": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CompactTotals"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Aggregate counts across the catalog. Present only on `--catalog` invocations."
     },
     "version": {
       "type": "string"
@@ -47,7 +122,6 @@
   "required": [
     "command",
     "dry_run",
-    "model",
     "statements",
     "target_size_mb",
     "version"


### PR DESCRIPTION
## Summary

- New `--catalog <name>` flag on both `rocky compact` and `rocky archive`. Resolves the set of Rocky-managed tables in the catalog from the pipeline config (replication discovery or transformation model files — no warehouse round trip) and aggregates per-table OPTIMIZE/VACUUM (compact) or DELETE/VACUUM (archive) SQL into a single envelope keyed by FQN.
- Managed-table resolver lifted from `commands/compact.rs` into a shared `rocky-cli/src/scope.rs` so the existing `--measure-dedup` path and the two new `--catalog` paths reuse one implementation. Pure refactor for the dedup path.
- `CompactOutput.model` relaxes from required to `Option<String>` so the catalog path can omit it. New optional `catalog` / `scope` / `tables` (per-FQN bundles) / `totals` (`table_count`, `statement_count`) fields populate only on `--catalog` invocations. Single-model JSON output is byte-stable — the new fields are `skip_serializing_if = \"Option::is_none\"`. Pydantic v2 + TypeScript bindings regenerated to match.

## Why

Multi-catalog deployments that want a per-catalog maintenance sweep have to reimplement catalog → schema → table enumeration in the orchestrator today, fanning out one subprocess invocation per table. Moving the resolver into the CLI lets the consumer call `rocky compact --catalog <name>` once per catalog and read aggregate stats from the envelope.

## Notes

- **Empty match errors with available catalogs listed** so consumer typos don't silently turn into no-ops (`Available catalogs: poc, …`).
- **Mutual exclusion** is enforced via clap: `--catalog` conflicts with `--model` on both commands and additionally with `--measure-dedup` on compact.
- **vscode `package-lock.json`** drifts from 1.9.1 to 1.11.0 — stale lockfile resync caught by codegen running `npm install`, unrelated to this change but bundled here rather than split into a prep commit.
- **Deferred:** improving clap's default no-scope error message (\"the following required arguments were not provided: <MODEL>\") to list every valid scope. The new `--help` output documents `--catalog` clearly; the error message itself stays on clap's default for now.

## Test plan

- [x] `cargo test -p rocky-cli --lib` (318 passed, includes 5 new unit tests on the catalog filter + case-insensitivity + empty-match error)
- [x] `cargo test` workspace-wide (all green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `just codegen` — schemas + Pydantic + TypeScript bindings regenerated, no drift after the run
- [x] Dagster integration tests against regenerated Pydantic types: 498 passed
- [x] End-to-end smoke against `examples/playground/pocs/06-developer-experience/11-lineage-diff/`:
  - `rocky compact --catalog poc --dry-run --output json` → 5 tables, both flat `statements` and `tables` map populated, `scope: \"catalog\"`
  - `rocky compact --catalog typo` → clear error listing `Available catalogs: poc`
  - `rocky compact poc.demo.fct_revenue --dry-run --output json` → byte-stable single-model envelope (no `catalog`/`scope`/`tables`/`totals` fields)