### PR TITLE
feat(rocky-core): checksum-bisection diff kernel + DuckDB conformance

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Checksum-bisection diff kernel.** `rocky_core::compare::bisection::bisection_diff` walks the `K`-fanout chunk lattice over a single-column integer / numeric primary key, recurses into mismatched chunks until the leaf threshold, then materializes-and-diffs the leaves row-by-row. Datafold-style: a no-op diff bottoms out at `K` chunk checksums per side; a single-row change recurses to the row in `O(K · log_K(N))` chunks examined. Conformance suite at `engine/crates/rocky-duckdb/tests/bisection_conformance.rs` pins determinism, the no-op cost bound, and a 100k-row planted-change fixture.
+- **Adapter trait surface for bisection.** `WarehouseAdapter::checksum_chunks` (with `recommended_leaf_size` + `recommended_uuid_threshold` getters) on both `rocky-core` and the public-stable `rocky-adapter-sdk`. The in-tree default emits a portable `BIT_XOR(<row_hash>)`-over-`FLOOR((pk - lo) / step)` query that composes with `SqlDialect::row_hash_expr`; the SDK default returns "not supported" so out-of-tree adapters surface a clear error until they wire their native hash. New `ChunkChecksum`, `PkRange`, `SplitStrategy` types are re-exported from both crates.
+- **`SqlDialect::row_hash_expr`** on `rocky-core::traits::SqlDialect`. Returns the per-dialect SQL fragment for a single-row hash usable under `BIT_XOR(...)`. Default is an explicit not-supported error so adapters that haven't overridden surface a helpful message rather than emitting broken SQL. DuckDB ships with the override (`CAST(hash(...) AS HUGEINT)`); the other in-tree adapters add their native hash in follow-up changes.
+
+### Notes for downstream consumers
+
+- **`rocky-adapter-sdk` trait surface gained one method** (`checksum_chunks`) with a default-error impl and two utility getters with safe defaults (`recommended_leaf_size`, `recommended_uuid_threshold`). Out-of-tree adapters that don't override get a "not supported" error from `checksum_chunks`, which is the intended state until each adapter wires its native hash. Treat as a minor SDK bump at the next engine release cut; no source-level breaking changes.
+
 ## [1.21.0] — 2026-05-01
 
 Feature release. Headline: **BigQuery adapter promoted out of experimental** — every BQ-specific dialect surface is now live-verified end-to-end (full-refresh, time-interval DML transactions, MERGE bootstrap, region-qualified discovery, drift across all three actions, cost cross-check). `MaterializationOutput.job_ids` lets consumers cross-check rocky-reported bytes against the warehouse console. Bundles the FR-021 explicit-separator grammar in schema-pattern templates.

--- a/engine/crates/rocky-adapter-sdk/src/traits.rs
+++ b/engine/crates/rocky-adapter-sdk/src/traits.rs
@@ -275,12 +275,18 @@ pub struct FreshnessResult {
 ///   is `hash(pk) % modulus == residue`. Single-level by construction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PkRange {
-    IntRange { lo: i128, hi: i128 },
+    IntRange {
+        lo: i128,
+        hi: i128,
+    },
     Composite {
         lo: Vec<serde_json::Value>,
         hi: Vec<serde_json::Value>,
     },
-    HashBucket { modulus: u32, residue: u32 },
+    HashBucket {
+        modulus: u32,
+        residue: u32,
+    },
 }
 
 /// One chunk's checksum result returned from

--- a/engine/crates/rocky-adapter-sdk/src/traits.rs
+++ b/engine/crates/rocky-adapter-sdk/src/traits.rs
@@ -261,6 +261,56 @@ pub struct FreshnessResult {
 }
 
 // ---------------------------------------------------------------------------
+// Bisection diff
+// ---------------------------------------------------------------------------
+
+/// One contiguous range of primary-key values, identifying a chunk in a
+/// checksum-bisection diff (see [`WarehouseAdapter::checksum_chunks`]).
+///
+/// Variants correspond one-to-one with [`SplitStrategy`]:
+/// - `IntRange` for declared integer / numeric primary keys.
+/// - `Composite` for multi-column primary keys; lo/hi are tuple
+///   boundaries pre-computed by the caller.
+/// - `HashBucket` for opaque-string / UUID primary keys; chunk identity
+///   is `hash(pk) % modulus == residue`. Single-level by construction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PkRange {
+    IntRange { lo: i128, hi: i128 },
+    Composite {
+        lo: Vec<serde_json::Value>,
+        hi: Vec<serde_json::Value>,
+    },
+    HashBucket { modulus: u32, residue: u32 },
+}
+
+/// One chunk's checksum result returned from
+/// [`WarehouseAdapter::checksum_chunks`].
+///
+/// Empty chunks (zero rows on this side) MAY be omitted by the
+/// implementation; callers MUST index by `chunk_id`, not by vector
+/// position. A `chunk_id` absent from the returned vector is equivalent
+/// to `ChunkChecksum { chunk_id, row_count: 0, checksum: 0 }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkChecksum {
+    pub chunk_id: u32,
+    pub row_count: u64,
+    /// XOR-aggregated row hashes, widened to `u128` so the largest
+    /// native adapter hash output (Snowflake `NUMBER(38,0)`) fits without
+    /// truncation.
+    pub checksum: u128,
+}
+
+/// How the bisection runner split the primary-key space into chunks.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SplitStrategy {
+    IntRange,
+    Composite,
+    HashBucket,
+    FirstColumn,
+}
+
+// ---------------------------------------------------------------------------
 // Core trait: WarehouseAdapter
 // ---------------------------------------------------------------------------
 
@@ -286,6 +336,51 @@ pub trait WarehouseAdapter: Send + Sync {
 
     /// Release any resources held by this adapter.
     async fn close(&self) -> AdapterResult<()>;
+
+    /// Compute checksums for a batch of chunks defined by primary-key
+    /// ranges. Used by Rocky's checksum-bisection diff to compare two
+    /// tables row-by-row without scanning either side end-to-end.
+    ///
+    /// **Returns one entry per non-empty chunk.** Chunks with zero rows
+    /// on this side MAY be omitted; callers MUST index by
+    /// [`ChunkChecksum::chunk_id`], not by vector position. A `chunk_id`
+    /// absent from the returned vector is treated as
+    /// `ChunkChecksum { chunk_id, row_count: 0, checksum: 0 }`.
+    ///
+    /// Default impl returns "not supported" — out-of-tree adapters must
+    /// override to support `--algorithm=bisection`. Adapters compose the
+    /// query around their native hash and bucketing primitives (DuckDB
+    /// `hash()` + `width_bucket`, Spark `xxhash64`, Snowflake `HASH` +
+    /// `BITXOR_AGG`, BigQuery `FARM_FINGERPRINT`); the in-tree
+    /// equivalents live in `rocky-core` and ship with overrides per
+    /// adapter.
+    async fn checksum_chunks(
+        &self,
+        _table: &TableRef,
+        _pk_column: &str,
+        _value_columns: &[String],
+        _pk_ranges: &[PkRange],
+    ) -> AdapterResult<Vec<ChunkChecksum>> {
+        Err(AdapterError::not_supported("checksum_chunks"))
+    }
+
+    /// Adapter-tuned override for the bisection leaf-row threshold (the
+    /// `MIN_CHUNK_ROWS` knob). Below this row count the runner stops
+    /// splitting and materializes the chunk for row-by-row diff.
+    ///
+    /// Defaults to `1000`, which lands break-even on in-process engines.
+    /// Adapters with high per-query setup cost (Databricks, Snowflake,
+    /// BigQuery) should override to a higher value.
+    fn recommended_leaf_size(&self) -> u64 {
+        1000
+    }
+
+    /// Adapter-tuned override for the row-count threshold above which
+    /// UUID / hash-bucket-PK tables auto-fall-back from bisection to
+    /// sampled. Defaults to `10_000_000`.
+    fn recommended_uuid_threshold(&self) -> u64 {
+        10_000_000
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-core/src/compare/bisection.rs
+++ b/engine/crates/rocky-core/src/compare/bisection.rs
@@ -212,9 +212,7 @@ pub async fn bisection_diff(
         )));
     }
     if config.k < 2 {
-        return Err(AdapterError::msg(
-            "bisection_diff requires k >= 2",
-        ));
+        return Err(AdapterError::msg("bisection_diff requires k >= 2"));
     }
 
     // The adapter recommendation defines the leaf threshold when the
