### PR TITLE
feat(rocky-core): explicit join separator in template placeholders

### DIFF
--- a/docs/src/content/docs/concepts/schema-patterns.md
+++ b/docs/src/content/docs/concepts/schema-patterns.md
@@ -139,6 +139,30 @@ Source: `src__acme__us_west__shopify`
 
 Target table: `acme_warehouse.staging__us_west__shopify.<table_name>`
 
+### Pinning the join separator at the use site
+
+By default, multi-valued components (`{regions}`) are joined with the caller-supplied separator. Different call sites supply different separators: target rendering uses `target.separator` while `metadata_columns.value` uses `pattern.separator`. The same placeholder can therefore resolve to different strings depending on which TOML field it appears in — a footgun for templates that hash or compare the rendered value (RLS keys, audit hashes).
+
+Use `{name:SEP}` to pin the join separator at the use site:
+
+```toml
+[pipeline.bronze]
+metadata_columns = [
+    { name = "permission_key", type = "STRING",
+      value = "md5('fivetran_{client}_{regions:_}_{source}')" }
+    #                              ^^^ join `regions` with "_" regardless of caller default
+]
+```
+
+Grammar:
+
+| Form | Behavior |
+|---|---|
+| `{name}` | Bare form — multi-valued components join with the caller-supplied default separator. |
+| `{name:SEP}` | Explicit form — multi-valued components join with the literal string `SEP` (may be empty, single-, or multi-character). The closing `}` terminates `SEP`, so a literal `}` cannot appear inside it. |
+
+`:SEP` is silently ignored when `name` resolves to a single-valued component, so swapping a component from single to variadic does not require updating every template.
+
 ## Error handling
 
 Rocky produces clear errors for invalid schemas:

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -322,8 +322,8 @@ Given `src__acme__us_west__us_east__shopify`, this pattern extracts:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `adapter` | string | Yes | Name of the warehouse adapter. Must match a `[adapter.NAME]` key. |
-| `catalog_template` | string | Yes | Template for the target catalog name. Uses `{component}` placeholders. |
-| `schema_template` | string | Yes | Template for the target schema name. Uses `{component}` placeholders. |
+| `catalog_template` | string | Yes | Template for the target catalog name. Uses `{component}` placeholders (or `{component:SEP}` to pin the join separator for variadic components). |
+| `schema_template` | string | Yes | Template for the target schema name. Uses `{component}` placeholders (or `{component:SEP}` to pin the join separator for variadic components). |
 
 ```toml
 [pipeline.bronze.target]

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`{name:SEP}` placeholder grammar in schema-pattern templates.** `ParsedSchema::resolve_template` now accepts an optional explicit join separator at the use site: `{name:SEP}` joins multi-valued components with the literal string `SEP` instead of the caller-supplied default. Closes a footgun where the same placeholder rendered differently across call sites — `target.{catalog,schema}_template` joins with `target.separator`, while `metadata_columns.value` joins with `pattern.separator`, so `{regions}` could resolve to `us_west_us_east` in one TOML field and `us_west__us_east` in another. Pinning the separator at the use site (`{regions:_}`) makes the rendered value stable across config changes — important for templates feeding hash functions (RLS keys, audit hashes, permission keys). Bare `{name}` is unchanged: every existing template renders identically. The grammar applies uniformly to `catalog_template`, `schema_template`, and `metadata_columns.value`.
+
 ## [1.20.1] — 2026-05-01
 
 Patch release. Root-cause fix for Fivetran auto-rename collisions surfacing as duplicate `DiscoveredTable` records in `rocky discover` output.

--- a/engine/crates/rocky-core/src/schema.rs
+++ b/engine/crates/rocky-core/src/schema.rs
@@ -637,21 +637,21 @@ mod tests {
             .unwrap();
 
         // Bare form joins with caller default — call-site dependent.
-        let bare_with_source_sep = parsed
-            .resolve_template("md5('fivetran_{client}_{hierarchies}_{connector}')", "__");
+        let bare_with_source_sep =
+            parsed.resolve_template("md5('fivetran_{client}_{hierarchies}_{connector}')", "__");
         assert_eq!(
             bare_with_source_sep,
             "md5('fivetran_pfizer_namer__can_googleads')"
         );
 
         // Explicit form pins the separator regardless of caller default.
-        let explicit = parsed
-            .resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "__");
+        let explicit =
+            parsed.resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "__");
         assert_eq!(explicit, "md5('fivetran_pfizer_namer_can_googleads')");
 
         // Same explicit form, caller passes target sep — same output.
-        let explicit_target_default = parsed
-            .resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "_");
+        let explicit_target_default =
+            parsed.resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "_");
         assert_eq!(
             explicit_target_default,
             "md5('fivetran_pfizer_namer_can_googleads')"

--- a/engine/crates/rocky-core/src/schema.rs
+++ b/engine/crates/rocky-core/src/schema.rs
@@ -50,6 +50,11 @@
 //!   the **target** separator, which may differ from the source
 //!   separator — a target using `_` can consume a multi-valued
 //!   component that was split by `__` in the source.
+//! * Authors can pin the join separator at the use site with
+//!   `{name:SEP}`. The rendered value is then independent of which
+//!   caller-default separator is in effect — useful for
+//!   `metadata_columns.value` templates whose hashed output must stay
+//!   stable across config changes. See [`ParsedSchema::resolve_template`].
 //!
 //! # Filter integration
 //!
@@ -290,21 +295,87 @@ impl ParsedSchema {
         }
     }
 
-    /// Resolves a template string by replacing `{name}` placeholders.
+    /// Resolves a template string by replacing `{name}` and `{name:sep}` placeholders.
     ///
-    /// - Single values: `{tenant}` → `acme`
-    /// - Multiple values: `{regions}` → `us_west__us_central` (joined with separator)
-    pub fn resolve_template(&self, template: &str, separator: &str) -> String {
-        let mut result = template.to_string();
-        for (name, value) in &self.values {
-            let placeholder = format!("{{{name}}}");
-            let replacement = match value {
-                SchemaValue::Single(s) => s.clone(),
-                SchemaValue::Multiple(v) => v.join(separator),
-            };
-            result = result.replace(&placeholder, &replacement);
+    /// # Grammar
+    ///
+    /// - `{name}` — bare form; multi-valued components join with `default_sep`.
+    /// - `{name:SEP}` — explicit form; multi-valued components join with the literal
+    ///   string `SEP` (which may be empty, single-, or multi-character). The closing
+    ///   `}` terminates `SEP`, so a literal `}` cannot appear inside it.
+    ///
+    /// `:SEP` is silently ignored when `name` resolves to a single-valued component.
+    /// Unknown placeholders pass through unchanged (same as the prior implementation).
+    ///
+    /// # Why explicit separators
+    ///
+    /// Different call sites pass different `default_sep` values: target rendering
+    /// uses `target.separator` while `metadata_columns.value` uses
+    /// `pattern.separator`. The same placeholder can therefore resolve to
+    /// different strings depending on which TOML field it appears in. Authors
+    /// who want a stable, audit-friendly value can pin the separator at the use
+    /// site with `{name:_}` — the rendered value is then independent of the
+    /// caller-default and stable across config changes.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Single value: separator is ignored.
+    /// // {tenant} → "acme"
+    ///
+    /// // Multi-valued, bare form uses default_sep.
+    /// // {regions} with default_sep="__" → "us_west__us_central"
+    ///
+    /// // Multi-valued, explicit form pins the separator.
+    /// // {regions:_} → "us_west_us_central"
+    /// // {regions:} → "us_westus_central"
+    /// // {regions:::} → "us_west::us_central"
+    /// ```
+    pub fn resolve_template(&self, template: &str, default_sep: &str) -> String {
+        // Single-pass scanner over byte indices. `{` and `}` are ASCII so they
+        // never appear inside multi-byte UTF-8 sequences; that means byte-index
+        // arithmetic stays on char boundaries even when the surrounding text
+        // contains non-ASCII content (the surrounding bytes copy through via
+        // the `&template[start..i]` slice, which preserves UTF-8).
+        let mut out = String::with_capacity(template.len());
+        let bytes = template.as_bytes();
+        let mut start = 0; // start of the next literal run to copy verbatim
+        let mut i = 0;
+
+        while i < bytes.len() {
+            if bytes[i] == b'{'
+                && let Some(rel_end) = template[i + 1..].find('}')
+            {
+                let body = &template[i + 1..i + 1 + rel_end];
+                let (name, sep) = match body.split_once(':') {
+                    Some((n, s)) => (n, s),
+                    None => (body, default_sep),
+                };
+                if let Some(value) = self.values.get(name) {
+                    // Flush literal run accumulated since the last placeholder.
+                    out.push_str(&template[start..i]);
+                    match value {
+                        SchemaValue::Single(s) => out.push_str(s),
+                        SchemaValue::Multiple(v) => {
+                            let mut iter = v.iter();
+                            if let Some(first) = iter.next() {
+                                out.push_str(first);
+                                for part in iter {
+                                    out.push_str(sep);
+                                    out.push_str(part);
+                                }
+                            }
+                        }
+                    }
+                    i += 1 + rel_end + 1; // advance past `{...}`
+                    start = i;
+                    continue;
+                }
+            }
+            i += 1;
         }
-        result
+        out.push_str(&template[start..]);
+        out
     }
 }
 
