### PR TITLE
docs: --catalog scope on compact/archive + --verbose on doctor

### DIFF
--- a/docs/src/content/docs/dagster/types.md
+++ b/docs/src/content/docs/dagster/types.md
@@ -735,6 +735,7 @@ A single health check result.
 | `status` | `HealthStatus` | One of `"healthy"`, `"warning"`, `"critical"` |
 | `message` | `str` | Check result message |
 | `duration_ms` | `int` | Check duration |
+| `details` | `list[tuple[str, str]]` | Optional per-check `(key, value)` context populated when `rocky doctor` is invoked with `--verbose` (config path, state file size, adapter type + credential signal, pipeline kind, state backend). Empty list when the engine omits the field. |
 
 ---
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -318,6 +318,14 @@ rocky doctor --check auth
 rocky doctor --check state_rw   # live round-trip probe against the remote state backend
 ```
 
+**Verbose mode (v1.20.0+):**
+
+```bash
+rocky doctor --verbose
+```
+
+Prints extra per-check context (config path, state file size, adapter type + credential signal, pipeline kind, state backend) under each check in human-readable output. The JSON output is unchanged unless `--verbose` is passed — each `checks[]` entry then carries a `details` array of `[key, value]` string pairs (omitted entirely when empty). Credential signal values: `token`, `oauth_client`, `oauth_token`, `key_pair`, `password`, `service_account`, `adc`, `env`, `none`.
+
 ---
 
 ### `rocky list`

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -345,19 +345,23 @@ Generate `OPTIMIZE` and `VACUUM` SQL for storage compaction on Delta tables. Com
 
 ```bash
 rocky compact <model> [flags]
-rocky compact --measure-dedup [flags]   # experimental, project-wide scope
+rocky compact --catalog <name> [flags]   # every Rocky-managed table in the catalog
+rocky compact --measure-dedup [flags]    # experimental, project-wide scope
 ```
+
+Exactly one scope is required: a fully-qualified `<model>`, `--catalog <name>`, or `--measure-dedup`. The three forms are mutually exclusive.
 
 ### Arguments
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `model` | `string` | **(required unless `--measure-dedup`)** | Target table in `catalog.schema.table` format. |
+| `model` | `string` | **(one scope required)** | Target table in `catalog.schema.table` format. |
 
 ### Flags
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
+| `--catalog <NAME>` | `string` | | Aggregate per-table OPTIMIZE/VACUUM SQL across every Rocky-managed table in the catalog. The managed-table set is resolved from the pipeline config (replication discovery or transformation model files) — no warehouse round trip. Mutually exclusive with `<model>` and `--measure-dedup`. Errors with the available catalogs listed if no managed tables match. |
 | `--target-size <SIZE>` | `string` | | Target file size (e.g., `256MB`, `512MB`, `1GB`). |
 | `--dry-run` | `bool` | `false` | Show SQL without executing. |
 | `--measure-dedup` | `bool` | `false` | Experimental. Measure the cross-table dedup ratio across all Rocky-managed tables in the project (Layer 0 storage experiment). Project-wide; does not take a model argument. |
@@ -396,6 +400,48 @@ rocky compact acme_warehouse.staging__us_west__shopify.orders --target-size 256M
 ```
 
 The generated SQL uses the Delta `ZORDER` / file-size hints; `target_size_mb` echoes the parsed value (e.g. `256` for `256MB`).
+
+#### Catalog-scoped compaction
+
+`--catalog <name>` resolves every Rocky-managed table in the named catalog and emits a single envelope keyed by FQN. The flat `statements` list still carries every SQL statement across all tables in iteration order — consumers that just want to execute the plan don't need to walk `tables`.
+
+```bash
+rocky compact --catalog acme_warehouse --target-size 256MB --dry-run
+```
+
+```json
+{
+  "version": "1.20.0",
+  "command": "compact",
+  "catalog": "acme_warehouse",
+  "scope": "catalog",
+  "dry_run": true,
+  "target_size_mb": 256,
+  "statements": [
+    { "purpose": "optimize", "sql": "OPTIMIZE acme_warehouse.staging__us_west__shopify.orders" },
+    { "purpose": "vacuum",   "sql": "VACUUM acme_warehouse.staging__us_west__shopify.orders RETAIN 168 HOURS" },
+    { "purpose": "optimize", "sql": "OPTIMIZE acme_warehouse.staging__us_west__shopify.events" },
+    { "purpose": "vacuum",   "sql": "VACUUM acme_warehouse.staging__us_west__shopify.events RETAIN 168 HOURS" }
+  ],
+  "tables": {
+    "acme_warehouse.staging__us_west__shopify.events": {
+      "statements": [
+        { "purpose": "optimize", "sql": "OPTIMIZE acme_warehouse.staging__us_west__shopify.events" },
+        { "purpose": "vacuum",   "sql": "VACUUM acme_warehouse.staging__us_west__shopify.events RETAIN 168 HOURS" }
+      ]
+    },
+    "acme_warehouse.staging__us_west__shopify.orders": {
+      "statements": [
+        { "purpose": "optimize", "sql": "OPTIMIZE acme_warehouse.staging__us_west__shopify.orders" },
+        { "purpose": "vacuum",   "sql": "VACUUM acme_warehouse.staging__us_west__shopify.orders RETAIN 168 HOURS" }
+      ]
+    }
+  },
+  "totals": { "table_count": 2, "statement_count": 4 }
+}
+```
+
+The single-model envelope is byte-stable — `catalog`, `scope`, `tables`, and `totals` are all `skip_serializing_if = "Option::is_none"`. The catalog identifier is normalized to lowercase to match the managed-table resolver.
 
 #### Layer 0 dedup measurement (experimental)
 