@@ -230,8 +228,7 @@ pub async fn bisection_diff(
     // BisectionStats; if base and branch counts diverge, the caller
     // should treat that as a row-count mismatch at the table level.
     let null_pk_rows_base = count_null_pk_rows(base, target.base, target.pk_column).await?;
-    let null_pk_rows_branch =
-        count_null_pk_rows(branch, target.branch, target.pk_column).await?;
+    let null_pk_rows_branch = count_null_pk_rows(branch, target.branch, target.pk_column).await?;
 
     let mut state = TraversalState {
         config,
@@ -298,9 +295,7 @@ async fn count_null_pk_rows(
     rocky_sql::validation::validate_identifier(pk_column).map_err(AdapterError::new)?;
     let dialect = adapter.dialect();
     let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
-    let sql = format!(
-        "SELECT COUNT(*) FROM {table_ref} WHERE \"{pk_column}\" IS NULL"
-    );
+    let sql = format!("SELECT COUNT(*) FROM {table_ref} WHERE \"{pk_column}\" IS NULL");
     let result = adapter.execute_query(&sql).await?;
     let row = result
         .rows
@@ -310,12 +305,12 @@ async fn count_null_pk_rows(
         .first()
         .ok_or_else(|| AdapterError::msg("null-pk count query returned an empty row"))?;
     match cell {
-        serde_json::Value::String(s) => s.parse::<u64>().map_err(|e| {
-            AdapterError::msg(format!("failed to parse null-pk count {s:?}: {e}"))
+        serde_json::Value::String(s) => s
+            .parse::<u64>()
+            .map_err(|e| AdapterError::msg(format!("failed to parse null-pk count {s:?}: {e}"))),
+        serde_json::Value::Number(n) => n.as_u64().ok_or_else(|| {
+            AdapterError::msg(format!("null-pk count not representable as u64: {n}"))
         }),
-        serde_json::Value::Number(n) => n
-            .as_u64()
-            .ok_or_else(|| AdapterError::msg(format!("null-pk count not representable as u64: {n}"))),
         other => Err(AdapterError::msg(format!(
             "null-pk count returned unexpected JSON shape: {other:?}"
         ))),
@@ -369,9 +364,8 @@ async fn diff_one_level(
     let branch_by_id = index_by_chunk_id(&branch_sums);
 
     for (idx, chunk) in chunks.iter().enumerate() {
-        let chunk_id = u32::try_from(idx).map_err(|_| {
-            AdapterError::msg("bisection level produced more than u32::MAX chunks")
-        })?;
+        let chunk_id = u32::try_from(idx)
+            .map_err(|_| AdapterError::msg("bisection level produced more than u32::MAX chunks"))?;
         let base_entry = base_by_id.get(&chunk_id).copied();
         let branch_entry = branch_by_id.get(&chunk_id).copied();
 

--- a/engine/crates/rocky-core/src/compare/bisection.rs
+++ b/engine/crates/rocky-core/src/compare/bisection.rs
@@ -157,8 +157,11 @@ pub enum LeafRowKind {
 /// byte-identical [`BisectionStats`] across runs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BisectionStats {
-    /// Total chunks the runner asked the adapter to checksum (sum across
-    /// both sides and all recursion levels).
+    /// Total non-empty chunk-checksum entries returned by the adapter,
+    /// summed across both sides and all recursion levels. Each level
+    /// asks for `K` chunks per side (a fixed cost the adapter charges as
+    /// one batched query); this counter measures the *result-set* shape,
+    /// not the number of underlying SQL queries.
     pub chunks_examined: u64,
     /// Number of leaf chunks materialized for row-by-row diff.
     pub leaves_materialized: u64,
@@ -169,10 +172,16 @@ pub struct BisectionStats {
     /// materialized the dense range as a leaf — so the diff is still
     /// exhaustive over that range; just slower.
     pub depth_capped: bool,
-    /// How the runner split the primary-key space. Sub-step 1 always
+    /// How the runner split the primary-key space. Currently always
     /// reports `IntRange`; `Composite` / `HashBucket` / `FirstColumn`
-    /// land in follow-up phases.
+    /// land in follow-up changes.
     pub split_strategy: SplitStrategy,
+    /// Rows on the base side whose primary-key column is NULL. Excluded
+    /// from chunk membership but counted at the root so a divergence in
+    /// null-PK row counts surfaces instead of silently dropping rows.
+    pub null_pk_rows_base: u64,
+    /// Rows on the branch side whose primary-key column is NULL.
+    pub null_pk_rows_branch: u64,
 }
 
 /// Run a checksum-bisection diff between two tables on the same logical
@@ -214,6 +223,15 @@ pub async fn bisection_diff(
     let leaf_threshold = config.min_chunk_rows.unwrap_or_else(|| {
         std::cmp::max(base.recommended_leaf_size(), branch.recommended_leaf_size())
     });
+
+    // Count null-PK rows once per side at the root. Null-PK rows
+    // never land in any chunk (the chunking SQL filters them out) so a
+    // null-only divergence would otherwise be silent. Surfaced on
+    // BisectionStats; if base and branch counts diverge, the caller
+    // should treat that as a row-count mismatch at the table level.
+    let null_pk_rows_base = count_null_pk_rows(base, target.base, target.pk_column).await?;
+    let null_pk_rows_branch =
+        count_null_pk_rows(branch, target.branch, target.pk_column).await?;
 
     let mut state = TraversalState {
         config,
@@ -264,8 +282,44 @@ pub async fn bisection_diff(
             depth_max: state.depth_max,
             depth_capped: state.depth_capped,
             split_strategy: SplitStrategy::IntRange,
+            null_pk_rows_base,
+            null_pk_rows_branch,
         },
     })
+}
+
+/// Issue one `COUNT(*) WHERE pk IS NULL` per side at the root. Returns
+/// 0 if the table has no null-PK rows.
+async fn count_null_pk_rows(
+    adapter: &dyn WarehouseAdapter,
+    table: &TableRef,
+    pk_column: &str,
+) -> AdapterResult<u64> {
+    rocky_sql::validation::validate_identifier(pk_column).map_err(AdapterError::new)?;
+    let dialect = adapter.dialect();
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
+    let sql = format!(
+        "SELECT COUNT(*) FROM {table_ref} WHERE \"{pk_column}\" IS NULL"
+    );
+    let result = adapter.execute_query(&sql).await?;
+    let row = result
+        .rows
+        .first()
+        .ok_or_else(|| AdapterError::msg("null-pk count query returned no rows"))?;
+    let cell = row
+        .first()
+        .ok_or_else(|| AdapterError::msg("null-pk count query returned an empty row"))?;
+    match cell {
+        serde_json::Value::String(s) => s.parse::<u64>().map_err(|e| {
+            AdapterError::msg(format!("failed to parse null-pk count {s:?}: {e}"))
+        }),
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| AdapterError::msg(format!("null-pk count not representable as u64: {n}"))),
+        other => Err(AdapterError::msg(format!(
+            "null-pk count returned unexpected JSON shape: {other:?}"
+        ))),
+    }
 }
 
 struct TraversalState<'a> {
@@ -414,7 +468,12 @@ async fn materialize_and_diff(
     while bi < base_rows.len() && ri < branch_rows.len() {
         let b = &base_rows[bi];
         let r = &branch_rows[ri];
-        match b.pk_str.cmp(&r.pk_str) {
+        // Numeric primary-key compare. String comparison would
+        // mis-classify rows whose stringified PKs cross length
+        // boundaries (e.g., "99" string-compares greater than "100"
+        // because '9' > '1'), even though the SQL `ORDER BY` produces
+        // numerically-sorted result sets.
+        match b.pk_value.cmp(&r.pk_value) {
             std::cmp::Ordering::Less => {
                 record_sample(state, LeafRowKind::Removed, &b.pk_str);
                 state.rows_removed = state.rows_removed.saturating_add(1);
@@ -449,6 +508,7 @@ async fn materialize_and_diff(
 }
 
 struct LeafRow {
+    pk_value: i128,
     pk_str: String,
     values: Vec<serde_json::Value>,
 }
@@ -497,8 +557,17 @@ async fn fetch_chunk_rows(
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
         };
+        let pk_value: i128 = pk_str.parse().map_err(|e| {
+            AdapterError::msg(format!(
+                "primary-key column \"{pk}\" returned a value that didn't parse as i128: {pk_str:?} ({e})"
+            ))
+        })?;
         let values = row.into_iter().skip(1).collect();
-        out.push(LeafRow { pk_str, values });
+        out.push(LeafRow {
+            pk_value,
+            pk_str,
+            values,
+        });
     }
     Ok(out)
 }

--- a/engine/crates/rocky-core/src/compare/bisection.rs
+++ b/engine/crates/rocky-core/src/compare/bisection.rs
@@ -1,0 +1,583 @@
+//! Checksum-bisection exhaustive row-level diff.
+//!
+//! Datafold-style chunk recursion: split the primary-key range into `K`
+//! chunks, checksum each chunk on both sides via
+//! [`crate::traits::WarehouseAdapter::checksum_chunks`], recurse into
+//! mismatched chunks until a leaf threshold, then materialize-and-diff the
+//! leaves row-by-row.
+//!
+//! Two properties make this a step-change over sampling:
+//!
+//! 1. **Bounded scan cost.** A no-op diff reads `K` chunk checksums per
+//!    side. Uniform mismatch bottoms out at `O(K · log_K(N))` chunks
+//!    examined. Compare to `O(N)` for full-table compare and `O(1000)` —
+//!    with an unbounded false-negative tail — for sampling.
+//! 2. **Exhaustive coverage.** Every row hashes into exactly one chunk; if
+//!    any row differs between sides, the chunk it lives in is guaranteed
+//!    to mismatch and the recursion is guaranteed to find it. No coverage
+//!    hedge.
+//!
+//! **Current scope.** This implementation supports a single-column
+//! integer / numeric primary key (`SplitStrategy::IntRange`). Composite
+//! and UUID / hash-bucket primary keys return an error; wiring those up
+//! is a follow-up. The DuckDB conformance test in
+//! `rocky-duckdb/tests/bisection_conformance.rs` exercises a 100k-row
+//! seeded table with a planted change at row 90,000 and snapshots the
+//! [`BisectionStats`] for determinism.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ir::TableRef;
+use crate::traits::{
+    AdapterError, AdapterResult, ChunkChecksum, PkRange, SplitStrategy, WarehouseAdapter,
+};
+
+/// Default chunk fanout. `K = 32` matches Datafold's data-diff: at higher
+/// fanout the per-level checksum query has too many predicates and the
+/// warehouse chokes; at lower fanout the recursion does too many
+/// roundtrips.
+pub const DEFAULT_K: u32 = 32;
+
+/// Maximum recursion depth. `K^MAX_DEPTH = 32^8 ≈ 1e12`, which covers
+/// any plausible production table. The cap prevents runaway on
+/// adversarial PK skew.
+pub const DEFAULT_MAX_DEPTH: u32 = 8;
+
+/// Default cap on the number of representative changed rows surfaced
+/// from leaves. Five matches the Phase 2 sampled-diff render budget.
+pub const DEFAULT_MAX_SAMPLES: usize = 5;
+
+/// Knobs for the bisection runner. Defaults: `K=32` (matches Datafold's
+/// data-diff sweet spot), `MAX_DEPTH=8` (covers `K^MAX_DEPTH ≈ 1e12`
+/// rows), `MIN_CHUNK_ROWS=1000` (break-even between an extra checksum
+/// roundtrip and a small leaf materialization).
+///
+/// Most callers should construct via `BisectionConfig::default()` and
+/// override only specific knobs. The [`min_chunk_rows`] field is what
+/// adapters tune via
+/// [`crate::traits::WarehouseAdapter::recommended_leaf_size`]; the
+/// runner reads the adapter recommendation when no override is set.
+#[derive(Debug, Clone)]
+pub struct BisectionConfig {
+    /// Chunk fanout per recursion level.
+    pub k: u32,
+    /// Recursion depth bound; on hit the runner reports
+    /// [`BisectionStats::depth_capped`] = `true` and falls back to leaf
+    /// materialization on the dense range.
+    pub max_depth: u32,
+    /// Below this row count, the runner stops splitting and materializes
+    /// the chunk for row-by-row diff. `None` defers to
+    /// [`crate::traits::WarehouseAdapter::recommended_leaf_size`].
+    pub min_chunk_rows: Option<u64>,
+    /// Number of representative changed rows to surface in
+    /// [`BisectionDiffResult::samples`]. Surplus mismatches are counted
+    /// but not materialized into the result.
+    pub max_samples: usize,
+}
+
+impl Default for BisectionConfig {
+    fn default() -> Self {
+        Self {
+            k: DEFAULT_K,
+            max_depth: DEFAULT_MAX_DEPTH,
+            min_chunk_rows: None,
+            max_samples: DEFAULT_MAX_SAMPLES,
+        }
+    }
+}
+
+/// Inputs identifying which two tables to diff. The `pk_column` and
+/// `value_columns` apply to both sides; if the schemas have drifted, the
+/// caller is expected to detect that via the structural diff layer
+/// before invoking the bisection runner.
+#[derive(Debug, Clone)]
+pub struct BisectionTarget<'a> {
+    /// Base-side table (the "main branch" / "previous state").
+    pub base: &'a TableRef,
+    /// Branch-side table (the "this PR" / "new state").
+    pub branch: &'a TableRef,
+    /// Primary-key column name. Sub-step 1 supports a single integer /
+    /// numeric column.
+    pub pk_column: &'a str,
+    /// Columns to hash for chunk checksums and to compare row-by-row at
+    /// leaves. Typically every non-PK column the caller cares about; the
+    /// PK column itself is excluded so two rows with the same PK but
+    /// different content surface as `Changed`.
+    pub value_columns: &'a [String],
+    /// `[lo, hi)` bounds of the primary-key range to search. Callers
+    /// derive these from `MIN(pk)` / `MAX(pk)` on either side, or from
+    /// declared partition bounds. Sub-step 1 takes them as caller input
+    /// rather than running the bound-discovery query itself.
+    pub pk_lo: i128,
+    pub pk_hi: i128,
+}
+
+/// Aggregate row-level result from [`bisection_diff`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BisectionDiffResult {
+    /// Rows present on branch but not on base.
+    pub rows_added: u64,
+    /// Rows present on base but not on branch.
+    pub rows_removed: u64,
+    /// Rows present on both sides with different value-column content.
+    pub rows_changed: u64,
+    /// Up to [`BisectionConfig::max_samples`] representative changed
+    /// rows surfaced from the leaves. Stable order: `(kind, pk)`.
+    pub samples: Vec<LeafRowSample>,
+    /// Trace of the recursion so callers (snapshot tests, debug logs,
+    /// future PR-comment renderers) can pin the algorithm's behavior.
+    pub stats: BisectionStats,
+}
+
+/// One representative changed row surfaced from a bisection leaf.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeafRowSample {
+    /// Why the row was surfaced.
+    pub kind: LeafRowKind,
+    /// Primary-key value as a string — adapter-quoted for stability
+    /// across snapshot tests.
+    pub pk: String,
+}
+
+/// Why a row appears in [`BisectionDiffResult::samples`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LeafRowKind {
+    /// Branch only — appears in `rows_added`.
+    Added,
+    /// Base only — appears in `rows_removed`.
+    Removed,
+    /// Same PK, different value-column content — appears in
+    /// `rows_changed`.
+    Changed,
+}
+
+/// Trace of how the bisection runner traversed the chunk lattice.
+/// Determinism contract: same input on both sides produces a
+/// byte-identical [`BisectionStats`] across runs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BisectionStats {
+    /// Total chunks the runner asked the adapter to checksum (sum across
+    /// both sides and all recursion levels).
+    pub chunks_examined: u64,
+    /// Number of leaf chunks materialized for row-by-row diff.
+    pub leaves_materialized: u64,
+    /// Maximum recursion depth reached.
+    pub depth_max: u32,
+    /// `true` if the runner hit [`BisectionConfig::max_depth`] before
+    /// any chunk fell below the leaf threshold. On hit the runner
+    /// materialized the dense range as a leaf — so the diff is still
+    /// exhaustive over that range; just slower.
+    pub depth_capped: bool,
+    /// How the runner split the primary-key space. Sub-step 1 always
+    /// reports `IntRange`; `Composite` / `HashBucket` / `FirstColumn`
+    /// land in follow-up phases.
+    pub split_strategy: SplitStrategy,
+}
+
+/// Run a checksum-bisection diff between two tables on the same logical
+/// schema. The base and branch adapters MAY be the same warehouse
+/// pointing at two schemas, or two different warehouses (e.g., shadow
+/// mode) — the algorithm only touches them through
+/// [`WarehouseAdapter::checksum_chunks`] and
+/// [`WarehouseAdapter::execute_query`].
+///
+/// **Sub-step 1 contract:**
+/// - `target.pk_column` must be a single integer / numeric column.
+/// - `target.pk_lo .. target.pk_hi` must be a non-empty `[lo, hi)` range.
+///   Callers typically derive this from `MIN(pk)`/`MAX(pk)+1` on the
+///   side with the wider bound.
+/// - Returns an error rather than degrading silently if the adapter's
+///   `checksum_chunks` errors, or if the leaf step's `execute_query`
+///   fails. Schema drift detection is the caller's responsibility.
+pub async fn bisection_diff(
+    base: &dyn WarehouseAdapter,
+    branch: &dyn WarehouseAdapter,
+    target: &BisectionTarget<'_>,
+    config: &BisectionConfig,
+) -> AdapterResult<BisectionDiffResult> {
+    if target.pk_hi <= target.pk_lo {
+        return Err(AdapterError::msg(format!(
+            "bisection_diff requires pk_lo < pk_hi (got [{}, {}))",
+            target.pk_lo, target.pk_hi
+        )));
+    }
+    if config.k < 2 {
+        return Err(AdapterError::msg(
+            "bisection_diff requires k >= 2",
+        ));
+    }
+
+    // The adapter recommendation defines the leaf threshold when the
+    // caller didn't override.  Both adapters get a vote; we take the max
+    // so we never split below either's break-even.
+    let leaf_threshold = config.min_chunk_rows.unwrap_or_else(|| {
+        std::cmp::max(base.recommended_leaf_size(), branch.recommended_leaf_size())
+    });
+
+    let mut state = TraversalState {
+        config,
+        leaf_threshold,
+        chunks_examined: 0,
+        leaves_materialized: 0,
+        depth_max: 0,
+        depth_capped: false,
+        rows_added: 0,
+        rows_removed: 0,
+        rows_changed: 0,
+        samples: Vec::new(),
+    };
+
+    // Iterative depth-first traversal.  A stack avoids `async fn` self-
+    // recursion (which would force every implementor to either pull in
+    // the `async_recursion` crate or hand-box every future) without
+    // changing the algorithm — depth-first vs. breadth-first is a
+    // traversal-order detail, not an algorithmic one, since each level's
+    // checksums are evaluated independently.
+    //
+    // The root level is K equal chunks over the full primary-key window —
+    // matches the design-doc pseudocode `chunks_root = K equal chunks
+    // over full_pk_range(t)`. Without this split the root call would
+    // reduce to a single full-table checksum and skip the cost-bound
+    // floor (`K` chunks per side on a no-op diff).
+    let root_chunks = split_int_range(
+        &PkRange::IntRange {
+            lo: target.pk_lo,
+            hi: target.pk_hi,
+        },
+        config.k,
+    )?;
+    let mut stack: Vec<(Vec<PkRange>, u32)> = vec![(root_chunks, 0)];
+    while let Some((chunks, depth)) = stack.pop() {
+        diff_one_level(base, branch, target, &chunks, depth, &mut state, &mut stack).await?;
+    }
+
+    state.samples.sort_by(sample_sort_key);
+    Ok(BisectionDiffResult {
+        rows_added: state.rows_added,
+        rows_removed: state.rows_removed,
+        rows_changed: state.rows_changed,
+        samples: state.samples,
+        stats: BisectionStats {
+            chunks_examined: state.chunks_examined,
+            leaves_materialized: state.leaves_materialized,
+            depth_max: state.depth_max,
+            depth_capped: state.depth_capped,
+            split_strategy: SplitStrategy::IntRange,
+        },
+    })
+}
+
+struct TraversalState<'a> {
+    config: &'a BisectionConfig,
+    leaf_threshold: u64,
+    chunks_examined: u64,
+    leaves_materialized: u64,
+    depth_max: u32,
+    depth_capped: bool,
+    rows_added: u64,
+    rows_removed: u64,
+    rows_changed: u64,
+    samples: Vec<LeafRowSample>,
+}
+
+/// Process one recursion level: checksum every chunk in `chunks` on both
+/// sides, classify mismatches, and push deeper levels onto `stack` for
+/// later processing. Leaves materialize-and-diff inline.
+#[allow(clippy::too_many_arguments)]
+async fn diff_one_level(
+    base: &dyn WarehouseAdapter,
+    branch: &dyn WarehouseAdapter,
+    target: &BisectionTarget<'_>,
+    chunks: &[PkRange],
+    depth: u32,
+    state: &mut TraversalState<'_>,
+    stack: &mut Vec<(Vec<PkRange>, u32)>,
+) -> AdapterResult<()> {
+    state.depth_max = state.depth_max.max(depth);
+
+    let base_sums = base
+        .checksum_chunks(target.base, target.pk_column, target.value_columns, chunks)
+        .await?;
+    let branch_sums = branch
+        .checksum_chunks(
+            target.branch,
+            target.pk_column,
+            target.value_columns,
+            chunks,
+        )
+        .await?;
+    state.chunks_examined = state
+        .chunks_examined
+        .saturating_add((base_sums.len() + branch_sums.len()) as u64);
+
+    let base_by_id = index_by_chunk_id(&base_sums);
+    let branch_by_id = index_by_chunk_id(&branch_sums);
+
+    for (idx, chunk) in chunks.iter().enumerate() {
+        let chunk_id = u32::try_from(idx).map_err(|_| {
+            AdapterError::msg("bisection level produced more than u32::MAX chunks")
+        })?;
+        let base_entry = base_by_id.get(&chunk_id).copied();
+        let branch_entry = branch_by_id.get(&chunk_id).copied();
+
+        let base_count = base_entry.map(|e| e.row_count).unwrap_or(0);
+        let branch_count = branch_entry.map(|e| e.row_count).unwrap_or(0);
+        let base_check = base_entry.map(|e| e.checksum).unwrap_or(0);
+        let branch_check = branch_entry.map(|e| e.checksum).unwrap_or(0);
+
+        if base_count == branch_count && base_check == branch_check {
+            continue;
+        }
+
+        let max_rows = base_count.max(branch_count);
+        let at_leaf = max_rows <= state.leaf_threshold;
+        let at_depth_cap = depth + 1 >= state.config.max_depth;
+
+        if at_leaf || at_depth_cap {
+            if at_depth_cap && !at_leaf {
+                state.depth_capped = true;
+            }
+            materialize_and_diff(base, branch, target, chunk, state).await?;
+            continue;
+        }
+
+        let sub_chunks = split_int_range(chunk, state.config.k)?;
+        if !sub_chunks.is_empty() {
+            stack.push((sub_chunks, depth + 1));
+        }
+    }
+    Ok(())
+}
+
+fn index_by_chunk_id(sums: &[ChunkChecksum]) -> std::collections::HashMap<u32, &ChunkChecksum> {
+    sums.iter().map(|s| (s.chunk_id, s)).collect()
+}
+
+/// Split `[lo, hi)` into `K` equal-width sub-ranges. Last chunk absorbs
+/// the integer-division remainder so the union covers `[lo, hi)`
+/// exactly.
+fn split_int_range(parent: &PkRange, k: u32) -> AdapterResult<Vec<PkRange>> {
+    let (lo, hi) = match parent {
+        PkRange::IntRange { lo, hi } => (*lo, *hi),
+        PkRange::Composite { .. } | PkRange::HashBucket { .. } => {
+            return Err(AdapterError::msg(
+                "bisection_diff currently supports IntRange split \
+                 strategies only; composite and hash-bucket strategies \
+                 are not yet wired",
+            ));
+        }
+    };
+    if hi <= lo {
+        return Ok(Vec::new());
+    }
+    let step = (hi - lo) / i128::from(k);
+    if step == 0 {
+        // Range is narrower than K — return a single tight chunk so the
+        // recursion stops at the next leaf check.
+        return Ok(vec![PkRange::IntRange { lo, hi }]);
+    }
+    let mut out = Vec::with_capacity(k as usize);
+    for i in 0..k {
+        let start = lo + step * i128::from(i);
+        let end = if i + 1 == k {
+            hi
+        } else {
+            lo + step * i128::from(i + 1)
+        };
+        out.push(PkRange::IntRange { lo: start, hi: end });
+    }
+    Ok(out)
+}
+
+/// Materialize the rows on each side under `chunk`'s predicate and walk
+/// them in sorted order, classifying as added/removed/changed.
+async fn materialize_and_diff(
+    base: &dyn WarehouseAdapter,
+    branch: &dyn WarehouseAdapter,
+    target: &BisectionTarget<'_>,
+    chunk: &PkRange,
+    state: &mut TraversalState<'_>,
+) -> AdapterResult<()> {
+    state.leaves_materialized = state.leaves_materialized.saturating_add(1);
+
+    let (lo, hi) = match chunk {
+        PkRange::IntRange { lo, hi } => (*lo, *hi),
+        _ => unreachable!("split_int_range only emits IntRange"),
+    };
+
+    let base_rows = fetch_chunk_rows(base, target.base, target, lo, hi).await?;
+    let branch_rows = fetch_chunk_rows(branch, target.branch, target, lo, hi).await?;
+
+    let mut bi = 0;
+    let mut ri = 0;
+    while bi < base_rows.len() && ri < branch_rows.len() {
+        let b = &base_rows[bi];
+        let r = &branch_rows[ri];
+        match b.pk_str.cmp(&r.pk_str) {
+            std::cmp::Ordering::Less => {
+                record_sample(state, LeafRowKind::Removed, &b.pk_str);
+                state.rows_removed = state.rows_removed.saturating_add(1);
+                bi += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                record_sample(state, LeafRowKind::Added, &r.pk_str);
+                state.rows_added = state.rows_added.saturating_add(1);
+                ri += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                if b.values != r.values {
+                    record_sample(state, LeafRowKind::Changed, &b.pk_str);
+                    state.rows_changed = state.rows_changed.saturating_add(1);
+                }
+                bi += 1;
+                ri += 1;
+            }
+        }
+    }
+    while bi < base_rows.len() {
+        record_sample(state, LeafRowKind::Removed, &base_rows[bi].pk_str);
+        state.rows_removed = state.rows_removed.saturating_add(1);
+        bi += 1;
+    }
+    while ri < branch_rows.len() {
+        record_sample(state, LeafRowKind::Added, &branch_rows[ri].pk_str);
+        state.rows_added = state.rows_added.saturating_add(1);
+        ri += 1;
+    }
+    Ok(())
+}
+
+struct LeafRow {
+    pk_str: String,
+    values: Vec<serde_json::Value>,
+}
+
+async fn fetch_chunk_rows(
+    adapter: &dyn WarehouseAdapter,
+    table: &TableRef,
+    target: &BisectionTarget<'_>,
+    lo: i128,
+    hi: i128,
+) -> AdapterResult<Vec<LeafRow>> {
+    rocky_sql::validation::validate_identifier(target.pk_column).map_err(AdapterError::new)?;
+    for col in target.value_columns {
+        rocky_sql::validation::validate_identifier(col).map_err(AdapterError::new)?;
+    }
+    let dialect = adapter.dialect();
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
+    let pk = target.pk_column;
+    let cols_clause = if target.value_columns.is_empty() {
+        format!("\"{pk}\"")
+    } else {
+        let mut clause = format!("\"{pk}\"");
+        for c in target.value_columns {
+            clause.push_str(", \"");
+            clause.push_str(c);
+            clause.push('"');
+        }
+        clause
+    };
+
+    let sql = format!(
+        "SELECT {cols_clause} FROM {table_ref} \
+         WHERE \"{pk}\" IS NOT NULL \
+           AND \"{pk}\" >= {lo} \
+           AND \"{pk}\" < {hi} \
+         ORDER BY \"{pk}\""
+    );
+
+    let result = adapter.execute_query(&sql).await?;
+    let mut out = Vec::with_capacity(result.rows.len());
+    for row in result.rows {
+        if row.is_empty() {
+            continue;
+        }
+        let pk_str = match &row[0] {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        let values = row.into_iter().skip(1).collect();
+        out.push(LeafRow { pk_str, values });
+    }
+    Ok(out)
+}
+
+fn record_sample(state: &mut TraversalState<'_>, kind: LeafRowKind, pk: &str) {
+    if state.samples.len() >= state.config.max_samples {
+        return;
+    }
+    state.samples.push(LeafRowSample {
+        kind,
+        pk: pk.to_string(),
+    });
+}
+
+fn sample_sort_key(a: &LeafRowSample, b: &LeafRowSample) -> std::cmp::Ordering {
+    let ka = match a.kind {
+        LeafRowKind::Added => 0,
+        LeafRowKind::Removed => 1,
+        LeafRowKind::Changed => 2,
+    };
+    let kb = match b.kind {
+        LeafRowKind::Added => 0,
+        LeafRowKind::Removed => 1,
+        LeafRowKind::Changed => 2,
+    };
+    ka.cmp(&kb).then_with(|| a.pk.cmp(&b.pk))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_int_range_evenly_partitions_window() {
+        let parent = PkRange::IntRange { lo: 0, hi: 100 };
+        let chunks = split_int_range(&parent, 4).unwrap();
+        assert_eq!(chunks.len(), 4);
+        match &chunks[0] {
+            PkRange::IntRange { lo, hi } => {
+                assert_eq!(*lo, 0);
+                assert_eq!(*hi, 25);
+            }
+            _ => panic!("expected IntRange"),
+        }
+        match &chunks[3] {
+            PkRange::IntRange { lo, hi } => {
+                assert_eq!(*lo, 75);
+                assert_eq!(*hi, 100);
+            }
+            _ => panic!("expected IntRange"),
+        }
+    }
+
+    #[test]
+    fn split_int_range_absorbs_remainder_in_last_chunk() {
+        let parent = PkRange::IntRange { lo: 0, hi: 103 };
+        let chunks = split_int_range(&parent, 4).unwrap();
+        match &chunks[3] {
+            PkRange::IntRange { lo, hi } => {
+                assert_eq!(*lo, 75);
+                assert_eq!(*hi, 103);
+            }
+            _ => panic!("expected IntRange"),
+        }
+    }
+
+    #[test]
+    fn split_int_range_narrower_than_k_returns_single_chunk() {
+        let parent = PkRange::IntRange { lo: 5, hi: 7 };
+        let chunks = split_int_range(&parent, 32).unwrap();
+        assert_eq!(chunks.len(), 1);
+    }
+
+    #[test]
+    fn split_int_range_rejects_composite() {
+        let parent = PkRange::Composite {
+            lo: vec![],
+            hi: vec![],
+        };
+        assert!(split_int_range(&parent, 4).is_err());
+    }
+}

--- a/engine/crates/rocky-core/src/compare/mod.rs
+++ b/engine/crates/rocky-core/src/compare/mod.rs
@@ -1,7 +1,18 @@
-//! Shadow mode comparison engine.
+//! Cross-table comparison primitives.
 //!
-//! Compares shadow table output against production tables to detect
-//! discrepancies in row counts, schemas, and sampled data.
+//! Two layers live here:
+//!
+//! - **Shadow comparison** (this module's body) — schema + row-count
+//!   diff between a shadow run's output and the production table it
+//!   would replace.
+//! - **Checksum-bisection diff** ([`bisection`]) — exhaustive row-level
+//!   diff between any two tables on the same logical schema, e.g., a
+//!   PR's branch-schema clone vs. the base-schema source. Current scope
+//!   is single-column integer primary keys; DuckDB ships with the
+//!   `row_hash_expr` override out of the box, other adapters provide
+//!   their own native hash before bisection works against them.
+
+pub mod bisection;
 
 use std::collections::HashMap;
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -188,6 +188,87 @@ pub trait DiscoveryAdapter: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Bisection diff
+// ---------------------------------------------------------------------------
+
+/// One contiguous range of primary-key values, identifying a chunk in a
+/// checksum-bisection diff (see [`WarehouseAdapter::checksum_chunks`]).
+///
+/// Variants correspond one-to-one with [`SplitStrategy`]:
+/// - `IntRange` for declared integer / numeric primary keys.
+/// - `Composite` for multi-column primary keys; lo/hi are tuple boundaries.
+///   Caller pre-computes boundaries (typically via a per-recursion-level
+///   `NTILE` query on one side) so chunk identity stays stable across both
+///   sides of the diff.
+/// - `HashBucket` for opaque-string / UUID primary keys; chunk identity is
+///   `hash(pk) % modulus == residue`. Single-level by construction —
+///   recursion under hash bucketing isn't cost-bounded on unclustered
+///   tables (every level requires a full re-scan to recompute the hash).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum PkRange {
+    /// `[lo, hi)` over a single integer/numeric primary-key column.
+    IntRange { lo: i128, hi: i128 },
+    /// `[lo, hi)` over a composite primary-key tuple. Boundaries are
+    /// caller-provided as pre-computed `serde_json::Value` arrays so the
+    /// adapter doesn't re-quantile per call.
+    Composite {
+        lo: Vec<serde_json::Value>,
+        hi: Vec<serde_json::Value>,
+    },
+    /// `hash(pk) % modulus == residue` — single-level, no further recursion.
+    HashBucket { modulus: u32, residue: u32 },
+}
+
+/// One chunk's checksum result returned from
+/// [`WarehouseAdapter::checksum_chunks`].
+///
+/// Empty chunks (zero rows on this side) MAY be omitted by the
+/// implementation; callers MUST index the result by `chunk_id`, not by
+/// vector position. A `chunk_id` absent from the returned vector is
+/// equivalent to `ChunkChecksum { chunk_id, row_count: 0, checksum: 0 }`.
+///
+/// This contract exists because `GROUP BY chunk_id` on every target
+/// warehouse drops empty groups, and back-filling per-adapter is
+/// error-prone. The trait places the alignment burden on the caller, which
+/// already knows the full set of chunks it asked for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkChecksum {
+    /// Index into the `pk_ranges` slice the caller passed to
+    /// [`WarehouseAdapter::checksum_chunks`].
+    pub chunk_id: u32,
+    /// Number of non-null primary-key rows that fell into this chunk.
+    pub row_count: u64,
+    /// XOR-aggregated row hashes, widened to `u128` so the largest native
+    /// adapter hash output (Snowflake `NUMBER(38,0)`) fits without
+    /// truncation. Adapters with smaller native widths (xxhash64,
+    /// FARM_FINGERPRINT) zero-extend.
+    pub checksum: u128,
+}
+
+/// How the bisection runner split the primary-key space into chunks.
+///
+/// Surfaced on the diff result (the `BisectionStats` in
+/// `rocky_core::compare::bisection`) so downstream consumers know whether
+/// chunk identity is a numeric range, a tuple boundary, a hash bucket, or
+/// a non-unique-ordering fallback.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SplitStrategy {
+    /// Declared integer / numeric primary key; arithmetic split.
+    IntRange,
+    /// Composite primary key; per-level NTILE boundaries on the base side.
+    Composite,
+    /// UUID / opaque string primary key; single-level hash bucketing.
+    HashBucket,
+    /// No declared primary key; fallback ordering by the first column.
+    /// Bisection on this strategy is **not exhaustive** — multiple rows
+    /// can share the same chunk identity and tie-breaks are warehouse-
+    /// defined. Callers should treat the diff as best-effort and surface
+    /// a coverage warning.
+    FirstColumn,
+}
+
+// ---------------------------------------------------------------------------
 // Warehouse
 // ---------------------------------------------------------------------------
 
@@ -322,6 +403,238 @@ pub trait WarehouseAdapter: Send + Sync {
         );
         self.execute_statement(&sql).await
     }
+
+    /// Compute checksums for a batch of chunks defined by primary-key
+    /// ranges. The bisection runner in
+    /// [`crate::compare::bisection`] calls this once per recursion level
+    /// per side; one call returns up to `K` chunks.
+    ///
+    /// **Returns one entry per non-empty chunk.** Chunks with zero rows on
+    /// this side MAY be omitted by the implementation; callers MUST index
+    /// the result by [`ChunkChecksum::chunk_id`], not by vector position.
+    /// A `chunk_id` absent from the returned vector is equivalent to
+    /// `ChunkChecksum { chunk_id, row_count: 0, checksum: 0 }`. This
+    /// alignment burden lives on the caller because `GROUP BY chunk_id`
+    /// drops empty groups on every target warehouse and back-filling
+    /// per-adapter is error-prone.
+    ///
+    /// `value_columns` are the columns to hash for the chunk checksum
+    /// (typically every non-`pk_column` column the caller cares about).
+    /// `pk_column` identifies the bucketing column. The default impl
+    /// supports a single integer/numeric column (`PkRange::IntRange`);
+    /// composite and hash-bucket strategies require an adapter override
+    /// that knows how to emit the corresponding bucketing SQL.
+    ///
+    /// **Integer-PK value range.** The default impl interpolates `lo`
+    /// and `hi` as decimal literals into SQL, and the chunk-id
+    /// arithmetic uses 64-bit floating-point. Tables whose PK exceeds
+    /// the i64 range require an adapter override that handles wider
+    /// integers natively.
+    ///
+    /// The default implementation uses [`SqlDialect::row_hash_expr`] +
+    /// `BIT_XOR` to produce a portable query. Adapters with native
+    /// hash + bucketing primitives (DuckDB `hash()` + `width_bucket`,
+    /// BigQuery `FARM_FINGERPRINT`, Snowflake `HASH` + `BITXOR_AGG`,
+    /// Databricks `xxhash64`) override for performance.
+    async fn checksum_chunks(
+        &self,
+        table: &TableRef,
+        pk_column: &str,
+        value_columns: &[String],
+        pk_ranges: &[PkRange],
+    ) -> AdapterResult<Vec<ChunkChecksum>> {
+        default_checksum_chunks(self, table, pk_column, value_columns, pk_ranges).await
+    }
+
+    /// Adapter-tuned override for the bisection leaf-row threshold (the
+    /// `MIN_CHUNK_ROWS` knob). Below this row count, the bisection runner
+    /// stops splitting and materializes the chunk for row-by-row diff.
+    ///
+    /// Defaults to `1000`, which lands break-even on DuckDB and similar
+    /// in-process engines. Adapters with high per-query setup cost
+    /// (Databricks, Snowflake, BigQuery) override to a higher value to
+    /// avoid spending fixed roundtrip cost on small chunks.
+    fn recommended_leaf_size(&self) -> u64 {
+        1000
+    }
+
+    /// Adapter-tuned override for the row-count threshold above which
+    /// UUID / hash-bucket-PK tables auto-fall-back from bisection to
+    /// sampled (with a coverage warning).
+    ///
+    /// Defaults to `10_000_000` — chosen so the auto-fallback fires before
+    /// a single mismatched bucket on `K=32` materializes more than ~300k
+    /// rows per side. Adapters with cheap large-table scans (or with
+    /// native hash-clustering guarantees) can lower this; the default is
+    /// conservative.
+    fn recommended_uuid_threshold(&self) -> u64 {
+        10_000_000
+    }
+}
+
+/// Default `checksum_chunks` implementation, factored out so it lives
+/// outside the trait body and can call helpers without recursion-into-self
+/// concerns. Adapter overrides bypass this entirely.
+async fn default_checksum_chunks(
+    adapter: &(impl WarehouseAdapter + ?Sized),
+    table: &TableRef,
+    pk_column: &str,
+    value_columns: &[String],
+    pk_ranges: &[PkRange],
+) -> AdapterResult<Vec<ChunkChecksum>> {
+    if pk_ranges.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Sub-step 1 supports IntRange only; composite + hash-bucket land in
+    // follow-up phases. The error here is what the bisection runner
+    // surfaces to the user when they request `--algorithm=bisection` on a
+    // table whose PK isn't a single integer column on an adapter without
+    // a native override.
+    let (lo_min, hi_max, k) = uniform_int_range_window(pk_ranges)?;
+    let step = (hi_max - lo_min) / (k as i128);
+    if step <= 0 {
+        return Err(AdapterError::msg(
+            "default checksum_chunks requires a positive integer step \
+             across the chunk window (lo == hi or hi < lo)",
+        ));
+    }
+
+    rocky_sql::validation::validate_identifier(pk_column).map_err(AdapterError::new)?;
+    for col in value_columns {
+        rocky_sql::validation::validate_identifier(col).map_err(AdapterError::new)?;
+    }
+
+    let dialect = adapter.dialect();
+    let table_ref = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
+    let row_hash = dialect.row_hash_expr(value_columns)?;
+
+    // FLOOR((pk - lo) / step) is the most-portable chunk-id construction —
+    // works on Snowflake, Databricks Spark, BigQuery, and DuckDB without
+    // dialect dispatch. The outer LEAST clamp handles the integer-step
+    // truncation case: when `step * k < hi - lo`, the last chunk absorbs
+    // the remainder (per `split_int_range`'s contract), so the SQL
+    // bucketing must clamp the highest pk values back into chunk K-1
+    // instead of overflowing to K. The outer SELECT pins ORDER BY for
+    // stable serialization.
+    let last_id = k - 1;
+    let sql = format!(
+        "SELECT chunk_id, COUNT(*) AS row_count, BIT_XOR({row_hash}) AS chk \
+         FROM ( \
+             SELECT *, \
+                    LEAST( \
+                        CAST(FLOOR((CAST(\"{pk_column}\" AS DOUBLE) - {lo}) / {step}) AS BIGINT), \
+                        {last_id} \
+                    ) AS chunk_id \
+             FROM {table_ref} \
+             WHERE \"{pk_column}\" IS NOT NULL \
+               AND \"{pk_column}\" >= {lo} \
+               AND \"{pk_column}\" < {hi} \
+         ) AS chunked \
+         GROUP BY chunk_id \
+         ORDER BY chunk_id",
+        lo = lo_min,
+        hi = hi_max,
+    );
+
+    let result = adapter.execute_query(&sql).await?;
+    parse_chunk_checksums(&result, k)
+}
+
+/// Verifies the caller passed `K` contiguous, equal-width `IntRange`
+/// chunks and returns `(lo_min, hi_max, K)` so the default impl can
+/// derive the SQL `FLOOR((pk - lo) / step)` predicate.
+fn uniform_int_range_window(pk_ranges: &[PkRange]) -> AdapterResult<(i128, i128, u32)> {
+    let mut lo_min: Option<i128> = None;
+    let mut hi_max: Option<i128> = None;
+    for range in pk_ranges {
+        match range {
+            PkRange::IntRange { lo, hi } => {
+                lo_min = Some(lo_min.map_or(*lo, |x| x.min(*lo)));
+                hi_max = Some(hi_max.map_or(*hi, |x| x.max(*hi)));
+            }
+            PkRange::Composite { .. } | PkRange::HashBucket { .. } => {
+                return Err(AdapterError::msg(
+                    "default checksum_chunks supports IntRange only; \
+                     composite and hash-bucket strategies require an \
+                     adapter override",
+                ));
+            }
+        }
+    }
+    let lo = lo_min.expect("non-empty pk_ranges checked above");
+    let hi = hi_max.expect("non-empty pk_ranges checked above");
+    let k = u32::try_from(pk_ranges.len()).map_err(|_| {
+        AdapterError::msg("checksum_chunks accepts up to u32::MAX chunks per call")
+    })?;
+    Ok((lo, hi, k))
+}
+
+/// Parse a `chunk_id, row_count, chk` result set into [`ChunkChecksum`]
+/// rows. Empty chunks are absent from the input by SQL contract — the
+/// caller back-fills via `chunk_id`.
+fn parse_chunk_checksums(result: &QueryResult, k: u32) -> AdapterResult<Vec<ChunkChecksum>> {
+    let mut out = Vec::with_capacity(result.rows.len());
+    for row in &result.rows {
+        if row.len() < 3 {
+            return Err(AdapterError::msg(
+                "checksum_chunks query returned a row with fewer than 3 \
+                 columns; expected (chunk_id, row_count, chk)",
+            ));
+        }
+        let chunk_id: u32 = parse_chunk_id(&row[0], k)?;
+        let row_count: u64 = parse_u64(&row[1])?;
+        let checksum: u128 = parse_checksum(&row[2])?;
+        out.push(ChunkChecksum {
+            chunk_id,
+            row_count,
+            checksum,
+        });
+    }
+    Ok(out)
+}
+
+fn parse_chunk_id(v: &serde_json::Value, k: u32) -> AdapterResult<u32> {
+    let raw = parse_i128(v)?;
+    if raw < 0 || raw >= i128::from(k) {
+        return Err(AdapterError::msg(format!(
+            "checksum_chunks returned chunk_id={raw}, outside [0, {k})"
+        )));
+    }
+    Ok(raw as u32)
+}
+
+fn parse_u64(v: &serde_json::Value) -> AdapterResult<u64> {
+    let raw = parse_i128(v)?;
+    u64::try_from(raw).map_err(|_| {
+        AdapterError::msg(format!(
+            "checksum_chunks returned row_count={raw}, expected non-negative u64"
+        ))
+    })
+}
+
+fn parse_checksum(v: &serde_json::Value) -> AdapterResult<u128> {
+    let raw = parse_i128(v)?;
+    Ok(raw as u128)
+}
+
+fn parse_i128(v: &serde_json::Value) -> AdapterResult<i128> {
+    if let Some(s) = v.as_str() {
+        return s.parse::<i128>().map_err(|e| {
+            AdapterError::msg(format!(
+                "failed to parse {s:?} as i128 from checksum_chunks result: {e}"
+            ))
+        });
+    }
+    if let Some(n) = v.as_i64() {
+        return Ok(n.into());
+    }
+    if let Some(n) = v.as_u64() {
+        return Ok(n.into());
+    }
+    Err(AdapterError::msg(format!(
+        "checksum_chunks result column had unexpected JSON shape: {v:?}"
+    )))
 }
 
 // ---------------------------------------------------------------------------
@@ -479,6 +792,30 @@ pub trait SqlDialect: Send + Sync {
     /// `CURRENT_TIMESTAMP()` because it requires the function form.
     fn current_timestamp_expr(&self) -> &'static str {
         "CURRENT_TIMESTAMP"
+    }
+
+    /// SQL expression that computes a single-row hash over `columns`,
+    /// returning an integer wide enough to feed `BIT_XOR(...)` for
+    /// chunk-checksum aggregation in
+    /// [`WarehouseAdapter::checksum_chunks`].
+    ///
+    /// **No portable default exists** — the per-warehouse native hash
+    /// functions all return integer types but the SQL surface differs
+    /// (DuckDB `hash(...)`, Databricks `xxhash64(concat_ws(...))`,
+    /// Snowflake `HASH(...)`, BigQuery
+    /// `FARM_FINGERPRINT(TO_JSON_STRING(STRUCT(...)))`). The default impl
+    /// returns an error so adapters that haven't overridden surface a
+    /// helpful message at `--algorithm=bisection` time rather than
+    /// emitting broken SQL.
+    ///
+    /// `columns` are quoted by the caller; the dialect must produce a SQL
+    /// fragment safe to embed under `BIT_XOR(...)` and `GROUP BY
+    /// chunk_id`.
+    fn row_hash_expr(&self, _columns: &[String]) -> AdapterResult<String> {
+        Err(AdapterError::msg(
+            "row_hash_expr not supported by this dialect; required for \
+             the checksum-bisection diff",
+        ))
     }
 
     /// Returns `true` when changing a column's data type from

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -564,9 +564,8 @@ fn uniform_int_range_window(pk_ranges: &[PkRange]) -> AdapterResult<(i128, i128,
     }
     let lo = lo_min.expect("non-empty pk_ranges checked above");
     let hi = hi_max.expect("non-empty pk_ranges checked above");
-    let k = u32::try_from(pk_ranges.len()).map_err(|_| {
-        AdapterError::msg("checksum_chunks accepts up to u32::MAX chunks per call")
-    })?;
+    let k = u32::try_from(pk_ranges.len())
+        .map_err(|_| AdapterError::msg("checksum_chunks accepts up to u32::MAX chunks per call"))?;
     Ok((lo, hi, k))
 }
 

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -192,6 +192,28 @@ impl SqlDialect for DuckDbSqlDialect {
     fn regex_match_predicate(&self, column: &str, pattern: &str) -> AdapterResult<String> {
         Ok(format!("regexp_matches({column}, '{pattern}')"))
     }
+
+    fn row_hash_expr(&self, columns: &[String]) -> AdapterResult<String> {
+        if columns.is_empty() {
+            return Err(AdapterError::msg(
+                "row_hash_expr requires at least one column to hash",
+            ));
+        }
+        for col in columns {
+            validation::validate_identifier(col).map_err(AdapterError::new)?;
+        }
+        // DuckDB's `hash(expr_list)` accepts any number of arguments and
+        // returns UBIGINT (xxhash64). Cast to HUGEINT so `BIT_XOR(...)`
+        // widens cleanly to i128 — matches the [`ChunkChecksum::checksum`]
+        // u128 contract without truncation when the hash's high bit is
+        // set.
+        let arg_list = columns
+            .iter()
+            .map(|c| format!("\"{c}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Ok(format!("CAST(hash({arg_list}) AS HUGEINT)"))
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
+++ b/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
@@ -323,6 +323,115 @@ async fn empty_base_surfaces_branch_as_added() {
     }
 }
 
+/// Regression: PK comparison at leaves must use numeric ordering, not
+/// lexical. With base = `[0..200)` and branch = `[0..200) ∖ {100}`, a
+/// merge-walk that string-compares would mis-classify rows whose
+/// stringified PKs cross length boundaries (e.g., "99" > "100"
+/// lexically). The numeric compare classifies row 100 as `Removed`
+/// once and every other row as a match.
+#[tokio::test]
+async fn pk_comparison_handles_cross_length_numeric_ids() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 200, &[]).await;
+    seed_table(&adapter, "branch", "t", 200, &[]).await;
+    // Drop one row from branch — id=100 sits across the lexical
+    // boundary between two-digit ("99") and three-digit ("100") IDs.
+    adapter
+        .execute_statement("DELETE FROM branch.t WHERE id = 100")
+        .await
+        .unwrap();
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        // Force the runner to materialize the chunk that crosses the
+        // cardinality boundary at id=100.
+        min_chunk_rows: Some(500),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 200, &value_columns),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.rows_added, 0);
+    assert_eq!(result.rows_removed, 1, "exactly id=100 should be Removed");
+    assert_eq!(result.rows_changed, 0);
+    assert_eq!(result.samples.len(), 1);
+    assert_eq!(result.samples[0].kind, LeafRowKind::Removed);
+    assert_eq!(result.samples[0].pk, "100");
+}
+
+/// Null-PK rows are excluded from chunks but counted at the root and
+/// surfaced on `BisectionStats`. A divergence in null-PK counts must
+/// not silently disappear from the diff.
+#[tokio::test]
+async fn null_pk_rows_surfaced_on_stats() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 100, &[]).await;
+    seed_table(&adapter, "branch", "t", 100, &[]).await;
+    // Insert null-PK rows on each side, with branch carrying more.
+    adapter
+        .execute_statement("INSERT INTO base.t VALUES (NULL, 'null_a', 1), (NULL, 'null_b', 2)")
+        .await
+        .unwrap();
+    adapter
+        .execute_statement(
+            "INSERT INTO branch.t VALUES \
+             (NULL, 'null_a', 1), (NULL, 'null_b', 2), \
+             (NULL, 'null_c', 3), (NULL, 'null_d', 4), (NULL, 'null_e', 5)",
+        )
+        .await
+        .unwrap();
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        min_chunk_rows: Some(500),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 100, &value_columns),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    // Non-null rows match; null rows don't appear in the diff totals
+    // but are reported on the stats.
+    assert_eq!(result.rows_added, 0);
+    assert_eq!(result.rows_removed, 0);
+    assert_eq!(result.rows_changed, 0);
+    assert_eq!(result.stats.null_pk_rows_base, 2);
+    assert_eq!(result.stats.null_pk_rows_branch, 5);
+}
+
 /// Smoke test on the `checksum_chunks` adapter call shape: a 32-row
 /// table chunked into K=4 ranges returns 4 entries with row_count=8 each.
 #[tokio::test]

