### PR TITLE
feat(rocky-cli): auto-sweep state retention at end-of-run

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2457,7 +2457,9 @@
               "audit"
             ],
             "max_age_days": 365,
-            "min_runs_kept": 100
+            "min_runs_kept": 100,
+            "sweep_budget_ms": 5000,
+            "sweep_interval_seconds": 3600
           },
           "description": "Retention policy applied to Rocky's own `state.redb` tables (run history, DAG snapshots, quality snapshots). Bounds the size of the control-plane store; operational tables (schema cache, watermarks, partition records) are never swept by this policy. See [`crate::retention::StateRetentionConfig`]."
         },
@@ -2544,6 +2546,20 @@
           "default": 100,
           "description": "Always preserve at least this many rows in each domain, even if every row is older than `max_age_days`. Applied per domain (last N runs, last N DAG snapshots, last N quality snapshots). Defaults to [`DEFAULT_STATE_RETENTION_MIN_RUNS_KEPT`].",
           "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sweep_budget_ms": {
+          "default": 5000,
+          "description": "Wall-clock budget (in milliseconds) the auto-sweep measures itself against at end-of-run. The sweep always runs to completion; exceeding the budget flips the per-run log line from `tracing::debug` to `tracing::warn` so operators can spot a state store that has grown large enough to warrant manual intervention. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS`].",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sweep_interval_seconds": {
+          "default": 3600,
+          "description": "Minimum number of seconds between two automatic end-of-run sweeps. The `rocky run` end-of-run hook reads `last_retention_sweep_at` from the state store's metadata table and skips the sweep when `now - last < sweep_interval_seconds`. The manual `rocky state retention sweep` subcommand is unaffected — it always runs. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS`].",
+          "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
         }
@@ -3023,7 +3039,9 @@
             "audit"
           ],
           "max_age_days": 365,
