### PR TITLE
fix(rocky-bigquery): wire alter_column_types drift via BQ-specific overrides

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -193,6 +193,57 @@ impl SqlDialect for BigQueryDialect {
     fn current_timestamp_expr(&self) -> &'static str {
         "CURRENT_TIMESTAMP()"
     }
+
+    /// BigQuery's safe-widening allowlist.
+    ///
+    /// Strict subset of BigQuery's documented `ALTER COLUMN SET DATA
+    /// TYPE` widenings — only the lossless numeric promotions:
+    ///
+    /// - `INT64 → NUMERIC`, `INT64 → BIGNUMERIC` — full INT64 range
+    ///   fits losslessly in NUMERIC (precision 38) and BIGNUMERIC.
+    /// - `NUMERIC → BIGNUMERIC` — strict precision widening.
+    ///
+    /// **Excluded by design:**
+    ///
+    /// - `INT64 → FLOAT64`, `NUMERIC → FLOAT64`, `BIGNUMERIC → FLOAT64`
+    ///   — BigQuery accepts these via `SET DATA TYPE` but they are
+    ///   lossy for absolute values > 2^53. Rocky's "safe widening"
+    ///   contract excludes any conversion with potential value loss
+    ///   (matches the strictness of the default Databricks/Spark
+    ///   allowlist, which also omits `INT → FLOAT`).
+    /// - **All `… → STRING` conversions.** Despite being lossless at
+    ///   the value level, BigQuery's `ALTER COLUMN SET DATA TYPE`
+    ///   rejects any conversion to `STRING` (`existing column type X
+    ///   is not assignable to STRING`). The default allowlist's
+    ///   "any numeric → STRING" pattern doesn't transfer to BigQuery.
+    ///
+    /// Drift involving any excluded pair falls through to
+    /// `DropAndRecreate`.
+    fn is_safe_type_widening(&self, source_type: &str, target_type: &str) -> bool {
+        let src = source_type.to_uppercase();
+        let tgt = target_type.to_uppercase();
+        matches!(
+            (tgt.as_str(), src.as_str()),
+            ("INT64", "NUMERIC") | ("INT64", "BIGNUMERIC") | ("NUMERIC", "BIGNUMERIC"),
+        )
+    }
+
+    /// BigQuery requires `ALTER COLUMN ... SET DATA TYPE ...`; the ANSI
+    /// `ALTER COLUMN ... TYPE ...` form returns `Expected keyword DROP
+    /// or keyword SET`. Other dialects use the default impl on the
+    /// `SqlDialect` trait.
+    fn alter_column_type_sql(
+        &self,
+        table_ref: &str,
+        column: &str,
+        new_type: &str,
+    ) -> AdapterResult<String> {
+        validation::validate_identifier(column).map_err(AdapterError::new)?;
+        rocky_core::sql_gen::validate_sql_type(new_type).map_err(AdapterError::new)?;
+        Ok(format!(
+            "ALTER TABLE {table_ref} ALTER COLUMN {column} SET DATA TYPE {new_type}"
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -312,5 +363,78 @@ mod tests {
             d.drop_table_sql("`p`.`d`.`t`"),
             "DROP TABLE IF EXISTS `p`.`d`.`t`"
         );
+    }
+
+    #[test]
+    fn alter_column_type_sql_uses_bq_set_data_type_form() {
+        let d = BigQueryDialect;
+        let sql = d
+            .alter_column_type_sql("`p`.`d`.`t`", "score", "NUMERIC")
+            .unwrap();
+        assert_eq!(
+            sql,
+            "ALTER TABLE `p`.`d`.`t` ALTER COLUMN score SET DATA TYPE NUMERIC"
+        );
+    }
+
+    #[test]
+    fn alter_column_type_sql_rejects_bad_identifier() {
+        let d = BigQueryDialect;
+        assert!(
+            d.alter_column_type_sql("`p`.`d`.`t`", "bad; DROP", "NUMERIC")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn alter_column_type_sql_rejects_bad_type() {
+        let d = BigQueryDialect;
+        assert!(
+            d.alter_column_type_sql("`p`.`d`.`t`", "score", "NUMERIC; DROP")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn is_safe_type_widening_int64_to_numeric() {
+        let d = BigQueryDialect;
+        assert!(d.is_safe_type_widening("NUMERIC", "INT64"));
+        assert!(d.is_safe_type_widening("BIGNUMERIC", "INT64"));
+        assert!(d.is_safe_type_widening("BIGNUMERIC", "NUMERIC"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_excludes_to_string() {
+        // BigQuery's ALTER COLUMN SET DATA TYPE rejects any conversion
+        // to STRING (`existing column type INT64 is not assignable to
+        // STRING`), so even though STRING is lossless at the value
+        // level, it can't be used as a drift evolution target.
+        let d = BigQueryDialect;
+        assert!(!d.is_safe_type_widening("STRING", "INT64"));
+        assert!(!d.is_safe_type_widening("STRING", "NUMERIC"));
+        assert!(!d.is_safe_type_widening("STRING", "FLOAT64"));
+        assert!(!d.is_safe_type_widening("STRING", "BOOL"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_excludes_to_float64() {
+        // BigQuery accepts these conversions via SET DATA TYPE, but
+        // they are lossy for absolute values > 2^53. Rocky's "safe"
+        // contract is strict — drift involving these falls through to
+        // DropAndRecreate.
+        let d = BigQueryDialect;
+        assert!(!d.is_safe_type_widening("FLOAT64", "INT64"));
+        assert!(!d.is_safe_type_widening("FLOAT64", "NUMERIC"));
+        assert!(!d.is_safe_type_widening("FLOAT64", "BIGNUMERIC"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_excludes_narrowing_and_unrelated() {
+        let d = BigQueryDialect;
+        // Narrowing is never safe.
+        assert!(!d.is_safe_type_widening("INT64", "STRING"));
+        assert!(!d.is_safe_type_widening("INT64", "NUMERIC"));
+        // Unrelated type families fall through.
+        assert!(!d.is_safe_type_widening("DATE", "TIMESTAMP"));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4133,6 +4133,61 @@ async fn process_table(
                 action: "drop_and_recreate".into(),
                 reason,
             });
+        } else if drift_result.action == DriftAction::AlterColumnTypes {
+            // Every drifted column passed the dialect's safe-widening
+            // check. Issue `ALTER TABLE ALTER COLUMN ... TYPE ...` (or
+            // BigQuery's `SET DATA TYPE` form) for each before the
+            // INSERT continues — target keeps its existing rows with
+            // the values reinterpreted under the new type.
+            info!(
+                table = target_table.full_name(),
+                drifted = drift_result.drifted_columns.len(),
+                "drift detected, widening {} column type(s)",
+                drift_result.drifted_columns.len()
+            );
+            let alter_stmts = drift::generate_alter_column_sql(
+                &target_table,
+                &drift_result.drifted_columns,
+                dialect,
+            )?;
+            for stmt in &alter_stmts {
+                warehouse
+                    .execute_statement(stmt)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+            }
+            // If the same drift round also surfaced added columns,
+            // apply them as part of the same schema-evolution step
+            // before the INSERT runs.
+            if !drift_result.added_columns.is_empty() {
+                let add_stmts = drift::generate_add_column_sql(
+                    &target_table,
+                    &drift_result.added_columns,
+                    dialect,
+                )?;
+                for stmt in &add_stmts {
+                    warehouse
+                        .execute_statement(stmt)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                }
+            }
+            let reason = drift_result
+                .drifted_columns
+                .iter()
+                .map(|c| {
+                    format!(
+                        "column '{}' widened {} → {}",
+                        c.name, c.target_type, c.source_type
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            drift_action = Some(DriftActionOutput {
+                table: target_table.full_name(),
+                action: "alter_column_types".into(),
+                reason,
+            });
         } else if !drift_result.added_columns.is_empty() {
             // Source added columns the target doesn't have. Without an
             // ALTER, the next `INSERT INTO target SELECT * FROM source`

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -12,7 +12,7 @@ end-to-end against a real GCP project and asserts the resulting state.
 | `time-interval/run.sh` | `time_interval` | `BigQueryDialect::insert_overwrite_partition` (BEGIN TRANSACTION / DELETE / INSERT / COMMIT TRANSACTION script) |
 | `merge/run.sh` | `merge` | `BigQueryDialect::merge_into` (`WHEN NOT MATCHED THEN INSERT ROW`) + first-run target bootstrap |
 | `discover/run.sh` | n/a | `BigQueryDiscoveryAdapter` enumerating datasets via region-qualified `INFORMATION_SCHEMA.SCHEMATA` |
-| `drift/run.sh` | `incremental` (replication) | Replication-from-BQ + per-table drift detection: `add_columns` (ALTER TABLE ADD COLUMN) and `drop_and_recreate` (column type change) |
+| `drift/run.sh` | `incremental` (replication) | Replication-from-BQ + per-table drift detection: `add_columns` (ALTER TABLE ADD COLUMN), `drop_and_recreate` (unsafe type change), and `alter_column_types` (safe widening, e.g. INT64 → NUMERIC) |
 
 Each driver:
 
@@ -120,12 +120,16 @@ Adapter-side gaps to revisit separately:
    source columns missing from the target, and the runtime issues
    `ALTER TABLE ADD COLUMN` for each before the next INSERT. The
    drift smoke test exercises this in stage 2 (`add_columns` action).
-9. **`alter_column_types` drift action is detected but not wired.**
-   `detect_drift` already classifies safe widenings (e.g.
-   `INT64`→`NUMERIC`) as `DriftAction::AlterColumnTypes`, but
-   `run.rs:4105` only emits SQL for `DropAndRecreate`. Safe widenings
-   silently fall through to the next INSERT and may fail with type
-   mismatch errors. Note that `is_safe_type_widening` lists
-   `INT`/`BIGINT`/etc., not BQ's `INT64` — fixing the wiring should
-   come with a BQ type-name expansion. Worth a separate
-   fix-with-receipt PR.
+9. ~~`alter_column_types` drift action is detected but not wired~~ —
+   **fixed**. `is_safe_type_widening` and `alter_column_type_sql` now
+   live on the `SqlDialect` trait so each adapter declares its own
+   widening semantics + SQL emit. The BigQuery dialect override
+   accepts only the strict lossless promotions BQ supports via
+   `ALTER COLUMN SET DATA TYPE`: `INT64 → NUMERIC`, `INT64 →
+   BIGNUMERIC`, `NUMERIC → BIGNUMERIC`. Lossy conversions (`… →
+   FLOAT64`) and unsupported targets (`… → STRING`, despite being
+   lossless at the value level — BQ's ALTER rejects this with
+   `existing column type X is not assignable to STRING`) are
+   excluded; drift involving them falls through to
+   `drop_and_recreate`. Stage 4 of `drift/run.sh` exercises the path
+   live (INT64 → NUMERIC).

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/drift/run.sh
@@ -40,17 +40,17 @@ drop_datasets() {
 drop_datasets
 trap drop_datasets EXIT
 
-echo "==> seeding source: $SRC_DS.customers (3-column schema with watermark)"
+echo "==> seeding source: $SRC_DS.customers (4-column schema with watermark + INT64 score)"
 bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$SRC_DS" > /dev/null
 bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
    "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
-    SELECT id, name, _updated_at FROM UNNEST([
-      STRUCT(1 AS id, 'alice' AS name, TIMESTAMP '2026-04-01 00:00:00' AS _updated_at),
-      STRUCT(2,        'bob',           TIMESTAMP '2026-04-01 00:00:00'),
-      STRUCT(3,        'carol',         TIMESTAMP '2026-04-01 00:00:00')
+    SELECT id, name, _updated_at, score FROM UNNEST([
+      STRUCT(1 AS id, 'alice' AS name, TIMESTAMP '2026-04-01 00:00:00' AS _updated_at, 100 AS score),
+      STRUCT(2,        'bob',           TIMESTAMP '2026-04-01 00:00:00',                200),
+      STRUCT(3,        'carol',         TIMESTAMP '2026-04-01 00:00:00',                300)
     ])" > /dev/null
 
-echo "==> stage 1: rocky run (initial — replicates 3-column source to target)"
+echo "==> stage 1: rocky run (initial — replicates 4-column source to target)"
 rocky -c live.rocky.toml run --output json > expected/run-initial.json
 
 ROW_COUNT="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
@@ -78,26 +78,48 @@ bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
    "DROP TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\`" > /dev/null
 bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
    "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
-    SELECT id, name, _updated_at, region FROM UNNEST([
+    SELECT id, name, _updated_at, region, score FROM UNNEST([
       STRUCT('1' AS id, 'alice' AS name,
-             TIMESTAMP '2026-04-03 00:00:00' AS _updated_at, 'EU' AS region),
-      STRUCT('2',         'bob',           TIMESTAMP '2026-04-03 00:00:00', 'US'),
-      STRUCT('3',         'carol',         TIMESTAMP '2026-04-03 00:00:00', 'APAC'),
-      STRUCT('4',         'dave',          TIMESTAMP '2026-04-03 00:00:00', 'EU')
+             TIMESTAMP '2026-04-03 00:00:00' AS _updated_at, 'EU' AS region, 100 AS score),
+      STRUCT('2',         'bob',           TIMESTAMP '2026-04-03 00:00:00', 'US',   200),
+      STRUCT('3',         'carol',         TIMESTAMP '2026-04-03 00:00:00', 'APAC', 300),
+      STRUCT('4',         'dave',          TIMESTAMP '2026-04-03 00:00:00', 'EU',   400)
     ])" > /dev/null
 
 echo "==> rocky run (post-type-change — should detect drop_and_recreate)"
 rocky -c live.rocky.toml run --output json > expected/run-type-change.json
 
-echo "==> verifying drift JSON output across all three runs"
+echo "==> stage 4: DROP+CREATE source with score INT64→NUMERIC (safe widening)"
+# After stage 3 the target's `score` is INT64. Widening to NUMERIC is
+# a lossless conversion BigQuery supports via `ALTER COLUMN ... SET
+# DATA TYPE` and Rocky's BQ widening allowlist accepts. Casting at
+# the SELECT level forces the source schema to NUMERIC.
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "DROP TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\`" > /dev/null
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+   "CREATE TABLE \`${PROJ}\`.\`${SRC_DS}\`.\`customers\` AS
+    SELECT id, name, _updated_at, region, CAST(score AS NUMERIC) AS score FROM UNNEST([
+      STRUCT('1' AS id, 'alice' AS name,
+             TIMESTAMP '2026-04-04 00:00:00' AS _updated_at, 'EU' AS region, 100 AS score),
+      STRUCT('2',         'bob',           TIMESTAMP '2026-04-04 00:00:00', 'US',   200),
+      STRUCT('3',         'carol',         TIMESTAMP '2026-04-04 00:00:00', 'APAC', 300),
+      STRUCT('4',         'dave',          TIMESTAMP '2026-04-04 00:00:00', 'EU',   400)
+    ])" > /dev/null
+
+echo "==> rocky run (post-widen — should detect alter_column_types)"
+rocky -c live.rocky.toml run --output json > expected/run-widen.json
+
+echo "==> verifying drift JSON output across all four runs"
 python3 - "$HERE/expected/run-initial.json" \
         "$HERE/expected/run-add-col.json" \
-        "$HERE/expected/run-type-change.json" <<'PY'
+        "$HERE/expected/run-type-change.json" \
+        "$HERE/expected/run-widen.json" <<'PY'
 import json, sys
 
 initial      = json.load(open(sys.argv[1]))
 add_col      = json.load(open(sys.argv[2]))
 type_change  = json.load(open(sys.argv[3]))
+widen        = json.load(open(sys.argv[4]))
 
 # Stage 1: target was just created from source, no drift.
 d = initial.get("drift", {})
@@ -121,6 +143,14 @@ if d.get("tables_drifted", 0) < 1 or not any(a.get("action") == "drop_and_recrea
     print(f"FAIL: expected drop_and_recreate action after type change, got {d}")
     sys.exit(1)
 print(f"    stage 3 drift: action=drop_and_recreate OK ({[a.get('reason') for a in actions]})")
+
+# Stage 4: score INT64→NUMERIC — safe widening, alter_column_types.
+d = widen.get("drift", {})
+actions = d.get("actions_taken", [])
+if d.get("tables_drifted", 0) < 1 or not any(a.get("action") == "alter_column_types" for a in actions):
+    print(f"FAIL: expected alter_column_types action after safe widening, got {d}")
+    sys.exit(1)
+print(f"    stage 4 drift: action=alter_column_types OK ({[a.get('reason') for a in actions]})")
 PY
 
 echo "==> verifying target schema reflects all mutations"
@@ -138,8 +168,16 @@ if [[ "$ID_TYPE" != "STRING" ]]; then
     echo "FAIL: expected target id type STRING after drop_and_recreate, got '$ID_TYPE'"
     exit 1
 fi
+SCORE_TYPE="$(bq --project_id="$PROJ" query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT data_type FROM \`${PROJ}\`.\`${TGT_DS}\`.INFORMATION_SCHEMA.COLUMNS \
+     WHERE table_name = 'customers' AND column_name = 'score'" | tail -n 1)"
+if [[ "$SCORE_TYPE" != "NUMERIC" ]]; then
+    echo "FAIL: expected target score type NUMERIC after alter_column_types, got '$SCORE_TYPE'"
+    exit 1
+fi
 echo "    target columns: $COLS"
 echo "    target customers.id is now STRING (drop_and_recreate took effect)"
+echo "    target customers.score is now NUMERIC (alter_column_types took effect)"
 
 echo
-echo "POC complete: BigQuery drift detection (add + type change) verified live."
+echo "POC complete: BigQuery drift detection (add + drop_and_recreate + alter_column_types) verified live."


### PR DESCRIPTION
Closes the second drift-evolution gap from #328. PR #332 lifted `is_safe_type_widening` + `alter_column_type_sql` onto the `SqlDialect` trait with default impls preserving Databricks/Spark semantics. This PR adds the BigQuery overrides + the runtime wiring to actually emit `AlterColumnTypes` SQL.

## Engine changes

- **`BigQueryDialect::alter_column_type_sql`** overrides the default ANSI form with BQ's required `ALTER COLUMN x SET DATA TYPE y`. The default `ALTER COLUMN x TYPE y` shape returns `Expected keyword DROP or keyword SET` from BigQuery.
- **`BigQueryDialect::is_safe_type_widening`** declares a strict BQ-specific allowlist:
  - `INT64 → NUMERIC` (lossless: INT64 fits in NUMERIC precision 38)
  - `INT64 → BIGNUMERIC` (lossless)
  - `NUMERIC → BIGNUMERIC` (strict precision widening)
  
  Excluded by design:
  - `… → FLOAT64`: lossy for absolute values > 2^53. BigQuery accepts via SET DATA TYPE but Rocky's "safe" contract is strict (matches the default Databricks/Spark allowlist that omits `INT → FLOAT`).
  - `… → STRING`: BigQuery's `ALTER COLUMN SET DATA TYPE` rejects these with `existing column type X is not assignable to STRING` even though STRING is lossless at the value level. The default allowlist's "any numeric → STRING" pattern doesn't transfer to BQ. **Discovered via live verification** — initial draft included these patterns and live runs surfaced the error against stage 3 of the existing smoke test.
- **`run.rs::process_table`** adds the `DriftAction::AlterColumnTypes` branch between `DropAndRecreate` and the existing `added_columns` branch. Emits via `drift::generate_alter_column_sql` (which routes through `dialect.alter_column_type_sql`) and surfaces as `action: "alter_column_types"` in the run output. If the same drift round also surfaced added columns, both apply before the INSERT continues.

## Smoke test

Extends `live/drift/run.sh` to a four-stage flow:

1. Initial 4-column source (with `score INT64`) → replicate clean
2. `ALTER source ADD COLUMN region` → `add_columns` action
3. `DROP+CREATE source` with `id INT64→STRING` → `drop_and_recreate` (unsafe per BQ allowlist)
4. `DROP+CREATE source` with `score INT64→NUMERIC` → `alter_column_types` (safe widening)

```
==> stage 4 drift: action=alter_column_types OK (["column 'score' widened INT64 → NUMERIC"])
==> target customers.score is now NUMERIC (alter_column_types took effect)
```

Idempotent across consecutive runs.

## Test plan

- [x] `cargo test -p rocky-bigquery --lib` — 68 passed (8 new dialect tests)
- [x] `cargo clippy -p rocky-bigquery -p rocky-cli -p rocky-core --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery -p rocky-cli -p rocky-core --check` clean
- [x] `live/drift/run.sh` against the BQ sandbox — exits 0, all 4 stages pass
- [x] Two consecutive runs both pass (idempotency)