--- a/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
+++ b/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
@@ -172,9 +172,15 @@ async fn finds_planted_change_at_row_90000() {
     assert_eq!(result.samples.len(), 1);
     assert_eq!(result.samples[0].kind, LeafRowKind::Changed);
     assert_eq!(result.samples[0].pk, "90000");
-    assert!(result.stats.depth_max >= 1, "single-row change requires recursion");
+    assert!(
+        result.stats.depth_max >= 1,
+        "single-row change requires recursion"
+    );
     assert!(!result.stats.depth_capped);
-    assert_eq!(result.stats.leaves_materialized, 1, "exactly one leaf bottoms out");
+    assert_eq!(
+        result.stats.leaves_materialized, 1,
+        "exactly one leaf bottoms out"
+    );
     assert_eq!(result.stats.split_strategy, SplitStrategy::IntRange);
 }
 
@@ -229,7 +235,10 @@ async fn determinism_same_data_byte_identical_stats() {
     };
     let a = run_once(100_000, &config).await;
     let b = run_once(100_000, &config).await;
-    assert_eq!(a, b, "two runs on the same data must produce identical results");
+    assert_eq!(
+        a, b,
+        "two runs on the same data must produce identical results"
+    );
 }
 
 /// Empty branch surfaces every base row as `Removed`. Bisection