@@ -539,6 +610,131 @@ mod tests {
             .unwrap();
         let catalog = parsed.resolve_template("warehouse_{client}", "_");
         assert_eq!(catalog, "warehouse_contoso");
+    }
+
+    #[test]
+    fn test_resolve_template_explicit_separator_pins_variadic_join() {
+        // The motivating Gold-Engine case: a `permission_key`
+        // metadata_columns.value template hashes a string composed of
+        // `{client}_{hierarchies}_{connector}`. Without an explicit
+        // separator, `{hierarchies}` is joined with whatever the caller
+        // passes — which today differs across call sites
+        // (target rendering vs metadata_columns rendering). Pinning the
+        // separator at the use site removes that ambiguity.
+        let pattern = SchemaPattern {
+            prefix: "q__raw__".into(),
+            separator: "__".into(),
+            components: SchemaPattern::parse_components(&[
+                "client".into(),
+                "hierarchies...".into(),
+                "connector".into(),
+            ])
+            .unwrap(),
+        };
+
+        let parsed = pattern
+            .parse("q__raw__pfizer__namer__can__googleads")
+            .unwrap();
+
+        // Bare form joins with caller default — call-site dependent.
+        let bare_with_source_sep = parsed
+            .resolve_template("md5('fivetran_{client}_{hierarchies}_{connector}')", "__");
+        assert_eq!(
+            bare_with_source_sep,
+            "md5('fivetran_pfizer_namer__can_googleads')"
+        );
+
+        // Explicit form pins the separator regardless of caller default.
+        let explicit = parsed
+            .resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "__");
+        assert_eq!(explicit, "md5('fivetran_pfizer_namer_can_googleads')");
+
+        // Same explicit form, caller passes target sep — same output.
+        let explicit_target_default = parsed
+            .resolve_template("md5('fivetran_{client}_{hierarchies:_}_{connector}')", "_");
+        assert_eq!(
+            explicit_target_default,
+            "md5('fivetran_pfizer_namer_can_googleads')"
+        );
+    }
+
+    #[test]
+    fn test_resolve_template_explicit_separator_edge_cases() {
+        let pattern = SchemaPattern {
+            prefix: "q__".into(),
+            separator: "__".into(),
+            components: SchemaPattern::parse_components(&[
+                "tenant".into(),
+                "regions...".into(),
+                "source".into(),
+            ])
+            .unwrap(),
+        };
+        let parsed = pattern.parse("q__acme__a__b__c__shopify").unwrap();
+
+        // Empty separator: `{regions:}` → "abc"
+        let v = parsed.resolve_template("{regions:}", "__");
+        assert_eq!(v, "abc");
+
+        // Multi-character separator: `{regions:--}` → "a--b--c"
+        let v = parsed.resolve_template("{regions:--}", "__");
+        assert_eq!(v, "a--b--c");
+
+        // Separator may itself contain a colon: `{regions:::}` → splits on the
+        // *first* colon, so name="regions", sep="::" → "a::b::c".
+        let v = parsed.resolve_template("{regions:::}", "__");
+        assert_eq!(v, "a::b::c");
+
+        // Single-valued component: `:sep` is silently ignored.
+        let v = parsed.resolve_template("{tenant:_}", "__");
+        assert_eq!(v, "acme");
+
+        // Unknown placeholder passes through unchanged (back-compat).
+        let v = parsed.resolve_template("{unknown:_}", "__");
+        assert_eq!(v, "{unknown:_}");
+
+        // Unmatched `{` passes through unchanged.
+        let v = parsed.resolve_template("prefix{ no close", "__");
+        assert_eq!(v, "prefix{ no close");
+
+        // Multiple placeholders in one template, mixed bare and explicit.
+        let v = parsed.resolve_template("{tenant}/{regions:_}/{source}", "__");
+        assert_eq!(v, "acme/a_b_c/shopify");
+    }
+
+    #[test]
+    fn test_resolve_template_explicit_separator_applies_to_all_call_sites() {
+        // The same scanner is used by `catalog_template`, `schema_template`,
+        // and `metadata_columns.value`. Pin the separator and the rendered
+        // value is identical regardless of which caller-default is passed.
+        let pattern = SchemaPattern {
+            prefix: "q__".into(),
+            separator: "__".into(),
+            components: SchemaPattern::parse_components(&[
+                "tenant".into(),
+                "regions...".into(),
+                "source".into(),
+            ])
+            .unwrap(),
+        };
+        let parsed = pattern.parse("q__acme__us__west__shopify").unwrap();
+
+        // Catalog template (single-valued usage — explicit sep is no-op).
+        let catalog_a = parsed.resolve_template("{tenant}_warehouse", "__");
+        let catalog_b = parsed.resolve_template("{tenant}_warehouse", "_");
+        assert_eq!(catalog_a, "acme_warehouse");
+        assert_eq!(catalog_b, "acme_warehouse");
+
+        // Schema template — pinned separator works the same as today's
+        // target-default for this caller.
+        let schema = parsed.resolve_template("staging_{regions:_}_{source}", "__");
+        assert_eq!(schema, "staging_us_west_shopify");
+
+        // Metadata template — pinned separator overrides the source default.
+        let meta_a = parsed.resolve_template("md5('{regions:_}__{source}')", "__");
+        let meta_b = parsed.resolve_template("md5('{regions:_}__{source}')", "_");
+        assert_eq!(meta_a, "md5('us_west__shopify')");
+        assert_eq!(meta_b, "md5('us_west__shopify')");
     }
 
     // Real-world connector pattern tests


