### PR TITLE
fix(rocky-cli): wire generate_transformation_initial_ddl for MERGE first-run

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3474,6 +3474,50 @@ pub(crate) async fn execute_models(
                 )
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+            // MERGE requires the target to exist before the statement runs.
+            // sql_gen exposes `generate_transformation_initial_ddl` for
+            // exactly this purpose but no call site has been wiring it up,
+            // so MERGE on a fresh target failed with "table not found".
+            // Mirror the time_interval bootstrap pattern: probe via
+            // describe_table().is_ok() and run the initial DDL if missing.
+            // (Adds one describe_table round-trip per MERGE model per run;
+            // matches the cost the time_interval path already pays at
+            // run.rs:3707.) Narrow to Merge for now — Incremental /
+            // DeleteInsert / Microbatch likely have the same gap, but each
+            // gets bootstrapped only when a live smoke test for that
+            // strategy lands and verifies the fix end-to-end.
+            if matches!(
+                plan.strategy,
+                rocky_core::ir::MaterializationStrategy::Merge { .. }
+            ) {
+                let target_table_struct = rocky_core::ir::TableRef {
+                    catalog: plan.target.catalog.clone(),
+                    schema: plan.target.schema.clone(),
+                    table: plan.target.table.clone(),
+                };
+                if warehouse
+                    .describe_table(&target_table_struct)
+                    .await
+                    .is_err()
+                {
+                    let initial_ddls =
+                        rocky_core::sql_gen::generate_transformation_initial_ddl(&plan, dialect)?;
+                    info!(
+                        model = model_name.as_str(),
+                        target = target_ref.as_str(),
+                        statements = initial_ddls.len(),
+                        "merge target does not exist — bootstrapping empty table from model schema"
+                    );
+                    for ddl in &initial_ddls {
+                        warehouse.execute_statement(ddl).await.map_err(|e| {
+                            anyhow::anyhow!(
+                                "bootstrap of '{target_ref}' for model '{model_name}' failed: {e}"
+                            )
+                        })?;
+                    }
+                }
+            }
+
             let exec_stmts = rocky_core::sql_gen::generate_transformation_sql(&plan, dialect)?;
 
             info!(

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -175,9 +175,11 @@ pub fn generate_transformation_sql(
 
     // If a lakehouse format is specified, use format-specific DDL generation
     // for strategies that create tables (FullRefresh, Incremental first-run,
-    // Merge first-run). The runtime calls `generate_transformation_initial_ddl`
-    // for the initial table creation of non-FullRefresh strategies; here we
-    // handle FullRefresh which always does CTAS.
+    // Merge first-run). For non-FullRefresh strategies, the runtime probes
+    // target existence via `describe_table` and calls
+    // `generate_transformation_initial_ddl` when missing (Merge today;
+    // Incremental / DeleteInsert / Microbatch wired in as their live smoke
+    // tests land). Here we handle FullRefresh which always does CTAS.
     if let Some(ref format) = plan.format {
         if matches!(plan.strategy, MaterializationStrategy::FullRefresh) {
             let opts = plan.format_options.as_ref().cloned().unwrap_or_default();

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -10,6 +10,7 @@ end-to-end against a real GCP project and asserts the resulting state.
 |---|---|---|
 | `./run.sh` | `full_refresh` | `BigQueryDialect::create_table_as` |
 | `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
+| `merge/run.sh` | `merge` | `BigQueryDialect::merge_into` (`WHEN NOT MATCHED THEN INSERT ROW`) + first-run target bootstrap |
 
 Each driver:
 
@@ -22,10 +23,12 @@ Each driver:
 
 ## What's not covered yet
 
-- Incremental and MERGE strategies (separate follow-up smoke tests).
+- Incremental strategy (separate follow-up smoke test).
+- Drift cycle (gated on `BigQueryDiscoveryAdapter` — see finding 1).
 - Time-interval failure-path (forced mid-transaction error → BQ
   auto-rollback). The script-as-transaction shape proves the happy
   path; rollback semantics are a separate property worth its own test.
+- MERGE without explicit `update_columns` (see finding 5).
 
 ## Run
 
@@ -35,6 +38,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/rocky/bq-sandbox.json"
 export BQ_LOCATION="EU"   # optional; default EU
 ./run.sh                   # full-refresh
 ./time-interval/run.sh     # time-interval (4-statement DML transaction)
+./merge/run.sh             # merge (bootstrap + UPSERT)
 ```
 
 Each script exits 0 on success after dropping its target dataset.
@@ -84,3 +88,10 @@ Adapter-side gaps to revisit separately:
    partition column has to be TIMESTAMP. Other dialects are more
    permissive. The time-interval model uses `TIMESTAMP_TRUNC(...)` to
    produce a TIMESTAMP partition column.
+5. **MERGE requires explicit `update_columns` on BigQuery.** When the
+   model TOML omits the list, the dialect emits the shorthand
+   `UPDATE SET target = source` (`dialect.rs:54`). BigQuery rejects
+   this with `UPDATE ... SET does not support updating the entire row`
+   — it needs explicit per-column assignments. The merge model
+   declares `update_columns = ["name", "amount"]` to sidestep it.
+   Snowflake/DuckDB may accept the shorthand; not verified.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/live.rocky.toml
@@ -1,0 +1,16 @@
+# Live BigQuery MERGE smoke test.
+#
+# Exercises the BQ-specific MERGE shape (`WHEN NOT MATCHED THEN INSERT
+# ROW`) end-to-end against a real GCP project, including the runtime's
+# bootstrap path that pre-creates the target on first run.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+type = "transformation"
+models = "models/**"
+
+[pipeline.live.target]

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/models/customers.sql
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/models/customers.sql
@@ -1,0 +1,2 @@
+SELECT id, name, amount
+FROM `rocky-sandbox-hc-test-63874`.`hc_phase1_live_merge`.`customers_src`

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/models/customers.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/models/customers.toml
@@ -1,0 +1,13 @@
+[strategy]
+type = "merge"
+unique_key = ["id"]
+# `update_columns` must be declared explicitly: BigQuery rejects the
+# default `UPDATE SET target = source` shorthand the dialect emits when
+# this list is omitted. Documented as a finding in ../README.md.
+update_columns = ["name", "amount"]
+
+# Hardcoded to the Rocky BQ sandbox project — model sidecar TOMLs don't
+# honor ${VAR} env substitution today (see live/README.md for context).
+[target]
+catalog = "rocky-sandbox-hc-test-63874"
+schema = "hc_phase1_live_merge"

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Live BigQuery MERGE smoke test.
+#
+# Verifies the MERGE strategy end-to-end against a real GCP project,
+# including:
+#   - Bootstrap path on first run (target created from model schema).
+#   - `WHEN NOT MATCHED THEN INSERT ROW` (BQ-unique syntax).
+#   - Upsert semantics: existing rows updated, new rows inserted,
+#     untouched rows unchanged across consecutive runs.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+DATASET="hc_phase1_live_merge"
+PROJ="$GCP_PROJECT_ID"
+
+drop_dataset() {
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$DATASET" 2>/dev/null || true
+}
+
+drop_dataset
+trap drop_dataset EXIT
+
+echo "==> dataset: $PROJ.$DATASET (location: $LOCATION)"
+bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$DATASET"
+
+echo "==> seeding source: customers_src (3 baseline rows)"
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+"CREATE TABLE \`${PROJ}\`.\`${DATASET}\`.\`customers_src\` AS
+ SELECT id, name, amount FROM UNNEST([
+   STRUCT(1 AS id, 'alice'   AS name, 100 AS amount),
+   STRUCT(2,        'bob',              200),
+   STRUCT(3,        'carol',            300)
+ ])" > /dev/null
+
+echo "==> rocky validate"
+rocky -c live.rocky.toml validate > /dev/null
+
+echo "==> rocky run (initial — bootstrap + MERGE inserts all 3 rows)"
+rocky -c live.rocky.toml run --output json > expected/run-initial.json
+
+EXPECTED_INITIAL='id,name,amount
+1,alice,100
+2,bob,200
+3,carol,300'
+ACTUAL="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT id, name, amount FROM \`${PROJ}\`.\`${DATASET}\`.\`customers\` ORDER BY id")"
+if [[ "$ACTUAL" != "$EXPECTED_INITIAL" ]]; then
+    echo "FAIL: initial materialization did not match"
+    echo "expected:"; echo "$EXPECTED_INITIAL"
+    echo "actual:";   echo "$ACTUAL"
+    exit 1
+fi
+echo "    initial: 3 rows (alice/bob/carol) — bootstrap + MERGE INSERT path"
+
+echo "==> mutating source: update bob, add dave"
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+"CREATE OR REPLACE TABLE \`${PROJ}\`.\`${DATASET}\`.\`customers_src\` AS
+ SELECT id, name, amount FROM UNNEST([
+   STRUCT(1 AS id, 'alice'   AS name, 100 AS amount),
+   STRUCT(2,        'bob',              250),
+   STRUCT(3,        'carol',            300),
+   STRUCT(4,        'dave',             400)
+ ])" > /dev/null
+
+echo "==> rocky run (delta — MERGE UPDATE + INSERT)"
+rocky -c live.rocky.toml run --output json > expected/run-delta.json
+
+EXPECTED_DELTA='id,name,amount
+1,alice,100
+2,bob,250
+3,carol,300
+4,dave,400'
+ACTUAL="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT id, name, amount FROM \`${PROJ}\`.\`${DATASET}\`.\`customers\` ORDER BY id")"
+if [[ "$ACTUAL" != "$EXPECTED_DELTA" ]]; then
+    echo "FAIL: delta materialization did not match"
+    echo "expected:"; echo "$EXPECTED_DELTA"
+    echo "actual:";   echo "$ACTUAL"
+    exit 1
+fi
+echo "    delta: bob updated to 250, dave inserted, alice/carol unchanged"
+
+echo
+echo "POC complete: BigQuery MERGE strategy verified live."


### PR DESCRIPTION
First live run of the MERGE strategy on BigQuery surfaced two structural bugs that pass unit tests (which use stubbed JSON) but fail against a real BQ project. This PR fixes the first one and uses a workaround for the second.

## What was broken

### MERGE first-run failed with "table not found"

`engine/crates/rocky-core/src/sql_gen.rs::generate_transformation_initial_ddl` was authored in PR #75 (2026-04-15) with a docstring and tests but no production call site. The runtime never bootstrapped the empty target table that MERGE requires, so a fresh target dataset hit:

```
BigQuery API error: Not found: Table ... was not found in location EU
```

Time-interval already had its own bootstrap path (`run.rs:3707`); MERGE silently didn't, even though the helper function existed.

## Fix

Mirrors the time-interval bootstrap pattern in `run.rs`. Before generating the MERGE statement:

1. Probe the target via `describe_table().is_ok()`. This works correctly on BigQuery only because of the previous PR's `INFORMATION_SCHEMA.COLUMNS`-empty-→-Err fix.
2. If missing, call `generate_transformation_initial_ddl` and execute the resulting CTAS.

Narrowed to `MaterializationStrategy::Merge` for now. Incremental / DeleteInsert / Microbatch likely have the same gap but each gets bootstrapped only when a live smoke test for that strategy lands. The pattern keeps fix-and-receipt discipline tight.

## Verification

Adds `live/merge/` — a credential-gated driver that:

1. Seeds a 3-row source (`alice`, `bob`, `carol`).
2. Runs `rocky run` → bootstrap creates target + MERGE inserts all 3 (no matches yet).
3. Mutates the source (`bob` amount changes; `dave` added).
4. Runs `rocky run` again → MERGE updates `bob`, inserts `dave`, leaves `alice` and `carol` unchanged.
5. Asserts the final state via `bq query`. Drops the dataset on exit.

Runs idempotently across consecutive invocations.

## A second BQ adapter gap surfaced (deferred)

`BigQueryDialect::merge_into` emits `UPDATE SET target = source` shorthand when `update_columns` is omitted on the model. BigQuery rejects this:

```
UPDATE ... SET does not support updating the entire row
```

BigQuery requires explicit per-column assignments. Worked around in the smoke test by declaring `update_columns = ["name", "amount"]` on the model TOML; a future fix-with-receipt PR will handle the shorthand path properly. Documented as finding #5 in `live/README.md`.

## Test plan

- [x] `cargo test -p rocky-bigquery -p rocky-core` clean
- [x] `cargo clippy -p rocky-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-cli -p rocky-core --check` clean
- [x] `live/merge/run.sh` against the sandbox: exits 0, both runs produce the expected upserts, dataset cleaned up
- [x] Two consecutive runs both pass (idempotency)