-          "min_runs_kept": 100
+          "min_runs_kept": 100,
+          "sweep_budget_ms": 5000,
+          "sweep_interval_seconds": 3600
         },
         "retry": {
           "backoff_multiplier": 2.0,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1386,4 +1386,12 @@ export interface StateRetentionConfig {
    * Always preserve at least this many rows in each domain, even if every row is older than `max_age_days`. Applied per domain (last N runs, last N DAG snapshots, last N quality snapshots). Defaults to [`DEFAULT_STATE_RETENTION_MIN_RUNS_KEPT`].
    */
   min_runs_kept?: number;
+  /**
+   * Wall-clock budget (in milliseconds) the auto-sweep measures itself against at end-of-run. The sweep always runs to completion; exceeding the budget flips the per-run log line from `tracing::debug` to `tracing::warn` so operators can spot a state store that has grown large enough to warrant manual intervention. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS`].
+   */
+  sweep_budget_ms?: number;
+  /**
+   * Minimum number of seconds between two automatic end-of-run sweeps. The `rocky run` end-of-run hook reads `last_retention_sweep_at` from the state store's metadata table and skips the sweep when `now - last < sweep_interval_seconds`. The manual `rocky state retention sweep` subcommand is unaffected — it always runs. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS`].
+   */
+  sweep_interval_seconds?: number;
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **End-of-run auto-sweep for state-store retention.** `rocky run` now invokes `StateStore::sweep_retention` at the end of every run so the policy declared in `[state.retention]` (introduced in 1.22.0) "just works" without an external cron. The sweep is gated by a `last_retention_sweep_at` metadata key in the state store: subsequent runs within `sweep_interval_seconds` (default 3600 = 1h) skip without doing any work, so a project running every minute does not pay sweep cost on every invocation. A `sweep_budget_ms` knob (default 5000 = 5s) controls the soft budget — the sweep always runs to completion, but exceeding the budget flips the per-run log line from `tracing::debug` to `tracing::warn` so operators can spot a state store grown large enough to warrant a manual `rocky state retention sweep` outside the normal run loop. Auto-sweep failures (cannot open state store, sweep itself errors) are swallowed as `tracing::warn` and never mask the run's exit code. Setting `applies_to = []` disables the auto-sweep without touching the manual subcommand. The two new `[state.retention]` fields (`sweep_interval_seconds`, `sweep_budget_ms`) are additive and default-populated — existing configs upgrade without changes.
+
 ## [1.22.0] — 2026-05-02
 
 Feature release. Headline: **exhaustive checksum-bisection diff** — `rocky preview diff --algorithm bisection` covers every row in a target table at bounded scan cost, ending the sampling false-negative ceiling. Live-verified on DuckDB, BigQuery, and Databricks; Snowflake stays on the sampled fallback until a consumer drives the override. Bundles pre-merge budget projection on `rocky preview cost`, rolling z-score + health score on `rocky history`, a state-store retention sweep, and a tagged-enum restructure of `PreviewDiffOutput` (the breaking shape change downstream consumers need to migrate for).

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -737,6 +737,19 @@ pub async fn run(
     let rocky_cfg_for_idemp = rocky_core::config::load_rocky_config(config_path).context(
         format!("failed to load config from {}", config_path.display()),
     )?;
+
+    // OTLP metrics exporter (feature-gated). Auto-initialises when
+    // `OTEL_EXPORTER_OTLP_ENDPOINT` is set so operators can opt in by
+    // env alone — no CLI flag needed. Drop flushes the final snapshot
+    // and shuts the periodic reader down, so this guard covers every
+    // exit path (happy, interrupted, error) without threading an
+    // explicit cleanup call.
+    //
+    // Held at function scope (not inside the inner async block) so the
+    // end-of-run auto-sweep call below still emits its spans through an
+    // active tracer before the guard drops at function return.
+    let _otel_guard = crate::otel_guard::OtelGuard::init_if_enabled();
+
     let mut idempotency_ctx = match idempotency_key {
         Some(key) => {
             match try_claim_idempotency(
@@ -766,14 +779,6 @@ pub async fn run(
     // one-shot (takes the ctx out of the `Option`); if that already fired,
     // the wrapper's error-path finalize is a no-op.
     let run_result: Result<()> = async {
-
-    // OTLP metrics exporter (feature-gated). Auto-initialises when
-    // `OTEL_EXPORTER_OTLP_ENDPOINT` is set so operators can opt in by
-    // env alone — no CLI flag needed. Drop flushes the final snapshot
-    // and shuts the periodic reader down, so this guard covers every
-    // exit path (happy, interrupted, error) without threading an
-    // explicit cleanup call.
-    let _otel_guard = crate::otel_guard::OtelGuard::init_if_enabled();
 
     // Detect Dagster Pipes mode. When the parent process is a Dagster
     // job that launched us via PipesSubprocessClient, both
@@ -3164,6 +3169,18 @@ pub async fn run(
     }
     .await;
 
+    // End-of-run retention auto-sweep. Wires `StateStore::sweep_retention`
+    // into the run loop so retention "just works" without an external cron
+    // — the manual `rocky state retention sweep` subcommand stays as the
+    // operator escape hatch. Runs unconditionally on both Ok and Err
+    // paths: a failed run shouldn't postpone state cleanup, and the
+    // interval gate inside `auto_sweep_retention_at_end_of_run` still
+    // suppresses thrash. All errors swallowed as `tracing::warn` — the
+    // run's exit code reflects the run, never the sweep. Placed before
+    // the idempotency error-path finalize so an over-budget sweep never
+    // delays the InFlight stamp release.
+    auto_sweep_retention_at_end_of_run(state_path, &rocky_cfg_for_idemp.state.retention).await;
+
     // FR-004 F1 error-path finalize. If the body returned `Err`, the
     // claim is almost certainly still `InFlight` (the happy/interrupted/
     // partial-failure sites all call `finalize_idempotency` which takes
@@ -3178,6 +3195,121 @@ pub async fn run(
     }
 
     run_result
+}
+
+/// End-of-run retention sweep, gated by `last_retention_sweep_at`.
+///
+/// Reads the configured `[state.retention]` policy and the timestamp of
+/// the most recent prior sweep from the state store's metadata table. If
+/// the prior sweep is younger than `sweep_interval_seconds`, returns
+/// without doing any work. Otherwise invokes [`StateStore::sweep_retention`],
+/// measures wall-clock against `sweep_budget_ms`, and emits a
+/// `tracing::warn` line on overrun. The sweep timestamp is stamped
+/// regardless of whether the budget was met — otherwise an over-budget
+/// sweep would fire every run.
+///
+/// Every error path is swallowed as `tracing::warn`. The run's exit code
+/// reflects the run, never the sweep — auto-sweep is opportunistic by
+/// contract.
+///
+/// Skipped when `applies_to = []` (sweep disabled by config) or when the
+/// state store cannot be opened (lock contention, missing file mid-run).
+/// In the disabled case we never stamp `last_retention_sweep_at` so
+/// flipping `applies_to` back on triggers a sweep next run regardless of
+/// recency.
+async fn auto_sweep_retention_at_end_of_run(
+    state_path: &Path,
+    policy: &rocky_core::retention::StateRetentionConfig,
+) {
+    if policy.applies_to.is_empty() {
+        // Sweep disabled by config. Don't stamp the timestamp — flipping
+        // `applies_to` back on should trigger a sweep next run.
+        return;
+    }
+
+    if !state_path.exists() {
+        // Fresh project on an ephemeral runner; nothing to sweep.
+        return;
+    }
+
+    // Safe to open: the inner async block's `state_store` (the writer
+    // held during the run body) has dropped by the time the outer
+    // `.await` resolves, so re-opening here doesn't deadlock on its
+    // exclusive flock.
+    let store = match rocky_core::state::StateStore::open(state_path) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %state_path.display(),
+                "auto-sweep: failed to open state store; skipping");
+            return;
+        }
+    };
+
+    let now = chrono::Utc::now();
+    match store.get_last_retention_sweep_at() {
+        Ok(Some(last)) => {
+            let elapsed = now.signed_duration_since(last);
+            let interval = chrono::Duration::seconds(policy.sweep_interval_seconds as i64);
+            if elapsed < interval {
+                tracing::debug!(
+                    last_sweep_at = %last.to_rfc3339(),
+                    elapsed_secs = elapsed.num_seconds(),
+                    interval_secs = policy.sweep_interval_seconds,
+                    "auto-sweep: within configured interval; skipping"
+                );
+                return;
+            }
+        }
+        Ok(None) => {
+            // First run with auto-sweep enabled — proceed.
+        }
+        Err(e) => {
+            tracing::warn!(error = %e,
+                "auto-sweep: cannot read last_retention_sweep_at; skipping");
+            return;
+        }
+    }
+
+    let started = std::time::Instant::now();
+    let report = match store.sweep_retention(policy) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "auto-sweep: sweep_retention failed");
+            // Do not stamp the timestamp — a sweep that never landed
+            // shouldn't reset the interval gate.
+            return;
+        }
+    };
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    if elapsed_ms > policy.sweep_budget_ms {
+        tracing::warn!(
+            elapsed_ms,
+            budget_ms = policy.sweep_budget_ms,
+            overrun_ms = elapsed_ms.saturating_sub(policy.sweep_budget_ms),
+            runs_deleted = report.runs_deleted,
+            lineage_deleted = report.lineage_deleted,
+            audit_deleted = report.audit_deleted,
+            "auto-sweep: budget exceeded; consider running `rocky state retention sweep` \
+             out-of-band or shortening max_age_days"
+        );
+    } else {
+        tracing::debug!(
+            elapsed_ms,
+            budget_ms = policy.sweep_budget_ms,
+            runs_deleted = report.runs_deleted,
+            lineage_deleted = report.lineage_deleted,
+            audit_deleted = report.audit_deleted,
+            "auto-sweep: complete"
+        );
+    }
+
+    // Stamp regardless of overrun — otherwise a consistently-slow sweep
+    // would fire every run and degrade the user experience further.
+    if let Err(e) = store.set_last_retention_sweep_at(now) {
+        tracing::warn!(error = %e,
+            "auto-sweep: failed to stamp last_retention_sweep_at");
+    }
 }
 
 /// Emit Dagster Pipes messages for every materialization, check, and
@@ -5320,5 +5452,155 @@ adapter = "default"
              Succeeded, not leave the InFlight claim for the TTL sweep to reap \
              (FR-004 F2 regression guard)"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // Auto-sweep at end-of-run
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn auto_sweep_missing_state_path_is_a_noop() {
+        // Ephemeral CI runner: no `state.redb` yet. The helper must
+        // exit quietly without creating the file.
+        use rocky_core::retention::StateRetentionConfig;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        assert!(!path.exists());
+
+        auto_sweep_retention_at_end_of_run(&path, &StateRetentionConfig::default()).await;
+        assert!(!path.exists(), "auto-sweep must not create state.redb");
+    }
+
+    #[tokio::test]
+    async fn auto_sweep_disabled_by_empty_applies_to_does_not_stamp() {
+        // applies_to = [] is the documented "disable" knob. We must
+        // skip the sweep AND not stamp last_retention_sweep_at — so
+        // flipping applies_to back on triggers a sweep next run
+        // regardless of recency.
+        use rocky_core::retention::StateRetentionConfig;
+        use rocky_core::state::StateStore;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        {
+            let _ = StateStore::open(&path).expect("init");
+        }
+
+        let mut policy = StateRetentionConfig::default();
+        policy.applies_to.clear();
+
+        auto_sweep_retention_at_end_of_run(&path, &policy).await;
+
+        let store = StateStore::open(&path).expect("reopen");
+        assert_eq!(
+            store.get_last_retention_sweep_at().unwrap(),
+            None,
+            "disabled sweep must not stamp last_retention_sweep_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_sweep_first_run_stamps_timestamp() {
+        // Fresh state store, default policy: the helper should run
+        // the sweep (no-op on an empty history table) and stamp the
+        // timestamp.
+        use rocky_core::retention::StateRetentionConfig;
+        use rocky_core::state::StateStore;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        {
+            let _ = StateStore::open(&path).expect("init");
+        }
+
+        let before = chrono::Utc::now();
+        auto_sweep_retention_at_end_of_run(&path, &StateRetentionConfig::default()).await;
+        let after = chrono::Utc::now();
+
+        let store = StateStore::open(&path).expect("reopen");
+        let stamped = store
+            .get_last_retention_sweep_at()
+            .unwrap()
+            .expect("first auto-sweep must stamp the timestamp");
+        assert!(
+            stamped >= before && stamped <= after,
+            "stamped timestamp {stamped} should sit between {before} and {after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_sweep_within_interval_skips_without_updating_stamp() {
+        // Pre-stamp a recent sweep timestamp. A second invocation
+        // within the configured interval must be a no-op — the
+        // stamp must NOT advance, so the same call once the interval
+        // does elapse will fire (if we'd advanced the stamp on every
+        // gated call we'd never sweep).
+        use rocky_core::retention::StateRetentionConfig;
+        use rocky_core::state::StateStore;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        let pre_stamp = chrono::Utc::now() - chrono::Duration::seconds(60);
+        {
+            let store = StateStore::open(&path).expect("init");
+            store.set_last_retention_sweep_at(pre_stamp).unwrap();
+        }
+
+        // Default interval is 1 hour; pre_stamp is 60s ago — gate fires.
+        auto_sweep_retention_at_end_of_run(&path, &StateRetentionConfig::default()).await;
+
+        let store = StateStore::open(&path).expect("reopen");
+        let stamped = store.get_last_retention_sweep_at().unwrap().unwrap();
+        assert_eq!(
+            stamped, pre_stamp,
+            "within-interval skip must not update last_retention_sweep_at"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_sweep_after_interval_runs_and_advances_stamp() {
+        // Pre-stamp a sweep timestamp older than the configured
+        // interval. The helper should run the sweep and advance the
+        // stamp.
+        use rocky_core::retention::StateRetentionConfig;
+        use rocky_core::state::StateStore;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        // Use a tight interval so the test is deterministic without
+        // having to fast-forward time.
+        let policy = StateRetentionConfig {
+            sweep_interval_seconds: 1,
+            ..StateRetentionConfig::default()
+        };
+        let pre_stamp = chrono::Utc::now() - chrono::Duration::seconds(10);
+        {
+            let store = StateStore::open(&path).expect("init");
+            store.set_last_retention_sweep_at(pre_stamp).unwrap();
+        }
+
+        auto_sweep_retention_at_end_of_run(&path, &policy).await;
+
+        let store = StateStore::open(&path).expect("reopen");
+        let stamped = store.get_last_retention_sweep_at().unwrap().unwrap();
+        assert!(
+            stamped > pre_stamp,
+            "post-interval sweep must advance stamp ({stamped} should be > {pre_stamp})"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_sweep_does_not_propagate_failure() {
+        // The contract: auto-sweep is opportunistic; any failure
+        // path is swallowed as `tracing::warn` so the run's exit
+        // code reflects the run, not the sweep. We exercise that
+        // by pointing at a directory (not a file) that opens as a
+        // path the StateStore cannot use as a database file. The
+        // helper must return cleanly.
+        use rocky_core::retention::StateRetentionConfig;
+        let dir = tempfile::TempDir::new().unwrap();
+        // Create a sub-directory, then point the state path AT the
+        // directory: redb cannot open a directory as a database.
+        let blocked = dir.path().join("blocked");
+        std::fs::create_dir(&blocked).unwrap();
+
+        // Should return without panicking or propagating.
+        auto_sweep_retention_at_end_of_run(&blocked, &StateRetentionConfig::default()).await;
     }
 }

--- a/engine/crates/rocky-core/src/retention.rs
+++ b/engine/crates/rocky-core/src/retention.rs
@@ -239,6 +239,28 @@ pub const DEFAULT_STATE_RETENTION_MAX_AGE_DAYS: u32 = 365;
 /// swept just because every row is older than `max_age_days`.
 pub const DEFAULT_STATE_RETENTION_MIN_RUNS_KEPT: u32 = 100;
 
+/// Default `sweep_interval_seconds` when `[state.retention]` is unset.
+///
+/// One hour: short enough that hourly-cron-style projects sweep every run,
+/// long enough that a project running every minute does not pay the sweep
+/// cost on every invocation. The `rocky run` end-of-run auto-sweep gates
+/// on this interval — see [`StateStore::get_last_retention_sweep_at`].
+///
+/// [`StateStore::get_last_retention_sweep_at`]: crate::state::StateStore::get_last_retention_sweep_at
+pub const DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS: u64 = 3_600;
+
+/// Default `sweep_budget_ms` when `[state.retention]` is unset.
+///
+/// Five seconds is the budget the auto-sweep at end-of-run measures itself
+/// against. The sweep runs to completion regardless — this value is the
+/// threshold that flips the per-run log line from `tracing::debug` to
+/// `tracing::warn` so operators can spot a state store that has grown
+/// large enough to warrant a manual `rocky state retention sweep` outside
+/// the normal run loop. Synchronous `redb` commits don't take cancellation,
+/// so the budget is intentionally a soft measure rather than a hard
+/// timeout.
+pub const DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS: u64 = 5_000;
+
 /// State-store retention policy.
 ///
 /// Bounds the size of Rocky's `state.redb` by sweeping rows older than
@@ -273,6 +295,24 @@ pub struct StateRetentionConfig {
     /// removing the config block — useful for staged rollouts.
     #[serde(default = "default_state_retention_applies_to")]
     pub applies_to: Vec<StateRetentionDomain>,
+
+    /// Minimum number of seconds between two automatic end-of-run sweeps.
+    /// The `rocky run` end-of-run hook reads `last_retention_sweep_at`
+    /// from the state store's metadata table and skips the sweep when
+    /// `now - last < sweep_interval_seconds`. The manual `rocky state
+    /// retention sweep` subcommand is unaffected — it always runs.
+    /// Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS`].
+    #[serde(default = "default_state_retention_sweep_interval_seconds")]
+    pub sweep_interval_seconds: u64,
+
+    /// Wall-clock budget (in milliseconds) the auto-sweep measures itself
+    /// against at end-of-run. The sweep always runs to completion;
+    /// exceeding the budget flips the per-run log line from
+    /// `tracing::debug` to `tracing::warn` so operators can spot a state
+    /// store that has grown large enough to warrant manual intervention.
+    /// Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS`].
+    #[serde(default = "default_state_retention_sweep_budget_ms")]
+    pub sweep_budget_ms: u64,
 }
 
 impl Default for StateRetentionConfig {
@@ -281,6 +321,8 @@ impl Default for StateRetentionConfig {
             max_age_days: default_state_retention_max_age_days(),
             min_runs_kept: default_state_retention_min_runs_kept(),
             applies_to: default_state_retention_applies_to(),
+            sweep_interval_seconds: default_state_retention_sweep_interval_seconds(),
+            sweep_budget_ms: default_state_retention_sweep_budget_ms(),
         }
     }
 }
@@ -299,6 +341,14 @@ fn default_state_retention_applies_to() -> Vec<StateRetentionDomain> {
         StateRetentionDomain::Lineage,
         StateRetentionDomain::Audit,
     ]
+}
+
+fn default_state_retention_sweep_interval_seconds() -> u64 {
+    DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS
+}
+
+fn default_state_retention_sweep_budget_ms() -> u64 {
+    DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS
 }
 
 impl StateRetentionConfig {

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -1453,7 +1453,61 @@ impl StateStore {
         }
         Ok(n)
     }
+
+    /// Read the timestamp of the most recent successful end-of-run
+    /// auto-sweep, if any.
+    ///
+    /// Returns `Ok(None)` when the key is absent (fresh store, or older
+    /// rocky binary that never wrote it). Returns `Err` only when the
+    /// stored value is present but unparseable as RFC3339 — that is a
+    /// genuine corruption signal, not a missing-key signal, and the
+    /// caller should treat it as "do not auto-sweep this run" so the
+    /// state store stays unchanged until an operator inspects it.
+    ///
+    /// The auto-sweep gate at end-of-run reads this value and skips
+    /// sweeping when `now - last < sweep_interval_seconds`. The manual
+    /// `rocky state retention sweep` subcommand never consults this
+    /// field — it always runs.
+    pub fn get_last_retention_sweep_at(
+        &self,
+    ) -> Result<Option<chrono::DateTime<chrono::Utc>>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(METADATA)?;
+        let Some(value) = table.get(LAST_RETENTION_SWEEP_AT_KEY)? else {
+            return Ok(None);
+        };
+        let parsed = chrono::DateTime::parse_from_rfc3339(value.value())
+            .map_err(|e| StateError::VersionParse(format!("last_retention_sweep_at: {e}")))?
+            .with_timezone(&chrono::Utc);
+        Ok(Some(parsed))
+    }
+
+    /// Stamp the `last_retention_sweep_at` metadata key to `at`,
+    /// serialised as RFC3339.
+    ///
+    /// Called by the end-of-run auto-sweep regardless of whether the
+    /// sweep stayed inside its budget — the stamp tracks "when did we
+    /// last attempt", not "when did we last finish quickly". That keeps
+    /// the interval gate from firing every run on a state store that
+    /// consistently breaches the soft budget.
+    pub fn set_last_retention_sweep_at(
+        &self,
+        at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), StateError> {
+        let formatted = at.to_rfc3339();
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(METADATA)?;
+            table.insert(LAST_RETENTION_SWEEP_AT_KEY, formatted.as_str())?;
+        }
+        txn.commit()?;
+        Ok(())
+    }
 }
+
+/// Metadata key for the timestamp of the most recent end-of-run
+/// auto-sweep (see [`StateStore::get_last_retention_sweep_at`]).
+const LAST_RETENTION_SWEEP_AT_KEY: &str = "last_retention_sweep_at";
 
 // ---------------------------------------------------------------------------
 // Idempotency-key persistence (see `crate::idempotency`)
@@ -4004,6 +4058,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 0,
             applies_to: vec![StateRetentionDomain::History],
+            ..StateRetentionConfig::default()
         };
         let report = store.sweep_retention(&policy).unwrap();
         assert_eq!(report.runs_deleted, 0);
