### PR TITLE
feat(dagster): add RockyComponent.strict_build opt-in for fail-loud loads

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`RockyComponent.strict_build` opt-in (FR-019).** New boolean field, default `False`. When set to `True`, three "log and swallow" paths in `build_defs` are converted into hard failures: (1) `_maybe_cold_start_discover` re-raises a failing `write_state_to_path` instead of warning and falling through to the empty-state path, (2) `build_defs_from_state` raises `dg.Failure` when state is missing or contains zero discover sources instead of returning empty `Definitions`, and (3) the discover slot of `write_state_to_path` re-raises instead of writing an empty discover envelope. Compile and optimize slots stay best-effort even under `strict_build` — they are augmentation surfaces (compiler diagnostics, optimize recommendations) rather than the asset graph itself, so a missing slot does not signal a broken graph. Use when an empty Rocky asset graph is never an acceptable code-server load — fail the deploy rather than ship a healthy-looking deployment with no assets. Default-off preserves existing behaviour for adopters who rely on best-effort load with empty graph as their failure mode.
+
 ## [1.18.1] — 2026-05-01
 
 Patch release. Defensive dedup of asset specs and check specs to survive duplicate table records from `rocky discover`.

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -437,6 +437,32 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: segment. Default ``False`` because N derived models = N CLI
     #: invocations on every code-server load.
     surface_column_lineage: bool = False
+    #: When ``True``, several "log and swallow" paths in :meth:`build_defs`
+    #: are converted into hard failures. Use when an empty Rocky asset
+    #: graph is never an acceptable outcome — better to fail the
+    #: code-server load than ship a healthy-looking deployment with no
+    #: assets.
+    #:
+    #: Specifically, when set to ``True``:
+    #:
+    #: * :meth:`_maybe_cold_start_discover` failures re-raise instead of
+    #:   logging at WARN and falling through to the empty-state path.
+    #: * :meth:`build_defs_from_state` raises :class:`dg.Failure` when
+    #:   the state file is missing or contains zero discover sources,
+    #:   instead of returning empty :class:`dg.Definitions`.
+    #: * The discover slot of :meth:`write_state_to_path` re-raises
+    #:   instead of writing an empty discover envelope.
+    #:
+    #: Compile and optimize stay best-effort even under ``strict_build``
+    #: — they are augmentation slots (compiler diagnostics surfaced as
+    #: checks, optimize recommendations as metadata) rather than the
+    #: asset graph itself. A missing compile slot does not mean the
+    #: graph is broken; a missing discover slot does.
+    #:
+    #: Default ``False`` preserves the existing behaviour for adopters
+    #: who rely on "best-effort load with empty graph" as their failure
+    #: mode.
+    strict_build: bool = False
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -505,6 +531,12 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             # DAG output is the primary data source, so an empty discover
             # envelope is acceptable. Log so operators can triage the
             # underlying cause.