@@ -488,6 +534,7 @@ Archive old data partitions by moving them to cold storage or deleting them base
 
 ```bash
 rocky archive [flags]
+rocky archive --catalog <name> [flags]   # every Rocky-managed table in the catalog
 ```
 
 ### Flags
@@ -495,7 +542,8 @@ rocky archive [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--older-than <DURATION>` | `string` | **(required)** | Age threshold. Accepted formats: `90d` (days), `6m` (months), `1y` (years). |
-| `--model <NAME>` | `string` | | Filter to a specific model. If omitted, archives across all models. |
+| `--model <NAME>` | `string` | | Filter to a specific model. If omitted, archives across all models. Mutually exclusive with `--catalog`. |
+| `--catalog <NAME>` | `string` | | Aggregate per-table archive SQL across every Rocky-managed table in the named catalog. The managed-table set is resolved from the pipeline config (no warehouse round trip). Mutually exclusive with `--model`. Errors with the available catalogs listed if no managed tables match. |
 | `--dry-run` | `bool` | `false` | Show SQL without executing. |
 
 ### Examples
@@ -535,6 +583,45 @@ rocky archive --older-than 6m --model acme_warehouse.staging__us_west__shopify.e
 ```
 
 Same output shape — `model` is set when `--model` filters the run. `older_than_days` is the parsed duration (`6m` → `180`), which lets orchestrators compute retention windows without re-parsing the string.
+
+#### Catalog-scoped archival
+
+`--catalog <name>` mirrors `rocky compact --catalog`: it resolves every Rocky-managed table in the catalog from the pipeline config and aggregates per-table DELETE SQL into a single envelope keyed by FQN. The flat `statements` list still carries every statement across every table.
+
+```bash
+rocky archive --older-than 90d --catalog acme_warehouse --dry-run
+```
+
+```json
+{
+  "version": "1.20.0",
+  "command": "archive",
+  "catalog": "acme_warehouse",
+  "scope": "catalog",
+  "older_than": "90d",
+  "older_than_days": 90,
+  "dry_run": true,
+  "statements": [
+    { "purpose": "archive:orders", "sql": "DELETE FROM acme_warehouse.staging__us_west__shopify.orders WHERE order_date < '2026-01-02'" },
+    { "purpose": "archive:events", "sql": "DELETE FROM acme_warehouse.staging__us_west__shopify.events WHERE event_date < '2026-01-02'" }
+  ],
+  "tables": {
+    "acme_warehouse.staging__us_west__shopify.events": {
+      "statements": [
+        { "purpose": "archive:events", "sql": "DELETE FROM acme_warehouse.staging__us_west__shopify.events WHERE event_date < '2026-01-02'" }
+      ]
+    },
+    "acme_warehouse.staging__us_west__shopify.orders": {
+      "statements": [
+        { "purpose": "archive:orders", "sql": "DELETE FROM acme_warehouse.staging__us_west__shopify.orders WHERE order_date < '2026-01-02'" }
+      ]
+    }
+  },
+  "totals": { "table_count": 2, "statement_count": 2 }
+}
+```
+
+The single-model envelope is byte-stable — `catalog`, `scope`, `tables`, and `totals` are absent on the existing `rocky archive` and `rocky archive --model` paths.
 
 ### Related Commands
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -442,11 +442,14 @@ rocky doctor                     # Run all checks
 rocky doctor --check config      # Run only the config check
 rocky doctor --check auth        # Verify credentials + connectivity for all adapters
 rocky doctor --check state_rw    # Round-trip a marker object against the state backend
+rocky doctor --verbose           # Add per-check context to human-readable output
 ```
 
 The `auth` check pings each registered warehouse adapter (via `SELECT 1` or an adapter-specific cheaper query) and each discovery adapter. Reports per-adapter pass/fail with latency.
 
 The `state_rw` check (v1.13.0+) runs a put → get → delete probe against the configured state backend so IAM and reachability problems surface at cold start rather than at end-of-run upload. Local backend is a no-op; tiered probes both legs.
+
+The `--verbose` flag (v1.20.0+) prints extra per-check context inline: config path, state file size, adapter type and credential signal (`token`, `oauth_client`, `oauth_token`, `key_pair`, `password`, `service_account`, `adc`, `env`, `none`), pipeline kind (`replication` / `transformation` / `quality` / `snapshot`), and state backend. JSON output is unchanged when `--verbose` is not passed — the new `details` array on each `HealthCheck` only serializes when populated, so existing consumers see byte-stable envelopes.
 
 See the [CLI Reference](/reference/cli/#rocky-doctor) for the full check list and JSON output format.
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -365,6 +365,7 @@ Aggregate health checks across config, state, adapters, and pipelines.
 | `checks[].status` | string | `"healthy"`, `"warning"`, or `"critical"`. |
 | `checks[].message` | string | Human-readable result. |
 | `checks[].duration_ms` | integer | Time spent on this check in milliseconds. |
+| `checks[].details` | array of `[key, value]` string pairs | Optional per-check context (config path, state file size, adapter type + credential signal, pipeline kind, state backend). Populated only when `--verbose` is passed; omitted from the envelope entirely otherwise (`skip_serializing_if = "Vec::is_empty"`). |
 | `suggestions` | array of strings | Actionable fix suggestions for any non-healthy checks. |
 
 ---
@@ -966,11 +967,15 @@ Generate `OPTIMIZE` and `VACUUM` SQL for Delta table compaction.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `model` | string | Target table in `catalog.schema.table` format. |
+| `model` | string or absent | Target table in `catalog.schema.table` format. Set when invoked as `rocky compact <fqn>`; absent under `--catalog` and `--measure-dedup`. |
+| `catalog` | string or absent | Catalog identifier (lowercased to match the managed-table resolver). Set only on `rocky compact --catalog <name>`. |
+| `scope` | string or absent | `"catalog"` for the catalog-scoped path; absent for single-model invocations to keep their envelope byte-stable. |
 | `dry_run` | boolean | Whether this was a dry run. |
 | `target_size_mb` | integer | Target file size in megabytes. |
 | `statements[].purpose` | string | Statement purpose (`"optimize"`, `"vacuum"`). |
-| `statements[].sql` | string | The SQL statement. |
+| `statements[].sql` | string | The SQL statement. Catalog-scoped invocations carry the concatenation of every per-table bundle here. |
+| `tables` | object or absent | Per-table breakdown keyed by fully-qualified table name. Each entry has the same `statements` shape as the flat list. Present only on `--catalog` invocations. |
+| `totals` | object or absent | Aggregate counts: `table_count` and `statement_count`. Present only on `--catalog` invocations. |
 
 ---
 
@@ -1003,12 +1008,16 @@ Generate or execute `DELETE` and `VACUUM` SQL for archiving old data.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `model` | string or absent | Target table, if filtered to a specific model. |
+| `model` | string or absent | Target table, if filtered to a specific model. Absent under `--catalog`. |
+| `catalog` | string or absent | Catalog identifier. Set only on `rocky archive --catalog <name>`. |
+| `scope` | string or absent | `"catalog"` for the catalog-scoped path; absent for single-model invocations. |
 | `older_than` | string | Age threshold as specified (e.g., `"90d"`, `"6m"`, `"1y"`). |
 | `older_than_days` | integer | Age threshold normalized to days. |
 | `dry_run` | boolean | Whether this was a dry run. |
 | `statements[].purpose` | string | Statement purpose (`"delete"`, `"vacuum"`). |
-| `statements[].sql` | string | The SQL statement. |
+| `statements[].sql` | string | The SQL statement. Catalog-scoped invocations carry every per-table statement here. |
+| `tables` | object or absent | Per-table breakdown keyed by fully-qualified table name. Present only on `--catalog` invocations. |
+| `totals` | object or absent | Aggregate counts: `table_count` and `statement_count`. Present only on `--catalog` invocations. |
 
 ---
 


### PR DESCRIPTION
## Summary

Catches the docs up to three recent CLI changes that landed without doc updates.

- **`rocky compact --catalog <name>` / `rocky archive --catalog <name>`** (#315) — aggregate per-table SQL across every Rocky-managed table in a catalog. Single-model envelopes remain byte-stable (`catalog`, `scope`, `tables`, `totals` all `skip_serializing_if`).
- **`rocky doctor --verbose`** (#304) — surfaces config path, state file size, adapter type + credential signal, pipeline kind, and state backend per check. JSON adds an optional `details` array on each `HealthCheck`, omitted when empty.

## Files touched

- `docs/src/content/docs/reference/commands/administration.md` — flag tables, mutual-exclusion note, catalog-scoped examples + JSON envelopes for both `compact` and `archive`.
- `docs/src/content/docs/reference/commands/development.md` — `rocky doctor --verbose` quickstart.
- `docs/src/content/docs/reference/cli.md` — verbose-mode block under `rocky doctor` with the full credential-signal enumeration.
- `docs/src/content/docs/reference/json-output.md` — `checks[].details`, `compact`/`archive` `catalog` / `scope` / `tables` / `totals` field descriptions.
- `docs/src/content/docs/dagster/types.md` — `HealthCheck.details` row to match the regenerated Pydantic model.

## Test plan

- [ ] `npm run build` under `docs/` succeeds (Astro build picks up the new sections cleanly).
- [ ] Spot-check that the rendered admin/doctor pages link correctly and the JSON examples are valid.
- [ ] Confirm `dagster/types.md` HealthCheck row matches the actual `dagster_rocky.types.HealthCheck` shape.
