### PR TITLE
chore: release engine-v1.22.0 + dagster-v1.20.0

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] — 2026-05-02
+
+Feature release. Headline: **exhaustive checksum-bisection diff** — `rocky preview diff --algorithm bisection` covers every row in a target table at bounded scan cost, ending the sampling false-negative ceiling. Live-verified on DuckDB, BigQuery, and Databricks; Snowflake stays on the sampled fallback until a consumer drives the override. Bundles pre-merge budget projection on `rocky preview cost`, rolling z-score + health score on `rocky history`, a state-store retention sweep, and a tagged-enum restructure of `PreviewDiffOutput` (the breaking shape change downstream consumers need to migrate for).
+
+**Migration callout (breaking JSON-shape change).** `PreviewDiffOutput.models[*].sampled` and `.sampling_window` move under a new `algorithm` discriminated union. Direct JSON readers must migrate from `model.sampled.rows_changed` to `model.algorithm.sampled.rows_changed` (with a `kind` discriminator check first). The dagster typed-resource layer and the VS Code extension's adapter absorb the shape change automatically through `dagster-rocky` 1.20.0's regenerated bindings — only third-party scripts that read the JSON directly need to update.
+
 ### Changed
 
 - **`PreviewDiffOutput.models[*].algorithm` tagged enum (breaking JSON-shape restructure).** Per-model row-level diff is now carried in a `PreviewModelDiffAlgorithm` discriminated union with two variants: `{ "kind": "sampled", "sampled": …, "sampling_window": … }` and `{ "kind": "bisection", "diff": …, "bisection_stats": … }`. The legacy `model.sampled` and `model.sampling_window` fields move under `model.algorithm` — direct JSON consumers (shell scripts, custom dashboards) must migrate to `model.algorithm.sampled.*` / `model.algorithm.bisection.*` with a `kind` discriminator check. The dagster typed-resource layer absorbs the change automatically through `dagster_rocky.types_generated`; the VS Code extension's adapter regenerates via `just codegen` and stays consumer-clean. `summary.any_coverage_warning` keeps its name and widens semantically — it now fires on `Sampled { sampling_window.coverage_warning: true }` *or* `Bisection { bisection_stats.depth_capped: true }`. The `--algorithm=bisection` CLI flag (previously `tracing`-log-only) now surfaces results as the typed `Bisection` variant on the JSON output.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "redis",
  "serde",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "logos",
  "miette",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "miette",
  "regex",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.21.0"
