### PR TITLE
feat(rocky-observe): register tracing-opentelemetry layer

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -4814,6 +4815,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -157,10 +157,13 @@ wasm-bindgen = "0.2"
 # Testing
 wiremock = "0.6"
 
-# OpenTelemetry (feature-gated in rocky-observe)
+# OpenTelemetry (feature-gated in rocky-observe).
+# `tracing-opentelemetry` major versions track `opentelemetry` minor
+# versions: 0.32 pairs with opentelemetry 0.31 — pin the pair together.
 opentelemetry = "0.31"
 opentelemetry_sdk = "0.31"
 opentelemetry-otlp = "0.31"
+tracing-opentelemetry = "0.32"
 
 [profile.release]
 opt-level = 3

--- a/engine/crates/rocky-cli/src/otel_guard.rs
+++ b/engine/crates/rocky-cli/src/otel_guard.rs
@@ -1,9 +1,15 @@
-//! Lifecycle wrapper around `rocky_observe::otel::OtelExporter`.
+//! Lifecycle wrapper around the OTLP **metrics** exporter
+//! ([`rocky_observe::otel::OtelExporter`]).
 //!
-//! When the `otel` feature is enabled, [`OtelGuard::init_if_enabled`]
-//! inspects the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable and
-//! — if set — spins up the OTLP metrics exporter. Dropping the guard
-//! flushes the final metrics snapshot and shuts the exporter down.
+//! Trace exporting now lives in `rocky_observe::tracing_setup` —
+//! `init_tracing` returns a `TracingGuard` that owns the tracer
+//! provider so spans are emitted from process-startup forward. This
+//! guard remains responsible for the metrics path only:
+//!
+//! - reads the in-process `RunMetrics` snapshot and pushes it through
+//!   the OTLP meter provider on a 30s periodic interval,
+//! - flushes a final snapshot on `Drop` so the exit-time counters
+//!   reach the collector before `rocky run` returns.
 //!
 //! When the `otel` feature is disabled, the module compiles to a
 //! zero-size struct so callers in `commands/run.rs` don't have to

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -8,7 +8,12 @@ rust-version.workspace = true
 
 [features]
 default = []
-otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp"]
+otel = [
+    "opentelemetry",
+    "opentelemetry_sdk",
+    "opentelemetry-otlp",
+    "tracing-opentelemetry",
+]
 
 [dependencies]
 chrono = { workspace = true }
@@ -19,8 +24,12 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true, features = ["rt-tokio", "metrics"] }
-opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "metrics"] }
+opentelemetry_sdk = { workspace = true, optional = true, features = ["rt-tokio", "metrics", "trace"] }
+opentelemetry-otlp = { workspace = true, optional = true, features = ["grpc-tonic", "metrics", "trace"] }
+tracing-opentelemetry = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-observe/src/tracing_setup.rs
+++ b/engine/crates/rocky-observe/src/tracing_setup.rs
@@ -1,39 +1,473 @@
+//! Structured-logging initialisation for the Rocky CLI.
+//!
+//! [`init_tracing`] sets up the [`tracing`] subscriber registry with the
+//! `fmt` layer (JSON or compact, written to stderr). When the `otel`
+//! feature is enabled and `OTEL_EXPORTER_OTLP_ENDPOINT` is set, it also:
+//!
+//! - registers the `tracing-opentelemetry` layer so every existing
+//!   `tracing::info_span!` is exported via OTLP gRPC,
+//! - installs the W3C `TraceContextPropagator` so a `TRACEPARENT` env
+//!   var (the convention Dagster, OpenTelemetry SDKs, and most
+//!   orchestrators use to forward trace context to subprocesses) is
+//!   honoured,
+//! - returns a [`TracingGuard`] that owns the tracer provider; the OTel
+//!   batch span processor only flushes its final buffer on
+//!   `provider.shutdown()`, so the caller in `main.rs` must hold this
+//!   guard for the lifetime of the process or risk losing the last
+//!   spans on exit.
+//!
+//! Metrics initialisation is still owned by `OtelGuard` in `rocky-cli`
+//! (it lives there because the metrics flush is wired into the `rocky
+//! run` lifecycle and reads the run-end snapshot). This split keeps
+//! the *tracer* provider — which must be installed before the first
+//! `info_span!` call we want captured — at the top of `main`, while
+//! the *metrics* flush stays scoped to the run.
+
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
-/// Initializes structured logging.
+/// Returned from [`init_tracing`]. Holds optional OTel state that must
+/// outlive the program so the batch span processor flushes on drop.
 ///
