### PR TITLE
test(07-adapters/05-bigquery-native-queries): add live drift smoke test

### DIFF
--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -12,6 +12,7 @@ end-to-end against a real GCP project and asserts the resulting state.
 | `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
 | `merge/run.sh` | `merge` | `BigQueryDialect::merge_into` (`WHEN NOT MATCHED THEN INSERT ROW`) + first-run target bootstrap |
 | `discover/run.sh` | n/a | `BigQueryDiscoveryAdapter` enumerating datasets via region-qualified `INFORMATION_SCHEMA.SCHEMATA` |
+| `drift/run.sh` | `incremental` (replication) | First end-to-end replication-from-BQ + per-table drift detection (column type change → `drop_and_recreate`) |
 
 Each driver:
 
@@ -24,13 +25,18 @@ Each driver:
 
 ## What's not covered yet
 
-- Incremental strategy (separate follow-up smoke test).
-- Drift cycle (now unblocked — replication-from-BQ works since
-  `BigQueryDiscoveryAdapter` shipped).
+- Incremental strategy as a transformation pipeline (the
+  transformation incremental path has no callers in the repo and
+  `sql_gen` ignores `timestamp_column` — separate design call).
 - Time-interval failure-path (forced mid-transaction error → BQ
   auto-rollback). The script-as-transaction shape proves the happy
   path; rollback semantics are a separate property worth its own test.
 - MERGE without explicit `update_columns` (see finding 5).
+- Drift detection on **added** columns (see finding 7).
+- Safe type-widening drift action (`alter_column_types`) — the
+  detection branch exists in `drift::detect_drift` but the runtime at
+  `run.rs:4137` only wires `drop_and_recreate`; safe widenings fall
+  through to the next `INSERT` and may fail.
 
 ## Run
 
@@ -42,6 +48,7 @@ export BQ_LOCATION="EU"   # optional; default EU
 ./time-interval/run.sh     # time-interval (4-statement DML transaction)
 ./merge/run.sh             # merge (bootstrap + UPSERT)
 ./discover/run.sh          # discover (lists matching datasets via INFORMATION_SCHEMA)
+./drift/run.sh             # drift (replication + drop_and_recreate on column type change)
 ```
 
 Each script exits 0 on success after dropping its target dataset.
@@ -110,3 +117,13 @@ Adapter-side gaps to revisit separately:
    cost wire-up runs but the figure is `0` rather than missing. Real
    models that scan source tables produce non-zero values (verified
    via `live/merge/run.sh` and `live/time-interval/run.sh`).