@@ -4028,6 +4083,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 10,
             applies_to: vec![StateRetentionDomain::History],
+            ..StateRetentionConfig::default()
         };
         let report = store.sweep_retention(&policy).unwrap();
         assert_eq!(report.runs_deleted, 0);
@@ -4062,6 +4118,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 5,
             applies_to: vec![StateRetentionDomain::History],
+            ..StateRetentionConfig::default()
         };
         let report = store.sweep_retention(&policy).unwrap();
         // The 7 old runs are not in the most-recent-5 and exceed cutoff →
@@ -4092,6 +4149,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 0,
             applies_to: vec![StateRetentionDomain::History],
+            ..StateRetentionConfig::default()
         };
 
         let dry = store.sweep_retention_dry_run(&policy).unwrap();
@@ -4122,6 +4180,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 0,
             applies_to: vec![StateRetentionDomain::Lineage],
+            ..StateRetentionConfig::default()
         };
         let report = store.sweep_retention(&policy).unwrap();
         assert_eq!(report.runs_deleted, 0);
@@ -4156,6 +4215,7 @@ mod tests {
             max_age_days: 30,
             min_runs_kept: 2,
             applies_to: vec![StateRetentionDomain::Audit],
+            ..StateRetentionConfig::default()
         };
         let report = store.sweep_retention(&policy).unwrap();
         assert_eq!(report.audit_deleted, 4);
