### PR TITLE
fix(rocky-core): detect added columns as drift + ALTER target before INSERT

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4133,6 +4133,43 @@ async fn process_table(
                 action: "drop_and_recreate".into(),
                 reason,
             });
+        } else if !drift_result.added_columns.is_empty() {
+            // Source added columns the target doesn't have. Without an
+            // ALTER, the next `INSERT INTO target SELECT * FROM source`
+            // produces more columns than the target accepts and BQ /
+            // Snowflake / Databricks all reject it. Issue
+            // `ALTER TABLE ADD COLUMN <name> <type>` for each new
+            // column before the regular INSERT path runs. New columns
+            // are nullable by default — historical rows stay NULL,
+            // newly inserted rows pick up source values via SELECT *.
+            info!(
+                table = target_table.full_name(),
+                added = drift_result.added_columns.len(),
+                "drift detected, adding {} column(s) to target",
+                drift_result.added_columns.len()
+            );
+            let alter_stmts = drift::generate_add_column_sql(
+                &target_table,
+                &drift_result.added_columns,
+                dialect,
+            )?;
+            for stmt in &alter_stmts {
+                warehouse
+                    .execute_statement(stmt)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
+            let reason = drift_result
+                .added_columns
+                .iter()
+                .map(|c| format!("added column '{}' ({})", c.name, c.data_type))
+                .collect::<Vec<_>>()
+                .join(", ");
+            drift_action = Some(DriftActionOutput {
+                table: target_table.full_name(),
+                action: "add_columns".into(),
+                reason,
+            });
         }
     }
 

--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -9,9 +9,21 @@ use crate::traits::SqlDialect;
 
 /// Compares source and target column types to detect schema drift.
 ///
