### PR TITLE
fix(rocky-bigquery): emit time-interval transaction as single script

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -329,6 +329,18 @@ impl WarehouseAdapter for BigQueryAdapter {
             })
             .collect();
 
+        // INFORMATION_SCHEMA.COLUMNS returns zero rows for a missing table
+        // rather than raising — so an empty result here means the table
+        // doesn't exist. Surface that as an error so callers using
+        // `describe_table().is_ok()` to probe existence (e.g. the
+        // time-interval bootstrap path) get the right answer.
+        if columns.is_empty() {
+            return Err(AdapterError::msg(format!(
+                "table `{}`.`{}`.`{}` not found",
+                table.catalog, table.schema, table.table
+            )));
+        }
+
         Ok(columns)
     }
 

--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -145,13 +145,19 @@ impl SqlDialect for BigQueryDialect {
         partition_filter: &str,
         select_sql: &str,
     ) -> AdapterResult<Vec<String>> {
-        // BigQuery supports DML transactions since 2023
-        Ok(vec![
-            "BEGIN TRANSACTION".to_string(),
-            format!("DELETE FROM {target} WHERE {partition_filter}"),
-            format!("INSERT INTO {target}\n{select_sql}"),
-            "COMMIT TRANSACTION".to_string(),
-        ])
+        // BigQuery's REST API is stateless — each `jobs.query` call is its
+        // own session, so issuing BEGIN/COMMIT as separate statements
+        // fails with `Transaction control statements are supported only in
+        // scripts or sessions`. Emit the DML transaction as a single
+        // semicolon-joined script so the runtime submits all four
+        // statements as one job, which BigQuery executes atomically and
+        // auto-rolls-back on any sub-statement error.
+        Ok(vec![format!(
+            "BEGIN TRANSACTION;\n\
+             DELETE FROM {target} WHERE {partition_filter};\n\
+             INSERT INTO {target}\n{select_sql};\n\
+             COMMIT TRANSACTION"
+        )])
     }
 
     fn list_tables_sql(
@@ -232,9 +238,14 @@ mod tests {
                 "SELECT * FROM src",
             )
             .unwrap();
-        assert_eq!(stmts.len(), 4);
-        assert_eq!(stmts[0], "BEGIN TRANSACTION");
-        assert_eq!(stmts[3], "COMMIT TRANSACTION");
+        // BigQuery requires the transaction to be a single script (its
+        // REST API rejects standalone BEGIN/COMMIT calls).
+        assert_eq!(stmts.len(), 1);
+        let script = &stmts[0];
+        assert!(script.starts_with("BEGIN TRANSACTION;\n"));
+        assert!(script.contains("DELETE FROM `p`.`d`.`t` WHERE date_col >= '2024-01-01';"));
+        assert!(script.contains("INSERT INTO `p`.`d`.`t`\nSELECT * FROM src;"));
+        assert!(script.ends_with("COMMIT TRANSACTION"));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3902,10 +3902,12 @@ async fn run_one_partition(
     // transactional dialects (Snowflake / DuckDB) don't leave partial state
     // visible.
     //
-    // Accumulate warehouse-reported bytes across all statements — the BQ
-    // `insert_overwrite_partition` contract emits 4 statements
-    // (BEGIN / DELETE / INSERT / COMMIT), each of which potentially reports
-    // its own `totalBytesBilled`. Summing gives the partition-total cost
+    // Accumulate warehouse-reported bytes across all statements. Snowflake
+    // and DuckDB emit 4 statements (BEGIN / DELETE / INSERT / COMMIT);
+    // BigQuery emits a single semicolon-joined script (its stateless REST
+    // API rejects standalone BEGIN/COMMIT calls); Databricks emits one
+    // `INSERT INTO ... REPLACE WHERE`. Each statement potentially reports
+    // its own `totalBytesBilled` — summing gives the partition-total cost
     // input. Non-BQ adapters return `None` from the default trait method,
     // so `bytes_acc` stays `None` and `compute_observed_cost_usd` falls
     // through to the duration-based branch.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -1,25 +1,31 @@
-# Live BigQuery smoke test
+# Live BigQuery smoke tests
 
-Credential-gated counterpart to the parent POC's `../run.sh` (which is
-compile-only). Runs a full-refresh materialization end-to-end against a
-real GCP project and asserts the resulting row count.
+Credential-gated counterparts to the parent POC's `../run.sh` (which is
+compile-only). Each driver runs a different materialization strategy
+end-to-end against a real GCP project and asserts the resulting state.
 