@@ -4183,5 +4243,63 @@ mod tests {
         assert_eq!(report.runs_kept, 3);
         assert_eq!(report.lineage_deleted, 0);
         assert_eq!(report.audit_deleted, 0);
+    }
+
+    #[test]
+    fn last_retention_sweep_at_absent_returns_none() {
+        // Fresh state store has no metadata key yet.
+        let (store, _dir) = temp_store();
+        let result = store.get_last_retention_sweep_at().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn last_retention_sweep_at_round_trips() {
+        // Stamp a known timestamp and read it back; the chrono RFC3339
+        // serializer is lossless at second precision so we round-trip
+        // exactly for second-aligned inputs.
+        let (store, _dir) = temp_store();
+        let stamped = chrono::DateTime::parse_from_rfc3339("2026-05-02T12:34:56Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        store.set_last_retention_sweep_at(stamped).unwrap();
+
+        let read_back = store.get_last_retention_sweep_at().unwrap();
+        assert_eq!(read_back, Some(stamped));
+    }
+
+    #[test]
+    fn last_retention_sweep_at_set_overwrites() {
+        // Subsequent stamps replace the prior value; we don't keep a
+        // history of sweep timestamps in the metadata table.
+        let (store, _dir) = temp_store();
+        let first = chrono::DateTime::parse_from_rfc3339("2026-05-02T01:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let second = chrono::DateTime::parse_from_rfc3339("2026-05-02T02:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        store.set_last_retention_sweep_at(first).unwrap();
+        store.set_last_retention_sweep_at(second).unwrap();
+
+        let read_back = store.get_last_retention_sweep_at().unwrap();
+        assert_eq!(read_back, Some(second));
+    }
+
+    #[test]
+    fn last_retention_sweep_at_persists_across_reopen() {
+        // The metadata key is durable: closing and reopening the store
+        // recovers the timestamp.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.redb");
+        let stamped = chrono::DateTime::parse_from_rfc3339("2026-05-02T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        {
+            let store = StateStore::open(&path).unwrap();
+            store.set_last_retention_sweep_at(stamped).unwrap();
+        }
+        let store = StateStore::open(&path).unwrap();
+        assert_eq!(store.get_last_retention_sweep_at().unwrap(), Some(stamped));
     }
 }

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1684,6 +1684,14 @@ class StateRetentionConfig(BaseModel):
     """
     Always preserve at least this many rows in each domain, even if every row is older than `max_age_days`. Applied per domain (last N runs, last N DAG snapshots, last N quality snapshots). Defaults to [`DEFAULT_STATE_RETENTION_MIN_RUNS_KEPT`].
     """
+    sweep_budget_ms: conint(ge=0) | None = 5000
+    """
+    Wall-clock budget (in milliseconds) the auto-sweep measures itself against at end-of-run. The sweep always runs to completion; exceeding the budget flips the per-run log line from `tracing::debug` to `tracing::warn` so operators can spot a state store that has grown large enough to warrant manual intervention. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS`].
+    """
+    sweep_interval_seconds: conint(ge=0) | None = 3600
+    """
+    Minimum number of seconds between two automatic end-of-run sweeps. The `rocky run` end-of-run hook reads `last_retention_sweep_at` from the state store's metadata table and skips the sweep when `now - last < sweep_interval_seconds`. The manual `rocky state retention sweep` subcommand is unaffected — it always runs. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS`].
+    """
 
 
 class ChecksConfig(BaseModel):
@@ -2054,6 +2062,8 @@ class StateConfig(BaseModel):
             "applies_to": ["history", "lineage", "audit"],
             "max_age_days": 365,
             "min_runs_kept": 100,
+            "sweep_budget_ms": 5000,
+            "sweep_interval_seconds": 3600,
         },
         validate_default=True,
     )
