### PR TITLE
refactor(rocky-core): move is_safe_type_widening + alter_column_type_sql onto SqlDialect trait

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4103,7 +4103,7 @@ async fn process_table(
     let mut drift_action: Option<DriftActionOutput> = None;
 
     if target_exists {
-        let drift_result = drift::detect_drift(&target_table, &source_cols, &target_cols);
+        let drift_result = drift::detect_drift(&target_table, &source_cols, &target_cols, dialect);
         if drift_result.action == DriftAction::DropAndRecreate {
             info!(
                 table = target_table.full_name(),

--- a/engine/crates/rocky-core/src/drift.rs
+++ b/engine/crates/rocky-core/src/drift.rs
@@ -28,6 +28,7 @@ pub fn detect_drift(
     table: &TableRef,
     source_columns: &[ColumnInfo],
     target_columns: &[ColumnInfo],
+    dialect: &dyn SqlDialect,
 ) -> DriftResult {
     let target_map = column_map::build_column_map(target_columns);
 
@@ -56,7 +57,7 @@ pub fn detect_drift(
         DriftAction::Ignore
     } else if drifted_columns
         .iter()
-        .all(|d| is_safe_type_widening(&d.source_type, &d.target_type))
+        .all(|d| dialect.is_safe_type_widening(&d.source_type, &d.target_type))
     {
         DriftAction::AlterColumnTypes
     } else {
@@ -91,12 +92,18 @@ pub fn generate_drop_table_sql(
     Ok(dialect.drop_table_sql(&ref_str))
 }
 
-/// Determines if a column type change from `target_type` to `source_type` is a safe
-/// widening that can be handled via ALTER TABLE instead of DROP+recreate.
+/// Default body of [`SqlDialect::is_safe_type_widening`] — Databricks /
+/// Spark / DuckDB / Snowflake share enough type-name conventions that
+/// a single allowlist covers them.
 ///
-/// Conservative allowlist -- only well-known safe promotions. Unknown types
-/// or narrowing changes fall back to DropAndRecreate.
-fn is_safe_type_widening(source_type: &str, target_type: &str) -> bool {
+/// Dialects with different type spellings (BigQuery `INT64` /
+/// `NUMERIC` / `FLOAT64` / `BIGNUMERIC`) override
+/// [`SqlDialect::is_safe_type_widening`] in their dialect impl rather
+/// than bolting names onto this list — keeping the global default
+/// dialect-neutral (no BQ types here) avoids the asymmetry of having
+/// e.g. both `BIGINT → STRING` and `INT64 → STRING` for what is
+/// semantically the same conversion.
+pub(crate) fn default_is_safe_type_widening(source_type: &str, target_type: &str) -> bool {
     let src = source_type.to_uppercase();
     let tgt = target_type.to_uppercase();
 
@@ -130,7 +137,7 @@ fn is_safe_type_widening(source_type: &str, target_type: &str) -> bool {
 }
 
 /// Checks DECIMAL(p1,s) -> DECIMAL(p2,s) where p2 >= p1 (precision widening).
-fn is_safe_decimal_widening(target: &str, source: &str) -> bool {
+pub(crate) fn is_safe_decimal_widening(target: &str, source: &str) -> bool {
     fn parse_decimal(t: &str) -> Option<(u32, u32)> {
         let t = t.trim();
         if !t.starts_with("DECIMAL(") || !t.ends_with(')') {
@@ -154,7 +161,7 @@ fn is_safe_decimal_widening(target: &str, source: &str) -> bool {
 }
 
 /// Checks VARCHAR(n) -> VARCHAR(m) where m >= n.
-fn is_safe_varchar_widening(target: &str, source: &str) -> bool {
+pub(crate) fn is_safe_varchar_widening(target: &str, source: &str) -> bool {
     fn parse_varchar(t: &str) -> Option<u32> {
         let t = t.trim();
         if !t.starts_with("VARCHAR(") || !t.ends_with(')') {
@@ -170,7 +177,11 @@ fn is_safe_varchar_widening(target: &str, source: &str) -> bool {
     }
 }
 
-/// Generates ALTER TABLE SQL for safe type changes.
+/// Generates ALTER TABLE SQL for safe type changes via the dialect's
+/// `alter_column_type_sql` (which validates identifier + type and emits
+/// the dialect-specific syntax). Most dialects use the default ANSI
+/// `ALTER COLUMN x TYPE y` form; BigQuery overrides to its
+/// `ALTER COLUMN x SET DATA TYPE y` form.
 pub fn generate_alter_column_sql(
     table: &TableRef,
     drifted_columns: &[DriftedColumn],
@@ -180,14 +191,7 @@ pub fn generate_alter_column_sql(
 
     let mut statements = Vec::new();
     for col in drifted_columns {
-        // Validate column name
-        rocky_sql::validation::validate_identifier(&col.name)?;
-        // Validate the type string to prevent injection
-        crate::sql_gen::validate_sql_type(&col.source_type)?;
-        statements.push(format!(
-            "ALTER TABLE {} ALTER COLUMN {} TYPE {}",
-            table_ref, col.name, col.source_type
-        ));
+        statements.push(dialect.alter_column_type_sql(&table_ref, &col.name, &col.source_type)?);
     }
     Ok(statements)
 }
@@ -473,7 +477,7 @@ mod tests {
     fn test_no_drift() {
         let source = vec![col("id", "INT"), col("name", "STRING")];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         assert!(result.drifted_columns.is_empty());
         assert_eq!(result.action, DriftAction::Ignore);
@@ -483,7 +487,7 @@ mod tests {
     fn test_type_mismatch() {
         let source = vec![col("id", "INT"), col("status", "INT")];
         let target = vec![col("id", "INT"), col("status", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         assert_eq!(result.drifted_columns.len(), 1);
         assert_eq!(result.drifted_columns[0].name, "status");
@@ -504,7 +508,7 @@ mod tests {
             col("amount", "STRING"),
             col("name", "STRING"),
         ];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         assert_eq!(result.drifted_columns.len(), 2);
         assert_eq!(result.action, DriftAction::DropAndRecreate);
@@ -514,7 +518,7 @@ mod tests {
     fn test_case_insensitive_column_names() {
         let source = vec![col("ID", "INT"), col("Name", "STRING")];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         assert!(result.drifted_columns.is_empty());
         assert_eq!(result.action, DriftAction::Ignore);
@@ -524,7 +528,7 @@ mod tests {
     fn test_case_insensitive_types() {
         let source = vec![col("id", "int"), col("name", "string")];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         assert!(result.drifted_columns.is_empty());
         assert_eq!(result.action, DriftAction::Ignore);
@@ -538,7 +542,7 @@ mod tests {
             col("new_col", "STRING"),
         ];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         // No type drift, so action stays `Ignore` — but the added
         // column is captured separately so the runtime can ALTER it
@@ -558,7 +562,7 @@ mod tests {
             col("new_col", "STRING"),
         ];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         // INT→BIGINT is safe widening, so action = AlterColumnTypes.
         // The new column is captured independently.
@@ -610,7 +614,7 @@ mod tests {
     fn test_column_removed_from_source_not_drift() {
         let source = vec![col("id", "INT")];
         let target = vec![col("id", "INT"), col("old_col", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
 
         // Columns only in target are not checked (source drives drift detection)
         assert!(result.drifted_columns.is_empty());
@@ -619,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_empty_columns() {
-        let result = detect_drift(&table_ref(), &[], &[]);
+        let result = detect_drift(&table_ref(), &[], &[], &dialect());
         assert!(result.drifted_columns.is_empty());
         assert_eq!(result.action, DriftAction::Ignore);
     }
@@ -658,7 +662,7 @@ mod tests {
     fn test_safe_int_to_bigint() {
         let source = vec![col("id", "BIGINT"), col("name", "STRING")];
         let target = vec![col("id", "INT"), col("name", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.drifted_columns.len(), 1);
         assert_eq!(result.action, DriftAction::AlterColumnTypes);
     }
@@ -667,7 +671,7 @@ mod tests {
     fn test_safe_float_to_double() {
         let source = vec![col("amount", "DOUBLE")];
         let target = vec![col("amount", "FLOAT")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::AlterColumnTypes);
     }
 
@@ -675,7 +679,7 @@ mod tests {
     fn test_safe_decimal_widening() {
         let source = vec![col("price", "DECIMAL(18,2)")];
         let target = vec![col("price", "DECIMAL(10,2)")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::AlterColumnTypes);
     }
 
@@ -683,7 +687,7 @@ mod tests {
     fn test_unsafe_decimal_scale_change() {
         let source = vec![col("price", "DECIMAL(10,4)")];
         let target = vec![col("price", "DECIMAL(10,2)")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::DropAndRecreate);
     }
 
@@ -691,7 +695,7 @@ mod tests {
     fn test_safe_varchar_widening() {
         let source = vec![col("code", "VARCHAR(200)")];
         let target = vec![col("code", "VARCHAR(100)")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::AlterColumnTypes);
     }
 
@@ -699,7 +703,7 @@ mod tests {
     fn test_unsafe_varchar_narrowing() {
         let source = vec![col("code", "VARCHAR(50)")];
         let target = vec![col("code", "VARCHAR(100)")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::DropAndRecreate);
     }
 
@@ -708,7 +712,7 @@ mod tests {
         // One safe (INT->BIGINT) + one unsafe (STRING->INT) = DropAndRecreate
         let source = vec![col("id", "BIGINT"), col("status", "INT")];
         let target = vec![col("id", "INT"), col("status", "STRING")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.drifted_columns.len(), 2);
         assert_eq!(result.action, DriftAction::DropAndRecreate);
     }
@@ -717,7 +721,7 @@ mod tests {
     fn test_int_to_string_safe() {
         let source = vec![col("code", "STRING")];
         let target = vec![col("code", "INT")];
-        let result = detect_drift(&table_ref(), &source, &target);
+        let result = detect_drift(&table_ref(), &source, &target, &dialect());
         assert_eq!(result.action, DriftAction::AlterColumnTypes);
     }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -467,6 +467,46 @@ pub trait SqlDialect: Send + Sync {
     fn current_timestamp_expr(&self) -> &'static str {
         "CURRENT_TIMESTAMP"
     }
+
+    /// Returns `true` when changing a column's data type from
+    /// `target_type` to `source_type` is safe enough to handle via
+    /// `ALTER TABLE` instead of dropping and recreating the table.
+    ///
+    /// "Safe" means existing target values can be losslessly
+    /// reinterpreted under the new type — typically a strict widening
+    /// (`INT → BIGINT`) or a representation change with no value loss
+    /// (`INT → STRING`). Each dialect's allowlist reflects its own
+    /// type system; the default impl encodes Databricks/Spark
+    /// conventions plus DECIMAL precision and VARCHAR length widening.
+    /// Adapters with different type names (BigQuery `INT64` /
+    /// `NUMERIC` / `FLOAT64` / `BIGNUMERIC`) override.
+    fn is_safe_type_widening(&self, source_type: &str, target_type: &str) -> bool {
+        crate::drift::default_is_safe_type_widening(source_type, target_type)
+    }
+
+    /// SQL to change a column's data type as part of drift evolution.
+    ///
+    /// Default emits the ANSI `ALTER TABLE x ALTER COLUMN y TYPE z`
+    /// form (works for Databricks / Snowflake / DuckDB). BigQuery
+    /// overrides — it requires `ALTER COLUMN y SET DATA TYPE z`.
+    ///
+    /// `column` is validated as a SQL identifier and `new_type` against
+    /// the strict type allowlist
+    /// ([`crate::sql_gen::validate_sql_type`]) before interpolation.
+    /// `table_ref` should already be a fully formatted dialect-specific
+    /// reference — the caller obtains it via `format_table_ref`.
+    fn alter_column_type_sql(
+        &self,
+        table_ref: &str,
+        column: &str,
+        new_type: &str,
+    ) -> AdapterResult<String> {
+        rocky_sql::validation::validate_identifier(column).map_err(AdapterError::new)?;
+        crate::sql_gen::validate_sql_type(new_type).map_err(AdapterError::new)?;
+        Ok(format!(
+            "ALTER TABLE {table_ref} ALTER COLUMN {column} TYPE {new_type}"
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -338,7 +338,7 @@ fn test_drift_detection_type_mismatch() {
         },
     ];
 
-    let result = drift::detect_drift(&table, &source_cols, &target_cols);
+    let result = drift::detect_drift(&table, &source_cols, &target_cols, &TestDialect);
 
     // Incompatible type changes trigger DropAndRecreate
     assert_eq!(
@@ -398,7 +398,7 @@ fn test_drift_detection_no_drift() {
         },
     ];
 
-    let result = drift::detect_drift(&table, &cols, &cols);
+    let result = drift::detect_drift(&table, &cols, &cols, &TestDialect);
     assert_eq!(result.action, DriftAction::Ignore);
     assert!(result.drifted_columns.is_empty());
 }
@@ -430,7 +430,7 @@ fn test_drift_new_column_not_drift() {
     }];
 
     // New columns in source are NOT drift (SELECT * picks them up)
-    let result = drift::detect_drift(&table, &source_cols, &target_cols);
+    let result = drift::detect_drift(&table, &source_cols, &target_cols, &TestDialect);
     assert_eq!(result.action, DriftAction::Ignore);
     assert!(result.drifted_columns.is_empty());
 }
@@ -961,7 +961,7 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
         schema: "staging__us_west__shopify".into(),
         table: "orders".into(),
     };
-    let drift_result = drift::detect_drift(&table, &source_cols, &target_cols);
+    let drift_result = drift::detect_drift(&table, &source_cols, &target_cols, &TestDialect);
     assert_eq!(drift_result.action, DriftAction::DropAndRecreate);
 
     // On drift: delete watermark to force full refresh

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -331,7 +331,7 @@ fn test_safe_widening_int_to_bigint() {
         schema: "s".into(),
         table: "t".into(),
     };
-    let result = drift::detect_drift(&table, &source, &target);
+    let result = drift::detect_drift(&table, &source, &target, &dialect());
     assert_eq!(result.action, DriftAction::AlterColumnTypes);
 }
 
@@ -352,7 +352,7 @@ fn test_safe_widening_float_to_double() {
         schema: "s".into(),
         table: "t".into(),
     };
-    let result = drift::detect_drift(&table, &source, &target);
+    let result = drift::detect_drift(&table, &source, &target, &dialect());
     assert_eq!(result.action, DriftAction::AlterColumnTypes);
 }
 
@@ -373,7 +373,7 @@ fn test_unsafe_change_triggers_drop_and_recreate() {
         schema: "s".into(),
         table: "t".into(),
     };
-    let result = drift::detect_drift(&table, &source, &target);
+    let result = drift::detect_drift(&table, &source, &target, &dialect());
     assert!(!result.drifted_columns.is_empty(), "should detect drift");
     assert_eq!(result.action, DriftAction::DropAndRecreate);
 }
@@ -403,7 +403,7 @@ fn test_new_column_no_drift() {
         schema: "s".into(),
         table: "t".into(),
     };
-    let result = drift::detect_drift(&table, &source, &target);
+    let result = drift::detect_drift(&table, &source, &target, &dialect());
     assert_eq!(
         result.action,
         DriftAction::Ignore,


### PR DESCRIPTION
First of two PRs enabling per-dialect drift evolution. This one is purely a trait-surface refactor with default impls preserving every existing behavior; the follow-up adds the BigQuery override + runtime wiring + live smoke.

## Why a refactor

Pre-flight against BigQuery surfaced two structural mismatches that ruled out a narrower fix:

- BQ rejects `ALTER TABLE x ALTER COLUMN y TYPE z` (the existing engine emit). It requires `ALTER COLUMN y SET DATA TYPE z`.
- `is_safe_type_widening` in `drift.rs` lists Databricks/Spark-flavored names (`INT`/`BIGINT`/`SMALLINT`/`FLOAT`/`DOUBLE`/`DECIMAL`/`VARCHAR`). None of BigQuery's canonical names (`INT64`/`NUMERIC`/`FLOAT64`/`BIGNUMERIC`) appear.

Bolting BQ types onto the global allowlist would lock in a structural compromise: `BIGINT → STRING` and `INT64 → STRING` would coexist as duplicate-meaning entries because the two adapters spell the same logical conversion differently. Once that ships, every future adapter inherits the same asymmetry.

## What this changes

- `SqlDialect::is_safe_type_widening(&str, &str) -> bool` with a default impl that preserves the current Databricks/Spark allowlist verbatim.
- `SqlDialect::alter_column_type_sql(&str, &str, &str) -> AdapterResult<String>` with a default impl emitting the existing ANSI form. Validation (identifier check + type allowlist) lives inside the default impl so any future override inherits it for free.
- `drift::detect_drift` takes `&dyn SqlDialect` and routes the widening check through the trait method.
- `drift::generate_alter_column_sql` delegates the SQL emit to the trait method.
- Free function `is_safe_type_widening` becomes `default_is_safe_type_widening` (`pub(crate)`) so the default trait impl can call it without exposing a public alias.

## What this does NOT change

- Any existing behavior. Default impls preserve every allowlist entry and emit string verbatim.
- BigQuery's `is_experimental` status — still flagged.
- Any adapter implementation. The defaults mean Databricks/Snowflake/DuckDB/BigQuery all keep the same drift semantics they had yesterday.

## Receipt

This is a refactor; the receipt is the regression suite, not a new live test:

- `cargo test -p rocky-core --lib` — 1129 passed
- `cargo test -p rocky-core --test e2e` — 30 passed
- `cargo test -p rocky-core --test integration` — 20 passed
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean

The live drift smoke test (`live/drift/run.sh`) still passes with no changes — verified end-to-end against the BQ sandbox.

## Next PR

Adds the BigQuery dialect override:

- `BigQueryDialect::alter_column_type_sql` — emits BQ's required `ALTER COLUMN ... SET DATA TYPE` form
- `BigQueryDialect::is_safe_type_widening` — declares BQ's widening allowlist (`INT64 → NUMERIC`, `INT64 → BIGNUMERIC`, `NUMERIC → BIGNUMERIC`, plus numeric-to-`STRING` for BQ types)
- Runtime wiring: `run.rs` currently only handles `DropAndRecreate`; the next PR adds the `AlterColumnTypes` branch that calls `generate_alter_column_sql`.
- Live smoke: `live/drift/run.sh` gains a fourth stage exercising a safe widening (e.g. `INT64 → NUMERIC`) end-to-end.

Open question to settle before that PR: is `INT64 → FLOAT64` "safe widening" under Rocky's definition? Lossy for values > 2^53.

## Test plan

- [x] All `rocky-core` tests pass with the new signature
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Existing `live/drift/run.sh` smoke test against the sandbox still passes (3-stage flow unchanged)