-## What it covers
+## Drivers
 
-- `BigQueryDialect::create_table_as` (`CREATE OR REPLACE TABLE … AS`)
-- HTTP/2 query path through `BigQueryAdapter`
-- `rocky run --output json` against BigQuery (captured to `expected/run.json`)
-- `bq` CLI dataset cleanup via shell `trap`
+| Path | Strategy | Covers |
+|---|---|---|
+| `./run.sh` | `full_refresh` | `BigQueryDialect::create_table_as` |
+| `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
 
-The model is a single-row `SELECT` literal so the test has zero seed
-dependency — every byte the smoke test exercises lives inside the model
-SQL.
+Each driver:
 
-## What it doesn't cover yet
+- Pre-creates a target dataset, runs `rocky run`, asserts the resulting
+  rows via `bq query`, drops the dataset on exit (success or failure).
+- Captures the `rocky run --output json` payload to `expected/run.json`
+  (gitignored).
+- Has its own `live.rocky.toml` and `models/` so they can run in any
+  order without coupling.
 
-The trial-window plan calls for incremental, MERGE, and time-interval
-strategies as separate substeps. Each gets its own follow-up smoke
-test once this one is merged.
+## What's not covered yet
+
+- Incremental and MERGE strategies (separate follow-up smoke tests).
+- Time-interval failure-path (forced mid-transaction error → BQ
+  auto-rollback). The script-as-transaction shape proves the happy
+  path; rollback semantics are a separate property worth its own test.
 
 ## Run
 
@@ -27,17 +33,19 @@ test once this one is merged.
 export GCP_PROJECT_ID="rocky-sandbox-hc-test-63874"
 export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/rocky/bq-sandbox.json"
 export BQ_LOCATION="EU"   # optional; default EU
-./run.sh
+./run.sh                   # full-refresh
+./time-interval/run.sh     # time-interval (4-statement DML transaction)
 ```
 
-`run.sh` exits 0 on success after dropping the target dataset.
+Each script exits 0 on success after dropping its target dataset.
 
 ## Sandbox-specific by construction
 
-The model sidecar `models/full_refresh_demo.toml` hardcodes
-`catalog = "rocky-sandbox-hc-test-63874"`. Model-sidecar TOMLs don't
-honor `${VAR}` env substitution today (only `rocky.toml` does), so this
-demo is wired to a single project. Patch the catalog field if pointing
+Model sidecar TOMLs (and the time-interval model SQL, which references
+the source table by 3-part name) hardcode the project ID
+`rocky-sandbox-hc-test-63874`. Model files don't honor `${VAR}` env
+substitution today (only `rocky.toml` does), so these demos are wired
+to a single project. Patch the catalog / hardcoded project if pointing
 elsewhere.
 
 ## Why a separate `live/` subdir
@@ -48,14 +56,14 @@ means that path is unchanged.
 
 ## Notes surfaced while authoring
 
-Three small adapter-side gaps to revisit separately:
+Adapter-side gaps to revisit separately:
 
 1. **No `BigQueryDiscoveryAdapter`** — the BQ adapter implements
    `WarehouseAdapter` only, and `engine/crates/rocky-core/src/adapter_capability.rs`
    correctly marks BQ as `DATA_ONLY`. As a result, replication
    pipelines with a BigQuery source bail with "no discovery adapter
-   configured" at run time. This smoke test deliberately uses a
-   transformation pipeline to exercise the BQ adapter without needing
+   configured" at run time. These smoke tests deliberately use
+   transformation pipelines to exercise the BQ adapter without needing
    discovery.
 2. **Model-sidecar TOMLs skip env substitution.** `rocky.toml` is piped
    through `substitute_env_vars` at parse time but model `.toml` files
@@ -67,5 +75,12 @@ Three small adapter-side gaps to revisit separately:
    never reads `pipeline.target.governance.auto_create_schemas` — only
    the replication path (`run.rs:1350`) does. As a result, `rocky run`
    on a transformation pipeline errors with 404 unless the dataset