@@ -2512,6 +2522,8 @@ class RockyConfig(BaseModel):
                 "applies_to": ["history", "lineage", "audit"],
                 "max_age_days": 365,
                 "min_runs_kept": 100,
+                "sweep_budget_ms": 5000,
+                "sweep_interval_seconds": 3600,
             },
             "retry": {
                 "backoff_multiplier": 2.0,

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2456,7 +2456,9 @@
               "audit"
             ],
             "max_age_days": 365,
-            "min_runs_kept": 100
+            "min_runs_kept": 100,
+            "sweep_budget_ms": 5000,
+            "sweep_interval_seconds": 3600
           },
           "description": "Retention policy applied to Rocky's own `state.redb` tables (run history, DAG snapshots, quality snapshots). Bounds the size of the control-plane store; operational tables (schema cache, watermarks, partition records) are never swept by this policy. See [`crate::retention::StateRetentionConfig`]."
         },
@@ -2543,6 +2545,20 @@
           "default": 100,
           "description": "Always preserve at least this many rows in each domain, even if every row is older than `max_age_days`. Applied per domain (last N runs, last N DAG snapshots, last N quality snapshots). Defaults to [`DEFAULT_STATE_RETENTION_MIN_RUNS_KEPT`].",
           "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sweep_budget_ms": {
+          "default": 5000,
+          "description": "Wall-clock budget (in milliseconds) the auto-sweep measures itself against at end-of-run. The sweep always runs to completion; exceeding the budget flips the per-run log line from `tracing::debug` to `tracing::warn` so operators can spot a state store that has grown large enough to warrant manual intervention. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_BUDGET_MS`].",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sweep_interval_seconds": {
+          "default": 3600,
+          "description": "Minimum number of seconds between two automatic end-of-run sweeps. The `rocky run` end-of-run hook reads `last_retention_sweep_at` from the state store's metadata table and skips the sweep when `now - last < sweep_interval_seconds`. The manual `rocky state retention sweep` subcommand is unaffected — it always runs. Defaults to [`DEFAULT_STATE_RETENTION_SWEEP_INTERVAL_SECONDS`].",
+          "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
         }
