### PR TITLE
feat(rocky-bigquery): add BigQueryDiscoveryAdapter + wire end-to-end

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -127,6 +127,24 @@ impl BigQueryAdapter {
         self
     }
 
+    /// GCP project ID this adapter is bound to. Exposed so adapters that
+    /// share state with this one (e.g. `BigQueryDiscoveryAdapter`) can
+    /// build region-qualified `INFORMATION_SCHEMA` queries without the
+    /// caller having to thread the project ID through twice.
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    /// Dataset location ("EU", "US", "us-east1", …). Used by
+    /// `BigQueryDiscoveryAdapter` to build region-scoped
+    /// `INFORMATION_SCHEMA.SCHEMATA` queries — BigQuery's
+    /// region-unqualified form returns rows only for datasets in the
+    /// region the query is *executed* in, so cross-region projects need
+    /// the explicit `region-<location>` qualifier.
+    pub fn location(&self) -> &str {
+        &self.location
+    }
+
     /// Execute a query via the BigQuery REST API.
     async fn run_query(&self, sql: &str) -> Result<BigQueryResponse, BigQueryError> {
         let token = self.auth.get_token(&self.client).await?;

--- a/engine/crates/rocky-bigquery/src/discovery.rs
+++ b/engine/crates/rocky-bigquery/src/discovery.rs
@@ -1,0 +1,176 @@
+//! BigQuery discovery adapter implementing [`DiscoveryAdapter`].
+//!
+//! Lists datasets in a GCP project that match a given prefix, returning
+//! them as [`DiscoveredConnector`]s with their tables. Discovery and
+//! the warehouse adapter share a single [`BigQueryAdapter`] so the same
+//! auth + retry budget cover both surfaces — there is no separate REST
+//! client to keep in sync.
+//!
+//! BigQuery's `INFORMATION_SCHEMA.SCHEMATA` view is region-scoped.
+//! Cross-region projects need the explicit
+//! `<project>.region-<location>.INFORMATION_SCHEMA.SCHEMATA` form;
+//! this adapter reads the region from the underlying
+//! [`BigQueryAdapter`]'s `location` so it always queries the same
+//! region the warehouse adapter writes to.
+//!
+//! The dataset prefix is matched via SQL `STARTS_WITH` rather than
+//! `LIKE 'prefix%'` because dataset names commonly contain the literal
+//! `_` character which `LIKE` treats as a wildcard.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use rocky_core::source::{DiscoveredConnector, DiscoveredTable, DiscoveryResult};
+use rocky_core::traits::{AdapterError, AdapterResult, DiscoveryAdapter, WarehouseAdapter};
+use rocky_sql::validation::{validate_gcp_project_id, validate_identifier};
+
+use crate::connector::BigQueryAdapter;
+
+/// BigQuery discovery adapter that lists datasets matching a prefix.
+pub struct BigQueryDiscoveryAdapter {
+    adapter: Arc<BigQueryAdapter>,
+}
+
+impl BigQueryDiscoveryAdapter {
+    pub fn new(adapter: Arc<BigQueryAdapter>) -> Self {
+        Self { adapter }
+    }
+
+    /// Build the region qualifier (e.g. `region-eu`) used in
+    /// `INFORMATION_SCHEMA.SCHEMATA` references. BigQuery accepts only
+    /// lowercase letters, digits, and hyphens here, so an unexpected
+    /// character is treated as an invalid configuration error rather
+    /// than silently embedded into SQL.
+    fn region_qualifier(&self) -> AdapterResult<String> {
+        let region = format!("region-{}", self.adapter.location().to_lowercase());
+        if region.is_empty()
+            || region == "region-"
+            || !region
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(AdapterError::msg(format!(
+                "invalid BigQuery location for INFORMATION_SCHEMA query: '{}'",
+                self.adapter.location()
+            )));
+        }
+        Ok(region)
+    }
+}
+
+#[async_trait]
+impl DiscoveryAdapter for BigQueryDiscoveryAdapter {
+    async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult> {
+        let project = self.adapter.project_id();
+        validate_gcp_project_id(project).map_err(AdapterError::new)?;
+        let region = self.region_qualifier()?;
+
+        // SQL string-literal escape. The prefix is user input; `'`
+        // would otherwise close the literal. `STARTS_WITH` makes
+        // wildcard characters (`_`, `%`) safe — they're treated as
+        // literals.
+        let prefix_lit = schema_prefix.replace('\'', "''");
+
+        let schemas_sql = format!(
+            "SELECT schema_name FROM `{project}.{region}.INFORMATION_SCHEMA.SCHEMATA` \
+             WHERE STARTS_WITH(schema_name, '{prefix_lit}') \
+             ORDER BY schema_name"
+        );
+
+        let schema_result = self.adapter.execute_query(&schemas_sql).await?;
+
+        let mut connectors = Vec::new();
+        for row in &schema_result.rows {
+            let schema = match row.first().and_then(|v| v.as_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+
+            // Per-dataset table list. `INFORMATION_SCHEMA.TABLES` lives
+            // under the dataset itself in BigQuery (four-part name),
+            // not at the project level — same shape `list_tables`
+            // already uses on the warehouse adapter.
+            validate_identifier(&schema).map_err(AdapterError::new)?;
+            let tables_sql = format!(
+                "SELECT table_name FROM `{project}`.`{schema}`.INFORMATION_SCHEMA.TABLES \
+                 WHERE table_type IN ('BASE TABLE', 'EXTERNAL') \
+                 ORDER BY table_name"
+            );
+
+            let table_result = self.adapter.execute_query(&tables_sql).await?;
+
+            let tables: Vec<DiscoveredTable> = table_result
+                .rows
+                .iter()
+                .filter_map(|r| r.first().and_then(|v| v.as_str()).map(String::from))
+                .map(|name| DiscoveredTable {
+                    name,
+                    row_count: None,
+                })
+                .collect();
+
+            connectors.push(DiscoveredConnector {
+                id: schema.clone(),
+                schema,
+                source_type: "bigquery".to_string(),
+                last_sync_at: None,
+                tables,
+                metadata: Default::default(),
+            });
+        }
+
+        // `INFORMATION_SCHEMA` queries are atomic per call — a partial
+        // result here would mean the dataset listing succeeded but
+        // table enumeration for one dataset failed. Today that throws
+        // out of `execute_query` and the whole `discover` returns an
+        // error; surfacing per-dataset partial failures is a future
+        // refinement (mirrors Fivetran's `failed` slot).
+        Ok(DiscoveryResult::ok(connectors))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::BigQueryAuth;
+
+    fn fake_adapter(location: &str) -> Arc<BigQueryAdapter> {
+        // BigQueryAuth::Bearer doesn't make a network call at
+        // construction; safe to use in unit tests that exercise pure
+        // logic on the adapter (region qualifier, etc.).
+        Arc::new(BigQueryAdapter::new(
+            "rocky-sandbox-hc-test-63874".to_string(),
+            location.to_string(),
+            BigQueryAuth::Bearer(rocky_core::redacted::RedactedString::new(
+                "test-token".to_string(),
+            )),
+        ))
+    }
+
+    #[test]
+    fn region_qualifier_accepts_eu() {
+        let disc = BigQueryDiscoveryAdapter::new(fake_adapter("EU"));
+        assert_eq!(disc.region_qualifier().unwrap(), "region-eu");
+    }
+
+    #[test]
+    fn region_qualifier_accepts_multi_part_location() {
+        let disc = BigQueryDiscoveryAdapter::new(fake_adapter("us-east1"));
+        assert_eq!(disc.region_qualifier().unwrap(), "region-us-east1");
+    }
+
+    #[test]
+    fn region_qualifier_rejects_injection_attempt() {
+        // Anything outside `[a-z0-9-]` is treated as misconfiguration
+        // rather than embedded into SQL.
+        let disc = BigQueryDiscoveryAdapter::new(fake_adapter("US`; DROP TABLE x; --"));
+        assert!(disc.region_qualifier().is_err());
+    }
+
+    #[test]
+    fn region_qualifier_rejects_empty_location() {
+        let disc = BigQueryDiscoveryAdapter::new(fake_adapter(""));
+        assert!(disc.region_qualifier().is_err());
+    }
+}

--- a/engine/crates/rocky-bigquery/src/lib.rs
+++ b/engine/crates/rocky-bigquery/src/lib.rs
@@ -1,15 +1,19 @@
 //! BigQuery warehouse adapter for Rocky.
 //!
-//! Implements the WarehouseAdapter, SqlDialect, and DiscoveryAdapter traits
-//! for Google BigQuery using the REST API (jobs.query + jobs.getQueryResults).
+//! Implements [`WarehouseAdapter`](rocky_core::traits::WarehouseAdapter),
+//! [`SqlDialect`](rocky_core::traits::SqlDialect), and
+//! [`DiscoveryAdapter`](rocky_core::traits::DiscoveryAdapter) for Google
+//! BigQuery using the REST API (jobs.query + jobs.getQueryResults).
 
 pub mod auth;
 pub mod batch;
 pub mod connector;
 pub mod dialect;
+pub mod discovery;
 pub mod governance;
 pub mod loader;
 
 pub use connector::BigQueryAdapter;
 pub use dialect::BigQueryDialect;
+pub use discovery::BigQueryDiscoveryAdapter;
 pub use loader::BigQueryLoaderAdapter;

--- a/engine/crates/rocky-bigquery/tests/integration.rs
+++ b/engine/crates/rocky-bigquery/tests/integration.rs
@@ -124,3 +124,97 @@ async fn test_clone_table_for_branch_copy() {
         .unwrap_or(-1);
     assert_eq!(n_num, 2, "cloned table should have 2 rows, got {n:?}");
 }
+
+/// Verifies `BigQueryDiscoveryAdapter::discover` lists matching
+/// datasets + their tables against the live sandbox. Creates two
+/// datasets with the `hc_phase14_disc_<ts>_` prefix, seeds one table
+/// in each, runs discover, and asserts both datasets and their tables
+/// are returned. Datasets are dropped on test exit (best-effort).
+#[tokio::test]
+#[ignore]
+async fn test_discover_lists_datasets_and_tables() {
+    use rocky_bigquery::BigQueryDiscoveryAdapter;
+    use rocky_core::traits::DiscoveryAdapter as _;
+    use std::sync::Arc;
+
+    let warehouse = adapter_from_env().expect("BigQuery env vars not set");
+    let project =
+        std::env::var("BIGQUERY_TEST_PROJECT").expect("BIGQUERY_TEST_PROJECT must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let prefix = format!("hc_phase14_disc_{suffix}_");
+    let alpha = format!("{prefix}alpha");
+    let beta = format!("{prefix}beta");
+
+    // Setup. Two datasets, one table each.
+    warehouse
+        .execute_statement(&format!("CREATE SCHEMA `{project}`.`{alpha}`"))
+        .await
+        .expect("create alpha");
+    warehouse
+        .execute_statement(&format!("CREATE SCHEMA `{project}`.`{beta}`"))
+        .await
+        .expect("create beta");
+    warehouse
+        .execute_statement(&format!(
+            "CREATE TABLE `{project}`.`{alpha}`.`orders` AS SELECT 1 AS id"
+        ))
+        .await
+        .expect("seed alpha.orders");
+    warehouse
+        .execute_statement(&format!(
+            "CREATE TABLE `{project}`.`{beta}`.`customers` AS SELECT 1 AS id"
+        ))
+        .await
+        .expect("seed beta.customers");
+
+    let discovery = BigQueryDiscoveryAdapter::new(Arc::new(warehouse));
+    let result = discovery.discover(&prefix).await;
+
+    // Re-construct the warehouse adapter for cleanup; we moved the
+    // original into the discovery adapter via Arc.
+    let cleanup_adapter = adapter_from_env().expect("BigQuery env vars not set");
+    let _ = cleanup_adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{alpha}` CASCADE"
+        ))
+        .await;
+    let _ = cleanup_adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{beta}` CASCADE"
+        ))
+        .await;
+
+    let result = result.expect("discover should succeed");
+    assert_eq!(
+        result.connectors.len(),
+        2,
+        "expected 2 datasets, got {:?}",
+        result
+            .connectors
+            .iter()
+            .map(|c| &c.schema)
+            .collect::<Vec<_>>()
+    );
+    assert!(result.failed.is_empty());
+
+    let alpha_conn = result
+        .connectors
+        .iter()
+        .find(|c| c.schema == alpha)
+        .expect("alpha dataset present");
+    assert_eq!(alpha_conn.source_type, "bigquery");
+    assert_eq!(alpha_conn.tables.len(), 1);
+    assert_eq!(alpha_conn.tables[0].name, "orders");
+
+    let beta_conn = result
+        .connectors
+        .iter()
+        .find(|c| c.schema == beta)
+        .expect("beta dataset present");
+    assert_eq!(beta_conn.tables.len(), 1);
+    assert_eq!(beta_conn.tables[0].name, "customers");
+}

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -315,6 +315,10 @@ impl AdapterRegistry {
                             .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300)),
                     );
                     bigquery_adapters.insert(name.clone(), adapter.clone());
