### PR TITLE
feat(rocky-cli): surface bisection results as PreviewModelDiffAlgorithm tagged enum

### DIFF
--- a/editors/vscode/src/types/generated/preview_diff.ts
+++ b/editors/vscode/src/types/generated/preview_diff.ts
@@ -6,11 +6,28 @@
  */
 
 /**
+ * Row-level diff payload tagged by which algorithm produced it. The `kind` discriminator (`"sampled"` or `"bisection"`) lets consumers reading the JSON pick the right shape without having to check optional fields.
+ */
+export type PreviewModelDiffAlgorithm =
+  | {
+      kind: "sampled";
+      sampled: PreviewSampledRowDiff;
+      sampling_window: PreviewSamplingWindow;
+      [k: string]: unknown;
+    }
+  | {
+      bisection_stats: BisectionStatsOutput;
+      diff: PreviewBisectionRowDiff;
+      kind: "bisection";
+      [k: string]: unknown;
+    };
+
+/**
  * JSON output for `rocky preview diff`.
  *
- * Combines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a sampled row-level diff that extends the `rocky_core::compare`/`shadow` kernel.
+ * Combines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`"sampled"` or `"bisection"`) plus the matching payload.
  *
- * **Sampling correctness ceiling.** Phase 2 sampling reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs. `sampling_window.coverage_warning = true` flags this risk on the per-model level so reviewers don't infer false coverage. A checksum-bisection exhaustive diff is the Phase 2.5 lift.
+ * **Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.
  */
 export interface PreviewDiffOutput {
   base_ref: string;
@@ -26,12 +43,14 @@ export interface PreviewDiffOutput {
   [k: string]: unknown;
 }
 /**
- * Per-model diff. Combines structural (column-level) and sampled (row-level) findings.
+ * Per-model diff. Combines a structural (column-level) delta with a row-level diff that was produced by either the sampled or the checksum-bisection algorithm. The active algorithm is encoded by the `kind` discriminator on [`PreviewModelDiffAlgorithm`].
  */
 export interface PreviewModelDiff {
+  /**
+   * Row-level diff payload, tagged by which algorithm produced it. Different models in the same run can carry different variants: a model with a single-column integer primary key runs through the bisection kernel, while a model that lacks a usable PK falls back to the sampled algorithm.
+   */
+  algorithm: PreviewModelDiffAlgorithm;
   model_name: string;
-  sampled: PreviewSampledRowDiff;
-  sampling_window: PreviewSamplingWindow;
   structural: PreviewStructuralDiff;
   [k: string]: unknown;
 }
@@ -75,12 +94,59 @@ export interface PreviewRowSampleChange {
  */
 export interface PreviewSamplingWindow {
   /**
-   * One of `"first_n_by_order"` (Phase 2) or `"checksum_bisection"` (Phase 2.5 lift, not yet shipped).
+   * Sampling-strategy tag. `"first_n_by_order"` is the standard PK-ordered window; `"not_yet_sampled"` is a placeholder used when the sampling layer didn't run (e.g. the structural-only fallback path).
    */
   coverage: string;
   coverage_warning: boolean;
   limit: number;
   ordered_by: string;
+  [k: string]: unknown;
+}
+/**
+ * CLI-side mirror of [`rocky_core::compare::bisection::BisectionStats`]. Kept separate so the JSON schema lives alongside the rest of the `rocky preview diff` output types — same pattern as [`BudgetBreachOutput`] mirroring `rocky_core::config::BudgetBreach`.
+ */
+export interface BisectionStatsOutput {
+  /**
+   * Total non-empty chunk-checksum entries returned across both sides and all recursion levels.
+   */
+  chunks_examined: number;
+  /**
+   * `true` if the runner hit the `max_depth` cap before any chunk fell below the leaf threshold. The dense range was still materialized exhaustively, so the diff is correct — just slower.
+   */
+  depth_capped: boolean;
+  /**
+   * Maximum recursion depth reached.
+   */
+  depth_max: number;
+  /**
+   * Number of leaf chunks materialized for row-by-row diff.
+   */
+  leaves_materialized: number;
+  /**
+   * Rows on the base side whose primary-key column was NULL. Excluded from chunk membership; counted at the root so a null-PK divergence surfaces instead of silently dropping rows.
+   */
+  null_pk_rows_base: number;
+  /**
+   * Rows on the branch side whose primary-key column was NULL.
+   */
+  null_pk_rows_branch: number;
+  /**
+   * How the runner split the primary-key space into chunks. One of `"int_range"`, `"composite"`, `"hash_bucket"`, `"first_column"`.
+   */
+  split_strategy: string;
+  [k: string]: unknown;
+}
+/**
+ * Row-level diff produced by the checksum-bisection algorithm. All counts are exhaustive over the diffed table — no sampling window.
+ */
+export interface PreviewBisectionRowDiff {
+  rows_added: number;
+  rows_changed: number;
+  rows_removed: number;
+  /**
+   * Up to `--max-samples` (default 5) representative changed rows surfaced from the leaves. Bisection samples only carry the primary key — column-level diffs are not retained on the kernel's leaf record. Empty when no rows differ.
+   */
+  samples: PreviewRowSample[];
   [k: string]: unknown;
 }
 /**
@@ -109,7 +175,7 @@ export interface PreviewColumnTypeChange {
  */
 export interface PreviewDiffSummary {
   /**
-   * `true` if **any** per-model diff carries `sampling_window.coverage_warning = true`.
+   * `true` if **any** per-model diff is either a sampled diff with `sampling_window.coverage_warning = true` or a bisection diff with `bisection_stats.depth_capped = true`. Both conditions indicate the row-level findings might be incomplete and a reviewer shouldn't infer "no change" from a clean result.
    */
   any_coverage_warning: boolean;
   models_unchanged: number;

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`PreviewDiffOutput.models[*].algorithm` tagged enum (breaking JSON-shape restructure).** Per-model row-level diff is now carried in a `PreviewModelDiffAlgorithm` discriminated union with two variants: `{ "kind": "sampled", "sampled": …, "sampling_window": … }` and `{ "kind": "bisection", "diff": …, "bisection_stats": … }`. The legacy `model.sampled` and `model.sampling_window` fields move under `model.algorithm` — direct JSON consumers (shell scripts, custom dashboards) must migrate to `model.algorithm.sampled.*` / `model.algorithm.bisection.*` with a `kind` discriminator check. The dagster typed-resource layer absorbs the change automatically through `dagster_rocky.types_generated`; the VS Code extension's adapter regenerates via `just codegen` and stays consumer-clean. `summary.any_coverage_warning` keeps its name and widens semantically — it now fires on `Sampled { sampling_window.coverage_warning: true }` *or* `Bisection { bisection_stats.depth_capped: true }`. The `--algorithm=bisection` CLI flag (previously `tracing`-log-only) now surfaces results as the typed `Bisection` variant on the JSON output.
+
 ### Added
 
 - **Databricks checksum-bisection support.** `DatabricksSqlDialect::row_hash_expr` (`xxhash64(\`col_a\`, \`col_b\`, ...)` — Spark's multi-arg form, positional NULL-aware + type-aware, no `concat_ws` collision risk) and `DatabricksSqlDialect::quote_identifier` (backticks — works under both `ANSI_MODE = on` and `off`) plus a Databricks-specific `WarehouseAdapter::checksum_chunks` override land. The override emits Databricks-canonical SQL — backtick-quoted columns, `BIGINT` cast (Spark's native integer type), the `LEAST(K-1, FLOOR(...))` clamp matching the kernel's last-chunk-absorbs-remainder contract. Unit-tested via 5 new dialect tests; live verification gates merge — `tests/bisection_live.rs` is `#[ignore]`-gated and runs locally with `DATABRICKS_HOST` + `DATABRICKS_HTTP_PATH` + `DATABRICKS_TOKEN` + `DATABRICKS_TEST_CATALOG` set.

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -64,8 +64,11 @@ use crate::output::{
 ///    resolve its source schema from the model sidecar (`target.schema`),
 ///    issue `CREATE SCHEMA IF NOT EXISTS branch_schema` then
 ///    `CREATE OR REPLACE TABLE branch_schema.model AS SELECT * FROM
-///    source_schema.model`. Phase 5 lifts this to native warehouse
-///    clones (`SHALLOW CLONE` / zero-copy `CLONE`).
+///    source_schema.model`. Adapters with native zero-copy clone
+///    primitives (Databricks `SHALLOW CLONE`, Snowflake `CLONE`,
+///    BigQuery `CREATE TABLE … COPY`) override
+///    `WarehouseAdapter::clone_table_for_branch` to swap the CTAS for
+///    the cheaper metadata-only operation.
 ///
 /// Returns a [`PreviewCreateOutput`] regardless of partial failures —
 /// the PR-comment surface needs to stay informative.
@@ -211,19 +214,25 @@ pub async fn run_preview_create(
 // `rocky preview diff`
 // ---------------------------------------------------------------------------
 
-/// Structural + (deferred) sampled row-level diff between branch and base
-/// for every model that ran on both sides.
+/// Structural + row-level diff between branch and base for every model
+/// that ran on both sides.
 ///
-/// **Phase 2 scope.** Ships the *structural* layer — for each model that
-/// has a `RunRecord` against both the branch run and the base run, surface
-/// the row-count delta + bytes-scanned/written deltas with a deterministic
-/// Markdown rendering. Each model carries a [`PreviewSamplingWindow`] with
-/// `coverage = "not_yet_sampled"` and `coverage_warning = true` — honest
-/// flag that row-level samples don't run yet. Phase 2.5 lifts to
-/// checksum-bisection exhaustive diff (datafold-style) over the
-/// `rocky_core::compare` shadow kernel; until then, structural deltas
-/// catch row-count and byte-volume regressions, which is the most common
-/// failure mode the PR-comment surface needs to flag.
+/// **Default (`--algorithm=sampled`).** Surfaces the row-count delta +
+/// bytes-scanned/written deltas computed off the per-model `RunRecord`
+/// pair. Each model carries a [`PreviewSamplingWindow`] with
+/// `coverage = "not_yet_sampled"` and `coverage_warning = true` — an
+/// honest flag that the sampled algorithm doesn't read row content
+/// yet, so changes that don't shift row counts won't surface here.
+///
+/// **`--algorithm=bisection`.** Runs the checksum-bisection kernel
+/// (`rocky_core::compare::bisection`) for every model in the branch
+/// run that declares a single-column integer / numeric `unique_key`
+/// on a Merge strategy. Each qualifying model emits a
+/// [`PreviewBisectionRowDiff`] with rows_added/removed/changed and a
+/// [`crate::output::BisectionStatsOutput`] trace; models that don't
+/// qualify (composite key, non-numeric PK, non-Merge strategy) fall
+/// back to the sampled placeholder with a `tracing::warn` skip
+/// reason.
 ///
 /// **Why structural-only is useful.** `RunRecord` carries `rows_affected`
 /// and `bytes_scanned` per model from the live run path, so a
@@ -278,10 +287,39 @@ pub async fn run_preview_diff(
         }
     }
 
-    let (summary, models) = match (branch_run.as_ref(), base_run.as_ref()) {
+    let (mut summary, mut models) = match (branch_run.as_ref(), base_run.as_ref()) {
         (Some(b), Some(p)) => build_preview_diff(b, p),
         _ => (empty_diff_summary(), Vec::new()),
     };
+
+    // When bisection is selected, run the kernel for every qualifying
+    // model and replace its `algorithm = Sampled { ... }` payload with
+    // `algorithm = Bisection { ... }` in-place. Models that don't
+    // qualify (no single-column unique_key, etc.) keep the sampled
+    // placeholder. This must happen before markdown rendering and JSON
+    // serialization so both surface the chosen algorithm.
+    if matches!(algorithm, PreviewDiffAlgorithmSelector::Bisection) {
+        if let Some(branch_run) = branch_run.as_ref() {
+            apply_bisection_to_models(
+                config_path,
+                models_dir,
+                branch_name,
+                branch_run,
+                &mut models,
+            )
+            .await?;
+            // Re-roll the summary's `any_coverage_warning` with the
+            // widened semantic — true if any model is sampled with
+            // coverage_warning OR bisected with depth_capped.
+            summary.any_coverage_warning = compute_any_coverage_warning(&models);
+        } else {
+            info!(
+                "preview diff '{branch_name}': no branch run found in state store; \
+                 nothing to bisect"
+            );
+        }
+    }
+
     let markdown = render_preview_diff_markdown(branch_name, base_ref, &summary, &models);
 
     let out = PreviewDiffOutput::new(
@@ -301,39 +339,42 @@ pub async fn run_preview_diff(
         );
     }
 
-    // Bisection is opt-in via `--algorithm=bisection`. The result is
-    // logged via tracing today; the JSON output stays unchanged so this
-    // change doesn't ride the schema-cascade gate. The follow-up output-
-    // schema swap is tracked separately and folds the bisection result
-    // into the `PreviewModelDiff` shape.
-    if matches!(algorithm, PreviewDiffAlgorithmSelector::Bisection) {
-        if let Some(branch_run) = branch_run.as_ref() {
-            run_bisection_for_branch_run(config_path, models_dir, branch_name, branch_run).await?;
-        } else {
-            info!(
-                "preview diff '{branch_name}': no branch run found in state store; \
-                 nothing to bisect"
-            );
-        }
-    }
     Ok(())
 }
 
+/// Compute `any_coverage_warning` over a per-model diff list. True if
+/// any model is sampled with `coverage_warning = true` or bisected
+/// with `depth_capped = true`.
+fn compute_any_coverage_warning(models: &[crate::output::PreviewModelDiff]) -> bool {
+    use crate::output::PreviewModelDiffAlgorithm;
+    models.iter().any(|m| match &m.algorithm {
+        PreviewModelDiffAlgorithm::Sampled {
+            sampling_window, ..
+        } => sampling_window.coverage_warning,
+        PreviewModelDiffAlgorithm::Bisection {
+            bisection_stats, ..
+        } => bisection_stats.depth_capped,
+    })
+}
+
 /// Run checksum-bisection diff for every model in the branch run that
-/// has a single integer / numeric primary key. Emits one
-/// `tracing::info!` per model with the diff totals and stats; logs a
-/// `tracing::warn!` skip-reason for models whose strategy doesn't
-/// declare a usable PK.
+/// has a single integer / numeric primary key, then fold the result
+/// into the matching `PreviewModelDiff::algorithm` slot. Models whose
+/// sidecar strategy doesn't expose a usable PK keep their sampled
+/// placeholder and the function logs a `tracing::warn!` skip-reason.
 ///
-/// JSON output is unchanged in this PR — bisection results land via
-/// tracing only. The `PreviewModelDiff` schema swap that surfaces them
-/// as a typed field is its own change.
-async fn run_bisection_for_branch_run(
+/// Failures from the kernel surface as a `tracing::warn!` per model
+/// and the model retains the sampled placeholder — one bad model
+/// doesn't poison the whole preview.
+async fn apply_bisection_to_models(
     config_path: &Path,
     models_dir: &Path,
     branch_name: &str,
     branch_run: &rocky_core::state::RunRecord,
+    models_out: &mut [crate::output::PreviewModelDiff],
 ) -> Result<()> {
+    use crate::output::{PreviewBisectionRowDiff, PreviewModelDiffAlgorithm};
+
     let cfg = rocky_core::config::load_rocky_config(config_path)
         .with_context(|| format!("loading config from {}", config_path.display()))?;
     let registry = crate::registry::AdapterRegistry::from_config(&cfg)
@@ -356,6 +397,10 @@ async fn run_bisection_for_branch_run(
         .with_context(|| format!("loading models from {}", models_dir.display()))?;
     let model_by_name: BTreeMap<String, &rocky_core::models::Model> =
         models.iter().map(|m| (m.config.name.clone(), m)).collect();
+    let mut model_out_idx: HashMap<String, usize> = HashMap::new();
+    for (i, m) in models_out.iter().enumerate() {
+        model_out_idx.insert(m.model_name.clone(), i);
+    }
 
     let branch_schema = format!("branch__{branch_name}");
 
@@ -388,16 +433,89 @@ async fn run_bisection_for_branch_run(
             table: model.config.target.table.clone(),
         };
 
-        if let Err(e) = bisect_one_model(
+        let bisection_outcome = bisect_one_model(
             adapter.as_ref(),
             &model.config.name,
             &pk,
             &base_table,
             &branch_table,
         )
-        .await
-        {
-            tracing::warn!("bisection: model '{}' failed: {e}", executed.model_name,);
+        .await;
+        let outcome = match bisection_outcome {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                tracing::warn!("bisection: model '{}' failed: {e}", executed.model_name);
+                continue;
+            }
+        };
+
+        let Some(out_idx) = model_out_idx.get(&executed.model_name).copied() else {
+            // Model isn't in the structural diff list (no base
+            // execution to pair against). Surface via tracing so the
+            // result isn't silently lost.
+            tracing::info!(
+                target: "rocky::preview::bisection",
+                model = %executed.model_name,
+                "bisection result has no paired entry in the diff list; skipping fold-in"
+            );
+            continue;
+        };
+        let bisection_kind = outcome.kind_for_log();
+        match outcome {
+            BisectionOutcome::Ran { result } => {
+                let stats = crate::output::BisectionStatsOutput::from_kernel(&result.stats);
+                info!(
+                    target: "rocky::preview::bisection",
+                    model = %executed.model_name,
+                    rows_added = result.rows_added,
+                    rows_removed = result.rows_removed,
+                    rows_changed = result.rows_changed,
+                    chunks_examined = stats.chunks_examined,
+                    leaves_materialized = stats.leaves_materialized,
+                    depth_max = stats.depth_max,
+                    depth_capped = stats.depth_capped,
+                    null_pk_rows_base = stats.null_pk_rows_base,
+                    null_pk_rows_branch = stats.null_pk_rows_branch,
+                    "bisection complete",
+                );
+                let samples = result
+                    .samples
+                    .iter()
+                    .map(|s| crate::output::PreviewRowSample {
+                        primary_key: s.pk.clone(),
+                        // Bisection's leaf record only carries the PK;
+                        // per-column changes are not retained on
+                        // LeafRowSample. Surface an empty `changes`
+                        // list to match the existing PreviewRowSample
+                        // shape.
+                        changes: Vec::new(),
+                    })
+                    .collect::<Vec<_>>();
+                models_out[out_idx].algorithm = PreviewModelDiffAlgorithm::Bisection {
+                    diff: PreviewBisectionRowDiff {
+                        rows_added: result.rows_added,
+                        rows_removed: result.rows_removed,
+                        rows_changed: result.rows_changed,
+                        samples,
+                    },
+                    bisection_stats: stats,
+                };
+            }
+            BisectionOutcome::EmptyWindow => {
+                info!(
+                    target: "rocky::preview::bisection",
+                    model = %executed.model_name,
+                    outcome = bisection_kind,
+                    "bisection short-circuited; leaving sampled placeholder"
+                );
+            }
+            BisectionOutcome::NoColumns => {
+                tracing::warn!(
+                    target: "rocky::preview::bisection",
+                    model = %executed.model_name,
+                    "bisection: model has no non-PK columns; leaving sampled placeholder"
+                );
+            }
         }
     }
     Ok(())
@@ -416,15 +534,45 @@ fn single_column_pk(strategy: &rocky_core::models::StrategyConfig) -> Option<Str
     }
 }
 
+/// Outcome of a single-model bisection invocation. Surfaces the three
+/// terminal states the runner cares about so the caller can fold the
+/// result back onto the matching `PreviewModelDiff` (or skip it).
+enum BisectionOutcome {
+    /// Kernel ran end-to-end; carries the diff result for the caller
+    /// to fold into the preview output.
+    Ran {
+        result: rocky_core::compare::bisection::BisectionDiffResult,
+    },
+    /// Both sides reported an empty `[pk_lo, pk_hi)` window — nothing
+    /// to diff.
+    EmptyWindow,
+    /// `DESCRIBE TABLE` returned only the PK column. Without any
+    /// value columns there's nothing meaningful to hash; the runner
+    /// skips this model.
+    NoColumns,
+}
+
+impl BisectionOutcome {
+    fn kind_for_log(&self) -> &'static str {
+        match self {
+            BisectionOutcome::Ran { .. } => "ran",
+            BisectionOutcome::EmptyWindow => "empty_window",
+            BisectionOutcome::NoColumns => "no_columns",
+        }
+    }
+}
+
 /// Run bisection for one model pair: query MIN/MAX of the PK, discover
-/// non-PK columns via DESCRIBE TABLE, and invoke the kernel.
+/// non-PK columns via DESCRIBE TABLE, and invoke the kernel. Returns a
+/// [`BisectionOutcome`] so the caller can decide what to surface in
+/// the preview output.
 async fn bisect_one_model(
     adapter: &dyn rocky_core::traits::WarehouseAdapter,
     model_name: &str,
     pk_column: &str,
     base_table: &rocky_core::ir::TableRef,
     branch_table: &rocky_core::ir::TableRef,
-) -> Result<()> {
+) -> Result<BisectionOutcome> {
     use rocky_core::compare::bisection::{BisectionConfig, BisectionTarget, bisection_diff};
 
     let (pk_lo, pk_hi) = pk_window(adapter, base_table, branch_table, pk_column)
@@ -435,15 +583,14 @@ async fn bisect_one_model(
             "bisection: model '{model_name}' has empty PK window [{pk_lo}, {pk_hi}); \
              nothing to diff"
         );
-        return Ok(());
+        return Ok(BisectionOutcome::EmptyWindow);
     }
 
     let columns = describe_value_columns(adapter, branch_table, base_table, pk_column)
         .await
         .with_context(|| format!("DESCRIBE TABLE for '{model_name}'"))?;
     if columns.is_empty() {
-        tracing::warn!("bisection: model '{model_name}' has no non-PK columns; skipping");
-        return Ok(());
+        return Ok(BisectionOutcome::NoColumns);
     }
 
     let target = BisectionTarget {
@@ -459,21 +606,7 @@ async fn bisect_one_model(
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
-    info!(
-        target: "rocky::preview::bisection",
-        model = model_name,
-        rows_added = result.rows_added,
-        rows_removed = result.rows_removed,
-        rows_changed = result.rows_changed,
-        chunks_examined = result.stats.chunks_examined,
-        leaves_materialized = result.stats.leaves_materialized,
-        depth_max = result.stats.depth_max,
-        depth_capped = result.stats.depth_capped,
-        null_pk_rows_base = result.stats.null_pk_rows_base,
-        null_pk_rows_branch = result.stats.null_pk_rows_branch,
-        "bisection complete",
-    );
-    Ok(())
+    Ok(BisectionOutcome::Ran { result })
 }
 
 /// Resolve `[lo, hi)` over the union of base + branch PK ranges.
@@ -587,14 +720,15 @@ fn build_preview_diff(
     Vec<crate::output::PreviewModelDiff>,
 ) {
     use crate::output::{
-        PreviewModelDiff, PreviewSampledRowDiff, PreviewSamplingWindow, PreviewStructuralDiff,
+        PreviewModelDiff, PreviewModelDiffAlgorithm, PreviewSampledRowDiff, PreviewSamplingWindow,
+        PreviewStructuralDiff,
     };
 
     let mut models: Vec<PreviewModelDiff> = Vec::new();
     let mut models_with_changes: usize = 0;
     let mut total_rows_added: u64 = 0;
     let mut total_rows_removed: u64 = 0;
-    let total_rows_changed: u64 = 0; // sampled-only; always 0 in Phase 2
+    let total_rows_changed: u64 = 0; // sampled-only; always 0 by default
 
     // Index base executions by model name for O(N) pairing.
     let base_by_name: BTreeMap<&str, &rocky_core::state::ModelExecution> = base
@@ -607,7 +741,7 @@ fn build_preview_diff(
         let base_exec = base_by_name.get(branch_exec.model_name.as_str()).copied();
 
         // Row delta: signed difference of `rows_affected`. None on either
-        // side surfaces as zero — the sampled layer (Phase 2.5) catches
+        // side surfaces as zero — the row-content layer catches
         // unreported row changes.
         let branch_rows = branch_exec.rows_affected.unwrap_or(0);
         let base_rows = base_exec.and_then(|e| e.rows_affected).unwrap_or(0);
@@ -627,29 +761,35 @@ fn build_preview_diff(
             // Structural column-level delta is an open follow-up — the
             // RunRecord doesn't persist column lists today, and the
             // compiler-IR-driven path requires both runs to be
-            // re-compiled (heavy). Phase 2.5 wires this; until then,
-            // empty arrays make the absence explicit on the wire.
+            // re-compiled (heavy). Empty arrays make the absence
+            // explicit on the wire.
             structural: PreviewStructuralDiff {
                 added_columns: Vec::new(),
                 removed_columns: Vec::new(),
                 type_changes: Vec::new(),
             },
-            sampled: PreviewSampledRowDiff {
-                rows_added,
-                rows_removed,
-                rows_changed: 0,
-                samples: Vec::new(),
-            },
-            sampling_window: PreviewSamplingWindow {
-                ordered_by: String::new(),
-                limit: 0,
-                // `coverage_warning = true` is honest: row content
-                // changes that don't change row counts will not
-                // surface in this diff. The PR-comment surface
-                // renders this verbatim so reviewers don't infer
-                // false coverage.
-                coverage: "not_yet_sampled".to_string(),
-                coverage_warning: true,
+            // Default to the sampled placeholder. The bisection runner
+            // overwrites this slot in `apply_bisection_to_models` for
+            // every qualifying model when `--algorithm=bisection` is
+            // selected.
+            algorithm: PreviewModelDiffAlgorithm::Sampled {
+                sampled: PreviewSampledRowDiff {
+                    rows_added,
+                    rows_removed,
+                    rows_changed: 0,
+                    samples: Vec::new(),
+                },
+                sampling_window: PreviewSamplingWindow {
+                    ordered_by: String::new(),
+                    limit: 0,
+                    // `coverage_warning = true` is honest: row content
+                    // changes that don't change row counts will not
+                    // surface in this diff. The PR-comment surface
+                    // renders this verbatim so reviewers don't infer
+                    // false coverage.
+                    coverage: "not_yet_sampled".to_string(),
+                    coverage_warning: true,
+                },
             },
         });
     }
@@ -674,6 +814,8 @@ fn render_preview_diff_markdown(
     summary: &crate::output::PreviewDiffSummary,
     models: &[crate::output::PreviewModelDiff],
 ) -> String {
+    use crate::output::PreviewModelDiffAlgorithm;
+
     if models.is_empty() {
         return format!(
             "**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n\
@@ -681,6 +823,11 @@ fn render_preview_diff_markdown(
              on the prune set, then re-invoke `rocky preview diff`._\n"
         );
     }
+
+    let any_bisection = models
+        .iter()
+        .any(|m| matches!(m.algorithm, PreviewModelDiffAlgorithm::Bisection { .. }));
+
     let mut out = String::new();
     out.push_str(&format!(
         "**Preview diff** — branch `{branch_name}` vs `{base_ref}`\n\n\
@@ -690,23 +837,91 @@ fn render_preview_diff_markdown(
         summary.total_rows_added,
         summary.total_rows_removed,
     ));
-    out.push_str("| model | +rows | −rows | sampled? |\n|---|---:|---:|---|\n");
-    for m in models {
-        let sampled = if m.sampling_window.coverage_warning {
-            ":warning: not yet sampled"
-        } else {
-            ":white_check_mark: sampled"
-        };
-        out.push_str(&format!(
-            "| `{}` | {} | {} | {} |\n",
-            m.model_name, m.sampled.rows_added, m.sampled.rows_removed, sampled,
-        ));
+
+    if any_bisection {
+        // Wider table — bisection rows have ~rows + chunks_examined +
+        // leaves_materialized + depth_max columns that the sampled
+        // table doesn't carry. Render every row in this layout for
+        // consistency; sampled rows leave the bisection-only columns
+        // blank.
+        out.push_str(
+            "| model | algorithm | +rows | −rows | ~rows | chunks | leaves | depth | notes |\n\
+             |---|---|---:|---:|---:|---:|---:|---:|---|\n",
+        );
+        for m in models {
+            match &m.algorithm {
+                PreviewModelDiffAlgorithm::Sampled {
+                    sampled,
+                    sampling_window,
+                } => {
+                    let note = if sampling_window.coverage_warning {
+                        ":warning: not yet sampled"
+                    } else {
+                        ":white_check_mark: sampled"
+                    };
+                    out.push_str(&format!(
+                        "| `{}` | sampled | {} | {} | 0 | — | — | — | {} |\n",
+                        m.model_name, sampled.rows_added, sampled.rows_removed, note,
+                    ));
+                }
+                PreviewModelDiffAlgorithm::Bisection {
+                    diff,
+                    bisection_stats,
+                } => {
+                    let note = if bisection_stats.depth_capped {
+                        ":warning: depth-capped"
+                    } else {
+                        ":white_check_mark: exhaustive"
+                    };
+                    out.push_str(&format!(
+                        "| `{}` | bisection | {} | {} | {} | {} | {} | {} | {} |\n",
+                        m.model_name,
+                        diff.rows_added,
+                        diff.rows_removed,
+                        diff.rows_changed,
+                        bisection_stats.chunks_examined,
+                        bisection_stats.leaves_materialized,
+                        bisection_stats.depth_max,
+                        note,
+                    ));
+                }
+            }
+        }
+    } else {
+        out.push_str("| model | +rows | −rows | sampled? |\n|---|---:|---:|---|\n");
+        for m in models {
+            let (rows_added, rows_removed, note) = match &m.algorithm {
+                PreviewModelDiffAlgorithm::Sampled {
+                    sampled,
+                    sampling_window,
+                } => {
+                    let note = if sampling_window.coverage_warning {
+                        ":warning: not yet sampled"
+                    } else {
+                        ":white_check_mark: sampled"
+                    };
+                    (sampled.rows_added, sampled.rows_removed, note)
+                }
+                PreviewModelDiffAlgorithm::Bisection { .. } => {
+                    // unreachable in this branch — `any_bisection` is
+                    // false here. Defensive fallback so the renderer
+                    // doesn't panic if invariants change.
+                    (0, 0, ":white_check_mark: exhaustive")
+                }
+            };
+            out.push_str(&format!(
+                "| `{}` | {} | {} | {} |\n",
+                m.model_name, rows_added, rows_removed, note,
+            ));
+        }
     }
+
     if summary.any_coverage_warning {
         out.push_str(
-            "\n> :warning: Row-content changes that don't move row counts \
-             are not surfaced in this diff. Phase 2.5 lifts to \
-             checksum-bisection exhaustive sampling.\n",
+            "\n> :warning: Row-content changes might not be fully surfaced. \
+             Sampled diffs miss content drift outside the sampling window; \
+             bisection diffs depth-capped on this run reached the recursion \
+             limit before bottoming out.\n",
         );
     }
     out
@@ -720,11 +935,13 @@ fn render_preview_diff_markdown(
 /// over `rocky cost latest`'s machinery — does not introduce new cost
 /// math.
 ///
-/// **Phase 3 scope.** Resolves the latest branch run and the most recent
-/// non-branch run from the state store, computes per-model deltas via
-/// `compute_observed_cost_usd` (the same formula `rocky cost` uses), and
-/// emits a `PreviewCostOutput`. Models on base but not on branch roll
-/// into `models_skipped_via_copy` + `savings_from_copy_usd`.
+/// Resolves the latest branch run and the most recent non-branch run
+/// from the state store, computes per-model deltas via
+/// `compute_observed_cost_usd` (the same formula `rocky cost` uses),
+/// and emits a `PreviewCostOutput`. Models on base but not on branch
+/// roll into `models_skipped_via_copy` + `savings_from_copy_usd`.
+/// Projected `[budget]` breaches against the branch totals land on
+/// `projected_budget_breaches` when a budget is configured.
 pub async fn run_preview_cost(
     config_path: &Path,
     state_path: &Path,
@@ -1679,8 +1896,11 @@ mod tests {
 
     /// Coverage-warning path: the sampling-window field surfaces verbatim
     /// in the per-model diff, even when the sampled deltas are zero.
+    /// Also pins the tagged-enum discriminator (`"kind":"sampled"`) on
+    /// the JSON wire — the schema-cascade pipeline relies on this.
     #[test]
     fn sampling_window_surfaces_coverage_warning() {
+        use crate::output::PreviewModelDiffAlgorithm;
         let m = PreviewModelDiff {
             model_name: "wide_table".into(),
             structural: PreviewStructuralDiff {
@@ -1688,22 +1908,65 @@ mod tests {
                 removed_columns: vec![],
                 type_changes: vec![],
             },
-            sampled: PreviewSampledRowDiff {
-                rows_added: 0,
-                rows_removed: 0,
-                rows_changed: 0,
-                samples: vec![],
-            },
-            sampling_window: PreviewSamplingWindow {
-                ordered_by: "id".into(),
-                limit: 1000,
-                coverage: "first_n_by_order".into(),
-                coverage_warning: true,
+            algorithm: PreviewModelDiffAlgorithm::Sampled {
+                sampled: PreviewSampledRowDiff {
+                    rows_added: 0,
+                    rows_removed: 0,
+                    rows_changed: 0,
+                    samples: vec![],
+                },
+                sampling_window: PreviewSamplingWindow {
+                    ordered_by: "id".into(),
+                    limit: 1000,
+                    coverage: "first_n_by_order".into(),
+                    coverage_warning: true,
+                },
             },
         };
         let s = serde_json::to_string(&m).unwrap();
         assert!(s.contains("\"coverage_warning\":true"));
         assert!(s.contains("\"first_n_by_order\""));
+        assert!(s.contains("\"kind\":\"sampled\""));
+    }
+
+    /// The bisection arm of `PreviewModelDiffAlgorithm` round-trips
+    /// through serde with the tagged-enum discriminator + the
+    /// bisection_stats payload intact.
+    #[test]
+    fn bisection_arm_surfaces_stats() {
+        use crate::output::{
+            BisectionStatsOutput, PreviewBisectionRowDiff, PreviewModelDiffAlgorithm,
+        };
+        let m = PreviewModelDiff {
+            model_name: "fct_revenue".into(),
+            structural: PreviewStructuralDiff {
+                added_columns: vec![],
+                removed_columns: vec![],
+                type_changes: vec![],
+            },
+            algorithm: PreviewModelDiffAlgorithm::Bisection {
+                diff: PreviewBisectionRowDiff {
+                    rows_added: 1,
+                    rows_removed: 0,
+                    rows_changed: 2,
+                    samples: vec![],
+                },
+                bisection_stats: BisectionStatsOutput {
+                    chunks_examined: 96,
+                    leaves_materialized: 1,
+                    depth_max: 2,
+                    depth_capped: false,
+                    split_strategy: "int_range".into(),
+                    null_pk_rows_base: 0,
+                    null_pk_rows_branch: 0,
+                },
+            },
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        assert!(s.contains("\"kind\":\"bisection\""));
+        assert!(s.contains("\"chunks_examined\":96"));
+        assert!(s.contains("\"split_strategy\":\"int_range\""));
+        assert!(s.contains("\"rows_changed\":2"));
     }
 
     /// Sample row roundtrips cleanly — sanity check on the nested struct.
@@ -1861,7 +2124,7 @@ mod tests {
         assert_eq!(out, vec!["foo.sql", "bar.toml", "baz"]);
     }
 
-    // ---------------------- Phase 2 + Phase 3 substance ----------------------
+    // ---------------------- diff + cost substance ----------------------
 
     use rocky_core::state::{ModelExecution, RunRecord, RunStatus, RunTrigger, SessionSource};
 
@@ -1933,24 +2196,38 @@ mod tests {
         assert!(summary.any_coverage_warning);
         let by_name: HashMap<&str, &crate::output::PreviewModelDiff> =
             models.iter().map(|m| (m.model_name.as_str(), m)).collect();
-        assert_eq!(by_name["a"].sampled.rows_added, 10);
-        assert_eq!(by_name["a"].sampled.rows_removed, 0);
-        assert_eq!(by_name["b"].sampled.rows_added, 0);
-        assert_eq!(by_name["b"].sampled.rows_removed, 10);
+        let sampled = |m: &crate::output::PreviewModelDiff| -> (u64, u64) {
+            match &m.algorithm {
+                crate::output::PreviewModelDiffAlgorithm::Sampled { sampled, .. } => {
+                    (sampled.rows_added, sampled.rows_removed)
+                }
+                _ => panic!("expected sampled arm"),
+            }
+        };
+        assert_eq!(sampled(by_name["a"]), (10, 0));
+        assert_eq!(sampled(by_name["b"]), (0, 10));
     }
 
     /// Identical row counts → no changes; coverage_warning still fires
-    /// because Phase 2 didn't sample contents.
+    /// because the structural-only fallback didn't sample contents.
     #[test]
     fn diff_no_change_still_warns_about_coverage() {
+        use crate::output::PreviewModelDiffAlgorithm;
         let branch = run_record("br", vec![exec("a", 100, Some(100), None)], Some("feature"));
         let base = run_record("ba", vec![exec("a", 100, Some(100), None)], None);
         let (summary, models) = build_preview_diff(&branch, &base);
         assert_eq!(summary.models_with_changes, 0);
         assert_eq!(summary.models_unchanged, 1);
         assert!(summary.any_coverage_warning);
-        assert!(models[0].sampling_window.coverage_warning);
-        assert_eq!(models[0].sampling_window.coverage, "not_yet_sampled");
+        match &models[0].algorithm {
+            PreviewModelDiffAlgorithm::Sampled {
+                sampling_window, ..
+            } => {
+                assert!(sampling_window.coverage_warning);
+                assert_eq!(sampling_window.coverage, "not_yet_sampled");
+            }
+            _ => panic!("expected sampled arm by default"),
+        }
     }
 
     /// Cost delta on paired models: branch faster than base → negative
@@ -2108,7 +2385,9 @@ mod tests {
         assert!(md.contains("| `a` |"));
         assert!(md.contains("| `b` |"));
         assert!(md.contains("not yet sampled"));
-        assert!(md.contains("Phase 2.5"));
+        // Coverage-warning hint surfaces on the structural-only fallback
+        // path. Wording is generic — no internal phase labels.
+        assert!(md.contains("might not be fully surfaced"));
     }
 
     /// Empty diff path produces a "no paired runs" hint, not an empty

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3737,15 +3737,21 @@ pub struct PreviewCopiedModel {
 /// JSON output for `rocky preview diff`.
 ///
 /// Combines the structural diff (column added/removed/type-changed) from
-/// the existing `rocky_core::ci_diff` machinery with a sampled row-level
-/// diff that extends the `rocky_core::compare`/`shadow` kernel.
+/// the existing `rocky_core::ci_diff` machinery with a row-level diff
+/// produced by either the sampled or the checksum-bisection algorithm.
+/// Each per-model entry's `algorithm` field carries a `kind`
+/// discriminator (`"sampled"` or `"bisection"`) plus the matching
+/// payload.
 ///
-/// **Sampling correctness ceiling.** Phase 2 sampling reads `LIMIT N`
-/// rows ordered by primary key (or first column). Changes outside that
-/// window appear as no-change unless the row count itself differs.
-/// `sampling_window.coverage_warning = true` flags this risk on the
-/// per-model level so reviewers don't infer false coverage. A
-/// checksum-bisection exhaustive diff is the Phase 2.5 lift.
+/// **Sampled correctness ceiling.** The sampled algorithm reads
+/// `LIMIT N` rows ordered by primary key (or first column). Changes
+/// outside that window appear as no-change unless the row count itself
+/// differs; `sampling_window.coverage_warning = true` flags that risk.
+/// **Bisection** walks the chunk lattice exhaustively over a
+/// single-column primary key; `bisection_stats.depth_capped = true`
+/// flags the rare case where the recursion bottomed out at the depth
+/// cap before reaching leaf size. `summary.any_coverage_warning` rolls
+/// both signals up.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PreviewDiffOutput {
     pub version: String,
@@ -3766,19 +3772,120 @@ pub struct PreviewDiffSummary {
     pub total_rows_added: u64,
     pub total_rows_removed: u64,
     pub total_rows_changed: u64,
-    /// `true` if **any** per-model diff carries
-    /// `sampling_window.coverage_warning = true`.
+    /// `true` if **any** per-model diff is either a sampled diff with
+    /// `sampling_window.coverage_warning = true` or a bisection diff
+    /// with `bisection_stats.depth_capped = true`. Both conditions
+    /// indicate the row-level findings might be incomplete and a
+    /// reviewer shouldn't infer "no change" from a clean result.
     pub any_coverage_warning: bool,
 }
 
-/// Per-model diff. Combines structural (column-level) and sampled
-/// (row-level) findings.
+/// Per-model diff. Combines a structural (column-level) delta with a
+/// row-level diff that was produced by either the sampled or the
+/// checksum-bisection algorithm. The active algorithm is encoded by the
+/// `kind` discriminator on [`PreviewModelDiffAlgorithm`].
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PreviewModelDiff {
     pub model_name: String,
     pub structural: PreviewStructuralDiff,
-    pub sampled: PreviewSampledRowDiff,
-    pub sampling_window: PreviewSamplingWindow,
+    /// Row-level diff payload, tagged by which algorithm produced it.
+    /// Different models in the same run can carry different variants:
+    /// a model with a single-column integer primary key runs through
+    /// the bisection kernel, while a model that lacks a usable PK
+    /// falls back to the sampled algorithm.
+    pub algorithm: PreviewModelDiffAlgorithm,
+}
+
+/// Row-level diff payload tagged by which algorithm produced it. The
+/// `kind` discriminator (`"sampled"` or `"bisection"`) lets consumers
+/// reading the JSON pick the right shape without having to check
+/// optional fields.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PreviewModelDiffAlgorithm {
+    /// Sampled diff — `LIMIT N` rows ordered by primary key (or first
+    /// column). Carries a coverage warning when changes outside the
+    /// sampling window are not surfaced.
+    Sampled {
+        sampled: PreviewSampledRowDiff,
+        sampling_window: PreviewSamplingWindow,
+    },
+    /// Checksum-bisection exhaustive diff. Walks the chunk lattice and
+    /// materializes leaves for row-by-row compare. Carries
+    /// [`BisectionStatsOutput`] so consumers can audit the recursion
+    /// trace.
+    Bisection {
+        diff: PreviewBisectionRowDiff,
+        bisection_stats: BisectionStatsOutput,
+    },
+}
+
+/// Row-level diff produced by the checksum-bisection algorithm. All
+/// counts are exhaustive over the diffed table — no sampling window.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PreviewBisectionRowDiff {
+    pub rows_added: u64,
+    pub rows_removed: u64,
+    pub rows_changed: u64,
+    /// Up to `--max-samples` (default 5) representative changed rows
+    /// surfaced from the leaves. Bisection samples only carry the
+    /// primary key — column-level diffs are not retained on the
+    /// kernel's leaf record. Empty when no rows differ.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub samples: Vec<PreviewRowSample>,
+}
+
+/// CLI-side mirror of [`rocky_core::compare::bisection::BisectionStats`].
+/// Kept separate so the JSON schema lives alongside the rest of the
+/// `rocky preview diff` output types — same pattern as
+/// [`BudgetBreachOutput`] mirroring `rocky_core::config::BudgetBreach`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct BisectionStatsOutput {
+    /// Total non-empty chunk-checksum entries returned across both
+    /// sides and all recursion levels.
+    pub chunks_examined: u64,
+    /// Number of leaf chunks materialized for row-by-row diff.
+    pub leaves_materialized: u64,
+    /// Maximum recursion depth reached.
+    pub depth_max: u32,
+    /// `true` if the runner hit the `max_depth` cap before any chunk
+    /// fell below the leaf threshold. The dense range was still
+    /// materialized exhaustively, so the diff is correct — just slower.
+    pub depth_capped: bool,
+    /// How the runner split the primary-key space into chunks. One of
+    /// `"int_range"`, `"composite"`, `"hash_bucket"`, `"first_column"`.
+    pub split_strategy: String,
+    /// Rows on the base side whose primary-key column was NULL.
+    /// Excluded from chunk membership; counted at the root so a
+    /// null-PK divergence surfaces instead of silently dropping rows.
+    pub null_pk_rows_base: u64,
+    /// Rows on the branch side whose primary-key column was NULL.
+    pub null_pk_rows_branch: u64,
+}
+
+impl BisectionStatsOutput {
+    /// Mirror a [`rocky_core::compare::bisection::BisectionStats`] into
+    /// the CLI-side output shape. The `split_strategy` enum is
+    /// flattened to its serde wire tag so the JSON schema doesn't have
+    /// to drag the rocky-core enum through `JsonSchema`.
+    pub fn from_kernel(stats: &rocky_core::compare::bisection::BisectionStats) -> Self {
+        let split_strategy = match stats.split_strategy {
+            rocky_core::traits::SplitStrategy::IntRange => "int_range",
+            rocky_core::traits::SplitStrategy::Composite => "composite",
+            rocky_core::traits::SplitStrategy::HashBucket => "hash_bucket",
+            rocky_core::traits::SplitStrategy::FirstColumn => "first_column",
+        }
+        .to_string();
+        BisectionStatsOutput {
+            chunks_examined: stats.chunks_examined,
+            leaves_materialized: stats.leaves_materialized,
+            depth_max: stats.depth_max,
+            depth_capped: stats.depth_capped,
+            split_strategy,
+            null_pk_rows_base: stats.null_pk_rows_base,
+            null_pk_rows_branch: stats.null_pk_rows_branch,
+        }
+    }
 }
 
 /// Column-level structural diff. Mirrors the shape produced by
@@ -3841,8 +3948,10 @@ pub struct PreviewRowSampleChange {
 pub struct PreviewSamplingWindow {
     pub ordered_by: String,
     pub limit: usize,
-    /// One of `"first_n_by_order"` (Phase 2) or `"checksum_bisection"`
-    /// (Phase 2.5 lift, not yet shipped).
+    /// Sampling-strategy tag. `"first_n_by_order"` is the standard
+    /// PK-ordered window; `"not_yet_sampled"` is a placeholder used
+    /// when the sampling layer didn't run (e.g. the structural-only
+    /// fallback path).
     pub coverage: String,
     pub coverage_warning: bool,
 }

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -3,7 +3,44 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from pydantic import BaseModel, Field, conint
+
+
+class BisectionStatsOutput(BaseModel):
+    """
+    CLI-side mirror of [`rocky_core::compare::bisection::BisectionStats`]. Kept separate so the JSON schema lives alongside the rest of the `rocky preview diff` output types — same pattern as [`BudgetBreachOutput`] mirroring `rocky_core::config::BudgetBreach`.
+    """
+
+    chunks_examined: conint(ge=0)
+    """
+    Total non-empty chunk-checksum entries returned across both sides and all recursion levels.
+    """
+    depth_capped: bool
+    """
+    `true` if the runner hit the `max_depth` cap before any chunk fell below the leaf threshold. The dense range was still materialized exhaustively, so the diff is correct — just slower.
+    """
+    depth_max: conint(ge=0)
+    """
+    Maximum recursion depth reached.
+    """
+    leaves_materialized: conint(ge=0)
+    """
+    Number of leaf chunks materialized for row-by-row diff.
+    """
+    null_pk_rows_base: conint(ge=0)
+    """
+    Rows on the base side whose primary-key column was NULL. Excluded from chunk membership; counted at the root so a null-PK divergence surfaces instead of silently dropping rows.
+    """
+    null_pk_rows_branch: conint(ge=0)
+    """
+    Rows on the branch side whose primary-key column was NULL.
+    """
+    split_strategy: str
+    """
+    How the runner split the primary-key space into chunks. One of `"int_range"`, `"composite"`, `"hash_bucket"`, `"first_column"`.
+    """
 
 
 class PreviewColumnTypeChange(BaseModel):
@@ -23,13 +60,21 @@ class PreviewDiffSummary(BaseModel):
 
     any_coverage_warning: bool
     """
-    `true` if **any** per-model diff carries `sampling_window.coverage_warning = true`.
+    `true` if **any** per-model diff is either a sampled diff with `sampling_window.coverage_warning = true` or a bisection diff with `bisection_stats.depth_capped = true`. Both conditions indicate the row-level findings might be incomplete and a reviewer shouldn't infer "no change" from a clean result.
     """
     models_unchanged: conint(ge=0)
     models_with_changes: conint(ge=0)
     total_rows_added: conint(ge=0)
     total_rows_changed: conint(ge=0)
     total_rows_removed: conint(ge=0)
+
+
+class Kind(StrEnum):
+    sampled = "sampled"
+
+
+class Kind1(StrEnum):
+    bisection = "bisection"
 
 
 class PreviewRowSampleChange(BaseModel):
@@ -51,7 +96,7 @@ class PreviewSamplingWindow(BaseModel):
 
     coverage: str
     """
-    One of `"first_n_by_order"` (Phase 2) or `"checksum_bisection"` (Phase 2.5 lift, not yet shipped).
+    Sampling-strategy tag. `"first_n_by_order"` is the standard PK-ordered window; `"not_yet_sampled"` is a placeholder used when the sampling layer didn't run (e.g. the structural-only fallback path).
     """
     coverage_warning: bool
     limit: conint(ge=0)
@@ -97,14 +142,50 @@ class PreviewSampledRowDiff(BaseModel):
     """
 
 
-class PreviewModelDiff(BaseModel):
+class PreviewBisectionRowDiff(BaseModel):
     """
-    Per-model diff. Combines structural (column-level) and sampled (row-level) findings.
+    Row-level diff produced by the checksum-bisection algorithm. All counts are exhaustive over the diffed table — no sampling window.
     """
 
-    model_name: str
+    rows_added: conint(ge=0)
+    rows_changed: conint(ge=0)
+    rows_removed: conint(ge=0)
+    samples: list[PreviewRowSample]
+    """
+    Up to `--max-samples` (default 5) representative changed rows surfaced from the leaves. Bisection samples only carry the primary key — column-level diffs are not retained on the kernel's leaf record. Empty when no rows differ.
+    """
+
+
+class PreviewModelDiffAlgorithm1(BaseModel):
+    """
+    Phase 2 sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.
+    """
+
+    kind: Kind
     sampled: PreviewSampledRowDiff
     sampling_window: PreviewSamplingWindow
+
+
+class PreviewModelDiffAlgorithm2(BaseModel):
+    """
+    Checksum-bisection exhaustive diff. Walks the chunk lattice and materializes leaves for row-by-row compare. Carries [`BisectionStatsOutput`] so consumers can audit the recursion trace.
+    """
+
+    bisection_stats: BisectionStatsOutput
+    diff: PreviewBisectionRowDiff
+    kind: Kind1
+
+
+class PreviewModelDiff(BaseModel):
+    """
+    Per-model diff. Combines a structural (column-level) delta with a row-level diff that was produced by either the sampled or the checksum-bisection algorithm. The active algorithm is encoded by the `kind` discriminator on [`PreviewModelDiffAlgorithm`].
+    """
+
+    algorithm: PreviewModelDiffAlgorithm1 | PreviewModelDiffAlgorithm2
+    """
+    Row-level diff payload, tagged by which algorithm produced it. Different models in the same run can carry different variants: a model with a single-column integer primary key runs through the bisection kernel, while a model that lacks a usable PK falls back to the sampled algorithm.
+    """
+    model_name: str
     structural: PreviewStructuralDiff
 
 
@@ -112,9 +193,9 @@ class PreviewDiffOutput(BaseModel):
     """
     JSON output for `rocky preview diff`.
 
-    Combines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a sampled row-level diff that extends the `rocky_core::compare`/`shadow` kernel.
+    Combines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`"sampled"` or `"bisection"`) plus the matching payload.
 
-    **Sampling correctness ceiling.** Phase 2 sampling reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs. `sampling_window.coverage_warning = true` flags this risk on the per-model level so reviewers don't infer false coverage. A checksum-bisection exhaustive diff is the Phase 2.5 lift.
+    **Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.
     """
 
     base_ref: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -158,7 +158,7 @@ class PreviewBisectionRowDiff(BaseModel):
 
 class PreviewModelDiffAlgorithm1(BaseModel):
     """
-    Phase 2 sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.
+    Sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.
     """
 
     kind: Kind

--- a/schemas/preview_diff.schema.json
+++ b/schemas/preview_diff.schema.json
@@ -180,7 +180,7 @@
       "description": "Row-level diff payload tagged by which algorithm produced it. The `kind` discriminator (`\"sampled\"` or `\"bisection\"`) lets consumers reading the JSON pick the right shape without having to check optional fields.",
       "oneOf": [
         {
-          "description": "Phase 2 sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.",
+          "description": "Sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.",
           "properties": {
             "kind": {
               "enum": [

--- a/schemas/preview_diff.schema.json
+++ b/schemas/preview_diff.schema.json
@@ -1,6 +1,93 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BisectionStatsOutput": {
+      "description": "CLI-side mirror of [`rocky_core::compare::bisection::BisectionStats`]. Kept separate so the JSON schema lives alongside the rest of the `rocky preview diff` output types — same pattern as [`BudgetBreachOutput`] mirroring `rocky_core::config::BudgetBreach`.",
+      "properties": {
+        "chunks_examined": {
+          "description": "Total non-empty chunk-checksum entries returned across both sides and all recursion levels.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "depth_capped": {
+          "description": "`true` if the runner hit the `max_depth` cap before any chunk fell below the leaf threshold. The dense range was still materialized exhaustively, so the diff is correct — just slower.",
+          "type": "boolean"
+        },
+        "depth_max": {
+          "description": "Maximum recursion depth reached.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "leaves_materialized": {
+          "description": "Number of leaf chunks materialized for row-by-row diff.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "null_pk_rows_base": {
+          "description": "Rows on the base side whose primary-key column was NULL. Excluded from chunk membership; counted at the root so a null-PK divergence surfaces instead of silently dropping rows.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "null_pk_rows_branch": {
+          "description": "Rows on the branch side whose primary-key column was NULL.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "split_strategy": {
+          "description": "How the runner split the primary-key space into chunks. One of `\"int_range\"`, `\"composite\"`, `\"hash_bucket\"`, `\"first_column\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "chunks_examined",
+        "depth_capped",
+        "depth_max",
+        "leaves_materialized",
+        "null_pk_rows_base",
+        "null_pk_rows_branch",
+        "split_strategy"
+      ],
+      "type": "object"
+    },
+    "PreviewBisectionRowDiff": {
+      "description": "Row-level diff produced by the checksum-bisection algorithm. All counts are exhaustive over the diffed table — no sampling window.",
+      "properties": {
+        "rows_added": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "rows_changed": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "rows_removed": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "samples": {
+          "description": "Up to `--max-samples` (default 5) representative changed rows surfaced from the leaves. Bisection samples only carry the primary key — column-level diffs are not retained on the kernel's leaf record. Empty when no rows differ.",
+          "items": {
+            "$ref": "#/definitions/PreviewRowSample"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "rows_added",
+        "rows_changed",
+        "rows_removed",
+        "samples"
+      ],
+      "type": "object"
+    },
     "PreviewColumnTypeChange": {
       "description": "One column-type change entry.",
       "properties": {
@@ -25,7 +112,7 @@
       "description": "Aggregate diff counts for [`PreviewDiffOutput`].",
       "properties": {
         "any_coverage_warning": {
-          "description": "`true` if **any** per-model diff carries `sampling_window.coverage_warning = true`.",
+          "description": "`true` if **any** per-model diff is either a sampled diff with `sampling_window.coverage_warning = true` or a bisection diff with `bisection_stats.depth_capped = true`. Both conditions indicate the row-level findings might be incomplete and a reviewer shouldn't infer \"no change\" from a clean result.",
           "type": "boolean"
         },
         "models_unchanged": {
@@ -65,28 +152,80 @@
       "type": "object"
     },
     "PreviewModelDiff": {
-      "description": "Per-model diff. Combines structural (column-level) and sampled (row-level) findings.",
+      "description": "Per-model diff. Combines a structural (column-level) delta with a row-level diff that was produced by either the sampled or the checksum-bisection algorithm. The active algorithm is encoded by the `kind` discriminator on [`PreviewModelDiffAlgorithm`].",
       "properties": {
+        "algorithm": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PreviewModelDiffAlgorithm"
+            }
+          ],
+          "description": "Row-level diff payload, tagged by which algorithm produced it. Different models in the same run can carry different variants: a model with a single-column integer primary key runs through the bisection kernel, while a model that lacks a usable PK falls back to the sampled algorithm."
+        },
         "model_name": {
           "type": "string"
-        },
-        "sampled": {
-          "$ref": "#/definitions/PreviewSampledRowDiff"
-        },
-        "sampling_window": {
-          "$ref": "#/definitions/PreviewSamplingWindow"
         },
         "structural": {
           "$ref": "#/definitions/PreviewStructuralDiff"
         }
       },
       "required": [
+        "algorithm",
         "model_name",
-        "sampled",
-        "sampling_window",
         "structural"
       ],
       "type": "object"
+    },
+    "PreviewModelDiffAlgorithm": {
+      "description": "Row-level diff payload tagged by which algorithm produced it. The `kind` discriminator (`\"sampled\"` or `\"bisection\"`) lets consumers reading the JSON pick the right shape without having to check optional fields.",
+      "oneOf": [
+        {
+          "description": "Phase 2 sampled diff — `LIMIT N` rows ordered by primary key (or first column). Carries a coverage warning when changes outside the sampling window are not surfaced.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "sampled"
+              ],
+              "type": "string"
+            },
+            "sampled": {
+              "$ref": "#/definitions/PreviewSampledRowDiff"
+            },
+            "sampling_window": {
+              "$ref": "#/definitions/PreviewSamplingWindow"
+            }
+          },
+          "required": [
+            "kind",
+            "sampled",
+            "sampling_window"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Checksum-bisection exhaustive diff. Walks the chunk lattice and materializes leaves for row-by-row compare. Carries [`BisectionStatsOutput`] so consumers can audit the recursion trace.",
+          "properties": {
+            "bisection_stats": {
+              "$ref": "#/definitions/BisectionStatsOutput"
+            },
+            "diff": {
+              "$ref": "#/definitions/PreviewBisectionRowDiff"
+            },
+            "kind": {
+              "enum": [
+                "bisection"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "bisection_stats",
+            "diff",
+            "kind"
+          ],
+          "type": "object"
+        }
+      ]
     },
     "PreviewRowSample": {
       "description": "One representative changed row in [`PreviewSampledRowDiff::samples`].",
@@ -166,7 +305,7 @@
       "description": "Sampling-window metadata surfaced verbatim in the PR comment.\n\n`coverage_warning = true` flags that the row count outside the sampling window is non-trivial; reviewers should not infer \"no change\" from a clean sample if this flag is set.",
       "properties": {
         "coverage": {
-          "description": "One of `\"first_n_by_order\"` (Phase 2) or `\"checksum_bisection\"` (Phase 2.5 lift, not yet shipped).",
+          "description": "Sampling-strategy tag. `\"first_n_by_order\"` is the standard PK-ordered window; `\"not_yet_sampled\"` is a placeholder used when the sampling layer didn't run (e.g. the structural-only fallback path).",
           "type": "string"
         },
         "coverage_warning": {
@@ -220,7 +359,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a sampled row-level diff that extends the `rocky_core::compare`/`shadow` kernel.\n\n**Sampling correctness ceiling.** Phase 2 sampling reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs. `sampling_window.coverage_warning = true` flags this risk on the per-model level so reviewers don't infer false coverage. A checksum-bisection exhaustive diff is the Phase 2.5 lift.",
+  "description": "JSON output for `rocky preview diff`.\n\nCombines the structural diff (column added/removed/type-changed) from the existing `rocky_core::ci_diff` machinery with a row-level diff produced by either the sampled or the checksum-bisection algorithm. Each per-model entry's `algorithm` field carries a `kind` discriminator (`\"sampled\"` or `\"bisection\"`) plus the matching payload.\n\n**Sampled correctness ceiling.** The sampled algorithm reads `LIMIT N` rows ordered by primary key (or first column). Changes outside that window appear as no-change unless the row count itself differs; `sampling_window.coverage_warning = true` flags that risk. **Bisection** walks the chunk lattice exhaustively over a single-column primary key; `bisection_stats.depth_capped = true` flags the rare case where the recursion bottomed out at the depth cap before reaching leaf size. `summary.any_coverage_warning` rolls both signals up.",
   "properties": {
     "base_ref": {
       "type": "string"


### PR DESCRIPTION
## Summary

Closes the bisection path that landed across #342/#344/#345/#346:
- #342 shipped the kernel
- #344 wired the hidden `--algorithm=bisection` CLI flag (results to tracing only)
- #345/#346 added BigQuery + Databricks adapter overrides

This PR surfaces bisection results as a typed JSON field on `PreviewDiffOutput`, replacing the tracing-log surface with structured output that downstream consumers (PR-comment templates, AI reviewers, JSON listeners) can read.

## Schema swap (breaking JSON-shape restructure)

- `PreviewModelDiff.{sampled, sampling_window}` move into `PreviewModelDiff.algorithm: PreviewModelDiffAlgorithm`, a tagged enum with `{ \"kind\": \"sampled\" }` and `{ \"kind\": \"bisection\" }` variants.
- New `PreviewBisectionRowDiff { rows_added, rows_removed, rows_changed, samples }` and `BisectionStatsOutput` (CLI-side mirror of `rocky_core::compare::bisection::BisectionStats` with `JsonSchema` derive).
- `PreviewDiffSummary.any_coverage_warning` keeps its name; semantic widens to *\"true if any model is Sampled with coverage_warning OR Bisection with depth_capped.\"*

## Codegen spike result

The design doc requires a codegen-pipeline spike before committing to the tagged enum shape. **Spike passed:**

- `schemas/preview_diff.schema.json` — clean discriminator field, no nested `anyOf` weirdness.
- `integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py` — Pydantic v2 discriminated union compiles; `pytest test_types.py` passes 24/24 on the regenerated bindings.
- `editors/vscode/src/types/generated/preview_diff.ts` — usable TypeScript union type.

So the tagged enum ships; no fallback to the flatter discriminator shape.

## Direct JSON consumer migration

- Readers of `model.sampled.*` migrate to `model.algorithm.sampled.*` with a `kind` discriminator check.
- The dagster typed-resource layer absorbs the change automatically through `dagster_rocky.types_generated` re-exports — no manual migration in client code.
- The VS Code extension's adapter regenerates; no manual migration.

## CLI behavior

- `--algorithm=sampled` (default): unchanged behavior — emits `algorithm: { kind: \"sampled\", ... }`.
- `--algorithm=bisection`: now populates `algorithm: { kind: \"bisection\", diff, bisection_stats }` on the JSON output for every model with a single-column `unique_key`. Models that don't qualify still emit the Sampled placeholder; reasons land in tracing as before.
- Markdown rendering surfaces the bisection variant with a per-model table including `chunks_examined` / `leaves_materialized` / `depth_max` / `null_pk_rows`.

## Hygiene

- Strip pre-existing `Phase 2` / `Phase 3` / `Phase 5` doc-comment leaks in `preview.rs` + `output.rs` that propagate via JsonSchema codegen — they were inherited from the structural-only era and contradict the new shape.

## Test plan

- [x] `cargo test -p rocky-cli --lib preview::` — 37/37 pass (1 added, existing adjusted to new shape)
- [x] `just codegen` — clean; regenerated artifacts committed alongside the Rust change
- [x] `uv run pytest -p integrations/dagster tests/test_types.py` — 24/24 pass on the new Pydantic discriminated union
- [x] `cargo fmt --check` + `cargo clippy -p rocky-cli --all-targets` — clean