-/// - `json=true`: JSON output (for machine consumption, dagster-rocky)
-/// - `json=false`: human-readable output (for local dev)
+/// The non-`otel` build is a zero-size type so callers don't need
+/// `cfg` attributes around the guard binding.
+pub struct TracingGuard {
+    #[cfg(feature = "otel")]
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+}
+
+impl Drop for TracingGuard {
+    fn drop(&mut self) {
+        #[cfg(feature = "otel")]
+        if let Some(provider) = self.tracer_provider.take() {
+            // Flush + shutdown the batch span processor so the final
+            // batch reaches the collector before the process exits.
+            // Errors here are non-fatal — log them and move on; we're
+            // already on the exit path.
+            if let Err(e) = provider.shutdown() {
+                tracing::warn!(error = %e, "OTLP tracer provider shutdown failed");
+            }
+        }
+    }
+}
+
+impl TracingGuard {
+    fn new_disabled() -> Self {
+        Self {
+            #[cfg(feature = "otel")]
+            tracer_provider: None,
+        }
+    }
+}
+
+/// Initialises structured logging and (when the `otel` feature is
+/// enabled and `OTEL_EXPORTER_OTLP_ENDPOINT` is set) the OTel tracing
+/// layer.
 ///
-/// Log level controlled by `RUST_LOG` env var (default: `info`).
-pub fn init_tracing(json: bool) {
+/// - `json=true`: JSON output to stderr (for machine consumption,
+///   dagster-rocky).
+/// - `json=false`: human-readable compact output (for local dev).
+///
+/// Log level controlled by `RUST_LOG` env var (default `info`).
+///
+/// **Hold the returned [`TracingGuard`] for the lifetime of the
+/// process** — dropping it earlier flushes and shuts down the batch
+/// span processor, after which subsequent spans go to the no-op
+/// tracer.
+#[must_use]
+pub fn init_tracing(json: bool) -> TracingGuard {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
-    // Always write logs to stderr so stdout is reserved for structured JSON output
-    // (discover, plan, run commands write their result JSON to stdout).
-    if json {
-        let fmt_layer = fmt::layer()
+    // `Layer::boxed()` erases the layer type so the if/else branch
+    // returns a uniform `BoxLayer` that still implements
+    // `Layer<Layered<...>>` for downstream composition. Always write
+    // logs to stderr so stdout stays reserved for the structured
+    // JSON output of `discover` / `plan` / `run`.
+    let fmt_layer = if json {
+        fmt::layer()
             .json()
             .with_target(true)
             .with_thread_ids(false)
-            .with_writer(std::io::stderr);
-
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(fmt_layer)
-            .init();
+            .with_writer(std::io::stderr)
+            .boxed()
     } else {
-        let fmt_layer = fmt::layer()
+        fmt::layer()
             .with_target(false)
             .with_thread_ids(false)
             .compact()
-            .with_writer(std::io::stderr);
+            .with_writer(std::io::stderr)
+            .boxed()
+    };
 
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(fmt_layer)
-            .init();
+    #[cfg(feature = "otel")]
+    {
+        if std::env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT").is_some() {
+            match build_otel_tracer() {
+                Ok(provider) => {
+                    use opentelemetry::trace::TracerProvider as _;
+                    let tracer = provider.tracer("rocky");
+                    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer).boxed();
+                    tracing_subscriber::registry()
+                        .with(filter)
+                        .with(fmt_layer)
+                        .with(otel_layer)
+                        .init();
+                    install_propagator();
+                    return TracingGuard {
+                        tracer_provider: Some(provider),
+                    };
+                }
+                Err(e) => {
+                    // Fall through to the fmt-only registry so the CLI
+                    // keeps working when the OTLP endpoint is unreachable
+                    // or misconfigured. The error is logged via the fmt
+                    // layer once it's installed.
+                    tracing_subscriber::registry()
+                        .with(filter)
+                        .with(fmt_layer)
+                        .init();
+                    tracing::warn!(
+                        error = %e,
+                        "OTLP tracer init failed; continuing without trace export"
+                    );
+                    return TracingGuard::new_disabled();
+                }
+            }
+        }
+    }
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .init();
+    TracingGuard::new_disabled()
+}
+
+#[cfg(feature = "otel")]
+fn build_otel_tracer()
+-> Result<opentelemetry_sdk::trace::SdkTracerProvider, Box<dyn std::error::Error + Send + Sync>> {
+    use opentelemetry_otlp::WithExportConfig;
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+
+    const DEFAULT_ENDPOINT: &str = "http://localhost:4317";
+    const DEFAULT_SERVICE_NAME: &str = "rocky";
+
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string());
+    let service_name =
+        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| DEFAULT_SERVICE_NAME.to_string());
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(&endpoint)
+        .build()?;
+
+    let resource = Resource::builder()
+        .with_service_name(service_name.clone())
+        .build();
+
+    // ParentBased(AlwaysOn) honours the upstream sampler decision when
+    // a remote `traceparent` is propagated (Dagster orchestrator), and
+    // falls back to "always sample" when running stand-alone. A finer
+    // sampling decision (head-based at a configurable rate, tail-based
+    // for failures) is left for a follow-up — 1000-table runs do
+    // produce 1000+ spans per run.
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .with_sampler(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
+        .build();
+
+    tracing::info!(
+        endpoint = %endpoint,
+        service = %service_name,
+        "OTLP tracer provider initialised"
+    );
+
+    Ok(provider)
+}
+
+#[cfg(feature = "otel")]
+fn install_propagator() {
+    // Install the W3C TraceContext propagator globally so that
+    // `extract_remote_context` (used at the top of subcommand entries)
+    // can pull the parent span out of carrier headers / env vars.
+    opentelemetry::global::set_text_map_propagator(
+        opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+    );
+}
+
+/// Reads the `TRACEPARENT` env var (W3C trace context) and returns the
+/// extracted [`opentelemetry::Context`], if any. The convention is set
+/// by orchestrators that launch Rocky as a subprocess (Dagster,
+/// Airflow's OpenLineage, the OTel Operator) so the spans we emit
+/// land as children of the orchestrator's run.
+///
+/// Returns `None` when the env var is unset, malformed, or when the
+/// `otel` feature is disabled.
+///
+/// Use the returned context with
+/// `tracing_opentelemetry::OpenTelemetrySpanExt::set_parent` on a
+/// `tracing::Span`, e.g.:
+///
+/// ```ignore
+/// use tracing_opentelemetry::OpenTelemetrySpanExt;
+/// let span = tracing::info_span!("rocky.run");
+/// if let Some(cx) = rocky_observe::tracing_setup::extract_remote_context() {
+///     let _ = span.set_parent(cx);
+/// }
+/// let _enter = span.enter();
+/// ```
+#[cfg(feature = "otel")]
+#[must_use]
+pub fn extract_remote_context() -> Option<opentelemetry::Context> {
+    use opentelemetry::propagation::TextMapPropagator;
+    use std::collections::HashMap;
+
+    let traceparent = std::env::var("TRACEPARENT").ok()?;
+    if traceparent.is_empty() {
+        return None;
+    }
+
+    let mut carrier = HashMap::new();
+    carrier.insert("traceparent".to_string(), traceparent);
+    if let Ok(tracestate) = std::env::var("TRACESTATE") {
+        if !tracestate.is_empty() {
+            carrier.insert("tracestate".to_string(), tracestate);
+        }
+    }
+
+    let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
+    let cx = propagator.extract(&carrier);
+
+    // The propagator returns a non-empty Context even on bad input —
+    // the only way to detect "no valid parent" is to inspect the
+    // SpanContext on the extracted Context.
+    use opentelemetry::trace::TraceContextExt;
+    if cx.span().span_context().is_valid() {
+        Some(cx)
+    } else {
+        None
+    }
+}
+
+/// Compatibility no-op for builds without the `otel` feature.
+#[cfg(not(feature = "otel"))]
+#[must_use]
+pub fn extract_remote_context() -> Option<()> {
+    None
+}
+
+#[cfg(all(test, feature = "otel"))]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+    use tracing::info_span;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// Cargo runs tests in this module in parallel within the same
+    /// process, so any test that reads / writes `TRACEPARENT` must hold
+    /// this mutex for the duration of its env mutation. Without it the
+    /// "set / extract / restore" sequence in one test races against the
+    /// "remove / extract / restore" in another, producing flaky failures
+    /// where `extract_remote_context_parses_valid_traceparent` sees an
+    /// empty env var because a sibling test happened to be in the
+    /// remove-restore window.
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// In-memory `SpanExporter` used to assert that spans land in the
+    /// pipeline. Mirrors the pattern in `tracing-opentelemetry`'s own
+    /// test suite.
+    #[derive(Clone, Default, Debug)]
+    struct CapturingExporter(Arc<Mutex<Vec<SpanData>>>);
+
+    impl SpanExporter for CapturingExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            if let Ok(mut g) = self.0.lock() {
+                g.extend(batch);
+            }
+            Ok(())
+        }
+    }
+
+    fn capturing_subscriber() -> (
+        CapturingExporter,
+        SdkTracerProvider,
+        impl tracing::Subscriber,
+    ) {
+        let exporter = CapturingExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("rocky_test");
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = tracing_subscriber::registry().with(layer);
+        (exporter, provider, subscriber)
+    }
+
+    /// PR 1 smoke test: an existing `info_span!` produces a span that
+    /// reaches the OTLP-side exporter once the layer is registered.
+    /// Asserts the layer routing is wired correctly — without it,
+    /// `dag_node` / `discover_sources` / `pipeline.run` etc. silently
+    /// drop on the floor.
+    #[test]
+    fn info_span_lands_at_otel_exporter() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _enter_rt = rt.enter();
+
+        let (exporter, provider, subscriber) = capturing_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!("pipeline.run", rocky.test = "smoke");
+            let _enter = span.enter();
+            // Some work happens here in production; the smoke test just
+            // creates and exits the span so the batch exporter can pick
+            // it up on shutdown.
+        });
+
+        provider.shutdown().expect("provider shutdown");
+        let captured = exporter.0.lock().unwrap();
+        assert!(
+            captured.iter().any(|s| s.name == "pipeline.run"),
+            "expected to see pipeline.run span in the exporter, got: {:?}",
+            captured.iter().map(|s| s.name.as_ref()).collect::<Vec<_>>()
+        );
+    }
+
+    /// `extract_remote_context` returns `None` when the env var is
+    /// unset (the no-Dagster path). Set + restore so the test is
+    /// hermetic.
+    #[test]
+    fn extract_remote_context_unset_returns_none() {
+        let _g = env_lock();
+        let prior = std::env::var_os("TRACEPARENT");
+        // SAFETY: held under `env_lock` so env mutation is serialised
+        // against the other env-var tests in this module.
+        unsafe {
+            std::env::remove_var("TRACEPARENT");
+        }
+        assert!(extract_remote_context().is_none());
+        if let Some(v) = prior {
+            unsafe {
+                std::env::set_var("TRACEPARENT", v);
+            }
+        }
+    }
+
+    /// Round-trip a valid W3C `traceparent` value through the
+    /// extractor and confirm the resulting context carries a valid
+    /// `SpanContext`.
+    #[test]
+    fn extract_remote_context_parses_valid_traceparent() {
+        use opentelemetry::trace::TraceContextExt as _;
+        let _g = env_lock();
+        // Format: 00-<32 hex traceid>-<16 hex spanid>-<2 hex flags>
+        let valid = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        let prior_tp = std::env::var_os("TRACEPARENT");
+        let prior_ts = std::env::var_os("TRACESTATE");
+        unsafe {
+            std::env::set_var("TRACEPARENT", valid);
+            std::env::remove_var("TRACESTATE");
+        }
+        let cx = extract_remote_context().expect("valid traceparent yields context");
+        // Bind the SpanRef to a local — `cx.span()` returns a borrow
+        // that must outlive `span_context()`'s usage.
+        let span_ref = cx.span();
+        let trace_id_str = {
+            let span_cx = span_ref.span_context();
+            assert!(span_cx.is_valid(), "extracted span context must be valid");
+            span_cx.trace_id().to_string()
+        };
+        assert_eq!(trace_id_str, "0af7651916cd43dd8448eb211c80319c");
+        unsafe {
+            match prior_tp {
+                Some(v) => std::env::set_var("TRACEPARENT", v),
+                None => std::env::remove_var("TRACEPARENT"),
+            }
+            if let Some(v) = prior_ts {
+                std::env::set_var("TRACESTATE", v);
+            }
+        }
+    }
+
+    /// Malformed `traceparent` should yield `None` rather than a
+    /// half-built context that would silently mis-parent every span.
+    #[test]
+    fn extract_remote_context_rejects_malformed_traceparent() {
+        let _g = env_lock();
+        let prior = std::env::var_os("TRACEPARENT");
+        unsafe {
+            std::env::set_var("TRACEPARENT", "definitely-not-a-traceparent");
+        }
+        assert!(extract_remote_context().is_none());
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("TRACEPARENT", v),
+                None => std::env::remove_var("TRACEPARENT"),
+            }
+        }
+    }
+
+    /// Round-trip: a span whose parent is set from a synthetic
+    /// `TRACEPARENT` should land at the exporter with the same trace
+    /// id as the env-var-supplied parent. Proves the propagator wiring
+    /// + `OpenTelemetrySpanExt::set_parent` integration.
+    #[test]
+    fn span_inherits_remote_parent_trace_id() {
+        let _g = env_lock();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _enter_rt = rt.enter();
+
+        let valid = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let expected_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+        let prior = std::env::var_os("TRACEPARENT");
+        unsafe {
+            std::env::set_var("TRACEPARENT", valid);
+        }
+
+        let (exporter, provider, subscriber) = capturing_subscriber();
+        tracing::subscriber::with_default(subscriber, || {
+            let span = info_span!("pipeline.run");
+            if let Some(cx) = extract_remote_context() {
+                let _ = span.set_parent(cx);
+            }
+            let _enter = span.enter();
+        });
+        provider.shutdown().expect("provider shutdown");
+
+        let captured = exporter.0.lock().unwrap();
+        let pipeline_run = captured
+            .iter()
+            .find(|s| s.name == "pipeline.run")
+            .expect("pipeline.run span captured");
+        assert_eq!(
+            pipeline_run.span_context.trace_id().to_string(),
+            expected_trace_id,
+            "span should inherit the trace id from the env-supplied parent"
+        );
+
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("TRACEPARENT", v),
+                None => std::env::remove_var("TRACEPARENT"),
+            }
+        }
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1310,8 +1310,15 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         .ok(); // Ignore if already set (e.g., in tests)
     }
 
