### PR TITLE
fix(rocky-bigquery): populate cost_usd / bytes_scanned for transformation runs

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -412,9 +412,19 @@ impl WarehouseAdapter for BigQueryAdapter {
 /// every downstream consumer can keep treating `bytes_scanned` as the
 /// single cost driver without BigQuery-specific branching.
 ///
-/// Returns an all-`None` [`ExecutionStats`] when BigQuery omits the
-/// `statistics` block (most commonly for DDL that completes without a
-/// query job) or when `totalBytesBilled` is missing / unparseable.
+/// Resolution order:
+///
+/// 1. `statistics.query.totalBytesBilled` — the cost-accurate figure
+///    (with 10 MB minimum applied), only present on `jobs.get`
+///    responses.
+/// 2. Top-level `totalBytesProcessed` — surfaced by `jobs.query` /
+///    `jobs.getQueryResults`, which is the path the runtime actually
+///    takes today. Off by the 10 MB floor on sub-10 MB queries; the
+///    cost calc therefore under-reports those slightly until a
+///    follow-up `jobs.get` is wired in.
+/// 3. `None` — no bytes information available (DDL responses BigQuery
+///    omits both fields on, or fields unparseable as `u64`).
+///
 /// `bytes_written` is always `None` — BigQuery query jobs don't expose
 /// a bytes-written figure naturally.
 fn stats_from_response(response: &BigQueryResponse) -> ExecutionStats {
@@ -422,7 +432,13 @@ fn stats_from_response(response: &BigQueryResponse) -> ExecutionStats {
         .statistics
         .as_ref()
         .and_then(|s| s.query.as_ref())
-        .and_then(BigQueryQueryStatistics::total_bytes_billed_u64);
+        .and_then(BigQueryQueryStatistics::total_bytes_billed_u64)
+        .or_else(|| {
+            response
+                .total_bytes_processed
+                .as_deref()
+                .and_then(|s| s.parse::<u64>().ok())
+        });
     ExecutionStats {
         bytes_scanned,
         bytes_written: None,
@@ -453,9 +469,22 @@ struct BigQueryResponse {
     #[allow(dead_code)]
     #[serde(default)]
     total_rows: Option<String>,
-    /// Query-job statistics. Populated for completed query jobs;
-    /// BigQuery may omit the field for DDL statements or async jobs
-    /// that haven't yet finished, so it's `Option`.
+    /// Top-level `totalBytesProcessed` from the `jobs.query` /
+    /// `jobs.getQueryResults` response shape (decimal-encoded int64).
+    /// Set on every successful query job. **Note:** the synchronous
+    /// `jobs.query` endpoint does *not* surface a `statistics` block
+    /// (that's exclusive to `jobs.get`), so this top-level field is
+    /// the only bytes-figure we can read without a follow-up API call.
+    /// `stats_from_response` falls back to this when `statistics` is
+    /// absent.
+    #[serde(default)]
+    total_bytes_processed: Option<String>,
+    /// Query-job statistics. Populated for `jobs.get` responses; the
+    /// synchronous `jobs.query` and `jobs.getQueryResults` endpoints
+    /// omit this entire block, so reading bytes from here alone leaves
+    /// every sync query with `bytes_scanned: None` (PR #326). The
+    /// top-level `total_bytes_processed` covers the sync path; this
+    /// stays `Option` for forward compatibility with `jobs.get` paths.
     #[serde(default)]
     statistics: Option<BigQueryStatistics>,
 }
@@ -723,5 +752,43 @@ mod tests {
         let rows = resp.rows.unwrap();
         assert!(rows[0].f[0].v.is_none());
         assert_eq!(rows[0].f[1].v.as_ref().unwrap(), "test");
+    }
+
+    #[test]
+    fn jobs_query_top_level_total_bytes_processed_is_used() {
+        // The synchronous `jobs.query` / `jobs.getQueryResults` endpoints
+        // surface `totalBytesProcessed` at the top level of the response
+        // and omit the `statistics` block entirely. Before PR #326 the
+        // connector only read from `statistics.query.totalBytesBilled`,
+        // so every sync query returned `bytes_scanned: None` and broke
+        // cost attribution end-to-end.
+        let json = r#"{
+            "jobComplete": true,
+            "totalBytesProcessed": "10485760"
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, Some(10_485_760));
+    }
+
+    #[test]
+    fn jobs_get_statistics_block_takes_precedence_over_top_level() {
+        // When both shapes are present (e.g., a future code path that
+        // also fetches `jobs.get`), the more accurate
+        // `statistics.query.totalBytesBilled` wins because it includes
+        // the 10 MB minimum-bill floor that `totalBytesProcessed`
+        // doesn't account for.
+        let json = r#"{
+            "jobComplete": true,
+            "totalBytesProcessed": "5242880",
+            "statistics": {
+                "query": {
+                    "totalBytesBilled": "10485760"
+                }
+            }
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let stats = stats_from_response(&resp);
+        assert_eq!(stats.bytes_scanned, Some(10_485_760));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -87,6 +87,17 @@ pub async fn run_transformation(
 
     output.duration_ms = start.elapsed().as_millis() as u64;
 
+    // Compute per-model cost_usd from accumulated bytes / duration. The
+    // replication path (run.rs:3030) and model-only path (run.rs:872)
+    // already do this; without it transformation runs always emit
+    // `cost_usd: null` even when adapters report bytes_scanned.
+    let adapter_type = rocky_cfg
+        .adapters
+        .get(&pipeline.target.adapter)
+        .map(|a| a.adapter_type.clone())
+        .unwrap_or_default();
+    output.populate_cost_summary(&adapter_type, &rocky_cfg.cost);
+
     if let Some(p) = &pipes {
         super::run::emit_pipes_events(p, &output);
         p.log(

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -95,3 +95,18 @@ Adapter-side gaps to revisit separately:
    — it needs explicit per-column assignments. The merge model
    declares `update_columns = ["name", "amount"]` to sidestep it.
    Snowflake/DuckDB may accept the shorthand; not verified.
+6. **`bytes_scanned` is `totalBytesProcessed`, not
+   `totalBytesBilled`, on the sync query path.** Synchronous
+   `jobs.query` / `jobs.getQueryResults` REST responses don't include
+   the `statistics` block (that's exclusive to `jobs.get`), so the
+   connector falls back to top-level `totalBytesProcessed`. This
+   under-reports cost for sub-10 MB queries by the 10 MB per-query
+   minimum-bill floor. Wiring a follow-up `jobs.get` call to surface
+   the billed figure is a Phase 2.1 task. The smoke tests today
+   assert `bytes_scanned > 0`, not exact value.
+7. **Full-refresh `bytes_scanned` is zero when the model has no
+   source.** The `live/run.sh` model is `SELECT 1 AS id, ...` with no
+   FROM clause, so BigQuery reports `totalBytesProcessed: 0`. The
+   cost wire-up runs but the figure is `0` rather than missing. Real
+   models that scan source tables produce non-zero values (verified
+   via `live/merge/run.sh` and `live/time-interval/run.sh`).

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
@@ -95,5 +95,22 @@ if [[ "$ACTUAL" != "$EXPECTED_DELTA" ]]; then
 fi
 echo "    delta: bob updated to 250, dave inserted, alice/carol unchanged"
 
+echo "==> verifying cost attribution populated"
+python3 - "$HERE/expected/run-delta.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    out = json.load(f)
+mat = out["materializations"][0]
+bs = mat.get("bytes_scanned")
+cu = mat.get("cost_usd")
+if not isinstance(bs, int) or bs <= 0:
+    print(f"FAIL: materializations[0].bytes_scanned not populated (got {bs!r})")
+    sys.exit(1)
+if not isinstance(cu, (int, float)) or cu < 0:
+    print(f"FAIL: materializations[0].cost_usd not populated (got {cu!r})")
+    sys.exit(1)
+print(f"    bytes_scanned = {bs}, cost_usd = {cu}")
+PY
+
 echo
 echo "POC complete: BigQuery MERGE strategy verified live."

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
@@ -87,5 +87,22 @@ fi
 echo "    2026-04-01: 3 orders, revenue=225"
 echo "    2026-04-02: 2 orders, revenue=500"
 
+echo "==> verifying cost attribution populated"
+python3 - "$HERE/expected/run-2026-04-02.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    out = json.load(f)
+mat = out["materializations"][0]
+bs = mat.get("bytes_scanned")
+cu = mat.get("cost_usd")
+if not isinstance(bs, int) or bs <= 0:
+    print(f"FAIL: materializations[0].bytes_scanned not populated (got {bs!r})")
+    sys.exit(1)
+if not isinstance(cu, (int, float)) or cu < 0:
+    print(f"FAIL: materializations[0].cost_usd not populated (got {cu!r})")
+    sys.exit(1)
+print(f"    bytes_scanned = {bs}, cost_usd = {cu}")
+PY
+
 echo
 echo "POC complete: BigQuery time-interval DML transaction verified live."


### PR DESCRIPTION
Cost attribution was a near no-op for every BigQuery transformation pipeline run because of two paired bugs:

## What was broken

### 1. `run_transformation` never called `populate_cost_summary`

`engine/crates/rocky-cli/src/commands/run.rs` calls `RunOutput::populate_cost_summary` after the model loop in two places — the replication path (line 3030) and the model-only path (line 872). The transformation path was the only one that didn't. Result: every transformation run emitted `materializations[].cost_usd: null` even when bytes were available.

### 2. BQ connector parsed bytes from a field that doesn't exist on the response shape it actually receives

`stats_from_response` read `response.statistics.query.totalBytesBilled`. That field exists on `jobs.get` responses, **not** on `jobs.query` / `jobs.getQueryResults`, which is what the connector calls. The unit tests stubbed a `jobs.get`-shaped JSON blob and passed — nothing exercised the real wire shape. Result: every sync query on real BigQuery returned `bytes_scanned: None`.

This is the fourth structural BQ-adapter bug in this arc that passed unit tests but failed live.

## Fix

- 5-line wire-up in `run_local.rs::run_transformation` mirroring the existing call sites.
- Added `total_bytes_processed: Option<String>` at the top level of `BigQueryResponse` (where `jobs.query` actually surfaces it).
- `stats_from_response` now prefers `statistics.query.totalBytesBilled` when present (more accurate — includes the 10 MB minimum-bill floor), falls back to top-level `total_bytes_processed` otherwise.
- Two new unit tests exercising both shapes.

## Verification

Extended the existing live MERGE and time-interval smoke tests with assertions on the captured `expected/run-*.json`:

```
==> verifying cost attribution populated
    bytes_scanned = 156, cost_usd = 9.75e-10        # MERGE
    bytes_scanned = 184, cost_usd = 1.15e-09        # time-interval
```

Both pass; idempotent across consecutive runs.

## Out of scope (documented in `live/README.md`)

- The sync `jobs.query` path reports `totalBytesProcessed`, not `totalBytesBilled` — under-reports the dollar figure for sub-10 MB queries by the 10 MB minimum-bill floor. Wiring a follow-up `jobs.get` call to surface the billed figure is tracked as a separate task.
- Full-refresh's no-source UNNEST literal model legitimately reports `bytes_scanned: 0` (BQ processed zero source bytes). Real source-scanning models populate non-zero values.

## Test plan

- [x] `cargo test -p rocky-bigquery --lib` — 57 passed, includes 2 new tests
- [x] `cargo clippy -p rocky-bigquery -p rocky-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery -p rocky-cli --check` clean
- [x] `live/merge/run.sh` against the sandbox — exits 0, bytes/cost populated
- [x] `live/time-interval/run.sh` against the sandbox — exits 0, bytes/cost populated