@@ -3022,7 +3038,9 @@
             "audit"
           ],
           "max_age_days": 365,
-          "min_runs_kept": 100
+          "min_runs_kept": 100,
+          "sweep_budget_ms": 5000,
+          "sweep_interval_seconds": 3600
         },
         "retry": {
           "backoff_multiplier": 2.0,


### PR DESCRIPTION
## Summary

Wires `StateStore::sweep_retention` (the foundation shipped in PR [#349](https://github.com/rocky-data/rocky/pull/349)) into the `rocky run` end-of-run path so the `[state.retention]` policy "just works" without an external cron. Closes the auto-invocation gap that #349's PR body documented as future work; aligns with the §B-3 entry in `~/Developer/rocky-plans/TODO.md`.

## Design calls

- **5s budget — soft, not hard.** `sweep_retention` is synchronous over `redb`; cancelling mid-commit doesn't leave a graceful "resume next time" state. Soft budget runs the sweep to completion, measures elapsed, and flips the per-run log from `tracing::debug` to `tracing::warn` on overrun. The 5s value is the documented call from the TODO entry — open to tuning if production telemetry shows it's mis-sized. The "resume on next run" semantics come from the interval gate, not from partial-completion.
- **1h default interval.** Configurable via the new `sweep_interval_seconds` field on the existing `[state.retention]` block. Long enough that an every-minute project does not pay sweep cost on every invocation; short enough that an hourly cron sweeps every run. Rationale documented inline in `retention.rs`.
- **`last_retention_sweep_at` lives in the existing `metadata` redb table.** No schema-version bump — it's just a new metadata key alongside `schema_version`. Stored as RFC3339 (lossless at second precision; matches the audit-trail conventions). Only stamped on actually-attempted sweeps, so flipping `applies_to = []` back on triggers a sweep next run regardless of recency.
- **Seam: outside the inner async block, before the idempotency error-path finalize.** `_otel_guard` lifts to function scope so the sweep's spans still flow through an active OTel tracer. Sweep runs unconditionally on both `Ok` and `Err` paths — a failed run shouldn't postpone state cleanup, and the interval gate prevents thrash. All sweep errors are swallowed as `tracing::warn` so the run's exit code reflects the run, never the sweep.
- **Idempotency-skipped runs do not auto-sweep.** A dedup-skipped run is a no-op against state; nothing to clean up. This is the natural consequence of the seam placement (after `try_claim_idempotency`'s early-return path) and is intentional.
- **`applies_to = []` is a clean off switch.** Skips the sweep AND skips the timestamp stamp, so re-enabling the policy mid-flight triggers a sweep on the next run.

## Test coverage

`engine/crates/rocky-core/src/state.rs` (4 unit tests):
- `last_retention_sweep_at_absent_returns_none` — fresh store has no metadata key.
- `last_retention_sweep_at_round_trips` — stamped → read returns the same instant.
- `last_retention_sweep_at_set_overwrites` — second stamp replaces the first.
- `last_retention_sweep_at_persists_across_reopen` — durable across `StateStore::open`.

`engine/crates/rocky-cli/src/commands/run.rs` (6 tokio tests on the helper):
- `auto_sweep_missing_state_path_is_a_noop` — ephemeral CI runner safe.
- `auto_sweep_disabled_by_empty_applies_to_does_not_stamp` — config off-switch preserves "last actual sweep" semantics.
- `auto_sweep_first_run_stamps_timestamp` — fresh store, default policy → sweeps + stamps.
- `auto_sweep_within_interval_skips_without_updating_stamp` — interval gate works without ratcheting the stamp forward.
- `auto_sweep_after_interval_runs_and_advances_stamp` — post-interval sweep advances the stamp.
- `auto_sweep_does_not_propagate_failure` — opportunistic-by-contract: opening a directory-as-DB fails inside the helper but never propagates to the caller.

Existing `sweep_retention_*` tests in `state.rs` updated to use struct update syntax (`..StateRetentionConfig::default()`) since two fields landed on the struct.

## Codegen cascade

Two new public fields on `StateRetentionConfig` triggered the schema cascade:
- `schemas/rocky_project.schema.json` — new `sweep_interval_seconds` / `sweep_budget_ms` properties with defaults populated in the existing `state.retention` block.
- `integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py` — Pydantic regenerated.
- `editors/vscode/src/types/generated/rocky_project.ts` — TypeScript regenerated.

`codegen-drift.yml` should pass.

## Test plan

- [x] `cargo test --workspace --no-fail-fast`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p rocky-core -p rocky-cli --no-deps -- -D warnings`
- [x] `uv run pytest` (dagster — 514/514 pass; regenerated Pydantic absorbs the schema additions cleanly)
- [x] `just codegen` clean (re-running it locally produces no further diff)
