### PR TITLE
Live full-refresh smoke test for the BigQuery POC

### DIFF
--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
@@ -62,6 +62,13 @@ POC complete: BigQuery adapter config validated and models compiled.
 3. `daily_revenue` uses time-interval strategy — at execution time, Rocky would run `BEGIN TRANSACTION; DELETE; INSERT; COMMIT TRANSACTION` per partition
 4. `customer_lifetime` uses full-refresh — `CREATE OR REPLACE TABLE`
 
+## Live execution
+
+The default `./run.sh` is compile-only. For an end-to-end materialization
+against a real BigQuery project, see [`live/`](./live/) — a separate,
+credential-gated driver that runs `rocky run` against the BigQuery REST
+API and asserts the resulting row count.
+
 ## Related
 
 - BigQuery adapter source: `engine/crates/rocky-bigquery/`

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -1,0 +1,71 @@
+# Live BigQuery smoke test
+
+Credential-gated counterpart to the parent POC's `../run.sh` (which is
+compile-only). Runs a full-refresh materialization end-to-end against a
+real GCP project and asserts the resulting row count.
+
+## What it covers
+
+- `BigQueryDialect::create_table_as` (`CREATE OR REPLACE TABLE … AS`)
+- HTTP/2 query path through `BigQueryAdapter`
+- `rocky run --output json` against BigQuery (captured to `expected/run.json`)
+- `bq` CLI dataset cleanup via shell `trap`
+
+The model is a single-row `SELECT` literal so the test has zero seed
+dependency — every byte the smoke test exercises lives inside the model
+SQL.
+
+## What it doesn't cover yet
+
+The trial-window plan calls for incremental, MERGE, and time-interval
+strategies as separate substeps. Each gets its own follow-up smoke
+test once this one is merged.
+
+## Run
+
+```bash
+export GCP_PROJECT_ID="rocky-sandbox-hc-test-63874"
+export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/rocky/bq-sandbox.json"
+export BQ_LOCATION="EU"   # optional; default EU
+./run.sh
+```
+
+`run.sh` exits 0 on success after dropping the target dataset.
+
+## Sandbox-specific by construction
+
+The model sidecar `models/full_refresh_demo.toml` hardcodes
+`catalog = "rocky-sandbox-hc-test-63874"`. Model-sidecar TOMLs don't
+honor `${VAR}` env substitution today (only `rocky.toml` does), so this
+demo is wired to a single project. Patch the catalog field if pointing
+elsewhere.
+
+## Why a separate `live/` subdir
+
+The parent POC's `../run.sh` is compile-only and runs as part of
+credential-free POC sweeps. Keeping the live driver in its own subdir
+means that path is unchanged.
+
+## Notes surfaced while authoring
+
+Three small adapter-side gaps to revisit separately:
+
+1. **No `BigQueryDiscoveryAdapter`** — the BQ adapter implements
+   `WarehouseAdapter` only, and `engine/crates/rocky-core/src/adapter_capability.rs`
+   correctly marks BQ as `DATA_ONLY`. As a result, replication
+   pipelines with a BigQuery source bail with "no discovery adapter
+   configured" at run time. This smoke test deliberately uses a
+   transformation pipeline to exercise the BQ adapter without needing
+   discovery.
+2. **Model-sidecar TOMLs skip env substitution.** `rocky.toml` is piped
+   through `substitute_env_vars` at parse time but model `.toml` files
+   are read raw (`engine/crates/rocky-core/src/models.rs:642`). The
+   existing parent-POC sidecars use `${GCP_PROJECT_ID}` expecting it to
+   work; it doesn't.
+3. **`auto_create_schemas` is unwired in the transformation run path.**
+   `engine/crates/rocky-cli/src/commands/run_local.rs::run_transformation`
+   never reads `pipeline.target.governance.auto_create_schemas` — only
+   the replication path (`run.rs:1350`) does. As a result, `rocky run`
+   on a transformation pipeline errors with 404 unless the dataset
+   already exists. `run.sh` pre-creates the dataset via `bq mk` to work
+   around it.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/live.rocky.toml
@@ -1,0 +1,18 @@
+# Live BigQuery smoke test — full-refresh materialization.
+#
+# Self-contained transformation pipeline that exercises the BigQuery
+# adapter end-to-end against a real GCP project. The model selects from
+# a single-row literal so no seed data is required — `run.sh` creates
+# the target dataset, runs the model, asserts row count, then drops the
+# dataset on exit.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+type = "transformation"
+models = "models/**"
+
+[pipeline.live.target]

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/models/full_refresh_demo.sql
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/models/full_refresh_demo.sql
@@ -1,0 +1,4 @@
+SELECT
+    1 AS id,
+    'alice' AS name,
+    100 AS amount

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/models/full_refresh_demo.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/models/full_refresh_demo.toml
@@ -1,0 +1,10 @@
+[strategy]
+type = "full_refresh"
+
+# Hardcoded to the Rocky BQ sandbox project. Model sidecar TOMLs don't
+# honor ${VAR} env substitution today (rocky.toml does), so this live
+# demo is sandbox-specific by construction. Patch both fields if running
+# against a different project.
+[target]
+catalog = "rocky-sandbox-hc-test-63874"
+schema = "hc_phase1_live"

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Live BigQuery smoke test — full-refresh materialization end-to-end.
+#
+# Runs `rocky run` against a real GCP project, asserts the resulting
+# table has the expected row count, then drops the target dataset
+# regardless of outcome.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or set BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+DATASET="hc_phase1_live"
+
+drop_dataset() {
+    bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+       rm -r -f -d "$DATASET" 2>/dev/null || true
+}
+
+# Drop any stale dataset from a previous failed run before starting.
+drop_dataset
+trap drop_dataset EXIT
+
+echo "==> dataset: $GCP_PROJECT_ID.$DATASET (location: $LOCATION)"
+
+# Pre-create the target dataset. `run_transformation` in the engine
+# does not honor `auto_create_schemas` (only the replication path
+# does), so the dataset must exist before `CREATE TABLE` runs.
+bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+   mk --dataset "$DATASET"
+
+echo "==> rocky validate"
+rocky -c live.rocky.toml validate
+
+echo "==> rocky run"
+rocky -c live.rocky.toml run --output json > expected/run.json
+echo "    exit ok"
+
+echo "==> verifying row count"
+ACTUAL_ROWS="$(bq --project_id="$GCP_PROJECT_ID" \
+    query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT COUNT(*) FROM \`${GCP_PROJECT_ID}\`.\`${DATASET}\`.\`full_refresh_demo\`" \
+    | tail -n 1)"
+
+if [[ "$ACTUAL_ROWS" != "1" ]]; then
+    echo "FAIL: expected 1 row, got '$ACTUAL_ROWS'"
+    exit 1
+fi
+echo "    rows = 1 (matches model SELECT literal)"
+
+echo
+echo "POC complete: BigQuery full-refresh materialization verified live."