+version = "1.22.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.21.0"
+version = "1.22.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.21.0"
+version = "1.22.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.21.0"
+version = "1.22.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.21.0"
+version = "1.22.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.21.0"
+version = "1.22.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.21.0"
+version = "1.22.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.21.0"
+version = "1.22.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.21.0"
+version = "1.22.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.21.0"
+version = "1.22.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.21.0"
+version = "1.22.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.21.0"
+version = "1.22.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.21.0"
+version = "1.22.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.21.0"
+version = "1.22.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.21.0"
+version = "1.22.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] — 2026-05-02
+
+Companion release to engine `v1.22.0`. The `dagster_rocky.types_generated` layer regenerates against the engine's checksum-bisection diff output, the rolling-stats history block, the projected-budget-breaches preview-cost block, and the new state-store retention sweep. The typed-resource layer absorbs the engine's breaking `PreviewModelDiff` shape change automatically — Dagster code that consumes `RockyResource.preview_diff(...)` results doesn't need any source-level migration, the new tagged-enum is exposed as a Pydantic discriminated union.
+
+### Added
+
+- **`PreviewModelDiff.algorithm` discriminated union** (engine [#347](https://github.com/rocky-data/rocky/pull/347)). The regenerated `dagster_rocky.types_generated.preview_diff_schema` exposes the engine's new `PreviewModelDiffAlgorithm` tagged enum as a Pydantic v2 discriminated union with two variants — `Sampled { sampled, sampling_window }` and `Bisection { diff, bisection_stats }`. Consumers branch on `model.algorithm.kind`. The `summary.any_coverage_warning` field stays in place but its semantic widens — it now fires on either sampled-with-coverage-warning or bisection-with-depth-cap.
+- **`PreviewCostOutput.projected_budget_breaches`** (engine [#343](https://github.com/rocky-data/rocky/pull/343)). New `List[BudgetBreachOutput]` field on the regenerated `PreviewCostOutput`. Mirrors `RunOutput.budget_breaches` so PR-comment templates and JSON listeners can process both with one code path.
+- **`ModelHistoryOutput.rolling_stats`** (engine [#348](https://github.com/rocky-data/rocky/pull/348)). New `Optional[RollingStats]` field exposing rolling z-score on `rows_affected` and `duration_ms` plus a composite `health_score`. Populated when the upstream call passes `--rolling-stats`.
+- **`RetentionSweepOutput`** (engine [#349](https://github.com/rocky-data/rocky/pull/349)). New typed wrapper around the `rocky state retention sweep` JSON output — per-domain delete/keep counts plus the dry-run flag.
+
+### Changed
+
+- **`PreviewModelDiff` shape restructure absorbed automatically.** The legacy `model.sampled` / `model.sampling_window` fields move under `model.algorithm` per engine [#347](https://github.com/rocky-data/rocky/pull/347). User code that touched `RockyResource.preview_diff(...)` results through the typed `dagster_rocky.types` re-exports keeps working — Pydantic auto-resolves to the right variant via the `kind` discriminator. Direct readers of the underlying JSON (e.g., `subprocess.run(["rocky", "preview", "diff", "-o", "json"])` and `json.loads`) need to migrate; the `dagster_rocky` typed path absorbs the change.
+
 ## [1.19.0] — 2026-05-01
 
 Companion release to engine `v1.21.0`. Headlines: **`RockyComponent.strict_build`** turns three "log and swallow" paths in `build_defs` into hard failures for adopters who never want an empty asset graph to ship as healthy, and **`_run_rocky` streams stderr to the module logger as it runs** so cold-start discover calls no longer go silent for 60+ seconds. Picks up regenerated Pydantic models for `MaterializationOutput.job_ids`.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.19.0"
+version = "1.20.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.19.0"
+version = "1.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
Coordinated minor release covering everything that landed since `engine-v1.21.0` (10 PRs).

## Headline

**Exhaustive checksum-bisection diff.** `rocky preview diff --algorithm bisection` covers every row in a target table at bounded scan cost, ending the sampling false-negative ceiling. Live-verified on DuckDB, BigQuery, and Databricks; Snowflake stays on the sampled fallback until a consumer drives the override.

Bundles pre-merge budget projection on `rocky preview cost`, rolling z-score + health score on `rocky history`, a state-store retention sweep, a tagged-enum restructure of `PreviewDiffOutput`, and post-Phase-2.5 doc + comment cleanup.

## :warning: Breaking JSON-shape change

`PreviewDiffOutput.models[*].sampled` and `.sampling_window` move under a new `algorithm` discriminated union (#347):

```diff
-"models": [{ "model_name": "...", "sampled": {...}, "sampling_window": {...} }]
+"models": [{ "model_name": "...", "algorithm": { "kind": "sampled", "sampled": {...}, "sampling_window": {...} } }]
```

**Direct JSON consumers (shell scripts, custom dashboards) must migrate** from `model.sampled.rows_changed` to `model.algorithm.sampled.rows_changed` (with a `kind` discriminator check first). The dagster typed-resource layer and the VS Code extension's adapter absorb the shape change automatically through `dagster-rocky` 1.20.0's regenerated bindings — only third-party scripts that read the JSON directly need to update.

`summary.any_coverage_warning` keeps its name and widens semantically — fires on either `Sampled { sampling_window.coverage_warning: true }` *or* `Bisection { bisection_stats.depth_capped: true }`.

## What's in the engine release

| PR | Summary |
|---|---|
| #342 | Checksum-bisection diff kernel + DuckDB conformance |
| #343 | Pre-merge budget projection on `rocky preview cost` |
| #344 | Hidden `--algorithm=bisection` flag on `rocky preview diff` |
| #345 | BigQuery `row_hash_expr` + `checksum_chunks` override (live-verified); kernel-level `SqlDialect::quote_identifier` |
| #346 | Databricks `row_hash_expr` + `checksum_chunks` override |
| #347 | `PreviewModelDiffAlgorithm` tagged enum (the breaking JSON-shape change) |
| #348 | `rocky history --rolling-stats` with z-score + health score |
| #349 | `[state.retention]` config + `rocky state retention sweep` |
| #351 | Docs + POC sweep |
| #352 | Strip internal phase / arc / sub-step references from source comments |

Public-stable adapter SDK gained one new method (`checksum_chunks`) with a default-error impl plus two utility getters with safe defaults — out-of-tree adapters stay source-compatible. Counts as the SDK minor bump for v1.22.0.

## What's in the dagster release

`dagster_rocky.types_generated` regenerates against the engine's new schemas (`PreviewModelDiffAlgorithm`, `RetentionSweepOutput`, `RollingStats`, `ProjectedBudgetBreaches`). The typed-resource layer absorbs the engine's breaking shape change so user code that consumes `RockyResource.preview_diff(...)` results doesn't need any source-level migration.

## Pre-flight (passed)

- [x] `cargo check --workspace` clean at v1.22.0
- [x] `cargo test --workspace --no-fail-fast` — 2759 tests pass
- [x] `pytest -p integrations/dagster tests/` — 514 tests pass
- [x] `just codegen` clean — no schema drift
- [x] All 20 engine `Cargo.toml` files bumped (rocky-bigquery on its own track stays at 0.1.0)
- [x] `integrations/dagster/pyproject.toml` bumped 1.19.0 → 1.20.0; `uv.lock` regenerated
- [x] `engine/CHANGELOG.md` + `integrations/dagster/CHANGELOG.md` rolled up

## After merge

```bash
git checkout main && git pull
git tag -a engine-v1.22.0 -m "Release engine-v1.22.0"
git tag -a dagster-v1.20.0 -m "Release dagster-v1.20.0"
git push origin engine-v1.22.0 dagster-v1.20.0
```

`engine-release.yml` and `dagster-release.yml` handle the rest. Per the `release isLatest race` memory: if both releases land within seconds of each other, pin `gh release edit engine-v1.22.0 --latest` afterward.

## VS Code

Unaffected — no LSP protocol changes. The regenerated TS types in `editors/vscode/src/types/generated/` are internal to the extension's compile and ship in the next vscode minor whenever one cuts.