### PR TITLE
fix(rocky-cli): list every valid scope in `rocky compact` no-scope error

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`CompactOutput.model` is now optional**. Was required (`String`); now `Option<String>` so the catalog-scope path can omit it. JSON schema relaxes from required to optional; existing single-model JSON output is byte-stable. Pydantic + TypeScript bindings regenerated accordingly.
 - **`rocky-cli/src/scope.rs`**. The managed-table resolver previously private to `commands/compact.rs` (`resolve_managed_tables`, `resolve_replication_managed_tables`, `resolve_transformation_managed_tables`, `managed_catalog_set`) lifted into a shared module so both `compact` (`--measure-dedup`, `--catalog`) and `archive` (`--catalog`) reuse one implementation. Pure refactor for the dedup path — its tests come along.
+- **`rocky compact` no-scope error message lists every valid scope.** Replaces clap's `required_unless_present_any` + per-flag `conflicts_with` declarations with a single `ArgGroup` (`compact_scope`) over `model` / `catalog` / `measure_dedup`. Running `rocky compact` with no scope now errors with `<MODEL|--catalog <CATALOG>|--measure-dedup>` instead of just `<MODEL>`, so the user sees that `--catalog` and `--measure-dedup` are valid alternatives. Mutual exclusion is unchanged — the group's `multiple(false)` enforces it.
 
 ## [1.19.2] — 2026-04-30
 

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 use tracing::warn;
 
 /// Extended help text for the shared `--filter` flag on `rocky plan`,
@@ -760,10 +760,15 @@ enum Command {
     },
 
     /// Generate OPTIMIZE/VACUUM SQL for storage compaction
+    #[command(group(
+        ArgGroup::new("compact_scope")
+            .args(["model", "catalog", "measure_dedup"])
+            .required(true)
+            .multiple(false),
+    ))]
     Compact {
         /// Target table (catalog.schema.table). Required unless one of
         /// --catalog or --measure-dedup is set.
-        #[arg(required_unless_present_any = ["measure_dedup", "catalog"])]
         model: Option<String>,
         /// Target file size (e.g., "256MB")
         #[arg(long)]
@@ -775,13 +780,13 @@ enum Command {
         /// Resolves the managed-table set from the pipeline config (no
         /// warehouse round trip) and aggregates per-table OPTIMIZE/VACUUM
         /// SQL into one envelope. Mutually exclusive with --model and
-        /// --measure-dedup.
-        #[arg(long, conflicts_with_all = ["model", "measure_dedup"])]
+        /// --measure-dedup (enforced via the `compact_scope` ArgGroup).
+        #[arg(long)]
         catalog: Option<String>,
         /// Measure cross-table dedup ratio across all Rocky-managed tables
         /// in the project (Layer 0 storage experiment). Project-wide; does
         /// not take a model argument.
-        #[arg(long, conflicts_with = "model")]
+        #[arg(long)]
         measure_dedup: bool,
         /// Comma-separated columns to exclude from the "semantic" dedup
         /// hash. Defaults to the Rocky-owned metadata columns:


### PR DESCRIPTION
## Summary

Replace `required_unless_present_any` on `model` + per-flag `conflicts_with` on `--catalog` and `--measure-dedup` with a single `ArgGroup` so `rocky compact` with no scope errors with every valid alternative listed.

**Before:**

```
error: the following required arguments were not provided:
  <MODEL>
```

**After:**

```
error: the following required arguments were not provided:
  <MODEL|--catalog <CATALOG>|--measure-dedup>
```

## Why

`--catalog` and `--measure-dedup` are valid scopes for `rocky compact` but the old error only mentioned `<MODEL>`. A consumer hitting it wouldn't know the alternatives exist without reading `--help`. Follow-up to #315 — that PR called this out as deferred.

## Notes

- `ArgGroup::required(true)` keeps "at least one is required"; `multiple(false)` keeps mutual exclusion. The per-flag `conflicts_with` attributes become redundant under the group and are removed.
- `--measure-dedup`'s dependent flags (`--exclude-columns`, `--calibrate-bytes`, `--all-tables`) keep their `requires = "measure_dedup"` — those are independent of the scope group.
- No schema or codegen changes — clap-only, the JSON output shape is unchanged.

## Test plan

- [x] `cargo test -p rocky-cli --lib` (318 passed)
- [x] `cargo clippy -p rocky --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] End-to-end against `examples/playground/pocs/06-developer-experience/11-lineage-diff/`:
  - `rocky compact` (no args) → new error listing all three scopes
  - `rocky compact <fqn>` → single-model SQL plan, byte-stable JSON
  - `rocky compact <fqn> --catalog x` → `error: the argument '[MODEL]' cannot be used with '--catalog <CATALOG>'`
  - `rocky compact --catalog x --measure-dedup` → `error: the argument '--catalog <CATALOG>' cannot be used with '--measure-dedup'`
  - `rocky compact <fqn> --measure-dedup` → `error: the argument '[MODEL]' cannot be used with '--measure-dedup'`