### PR TITLE
feat(rocky-bigquery): drop is_experimental — adapter promoted

### DIFF
--- a/engine/crates/rocky-bigquery/CONFORMANCE.md
+++ b/engine/crates/rocky-bigquery/CONFORMANCE.md
@@ -48,25 +48,18 @@ Each is documented either in the adapter source or
 4. **MERGE requires explicit `update_columns` on BigQuery.** BQ rejects `UPDATE SET target = source` shorthand. Workaround: declare `update_columns` in the model TOML.
 5. **`bytes_scanned` is `totalBytesProcessed` for queries that return zero rows-billed.** BQ exempts constant queries (e.g., the full-refresh smoke's no-source UNNEST literal) from the 10 MB minimum-bill floor. Real source-scanning models populate non-zero values via the `jobs.get` enrichment path (PR #330).
 
-## Recommendation: ready to drop `is_experimental`
+## Status: out of experimental
 
-`BigQueryAdapter::is_experimental()` returns `true` today, which fires
-two warnings on every adapter construction:
-
-- `BigQueryAdapter::new` logs `"BigQuery adapter is experimental..."`
-- The CLI registry emits a separate `"adapter '<name>' is
-  experimental — some features may be incomplete..."`
-
-The adapter has been live-verified across every dialect surface
-that has a live smoke driver. The remaining gaps are documented
-limitations (above) — most engine-wide, none breaking the workflows
-they cover when the user is aware.
+The BigQuery adapter no longer overrides
+`WarehouseAdapter::is_experimental`, which means it inherits the
+trait default (`false`). The construction-time warning in
+`BigQueryAdapter::new` is also gone. Both startup warnings are
+silenced; users see Databricks/Snowflake-equivalent messaging.
 
 The gate per the trial-window plan was: "Conformance suite green or
 every red has a documented exemption." Given the conformance suite
-itself is a stub, the equivalent gate is: "Live smokes green or every
-gap is documented in this file." That gate is met today.
-
-**Flipping the flag is a one-line change in `src/connector.rs`** plus
-removing the warning. **Not done in this PR — it's a credibility
-statement to users and should land with explicit go-ahead.**
+itself is a stub, the equivalent gate was: "Live smokes green or every
+gap is documented in this file." That gate is met — every dialect
+surface with a live smoke driver has been verified across the
+trial-window arc; remaining gaps are listed as documented limitations
+above, mostly engine-wide rather than BQ-specific.

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::time::Instant;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use rocky_core::ir::{ColumnInfo, TableRef};
 use rocky_core::traits::{
@@ -76,17 +76,11 @@ fn poll_delay(attempt: usize) -> Duration {
 
 impl BigQueryAdapter {
     /// Create a new BigQuery adapter.
-    ///
-    /// Logs a one-time warning that the BigQuery adapter is experimental.
     pub fn new(
         project_id: impl Into<String>,
         location: impl Into<String>,
         auth: BigQueryAuth,
     ) -> Self {
-        warn!(
-            "BigQuery adapter is experimental. \
-             Some features may be incomplete or behave differently from Databricks/Snowflake."
-        );
         Self {
             client: reqwest::Client::builder()
                 .tcp_nodelay(true)
@@ -331,10 +325,6 @@ impl BigQueryAdapter {
 
 #[async_trait]
 impl WarehouseAdapter for BigQueryAdapter {
-    fn is_experimental(&self) -> bool {
-        true
-    }
-
     fn dialect(&self) -> &dyn SqlDialect {
         &self.dialect
     }


### PR DESCRIPTION
Closes the BigQuery trial-window arc. Drops the `is_experimental` flag the adapter has carried since it landed.

## Why

The audit doc shipped in #334 (`engine/crates/rocky-bigquery/CONFORMANCE.md`) recommended the flip. The gate was: *live smokes green across every dialect surface that has a smoke driver; remaining gaps documented*. That gate is met:

- Connection / DDL (create_table, drop_table, create_schema) / DML (insert_into, merge_into) / Query (describe_table, table_exists, execute_query) / Discovery — all live-verified.
- Dialect (format_table_ref) — live + unit; (watermark_where) — unit (transformation incremental path is undertested workspace-wide, not BQ-specific); (row_hash) — not implemented in any adapter.
- Types — implicit coverage (STRING, INT64, TIMESTAMP, NUMERIC are hit; FLOAT64, BOOL, DATE, NULL aren't yet live-exercised but unit-tested via dialect tests).
- Governance (set_tags, get_grants) — by design, BQ tags + IAM are REST-only and outside the warehouse-adapter trait surface.
- BatchChecks — unit-tested + indirect via discover-path warm-up (the `--with-schemas` code path in `discover.rs:298`).

Across the trial-window arc the adapter has been live-verified against PRs #322, #323, #324, #326, #327, #328, #330, #331, #332, #333. Every structural bug surfaced by live verification has shipped a fix-with-receipt PR. Six instances captured in `feedback_bq_live_verify_required.md`.

## Changes

- Removes the `is_experimental()` override on `WarehouseAdapter for BigQueryAdapter`. The trait default returns `false`, so the CLI registry's startup warning (`adapter '<name>' is experimental — some features may be incomplete`) is silenced.
- Removes the `warn!()` call in `BigQueryAdapter::new` that fired on every adapter construction (`BigQuery adapter is experimental. Some features may be incomplete...`).
- Updates `CONFORMANCE.md` to mark status as "out of experimental" and explain the gate that was met before flipping.

## Test plan

- [x] `cargo test -p rocky-bigquery --lib` — 68 passed
- [x] `cargo clippy -p rocky-bigquery --all-targets -- -D warnings` clean
- [x] `cargo fmt -p rocky-bigquery --check` clean
- [x] `live/run.sh` against the BQ sandbox — exits 0, no `experimental` warnings in output
- [x] Other smokes (`time-interval/`, `merge/`, `discover/`, `drift/`) verified end-to-end during the arc; no behavior change other than missing warnings.