+8. **`detect_drift` ignores added columns.** The function in
+   `engine/crates/rocky-core/src/drift.rs` only flags type changes on
+   columns present in BOTH source and target. A column added to the
+   source after the initial replication is not classified as drift —
+   the comment claims "they appear naturally via SELECT *", but the
+   incremental strategy then issues `INSERT INTO target SELECT * FROM
+   source` against a target whose schema is fixed, and BigQuery
+   rejects it with `Inserted row has wrong column count`. The drift
+   smoke test sidesteps this by changing an existing column's type
+   instead. Worth a separate fix-with-receipt PR.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/live.rocky.toml
@@ -1,0 +1,36 @@
+# Live BigQuery drift smoke test.
+#
+# First end-to-end replication-from-BQ test: the BigQueryDiscoveryAdapter
+# (PR #327) enumerates source datasets matching the schema_pattern, the
+# warehouse adapter materializes them into target datasets, and per-table
+# drift detection compares source vs target schemas on each run.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+strategy = "incremental"
+# Watermark column must exist on both source and target — the seed
+# in run.sh adds `_updated_at` to the source so the incremental
+# subquery can MAX() it on the target and filter the source.
+timestamp_column = "_updated_at"
+
+[pipeline.live.source]
+catalog = "${GCP_PROJECT_ID}"
+
+[pipeline.live.source.discovery]
+adapter = "default"
+
+[pipeline.live.source.schema_pattern]
+prefix = "hc_phase13_drift_src_"
+separator = "_"
+components = ["source"]
+
+[pipeline.live.target]
+catalog_template = "${GCP_PROJECT_ID}"
+schema_template = "hc_phase13_drift_tgt_{source}"
+
+[pipeline.live.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Live BigQuery drift smoke test — first end-to-end replication-from-BQ.
+#
+# Runs `rocky run` twice:
+#   1. Initial: replicates a 2-column source table to the target.
+#   2. After ALTER source ADD COLUMN: re-runs and verifies drift was
+#      detected + the target reflects the new column.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+PROJ="$GCP_PROJECT_ID"
+SRC_DS="hc_phase13_drift_src_orders"
+TGT_DS="hc_phase13_drift_tgt_orders"
+
+drop_datasets() {
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$SRC_DS" 2>/dev/null || true
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$TGT_DS" 2>/dev/null || true
+}
+
+drop_datasets
+trap drop_datasets EXIT
+
+echo "==> seeding source: $SRC_DS.customers (3-column schema with watermark)"
+bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$SRC_DS" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
+    SELECT id, name, _updated_at FROM UNNEST([
+      STRUCT(1 AS id, 'alice' AS name, TIMESTAMP '2026-04-01 00:00:00' AS _updated_at),
+      STRUCT(2,        'bob',           TIMESTAMP '2026-04-01 00:00:00'),
+      STRUCT(3,        'carol',         TIMESTAMP '2026-04-01 00:00:00')
+    ])" > /dev/null
+
+echo "==> rocky run (initial — replicates 2-column source to target)"
+rocky -c live.rocky.toml run --output json > expected/run-initial.json
+
+ROW_COUNT="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT COUNT(*) FROM \`${PROJ}\`.\`${TGT_DS}\`.\`customers\`" | tail -n 1)"
+if [[ "$ROW_COUNT" != "3" ]]; then
+    echo "FAIL: expected 3 rows in target after initial replication, got $ROW_COUNT"
+    exit 1
+fi
+echo "    target replicated, 3 rows"
+
+echo "==> mutating source: change id from INT64 to STRING (unsafe widening)"
+# BigQuery doesn't support ALTER COLUMN TYPE for type swaps, so we DROP +
+# CREATE the source. The new schema differs from the target by the `id`
+# column type — which Rocky's drift detection should classify as
+# DropAndRecreate (no safe widening from STRING to INT64 either way).
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "DROP TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\`" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
+    SELECT id, name, _updated_at FROM UNNEST([
+      STRUCT('1' AS id, 'alice' AS name, TIMESTAMP '2026-04-02 00:00:00' AS _updated_at),
+      STRUCT('2',         'bob',           TIMESTAMP '2026-04-02 00:00:00'),
+      STRUCT('3',         'carol',         TIMESTAMP '2026-04-02 00:00:00'),
+      STRUCT('4',         'dave',          TIMESTAMP '2026-04-02 00:00:00')
+    ])" > /dev/null
+
+echo "==> rocky run (post-drift — should detect type change + drop_and_recreate)"
+rocky -c live.rocky.toml run --output json > expected/run-drift.json
+
+echo "==> verifying drift detected in JSON output"
+python3 - "$HERE/expected/run-initial.json" "$HERE/expected/run-drift.json" <<'PY'
+import json, sys
+
+initial = json.load(open(sys.argv[1]))
+drift   = json.load(open(sys.argv[2]))
+
+# Initial run: target was just created from source, so no drift yet.
+init_drift = initial.get("drift", {})
+if init_drift.get("tables_drifted", -1) != 0:
+    print(f"FAIL: initial run reported drift unexpectedly: {init_drift}")
+    sys.exit(1)
+print(f"    initial drift summary: tables_checked={init_drift.get('tables_checked')}, tables_drifted=0")
+
+# Second run: id type changed INT64 → STRING; drift must classify
+# as drop_and_recreate (not a safe widening either way).
+d = drift.get("drift", {})
+if d.get("tables_drifted", 0) < 1:
+    print(f"FAIL: post-mutation drift not detected: {d}")
+    sys.exit(1)
+actions = d.get("actions_taken", [])
+if not any(a.get("action") == "drop_and_recreate" for a in actions):
+    print(f"FAIL: expected drop_and_recreate action, got {actions}")
+    sys.exit(1)
+print(f"    drift run summary: tables_checked={d.get('tables_checked')}, tables_drifted={d.get('tables_drifted')}")
+for a in actions:
+    print(f"    action: table={a.get('table')} action={a.get('action')} reason={a.get('reason')}")
+PY
+
+echo "==> verifying target reflects new id type (STRING)"
+ID_TYPE="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT data_type FROM \`${PROJ}\`.\`${TGT_DS}\`.INFORMATION_SCHEMA.COLUMNS \
+     WHERE table_name = 'customers' AND column_name = 'id'" | tail -n 1)"
+if [[ "$ID_TYPE" != "STRING" ]]; then
+    echo "FAIL: expected target id type STRING after drop_and_recreate, got '$ID_TYPE'"
+    exit 1
+fi
+echo "    target customers.id is now STRING (drop_and_recreate took effect)"
+
+echo
+echo "POC complete: BigQuery drift detection verified live."


