### PR TITLE
fix: dedupe duplicate table records in Fivetran discover (engine + dagster-rocky)

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.1] — 2026-05-01
+
+Patch release. Root-cause fix for Fivetran auto-rename collisions surfacing as duplicate `DiscoveredTable` records in `rocky discover` output.
+
 ### Fixed
 
 - **Fivetran discover: dedupe table records per source.** The Fivetran `/v1/connectors/{id}/schemas` response can list two distinct schema-entry keys that resolve to the same destination table name (e.g. an auto-rename leaves the original logical key alongside a fresh entry whose `name_in_destination` matches the renamed table). `SchemaConfig::enabled_tables()` faithfully forwards both rows, which left duplicate `DiscoveredTable` records in the discover output and broke downstream consumers — Dagster's `multi_asset` rejects duplicate `AssetCheckSpec`s, which crashed the entire `RockyComponent` build for affected pipelines. The Fivetran adapter now dedupes the per-connector table list by name (preserving first occurrence) with a WARN log carrying the connector id and the duplicate count, so the upstream-config quirk stays visible to operators rather than getting silently swallowed.

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fivetran discover: dedupe table records per source.** The Fivetran `/v1/connectors/{id}/schemas` response can list two distinct schema-entry keys that resolve to the same destination table name (e.g. an auto-rename leaves the original logical key alongside a fresh entry whose `name_in_destination` matches the renamed table). `SchemaConfig::enabled_tables()` faithfully forwards both rows, which left duplicate `DiscoveredTable` records in the discover output and broke downstream consumers — Dagster's `multi_asset` rejects duplicate `AssetCheckSpec`s, which crashed the entire `RockyComponent` build for affected pipelines. The Fivetran adapter now dedupes the per-connector table list by name (preserving first occurrence) with a WARN log carrying the connector id and the duplicate count, so the upstream-config quirk stays visible to operators rather than getting silently swallowed.
+
 ## [1.20.0] — 2026-05-01
 
 Feature release. Headline: **`rocky compact --catalog <name>` and `rocky archive --catalog <name>`** turn the two storage-maintenance commands from per-table-only into per-catalog-aware. Multi-catalog deployments that drove weekly compaction sweeps had to reimplement catalog → schema → table enumeration in the orchestrator and fan out one subprocess per table; now one CLI invocation per catalog returns aggregated SQL. Bundled with a clap UX cleanup so `rocky compact` with no scope errors with every valid alternative listed.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "redis",
  "serde",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "logos",
  "miette",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "miette",
  "regex",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.20.0"