### PR DESCRIPTION
First end-to-end execution of the BigQuery adapter against a real GCP project from this repo. Adds a credential-gated `live/` driver alongside the existing compile-only `run.sh` in `examples/playground/pocs/07-adapters/05-bigquery-native-queries/`.

The driver:

- Pre-creates a target dataset, runs `rocky run` against a single-row transformation model, asserts the resulting row count via `bq query`, and drops the dataset on exit (success or failure).
- Captures the `rocky run --output json` payload to `live/expected/run.json` (gitignored).
- Has zero seed dependency — the model is `SELECT 1 AS id, …` so the test exercises only the adapter's `CREATE TABLE … AS` path.

Run:

```bash
export GCP_PROJECT_ID="rocky-sandbox-hc-test-63874"
export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/rocky/bq-sandbox.json"
export BQ_LOCATION="EU"
./examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/run.sh
```

Exits 0 with `rows = 1 (matches model SELECT literal)`.

## Findings worth following up separately

Documented in `live/README.md`:

1. **No `BigQueryDiscoveryAdapter`.** BQ implements `WarehouseAdapter` only; `adapter_capability.rs` correctly marks BQ `DATA_ONLY`. Replication-from-BQ pipelines bail with "no discovery adapter configured" at run time. This smoke test uses a transformation pipeline to sidestep it.
2. **Model sidecar TOMLs skip env substitution.** `rocky.toml` is interpolated at parse time but model `.toml` files are read raw (`models.rs:642`). The catalog field has to be hardcoded.
3. **`auto_create_schemas` is unwired in the transformation run path.** `run_local.rs::run_transformation` never reads the governance flag — only the replication path does (`run.rs:1350`). `run.sh` works around it with `bq mk`.

Each is a small, isolatable engine PR.

## Scope

Full-refresh only. Incremental, MERGE, and time-interval are follow-ups.

## Test plan

- [x] `./live/run.sh` against sandbox: exits 0, row count assertion passes, dataset cleaned up
- [x] Idempotency: two consecutive runs both pass (stale-dataset drop at start handles it)
- [x] Existing compile-only `./run.sh` untouched