### PR TITLE
fix(rocky-bigquery): enrich execute_statement_with_stats via jobs.get for totalBytesBilled

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -267,6 +267,66 @@ impl BigQueryAdapter {
             timeout_secs: self.timeout_secs,
         })
     }
+
+    /// Fetch the full `Job` resource for a completed job ID and return
+    /// just its `statistics` block.
+    ///
+    /// The synchronous `jobs.query` and `jobs.getQueryResults` endpoints
+    /// only surface `totalBytesProcessed` at the top level of the
+    /// response; the `statistics.query.totalBytesBilled` figure (which
+    /// applies the 10 MB per-query minimum-bill floor and is what the
+    /// BigQuery console displays) is exclusive to `jobs.get`. Calling
+    /// this method after `run_query` succeeds enriches the existing
+    /// response so [`stats_from_response`] picks the billed figure
+    /// rather than falling back to processed bytes.
+    ///
+    /// One extra HTTP roundtrip per query. `jobs.get` is free and
+    /// returns in tens of milliseconds for a fresh job, so the trade-off
+    /// is a small latency tax for accurate cost numbers.
+    async fn fetch_job_statistics(
+        &self,
+        job_ref: &JobReference,
+    ) -> Result<BigQueryStatistics, BigQueryError> {
+        let token = self.auth.get_token(&self.client).await?;
+        let url = format!(
+            "https://bigquery.googleapis.com/bigquery/v2/projects/{}/jobs/{}",
+            self.project_id, job_ref.job_id
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .query(&[("location", self.location.as_str())])
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().to_string();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(BigQueryError::ApiError {
+                status,
+                message: body,
+            });
+        }
+
+        // `jobs.get` returns the full Job resource; we only care about
+        // `statistics`. A minimal local struct keeps the deserializer
+        // tolerant of fields we don't read.
+        #[derive(Deserialize)]
+        struct JobGetResponse {
+            statistics: Option<BigQueryStatistics>,
+        }
+
+        let job: JobGetResponse = resp.json().await?;
+        job.statistics.ok_or_else(|| BigQueryError::ApiError {
+            status: "missing statistics".into(),
+            message: format!(
+                "jobs.get response for job '{}' had no statistics block",
+                job_ref.job_id
+            ),
+        })
+    }
 }
 
 #[async_trait]