+version = "1.20.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.20.0"
+version = "1.20.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.20.0"
+version = "1.20.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.20.0"
+version = "1.20.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.20.0"
+version = "1.20.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.20.0"
+version = "1.20.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.20.0"
+version = "1.20.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.20.0"
+version = "1.20.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.20.0"
+version = "1.20.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -63,7 +63,7 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
         for (conn, schema_result) in fetched {
             match schema_result {
                 Ok(schema_config) => {
-                    let tables = schema_config
+                    let raw_tables: Vec<DiscoveredTable> = schema_config
                         .enabled_tables()
                         .iter()
                         .map(|t| DiscoveredTable {
@@ -71,6 +71,7 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
                             row_count: None,
                         })
                         .collect();
+                    let tables = dedup_tables_by_name(raw_tables, &conn.id);
                     let metadata = metadata_from_connector(&conn);
                     connectors.push(DiscoveredConnector {
                         id: conn.id,
@@ -163,6 +164,54 @@ fn classify_status_code(status: u16) -> FailedSourceErrorClass {
         500..=599 => FailedSourceErrorClass::Transient,
         _ => FailedSourceErrorClass::Unknown,
     }
+}
+
+/// Deduplicate the per-connector table list by table name, preserving the
+/// first occurrence.
+///
+/// Fivetran's `/v1/connectors/{id}/schemas` response can list two distinct
+/// logical schema-entry keys that resolve to the same destination name —
+/// for example, when Fivetran auto-renames a table (`do_not_alter_*` prefix
+/// after a breaking schema change) the original logical key may stay
+/// alongside a fresh entry whose `name_in_destination` matches the renamed
+/// table that already exists. `SchemaConfig::enabled_tables()` faithfully
+/// forwards both rows, which leaves duplicate `DiscoveredTable` records in
+/// the discover output and breaks downstream consumers (e.g. dagster-rocky's
+/// `multi_asset` decorator rejects duplicate `AssetCheckSpec`s).
+///
+/// Dedup is Fivetran-specific: this is an upstream API quirk, not something
+/// other discovery adapters share, so it lives here rather than in
+/// `rocky-core`. A WARN is emitted with the connector id and the duplicate
+/// count so the noise is visible — silently dropping rows would hide a real
+/// upstream-config problem worth surfacing to operators.
+fn dedup_tables_by_name(tables: Vec<DiscoveredTable>, source_id: &str) -> Vec<DiscoveredTable> {
+    let mut seen = std::collections::HashSet::with_capacity(tables.len());
+    let mut deduped = Vec::with_capacity(tables.len());
+    let mut dropped: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for table in tables {
+        if seen.insert(table.name.clone()) {
+            deduped.push(table);
+        } else {
+            *dropped.entry(table.name.clone()).or_insert(0) += 1;
+        }
+    }
+    if !dropped.is_empty() {
+        let total: usize = dropped.values().sum();
+        let detail = dropped
+            .iter()
+            .map(|(name, count)| format!("{name}={count}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        warn!(
+            source_id,
+            duplicates = total,
+            duplicate_names = detail.as_str(),
+            "fivetran discover: dropped duplicate table records — Fivetran returned multiple \
+             schema entries that resolve to the same destination table name (likely an \
+             auto-rename collision); first occurrence kept"
+        );
+    }
+    deduped
 }
 
 /// Project a stable, namespaced subset of Fivetran connector config into the
@@ -289,6 +338,72 @@ mod tests {
         assert!(!metadata.contains_key("fivetran.custom_reports"));
         // Empty arrays still stamp (distinguishable from "not configured").
         assert!(metadata.contains_key("fivetran.custom_tables"));
+    }
+
+    #[test]
+    fn dedup_tables_drops_duplicates_preserving_first_occurrence() {
+        // Reproduces the Fivetran auto-rename collision: two schema entries
+        // resolve to the same destination table name. `enabled_tables()`
+        // faithfully forwards both; the adapter must dedup before handing
+        // the list to downstream consumers (Dagster's `multi_asset`
+        // rejects duplicate `AssetCheckSpec`s).
+        let input = vec![
+            DiscoveredTable {
+                name: "do_not_alter_dpm_raw_youtube".into(),
+                row_count: Some(100),
+            },
+            DiscoveredTable {
+                name: "orders".into(),
+                row_count: None,
+            },
+            // Duplicate of the first entry, with different metadata to
+            // confirm we keep the first occurrence rather than the last.
+            DiscoveredTable {
+                name: "do_not_alter_dpm_raw_youtube".into(),
+                row_count: Some(999),
+            },
+            DiscoveredTable {
+                name: "orders".into(),
+                row_count: Some(42),
+            },
+        ];
+        let deduped = dedup_tables_by_name(input, "conn_test");
+        assert_eq!(deduped.len(), 2);
+        // First occurrence preserved (row_count: Some(100), not Some(999)).
+        let yt = deduped
+            .iter()
+            .find(|t| t.name == "do_not_alter_dpm_raw_youtube")
+            .expect("youtube table should be present");
+        assert_eq!(yt.row_count, Some(100));
+        let orders = deduped
+            .iter()
+            .find(|t| t.name == "orders")
+            .expect("orders table should be present");
+        assert_eq!(orders.row_count, None);
+    }
+
+    #[test]
+    fn dedup_tables_is_noop_when_no_duplicates() {
+        let input = vec![
+            DiscoveredTable {
+                name: "a".into(),
+                row_count: None,
+            },
+            DiscoveredTable {
+                name: "b".into(),
+                row_count: None,
+            },
+        ];
+        let deduped = dedup_tables_by_name(input.clone(), "conn_test");
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].name, "a");
+        assert_eq!(deduped[1].name, "b");
+    }
+
+    #[test]
+    fn dedup_tables_handles_empty_input() {
+        let deduped = dedup_tables_by_name(Vec::new(), "conn_test");
+        assert!(deduped.is_empty());
     }
 
     #[test]

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.20.0"
+version = "1.20.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.20.0"
+version = "1.20.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.20.0"
+version = "1.20.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.20.0"
+version = "1.20.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.20.0"
+version = "1.20.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.20.0"
+version = "1.20.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.1] — 2026-05-01
+
+Patch release. Defensive dedup of asset specs and check specs to survive duplicate table records from `rocky discover`.
+
+### Fixed
+
+- **Defensive dedupe of asset specs and check specs in `RockyComponent`.** When `rocky discover` returned the same `(asset_key, name)` tuple twice — typically a single source whose `tables` list contained the same table name twice, often from upstream metadata races — `_build_check_specs` appended `DEFAULT_CHECK_NAMES` once per duplicate spec, the resulting list contained duplicate `(asset_key, name)` check spec tuples, and `@multi_asset(check_specs=...)` raised `DagsterInvalidDefinitionError`. Symptom: every Rocky-derived asset disappeared from the user's Dagster graph for one bad discover record. Fix is two-layered: (1) `_build_group_contexts` now dedupes by `AssetKey` per group as it walks the discover output and logs a warning naming the offending key + source id, and (2) `_build_check_specs` filters by `(asset_key, name)` as it builds — belt-and-suspenders for any future code path that bypasses the group-level dedup. The matching root-cause fix lives in the engine; this is the orchestrator-side hardening so a single weird source record degrades gracefully instead of taking down the whole asset graph.
+
 ## [1.18.0] — 2026-05-01
 
 Companion release to engine `v1.20.0`. Picks up the regenerated Pydantic models for the new catalog-scope shapes on `rocky compact` and `rocky archive`.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.18.0"
+version = "1.18.1"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1044,6 +1044,18 @@ def _build_group_contexts(
             group.filter = _build_filter(source)
         group.source_ids.add(source.id)
 
+        # Track AssetKeys already accumulated for this group so a duplicate
+        # ``(source, table)`` pair from ``rocky discover`` (or two distinct
+        # tables that happen to translate to the same key) doesn't smuggle
+        # the same spec — and therefore the same set of check specs — into
+        # the build twice. ``@multi_asset(check_specs=...)`` rejects
+        # duplicate ``(asset_key, name)`` tuples with
+        # ``DagsterInvalidDefinitionError``, which would otherwise drop
+        # *every* Rocky-derived asset from the user's graph for one bad
+        # discover record. Drop the duplicate, log a warning naming the
+        # offending key + source id so it's traceable, and keep building.
+        seen_keys: set[dg.AssetKey] = {spec.key for spec in group.specs}
+
         for table in source.tables:
             # Per-model freshness wins over pipeline-level when the source
             # table name matches a compiled model name. This makes
@@ -1057,6 +1069,18 @@ def _build_group_contexts(
                 policy,
                 translation=translation,
             )
+            if spec.key in seen_keys:
+                _log.warning(
+                    "Dropping duplicate Rocky asset spec for key %s "
+                    "(source id=%s, table=%s) — `rocky discover` returned "
+                    "the same (asset_key, table) twice in this group; the "
+                    "first occurrence wins.",
+                    spec.key.to_user_string(),
+                    source.id,
+                    table.name,
+                )
+                continue
+            seen_keys.add(spec.key)
             group.specs.append(spec)
             group.key_to_source_id[spec.key] = source.id
             group.rocky_key_to_dagster_key[_native_rocky_key(source, table.name)] = spec.key
@@ -1134,22 +1158,47 @@ def _build_check_specs(
     """
     contract_rules_by_model = contract_rules_by_model or {}
     specs: list[dg.AssetCheckSpec] = []
+    # Belt-and-suspenders dedupe: ``_build_group_contexts`` already drops
+    # duplicate ``AssetSpec``s within a group, but a future code path
+    # (custom ``translation``, derived-model surfaces, or a caller that
+    # builds ``_GroupBuild`` directly) could still hand us a
+    # ``group.specs`` list with the same key twice. ``@multi_asset``
+    # raises ``DagsterInvalidDefinitionError`` on duplicate
+    # ``(asset_key, name)`` check spec tuples — which would tear down
+    # every Rocky-derived asset for one bad input — so filter as we
+    # build.
+    seen: set[tuple[dg.AssetKey, str]] = set()
+
+    def _add(spec: dg.AssetCheckSpec) -> None:
+        marker = (spec.asset_key, spec.name)
+        if marker in seen:
+            _log.warning(
+                "Dropping duplicate Rocky asset check spec %s on %s — "
+                "upstream produced the same (asset_key, name) twice; "
+                "the first occurrence wins.",
+                spec.name,
+                spec.asset_key.to_user_string(),
+            )
+            return
+        seen.add(marker)
+        specs.append(spec)
 
     for group in groups:
         for spec in group.specs:
             # Default checks (4 per asset)
             for check_name in DEFAULT_CHECK_NAMES:
-                specs.append(dg.AssetCheckSpec(name=check_name, asset=spec.key))
+                _add(dg.AssetCheckSpec(name=check_name, asset=spec.key))
 
             # Governance compliance check (Wave B, opt-in)
             if surface_compliance:
-                specs.append(dg.AssetCheckSpec(name=COMPLIANCE_CHECK_NAME, asset=spec.key))
+                _add(dg.AssetCheckSpec(name=COMPLIANCE_CHECK_NAME, asset=spec.key))
 
             # Contract checks (per declared rule kind, when matched)
             table_name = spec.key.path[-1]
             rules = contract_rules_by_model.get(table_name)
             if rules is not None:
-                specs.extend(contract_check_specs_for_model(spec.key, rules))
+                for contract_spec in contract_check_specs_for_model(spec.key, rules):
+                    _add(contract_spec)
 
     return specs
 

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -1084,3 +1084,86 @@ def test_rocky_component_python_kwarg_post_state_write_hook_preserved(tmp_path: 
     assert callable(component.post_state_write_hook)
     component.post_state_write_hook(tmp_path)
     assert calls == [tmp_path]
+
+
+def test_build_defs_survives_duplicate_table_records(tmp_path: Path, caplog):
+    """Defensive: a duplicate ``(asset_key, name)`` from ``rocky discover``
+    must not bring down the whole asset graph.
+
+    Regression: previously a single source whose ``tables`` list contained
+    the same name twice produced two identical ``AssetSpec``s in the
+    group, which fanned out into two identical sets of
+    ``DEFAULT_CHECK_NAMES`` ``AssetCheckSpec``s, which then caused
+    ``@multi_asset(check_specs=...)`` to raise
+    ``DagsterInvalidDefinitionError`` and drop *every* Rocky-derived
+    asset from the user's Dagster graph.
+
+    Expected: dedupe layer warns + keeps the first occurrence, build
+    succeeds with one asset and the four ``DEFAULT_CHECK_NAMES`` checks.
+    """
+    import logging
+
+    discover_payload = {
+        "version": "0.1.0",
+        "command": "discover",
+        "checks": {"freshness": {"threshold_seconds": 86400}},
+        "sources": [
+            {
+                "id": "src_dup",
+                "components": {
+                    "tenant": "pfizer",
+                    "region": "namer",
+                    "subregion": "usa",
+                    "source": "dv360",
+                },
+                "source_type": "fivetran",
+                "last_sync_at": "2026-04-01T10:00:00Z",
+                # Duplicate table record — the bug input.
+                "tables": [
+                    {"name": "do_not_alter_dpm_raw_youtube", "row_count": 1},
+                    {"name": "do_not_alter_dpm_raw_youtube", "row_count": 1},
+                ],
+            }
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover_payload}))
+
+    component = RockyComponent(config_path="rocky.toml")
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    assets = list(defs.assets or [])
+    # One multi_asset for the (sole) group, with one (deduped) asset key.
+    assert len(assets) == 1
+    asset = assets[0]
+    keys = list(asset.keys)
+    assert len(keys) == 1
+    # And exactly the four DEFAULT_CHECK_NAMES, not eight.
+    check_specs = list(asset.check_specs)
+    assert len(check_specs) == 4
+    check_names = sorted(cs.name for cs in check_specs)
+    assert check_names == sorted(component_module.DEFAULT_CHECK_NAMES)
+    # Group-level dedupe warning fired (names the offending key + source id).
+    warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("src_dup" in m and "duplicate" in m.lower() for m in warnings)
+
+
+def test_build_check_specs_dedupes_when_group_has_duplicate_specs():
+    """Belt-and-suspenders: even if a future code path bypasses the
+    group-level dedup and hands ``_build_check_specs`` a ``_GroupBuild``
+    with two identical ``AssetSpec`` entries, the returned check spec
+    list must not contain the same ``(asset_key, name)`` twice.
+    """
+    key = dg.AssetKey(["dup", "table"])
+    spec = dg.AssetSpec(key=key)
+    group = component_module._GroupBuild(name="dup")
+    # Bypass the group-level dedup explicitly.
+    group.specs = [spec, spec]
+
+    check_specs = component_module._build_check_specs([group])
+
+    # Four DEFAULT_CHECK_NAMES once, not twice.
+    assert len(check_specs) == len(component_module.DEFAULT_CHECK_NAMES)
+    markers = {(cs.asset_key, cs.name) for cs in check_specs}
+    assert len(markers) == len(check_specs)

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Fixes a class of bug where `rocky discover` returns the same table twice within a single source, causing downstream consumers (notably `dagster-rocky`) to fail their build with `DagsterInvalidDefinitionError: Duplicate check specs`.

Two layers of fix:

1. **Engine fix (`rocky-fivetran`)** — root cause. Fivetran's `GET /v1/connectors/{id}/schemas` can return two distinct logical schema-entry keys that both resolve to the same destination table name (most commonly when an auto-rename leaves the original logical key alongside a new entry whose `name_in_destination` matches the renamed table — the `do_not_alter_*` prefix Fivetran applies after a breaking schema change). `SchemaConfig::enabled_tables()` faithfully forwarded both rows. Added `dedup_tables_by_name` in `rocky-fivetran/src/adapter.rs`, called between `enabled_tables()` and the `DiscoveredConnector` push. Logs a WARN naming the connector + per-name counts so operators see the upstream oddity.

2. **`dagster-rocky` fix** — defensive. Even after the engine fix, a single weird source record shouldn't take down the whole asset graph. Two-layer dedup in `dagster_rocky/component.py`: (a) per-group `seen_keys: set[AssetKey]` filters duplicate specs in `_build_group_contexts` (root path), (b) belt-and-suspenders `(asset_key, name)` membership check in `_build_check_specs` covers any future caller (custom translator, derived models, direct `_GroupBuild` construction) that might bypass layer 1. Both log warnings naming the offending key.

Symptom in the wild: a connector with one duplicated table caused the entire `RockyComponent` build to throw, which removed every Rocky-derived asset from the Dagster asset graph and silently broke any sensor that gates on those assets being present.

## Test plan

- [x] `cargo test -p rocky-fivetran` — 32 passed (3 new tests for `dedup_tables_by_name`)
- [x] `cargo build -p rocky-cli` — no regressions
- [x] `uv run pytest` in `integrations/dagster` — 500 passed (2 new tests for the dedup layers)
- [x] `ruff check` + `ruff format --check` clean
- [x] Reproducer with rebuilt `rocky` binary — duplicate is gone, downstream build succeeds
- [ ] CI green
- [ ] Cut a `dagster-rocky` 1.18.1 release after merge so consumers can pin the defensive fix