### PR DESCRIPTION
First end-to-end replication-from-BQ smoke test. Exercises per-table drift detection on the BigQuery adapter — possible now that the DiscoveryAdapter shipped in #327, which unblocked replication-from-BQ pipelines.

## What it covers

`live/drift/run.sh`:

1. Seeds a 3-column source table (`id INT64, name STRING, _updated_at TIMESTAMP`) in a `hc_phase13_drift_src_orders` dataset.
2. Runs `rocky run` — initial `full_refresh` since target doesn't exist; `drift.tables_drifted == 0`.
3. Drops + recreates the source with `id` changed from `INT64` to `STRING` (BigQuery doesn't support `ALTER COLUMN TYPE` for non-widening conversions, so DROP/CREATE is the only path).
4. Runs `rocky run` again — drift detected, classified as `drop_and_recreate` per `detect_drift`, target dropped + re-replicated with the new schema.
5. Asserts the JSON output includes `drop_and_recreate` in `drift.actions_taken` and the target's `id` column is now `STRING`.

```
==> drift run summary: tables_checked=1, tables_drifted=1
==> action: drop_and_recreate, reason=column 'id' changed STRING → INT64
==> target customers.id is now STRING (drop_and_recreate took effect)
```

Idempotent across consecutive runs.

## Findings surfaced (documented in `live/README.md`)

- **Finding #8**: `detect_drift` (`engine/crates/rocky-core/src/drift.rs`) ignores added columns. The function's docstring claims "they appear naturally via `SELECT *`", but the incremental strategy then issues `INSERT INTO target SELECT * FROM source` against a target whose schema is fixed, and BigQuery rejects with `Inserted row has wrong column count`. The smoke test sidesteps this by changing an existing column's type instead. Worth a separate fix-with-receipt PR (graduated drift evolution: emit `ALTER TABLE ADD COLUMN` or restrict source SELECT to known target columns).
- The runtime at `run.rs:4137` only wires the `drop_and_recreate` branch from `DriftAction`; `alter_column_types` (the safe-widening case) is detected but takes no action. Same shape as #8 — also worth a follow-up.

These are pre-existing gaps in `rocky-core`, surfaced by the first live drift exercise. Not blocking this PR.

## Test plan

- [x] `live/drift/run.sh` against the sandbox: exits 0, drift detected, target reflects new schema
- [x] Idempotency: two consecutive runs both pass
- [x] Stale dataset cleanup via `trap` — `bq rm -r -f -d` runs even on failure