### PR TITLE
feat(otel): per-adapter statement.execute spans

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "wiremock",
 ]
 

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::time::Instant;
-use tracing::debug;
+use tracing::{Instrument, debug, info_span};
 
 use rocky_core::ir::{ColumnInfo, TableRef};
 use rocky_core::traits::{
@@ -141,58 +141,79 @@ impl BigQueryAdapter {
     }
 
     /// Execute a query via the BigQuery REST API.
+    ///
+    /// Wrapped in a `statement.execute` span so every BigQuery API call —
+    /// `execute_statement`, `execute_statement_with_stats`, `execute_query`,
+    /// `describe_table`, `list_tables`, etc. — appears under a consistent,
+    /// adapter-tagged child span when traced. Mirrors the OTel
+    /// `<verb>.<resource>` shape used by the `materialize.table` parent.
     async fn run_query(&self, sql: &str) -> Result<BigQueryResponse, BigQueryError> {
-        let token = self.auth.get_token(&self.client).await?;
-        let url = format!(
-            "https://bigquery.googleapis.com/bigquery/v2/projects/{}/queries",
-            self.project_id
+        // `statement.kind = "query"` is a best-effort default — BigQuery
+        // routes DDL, DML, and SELECT through the same `jobs.query`
+        // endpoint and the wire request doesn't surface the parsed
+        // statement kind. TODO: classify via `rocky-sql` if downstream
+        // consumers need to filter ddl/dml from query traffic.
+        let span = info_span!(
+            "statement.execute",
+            adapter = "bigquery",
+            statement.kind = "query",
         );
+        async move {
+            let token = self.auth.get_token(&self.client).await?;
+            let url = format!(
+                "https://bigquery.googleapis.com/bigquery/v2/projects/{}/queries",
+                self.project_id
+            );
 
-        let request = QueryRequest {
-            query: sql.to_string(),
-            use_legacy_sql: false,
-            location: self.location.clone(),
-            timeout_ms: self.timeout_secs * 1000,
-            max_results: MAX_RESULTS_PER_PAGE,
-        };
+            let request = QueryRequest {
+                query: sql.to_string(),
+                use_legacy_sql: false,
+                location: self.location.clone(),
+                timeout_ms: self.timeout_secs * 1000,
+                max_results: MAX_RESULTS_PER_PAGE,
+            };
 
-        debug!(sql = sql, project = %self.project_id, "executing BigQuery query");
+            debug!(sql = sql, project = %self.project_id, "executing BigQuery query");
 
-        let resp = self
-            .client
-            .post(&url)
-            .bearer_auth(&token)
-            .json(&request)
-            .send()
-            .await?;
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&request)
+                .send()
+                .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status().to_string();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(BigQueryError::ApiError {
-                status,
-                message: body,
-            });
+            if !resp.status().is_success() {
+                let status = resp.status().to_string();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(BigQueryError::ApiError {
+                    status,
+                    message: body,
+                });
+            }
+
+            let response: BigQueryResponse = resp.json().await?;
+
+            if response.job_complete {
+                return Ok(response);
+            }
+
+            // Async job: BigQuery deferred the result. Poll jobs.getQueryResults
+            // until it reports `job_complete=true` or `timeout_secs` elapses.
+            // Without this, the previous behaviour silently returned an empty
+            // rows array for any query slower than BigQuery's sync window.
+            let job_ref = response
+                .job_reference
+                .ok_or_else(|| BigQueryError::ApiError {
+                    status: "missing jobReference".into(),
+                    message:
+                        "BigQuery returned job_complete=false with no job_reference; cannot poll"
+                            .into(),
+                })?;
+            self.poll_query_results(&job_ref).await
         }
-
-        let response: BigQueryResponse = resp.json().await?;
-
-        if response.job_complete {
-            return Ok(response);
-        }
-
-        // Async job: BigQuery deferred the result. Poll jobs.getQueryResults
-        // until it reports `job_complete=true` or `timeout_secs` elapses.
-        // Without this, the previous behaviour silently returned an empty
-        // rows array for any query slower than BigQuery's sync window.
-        let job_ref = response
-            .job_reference
-            .ok_or_else(|| BigQueryError::ApiError {
-                status: "missing jobReference".into(),
-                message: "BigQuery returned job_complete=false with no job_reference; cannot poll"
-                    .into(),
-            })?;
-        self.poll_query_results(&job_ref).await
+        .instrument(span)
+        .await
     }
 
     /// Poll `jobs.getQueryResults` until the job finishes or the configured

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -33,6 +33,7 @@ required-features = ["test-support"]
 
 [dev-dependencies]
 tokio = { workspace = true }
+tracing-subscriber = { workspace = true }
 wiremock = { workspace = true }
 serde_json = { workspace = true }
 

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -19,7 +19,7 @@ use rocky_observe::events::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{debug, warn};
+use tracing::{Instrument, debug, info_span, warn};
 
 use crate::auth::Auth;
 
@@ -250,7 +250,27 @@ impl SnowflakeConnector {
     }
 
     /// Submit with retry logic and circuit breaker.
+    ///
+    /// Wrapped in a single `statement.execute` span per logical statement
+    /// — retries surface as `statement_retry` / `circuit_breaker_*` span
+    /// events on the same parent (see `record_span_event` calls below)
+    /// rather than spawning a new span per attempt. Mirrors the OTel
+    /// `<verb>.<resource>` shape used by the `materialize.table` parent.
     async fn submit_and_wait(&self, sql: &str) -> Result<StatementResponse, ConnectorError> {
+        // `statement.kind = "query"` is a best-effort default — Snowflake
+        // routes DDL, DML, and SELECT through the same `/statements`
+        // endpoint and the wire request doesn't surface the parsed
+        // statement kind. TODO: classify via `rocky-sql` if downstream
+        // consumers need to filter ddl/dml from query traffic.
+        let span = info_span!(
+            "statement.execute",
+            adapter = "snowflake",
+            statement.kind = "query",
+        );
+        self.submit_and_wait_inner(sql).instrument(span).await
+    }
+
+    async fn submit_and_wait_inner(&self, sql: &str) -> Result<StatementResponse, ConnectorError> {
         let retry = &self.config.retry;
 
         // Circuit breaker: fail fast if Open. When timed half-open

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -966,3 +966,129 @@ async fn test_read_retention_days_empty_rows_returns_none() {
     };
     assert_eq!(governance.read_retention_days(&table).await.unwrap(), None);
 }
+
+type SpanFields = Vec<(String, String)>;
+type CapturedSpan = (String, SpanFields);
+
+/// Capture sink for the test-binary-wide span subscriber installed by
+/// [`init_capture_subscriber`]. A global-default subscriber is the only
+/// way a span born in an `async fn` polled by tokio's runtime sees our
+/// test's layer reliably across cargo's parallel test runner — per-thread
+/// `set_default` works under `#[test]` alone but loses spans created on
+/// runtime worker threads when other `#[tokio::test]` cases are in flight.
+static CAPTURED_SPANS: std::sync::OnceLock<std::sync::Mutex<Vec<CapturedSpan>>> =
+    std::sync::OnceLock::new();
+
+fn captured_spans() -> &'static std::sync::Mutex<Vec<CapturedSpan>> {
+    CAPTURED_SPANS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+fn init_capture_subscriber() {
+    use std::sync::Once;
+    use tracing::{Subscriber, span};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+    use tracing_subscriber::{Layer, Registry};
+
+    static INIT: Once = Once::new();
+
+    struct CaptureLayer;
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+    {
+        fn on_new_span(&self, attrs: &span::Attributes<'_>, _id: &span::Id, _ctx: Context<'_, S>) {
+            // Filter to spans we care about so unrelated `info_span!`
+            // calls in other crates (rocky-core, reqwest, etc.) don't
+            // grow the capture buffer unbounded.
+            if attrs.metadata().name() != "statement.execute" {
+                return;
+            }
+            struct Visit<'a>(&'a mut Vec<(String, String)>);
+            impl<'a> tracing::field::Visit for Visit<'a> {
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    self.0.push((field.name().to_string(), value.to_string()));
+                }
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    self.0
+                        .push((field.name().to_string(), format!("{value:?}")));
+                }
+            }
+            let mut fields = Vec::new();
+            attrs.record(&mut Visit(&mut fields));
+            captured_spans()
+                .lock()
+                .unwrap()
+                .push((attrs.metadata().name().to_string(), fields));
+        }
+    }
+
+    INIT.call_once(|| {
+        let subscriber = Registry::default().with(CaptureLayer);
+        // `try_init`-style: ignore the error if some other test happened
+        // to register a global subscriber first. The capture layer is
+        // additive — no fmt formatter, no IO — so installing it as the
+        // process-wide default has no effect on tests that don't inspect
+        // spans.
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
+/// Canary: a `statement.execute` span is opened around every Snowflake
+/// statement submission with `adapter = "snowflake"` and a
+/// `statement.kind` attribute. Asserted via a tracing-subscriber
+/// `Layer` that captures spans into a process-wide static — the only
+/// reliable approach across cargo's parallel test runner because the
+/// span is created inside an `async fn` whose polling thread isn't
+/// guaranteed to be the one that called `set_default`.
+#[tokio::test]
+async fn test_statement_execute_span_emitted() {
+    init_capture_subscriber();
+    captured_spans().lock().unwrap().clear();
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-span-canary",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = test_connector(&server);
+    connector
+        .execute_statement("CREATE TABLE canary (id INT)")
+        .await
+        .unwrap();
+
+    let captured = captured_spans().lock().unwrap();
+    let stmt_span = captured
+        .iter()
+        .find(|(name, _)| name == "statement.execute")
+        .unwrap_or_else(|| {
+            let names: Vec<&str> = captured.iter().map(|(n, _)| n.as_str()).collect();
+            panic!("expected a statement.execute span, got: {names:?}")
+        });
+    let adapter = stmt_span
+        .1
+        .iter()
+        .find(|(k, _)| k == "adapter")
+        .expect("expected `adapter` attribute on statement.execute span");
+    assert_eq!(adapter.1, "snowflake");
+    let kind = stmt_span
+        .1
+        .iter()
+        .find(|(k, _)| k == "statement.kind")
+        .expect("expected `statement.kind` attribute on statement.execute span");
+    assert_eq!(kind.1, "query");
+}


### PR DESCRIPTION
## Summary

Wraps the central statement-submission path in BigQuery and Snowflake with an `info_span!("statement.execute", adapter, statement.kind)` so warehouse traffic appears under a consistent, adapter-tagged child span beneath the existing `materialize.table` parent. Matches the OTel `<verb>.<resource>` shape used elsewhere in the engine.

## Adapters touched

| Crate | Wrapped function | `statement.kind` |
|---|---|---|
| `rocky-bigquery` | `run_query` (the central submit+poll path used by `execute_statement`, `execute_statement_with_stats`, `execute_query`, `describe_table`, `list_tables`, etc.) | `"query"` |
| `rocky-snowflake` | `submit_and_wait` — split into a span-wrapping outer + retry-loop inner so retries surface as `statement_retry` / `circuit_breaker_*` events on the same parent span rather than spawning a new span per attempt. | `"query"` |

`statement.kind = "query"` is a best-effort default — neither BQ's `jobs.query` nor Snowflake's `/statements` surfaces ddl/dml/select discrimination on the wire. TODO comments mark the spot for a future `rocky-sql` classification pass.

## Adapters intentionally skipped

- **`rocky-iceberg`**, **`rocky-airbyte`**, **`rocky-fivetran`**: pure REST `DiscoveryAdapter` implementations (`list_namespaces`, `list_connections`, `discover_connectors`). No SQL execution, no sync trigger, no batch-ingest surface. A `statement.execute` span would be semantically wrong on all three. If per-call discovery traces become useful later they would use a different span name (e.g. `discover.connectors`), which is a separate change.
- **`rocky-databricks`**: already inherits the `materialize.table` parent span at the dispatcher level. A redundant adapter span would clutter traces.

## Tests

- New canary `test_statement_execute_span_emitted` in `rocky-snowflake/tests/wiremock_tests.rs` — installs a process-wide `OnceLock`-backed capture layer and asserts the span is created with `adapter = "snowflake"` and `statement.kind = "query"`.
- BigQuery shares the same span shape but does not yet have its own span-capture test (known gap, callable as a follow-up if regressions show up).
- The capture layer uses `set_global_default` rather than per-thread `set_default` because the latter is unreliable when an `async fn` is polled across runtime worker threads under cargo's parallel test runner.

## Test plan

- [x] `cargo build -p rocky-bigquery -p rocky-snowflake`
- [x] `cargo test -p rocky-snowflake --features test-support` (23/23 pass, including the new canary)
- [x] `cargo test -p rocky-bigquery` (no regressions)
- [x] `cargo test --workspace --no-fail-fast` (all crates green)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`