### PR TITLE
docs: drift sweep against engine-v1.20.0 (catalog scoping + Phase 5 + lineage-diff)

### DIFF
--- a/docs/src/content/docs/concepts/preview-internals.md
+++ b/docs/src/content/docs/concepts/preview-internals.md
@@ -15,7 +15,7 @@ sidebar:
 
 2. **Compute the prune set from the compiler IR.** Loading the working-tree models into the [compiler](/concepts/compiler/) gives a column-level dependency graph. The prune set is every changed model **plus** every model that transitively depends on a changed column. Models downstream of an *unchanged* column on a changed model are not pulled in — column-level pruning is strictly tighter than git-diff alone.
 
-3. **Compute the copy set.** Every working-DAG model not in the prune set is a copy candidate: it's logically identical to its counterpart on `--base`, so re-running it would produce the same bytes. For each copy-set model, Rocky issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` against the configured adapter. This is the Phase 1 substrate.
+3. **Compute the copy set.** Every working-DAG model not in the prune set is a copy candidate: it's logically identical to its counterpart on `--base`, so re-running it would produce the same bytes. For each copy-set model, Rocky issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` against the configured adapter — the portable copy substrate, with per-adapter overrides described below.
 
 4. **Run the prune set.** Rocky calls the existing branch run path ([`rocky run --branch <name>`](/reference/commands/core-pipeline/#rocky-run)) with a model selector limited to the prune set. The branch is registered via [`rocky branch create`](/reference/commands/core-pipeline/#rocky-branch); the run writes into the branch's `schema_prefix`.
 
@@ -49,7 +49,7 @@ The article does not document Smart Run's internal mechanism beyond the conceptu
 
 ## Sampling correctness ceiling
 
-`rocky preview diff` produces a row-level diff per model in the prune set by sampling. The Phase 1 sampling rule is:
+`rocky preview diff` produces a row-level diff per model in the prune set by sampling. The current sampling rule is:
 
 ```
 ORDER BY <primary_key>     -- or first column if no PK declared
@@ -69,7 +69,7 @@ This is fast, deterministic, and bounded — but it has a known false-negative m
 
 `coverage_warning: true` means the row count outside the sampling window is non-trivial — a clean sample does not imply "no change". The aggregate `summary.any_coverage_warning` lifts the flag to the run level so a reviewer can spot it without scanning every model.
 
-A checksum-bisection exhaustive diff (the technique [datafold's data-diff](https://github.com/datafold/data-diff) uses — split the table into PK-range chunks, checksum each chunk, recurse into mismatched chunks for bounded scan cost with exhaustive coverage) is the planned Phase 2.5 lift. Until then, treat the row-level diff as a sample-quality signal, not a correctness primitive — and don't ignore `coverage_warning`.
+A checksum-bisection exhaustive diff (the technique [datafold's data-diff](https://github.com/datafold/data-diff) uses — split the table into PK-range chunks, checksum each chunk, recurse into mismatched chunks for bounded scan cost with exhaustive coverage) is the planned next lift. Until then, treat the row-level diff as a sample-quality signal, not a correctness primitive — and don't ignore `coverage_warning`.
 
 ## Output shapes
 

--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -141,7 +141,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 `init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch` · `preview create` · `preview diff` · `preview cost`
 
 ### Modeling & Compilation
-`compile` · `lineage` · `test` · `ci` · `ci-diff` · `export-schemas`
+`compile` · `lineage` · `lineage-diff` · `test` · `ci` · `ci-diff` · `export-schemas`
 
 ### AI
 `ai` (generate) · `ai-sync` · `ai-explain` · `ai-test`

--- a/docs/src/content/docs/guides/playground.md
+++ b/docs/src/content/docs/guides/playground.md
@@ -455,7 +455,7 @@ The playground includes a curated catalog of 58 POCs that showcase Rocky's disti
 | `08-circuit-breaker` | Trust arc 3: retry policy + three-state circuit breaker |
 | `09-idempotency-key` | `rocky run --idempotency-key` dedup + skip semantics |
 
-### Developer Experience (10 POCs)
+### Developer Experience (11 POCs)
 
 | POC | Feature |
 |---|---|
@@ -469,8 +469,9 @@ The playground includes a curated catalog of 58 POCs that showcase Rocky's disti
 | `08-portability-lint` | Trust arc 6: compile-time portability gate via `[portability]` |
 | `09-sql-types-blast-radius` | Trust arc 7: SQL as first-class with typed blast-radius |
 | `10-pr-preview-and-data-diff` | `rocky preview create / diff / cost` end-to-end PR bundle |
+| `11-lineage-diff` | `rocky lineage-diff <base_ref>` — per-changed-column downstream blast-radius for PR review |
 
-### Adapters (5 POCs)
+### Adapters (6 POCs)
 
 | POC | Feature |
 |---|---|
@@ -479,6 +480,7 @@ The playground includes a curated catalog of 58 POCs that showcase Rocky's disti
 | `03-fivetran-discover` | `rocky discover` against Fivetran REST API |
 | `04-custom-process-adapter` | Python adapter via JSON-RPC over stdio |
 | `05-bigquery-native-queries` | BigQuery adapter end-to-end with native query patterns |
+| `06-rust-native-adapter-skeleton` | Rust-native out-of-tree adapter via the `rocky-adapter-sdk` |
 
 ### Running a POC
 

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -119,7 +119,7 @@ When you see this flag, your options are:
 
 - Re-run with a larger `--sample-size` if a bounded sample of N more rows is enough confidence for this PR.
 - Inspect the changed columns directly via `rocky compile --model <name>` and reason about the change manually.
-- Wait for the Phase 2.5 checksum-bisection exhaustive diff (planned) — it covers the whole table at bounded scan cost.
+- Wait for the planned checksum-bisection exhaustive diff — it covers the whole table at bounded scan cost.
 
 A clean sample with `coverage_warning: true` is **not** evidence the PR is no-op for that model.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -8,7 +8,7 @@ sidebar:
 Rocky provides a single binary with subcommands for the full pipeline lifecycle. Commands are organized into categories:
 
 - **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `run`, `state`, `branch`
-- **Modeling**: `compile`, `lineage`, `test`, `ci`, `ci-diff`, `preview`
+- **Modeling**: `compile`, `lineage`, `lineage-diff`, `test`, `ci`, `ci-diff`, `preview`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
 - **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `hooks`, `validate-migration`, `test-adapter`

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -230,6 +230,7 @@ Returns a complete summary of the pipeline execution.
 | `metadata.column_count` | integer or absent | Number of columns in the materialized table. |
 | `metadata.compile_time_ms` | integer or absent | Compile time in milliseconds for derived models. |
 | `metadata.cost_usd` | float or absent | Estimated cost for this materialization in USD. Rolls up into `cost_summary.total_usd` at the run level. |
+| `job_ids` | array of strings | Warehouse-side job IDs for the statements this materialization issued, accumulated alongside `bytes_scanned` / `bytes_written`. Lets orchestrators cross-check rocky-reported figures against the warehouse console (`bq show -j`, Snowflake query history, Databricks SQL warehouse history). Empty `[]` for adapters that don't surface a job id. Available since engine `1.21.0`. |
 | `partition` | object or absent | Partition window info for `time_interval` materializations. |
 
 **`check_results[]`:**

--- a/engine/README.md
+++ b/engine/README.md
@@ -72,6 +72,7 @@ rocky run            # Execute the pipeline
 rocky state          # Inspect stored watermarks
 rocky ai "<intent>"  # Generate a model from natural language
 rocky lineage        # Trace column-level lineage
+rocky lineage-diff   # Per-changed-column downstream blast-radius for PR review
 rocky doctor         # Aggregate health checks
 rocky serve          # HTTP API + live watch
 rocky lsp            # Language Server Protocol for IDEs

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/rocky.toml
@@ -27,11 +27,11 @@ row_count = true
 column_match = { enabled = true, severity = "warning" }
 freshness = { threshold_seconds = 86400, severity = "warning" }
 anomaly_threshold_pct = 30.0
-# Phase 2 escape hatch: keep the POC green while surfacing failing rows.
+# Escape hatch: keep the POC green while surfacing failing rows.
 # Remove (or set `true`) to fail CI on any error-severity violation.
 fail_on_error = false
 
-# --- Phase 3: row quarantine (split mode) ---
+# --- Row quarantine (split mode) ---
 # Splits `orders` into `orders__valid` (passing rows) and
 # `orders__quarantine` (failing rows with `_error_*` label columns).
 # Only error-severity row-level assertions on `orders` drive the split:
@@ -42,7 +42,7 @@ fail_on_error = false
 enabled = true
 mode    = "split"
 
-# --- Phase 1: row-level assertions (unified surface) ---
+# --- Row-level assertions (unified surface) ---
 
 # not_null — 2 rows (order_id 7, 42) violate this.
 [[pipeline.nightly_dq.checks.assertions]]
@@ -90,7 +90,7 @@ min      = 40
 max      = 60
 severity = "error"
 
-# --- Phase 4a: in_range + regex_match + per-check filter ---
+# --- in_range + regex_match + per-check filter ---
 
 # in_range — amount should be within [0, 10000]. Row 99 has amount = -5
 # (failing) but the `expression` assertion above already catches it at
@@ -129,7 +129,7 @@ column   = "customer_id"
 filter   = "status = 'shipped'"
 severity = "warning"
 
-# --- Phase 4b: aggregate + composite unique + time_window ---
+# --- aggregate + composite unique + time_window ---
 
 # aggregate — sum(amount) must be > 0. Passes because positive amounts
 # dominate (the single row with amount = -5 doesn't flip the sign).

--- a/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
+++ b/examples/playground/pocs/01-quality/06-quality-pipeline-standalone/run.sh
@@ -39,5 +39,5 @@ duckdb poc.duckdb -c "SELECT order_id, customer_id, status,
   ORDER BY order_id;"
 
 echo
-echo "POC complete: unified check surface + mixed severity + Phase 3 row quarantine (split)."
+echo "POC complete: unified check surface + mixed severity + row quarantine (split)."
 echo "Flip fail_on_error=true in rocky.toml to make error-severity failures non-zero."

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
@@ -15,7 +15,7 @@ DuckDB transformation pipeline:
 1. **`rocky preview create --base <ref>`** — git-diff identifies changed
    model files between `<ref>` and HEAD; the compiler IR computes a
    **column-level prune set**; every model *not* in the prune set is
-   copied from the base schema via CTAS (Phase 1) into a per-PR branch
+   copied from the base schema via CTAS into a per-PR branch
    schema; the prune set re-executes against the branch.
 2. **`rocky preview diff`** — structural (column added/removed/type
    changed) plus sampled row-level diff between branch and base for
@@ -55,10 +55,10 @@ without rewriting dbt's compiler:
   no output diff"* — is something only a compiled engine can do.
 - **Cost delta as a state-store query, not a fresh measurement.**
   `rocky cost latest` already rolls per-run cost from adapter telemetry;
-  Phase 3 is the diff layer over that machinery.
-- **Single artefact for the reviewer.** Phase 4 stitches all three
-  outputs into one PR comment that answers *"should I merge this?"*
-  with row counts, columns, and dollars — not log lines.
+  `preview cost` is the diff layer over that machinery.
+- **Single artefact for the reviewer.** The composite GitHub Action
+  stitches all three outputs into one PR comment that answers *"should
+  I merge this?"* with row counts, columns, and dollars — not log lines.
 
 Compare:
 
@@ -90,9 +90,9 @@ Compare:
 └── expected/
     ├── compile.json                   from `rocky compile`
     ├── run_main.json                  from `rocky run`
-    ├── preview_create.example.json    target shape (Phase 1 not yet wired)
-    ├── preview_diff.example.json      target shape (Phase 2 not yet wired)
-    └── preview_cost.example.json      target shape (Phase 3 not yet wired)
+    ├── preview_create.example.json    shape contract for `rocky preview create`
+    ├── preview_diff.example.json      shape contract for `rocky preview diff`
+    └── preview_cost.example.json      shape contract for `rocky preview cost`
 ```
 
 ## Note on model surfaces
@@ -106,11 +106,11 @@ run` for both DSL and SQL surfaces.
 
 ## Status
 
-Production path as of **engine-v1.18.0** (Phases 1, 1.5, 2, 3 all merged).
-Earlier revisions of `run.sh` wrapped each preview call in a
-stub-tolerating helper while the engine handlers were still scaffolding;
-that scaffolding is gone — the script now treats `preview create / diff /
-cost` like any other production CLI command (`set -e` enforces failure).
+Production path as of **engine-v1.18.0**. Earlier revisions of `run.sh`
+wrapped each preview call in a stub-tolerating helper while the engine
+handlers were still scaffolding; that scaffolding is gone — the script
+now treats `preview create / diff / cost` like any other production CLI
+command (`set -e` enforces failure).
 
 The `expected/preview_*.example.json` files remain as the shape contract
 that the live `expected/preview_*.json` outputs should match modulo
@@ -153,8 +153,7 @@ cd examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff
   — the four trust-arc primitives (branches, replay, column lineage,
   state store) that `preview` composes.
 - Sibling POC: [`06-developer-experience/04-shadow-mode-compare/`](../04-shadow-mode-compare/)
-  — the precursor `rocky compare` kernel that Phase 2's `preview diff`
-  extends.
+  — the precursor `rocky compare` kernel that `preview diff` extends.
 - Engine source: `engine/crates/rocky-cli/src/commands/preview.rs`,
   `engine/crates/rocky-cli/src/output.rs`
   (`PreviewCreateOutput`, `PreviewDiffOutput`, `PreviewCostOutput`).

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/run.sh
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # 10-pr-preview-and-data-diff — `rocky preview create / diff / cost` on a
-# 5-model DAG. Production path as of engine-v1.18.0 (Phases 1, 1.5, 2, 3
-# all merged). Earlier revisions of this script wrapped each preview call
-# in a stub-tolerating helper; that scaffolding is gone.
+# 5-model DAG. Production path as of engine-v1.18.0. Earlier revisions of
+# this script wrapped each preview call in a stub-tolerating helper; that
+# scaffolding is gone.
 #
 # Flow:
 #   1. Compile + seed DuckDB.


### PR DESCRIPTION
## Summary

Doc + POC drift audit against the engine v1.20.0 / dagster v1.18.0 / vscode v1.11.0 line. Four scoped commits, each addressing one drift class:

- **Strip internal phase-number leaks from public docs and POCs** (`f89cdd3`) — eight sites in `docs/concepts/preview-internals.md`, `docs/guides/preview-a-pr.md`, and two playground POCs were referencing internal phase numbers. Neutralised to topic-only language.
- **Refresh POC catalog counts in `docs/guides/playground.md`** (`f552b74`) — Developer Experience 10→11 and Adapters 5→6; add entries for `11-lineage-diff` and `06-rust-native-adapter-skeleton` shipped in v1.19.0.
- **Add `rocky lineage-diff` to CLI index surfaces** (`d367295`) — was missing from `docs/reference/cli.md` Modeling row, `docs/features/all-features.md` Modeling chip, and `engine/README.md` "CLI at a glance".
- **Document `MaterializationOutput.job_ids`** (`82aa19c`) — new field shipped in PR #337 was missing from `docs/reference/json-output.md`.

## Validation

- `npm run build` from `docs/` produces 72 pages clean.
- `./run.sh` re-run on both edited POCs (`01-quality/06-quality-pipeline-standalone`, `06-developer-experience/10-pr-preview-and-data-diff`) — both pass.

## Out of scope (flagged for follow-up)

- `rocky lineage-diff` has no full reference page under `docs/reference/commands/modeling/`. Index entries only here; design call on whether to add a full page belongs elsewhere.
- `engine/README.md` adapter status table still says BigQuery + Snowflake are "Beta"; v1.21.0 dropped the BigQuery experimental override. Positioning call.
- `10-pr-preview-and-data-diff` POC triggers `invalid SQL identifier 'branch__pr-preview-poc-10'` WARN logs because the POC's `--name` contains hyphens. POC still exits 0 but engine refuses to copy unchanged tables on this path. Engine source change needed.

## Test plan

- [x] \`npm run build\` clean from \`docs/\`
- [x] Both edited POCs \`./run.sh\` exit 0