### PR TITLE
feat(rocky-cli): emit warehouse job_ids on materialization output + cost cross-check smoke

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -290,6 +290,12 @@ export interface MaterializationOutput {
    */
   cost_usd?: number | null;
   duration_ms: number;
+  /**
+   * Warehouse-side job identifiers for the SQL statements rocky issued to materialize this output. Populated for adapters whose REST API surfaces a job reference per statement (BigQuery today via `jobReference.jobId`).
+   *
+   * Useful for cross-checking rocky's reported figures against the warehouse's own statistics — e.g., feeding a job ID into `bq show -j <id>` and comparing `totalBytesBilled` to [`Self::bytes_scanned`]. Empty `Vec` for adapters that don't surface a job concept (DuckDB) or haven't wired it yet (Databricks, Snowflake).
+   */
+  job_ids?: string[];
   metadata: MaterializationMetadata;
   /**
    * Partition window this materialization targeted, present only when the model's strategy is `time_interval`. `None` for unpartitioned strategies (full_refresh, incremental, merge).

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -544,10 +544,12 @@ fn stats_from_response(response: &BigQueryResponse) -> ExecutionStats {
                 .as_deref()
                 .and_then(|s| s.parse::<u64>().ok())
         });
+    let job_id = response.job_reference.as_ref().map(|jr| jr.job_id.clone());
     ExecutionStats {
         bytes_scanned,
         bytes_written: None,
         rows_affected: None,
+        job_id,
     }
 }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3536,6 +3536,7 @@ pub(crate) async fn execute_models(
             let mut exec_error: Option<anyhow::Error> = None;
             let mut bytes_scanned_acc: Option<u64> = None;
             let mut bytes_written_acc: Option<u64> = None;
+            let mut job_ids_acc: Vec<String> = Vec::new();
             for exec_sql in &exec_stmts {
                 match warehouse.execute_statement_with_stats(exec_sql).await {
                     Ok(stats) => {
@@ -3543,6 +3544,9 @@ pub(crate) async fn execute_models(
                             accumulate_bytes(bytes_scanned_acc, stats.bytes_scanned);
                         bytes_written_acc =
                             accumulate_bytes(bytes_written_acc, stats.bytes_written);
+                        if let Some(jid) = stats.job_id {
+                            job_ids_acc.push(jid);
+                        }
                     }
                     Err(e) => {
                         exec_error = Some(anyhow::anyhow!("model '{model_name}' failed: {e}"));
@@ -3594,6 +3598,7 @@ pub(crate) async fn execute_models(
                 cost_usd: None,
                 bytes_scanned: bytes_scanned_acc,
                 bytes_written: bytes_written_acc,
+                job_ids: job_ids_acc,
             });
             if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
                 let _ = reg
@@ -3958,11 +3963,15 @@ async fn run_one_partition(
     let mut exec_err: Option<anyhow::Error> = None;
     let mut bytes_scanned_acc: Option<u64> = None;
     let mut bytes_written_acc: Option<u64> = None;
+    let mut job_ids_acc: Vec<String> = Vec::new();
     for stmt in &stmts {
         match warehouse.execute_statement_with_stats(stmt).await {
             Ok(stats) => {
                 bytes_scanned_acc = accumulate_bytes(bytes_scanned_acc, stats.bytes_scanned);
                 bytes_written_acc = accumulate_bytes(bytes_written_acc, stats.bytes_written);
+                if let Some(jid) = stats.job_id {
+                    job_ids_acc.push(jid);
+                }
             }
             Err(e) => {
                 exec_err = Some(anyhow::anyhow!("{e}"));
@@ -4030,6 +4039,7 @@ async fn run_one_partition(
             cost_usd: None,
             bytes_scanned: bytes_scanned_acc,
             bytes_written: bytes_written_acc,
+            job_ids: job_ids_acc,
         }),
     }
 }
@@ -4411,6 +4421,7 @@ async fn process_table(
             cost_usd: None,
             bytes_scanned: exec_stats.bytes_scanned,
             bytes_written: exec_stats.bytes_written,
+            job_ids: exec_stats.job_id.clone().into_iter().collect(),
         },
         drift_checked: true,
         drift_detected: drift_action,

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -693,9 +693,10 @@ pub async fn run_snapshot(
             cost_usd: None,
             // snapshot_scd2 uses `execute_query` (multi-statement) and
             // doesn't thread stats through yet — BigQuery snapshot cost
-            // attribution is a follow-up wave.
+            // attribution + job-id capture is a follow-up wave.
             bytes_scanned: None,
             bytes_written: None,
+            job_ids: Vec::new(),
         });
     } else {
         output.tables_failed = 1;

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -461,6 +461,19 @@ pub struct MaterializationOutput {
     /// can populate it without a schema break.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes_written: Option<u64>,
+    /// Warehouse-side job identifiers for the SQL statements rocky
+    /// issued to materialize this output. Populated for adapters whose
+    /// REST API surfaces a job reference per statement (BigQuery
+    /// today via `jobReference.jobId`).
+    ///
+    /// Useful for cross-checking rocky's reported figures against the
+    /// warehouse's own statistics — e.g., feeding a job ID into
+    /// `bq show -j <id>` and comparing `totalBytesBilled` to
+    /// [`Self::bytes_scanned`]. Empty `Vec` for adapters that don't
+    /// surface a job concept (DuckDB) or haven't wired it yet
+    /// (Databricks, Snowflake).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub job_ids: Vec<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -2788,6 +2801,7 @@ mod cost_finalize_tests {
             cost_usd: None,
             bytes_scanned: None,
             bytes_written: None,
+            job_ids: Vec::new(),
         }
     }
 
@@ -2998,6 +3012,7 @@ mod run_record_tests {
             cost_usd: None,
             bytes_scanned: None,
             bytes_written: None,
+            job_ids: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -103,7 +103,7 @@ pub struct ExplainResult {
 /// `MaterializationOutput.bytes_scanned` / `.bytes_written` so
 /// `rocky cost` can compute real dollar figures without re-querying the
 /// warehouse.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ExecutionStats {
     /// Adapter-reported bytes figure used for cost accounting. This is
     /// the *billing-relevant* number per adapter, not literal scan
@@ -141,6 +141,19 @@ pub struct ExecutionStats {
     /// per-adapter row counts through without another trait-method
     /// addition.
     pub rows_affected: Option<u64>,
+    /// Warehouse-specific job identifier for this statement, when one
+    /// exists. Threaded into `MaterializationOutput.job_ids` so callers
+    /// can cross-check warehouse-side statistics against rocky's
+    /// reported figures (e.g., comparing `bytes_scanned` to
+    /// `bq show -j <id>`'s `totalBytesBilled`).
+    ///
+    /// - **BigQuery:** `jobReference.jobId` from the `jobs.query`
+    ///   response.
+    /// - **Databricks / Snowflake:** `None` today — both surface a
+    ///   statement identifier in their REST responses; wiring is a
+    ///   follow-up wave.
+    /// - **DuckDB:** `None` — no job concept.
+    pub job_id: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -600,6 +600,10 @@ fn stats_from_response(response: &StatementResponse) -> rocky_core::traits::Exec
         bytes_scanned,
         bytes_written: None,
         rows_affected: None,
+        // Databricks surfaces a statement identifier on the response;
+        // wiring it is a follow-up wave (deferred along with the
+        // `bytes_written` / `rows_affected` fields).
+        job_id: None,
     }
 }
 

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/live.rocky.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/live.rocky.toml
@@ -1,0 +1,18 @@
+# Live BigQuery cost cross-check.
+#
+# Runs a single-statement transformation that scans a real source
+# table, captures the job_id from the rocky run output, and
+# cross-checks rocky's reported `bytes_scanned` against the
+# `totalBytesBilled` BigQuery reports for the same job via
+# `bq show -j`.
+
+[adapter]
+type = "bigquery"
+project_id = "${GCP_PROJECT_ID}"
+location = "${BQ_LOCATION:-EU}"
+
+[pipeline.live]
+type = "transformation"
+models = "models/**"
+
+[pipeline.live.target]

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/models/orders_aggregated.sql
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/models/orders_aggregated.sql
@@ -1,0 +1,6 @@
+SELECT
+    customer_id,
+    COUNT(*)    AS order_count,
+    SUM(amount) AS revenue
+FROM `rocky-sandbox-hc-test-63874`.`hc_phase21_cost_check`.`orders_src`
+GROUP BY customer_id

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/models/orders_aggregated.toml
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/models/orders_aggregated.toml
@@ -1,0 +1,8 @@
+[strategy]
+type = "full_refresh"
+
+# Hardcoded to the Rocky BQ sandbox project — model sidecar TOMLs
+# don't honor `${VAR}` env substitution today (see live/README.md).
+[target]
+catalog = "rocky-sandbox-hc-test-63874"
+schema = "hc_phase21_cost_check"

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/cost-cross-check/run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Live BigQuery cost cross-check.
+#
+# Runs a single-statement transformation that scans a real source
+# table, then verifies rocky's reported `bytes_scanned` matches the
+# `totalBytesBilled` BigQuery itself reports for the same job ID via
+# `bq show -j`. This is the receipt that the cost-attribution chain
+# (`stats_from_response` → `populate_cost_summary` → `bq show -j`)
+# round-trips exact billed bytes, not just an approximation.
+#
+# Required env:
+#   GCP_PROJECT_ID                  — GCP project to run against
+#   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
+# Optional:
+#   BQ_LOCATION                     — dataset location (default: EU)
+
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this live smoke test}"
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+
+LOCATION="${BQ_LOCATION:-EU}"
+PROJ="$GCP_PROJECT_ID"
+DATASET="hc_phase21_cost_check"
+
+drop_dataset() {
+    bq --location="$LOCATION" --project_id="$PROJ" \
+       rm -r -f -d "$DATASET" 2>/dev/null || true
+}
+
+drop_dataset
+trap drop_dataset EXIT
+
+echo "==> dataset: $PROJ.$DATASET (location: $LOCATION)"
+bq --location="$LOCATION" --project_id="$PROJ" mk --dataset "$DATASET"
+
+echo "==> seeding source: orders_src (10 rows)"
+bq --project_id="$PROJ" query --use_legacy_sql=false --quiet \
+"CREATE TABLE \`${PROJ}\`.\`${DATASET}\`.\`orders_src\` AS
+ SELECT customer_id, amount FROM UNNEST([
+   STRUCT( 1 AS customer_id, 100 AS amount),
+   STRUCT( 1,                 50),
+   STRUCT( 2,                200),
+   STRUCT( 2,                150),
+   STRUCT( 3,                300),
+   STRUCT( 3,                400),
+   STRUCT( 4,                250),
+   STRUCT( 5,                100),
+   STRUCT( 5,                 75),
+   STRUCT( 6,                500)
+ ])" > /dev/null
+
+echo "==> rocky validate"
+rocky -c live.rocky.toml validate > /dev/null
+
+echo "==> rocky run --output json"
+rocky -c live.rocky.toml run --output json > expected/run.json
+
+echo "==> verifying job_ids captured + bytes match BQ console"
+python3 - "$HERE/expected/run.json" "$PROJ" <<'PY'
+import json, subprocess, sys
+out = json.load(open(sys.argv[1]))
+project = sys.argv[2]
+mat = out["materializations"][0]
+job_ids = mat.get("job_ids", [])
+rocky_bytes = mat.get("bytes_scanned")
+if not job_ids:
+    print(f"FAIL: materializations[0].job_ids empty (got {mat!r})")
+    sys.exit(1)
+if not isinstance(rocky_bytes, int) or rocky_bytes <= 0:
+    print(f"FAIL: bytes_scanned not populated (got {rocky_bytes!r})")
+    sys.exit(1)
+print(f"    rocky bytes_scanned = {rocky_bytes} (across {len(job_ids)} job(s))")
+
+# `bq show -j <id>` reports the same `totalBytesBilled` rocky should be
+# reading via `jobs.get`. Sum across all captured jobs and compare.
+total_bq_billed = 0
+for jid in job_ids:
+    res = subprocess.run(
+        ["bq", "show", "--format=prettyjson", "--project_id", project, "-j", jid],
+        capture_output=True, text=True, check=True,
+    )
+    data = json.loads(res.stdout)
+    billed = int(data.get("statistics", {}).get("query", {}).get("totalBytesBilled", "0"))
+    print(f"    bq show -j {jid}: totalBytesBilled = {billed}")
+    total_bq_billed += billed
+
+if rocky_bytes != total_bq_billed:
+    print(f"FAIL: rocky's bytes_scanned ({rocky_bytes}) != sum of BQ totalBytesBilled ({total_bq_billed})")
+    sys.exit(1)
+print(f"    rocky bytes_scanned = bq totalBytesBilled = {total_bq_billed}")
+PY
+
+echo
+echo "POC complete: BigQuery cost cross-check verified live."

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -430,6 +430,12 @@ class MaterializationOutput(BaseModel):
     Observed dollar cost of this materialization, computed post-hoc from the adapter-appropriate formula (duration × DBU rate for Databricks/Snowflake, bytes × $/TB for BigQuery, zero for DuckDB). `None` when the warehouse type isn't billed or the adapter didn't report the inputs the formula needs. Populated by the run finalizer via `rocky_core::cost::compute_observed_cost_usd`.
     """
     duration_ms: conint(ge=0)
+    job_ids: list[str] | None = None
+    """
+    Warehouse-side job identifiers for the SQL statements rocky issued to materialize this output. Populated for adapters whose REST API surfaces a job reference per statement (BigQuery today via `jobReference.jobId`).
+
+    Useful for cross-checking rocky's reported figures against the warehouse's own statistics — e.g., feeding a job ID into `bq show -j <id>` and comparing `totalBytesBilled` to [`Self::bytes_scanned`]. Empty `Vec` for adapters that don't surface a job concept (DuckDB) or haven't wired it yet (Databricks, Snowflake).
+    """
     metadata: MaterializationMetadata
     partition: PartitionInfo | None = None
     """

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -432,6 +432,13 @@
           "minimum": 0.0,
           "type": "integer"
         },
+        "job_ids": {
+          "description": "Warehouse-side job identifiers for the SQL statements rocky issued to materialize this output. Populated for adapters whose REST API surfaces a job reference per statement (BigQuery today via `jobReference.jobId`).\n\nUseful for cross-checking rocky's reported figures against the warehouse's own statistics — e.g., feeding a job ID into `bq show -j <id>` and comparing `totalBytesBilled` to [`Self::bytes_scanned`]. Empty `Vec` for adapters that don't surface a job concept (DuckDB) or haven't wired it yet (Databricks, Snowflake).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "metadata": {
           "$ref": "#/definitions/MaterializationMetadata"
         },


### PR DESCRIPTION
PR #330 wired BigQuery's `totalBytesBilled` (with the 10 MB minimum-bill floor) into `bytes_scanned` via a follow-up `jobs.get` enrichment. But there was no way to verify rocky's reported figure matched what the BigQuery console actually shows — the run output didn't surface a job identifier the caller could feed into `bq show -j <id>` for an exact-match cross-check.

This PR threads warehouse-side job identifiers through to `MaterializationOutput.job_ids` so callers can do the round-trip. Adds a smoke driver that exercises it end-to-end.

## Engine changes

- **`ExecutionStats` gains `job_id: Option<String>`** so adapters whose REST API returns a job reference (BigQuery's `jobReference.jobId`) thread it through. Drops the `Copy` derive — `String` isn't `Copy`, but `ExecutionStats` is only cloned at materialization boundaries so the derive change is functionally a no-op.
- **`BigQueryAdapter::stats_from_response`** populates `job_id` from `response.job_reference.job_id`. **Databricks** leaves it `None` (the statement-execution endpoint surfaces `statementId` but wiring is deferred with the existing `bytes_written` / `rows_affected` fields).
- **`MaterializationOutput` gains `job_ids: Vec<String>`** (`#[serde(skip_serializing_if = "Vec::is_empty")]`). The four production construction sites (transformation, time-interval partition, replication, snapshot) accumulate job_ids from `ExecutionStats` alongside the existing bytes accumulators.
- **Codegen cascade** via `just codegen`: regenerated `schemas/run.schema.json`, the Pydantic `run_schema.py`, and the TypeScript `run.ts`.

## Verification

New `live/cost-cross-check/` driver:

1. Seeds a 10-row source table.
2. Runs a single-statement transformation that scans it.
3. Captures `materializations[0].job_ids` and `bytes_scanned` from `rocky run --output json`.
4. For each captured job_id, runs `bq show -j <id>` and reads `statistics.query.totalBytesBilled`.
5. Asserts `rocky.bytes_scanned == sum(bq.totalBytesBilled)` — **exact match**, not approximate.

```
==> rocky bytes_scanned = 10485760 (across 1 job(s))
==> bq show -j job_…: totalBytesBilled = 10485760
==> rocky bytes_scanned = bq totalBytesBilled = 10485760
```

Idempotent across consecutive runs.

## Test plan

- [x] `cargo test -p rocky-cli -p rocky-core -p rocky-bigquery -p rocky-databricks --lib` — all green; existing tests updated to construct with empty `job_ids`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `just codegen` ran clean — drift-CI will verify bindings match
- [x] `live/cost-cross-check/run.sh` against the BQ sandbox: exact match between rocky and `bq show -j`
- [x] Two consecutive runs both pass (idempotency)