### PR DESCRIPTION
## Summary

Extend the schema-pattern template grammar from `{name}` to `{name(:SEP)?}`. When `:SEP` is present, multi-valued components join with the literal string `SEP` instead of the caller-supplied default; when absent, behaviour is unchanged.

Closes a footgun where the same placeholder rendered differently across call sites:

| Call site | Default separator |
|---|---|
| `target.catalog_template`, `target.schema_template` | `target.separator` |
| `metadata_columns.value` | `pattern.separator` |

So given `pattern.separator = "__"` and `target.separator = "_"`, the placeholder `{regions}` could resolve to `us_west_us_east` in one TOML field and `us_west__us_east` in another — a footgun for templates that hash or compare the rendered value (RLS keys, audit hashes, permission keys). Pinning the separator at the use site (`{regions:_}`) makes the rendered value independent of which caller-default is in effect, and stable across config changes.

```toml
metadata_columns = [
    { name = "permission_key", type = "STRING",
      value = "md5('fivetran_{client}_{regions:_}_{connector}')" }
    #                              ^^^ join `regions` with "_" regardless of caller default
]
```

## Grammar

| Form | Behaviour |
|---|---|
| `{name}` | Bare form — multi-valued components join with caller default. **Unchanged from prior behaviour.** |
| `{name:SEP}` | Explicit form — multi-valued components join with the literal string `SEP` (may be empty, single-, or multi-character). The closing `}` terminates `SEP`. |