@@ -287,7 +347,34 @@ impl WarehouseAdapter for BigQueryAdapter {
     }
 
     async fn execute_statement_with_stats(&self, sql: &str) -> AdapterResult<ExecutionStats> {
-        let response = self.run_query(sql).await.map_err(AdapterError::new)?;
+        let mut response = self.run_query(sql).await.map_err(AdapterError::new)?;
+
+        // Enrich with `jobs.get` statistics so cost reporting reflects
+        // `totalBytesBilled` (10 MB minimum-bill floor applied) instead
+        // of the bare `totalBytesProcessed` `jobs.query` returns.
+        // `run_query`'s response shape never carries `statistics` on the
+        // sync path, so the `is_none()` check is currently always true
+        // when a job ran — but keeping it defensive against future
+        // codepaths that might pre-populate the field.
+        if response.statistics.is_none() {
+            if let Some(ref job_ref) = response.job_reference {
+                match self.fetch_job_statistics(job_ref).await {
+                    Ok(stats) => response.statistics = Some(stats),
+                    Err(e) => {
+                        // Best-effort: fall back to top-level
+                        // `total_bytes_processed`. Logged so a future
+                        // "cost numbers look low" debug session has the
+                        // failure reason recorded.
+                        debug!(
+                            job_id = %job_ref.job_id,
+                            error = %e,
+                            "jobs.get failed; falling back to totalBytesProcessed",
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(stats_from_response(&response))
     }
 

--- a/engine/crates/rocky-bigquery/tests/integration.rs
+++ b/engine/crates/rocky-bigquery/tests/integration.rs
@@ -218,3 +218,43 @@ async fn test_discover_lists_datasets_and_tables() {
     assert_eq!(beta_conn.tables.len(), 1);
     assert_eq!(beta_conn.tables[0].name, "customers");
 }
+
+/// Verifies `execute_statement_with_stats` enriches the response with
+/// `statistics.query.totalBytesBilled` via a follow-up `jobs.get` call.
+/// Without the enrichment, only the bare `totalBytesProcessed` from
+/// the synchronous `jobs.query` response would surface — which doesn't
+/// apply BigQuery's 10 MB minimum-bill floor.
+///
+/// Uses `INFORMATION_SCHEMA.SCHEMATA` so the query reads real data
+/// (constant queries like `SELECT 1` are exempt from the bill floor).
+/// If the enrichment regresses, `bytes_scanned` falls back to
+/// `totalBytesProcessed` — which is small for a metadata view scan
+/// and well below the 10 MB floor.
+#[tokio::test]
+#[ignore]
+async fn test_execute_statement_with_stats_reports_billed_bytes() {
+    use rocky_core::traits::WarehouseAdapter;
+
+    let project =
+        std::env::var("BIGQUERY_TEST_PROJECT").expect("BIGQUERY_TEST_PROJECT must be set");
+    let location = std::env::var("BIGQUERY_TEST_LOCATION").unwrap_or_else(|_| "EU".to_string());
+
+    let adapter = adapter_from_env().expect("BigQuery env vars not set");
+    let region = format!("region-{}", location.to_lowercase());
+    let sql = format!("SELECT COUNT(*) AS n FROM `{project}.{region}.INFORMATION_SCHEMA.SCHEMATA`");
+
+    let stats = adapter
+        .execute_statement_with_stats(&sql)
+        .await
+        .expect("execute_statement_with_stats");
+
+    let bytes = stats
+        .bytes_scanned
+        .expect("bytes_scanned should be populated via jobs.get enrichment");
+    const MIN_BILL: u64 = 10 * 1024 * 1024;
+    assert!(
+        bytes >= MIN_BILL,
+        "bytes_scanned ({bytes}) below 10 MB minimum-bill floor — \
+         likely fell back to totalBytesProcessed from jobs.query"
+    );
+}

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -102,15 +102,13 @@ Adapter-side gaps to revisit separately:
    — it needs explicit per-column assignments. The merge model
    declares `update_columns = ["name", "amount"]` to sidestep it.
    Snowflake/DuckDB may accept the shorthand; not verified.
-6. **`bytes_scanned` is `totalBytesProcessed`, not
-   `totalBytesBilled`, on the sync query path.** Synchronous
-   `jobs.query` / `jobs.getQueryResults` REST responses don't include
-   the `statistics` block (that's exclusive to `jobs.get`), so the
-   connector falls back to top-level `totalBytesProcessed`. This
-   under-reports cost for sub-10 MB queries by the 10 MB per-query
-   minimum-bill floor. Wiring a follow-up `jobs.get` call to surface
-   the billed figure is a Phase 2.1 task. The smoke tests today
-   assert `bytes_scanned > 0`, not exact value.
+6. ~~`bytes_scanned` is `totalBytesProcessed`, not `totalBytesBilled`~~
+   — **fixed**. `execute_statement_with_stats` now follows up
+   `jobs.query` with a `jobs.get` call to enrich the response with
+   the full `statistics` block (where `totalBytesBilled` lives, with
+   the 10 MB minimum-bill floor applied). The merge and time-interval
+   smoke tests assert `bytes_scanned >= 10 MiB` to verify the
+   enrichment is firing.
 7. **Full-refresh `bytes_scanned` is zero when the model has no
    source.** The `live/run.sh` model is `SELECT 1 AS id, ...` with no
    FROM clause, so BigQuery reports `totalBytesProcessed: 0`. The

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/merge/run.sh
@@ -95,7 +95,7 @@ if [[ "$ACTUAL" != "$EXPECTED_DELTA" ]]; then
 fi
 echo "    delta: bob updated to 250, dave inserted, alice/carol unchanged"
 
-echo "==> verifying cost attribution populated"
+echo "==> verifying cost attribution reports billed bytes (with 10MB floor)"
 python3 - "$HERE/expected/run-delta.json" <<'PY'
 import json, sys
 with open(sys.argv[1]) as f:
@@ -103,13 +103,21 @@ with open(sys.argv[1]) as f:
 mat = out["materializations"][0]
 bs = mat.get("bytes_scanned")
 cu = mat.get("cost_usd")
-if not isinstance(bs, int) or bs <= 0:
-    print(f"FAIL: materializations[0].bytes_scanned not populated (got {bs!r})")
+# Sub-10MB queries (this MERGE seeds 4 rows) MUST report at the 10 MB
+# minimum-bill floor when the connector reads `totalBytesBilled` via
+# the jobs.get enrichment path. If this falls back to the bare
+# `totalBytesProcessed` from the `jobs.query` response, the figure
+# would be a few hundred bytes — which is correct for "scanned" but
+# wrong for "billed", and misrepresents the actual GCP charge.
+MIN_BILL = 10 * 1024 * 1024  # 10 MiB
+if not isinstance(bs, int) or bs < MIN_BILL:
+    print(f"FAIL: bytes_scanned ({bs!r}) below 10MB minimum bill — "
+          f"connector likely fell back to totalBytesProcessed")
     sys.exit(1)
-if not isinstance(cu, (int, float)) or cu < 0:
-    print(f"FAIL: materializations[0].cost_usd not populated (got {cu!r})")
+if not isinstance(cu, (int, float)) or cu <= 0:
+    print(f"FAIL: cost_usd not populated (got {cu!r})")
     sys.exit(1)
-print(f"    bytes_scanned = {bs}, cost_usd = {cu}")
+print(f"    bytes_scanned = {bs} (= 10MB floor), cost_usd = {cu}")
 PY
 
 echo

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/time-interval/run.sh
@@ -87,7 +87,7 @@ fi
 echo "    2026-04-01: 3 orders, revenue=225"
 echo "    2026-04-02: 2 orders, revenue=500"
 
-echo "==> verifying cost attribution populated"
+echo "==> verifying cost attribution reports billed bytes (with 10MB floor)"
 python3 - "$HERE/expected/run-2026-04-02.json" <<'PY'
 import json, sys
 with open(sys.argv[1]) as f:
@@ -95,13 +95,20 @@ with open(sys.argv[1]) as f:
 mat = out["materializations"][0]
 bs = mat.get("bytes_scanned")
 cu = mat.get("cost_usd")
-if not isinstance(bs, int) or bs <= 0:
-    print(f"FAIL: materializations[0].bytes_scanned not populated (got {bs!r})")
+# The time-interval source seeds 5 rows; well under 10MB. After the
+# jobs.get enrichment lands, `bytes_scanned` reflects
+# `totalBytesBilled` — which BigQuery floors at 10 MB per query.
+# A figure smaller than that means the connector fell back to the
+# bare `totalBytesProcessed` from the sync `jobs.query` response.
+MIN_BILL = 10 * 1024 * 1024  # 10 MiB
+if not isinstance(bs, int) or bs < MIN_BILL:
+    print(f"FAIL: bytes_scanned ({bs!r}) below 10MB minimum bill — "
+          f"connector likely fell back to totalBytesProcessed")
     sys.exit(1)
-if not isinstance(cu, (int, float)) or cu < 0:
-    print(f"FAIL: materializations[0].cost_usd not populated (got {cu!r})")
+if not isinstance(cu, (int, float)) or cu <= 0:
+    print(f"FAIL: cost_usd not populated (got {cu!r})")
     sys.exit(1)
-print(f"    bytes_scanned = {bs}, cost_usd = {cu}")
+print(f"    bytes_scanned = {bs} (>= 10MB floor), cost_usd = {cu}")
 PY
 
 echo


### PR DESCRIPTION
The post-PR-#326 cost path correctly prefers `statistics.query.totalBytesBilled` when present and falls back to top-level `totalBytesProcessed` otherwise. But the synchronous `jobs.query` / `jobs.getQueryResults` REST responses don't include the `statistics` block at all — that's exclusive to `jobs.get`. Every sync query was therefore falling back to processed bytes, which doesn't apply BigQuery's 10 MB per-query minimum-bill floor and misrepresents the actual GCP charge.

## What this adds

`BigQueryAdapter::fetch_job_statistics` — async helper that calls `GET /projects/<p>/jobs/<id>?location=<loc>` for a job ID returned by `run_query`. The full Job resource includes the `statistics` block.

`execute_statement_with_stats` now enriches the response with that block before passing it to `stats_from_response`, so cost reporting reflects what the BigQuery console actually charges.

- One extra HTTP roundtrip per query. `jobs.get` is free and returns in tens of milliseconds for a fresh job.
- Best-effort: if `jobs.get` fails for any reason, the path falls back to the existing `totalBytesProcessed` parsing with a `debug!` log so future "cost looks low" debugging has the failure reason recorded.

## Verification

- New `#[ignore]` integration test runs `SELECT COUNT(*) FROM <project>.region-eu.INFORMATION_SCHEMA.SCHEMATA` and asserts `bytes_scanned >= 10 MiB` — proving the floor is applied. (Constant queries like `SELECT 1` are exempt from the floor and don't make a useful signal.)
- The merge and time-interval live smoke tests both have their assertions tightened from `bytes_scanned > 0` to `bytes_scanned >= 10 MiB`. Both now report 20–30 MB across their multi-statement runs (one floor per `jobs.query` call).

```
==> verifying cost attribution reports billed bytes (with 10MB floor)
    bytes_scanned = 20971520 (= 10MB floor), cost_usd = 0.000131
```

## Test plan

- [x] `cargo test -p rocky-bigquery --lib` — 61 passed
- [x] `cargo test -p rocky-bigquery --test integration -- --ignored` — 3 passed (incl. new bytes-billed test)
- [x] `cargo clippy -p rocky-bigquery --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery --check` clean
- [x] `live/merge/run.sh` against the sandbox — exits 0, asserts ≥ 10 MiB
- [x] `live/time-interval/run.sh` against the sandbox — exits 0, asserts ≥ 10 MiB