### PR TITLE
feat(rocky-cli): emit OTel span events at PipelineEvent sites

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -738,16 +738,19 @@ pub async fn run(
         format!("failed to load config from {}", config_path.display()),
     )?;
 
-    // OTLP metrics exporter (feature-gated). Auto-initialises when
+    // OTLP **metrics** exporter (feature-gated). Auto-initialises when
     // `OTEL_EXPORTER_OTLP_ENDPOINT` is set so operators can opt in by
     // env alone — no CLI flag needed. Drop flushes the final snapshot
     // and shuts the periodic reader down, so this guard covers every
     // exit path (happy, interrupted, error) without threading an
     // explicit cleanup call.
     //
-    // Held at function scope (not inside the inner async block) so the
-    // end-of-run auto-sweep call below still emits its spans through an
-    // active tracer before the guard drops at function return.
+    // The OTel **tracer** provider is owned by `init_tracing` at the
+    // top of `main.rs` — see the `TracingGuard` returned there. This
+    // split lets every existing `info_span!` (in
+    // `dag_executor::materialize.table`, `commands/run.rs::*`,
+    // `state_sync.rs::state.*`, etc.) reach the OTLP collector even
+    // before the run dispatch enters this function.
     let _otel_guard = crate::otel_guard::OtelGuard::init_if_enabled();
 
     let mut idempotency_ctx = match idempotency_key {

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2679,6 +2679,10 @@ impl RunOutput {
             if let Some(rid) = run_id {
                 evt = evt.with_run_id(rid);
             }
+            // Annotate the active span with this breach as an OTel
+            // span event before fanning out to bus subscribers. No-op
+            // when the `otel` feature is off.
+            rocky_observe::events::record_span_event(&evt);
             bus.emit(evt);
         }
 

--- a/engine/crates/rocky-core/src/dag_executor.rs
+++ b/engine/crates/rocky-core/src/dag_executor.rs
@@ -224,7 +224,18 @@ impl<D: NodeDispatcher + 'static> DagExecutor<D> {
                 let kind_str = kind.to_string();
                 let id_str = id.0.clone();
                 let label_for_task = label.clone();
-                let span = info_span!("dag_node", id = %id, kind = %kind);
+                // OTel-conventional span name: `<verb>.<resource>`. Each
+                // node corresponds to materialising a model, so
+                // `materialize.table` is the user-facing name.
+                // `rocky.model.fqn` / `rocky.model.kind` follow the
+                // `<vendor>.<resource>.<name>` attribute convention so
+                // dashboards and trace views can pivot consistently
+                // across the rest of the wave's instrumentation.
+                let span = info_span!(
+                    "materialize.table",
+                    rocky.model.fqn = %id,
+                    rocky.model.kind = %kind,
+                );
 
                 join_set.spawn(
                     async move {

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 use reqwest::Client;
 use rocky_core::config::RetryConfig;
 use rocky_core::retry::compute_backoff;
-use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
+use rocky_observe::events::{
+    ErrorClass, PipelineEvent, global_event_bus, record_span_event, set_current_span_error,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -276,10 +278,10 @@ impl DatabricksConnector {
             match self.submit_and_wait_once(sql).await {
                 Ok(resp) => {
                     if self.circuit_breaker.record_success() == TransitionOutcome::Recovered {
-                        global_event_bus().emit(
-                            PipelineEvent::new("circuit_breaker_recovered")
-                                .with_target("databricks"),
-                        );
+                        let evt = PipelineEvent::new("circuit_breaker_recovered")
+                            .with_target("databricks");
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                     }
                     if attempt > 0 {
                         rocky_observe::metrics::METRICS.inc_retries_succeeded();
@@ -291,12 +293,12 @@ impl DatabricksConnector {
                         && self.circuit_breaker.record_failure(&err.to_string())
                             == TransitionOutcome::Tripped
                     {
-                        global_event_bus().emit(
-                            PipelineEvent::new("circuit_breaker_tripped")
-                                .with_target("databricks")
-                                .with_error(err.to_string())
-                                .with_error_class(classify_error(&err)),
-                        );
+                        let evt = PipelineEvent::new("circuit_breaker_tripped")
+                            .with_target("databricks")
+                            .with_error(err.to_string())
+                            .with_error_class(classify_error(&err));
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                     }
                     if attempt < retry.max_retries && is_transient(&err) {
                         // Run-level retry budget (§P2.7). If exhausted, abort
@@ -312,18 +314,25 @@ impl DatabricksConnector {
                                 error = %err,
                                 "retry budget exhausted for this run; aborting further retries",
                             );
+                            // Mark the active OTel span as Error so trace
+                            // viewers surface the run-level retry-budget
+                            // exhaustion without dashboard-side log
+                            // string-matching. No-op when `otel` is off.
+                            set_current_span_error(format!(
+                                "retry budget exhausted (limit {limit})"
+                            ));
                             return Err(ConnectorError::RetryBudgetExhausted { limit });
                         }
                         // §P2.8 emit site: retry-about-to-fire with structured
                         // attempt / classification so event-bus subscribers
                         // (Dagster, dashboards) can tell "retry 2/5" from
                         // terminal failure without string-matching.
-                        global_event_bus().emit(
-                            PipelineEvent::new("statement_retry")
-                                .with_error(err.to_string())
-                                .with_attempt(attempt + 1, retry.max_retries)
-                                .with_error_class(classify_error(&err)),
-                        );
+                        let evt = PipelineEvent::new("statement_retry")
+                            .with_error(err.to_string())
+                            .with_attempt(attempt + 1, retry.max_retries)
+                            .with_error_class(classify_error(&err));
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                         rocky_observe::metrics::METRICS.inc_retries_attempted();
                         // 401/403 typically mean the OAuth token expired
                         // between cache-mint and server-use. Databricks
@@ -352,6 +361,9 @@ impl DatabricksConnector {
                         tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                         continue;
                     }
+                    // Retry exhausted (or non-transient error) — terminal
+                    // failure. Mark the active OTel span as Error.
+                    set_current_span_error(err.to_string());
                     return Err(err);
                 }
             }

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -31,7 +31,7 @@ fn build_http_client() -> Client {
 }
 use rocky_core::config::RetryConfig;
 use rocky_core::redacted::RedactedString;
-use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
+use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus, record_span_event};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -139,12 +139,12 @@ impl FivetranClient {
     /// `get_single_page` should call this so event-bus subscribers see
     /// structured attempt count + classification instead of free-form text.
     fn emit_retry_event(&self, attempt: u32, reason: &str, class: ErrorClass) {
-        global_event_bus().emit(
-            PipelineEvent::new("http_retry")
-                .with_error(reason.to_string())
-                .with_attempt(attempt + 1, self.retry.max_retries)
-                .with_error_class(class),
-        );
+        let evt = PipelineEvent::new("http_retry")
+            .with_error(reason.to_string())
+            .with_attempt(attempt + 1, self.retry.max_retries)
+            .with_error_class(class);
+        record_span_event(&evt);
+        global_event_bus().emit(evt);
     }
 
     /// GET request with automatic response envelope unwrapping and retry on transient errors.

--- a/engine/crates/rocky-observe/src/events.rs
+++ b/engine/crates/rocky-observe/src/events.rs
@@ -218,6 +218,113 @@ pub fn global_event_bus() -> &'static EventBus {
 }
 
 // ---------------------------------------------------------------------------
+// OTel span-event bridge
+// ---------------------------------------------------------------------------
+
+/// Annotate the current `tracing::Span` with a span event derived from the
+/// given [`PipelineEvent`].
+///
+/// When the `otel` feature is enabled and a `tracing-opentelemetry` layer
+/// is registered (see `rocky_observe::tracing_setup::init_tracing`), this
+/// translates the event's structured fields (`event_type` becomes the
+/// span event name; `error`, `target`, `attempt`/`max_attempts`, and
+/// `error_class` become attributes) into an OTLP span event on
+/// `Span::current()`. Without the layer or feature, this is a no-op so
+/// callers don't need to gate the call.
+///
+/// Use this at every `EventBus::emit` site where the event represents a
+/// point-in-time annotation (retry fired, breaker tripped, budget
+/// breached). Span boundaries (`pipeline_start` / `pipeline_complete`)
+/// stay as bus events and are *not* converted — the per-run lifecycle
+/// span is the OTel-native shape for those.
+pub fn record_span_event(event: &PipelineEvent) {
+    #[cfg(feature = "otel")]
+    {
+        use opentelemetry::KeyValue;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        let mut attrs: Vec<KeyValue> = Vec::with_capacity(4 + event.metadata.len());
+        if let Some(target) = &event.target {
+            attrs.push(KeyValue::new("rocky.event.target", target.clone()));
+        }
+        if let Some(err) = &event.error {
+            attrs.push(KeyValue::new("rocky.event.error", err.clone()));
+        }
+        if let (Some(a), Some(m)) = (event.attempt, event.max_attempts) {
+            attrs.push(KeyValue::new("rocky.event.attempt", i64::from(a)));
+            attrs.push(KeyValue::new("rocky.event.max_attempts", i64::from(m)));
+        }
+        if let Some(class) = event.error_class {
+            attrs.push(KeyValue::new(
+                "rocky.event.error_class",
+                error_class_to_str(class).to_string(),
+            ));
+        }
+        // Numeric / string metadata is forwarded too; complex values get
+        // their JSON serialisation as a string so dashboards can pivot
+        // without the producer learning the OTel attribute taxonomy.
+        for (k, v) in &event.metadata {
+            let key = format!("rocky.event.metadata.{k}");
+            match v {
+                serde_json::Value::String(s) => attrs.push(KeyValue::new(key, s.clone())),
+                serde_json::Value::Bool(b) => attrs.push(KeyValue::new(key, *b)),
+                serde_json::Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        attrs.push(KeyValue::new(key, i));
+                    } else if let Some(f) = n.as_f64() {
+                        attrs.push(KeyValue::new(key, f));
+                    } else {
+                        attrs.push(KeyValue::new(key, n.to_string()));
+                    }
+                }
+                _ => attrs.push(KeyValue::new(key, v.to_string())),
+            }
+        }
+
+        // `Cow<'static, str>` requires the name to be 'static, but
+        // `PipelineEvent::event_type` is a `String`. The underlying OTel
+        // API takes `Into<Cow<...>>`; `String` works directly because
+        // `Cow<'static, str>` accepts owned `String` via `From`.
+        tracing::Span::current().add_event(event.event_type.clone(), attrs);
+    }
+    #[cfg(not(feature = "otel"))]
+    {
+        let _ = event;
+    }
+}
+
+/// Mark the current `tracing::Span` as `Error` with the supplied
+/// description. Used at retry-loop terminal-failure sites so the active
+/// adapter span (and, by inheritance, the parent `materialize.table`
+/// span) carries the right OTel status.
+///
+/// No-op when the `otel` feature is disabled.
+pub fn set_current_span_error(message: impl Into<String>) {
+    #[cfg(feature = "otel")]
+    {
+        use opentelemetry::trace::Status;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        tracing::Span::current().set_status(Status::error(message.into()));
+    }
+    #[cfg(not(feature = "otel"))]
+    {
+        let _ = message.into();
+    }
+}
+
+#[cfg(feature = "otel")]
+fn error_class_to_str(class: ErrorClass) -> &'static str {
+    match class {
+        ErrorClass::Transient => "transient",
+        ErrorClass::Permanent => "permanent",
+        ErrorClass::Timeout => "timeout",
+        ErrorClass::Auth => "auth",
+        ErrorClass::Config => "config",
+        ErrorClass::RateLimit => "rate_limit",
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -387,5 +494,181 @@ mod tests {
         assert_eq!(event.attempt, None);
         assert_eq!(event.max_attempts, None);
         assert_eq!(event.error_class, None);
+    }
+
+    /// `record_span_event` must not panic when called outside any
+    /// `tracing` span (e.g., a unit test that didn't enter a span).
+    /// `Span::current()` returns the no-op span; the OTel layer's
+    /// `add_event` impl is a silent drop on a no-op span.
+    #[test]
+    fn record_span_event_no_span_is_noop() {
+        let evt = PipelineEvent::new("statement_retry")
+            .with_target("databricks")
+            .with_attempt(2, 5)
+            .with_error_class(ErrorClass::Transient);
+        // Must not panic.
+        record_span_event(&evt);
+    }
+
+    /// `set_current_span_error` likewise must not panic on a no-op span.
+    #[test]
+    fn set_current_span_error_no_span_is_noop() {
+        // Must not panic.
+        set_current_span_error("retry budget exhausted (limit 25)");
+    }
+
+    /// With the `otel` feature on and a `tracing-opentelemetry` layer
+    /// registered, `record_span_event` annotates the active span. The
+    /// in-memory exporter pattern from `tracing_setup::tests` confirms
+    /// the event lands with the right name and attribute values.
+    #[cfg(feature = "otel")]
+    #[test]
+    fn record_span_event_annotates_active_span() {
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::error::OTelSdkResult;
+        use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone, Default, Debug)]
+        struct Cap(Arc<Mutex<Vec<SpanData>>>);
+        impl SpanExporter for Cap {
+            async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+                if let Ok(mut g) = self.0.lock() {
+                    g.extend(batch);
+                }
+                Ok(())
+            }
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _enter_rt = rt.enter();
+
+        let exp = Cap::default();
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exp.clone())
+            .build();
+        let tracer = provider.tracer("rocky_test");
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("materialize.table");
+            let _enter = span.enter();
+            let evt = PipelineEvent::new("statement_retry")
+                .with_target("databricks")
+                .with_error("HTTP 503")
+                .with_attempt(2, 5)
+                .with_error_class(ErrorClass::Transient);
+            record_span_event(&evt);
+        });
+        provider.shutdown().expect("shutdown");
+
+        let captured = exp.0.lock().unwrap();
+        let span = captured
+            .iter()
+            .find(|s| s.name == "materialize.table")
+            .expect("span captured");
+        let event = span
+            .events
+            .iter()
+            .find(|e| e.name == "statement_retry")
+            .expect("statement_retry event captured");
+
+        // Iterate attributes and confirm the structured fields landed.
+        let attrs: Vec<(String, String)> = event
+            .attributes
+            .iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect();
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "rocky.event.target" && v == "databricks"),
+            "expected target attr, got {attrs:?}"
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "rocky.event.error_class" && v == "transient"),
+            "expected error_class attr, got {attrs:?}"
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "rocky.event.attempt" && v == "2"),
+            "expected attempt attr, got {attrs:?}"
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "rocky.event.max_attempts" && v == "5"),
+            "expected max_attempts attr, got {attrs:?}"
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "rocky.event.error" && v == "HTTP 503"),
+            "expected error attr, got {attrs:?}"
+        );
+    }
+
+    /// `set_current_span_error` should set the OTel span status to
+    /// `Error` with the supplied description when the layer is on.
+    #[cfg(feature = "otel")]
+    #[test]
+    fn set_current_span_error_sets_otel_status() {
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::error::OTelSdkResult;
+        use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone, Default, Debug)]
+        struct Cap(Arc<Mutex<Vec<SpanData>>>);
+        impl SpanExporter for Cap {
+            async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+                if let Ok(mut g) = self.0.lock() {
+                    g.extend(batch);
+                }
+                Ok(())
+            }
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _enter_rt = rt.enter();
+
+        let exp = Cap::default();
+        let provider = SdkTracerProvider::builder()
+            .with_batch_exporter(exp.clone())
+            .build();
+        let tracer = provider.tracer("rocky_test");
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("materialize.table");
+            let _enter = span.enter();
+            set_current_span_error("retry budget exhausted (limit 25)");
+        });
+        provider.shutdown().expect("shutdown");
+
+        let captured = exp.0.lock().unwrap();
+        let span = captured
+            .iter()
+            .find(|s| s.name == "materialize.table")
+            .expect("span captured");
+        match &span.status {
+            opentelemetry::trace::Status::Error { description } => {
+                assert_eq!(description.as_ref(), "retry budget exhausted (limit 25)");
+            }
+            other => panic!("expected Error status, got {other:?}"),
+        }
     }
 }