`:SEP` is silently ignored when `name` resolves to a single-valued component, so swapping a component from single to variadic does not require updating every template.

## Implementation

- Replace the literal-string `String::replace` loop in `ParsedSchema::resolve_template` with a single-pass scanner. Same complexity, no regex dependency.
- The scanner is shared by all three call sites (`catalog_template`, `schema_template`, `metadata_columns.value`) so the new grammar is uniformly available.

## Back-compat

Bare `{name}` keeps the prior behaviour exactly. A repo-wide search for `{name:something}` patterns in `*.toml` / `*.rs` test fixtures finds zero matches — no template that renders today changes behaviour. New tests pin: bare-form output, explicit-form output, empty separator, multi-character separator, separator containing `:`, single-valued component with `:sep` (ignored), unknown placeholder pass-through, unmatched `{` pass-through, and that the same explicit form renders identically across `catalog_template`, `schema_template`, and `metadata_columns.value`.

## Test plan

- [x] `cargo test -p rocky-core` (18 schema tests, full crate green)
- [x] `cargo test -p rocky-cli --lib` (320 tests green)
- [x] `cargo clippy -p rocky-core --tests -- -D warnings`
- [x] `cargo run --bin rocky -- export-schemas` shows no schema drift (the change is engine-internal — no `*Output` struct touched)