### PR TITLE
fix(rocky-observe): record table durations as histograms not gauges

### DIFF
--- a/engine/crates/rocky-observe/src/metrics.rs
+++ b/engine/crates/rocky-observe/src/metrics.rs
@@ -79,6 +79,28 @@ impl RunMetrics {
         }
     }
 
+    /// Snapshot the raw table-duration observations without draining them.
+    ///
+    /// Append-only by design: the periodic OTLP exporter (when the `otel`
+    /// feature is enabled) tracks its own cursor over this slice so it can
+    /// stream new observations into a histogram instrument without
+    /// double-counting and without disturbing the run-end JSON snapshot.
+    pub fn read_table_durations(&self) -> Vec<u64> {
+        self.table_durations_ms
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    }
+
+    /// Snapshot the raw query-duration observations without draining them.
+    /// See [`Self::read_table_durations`] for the cursor protocol.
+    pub fn read_query_durations(&self) -> Vec<u64> {
+        self.query_durations_ms
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    }
+
     /// Snapshot all metrics into a serializable summary.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let table_durations = self
@@ -184,5 +206,46 @@ mod tests {
         assert_eq!(snap.tables_processed, 2);
         assert_eq!(snap.retries_attempted, 1);
         assert_eq!(snap.table_duration_max_ms, 200);
+    }
+
+    #[test]
+    fn test_read_table_durations_does_not_drain() {
+        // The OTLP exporter (when the `otel` feature is enabled) reads
+        // raw observations through a cursor and pumps them into a
+        // histogram instrument. The accessor must be append-only so the
+        // run-end JSON snapshot still sees every observation.
+        let m = RunMetrics::new();
+        m.record_table_duration_ms(10);
+        m.record_table_duration_ms(20);
+        m.record_table_duration_ms(30);
+
+        let read1 = m.read_table_durations();
+        assert_eq!(read1, vec![10, 20, 30]);
+
+        // Snapshot taken after read should still see everything.
+        let snap = m.snapshot();
+        assert_eq!(snap.table_duration_max_ms, 30);
+
+        // A second read should still return all three observations
+        // (proving the accessor is non-draining).
+        m.record_table_duration_ms(40);
+        let read2 = m.read_table_durations();
+        assert_eq!(read2, vec![10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn test_read_query_durations_does_not_drain() {
+        let m = RunMetrics::new();
+        m.record_query_duration_ms(5);
+        m.record_query_duration_ms(15);
+
+        let read1 = m.read_query_durations();
+        assert_eq!(read1, vec![5, 15]);
+
+        let snap = m.snapshot();
+        assert_eq!(snap.query_duration_max_ms, 15);
+
+        let read2 = m.read_query_durations();
+        assert_eq!(read2, vec![5, 15]);
     }
 }

--- a/engine/crates/rocky-observe/src/otel.rs
+++ b/engine/crates/rocky-observe/src/otel.rs
@@ -14,6 +14,7 @@
 //! | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | gRPC endpoint of the OTLP collector |
 //! | `OTEL_SERVICE_NAME` | `rocky` | Value of the `service.name` resource attribute |
 
+use std::sync::Mutex;
 use std::sync::atomic::Ordering;
 
 use opentelemetry::metrics::MeterProvider;
@@ -31,6 +32,14 @@ const DEFAULT_SERVICE_NAME: &str = "rocky";
 /// pushing Rocky's in-process metrics to an external collector.
 pub struct OtelExporter {
     provider: SdkMeterProvider,
+    /// Cursor over `METRICS.table_durations_ms` — index of the next
+    /// unrecorded observation. Each call to [`Self::export_metrics`] reads
+    /// the slice from this cursor onwards and feeds the new observations
+    /// into the OTLP histogram instrument, so the periodic flush stays
+    /// idempotent and the run-end JSON snapshot (which reads the full Vec)
+    /// is not disturbed.
+    table_cursor: Mutex<usize>,
+    query_cursor: Mutex<usize>,
 }
 
 impl OtelExporter {
@@ -73,15 +82,25 @@ impl OtelExporter {
 
         debug!("OTLP meter provider initialised");
 
-        Ok(OtelExporter { provider })
+        Ok(OtelExporter {
+            provider,
+            table_cursor: Mutex::new(0),
+            query_cursor: Mutex::new(0),
+        })
     }
 
-    /// Record the current in-process metrics snapshot as OTLP gauge/counter
-    /// observations.
+    /// Record the current in-process metrics snapshot as OTLP observations.
     ///
-    /// This reads the global [`METRICS`] singleton, creates OTel instruments on
-    /// the meter, and records the current values. The `PeriodicReader` will
-    /// flush them to the collector on its next interval (or on [`shutdown`](Self::shutdown)).
+    /// Counter values are emitted as gauges (last-value-wins is the right
+    /// shape for monotonic process-local counters); duration distributions
+    /// are emitted as histograms. The `PeriodicReader` flushes the
+    /// instruments to the collector on its next interval (or on
+    /// [`shutdown`](Self::shutdown)).
+    ///
+    /// Histogram observations are streamed from the cursor stored on
+    /// `self` so successive flushes never double-count. The source `Vec`
+    /// in [`crate::metrics::METRICS`] is never drained — callers reading
+    /// the run-end JSON snapshot still see every observation.
     pub fn export_metrics(&self) {
         let meter = self.provider.meter("rocky");
 
@@ -131,42 +150,36 @@ impl OtelExporter {
             .build();
         error_rate.record(snap.error_rate_pct, &[]);
 
-        // --- Duration histograms (p50, p95, max) ---
-        let table_p50 = meter
-            .u64_gauge("rocky.table_duration_p50_ms")
-            .with_description("Table materialisation duration p50 (ms)")
+        // --- Duration histograms ---
+        //
+        // OTel semantic conventions specify duration metrics as histogram
+        // instruments (the backend computes percentiles across hosts/runs).
+        // The previous shape — emitting in-process p50/p95/max as gauges —
+        // both lost information at the OTLP boundary and conflicted with
+        // semantic conventions. Switch to histograms recording each raw
+        // observation; cursor state on `self` keeps the periodic reader
+        // idempotent (no double-counting between flushes) without draining
+        // the source Vec, so the run-end JSON snapshot still sees every
+        // observation.
+        let table_durations = meter
+            .u64_histogram("rocky.table_duration_ms")
+            .with_unit("ms")
+            .with_description("Table materialisation duration distribution")
             .build();
-        table_p50.record(snap.table_duration_p50_ms, &[]);
+        let table_obs = METRICS.read_table_durations();
+        for ms in advance_cursor(&self.table_cursor, &table_obs) {
+            table_durations.record(ms, &[]);
+        }
 
-        let table_p95 = meter
-            .u64_gauge("rocky.table_duration_p95_ms")
-            .with_description("Table materialisation duration p95 (ms)")
+        let query_durations = meter
+            .u64_histogram("rocky.query_duration_ms")
+            .with_unit("ms")
+            .with_description("SQL statement duration distribution")
             .build();
-        table_p95.record(snap.table_duration_p95_ms, &[]);
-
-        let table_max = meter
-            .u64_gauge("rocky.table_duration_max_ms")
-            .with_description("Table materialisation duration max (ms)")
-            .build();
-        table_max.record(snap.table_duration_max_ms, &[]);
-
-        let query_p50 = meter
-            .u64_gauge("rocky.query_duration_p50_ms")
-            .with_description("Query duration p50 (ms)")
-            .build();
-        query_p50.record(snap.query_duration_p50_ms, &[]);
-
-        let query_p95 = meter
-            .u64_gauge("rocky.query_duration_p95_ms")
-            .with_description("Query duration p95 (ms)")
-            .build();
-        query_p95.record(snap.query_duration_p95_ms, &[]);
-
-        let query_max = meter
-            .u64_gauge("rocky.query_duration_max_ms")
-            .with_description("Query duration max (ms)")
-            .build();
-        query_max.record(snap.query_duration_max_ms, &[]);
+        let query_obs = METRICS.read_query_durations();
+        for ms in advance_cursor(&self.query_cursor, &query_obs) {
+            query_durations.record(ms, &[]);
+        }
 
         debug!("OTLP metrics recorded — awaiting next periodic flush");
     }
@@ -179,5 +192,59 @@ impl OtelExporter {
         if let Err(e) = self.provider.shutdown() {
             error!(error = %e, "OTLP meter provider shutdown failed");
         }
+    }
+}
+
+/// Returns the slice of observations the caller has not yet consumed and
+/// advances the cursor past them. The `min()` guards against an
+/// out-of-bounds cursor in the unlikely event the source `Vec` is
+/// truncated externally (it isn't today, but defending against future
+/// drift is cheap).
+fn advance_cursor(cursor: &Mutex<usize>, observations: &[u64]) -> Vec<u64> {
+    let mut guard = cursor.lock().expect("OTLP histogram cursor poisoned");
+    let start = (*guard).min(observations.len());
+    let new = observations[start..].to_vec();
+    *guard = observations.len();
+    new
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_cursor_returns_only_new_observations() {
+        let cursor = Mutex::new(0);
+        let obs = vec![10, 20, 30];
+        assert_eq!(advance_cursor(&cursor, &obs), vec![10, 20, 30]);
+        assert_eq!(*cursor.lock().unwrap(), 3);
+
+        // No new observations since the last flush.
+        assert!(advance_cursor(&cursor, &obs).is_empty());
+        assert_eq!(*cursor.lock().unwrap(), 3);
+
+        // Two more observations appear; the next flush should record only those.
+        let obs = vec![10, 20, 30, 40, 50];
+        assert_eq!(advance_cursor(&cursor, &obs), vec![40, 50]);
+        assert_eq!(*cursor.lock().unwrap(), 5);
+    }
+
+    #[test]
+    fn advance_cursor_handles_empty_initial_state() {
+        let cursor = Mutex::new(0);
+        let obs: Vec<u64> = vec![];
+        assert!(advance_cursor(&cursor, &obs).is_empty());
+        assert_eq!(*cursor.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn advance_cursor_clamps_when_cursor_exceeds_length() {
+        // Defensive: if the source Vec ever shrinks below the cursor (it
+        // won't today — `read_table_durations` clones an append-only
+        // Mutex<Vec>) the helper must not panic on slice-out-of-bounds.
+        let cursor = Mutex::new(10);
+        let obs = vec![1, 2, 3];
+        assert!(advance_cursor(&cursor, &obs).is_empty());
+        assert_eq!(*cursor.lock().unwrap(), 3);
     }
 }


### PR DESCRIPTION
## Scope

The OTLP metrics exporter at `engine/crates/rocky-observe/src/otel.rs` previously emitted six `u64_gauge` instruments (`rocky.table_duration_p50_ms` / `_p95_ms` / `_max_ms` and the query-side equivalents) using the in-process percentile aggregations from `MetricsSnapshot`. Two problems:

- **Information loss at the OTLP boundary.** Backends only see the in-process p50/p95/max and cannot recompute percentiles across hosts, runs, or time windows.
- **Conflicts with OTel semantic conventions.** Duration metrics are spec'd as histograms; gauges break out-of-the-box visualisations and aggregation queries downstream.

This PR replaces the six gauges with two `u64_histogram` instruments — `rocky.table_duration_ms` and `rocky.query_duration_ms` — that record raw per-observation values. The OTel SDK's periodic reader handles bucketing and aggregation backend-side.

## Design calls

- **Append-only source, cursor on the exporter.** A per-exporter `Mutex<usize>` cursor over the existing `Mutex<Vec<u64>>` in `RunMetrics` keeps successive periodic flushes idempotent (no double-counting between intervals). The source `Vec` is not drained — the run-end JSON snapshot, which percentile-folds the same `Vec`, is unchanged for non-OTel consumers (dagster integration, terminal output).
- **New non-draining accessors.** `RunMetrics::read_table_durations` / `read_query_durations` clone the `Vec` for the exporter; the existing `record_table_duration_ms` / `record_query_duration_ms` write paths and the `snapshot()` reader are untouched.
- **`advance_cursor` extracted as a module-private helper.** Lets the cursor logic be unit-tested without bringing up a real tonic gRPC endpoint.

## Test coverage

`cargo test -p rocky-observe --features otel` (20 tests, all green). New tests:

- `test_read_table_durations_does_not_drain` — verifies the accessor preserves observations across reads and the snapshot still sees everything.
- `test_read_query_durations_does_not_drain` — same for the query-duration side.
- `advance_cursor_returns_only_new_observations` — three flushes across a growing observation set; each flush sees only the delta.
- `advance_cursor_handles_empty_initial_state` — flush before any observation.
- `advance_cursor_clamps_when_cursor_exceeds_length` — defensive bound check (uses `min()`) so a future Vec-truncation refactor wouldn't slice-out-of-bounds.

`cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Backward compatibility

Operators with existing dashboards watching `rocky.table_duration_p50_ms` / `_p95_ms` / `_max_ms` (or the query-side equivalents) need to update their queries to use the new histogram instrument's percentile aggregations on the OTLP backend.