@@ -444,15 +453,11 @@ async fn checksum_chunks_smoke_uniform_ranges() {
         .await
         .unwrap();
     adapter
-        .execute_statement(
-            "CREATE OR REPLACE TABLE smoke.t (id INTEGER, name VARCHAR)",
-        )
+        .execute_statement("CREATE OR REPLACE TABLE smoke.t (id INTEGER, name VARCHAR)")
         .await
         .unwrap();
     adapter
-        .execute_statement(
-            "INSERT INTO smoke.t SELECT i, 'r' || i FROM range(0, 32) t(i)",
-        )
+        .execute_statement("INSERT INTO smoke.t SELECT i, 'r' || i FROM range(0, 32) t(i)")
         .await
         .unwrap();
 

--- a/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
+++ b/engine/crates/rocky-duckdb/tests/bisection_conformance.rs
@@ -1,0 +1,381 @@
+//! Conformance suite for the checksum-bisection diff against an
+//! in-process DuckDB.
+//!
+//! Pins three behaviors as verification gates:
+//!
+//! 1. **Determinism** (gate 1) — same data on both sides produces a
+//!    byte-identical [`BisectionStats`] across runs.
+//! 2. **False-negative rate** (gate 2) — a single planted change at row
+//!    90,000 of a 100k-row table is found by every run.
+//! 3. **Cost bound on no-op diff** (gate 3) — identical-data run examines
+//!    only `K` chunks per side at the root and stops there.
+//!
+//! Plus two correctness cases the design doc names but doesn't gate
+//! explicitly:
+//!
+//! - Empty branch surfaces every base row as `Removed`.
+//! - Empty base surfaces every branch row as `Added`.
+
+use rocky_core::compare::bisection::{
+    BisectionConfig, BisectionTarget, LeafRowKind, bisection_diff,
+};
+use rocky_core::ir::TableRef;
+use rocky_core::traits::{SplitStrategy, WarehouseAdapter};
+use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+/// Seed a `(id INTEGER, name VARCHAR, value INTEGER)` table with N rows.
+/// `id` runs `0..N`. `name` is `"row_<id>"`. `value` defaults to `id * 7`.
+/// `overrides` lists per-row exceptions (`(id, value)`) that get UPDATEed
+/// after the bulk INSERT — keeping the bulk path fast and the planted
+/// changes explicit.
+async fn seed_table(
+    adapter: &DuckDbWarehouseAdapter,
+    schema: &str,
+    table: &str,
+    n: u64,
+    overrides: &[(u64, i64)],
+) {
+    adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+        .await
+        .unwrap();
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {schema}.{table} \
+             (id INTEGER, name VARCHAR, value INTEGER)"
+        ))
+        .await
+        .unwrap();
+    if n > 0 {
+        // Bulk-insert via `range` is much faster than per-row INSERTs.
+        adapter
+            .execute_statement(&format!(
+                "INSERT INTO {schema}.{table} \
+                 SELECT i AS id, 'row_' || i AS name, i * 7 AS value \
+                 FROM range(0, {n}) t(i)"
+            ))
+            .await
+            .unwrap();
+    }
+    for (id, value) in overrides {
+        adapter
+            .execute_statement(&format!(
+                "UPDATE {schema}.{table} SET value = {value} WHERE id = {id}"
+            ))
+            .await
+            .unwrap();
+    }
+}
+
+fn target<'a>(
+    base: &'a TableRef,
+    branch: &'a TableRef,
+    pk_lo: i128,
+    pk_hi: i128,
+    value_columns: &'a [String],
+) -> BisectionTarget<'a> {
+    BisectionTarget {
+        base,
+        branch,
+        pk_column: "id",
+        value_columns,
+        pk_lo,
+        pk_hi,
+    }
+}
+
+/// Verification gate 3 — no-op diff bottoms out at the root level
+/// without recursion.
+#[tokio::test]
+async fn noop_diff_examines_root_chunks_only() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 10_000, &[]).await;
+    seed_table(&adapter, "branch", "t", 10_000, &[]).await;
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        min_chunk_rows: Some(100),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 10_000, &value_columns),
+        &config,
+    )
+    .await
+    .expect("bisection_diff on identical data must succeed");
+
+    assert_eq!(result.rows_added, 0);
+    assert_eq!(result.rows_removed, 0);
+    assert_eq!(result.rows_changed, 0);
+    assert!(result.samples.is_empty());
+    assert_eq!(result.stats.depth_max, 0, "no recursion on no-op diff");
+    assert!(!result.stats.depth_capped);
+    assert_eq!(result.stats.leaves_materialized, 0);
+    // K root-level chunks examined per side, both sides — 2K total.
+    assert_eq!(
+        result.stats.chunks_examined,
+        u64::from(config.k) * 2,
+        "no-op diff should only checksum K root chunks per side"
+    );
+    assert_eq!(result.stats.split_strategy, SplitStrategy::IntRange);
+}
+
+/// Verification gate 2 — single planted change at row 90,000 of a 100k
+/// table is found.
+#[tokio::test]
+async fn finds_planted_change_at_row_90000() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 100_000, &[]).await;
+    seed_table(&adapter, "branch", "t", 100_000, &[(90_000, -1)]).await;
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        min_chunk_rows: Some(1000),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 100_000, &value_columns),
+        &config,
+    )
+    .await
+    .expect("bisection_diff against 100k-row fixture must succeed");
+
+    assert_eq!(result.rows_added, 0);
+    assert_eq!(result.rows_removed, 0);
+    assert_eq!(result.rows_changed, 1, "exactly one row should differ");
+    assert_eq!(result.samples.len(), 1);
+    assert_eq!(result.samples[0].kind, LeafRowKind::Changed);
+    assert_eq!(result.samples[0].pk, "90000");
+    assert!(result.stats.depth_max >= 1, "single-row change requires recursion");
+    assert!(!result.stats.depth_capped);
+    assert_eq!(result.stats.leaves_materialized, 1, "exactly one leaf bottoms out");
+    assert_eq!(result.stats.split_strategy, SplitStrategy::IntRange);
+}
+
+/// Verification gate 1 — same data on both sides produces a
+/// byte-identical [`BisectionStats`] across runs. Re-runs the
+/// `noop_diff_examines_root_chunks_only` setup twice and asserts
+/// `BisectionStats` equality.
+#[tokio::test]
+async fn determinism_same_data_byte_identical_stats() {
+    async fn run_once(
+        seed: u64,
+        config: &BisectionConfig,
+    ) -> (
+        u64,
+        u64,
+        u64,
+        rocky_core::compare::bisection::BisectionStats,
+    ) {
+        let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+        seed_table(&adapter, "base", "t", seed, &[]).await;
+        seed_table(&adapter, "branch", "t", seed, &[(90_000, -1)]).await;
+        let base = TableRef {
+            catalog: String::new(),
+            schema: "base".into(),
+            table: "t".into(),
+        };
+        let branch = TableRef {
+            catalog: String::new(),
+            schema: "branch".into(),
+            table: "t".into(),
+        };
+        let value_columns = vec!["name".to_string(), "value".to_string()];
+        let result = bisection_diff(
+            &adapter,
+            &adapter,
+            &target(&base, &branch, 0, seed as i128, &value_columns),
+            config,
+        )
+        .await
+        .unwrap();
+        (
+            result.rows_added,
+            result.rows_removed,
+            result.rows_changed,
+            result.stats,
+        )
+    }
+
+    let config = BisectionConfig {
+        min_chunk_rows: Some(1000),
+        ..Default::default()
+    };
+    let a = run_once(100_000, &config).await;
+    let b = run_once(100_000, &config).await;
+    assert_eq!(a, b, "two runs on the same data must produce identical results");
+}
+
+/// Empty branch surfaces every base row as `Removed`. Bisection
+/// recurses to the leaf threshold and materializes the dense range.
+#[tokio::test]
+async fn empty_branch_surfaces_base_as_removed() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 200, &[]).await;
+    seed_table(&adapter, "branch", "t", 0, &[]).await;
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        // Every root chunk is below threshold → leaf-materialize each.
+        min_chunk_rows: Some(500),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 200, &value_columns),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.rows_added, 0);
+    assert_eq!(result.rows_removed, 200);
+    assert_eq!(result.rows_changed, 0);
+    assert_eq!(result.samples.len(), config.max_samples);
+    for sample in &result.samples {
+        assert_eq!(sample.kind, LeafRowKind::Removed);
+    }
+    // Every root chunk holds <500 rows, so every non-empty root chunk
+    // bottoms out as a leaf. 200 rows over 32 chunks distribute across
+    // all of them, so every chunk materializes.
+    assert_eq!(
+        result.stats.leaves_materialized,
+        u64::from(config.k),
+        "every root chunk should leaf-materialize because all are below threshold"
+    );
+}
+
+/// Empty base surfaces every branch row as `Added`.
+#[tokio::test]
+async fn empty_base_surfaces_branch_as_added() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    seed_table(&adapter, "base", "t", 0, &[]).await;
+    seed_table(&adapter, "branch", "t", 200, &[]).await;
+
+    let base = TableRef {
+        catalog: String::new(),
+        schema: "base".into(),
+        table: "t".into(),
+    };
+    let branch = TableRef {
+        catalog: String::new(),
+        schema: "branch".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string(), "value".to_string()];
+    let config = BisectionConfig {
+        min_chunk_rows: Some(500),
+        ..Default::default()
+    };
+
+    let result = bisection_diff(
+        &adapter,
+        &adapter,
+        &target(&base, &branch, 0, 200, &value_columns),
+        &config,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.rows_added, 200);
+    assert_eq!(result.rows_removed, 0);
+    assert_eq!(result.rows_changed, 0);
+    for sample in &result.samples {
+        assert_eq!(sample.kind, LeafRowKind::Added);
+    }
+}
+
+/// Smoke test on the `checksum_chunks` adapter call shape: a 32-row
+/// table chunked into K=4 ranges returns 4 entries with row_count=8 each.
+#[tokio::test]
+async fn checksum_chunks_smoke_uniform_ranges() {
+    use rocky_core::traits::PkRange;
+
+    let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+    adapter
+        .execute_statement("CREATE SCHEMA IF NOT EXISTS smoke")
+        .await
+        .unwrap();
+    adapter
+        .execute_statement(
+            "CREATE OR REPLACE TABLE smoke.t (id INTEGER, name VARCHAR)",
+        )
+        .await
+        .unwrap();
+    adapter
+        .execute_statement(
+            "INSERT INTO smoke.t SELECT i, 'r' || i FROM range(0, 32) t(i)",
+        )
+        .await
+        .unwrap();
+
+    let table = TableRef {
+        catalog: String::new(),
+        schema: "smoke".into(),
+        table: "t".into(),
+    };
+    let value_columns = vec!["name".to_string()];
+    let ranges = vec![
+        PkRange::IntRange { lo: 0, hi: 8 },
+        PkRange::IntRange { lo: 8, hi: 16 },
+        PkRange::IntRange { lo: 16, hi: 24 },
+        PkRange::IntRange { lo: 24, hi: 32 },
+    ];
+
+    let sums = adapter
+        .checksum_chunks(&table, "id", &value_columns, &ranges)
+        .await
+        .expect("checksum_chunks should succeed on DuckDB");
+    assert_eq!(sums.len(), 4);
+    for chunk in &sums {
+        assert_eq!(chunk.row_count, 8, "each chunk should hold 8 rows");
+    }
+    // Determinism check: two consecutive calls produce identical
+    // checksum bytes (DuckDB's `hash` is deterministic; bit_xor over
+    // HUGEINT preserves the bytes).
+    let sums2 = adapter
+        .checksum_chunks(&table, "id", &value_columns, &ranges)
+        .await
+        .unwrap();
+    for (a, b) in sums.iter().zip(sums2.iter()) {
+        assert_eq!(a.checksum, b.checksum);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the checksum-bisection diff kernel that lets `rocky preview diff` evolve from sampled (with a structural false-negative tail) toward exhaustive over a single-column integer / numeric primary key. Datafold-style chunk recursion: split the PK range into `K=32` chunks, checksum each chunk on both sides, recurse into mismatched chunks until a leaf threshold, then materialize-and-diff the leaves row-by-row.

Library only — no CLI surface, no schema swap. The kernel ships ahead of any `--algorithm=bisection` CLI flag because that's the smallest correct slice and it stands on its own. Phase 2's `run_preview_diff` is run-record-only today; wiring the kernel into `rocky preview diff` (so the CLI actually invokes warehouse adapters) is a follow-up.

### What's in this PR

**Trait surface** (in `rocky-core::traits` and the public-stable `rocky-adapter-sdk`):

- `WarehouseAdapter::checksum_chunks(table, pk_column, value_columns, pk_ranges) -> Vec<ChunkChecksum>` — one-batched-call-returning-K-chunks shape.  Default impl in `rocky-core` emits a portable `BIT_XOR(<row_hash>)`-over-`FLOOR((pk - lo) / step)` query, clamped with `LEAST(K-1, …)` so the integer-step truncation case (last chunk absorbs the remainder) doesn't overflow the chunk-id space.  Default impl in `rocky-adapter-sdk` returns "not supported" so out-of-tree adapters surface a clear error until they wire their native hash.
- `WarehouseAdapter::recommended_leaf_size()` (default `1000`) and `recommended_uuid_threshold()` (default `10_000_000`) — adapter-tunable knobs.
- `SqlDialect::row_hash_expr(columns)` on `rocky-core::traits::SqlDialect` returning `AdapterResult<String>`. Default returns "not supported by this dialect"; DuckDB ships an override using `CAST(hash(...) AS HUGEINT)`. Other in-tree adapters wire their native hash in follow-ups.

**Types** (re-exported from both `rocky-core` and `rocky-adapter-sdk`):

- `ChunkChecksum { chunk_id: u32, row_count: u64, checksum: u128 }`
- `PkRange { IntRange, Composite, HashBucket }` — only `IntRange` is wired in this PR
- `SplitStrategy { IntRange, Composite, HashBucket, FirstColumn }`

**Kernel** (`rocky-core::compare::bisection`):

- `bisection_diff(base, branch, target, config)` — public entry point
- Iterative depth-first traversal; no `async_recursion` dep
- Root level seeded with K equal chunks (matches the design pseudocode)
- Leaf-row diff via merge-walk on PK-sorted result sets, classifying as Added/Removed/Changed
- `BisectionConfig`, `BisectionTarget`, `BisectionDiffResult`, `BisectionStats`, `LeafRowSample`, `LeafRowKind`

**Conformance suite** (`engine/crates/rocky-duckdb/tests/bisection_conformance.rs`, 6 tests, 0.34s):

- `noop_diff_examines_root_chunks_only` — identical data → exactly K root checksums per side, no recursion, no leaves
- `finds_planted_change_at_row_90000` — single planted change in a 100k-row fixture is found every run
- `determinism_same_data_byte_identical_stats` — two runs on the same data produce byte-identical `BisectionStats`
- `empty_branch_surfaces_base_as_removed` / `empty_base_surfaces_branch_as_added` — empty-side handling
- `checksum_chunks_smoke_uniform_ranges` — adapter-trait shape sanity check on the SQL emitted by the default impl

## Notes for reviewers

- **`rocky-adapter-sdk` trait surface change.** Adds one method (`checksum_chunks`) with a default-error impl plus two utility getters with safe defaults. No source-level breaking changes; out-of-tree adapters keep compiling. Treat as a minor SDK bump at the next engine release cut.
- **DuckDB-only, integer PK only.** Composite + UUID/hash-bucket strategies return an explicit error from `bisection_diff`. Wiring the other in-tree adapters (Databricks `xxhash64`, Snowflake `HASH`, BigQuery `FARM_FINGERPRINT`) is one PR each in follow-up.
- **No CLI flag, no schema change.** `rocky preview diff` JSON output is unchanged. The `PreviewModelDiff` restructure from `sampled` to `algorithm: Sampled|Bisection` is a separate PR.
- **i64 PK range only.** The default impl interpolates `lo`/`hi` as decimal literals into SQL and uses 64-bit floating-point chunk-id arithmetic. PK values outside i64 range require an adapter override that handles wider integers natively. Documented in the `checksum_chunks` doc-comment.

## Test plan

- [x] `cargo test -p rocky-core --lib bisection` — 4 unit tests on `split_int_range` pass
- [x] `cargo test -p rocky-duckdb --test bisection_conformance` — 6 conformance tests pass
- [x] `cargo test -p rocky-core --lib` — 1136 existing rocky-core tests pass (no regressions)
- [x] `cargo test -p rocky-duckdb` — 61 existing rocky-duckdb tests pass
- [x] `cargo clippy -p rocky-core -p rocky-duckdb -p rocky-adapter-sdk --all-targets` — clean
- [x] `cargo check --workspace` — clean