-    // Init structured logging (JSON when output is JSON, human-readable otherwise)
-    rocky_observe::tracing_setup::init_tracing(json);
+    // Init structured logging (JSON when output is JSON, human-readable
+    // otherwise). When the `otel` feature is enabled and
+    // `OTEL_EXPORTER_OTLP_ENDPOINT` is set, this also registers the
+    // `tracing-opentelemetry` layer + W3C `TraceContextPropagator` so
+    // every existing `info_span!` is exported via OTLP gRPC. The
+    // returned guard owns the OTel batch span processor's tracer
+    // provider — bind it to a `_` prefix so it lives until the end of
+    // `run_async`; dropping it earlier loses the final batch on exit.
+    let _tracing_guard = rocky_observe::tracing_setup::init_tracing(json);
 
     let config_path = cli.config.clone();
 


### PR DESCRIPTION
## Scope

Today the OTLP integration is metrics-only. `engine/crates/rocky-observe/src/tracing_setup.rs::init_tracing` registers only `fmt::layer()`, so every existing `tracing::info_span!` (10+ sites in production: `dag_node`, `discover_sources`, `governance_setup`, `state.{download,upload,probe}`, ...) hits a no-op tracer. Operators with `OTEL_EXPORTER_OTLP_ENDPOINT` set today see counters but no traces.

