### PR TITLE
docs(rocky-bigquery): conformance audit + recommendation to drop is_experimental

### DIFF
--- a/engine/crates/rocky-bigquery/CONFORMANCE.md
+++ b/engine/crates/rocky-bigquery/CONFORMANCE.md
@@ -1,0 +1,72 @@
+# BigQuery adapter conformance
+
+This document maps the conformance categories defined in
+`rocky-adapter-sdk::conformance::test_specs` to the live smoke drivers
+that exercise the BigQuery adapter end-to-end against a real GCP
+project. It's the receipt for "we exercised the surface" — the
+runtime version of the suite (`rocky test-adapter`) is currently a
+stub (per the docstring on `run_conformance`: "this returns a plan
+with all tests marked as skipped or with placeholder timing"); the
+live smoke drivers under
+`examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/`
+are what actually exercise the adapter.
+
+## Coverage matrix
+
+| Category | Test | Status | Receipt |
+|---|---|---|---|
+| Connection | `connect` | ✅ live | every smoke driver authenticates and runs at least one query |
+| DDL | `create_table` | ✅ live | `live/run.sh` (full-refresh CTAS), `live/merge/run.sh` (bootstrap) |
+| DDL | `drop_table` | ✅ live | `live/drift/run.sh` stage 3 (`drop_and_recreate` action) |
+| DDL | `create_catalog` | ⚪ N/A | `BigQueryDialect::create_catalog_sql` returns `None`; BQ projects can't be created via SQL. Documented in adapter source. |
+| DDL | `create_schema` | ✅ live | exercised inside `live/<strategy>/run.sh` cleanup (`bq rm -r -f -d`) and via `auto_create_schemas` on the replication path |
+| DML | `insert_into` | ✅ live | `live/drift/run.sh` (incremental replication) |
+| DML | `merge_into` | ✅ live | `live/merge/run.sh` (bootstrap + UPSERT) |
+| Query | `describe_table` | ✅ live | `live/drift/run.sh` (existence probe + drift detection); covered by `BigQueryAdapter::describe_table` integration test |
+| Query | `table_exists_true` / `table_exists_false` | ✅ live | `live/merge/run.sh` first-run bootstrap probes target absence; subsequent run probes target presence |
+| Query | `execute_query` | ✅ live | every smoke driver round-trips at least one `SELECT` |
+| Types | `type_string`, `type_integer`, `type_float`, `type_boolean`, `type_date`, `type_timestamp`, `type_null` | 🟡 implicit | not exercised by a dedicated type-coverage driver. The shipped smokes use STRING (`name`), INT64 (`id`, `score`), TIMESTAMP (`_updated_at`), NUMERIC (`score` after widening). FLOAT64, BOOL, DATE, and explicit NULL are not live-exercised yet. |
+| Dialect | `format_table_ref` | ✅ unit + live | unit tests in `dialect.rs::tests` plus implicit coverage in every smoke (every query references three-part names) |
+| Dialect | `watermark_where` | ✅ unit | unit-tested in `dialect.rs`. Not exercised by a live transformation pipeline today (the transformation incremental path is undertested workspace-wide; see `feedback_helpers_without_call_sites.md`). |
+| Dialect | `row_hash` | ⚪ not implemented | the trait method isn't on `SqlDialect` today; no adapter implements it. Conformance test references a future trait surface. |
+| Governance | `set_tags` | ⚪ no-op by design | `BigQueryGovernanceAdapter::set_tags` warns + returns `Ok(())`. BQ tag application requires the IAM Resource Manager API, not SQL — outside the warehouse-adapter trait surface. Documented in `governance.rs:175-189`. |
+| Governance | `get_grants` | ⚪ no-op by design | same as `set_tags` — IAM grants are REST-only, not SQL-issuable. |
+| BatchChecks | `batch_row_counts` / `batch_freshness` | 🟡 unit-tested | `BigQueryBatchCheckAdapter` is exercised by unit tests + the discover-path's `--with-schemas` warm-up code path. Not exercised in any current smoke driver. Adding `--with-schemas` to `live/discover/run.sh` would close this gap. |
+| Discovery | `discover` | ✅ live | `live/discover/run.sh` |
+
+Legend: ✅ exercised live · 🟡 implicit / partial · ⚪ N/A or by design
+
+## Open findings (documented limitations)
+
+These are known limitations carried forward in the adapter today.
+Each is documented either in the adapter source or
+`live/README.md`; none break the workflow when the caller is aware:
+
+1. **Model-sidecar TOMLs skip env-var substitution.** Engine-wide gap (not BQ-specific). Workaround: hardcode catalog in model TOML.
+2. **`auto_create_schemas` unwired in transformation run path.** Engine-wide gap (not BQ-specific). Workaround: pre-create the dataset via `bq mk`.
+3. **Time-interval `time_column` must be TIMESTAMP on BigQuery.** The runtime emits the partition filter as `'YYYY-MM-DD HH:MM:SS'` literals; BQ refuses to coerce to a DATE column. `sql_gen.rs:239`. Workaround: model SQL uses `TIMESTAMP_TRUNC(...)`.
+4. **MERGE requires explicit `update_columns` on BigQuery.** BQ rejects `UPDATE SET target = source` shorthand. Workaround: declare `update_columns` in the model TOML.
+5. **`bytes_scanned` is `totalBytesProcessed` for queries that return zero rows-billed.** BQ exempts constant queries (e.g., the full-refresh smoke's no-source UNNEST literal) from the 10 MB minimum-bill floor. Real source-scanning models populate non-zero values via the `jobs.get` enrichment path (PR #330).
+
+## Recommendation: ready to drop `is_experimental`
+
+`BigQueryAdapter::is_experimental()` returns `true` today, which fires
+two warnings on every adapter construction:
+
+- `BigQueryAdapter::new` logs `"BigQuery adapter is experimental..."`
+- The CLI registry emits a separate `"adapter '<name>' is
+  experimental — some features may be incomplete..."`
+
+The adapter has been live-verified across every dialect surface
+that has a live smoke driver. The remaining gaps are documented
+limitations (above) — most engine-wide, none breaking the workflows
+they cover when the user is aware.
+
+The gate per the trial-window plan was: "Conformance suite green or
+every red has a documented exemption." Given the conformance suite
+itself is a stub, the equivalent gate is: "Live smokes green or every
+gap is documented in this file." That gate is met today.
+
+**Flipping the flag is a one-line change in `src/connector.rs`** plus
+removing the warning. **Not done in this PR — it's a credibility
+statement to users and should land with explicit go-ahead.**


### PR DESCRIPTION
Closes Phase 3.1 + 3.2 of the BQ trial-window arc. Phase 3.3 (drop the `is_experimental` flag) recommended but held for explicit go-ahead.

## Why this is a doc PR

The trial-window plan's Phase 3 was framed as "run `rocky test-adapter`, capture failures, fix or document each one." Two findings made that path unusable as written:

1. **BigQuery isn't in `run_test_adapter_builtin`'s match list** — only `databricks`, `snowflake`, `duckdb` are recognized.
2. **`run_conformance` is a stub.** Per the docstring on `engine/crates/rocky-adapter-sdk/src/conformance.rs:309`: *"this returns a plan with all tests marked as skipped or with placeholder timing. Actual test execution will be wired up when adapters implement the traits against live warehouses."*

So even if BQ were wired in, the suite wouldn't actually exercise the warehouse. Wiring `run_conformance` to execute is a different arc (engine SDK work, not trial-window).

What the BigQuery adapter actually has for conformance coverage today is the set of live smoke drivers we've shipped over the last week. This PR formalizes that.

## What this adds

`engine/crates/rocky-bigquery/CONFORMANCE.md` — a coverage matrix mapping each conformance category to:

- The live smoke driver that exercises it (✅ live).
- "Implicit / partial" (🟡) when exercised indirectly through data-shape coverage. Notable: the Types category — STRING, INT64, TIMESTAMP, NUMERIC are hit by the existing smokes; FLOAT64, BOOL, DATE, NULL are not yet live-exercised.
- "By design" (⚪) when the test genuinely doesn't apply (CREATE CATALOG — BQ projects can't be created via SQL; Governance set_tags / get_grants — IAM/tags are REST-only, outside the warehouse-adapter trait surface).
- The known limitation when there's a documented gap that doesn't break the workflow.

The doc also lists the five open documented limitations (model-sidecar env-subst, transformation `auto_create_schemas`, time-interval `time_column` TIMESTAMP requirement, MERGE explicit `update_columns`, full-refresh zero-byte sourceless models). Most are engine-wide; none break workflows when the user is aware.

## Recommendation: ready to drop `is_experimental`

Today `BigQueryAdapter::is_experimental()` returns `true`, firing two warnings on every connection:

- `BigQueryAdapter::new` logs *"BigQuery adapter is experimental..."*
- The CLI registry emits a separate *"adapter '\<name\>' is experimental"* warning at startup.

Across the BQ trial-window arc (PRs #322, #323, #324, #326, #327, #328, #330, #331, #332, #333), the adapter has been live-verified across every dialect surface we have a smoke driver for. Each surface caught at least one structural bug that unit tests passed (live-verify-required pattern per `feedback_bq_live_verify_required.md`). All surfaced bugs have shipped fixes.

The trial-window plan's Phase 3.3 gate was: "Conformance suite green or every red has a documented exemption." Given the conformance suite is a stub, the equivalent gate is: "Live smokes green or every gap is documented." That gate is met.

**Recommended next step**: flip `is_experimental` to `false` and remove the two warnings. One-line code change in `connector.rs`. Not done in this PR — flipping the flag is a credibility statement to users and shouldn't merge without explicit approval.

## Test plan

- [x] `cargo build -p rocky-bigquery` clean (no code changes; doc-only)
- [x] All references in CONFORMANCE.md resolve (live drivers exist; line numbers verified)
- [x] No engine code touched in this PR

## Decision needed

After this merges, do you want me to follow up with the `is_experimental: false` flip + warning removal? It's a separate ~5-line PR that closes the arc.