+            #
+            # Under ``strict_build`` adopters have explicitly opted into
+            # "fail the deploy rather than ship a partial graph", so the
+            # exception propagates instead of being swallowed.
+            if self.strict_build:
+                raise
             _log.warning(
                 "rocky discover failed during state write — writing empty discover envelope",
                 exc_info=True,
@@ -705,6 +737,8 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         try:
             self.write_state_to_path(state_path)
         except Exception:
+            if self.strict_build:
+                raise
             _log.warning(
                 "RockyComponent fallback discover failed — component will load with no assets",
                 exc_info=True,
@@ -811,6 +845,14 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     ) -> dg.Definitions:
         """Build materializable assets from the cached discover/compile state."""
         if state_path is None:
+            if self.strict_build:
+                raise dg.Failure(
+                    description=(
+                        "RockyComponent strict_build=True: cannot build asset "
+                        "graph from missing state. Either pre-seed state, set "
+                        "discover_on_missing_state=true, or unset strict_build."
+                    ),
+                )
             return dg.Definitions()
 
         # DAG-mode: build the full connected asset graph from ``rocky dag``.
@@ -818,6 +860,15 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             return self._build_defs_from_dag(context, state_path)
 
         discover, compile_result, optimize_result = _load_state(state_path)
+        if self.strict_build and not discover.sources:
+            raise dg.Failure(
+                description=(
+                    "RockyComponent strict_build=True: cannot build asset "
+                    f"graph from state at {state_path} — discover envelope "
+                    "contains zero sources. Either pre-seed state, set "
+                    "discover_on_missing_state=true, or unset strict_build."
+                ),
+            )
         compile_state = _CompileState.from_result(compile_result)
 
         translator = self._get_translator()

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -1167,3 +1167,214 @@ def test_build_check_specs_dedupes_when_group_has_duplicate_specs():
     assert len(check_specs) == len(component_module.DEFAULT_CHECK_NAMES)
     markers = {(cs.asset_key, cs.name) for cs in check_specs}
     assert len(markers) == len(check_specs)
+
+
+# ---------------------------------------------------------------------------
+# FR-019: strict_build converts log-and-swallow paths into hard failures.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_build_default_is_off():
+    """``strict_build`` is opt-in — existing adopters get the legacy
+    log-and-swallow behaviour unless they flip the flag."""
+    component = RockyComponent(config_path="rocky.toml")
+    assert component.strict_build is False
+
+
+def test_strict_build_cold_start_reraises_write_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Under ``strict_build``, a failing ``write_state_to_path`` in the
+    cold-start fallback propagates instead of falling through to the
+    empty-state path."""
+    state_path = tmp_path / "missing-state"
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+        strict_build=True,
+    )
+
+    def raises(self_, p):
+        raise RuntimeError("S3 + state-store both down")
+
+    monkeypatch.setattr(RockyComponent, "write_state_to_path", raises)
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    with pytest.raises(RuntimeError, match="S3"):
+        component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+
+def test_strict_build_off_cold_start_swallows_write_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """``strict_build=False`` (default) preserves the existing
+    log-and-swallow behaviour. Companion to the strict-on test above."""
+    state_path = tmp_path / "missing-state"
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        discover_on_missing_state=True,
+        # strict_build defaults to False
+    )
+
+    def raises(self_, p):
+        raise RuntimeError("transient failure")
+
+    monkeypatch.setattr(RockyComponent, "write_state_to_path", raises)
+    _patch_state_path(monkeypatch, state_path, is_dev=False)
+
+    with caplog.at_level("WARNING", logger="dagster_rocky.component"):
+        # Must not raise.
+        component._maybe_cold_start_discover(SimpleNamespace(project_root=tmp_path))  # type: ignore[arg-type]
+
+    assert any("fallback discover failed" in r.message for r in caplog.records)
+
+
+def test_strict_build_raises_on_none_state_path():
+    """Under ``strict_build``, ``build_defs_from_state(None)`` fails the
+    code-server load instead of returning empty ``Definitions``."""
+    component = RockyComponent(config_path="rocky.toml", strict_build=True)
+    with pytest.raises(dg.Failure) as excinfo:
+        component.build_defs_from_state(context=None, state_path=None)
+    assert "missing state" in (excinfo.value.description or "").lower()
+    assert "strict_build" in (excinfo.value.description or "")
+
+
+def test_strict_build_off_returns_empty_defs_on_none_state_path():
+    """Default ``strict_build=False`` keeps the legacy "return empty
+    Definitions" behaviour for missing state."""
+    component = RockyComponent(config_path="rocky.toml")  # strict_build=False
+    defs = component.build_defs_from_state(context=None, state_path=None)
+    assert list(defs.assets or []) == []
+
+
+def test_strict_build_raises_on_empty_discover_sources(tmp_path: Path):
+    """Under ``strict_build``, an on-disk state file whose discover
+    envelope contains zero sources fails the load — same operator
+    signal as missing state."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "discover": {
+                    "version": "0.0.0",
+                    "command": "discover",
+                    "sources": [],
+                }
+            }
+        )
+    )
+
+    component = RockyComponent(config_path="rocky.toml", strict_build=True)
+    with pytest.raises(dg.Failure) as excinfo:
+        component.build_defs_from_state(context=None, state_path=state_file)
+    assert "zero sources" in (excinfo.value.description or "").lower()
+    assert "strict_build" in (excinfo.value.description or "")
+
+
+def test_strict_build_off_returns_empty_defs_on_empty_discover_sources(tmp_path: Path):
+    """Default ``strict_build=False`` returns empty ``Definitions`` for an
+    on-disk state file with zero sources — no load failure."""
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "discover": {
+                    "version": "0.0.0",
+                    "command": "discover",
+                    "sources": [],
+                }
+            }
+        )
+    )
+
+    component = RockyComponent(config_path="rocky.toml")
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    assert list(defs.assets or []) == []
+
+
+def test_strict_build_write_state_reraises_discover_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Under ``strict_build``, a failing ``rocky discover`` in
+    ``write_state_to_path`` propagates instead of writing an empty
+    discover envelope."""
+    stub = _StubResource(discover_result=RuntimeError("binary missing"))
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+        strict_build=True,
+    )
+
+    with pytest.raises(RuntimeError, match="binary missing"):
+        component.write_state_to_path(tmp_path / "state")
+
+    # No partial state should have been written.
+    assert not (tmp_path / "state").exists()
+
+
+def test_strict_build_write_state_compile_slot_stays_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Compile is an augmentation slot — under ``strict_build`` a compile
+    failure still omits the slot and writes successful discover state.
+    The asset graph itself is what matters; compiler diagnostics are not
+    a build precondition."""
+    discover = _make_discover_result()
+    stub = _StubResource(
+        discover_result=discover,
+        compile_result=RuntimeError("compile crashed"),
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_existing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+        strict_build=True,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)  # must not raise
+
+    state = json.loads(state_path.read_text())
+    assert "discover" in state
+    assert "compile" not in state
+
+
+def test_strict_build_write_state_optimize_slot_stays_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Optimize is an augmentation slot — under ``strict_build`` an
+    optimize failure still omits the slot and writes successful discover
+    state. Same rationale as compile."""
+    discover = _make_discover_result()
+    stub = _StubResource(
+        discover_result=discover,
+        optimize_result=RuntimeError("optimize crashed"),
+    )
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),  # skip compile
+        surface_optimize_metadata=True,
+        strict_build=True,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)  # must not raise
+
+    state = json.loads(state_path.read_text())
+    assert "discover" in state
+    assert "optimize" not in state