+                    let discovery_adapter = Arc::new(
+                        rocky_bigquery::BigQueryDiscoveryAdapter::new(adapter.clone()),
+                    );
+                    discovery.insert(name.clone(), discovery_adapter as Arc<dyn DiscoveryAdapter>);
                     warehouse.insert(name.clone(), adapter as Arc<dyn WarehouseAdapter>);
                 }
                 other => {

--- a/engine/crates/rocky-core/src/adapter_capability.rs
+++ b/engine/crates/rocky-core/src/adapter_capability.rs
@@ -56,9 +56,9 @@ impl AdapterCapability {
 /// adapter implementations in the workspace.
 pub fn capability_for(adapter_type: &str) -> Option<AdapterCapability> {
     let cap = match adapter_type {
-        "databricks" | "snowflake" | "bigquery" => AdapterCapability::DATA_ONLY,
+        "databricks" | "snowflake" => AdapterCapability::DATA_ONLY,
         "fivetran" | "airbyte" | "iceberg" | "manual" => AdapterCapability::DISCOVERY_ONLY,
-        "duckdb" => AdapterCapability::BOTH,
+        "duckdb" | "bigquery" => AdapterCapability::BOTH,
         _ => return None,
     };
     Some(cap)
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn data_only_adapters() {
-        for adapter_type in ["databricks", "snowflake", "bigquery"] {
+        for adapter_type in ["databricks", "snowflake"] {
             let cap = capability_for(adapter_type).expect("known type");
             assert!(cap.supports_data, "{adapter_type} should support data");
             assert!(
@@ -93,10 +93,15 @@ mod tests {
     }
 
     #[test]
-    fn duckdb_supports_both() {
-        let cap = capability_for("duckdb").expect("known type");
-        assert!(cap.supports_data);
-        assert!(cap.supports_discovery);
+    fn duckdb_and_bigquery_support_both() {
+        for adapter_type in ["duckdb", "bigquery"] {
+            let cap = capability_for(adapter_type).expect("known type");
+            assert!(cap.supports_data, "{adapter_type} should support data");
+            assert!(
+                cap.supports_discovery,
+                "{adapter_type} should support discovery"
+            );
+        }
     }
 
     #[test]

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -11,6 +11,7 @@ end-to-end against a real GCP project and asserts the resulting state.
 | `./run.sh` | `full_refresh` | `BigQueryDialect::create_table_as` |
 | `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
 | `merge/run.sh` | `merge` | `BigQueryDialect::merge_into` (`WHEN NOT MATCHED THEN INSERT ROW`) + first-run target bootstrap |
+| `discover/run.sh` | n/a | `BigQueryDiscoveryAdapter` enumerating datasets via region-qualified `INFORMATION_SCHEMA.SCHEMATA` |
 
 Each driver:
 
@@ -24,7 +25,8 @@ Each driver:
 ## What's not covered yet
 
 - Incremental strategy (separate follow-up smoke test).
-- Drift cycle (gated on `BigQueryDiscoveryAdapter` — see finding 1).
+- Drift cycle (now unblocked — replication-from-BQ works since
+  `BigQueryDiscoveryAdapter` shipped).
 - Time-interval failure-path (forced mid-transaction error → BQ
   auto-rollback). The script-as-transaction shape proves the happy
   path; rollback semantics are a separate property worth its own test.
@@ -39,6 +41,7 @@ export BQ_LOCATION="EU"   # optional; default EU
 ./run.sh                   # full-refresh
 ./time-interval/run.sh     # time-interval (4-statement DML transaction)
 ./merge/run.sh             # merge (bootstrap + UPSERT)
+./discover/run.sh          # discover (lists matching datasets via INFORMATION_SCHEMA)
 ```
 
 Each script exits 0 on success after dropping its target dataset.
@@ -62,13 +65,10 @@ means that path is unchanged.
 
 Adapter-side gaps to revisit separately:
 
-1. **No `BigQueryDiscoveryAdapter`** — the BQ adapter implements
-   `WarehouseAdapter` only, and `engine/crates/rocky-core/src/adapter_capability.rs`
-   correctly marks BQ as `DATA_ONLY`. As a result, replication
-   pipelines with a BigQuery source bail with "no discovery adapter
-   configured" at run time. These smoke tests deliberately use
-   transformation pipelines to exercise the BQ adapter without needing
-   discovery.
+1. ~~No `BigQueryDiscoveryAdapter`~~ — **shipped**. BQ now
+   supports both `WarehouseAdapter` and `DiscoveryAdapter` traits;
+   `adapter_capability.rs` reports `BOTH`. Replication-from-BQ
+   pipelines work end-to-end (see `discover/run.sh`).
 2. **Model-sidecar TOMLs skip env substitution.** `rocky.toml` is piped
    through `substitute_env_vars` at parse time but model `.toml` files
    are read raw (`engine/crates/rocky-core/src/models.rs:642`). The

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/discover/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/discover/live.rocky.toml
@@ -1,0 +1,28 @@
+# Live BigQuery discovery smoke test.
+#
+# Exercises the BigQueryDiscoveryAdapter end-to-end via `rocky discover`,
+# which uses region-qualified `INFORMATION_SCHEMA.SCHEMATA` to enumerate
+# datasets matching the configured prefix.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+strategy = "full_refresh"
+
+[pipeline.live.source]
+catalog = "${GCP_PROJECT_ID}"
+
+[pipeline.live.source.discovery]
+adapter = "default"
+
+[pipeline.live.source.schema_pattern]
+prefix = "hc_phase14_disc_"
+separator = "_"
+components = ["source"]
+
+[pipeline.live.target]
+catalog_template = "${GCP_PROJECT_ID}"
+schema_template = "hc_phase14_disc_dummy_target"

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/discover/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/discover/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Live BigQuery discovery smoke test.
+#
+# Runs `rocky discover --output json` against a real GCP project,
+# proving the BigQueryDiscoveryAdapter wires up correctly through the
+# CLI registry — the same path replication-from-BQ pipelines use.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+PROJ="$GCP_PROJECT_ID"
+DS_ALPHA="hc_phase14_disc_alpha"
+DS_BETA="hc_phase14_disc_beta"
+
+drop_datasets() {
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$DS_ALPHA" 2>/dev/null || true
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$DS_BETA" 2>/dev/null || true
+}
+
+drop_datasets
+trap drop_datasets EXIT
+
+echo "==> seeding two datasets matching prefix 'hc_phase14_disc_'"
+bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$DS_ALPHA" > /dev/null
+bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$DS_BETA" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "CREATE TABLE \`${PROJ}\`.\`${DS_ALPHA}\`.\`orders\` AS SELECT 1 AS id" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "CREATE TABLE \`${PROJ}\`.\`${DS_BETA}\`.\`customers\` AS SELECT 1 AS id" > /dev/null
+
+echo "==> rocky discover --output json"
+rocky -c live.rocky.toml discover --output json > expected/discover.json
+
+echo "==> verifying both datasets surfaced"
+python3 - "$HERE/expected/discover.json" "$DS_ALPHA" "$DS_BETA" <<'PY'
+import json, sys
+out = json.load(open(sys.argv[1]))
+expected_schemas = set(sys.argv[2:])
+sources = out.get("sources", [])
+schemas = {s.get("components", {}).get("source") for s in sources if s.get("components")}
+# `source` component value is whatever the schema_pattern parser
+# extracted — it'll be the suffix after the prefix (e.g. "alpha").
+expected_components = {s.removeprefix("hc_phase14_disc_") for s in expected_schemas}
+if not expected_components.issubset(schemas):
+    print(f"FAIL: expected components {expected_components} not all in {schemas}")
+    sys.exit(1)
+print(f"    sources discovered: {sorted(schemas)}")
+PY
+
+echo
+echo "POC complete: BigQuery discovery verified live."


### PR DESCRIPTION
The BigQuery adapter has only ever implemented `WarehouseAdapter`, even though the lib.rs docstring claimed otherwise. As a result:

- The capability table correctly marked `bigquery` as `DATA_ONLY`.
- Any pipeline declaring `[pipeline.X.source.discovery] adapter = "bigquery"` failed config validation.
- Replication-from-BQ pipelines bailed at run time with `no discovery adapter configured for this pipeline`.

This blocked drift verification, the conformance suite, and the natural source-to-target replication path on BQ.

## What this adds

`BigQueryDiscoveryAdapter` (`engine/crates/rocky-bigquery/src/discovery.rs`):

- Lists matching datasets via the region-qualified `INFORMATION_SCHEMA.SCHEMATA` view. The unqualified form is region-scoped to wherever the query runs — cross-region projects silently get an empty result, which I confirmed live against the EU sandbox before writing the adapter.
- Uses `STARTS_WITH` for the prefix match (dataset names commonly contain literal `_` that SQL `LIKE` would treat as a wildcard).
- Shares the same `BigQueryAdapter` instance as the warehouse path so auth, retry budgets, and HTTP client config are identical.
- Region is read from `BigQueryAdapter::location()`; the qualifier is validated as `[a-z0-9-]+` to keep the value out of the SQL-injection surface.

## Wire-up

- Capability table flipped: `bigquery` → `BOTH`.
- CLI registry instantiates the discovery adapter alongside the warehouse one whenever a `bigquery` adapter is configured (mirrors how DuckDB already does both roles).
- New public accessors `BigQueryAdapter::project_id()` / `location()` so the discovery adapter doesn't need them threaded separately.

## Verification

- Unit tests for the region-qualifier escape paths (EU, multi-part `us-east1`, injection rejection, empty-location rejection).
- `#[ignore]` integration test: creates two datasets with one table each, runs `discover`, asserts both surface with their tables.
- `live/discover/run.sh` smoke driver: runs the full `rocky discover --output json` path through the CLI registry.

Both pass against the sandbox; idempotent across consecutive runs.

```
==> rocky discover --output json
==> verifying both datasets surfaced
    sources discovered: ['alpha', 'beta']
POC complete: BigQuery discovery verified live.
```

## Test plan

- [x] `cargo test -p rocky-bigquery --lib` — 61 passed
- [x] `cargo test -p rocky-bigquery --test integration -- --ignored` — 2 passed
- [x] `cargo test -p rocky-core --lib adapter_capability` — 4 passed
- [x] `cargo clippy -p rocky-bigquery -p rocky-cli -p rocky-core --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery -p rocky-cli -p rocky-core --check` clean
- [x] `live/discover/run.sh` against the sandbox — exits 0, both datasets surface, dataset cleanup runs
- [x] Two consecutive runs both pass (idempotency)