This PR registers `tracing-opentelemetry::layer()` alongside the fmt layer when the `otel` feature is enabled and the env var is set, routing every existing `info_span!` to OTLP gRPC. No instrumentation sites change.

Adds three pieces:

1. **OTel tracing layer registration** in `init_tracing`, gated on the `otel` feature + `OTEL_EXPORTER_OTLP_ENDPOINT`.
2. **`init_tracing` reshape (mandatory)** so the tracer provider is installed *before* the first captured span.
3. **W3C `TRACEPARENT` honouring** so subprocess Rocky lands as a child of the orchestrator's run.

## Design calls

- **Tracer init moves up; metrics stays put.** The tracer provider must be installed before any `info_span!` we want captured. Previously `init_tracing(json)` ran at the top of `main.rs` while `OtelGuard::init_if_enabled()` ran inside `commands/run.rs` — every span between those points fired against a no-op tracer. Fix: collapse tracer-provider init into `init_tracing` (returning a `TracingGuard` held for process lifetime); demote `OtelGuard` to a metrics-only lifecycle wrapper. The metrics flush behaviour is unchanged.
- **`TracingGuard` owns the tracer provider.** Drops on `main.rs` exit and runs `provider.shutdown()` so the OTel batch span processor flushes its final buffer to the collector. Without this, the last batch of spans on a fast-exiting `rocky` invocation silently drops — the kind of bug only caught in production.
- **`extract_remote_context` is opt-in per-span.** Rather than a magic side-effect during `init_tracing`, callers attach the parsed context via `tracing_opentelemetry::OpenTelemetrySpanExt::set_parent` on whatever span they want to be the trace root. Returns `None` when the env var is unset, empty, or yields an invalid SpanContext. Defensive rejection of malformed input — `propagator.extract` returns a non-empty Context even on garbage, so we inspect `span_context().is_valid()` before accepting.
- **Default sampler: `ParentBased(AlwaysOn)`.** Honours the upstream Dagster sampler decision when traceparent propagation lands, falls back to "always sample" stand-alone. 1000-table runs do produce 1000+ spans per run; finer sampling (head-based rate, tail-based for failures) is a follow-up.
- **Version pin: `tracing-opentelemetry = "0.32"` paired with `opentelemetry = "0.31"`.** They must move together.