### PR DESCRIPTION
## Summary

Adds a default-off `strict_build: bool` field to `RockyComponent` that converts three "log and swallow" paths in `build_defs` into hard failures, so adopters who decide an empty Rocky asset graph is never acceptable can fail the code-server load instead of shipping a healthy-looking deployment with no assets.

When `strict_build=True`:

- `_maybe_cold_start_discover` re-raises a failing `write_state_to_path` instead of warning and falling through to the empty-state path.
- `build_defs_from_state` raises `dg.Failure` when state is missing or contains zero discover sources, instead of returning empty `Definitions`.
- The discover slot of `write_state_to_path` re-raises instead of writing an empty discover envelope.

Compile and optimize slots stay best-effort even under `strict_build` — they are augmentation surfaces (compiler diagnostics, optimize recommendations) rather than the asset graph itself, so a missing slot does not signal a broken graph.

Default `False` preserves existing behaviour for adopters who rely on best-effort load with empty graph as their failure mode.

## Motivation

The cumulative effect of three individually defensible best-effort defaults can produce the worst kind of operational state: a code-server load that reports `LOADED`, a UI that shows the location is healthy, sensors targeting `raw.*` selections evaluating green-with-no-runs, and no alerts firing — even though zero Rocky assets actually shipped. Detection is by user complaint. The recent duplicate-`DiscoveredTable` incident (root cause fixed in engine v1.20.1, defensive dedup added in dagster-rocky 1.18.1) was such a case: a one-table input quirk took every Rocky-derived asset out of a deployment, and the deployment looked healthy in the UI for hours. `strict_build` is the orthogonal "make the failure visible next time" hardening — adopters opt in and the deploy fails fast at code-server load instead of degrading silently.

## Test plan

- [x] `uv run pytest tests/test_component.py` — all 57 tests pass (47 existing + 10 new strict_build tests covering: default-off, cold-start re-raise under strict, cold-start swallow under default, `build_defs_from_state(None)` raises `dg.Failure` under strict and returns empty `Definitions` under default, empty-discover-sources state file raises `dg.Failure` under strict and returns empty `Definitions` under default, `write_state_to_path` discover slot re-raises under strict, compile/optimize slots stay best-effort even under strict).
- [x] `uv run pytest` (full suite) — 510 tests pass, no regressions.
- [x] `uv run ruff check src tests` and `uv run ruff format --check src tests` — clean.
- [ ] Manually verified default-off behaviour by running the existing cold-start / write-state / load-state suite — they all still pass with no changes to assertions.