-   already exists. `run.sh` pre-creates the dataset via `bq mk` to work
-   around it.
+   already exists. The drivers pre-create the dataset via `bq mk` to
+   work around it.
+4. **Time-interval `time_column` must be TIMESTAMP on BigQuery.** The
+   runtime emits the partition filter as `'YYYY-MM-DD HH:MM:SS'`
+   string literals (`sql_gen.rs:239`). BigQuery refuses to coerce a
+   timestamp-shape literal to a DATE column, so the model output's
+   partition column has to be TIMESTAMP. Other dialects are more
+   permissive. The time-interval model uses `TIMESTAMP_TRUNC(...)` to
+   produce a TIMESTAMP partition column.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/live.rocky.toml
@@ -1,0 +1,16 @@
+# Live BigQuery time-interval smoke test.
+#
+# Exercises the BQ-specific 4-statement DML transaction the time-interval
+# strategy emits (BEGIN TRANSACTION; DELETE; INSERT; COMMIT TRANSACTION)
+# end-to-end against a real GCP project.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+type = "transformation"
+models = "models/**"
+
+[pipeline.live.target]

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/models/orders_daily.sql
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/models/orders_daily.sql
@@ -1,0 +1,9 @@
+SELECT
+    TIMESTAMP_TRUNC(order_at, DAY) AS order_day,
+    customer_id,
+    COUNT(*)                       AS order_count,
+    SUM(amount)                    AS revenue
+FROM `rocky-sandbox-hc-test-63874`.`hc_phase1_live_ti`.`orders_src`
+WHERE order_at >= @start_date
+  AND order_at <  @end_date
+GROUP BY 1, 2

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/models/orders_daily.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/models/orders_daily.toml
@@ -1,0 +1,15 @@
+[strategy]
+type = "time_interval"
+# Must be a TIMESTAMP column on BigQuery: the runtime emits the partition
+# filter as `'YYYY-MM-DD HH:MM:SS'` literals, which BQ refuses to coerce
+# to a DATE column.
+time_column = "order_day"
+granularity = "day"
+lookback = 0
+first_partition = "2026-04-01"
+
+# Hardcoded to the Rocky BQ sandbox project — model sidecar TOMLs don't
+# honor ${VAR} env substitution today (see live/README.md for context).
+[target]
+catalog = "rocky-sandbox-hc-test-63874"
+schema = "hc_phase1_live_ti"

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Live BigQuery time-interval smoke test.
+#
+# Runs `rocky run --partition KEY` for two consecutive day partitions
+# against a real GCP project, exercising the 4-statement DML
+# transaction (BEGIN TRANSACTION; DELETE; INSERT; COMMIT TRANSACTION)
+# the BigQuery dialect emits for time-interval models. Verifies that
+# both partitions materialize the expected aggregated row counts.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+DATASET="hc_phase1_live_ti"
+
+drop_dataset() {
+    bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+       rm -r -f -d "$DATASET" 2>/dev/null || true
+}
+
+# Drop any stale dataset from a previous failed run before starting.
+drop_dataset
+trap drop_dataset EXIT
+
+echo "==> dataset: $GCP_PROJECT_ID.$DATASET (location: $LOCATION)"
+
+# Pre-create the target dataset. `run_transformation` doesn't honor
+# `auto_create_schemas` today (see ../README.md), so the dataset must
+# exist before CREATE TABLE / DML transactions run.
+bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+   mk --dataset "$DATASET"
+
+echo "==> seeding source: orders_src (5 rows across 2 days)"
+bq --project_id="$GCP_PROJECT_ID" query --use_legacy_sql=false --quiet \
+"CREATE TABLE \`${GCP_PROJECT_ID}\`.\`${DATASET}\`.\`orders_src\` AS
+ SELECT order_at, customer_id, amount FROM UNNEST([
+   STRUCT(TIMESTAMP '2026-04-01 09:00:00' AS order_at, 1 AS customer_id, 100 AS amount),
+   STRUCT(TIMESTAMP '2026-04-01 14:00:00',             1,                 50),
+   STRUCT(TIMESTAMP '2026-04-01 19:00:00',             2,                 75),
+   STRUCT(TIMESTAMP '2026-04-02 08:00:00',             1,                200),
+   STRUCT(TIMESTAMP '2026-04-02 16:00:00',             3,                300)
+ ])" > /dev/null
+
+echo "==> rocky validate"
+rocky -c live.rocky.toml validate > /dev/null
+
+echo "==> rocky run --partition 2026-04-01"
+rocky -c live.rocky.toml run --partition 2026-04-01 --output json \
+    > expected/run-2026-04-01.json
+
+echo "==> rocky run --partition 2026-04-02"
+rocky -c live.rocky.toml run --partition 2026-04-02 --output json \
+    > expected/run-2026-04-02.json
+
+echo "==> verifying materialized output"
+RESULT="$(bq --project_id="$GCP_PROJECT_ID" \
+    query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT order_day, SUM(order_count) AS o, SUM(revenue) AS r
+     FROM \`${GCP_PROJECT_ID}\`.\`${DATASET}\`.\`orders_daily\`
+     GROUP BY order_day
+     ORDER BY order_day")"
+
+EXPECTED='order_day,o,r
+2026-04-01 00:00:00,3,225
+2026-04-02 00:00:00,2,500'
+
+if [[ "$RESULT" != "$EXPECTED" ]]; then
+    echo "FAIL: materialized output did not match"
+    echo "expected:"
+    echo "$EXPECTED"
+    echo "actual:"
+    echo "$RESULT"
+    exit 1
+fi
+echo "    2026-04-01: 3 orders, revenue=225"
+echo "    2026-04-02: 2 orders, revenue=500"
+
+echo
+echo "POC complete: BigQuery time-interval DML transaction verified live."


### PR DESCRIPTION
First end-to-end run of the BigQuery time-interval strategy surfaced two structural bugs in the BQ adapter that pass unit tests (which use stubbed JSON responses) but fail against a real BigQuery project.

## What was broken

### 1. `BEGIN TRANSACTION` / `COMMIT TRANSACTION` as separate REST calls

`BigQueryDialect::insert_overwrite_partition` returned four statements (`BEGIN TRANSACTION`, `DELETE`, `INSERT`, `COMMIT TRANSACTION`). The runtime issues each `Vec<String>` element as its own `jobs.query` REST call. BigQuery's REST API is stateless — every call is its own session — so `BEGIN TRANSACTION` issued as a standalone statement immediately fails:

```
Transaction control statements are supported only in scripts or sessions
```

Other adapters cope with this differently:

- Databricks emits a single `INSERT INTO ... REPLACE WHERE` (one atomic statement).
- Snowflake/DuckDB use session-aware connections so the transaction state persists across separate calls.

The BQ implementation was the only one structurally broken on its own contract.

### 2. `describe_table` reported missing tables as existing

`BigQueryAdapter::describe_table` queries `INFORMATION_SCHEMA.COLUMNS WHERE table_name = '...'`. For a non-existent table BQ returns zero rows (no error), so the function returned `Ok(empty_vec)`. Callers using `describe_table().is_ok()` to probe for table existence — notably the time-interval bootstrap path — therefore skipped bootstrap and tried to `DELETE` from a table that didn't exist.

Databricks/Snowflake already error on missing tables (because `DESCRIBE TABLE` raises). This brings BQ into alignment.

## What's fixed

- `insert_overwrite_partition` now returns a single semicolon-joined script. BigQuery executes it as one atomic job and auto-rolls-back on any sub-statement error.
- `describe_table` returns `Err` when the result is empty, so existence probes work correctly.
- Updated unit test to match the new shape.

## Verification

Adds `examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/` — a credential-gated live driver that:

1. Seeds a 5-row source table spanning two days.
2. Runs `rocky run --partition 2026-04-01` → bootstrap + 1-partition transaction.
3. Runs `rocky run --partition 2026-04-02` → 1-partition transaction.
4. Asserts the materialized table has the expected per-day aggregates via `bq query`.
5. Drops the dataset on exit (success or failure) via shell `trap`.

Both partitions materialize correctly, idempotent across consecutive runs.

```
==> 2026-04-01: 3 orders, revenue=225
==> 2026-04-02: 2 orders, revenue=500
POC complete: BigQuery time-interval DML transaction verified live.
```

## Out of scope

- Failure-path verification (forced mid-transaction error → BQ auto-rollback). Separate property worth its own test.
- A fourth adapter-side gap surfaced while authoring: the runtime emits partition filters as `'YYYY-MM-DD HH:MM:SS'` literals regardless of column type, so BigQuery `time_column` must be TIMESTAMP rather than DATE. Documented in `live/README.md`; cross-dialect fix belongs in `sql_gen.rs` and is bigger surgery.

## Test plan

- [x] `cargo test -p rocky-bigquery` clean
- [x] `cargo clippy -p rocky-bigquery -p rocky-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery -p rocky-cli --check` clean
- [x] `live/time-interval/run.sh` against the BQ sandbox: exits 0, both partitions materialize, dataset cleaned up
- [x] Two consecutive runs both pass (idempotency)