-/// A type mismatch on any existing column triggers `DropAndRecreate` (current default behavior:
-/// drop the target table and do a full refresh). Columns present in the source but missing
-/// from the target are not considered drift — they appear naturally via `SELECT *`.
+/// Three categories surface from a single pass over the source columns:
+///
+/// - **Type mismatches** on an existing column populate `drifted_columns`
+///   and drive the [`DriftAction`] (`AlterColumnTypes` when every change
+///   is a safe widening, `DropAndRecreate` otherwise).
+/// - **Added columns** (present in the source, missing from the target)
+///   populate `added_columns`. The runtime issues `ALTER TABLE ADD
+///   COLUMN` for each before the incremental INSERT — without that
+///   step, a `SELECT * FROM source` produces more columns than the
+///   target accepts, and BigQuery / Snowflake / Databricks all reject
+///   the INSERT.
+///
+/// `DriftAction` reflects only the type-change side of drift; added
+/// columns are an additional ALTER step the runtime applies regardless
+/// of `action` (and even when `action == Ignore`).
 pub fn detect_drift(
     table: &TableRef,
     source_columns: &[ColumnInfo],
@@ -20,16 +32,22 @@ pub fn detect_drift(
     let target_map = column_map::build_column_map(target_columns);
 
     let mut drifted_columns = Vec::new();
+    let mut added_columns = Vec::new();
 
     for source_col in source_columns {
         // §P1.9: look up via CiStr borrow — no allocation per column.
-        if let Some(target_col) = target_map.get(column_map::CiStr::new(&source_col.name)) {
-            if source_col.data_type.to_lowercase() != target_col.data_type.to_lowercase() {
-                drifted_columns.push(DriftedColumn {
-                    name: source_col.name.clone(),
-                    source_type: source_col.data_type.clone(),
-                    target_type: target_col.data_type.clone(),
-                });
+        match target_map.get(column_map::CiStr::new(&source_col.name)) {
+            Some(target_col) => {
+                if source_col.data_type.to_lowercase() != target_col.data_type.to_lowercase() {
+                    drifted_columns.push(DriftedColumn {
+                        name: source_col.name.clone(),
+                        source_type: source_col.data_type.clone(),
+                        target_type: target_col.data_type.clone(),
+                    });
+                }
+            }
+            None => {
+                added_columns.push(source_col.clone());
             }
         }
     }
@@ -49,6 +67,7 @@ pub fn detect_drift(
         table: table.clone(),
         drifted_columns,
         action,
+        added_columns,
         grace_period_columns: Vec::new(),
         columns_to_drop: Vec::new(),
     }
@@ -168,6 +187,34 @@ pub fn generate_alter_column_sql(
         statements.push(format!(
             "ALTER TABLE {} ALTER COLUMN {} TYPE {}",
             table_ref, col.name, col.source_type
+        ));
+    }
+    Ok(statements)
+}
+
+/// Generates `ALTER TABLE ... ADD COLUMN` SQL for columns present in
+/// the source but missing from the target.
+///
+/// Standard SQL across BigQuery / Snowflake / Databricks / DuckDB; no
+/// dialect override needed today. Each new column is added as
+/// nullable (the syntax `<name> <type>` defaults to nullable on every
+/// supported dialect), which matches the runtime's
+/// `INSERT INTO target SELECT * FROM source` semantic — backfill is
+/// the responsibility of the next replication run.
+pub fn generate_add_column_sql(
+    table: &TableRef,
+    added_columns: &[ColumnInfo],
+    dialect: &dyn SqlDialect,
+) -> Result<Vec<String>, SqlGenError> {
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
+
+    let mut statements = Vec::new();
+    for col in added_columns {
+        rocky_sql::validation::validate_identifier(&col.name)?;
+        crate::sql_gen::validate_sql_type(&col.data_type)?;
+        statements.push(format!(
+            "ALTER TABLE {} ADD COLUMN {} {}",
+            table_ref, col.name, col.data_type
         ));
     }
     Ok(statements)
@@ -484,7 +531,7 @@ mod tests {
     }
 
     #[test]
-    fn test_new_column_in_source_not_drift() {
+    fn test_new_column_in_source_populates_added_columns() {
         let source = vec![
             col("id", "INT"),
             col("name", "STRING"),
@@ -493,9 +540,70 @@ mod tests {
         let target = vec![col("id", "INT"), col("name", "STRING")];
         let result = detect_drift(&table_ref(), &source, &target);
 
-        // New columns in source are not drift — SELECT * picks them up
+        // No type drift, so action stays `Ignore` — but the added
+        // column is captured separately so the runtime can ALTER it
+        // before the next INSERT.
         assert!(result.drifted_columns.is_empty());
         assert_eq!(result.action, DriftAction::Ignore);
+        assert_eq!(result.added_columns.len(), 1);
+        assert_eq!(result.added_columns[0].name, "new_col");
+        assert_eq!(result.added_columns[0].data_type, "STRING");
+    }
+
+    #[test]
+    fn test_added_columns_alongside_type_drift() {
+        let source = vec![
+            col("id", "BIGINT"),
+            col("name", "STRING"),
+            col("new_col", "STRING"),
+        ];
+        let target = vec![col("id", "INT"), col("name", "STRING")];
+        let result = detect_drift(&table_ref(), &source, &target);
+
+        // INT→BIGINT is safe widening, so action = AlterColumnTypes.
+        // The new column is captured independently.
+        assert_eq!(result.drifted_columns.len(), 1);
+        assert_eq!(result.action, DriftAction::AlterColumnTypes);
+        assert_eq!(result.added_columns.len(), 1);
+        assert_eq!(result.added_columns[0].name, "new_col");
+    }
+
+    #[test]
+    fn test_generate_add_column_sql() {
+        let table = table_ref();
+        let added = vec![ColumnInfo {
+            name: "region".into(),
+            data_type: "STRING".into(),
+            nullable: true,
+        }];
+        let stmts = generate_add_column_sql(&table, &added, &dialect()).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(
+            stmts[0],
+            "ALTER TABLE acme_warehouse.staging__us_west__shopify.orders ADD COLUMN region STRING"
+        );
+    }
+
+    #[test]
+    fn test_generate_add_column_rejects_bad_identifier() {
+        let table = table_ref();
+        let added = vec![ColumnInfo {
+            name: "bad; DROP".into(),
+            data_type: "STRING".into(),
+            nullable: true,
+        }];
+        assert!(generate_add_column_sql(&table, &added, &dialect()).is_err());
+    }
+
+    #[test]
+    fn test_generate_add_column_rejects_bad_type() {
+        let table = table_ref();
+        let added = vec![ColumnInfo {
+            name: "region".into(),
+            data_type: "STRING'; DROP".into(),
+            nullable: true,
+        }];
+        assert!(generate_add_column_sql(&table, &added, &dialect()).is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -262,6 +262,13 @@ pub struct DriftResult {
     pub table: TableRef,
     pub drifted_columns: Vec<DriftedColumn>,
     pub action: DriftAction,
+    /// Columns present in the source but absent from the target — the
+    /// target needs an `ALTER TABLE ADD COLUMN` before the next
+    /// incremental INSERT can succeed (otherwise BigQuery rejects with
+    /// `Inserted row has wrong column count`, and Snowflake/Databricks
+    /// have analogous failures). Populated by [`detect_drift`].
+    #[serde(default)]
+    pub added_columns: Vec<ColumnInfo>,
     /// Columns in grace period (present in target, absent from source, not yet expired).
     #[serde(default)]
     pub grace_period_columns: Vec<GracePeriodColumn>,

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -12,7 +12,7 @@ end-to-end against a real GCP project and asserts the resulting state.
 | `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
 | `merge/run.sh` | `merge` | `BigQueryDialect::merge_into` (`WHEN NOT MATCHED THEN INSERT ROW`) + first-run target bootstrap |
 | `discover/run.sh` | n/a | `BigQueryDiscoveryAdapter` enumerating datasets via region-qualified `INFORMATION_SCHEMA.SCHEMATA` |
-| `drift/run.sh` | `incremental` (replication) | First end-to-end replication-from-BQ + per-table drift detection (column type change → `drop_and_recreate`) |
+| `drift/run.sh` | `incremental` (replication) | Replication-from-BQ + per-table drift detection: `add_columns` (ALTER TABLE ADD COLUMN) and `drop_and_recreate` (column type change) |
 
 Each driver:
 
@@ -115,13 +115,17 @@ Adapter-side gaps to revisit separately:
    cost wire-up runs but the figure is `0` rather than missing. Real
    models that scan source tables produce non-zero values (verified
    via `live/merge/run.sh` and `live/time-interval/run.sh`).
-8. **`detect_drift` ignores added columns.** The function in
-   `engine/crates/rocky-core/src/drift.rs` only flags type changes on
-   columns present in BOTH source and target. A column added to the
-   source after the initial replication is not classified as drift —
-   the comment claims "they appear naturally via SELECT *", but the
-   incremental strategy then issues `INSERT INTO target SELECT * FROM
-   source` against a target whose schema is fixed, and BigQuery
-   rejects it with `Inserted row has wrong column count`. The drift
-   smoke test sidesteps this by changing an existing column's type
-   instead. Worth a separate fix-with-receipt PR.
+8. ~~`detect_drift` ignores added columns~~ — **fixed**.
+   `detect_drift` now populates `added_columns: Vec<ColumnInfo>` for
+   source columns missing from the target, and the runtime issues
+   `ALTER TABLE ADD COLUMN` for each before the next INSERT. The
+   drift smoke test exercises this in stage 2 (`add_columns` action).
+9. **`alter_column_types` drift action is detected but not wired.**
+   `detect_drift` already classifies safe widenings (e.g.
+   `INT64`→`NUMERIC`) as `DriftAction::AlterColumnTypes`, but
+   `run.rs:4105` only emits SQL for `DropAndRecreate`. Safe widenings
+   silently fall through to the next INSERT and may fail with type
+   mismatch errors. Note that `is_safe_type_widening` lists
+   `INT`/`BIGINT`/etc., not BQ's `INT64` — fixing the wiring should
+   come with a BQ type-name expansion. Worth a separate
+   fix-with-receipt PR.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# Live BigQuery drift smoke test — first end-to-end replication-from-BQ.
+# Live BigQuery drift smoke test — three-stage replication-from-BQ.
 #
-# Runs `rocky run` twice:
-#   1. Initial: replicates a 2-column source table to the target.
-#   2. After ALTER source ADD COLUMN: re-runs and verifies drift was
-#      detected + the target reflects the new column.
+# Runs `rocky run` three times against the same source/target pair:
+#   1. Initial: replicates a 3-column source to the target. No drift.
+#   2. After ALTER source ADD COLUMN: re-runs and verifies the
+#      `add_columns` drift action fired and the target gained the new
+#      column (no full refresh — historical rows stay intact).
+#   3. After DROP+CREATE source with INT64→STRING column type change:
+#      re-runs and verifies the `drop_and_recreate` action fired and
+#      the target's column type updated.
 #
 # Required env:
 #   GCP_PROJECT_ID                  — GCP project to run against
@@ -46,7 +50,7 @@ bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
       STRUCT(3,        'carol',         TIMESTAMP '2026-04-01 00:00:00')
     ])" > /dev/null
 
-echo "==> rocky run (initial — replicates 2-column source to target)"
+echo "==> stage 1: rocky run (initial — replicates 3-column source to target)"
 rocky -c live.rocky.toml run --output json > expected/run-initial.json
 
 ROW_COUNT="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
@@ -57,55 +61,76 @@ if [[ "$ROW_COUNT" != "3" ]]; then
 fi
 echo "    target replicated, 3 rows"
 
-echo "==> mutating source: change id from INT64 to STRING (unsafe widening)"
-# BigQuery doesn't support ALTER COLUMN TYPE for type swaps, so we DROP +
-# CREATE the source. The new schema differs from the target by the `id`
-# column type — which Rocky's drift detection should classify as
-# DropAndRecreate (no safe widening from STRING to INT64 either way).
+echo "==> stage 2: ALTER source ADD COLUMN region STRING; backfill"
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "ALTER TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` ADD COLUMN region STRING" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "UPDATE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\`
+    SET region = CASE id WHEN 1 THEN 'EU' WHEN 2 THEN 'US' ELSE 'APAC' END,
+        _updated_at = TIMESTAMP '2026-04-02 00:00:00'
+    WHERE id > 0" > /dev/null
+
+echo "==> rocky run (post-add — should detect added column, ALTER target)"
+rocky -c live.rocky.toml run --output json > expected/run-add-col.json
+
+echo "==> stage 3: DROP+CREATE source with INT64→STRING id type change"
 bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
    "DROP TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\`" > /dev/null
 bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
    "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
-    SELECT id, name, _updated_at FROM UNNEST([
-      STRUCT('1' AS id, 'alice' AS name, TIMESTAMP '2026-04-02 00:00:00' AS _updated_at),
-      STRUCT('2',         'bob',           TIMESTAMP '2026-04-02 00:00:00'),
-      STRUCT('3',         'carol',         TIMESTAMP '2026-04-02 00:00:00'),
-      STRUCT('4',         'dave',          TIMESTAMP '2026-04-02 00:00:00')
+    SELECT id, name, _updated_at, region FROM UNNEST([
+      STRUCT('1' AS id, 'alice' AS name,
+             TIMESTAMP '2026-04-03 00:00:00' AS _updated_at, 'EU' AS region),
+      STRUCT('2',         'bob',           TIMESTAMP '2026-04-03 00:00:00', 'US'),
+      STRUCT('3',         'carol',         TIMESTAMP '2026-04-03 00:00:00', 'APAC'),
+      STRUCT('4',         'dave',          TIMESTAMP '2026-04-03 00:00:00', 'EU')
     ])" > /dev/null
 
-echo "==> rocky run (post-drift — should detect type change + drop_and_recreate)"
-rocky -c live.rocky.toml run --output json > expected/run-drift.json
+echo "==> rocky run (post-type-change — should detect drop_and_recreate)"
+rocky -c live.rocky.toml run --output json > expected/run-type-change.json
 
-echo "==> verifying drift detected in JSON output"
-python3 - "$HERE/expected/run-initial.json" "$HERE/expected/run-drift.json" <<'PY'
+echo "==> verifying drift JSON output across all three runs"
+python3 - "$HERE/expected/run-initial.json" \
+        "$HERE/expected/run-add-col.json" \
+        "$HERE/expected/run-type-change.json" <<'PY'
 import json, sys
 
-initial = json.load(open(sys.argv[1]))
-drift   = json.load(open(sys.argv[2]))
+initial      = json.load(open(sys.argv[1]))
+add_col      = json.load(open(sys.argv[2]))
+type_change  = json.load(open(sys.argv[3]))
 
-# Initial run: target was just created from source, so no drift yet.
-init_drift = initial.get("drift", {})
-if init_drift.get("tables_drifted", -1) != 0:
-    print(f"FAIL: initial run reported drift unexpectedly: {init_drift}")
+# Stage 1: target was just created from source, no drift.
+d = initial.get("drift", {})
+if d.get("tables_drifted", -1) != 0:
+    print(f"FAIL: initial run reported drift unexpectedly: {d}")
     sys.exit(1)
-print(f"    initial drift summary: tables_checked={init_drift.get('tables_checked')}, tables_drifted=0")
+print(f"    stage 1 drift: tables_checked={d.get('tables_checked')}, tables_drifted=0 OK")
 
-# Second run: id type changed INT64 → STRING; drift must classify
-# as drop_and_recreate (not a safe widening either way).
-d = drift.get("drift", {})
-if d.get("tables_drifted", 0) < 1:
-    print(f"FAIL: post-mutation drift not detected: {d}")
-    sys.exit(1)
+# Stage 2: source added `region`, drift must report `add_columns`.
+d = add_col.get("drift", {})
 actions = d.get("actions_taken", [])
-if not any(a.get("action") == "drop_and_recreate" for a in actions):
-    print(f"FAIL: expected drop_and_recreate action, got {actions}")
+if d.get("tables_drifted", 0) < 1 or not any(a.get("action") == "add_columns" for a in actions):
+    print(f"FAIL: expected add_columns action after ALTER ADD, got {d}")
     sys.exit(1)
-print(f"    drift run summary: tables_checked={d.get('tables_checked')}, tables_drifted={d.get('tables_drifted')}")
-for a in actions:
-    print(f"    action: table={a.get('table')} action={a.get('action')} reason={a.get('reason')}")
+print(f"    stage 2 drift: action=add_columns OK ({[a.get('reason') for a in actions]})")
+
+# Stage 3: id type INT64→STRING — drop_and_recreate.
+d = type_change.get("drift", {})
+actions = d.get("actions_taken", [])
+if d.get("tables_drifted", 0) < 1 or not any(a.get("action") == "drop_and_recreate" for a in actions):
+    print(f"FAIL: expected drop_and_recreate action after type change, got {d}")
+    sys.exit(1)
+print(f"    stage 3 drift: action=drop_and_recreate OK ({[a.get('reason') for a in actions]})")
 PY
 
-echo "==> verifying target reflects new id type (STRING)"
+echo "==> verifying target schema reflects all mutations"
+COLS="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT column_name FROM \`${PROJ}\`.\`${TGT_DS}\`.INFORMATION_SCHEMA.COLUMNS \
+     WHERE table_name = 'customers' ORDER BY ordinal_position" | tail -n +2 | tr '\n' ',' | sed 's/,$//')"
+if [[ "$COLS" != *"region"* ]]; then
+    echo "FAIL: target column list missing 'region': $COLS"
+    exit 1
+fi
 ID_TYPE="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
     "SELECT data_type FROM \`${PROJ}\`.\`${TGT_DS}\`.INFORMATION_SCHEMA.COLUMNS \
      WHERE table_name = 'customers' AND column_name = 'id'" | tail -n 1)"
@@ -113,7 +138,8 @@ if [[ "$ID_TYPE" != "STRING" ]]; then
     echo "FAIL: expected target id type STRING after drop_and_recreate, got '$ID_TYPE'"
     exit 1
 fi
+echo "    target columns: $COLS"
 echo "    target customers.id is now STRING (drop_and_recreate took effect)"
 
 echo
-echo "POC complete: BigQuery drift detection verified live."
+echo "POC complete: BigQuery drift detection (add + type change) verified live."


### PR DESCRIPTION
`detect_drift` previously ignored columns present in the source but absent from the target. The docstring claimed "they appear naturally via SELECT *", but the runtime's incremental INSERT path then issues `INSERT INTO target SELECT * FROM source` against a target whose schema is fixed — and BigQuery / Snowflake / Databricks all reject with `Inserted row has wrong column count`.

The natural "source schema evolves; replicate again" workflow was structurally broken.

## What this adds

- `DriftResult.added_columns: Vec<ColumnInfo>` populated in the same single pass over source columns. Reuses the existing `ColumnInfo` shape (name + data_type) so no codegen ripple.
- New helper `drift::generate_add_column_sql` mirroring `generate_alter_column_sql`. Standard `ALTER TABLE … ADD COLUMN` works across all four adapters; no dialect override needed.
- Runtime change in `run.rs`: when the drift result reports added columns (and `DropAndRecreate` isn't already firing for type drift), execute the ALTER statements before the regular INSERT path. Surfaces as `action: "add_columns"` in `drift.actions_taken` so orchestrators can observe schema evolution alongside data movement.

## Verification

Extended `live/drift/run.sh` into a three-stage flow:

1. **Stage 1**: initial replication of a 3-column source. No drift.
2. **Stage 2**: `ALTER source ADD COLUMN region`; rerun — asserts `add_columns` action fires and target gains the column without a full refresh (historical rows stay, new rows include the source value).
3. **Stage 3**: DROP + CREATE source with `id` type changed `INT64`→`STRING`; rerun — asserts `drop_and_recreate` action fires and target's `id` column is now `STRING`.

```
==> stage 1 drift: tables_checked=1, tables_drifted=0 OK
==> stage 2 drift: action=add_columns OK (["added column 'region' (STRING)"])
==> stage 3 drift: action=drop_and_recreate OK (["column 'id' changed STRING → INT64"])
==> target columns: id,name,_updated_at,region
==> target customers.id is now STRING (drop_and_recreate took effect)
```

Idempotent across consecutive runs.

## Sibling gap (not fixed here)

`DriftAction::AlterColumnTypes` is detected in `drift.rs` for safe widenings (e.g. `INT`→`BIGINT`) but the runtime at `run.rs:4105` still only wires `DropAndRecreate`. Safe widenings silently fall through to the next INSERT. Documented as finding #9 in `live/README.md`.

## Test plan

- [x] `cargo test -p rocky-core --lib drift` — 35 passed (includes 4 new tests)
- [x] `cargo clippy -p rocky-core -p rocky-cli --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-core -p rocky-cli --check` clean
- [x] `live/drift/run.sh` against the BQ sandbox — exits 0, all three stages pass
- [x] Two consecutive runs both pass (idempotency)