### PR TITLE
chore: strip internal phase / arc / sub-step references from source comments

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -1617,7 +1617,7 @@
           "type": "object"
         },
         {
-          "description": "Assert that a column's values fall within a numeric range (inclusive, half-open either side). Phase 4a supports numeric bounds only — use `time_window` (Phase 4b) or `expression` for temporal comparisons.\n\nNULL column values pass (consistent with existing `NOT IN` / `NOT (expr)` semantics).",
+          "description": "Assert that a column's values fall within a numeric range (inclusive, half-open either side). `in_range` supports numeric bounds only — use `time_window` or `expression` for temporal comparisons.\n\nNULL column values pass (consistent with existing `NOT IN` / `NOT (expr)` semantics).",
           "properties": {
             "max": {
               "default": null,
@@ -1972,7 +1972,7 @@
         },
         "depends_on": {
           "default": [],
-          "description": "Pipeline dependencies for chaining (Phase 4).",
+          "description": "Pipeline dependencies for chaining.",
           "items": {
             "type": "string"
           },

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -687,7 +687,7 @@ export interface ReplicationPipelineConfig {
    */
   checks?: ChecksConfig;
   /**
-   * Pipeline dependencies for chaining (Phase 4).
+   * Pipeline dependencies for chaining.
    */
   depends_on?: string[];
   /**

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -184,11 +184,11 @@ pub async fn run_preview_create(
 
     let duration_ms = start.elapsed().as_millis() as u64;
 
-    // Phase 1 emits `run_status = "planned"` — actually invoking
+    // Emits `run_status = "planned"` — actually invoking
     // `rocky run --branch <name>` for each prune-set model is left to
-    // the caller (or to the Phase 4 GitHub Action). Going planned-only
-    // keeps Phase 1 honest about scope without breaking the PR-comment
-    // contract.
+    // the caller (or to the GitHub Action). Going planned-only keeps
+    // the contract honest about scope without breaking the PR-comment
+    // surface.
     let out = PreviewCreateOutput::new(
         resolved_branch_name,
         branch_schema,
@@ -2358,7 +2358,7 @@ mod tests {
     }
 
     /// Markdown rendering is deterministic and includes the headline
-    /// metrics. Used by the Phase 4 GitHub Action.
+    /// metrics. Used by the `rocky-preview` GitHub Action.
     #[test]
     fn diff_markdown_renders_table() {
         let branch = run_record(

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2385,7 +2385,7 @@ pub struct ReplicationPipelineConfig {
     #[serde(default)]
     pub execution: ExecutionConfig,
 
-    /// Pipeline dependencies for chaining (Phase 4).
+    /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
 }

--- a/engine/crates/rocky-core/src/idempotency.rs
+++ b/engine/crates/rocky-core/src/idempotency.rs
@@ -22,13 +22,12 @@
 //! |---|---|
 //! | [`StateBackend::Local`] | redb write transaction inside the existing `state.redb.lock` file lock |
 //! | [`StateBackend::Valkey`] / [`StateBackend::Tiered`] | Valkey `SET NX EX` on `{prefix}idempotency:<key>` |
-//! | [`StateBackend::S3`] | S3 `PutObject` with `If-None-Match: "*"` (Phase 2) |
-//! | [`StateBackend::Gcs`] | GCS `insertObject` with `x-goog-if-generation-match: 0` (Phase 3) |
+//! | [`StateBackend::S3`] | S3 `PutObject` with `If-None-Match: "*"` |
+//! | [`StateBackend::Gcs`] | GCS `insertObject` with `x-goog-if-generation-match: 0` |
 //!
-//! For `s3` / `gcs` backends before Phase 2 / Phase 3 ship, this module
-//! returns [`IdempotencyError::UnsupportedBackend`] on any idempotency op —
-//! consumed by `rocky run` at flag-parse time with a clear "switch to
-//! tiered" error message.
+//! The `s3` / `gcs` backends are not yet wired through this module — calls
+//! return [`IdempotencyError::UnsupportedBackend`], consumed by `rocky run`
+//! at flag-parse time with a clear "switch to tiered" error message.
 //!
 //! # Key storage
 //!
@@ -876,7 +875,7 @@ pub(crate) fn classify_existing(
 // the types, even though the concrete providers land in later patches.
 // -----------------------------------------------------------------------
 
-/// Object-store–backed idempotency key path for Phase 2 / Phase 3.
+/// Object-store–backed idempotency key path (S3 / GCS).
 ///
 /// Layout: `idempotency/<sha256-hex>` — hashed to keep the object name
 /// URL-safe + bounded regardless of caller-supplied key shape. The key

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -233,7 +233,7 @@ impl ObjectStoreProvider {
     /// through [`ObjectStoreError::Backend`].
     ///
     /// This is the atomic primitive backing `rocky run --idempotency-key` on
-    /// `s3`-only and `gcs`-only state backends (FR-004 Phase 2 / Phase 3).
+    /// `s3`-only and `gcs`-only state backends.
     pub async fn put_if_not_exists(
         &self,
         relative_path: &str,

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -1,6 +1,6 @@
 //! Row-quarantine SQL compilation for the quality pipeline.
 //!
-//! Phase 3 of the DQX parity plan. Lowers a subset of row-level
+//! Lowers a subset of row-level
 //! [`crate::tests::TestType`] assertions into a single boolean predicate
 //! per target table, and emits CTAS statements that split the source into
 //! `<table>__valid` (passing rows) and `<table>__quarantine` (failing
@@ -922,7 +922,7 @@ mod unit_tests {
         assert!(err.is_some());
     }
 
-    // ----- Phase 4a -----
+    // ----- where-clause filter handling -----
 
     fn assertion_with_filter(
         kind: TestType,

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -29,7 +29,7 @@ pub enum TestGenError {
     MissingInRangeBound,
 
     #[error(
-        "in_range bound '{value}' must parse as a number (Phase 4a supports numeric ranges only; use `time_window` or `expression` for temporal bounds)"
+        "in_range bound '{value}' must parse as a number — `in_range` supports numeric ranges only; use `time_window` or `expression` for temporal bounds"
     )]
     InvalidInRangeBound { value: String },
 
@@ -107,8 +107,8 @@ pub enum TestType {
         max: Option<u64>,
     },
     /// Assert that a column's values fall within a numeric range
-    /// (inclusive, half-open either side). Phase 4a supports numeric
-    /// bounds only — use `time_window` (Phase 4b) or `expression` for
+    /// (inclusive, half-open either side). `in_range` supports
+    /// numeric bounds only — use `time_window` or `expression` for
     /// temporal comparisons.
     ///
     /// NULL column values pass (consistent with existing `NOT IN` /

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -763,8 +763,8 @@ pub trait SqlDialect: Send + Sync {
     /// `column` matches `pattern` (`REGEXP` / `RLIKE` / `REGEXP_LIKE` /
     /// `REGEXP_CONTAINS`, depending on the warehouse).
     ///
-    /// Used by `TestType::RegexMatch` (Phase 4a). The default impl
-    /// returns an error — adapters that support regex must override.
+    /// Used by `TestType::RegexMatch`. The default impl returns an
+    /// error — adapters that support regex must override.
     /// `column` is already validated as a SQL identifier; `pattern` is
     /// already validated against the strict allowlist
     /// ([`crate::tests::validate_regex_pattern`]).
@@ -775,8 +775,8 @@ pub trait SqlDialect: Send + Sync {
     }
 
     /// Build a dialect-specific SQL expression equivalent to
-    /// `CURRENT_DATE - N days`. Used by `TestType::OlderThanNDays`
-    /// (Phase 4b). The default impl uses the ANSI
+    /// `CURRENT_DATE - N days`. Used by `TestType::OlderThanNDays`.
+    /// The default impl uses the ANSI
     /// `CURRENT_DATE - INTERVAL 'N' DAY` form, which works for
     /// Databricks, Snowflake, and DuckDB. BigQuery overrides because
     /// it requires `DATE_SUB(CURRENT_DATE(), INTERVAL N DAY)`.
@@ -785,7 +785,7 @@ pub trait SqlDialect: Send + Sync {
     }
 
     /// SQL expression returning the current timestamp. Used by
-    /// `TestType::NotInFuture` (Phase 4b).
+    /// `TestType::NotInFuture`.
     ///
     /// Default: `CURRENT_TIMESTAMP` (ANSI keyword, no parens). Works for
     /// Databricks, Snowflake, DuckDB. BigQuery overrides to

--- a/engine/crates/rocky-wasm/src/lib.rs
+++ b/engine/crates/rocky-wasm/src/lib.rs
@@ -286,7 +286,7 @@ pub fn compile_rocky_model(source: &str) -> String {
         }
     };
 
-    // Phase 3: Extract lineage from lowered SQL
+    // Extract lineage from lowered SQL
     let lineage = match rocky_sql::lineage::extract_lineage(&sql) {
         Ok(result) => serde_json::to_value(&result).ok(),
         Err(e) => {

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -82,9 +82,8 @@ struct Cli {
 
     /// Override `[cache.schemas] ttl_seconds` for this invocation.
     ///
-    /// Precedence (Arc 7 wave 2 wave-2 PR 4):
-    /// `--cache-ttl` > `[cache.schemas] ttl_seconds` in `rocky.toml`
-    /// > built-in default (86400s / 24h).
+    /// Precedence: `--cache-ttl` > `[cache.schemas] ttl_seconds` in
+    /// `rocky.toml` > built-in default (86400s / 24h).
     ///
     /// `--cache-ttl 0` treats every entry as instantly stale (the read
     /// path returns an empty map). To disable the cache entirely, set
@@ -191,10 +190,10 @@ enum Command {
         /// adapter, issues one `batch_describe_schema` round-trip and
         /// persists the per-table columns to `state.redb::schema_cache`.
         /// Subsequent `rocky compile` / `rocky lsp` invocations pick up
-        /// the entries via the Arc 7 wave 2 wave-2 schema cache instead
-        /// of typechecking leaf models as `Unknown`. Errors on individual
-        /// sources are logged and skipped — one bad source does not
-        /// abort the warm-up.
+        /// the entries via the schema cache instead of typechecking
+        /// leaf models as `Unknown`. Errors on individual sources are
+        /// logged and skipped — one bad source does not abort the
+        /// warm-up.
         #[arg(long)]
         with_schemas: bool,
     },
@@ -259,7 +258,7 @@ enum Command {
         #[arg(long, conflicts_with_all = ["shadow", "shadow_schema"])]
         branch: Option<String>,
 
-        // ----- time_interval partition selection (Phase 3) -----
+        // ----- time_interval partition selection -----
         /// Run a single partition by canonical key (e.g. 2026-04-07 for daily,
         /// 2026-04 for monthly). Errors if the format doesn't match the
         /// model's granularity. Mutually exclusive with --from/--to/--latest/--missing.
@@ -432,7 +431,7 @@ enum Command {
         /// Run `data/seed.sql` against an in-memory DuckDB before compiling
         /// and use its `information_schema` as the source-of-truth for
         /// raw source schemas. Turns leaf .sql models from `Unknown`
-        /// columns into concrete types (Arc 7 wave 2).
+        /// columns into concrete types.
         #[arg(long)]
         with_seed: bool,
     },
@@ -1142,13 +1141,12 @@ enum BranchAction {
 enum StateAction {
     /// Show stored watermarks (same as bare `rocky state`).
     Show,
-    /// Flush the Arc 7 wave 2 wave-2 `DESCRIBE TABLE` cache.
+    /// Flush the cached `DESCRIBE TABLE` results.
     ///
     /// Removes every `SCHEMA_CACHE` entry from `state.redb`. The next
-    /// `rocky run` (PR 2 write tap) or `rocky discover --with-schemas`
-    /// (PR 3) warms it back up — until then, `rocky compile` falls back
-    /// to `RockyType::Unknown` for leaf models, matching pre-wave-2
-    /// behaviour.
+    /// `rocky run` (write tap) or `rocky discover --with-schemas` warms
+    /// the cache back up — until then, `rocky compile` falls back to
+    /// `RockyType::Unknown` for leaf models.
     ///
     /// Use cases:
     ///   * After a manual warehouse DDL change, when TTL expiry would

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1391,7 +1391,7 @@ class QualityAssertion6(BaseModel):
 
 class QualityAssertion7(BaseModel):
     """
-    Assert that a column's values fall within a numeric range (inclusive, half-open either side). Phase 4a supports numeric bounds only — use `time_window` (Phase 4b) or `expression` for temporal comparisons.
+    Assert that a column's values fall within a numeric range (inclusive, half-open either side). `in_range` supports numeric bounds only — use `time_window` or `expression` for temporal comparisons.
 
     NULL column values pass (consistent with existing `NOT IN` / `NOT (expr)` semantics).
     """
@@ -1940,7 +1940,7 @@ class ReplicationPipelineConfig(BaseModel):
     """
     depends_on: list[str] | None = []
     """
-    Pipeline dependencies for chaining (Phase 4).
+    Pipeline dependencies for chaining.
     """
     execution: ExecutionConfig | None = Field(
         {

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -1616,7 +1616,7 @@
           "type": "object"
         },
         {
-          "description": "Assert that a column's values fall within a numeric range (inclusive, half-open either side). Phase 4a supports numeric bounds only — use `time_window` (Phase 4b) or `expression` for temporal comparisons.\n\nNULL column values pass (consistent with existing `NOT IN` / `NOT (expr)` semantics).",
+          "description": "Assert that a column's values fall within a numeric range (inclusive, half-open either side). `in_range` supports numeric bounds only — use `time_window` or `expression` for temporal comparisons.\n\nNULL column values pass (consistent with existing `NOT IN` / `NOT (expr)` semantics).",
           "properties": {
             "max": {
               "default": null,
@@ -1971,7 +1971,7 @@
         },
         "depends_on": {
           "default": [],
-          "description": "Pipeline dependencies for chaining (Phase 4).",
+          "description": "Pipeline dependencies for chaining.",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
## Summary

Internal sequencing labels (`Phase 2`, `Phase 3`, `Phase 4a/b`, `Phase 5`, `Arc 7 wave 2 wave-2 PR N`, `sub-step`) carry no useful information for end users — they're internal scheduling marks that propagate via:

- `JsonSchema`-derived doc-comments → Pydantic + TypeScript bindings (visible in IDE hover and Dagster intellisense)
- `clap` `#[arg(...)]` doc-comments → CLI `--help` output
- `thiserror` `#[error("...")]` strings → user-visible runtime errors

This change scrubs the references in production code and leaves the factual content. Test-file comments keep their phase markers — those are internal navigation aids and don't propagate anywhere user-visible.

## Why now

Five source files (`preview.rs`, `output.rs`, etc.) got the same treatment in #347 as a side-effect of the schema swap. This PR finishes the sweep across the rest of the production tree.

## Files touched

| File | Leaks stripped |
|---|---:|
| `engine/crates/rocky-cli/src/commands/preview.rs` | 2 |
| `engine/crates/rocky-core/src/config.rs` | 1 |
| `engine/crates/rocky-core/src/idempotency.rs` | 3 |
| `engine/crates/rocky-core/src/object_store.rs` | 1 |
| `engine/crates/rocky-core/src/quarantine.rs` | 2 |
| `engine/crates/rocky-core/src/tests.rs` | 2 (incl. user-visible `thiserror` string) |
| `engine/crates/rocky-core/src/traits.rs` | 3 |
| `engine/crates/rocky-wasm/src/lib.rs` | 1 |
| `engine/rocky/src/main.rs` | 5 |

## Codegen cascade

`RockyConfig.depends_on`'s doc-comment dropped its `(Phase 4)` parenthetical, so the regenerated `schemas/rocky_project.schema.json` + Pydantic + TypeScript bindings reflect that one-word edit. No semantic change to the JSON schema.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — 2759 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `uv run pytest -p integrations/dagster tests/test_types.py` — 24/24 pass on regenerated bindings
- [x] `grep -rnE "Phase 2\\.|Phase 5|Phase 4|Phase 3\\b|Phase 2A\\b|Arc 7 wave|wave-2 PR|sub-step" engine/crates/ engine/rocky/src/` returns only test-file hits after this change