### PR TITLE
fix(rocky-snowflake): add missing pat field to wiremock_tests AuthConfig literals

### DIFF
--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -23,6 +23,7 @@ fn test_connector(server: &MockServer) -> SnowflakeConnector {
         password: None,
         oauth_token: Some("test-sf-token".into()),
         private_key_path: None,
+        pat: None,
     })
     .unwrap();
 
@@ -50,6 +51,7 @@ fn test_connector_with_retries(server: &MockServer, max_retries: u32) -> Snowfla
         password: None,
         oauth_token: Some("test-sf-token".into()),
         private_key_path: None,
+        pat: None,
     })
     .unwrap();
 
@@ -637,6 +639,7 @@ async fn test_keypair_auth_headers() {
         password: None,
         oauth_token: None,
         private_key_path: Some("/unused-because-cache-primed.pem".into()),
+        pat: None,
     })
     .unwrap();
     auth.prime_cache_with("fake-jwt-token", Duration::from_secs(3540))
@@ -714,6 +717,7 @@ async fn test_password_auth_omits_token_type_header() {
         password: Some("test_pass".into()),
         oauth_token: None,
         private_key_path: None,
+        pat: None,
     })
     .unwrap();
     // Skip the live login-request hit by priming the session-token cache.


### PR DESCRIPTION
## Summary

The `pat` field added to `AuthConfig` in #357 wasn't propagated to the four `AuthConfig` literals in `engine/crates/rocky-snowflake/tests/wiremock_tests.rs` because the file is feature-gated (the literals weren't surfaced by `cargo test --workspace` in the default profile during pre-merge verification). Build fails with `error[E0063]: missing field \`pat\`` once the gated profile runs.

This PR adds `pat: None,` to each of the four sites. No behavioural change — all four sites are already exercising other auth modes (token / oauth / etc.), and `pat = None` simply preserves the existing routing through `Auth::from_config`.

## Test plan

- [x] \`cargo build -p rocky-snowflake --tests\` clean
- [x] \`cargo fmt --check\` clean

Unblocks the CI on PR #359 (release cut v1.23.0).