--- a/engine/crates/rocky-observe/src/tracing_setup.rs
+++ b/engine/crates/rocky-observe/src/tracing_setup.rs
@@ -319,8 +319,8 @@ mod tests {
     /// PR 1 smoke test: an existing `info_span!` produces a span that
     /// reaches the OTLP-side exporter once the layer is registered.
     /// Asserts the layer routing is wired correctly — without it,
-    /// `dag_node` / `discover_sources` / `pipeline.run` etc. silently
-    /// drop on the floor.
+    /// `materialize.table` / `discover_sources` / `pipeline.run` etc.
+    /// silently drop on the floor.
     #[test]
     fn info_span_lands_at_otel_exporter() {
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -14,7 +14,9 @@ use reqwest::{Client, RequestBuilder};
 use rocky_core::circuit_breaker::{CircuitBreaker, TransitionOutcome};
 use rocky_core::config::RetryConfig;
 use rocky_core::retry::compute_backoff;
-use rocky_observe::events::{ErrorClass, PipelineEvent, global_event_bus};
+use rocky_observe::events::{
+    ErrorClass, PipelineEvent, global_event_bus, record_span_event, set_current_span_error,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -265,10 +267,10 @@ impl SnowflakeConnector {
             match self.submit_and_wait_once(sql).await {
                 Ok(resp) => {
                     if self.circuit_breaker.record_success() == TransitionOutcome::Recovered {
-                        global_event_bus().emit(
-                            PipelineEvent::new("circuit_breaker_recovered")
-                                .with_target("snowflake"),
-                        );
+                        let evt = PipelineEvent::new("circuit_breaker_recovered")
+                            .with_target("snowflake");
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                     }
                     return Ok(resp);
                 }
@@ -277,12 +279,12 @@ impl SnowflakeConnector {
                         && self.circuit_breaker.record_failure(&err.to_string())
                             == TransitionOutcome::Tripped
                     {
-                        global_event_bus().emit(
-                            PipelineEvent::new("circuit_breaker_tripped")
-                                .with_target("snowflake")
-                                .with_error(err.to_string())
-                                .with_error_class(classify_error(&err)),
-                        );
+                        let evt = PipelineEvent::new("circuit_breaker_tripped")
+                            .with_target("snowflake")
+                            .with_error(err.to_string())
+                            .with_error_class(classify_error(&err));
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                     }
                     if attempt < retry.max_retries && is_transient(&err) {
                         // Run-level retry budget (§P2.7). Short-circuit if
@@ -297,15 +299,19 @@ impl SnowflakeConnector {
                                 error = %err,
                                 "retry budget exhausted for this run; aborting further retries",
                             );
+                            // Mark active span Error — terminal failure.
+                            set_current_span_error(format!(
+                                "retry budget exhausted (limit {limit})"
+                            ));
                             return Err(ConnectorError::RetryBudgetExhausted { limit });
                         }
                         // §P2.8 retry event emission — see databricks/connector.rs
-                        global_event_bus().emit(
-                            PipelineEvent::new("statement_retry")
-                                .with_error(err.to_string())
-                                .with_attempt(attempt + 1, retry.max_retries)
-                                .with_error_class(classify_error(&err)),
-                        );
+                        let evt = PipelineEvent::new("statement_retry")
+                            .with_error(err.to_string())
+                            .with_attempt(attempt + 1, retry.max_retries)
+                            .with_error_class(classify_error(&err));
+                        record_span_event(&evt);
+                        global_event_bus().emit(evt);
                         // 401 from Snowflake often means the cached keypair
                         // JWT crossed the server-side expiry boundary between
                         // mint and request. Drop the cache so the next
@@ -325,6 +331,8 @@ impl SnowflakeConnector {
                         tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
                         continue;
                     }
+                    // Retry exhausted (or non-transient) — terminal failure.
+                    set_current_span_error(err.to_string());
                     return Err(err);
                 }
             }


### PR DESCRIPTION
Builds on #360 (now merged into `main`). With the `tracing-opentelemetry` layer registered, this PR makes every existing `PipelineEvent::new(...).emit()` site also annotate the active `tracing::Span` with an OTLP span event, so retries, circuit-breaker transitions, and budget breaches show up natively in trace viewers (Jaeger, Honeycomb, Datadog, Grafana Tempo) without operators wiring up an EventBus subscriber separately.

Plus a span-name + attribute rename of the per-DAG-node materialization span to OTel-conventional shapes.

## Design calls

- **One bridge helper, eight call sites.** `events::record_span_event(&PipelineEvent)` in `rocky-observe` translates the event type to a span-event name and the structured fields (`target` / `error` / `attempt` / `max_attempts` / `error_class` / any `metadata`) to OTel `KeyValue` attributes under the `rocky.event.*` namespace. No-op without the `otel` feature so call sites don't need cfg gates. Single API, all 8 sites use it.
- **`set_current_span_error` for retry-loop terminal failures (memo §"Self-review" #13).** When the retry loop in `connector.rs` gives up — either because retries are exhausted or because `RetryBudget` is drained — the active span gets `Status::Error(description)` so trace viewers surface the failure without dashboard-side log string-matching. Called from both Databricks and Snowflake retry paths.
- **`dag_node` → `materialize.table` rename + attribute rename.** `crates/rocky-core/src/dag_executor.rs:227` previously emitted `info_span!("dag_node", id, kind)`. Now `info_span!("materialize.table", rocky.model.fqn, rocky.model.kind)` following OTel `<verb>.<resource>` span-name and `<vendor>.<resource>.<name>` attribute conventions, so dashboards across this wave's instrumentation pivot consistently. Per memo §"Design forks" #3.
- **Span events vs span boundaries.** Per the wave-A scope memo: retries, circuit-breaker transitions, budget breaches are *point-in-time* annotations and become span events on the active span. `pipeline_start` / `pipeline_complete` / `after_materialize` are *boundary markers* and stay as bus events only — no span-event translation. (They'd already be implicit in the `materialize.table` span's start/end timestamps.)

## Eight emit sites updated

- `crates/rocky-databricks/src/connector.rs` — `circuit_breaker_recovered`, `circuit_breaker_tripped`, `statement_retry`. Plus `set_current_span_error` on retry-budget exhaustion and on terminal retry exhaustion.
- `crates/rocky-snowflake/src/connector.rs` — same three events + the same two error-path annotations.
- `crates/rocky-fivetran/src/client.rs` — `http_retry`.
- `crates/rocky-cli/src/output.rs` — `budget_breach` (one event per breach, since the loop emits one per breached budget dimension).

## Test coverage

- `record_span_event_no_span_is_noop` — `Span::current()` returns the no-op span when no span is active; the helper must not panic.
- `set_current_span_error_no_span_is_noop` — same for the error-status helper.
- `record_span_event_annotates_active_span` (otel-gated) — end-to-end via an in-memory `SpanExporter`: records a `statement_retry` on a `materialize.table` span, then asserts every translated attribute (`rocky.event.target`, `rocky.event.error_class`, `rocky.event.attempt`, `rocky.event.max_attempts`, `rocky.event.error`) lands on the captured span event.
- `set_current_span_error_sets_otel_status` (otel-gated) — span lands with `Status::Error { description }` matching the supplied message.

`cargo test --workspace --no-fail-fast` clean. `cargo clippy --workspace --all-targets [--features rocky-cli/otel] -- -D warnings` clean. `cargo fmt --check` clean.