## Test coverage

`cargo test -p rocky-observe --features otel` (20 tests, all green). New tests:

- `info_span_lands_at_otel_exporter` — smoke test: an in-memory `SpanExporter` captures a `pipeline.run` span produced by `tracing::info_span!` once the layer is registered. Without the layer it would be dropped silently.
- `extract_remote_context_unset_returns_none` — no-Dagster path.
- `extract_remote_context_parses_valid_traceparent` — spec-valid W3C input round-trips.
- `extract_remote_context_rejects_malformed_traceparent` — bad input does not silently mis-parent every span.
- `span_inherits_remote_parent_trace_id` — end-to-end: a span whose parent is set from a synthetic `TRACEPARENT` lands at the exporter with the right trace id, proving the propagator wiring + `set_parent` integration.

Env-var tests share a module-level `Mutex` because cargo runs them in-process and parallel-by-default. Without serialisation, `set / extract / restore` in one test races against `remove / extract / restore` in a sibling.

`cargo test --workspace --no-fail-fast` clean. `cargo clippy --workspace --all-targets [--features rocky-cli/otel] -- -D warnings` clean. `cargo fmt --check` clean.

## Follow-ups flagged for separate dispatch

- **METRICS coverage is asymmetric.** `record_query_duration_ms` / `inc_statements_executed` fire only in `rocky-databricks/connector.rs` today, so `rocky.statements_executed` systematically under-counts for BigQuery / Snowflake / DuckDB / Fivetran. Pre-existing bug; flagged but **out of scope** for this dispatch per the wave-A scope memo.
- **Per-adapter `statement.execute` consistency span** across BQ / Snowflake / Iceberg / Airbyte / Fivetran is also deferred (was scoped as a separate PR and explicitly cut from this wave per Hugo on 2026-05-02).