### PR TITLE
feat(rocky-cli): rocky catalog parquet emit

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -53,6 +53,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,20 +200,55 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ec52ba94edeed950e4a41f75d35376df196e8cb04437f7280a5aa49f20f796"
+dependencies = [
+ "arrow-arith 54.3.1",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-csv",
+ "arrow-data 54.3.1",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord 54.3.1",
+ "arrow-row 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "arrow-string 54.3.1",
+]
+
+[[package]]
+name = "arrow"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 56.2.0",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-cast 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-ord 56.2.0",
+ "arrow-row 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+ "arrow-string 56.2.0",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc766fdacaf804cb10c7c70580254fcdb5d55cdfda2bc57b02baf5223a3af9e"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "num",
 ]
 
 [[package]]
@@ -207,11 +257,27 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
  "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12fcdb3f1d03f69d3ec26ac67645a8fe3f878d77b5ebb0b15d64a116c212985"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "hashbrown 0.15.5",
  "num",
 ]
 
@@ -222,12 +288,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
+dependencies = [
+ "bytes",
+ "half",
  "num",
 ]
 
@@ -244,15 +321,35 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede6175fbc039dfc946a61c1b6d42fd682fcecf5ab5d148fbe7667705798cac9"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
  "atoi",
  "base64",
  "chrono",
@@ -264,15 +361,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
+dependencies = [
+ "arrow-buffer 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-data"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 56.2.0",
+ "arrow-schema 56.2.0",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ff528658b521e33905334723b795ee56b393dbe9cf76c8b1f64b648c65a60c"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "chrono",
+ "half",
+ "indexmap",
+ "lexical-core",
+ "memchr",
+ "num",
+ "serde",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a3334a743bd2a1479dbc635540617a3923b4b2f6870f37357339e6b5363c21"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
 ]
 
 [[package]]
@@ -281,11 +454,24 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1d7a7291d2c5107e92140f75257a99343956871f3d3ab33a7b41532f79cb68"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "half",
 ]
 
 [[package]]
@@ -294,12 +480,18 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
  "half",
 ]
+
+[[package]]
+name = "arrow-schema"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
 
 [[package]]
 name = "arrow-schema"
@@ -312,16 +504,47 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69efcd706420e52cd44f5c4358d279801993846d1c2a8e52111853d61d55a619"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
 version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
  "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21546b337ab304a32cfc0770f671db7411787586b45b78b4593ae78e64e2b03"
+dependencies = [
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -330,11 +553,11 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 56.2.0",
+ "arrow-buffer 56.2.0",
+ "arrow-data 56.2.0",
+ "arrow-schema 56.2.0",
+ "arrow-select 56.2.0",
  "memchr",
  "num",
  "regex",
@@ -639,6 +862,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +915,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1170,7 +1420,7 @@ version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8685352ce688883098b61a361e86e87df66fc8c444f4a2411e884c16d5243a65"
 dependencies = [
- "arrow",
+ "arrow 56.2.0",
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -1290,6 +1540,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -1942,6 +2202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2544,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -2674,6 +2949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +3007,45 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "54.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb15796ac6f56b429fd99e33ba133783ad75b27c36b4b5ce06f1f82cc97754e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 54.3.1",
+ "arrow-buffer 54.3.1",
+ "arrow-cast 54.3.1",
+ "arrow-data 54.3.1",
+ "arrow-ipc",
+ "arrow-schema 54.3.1",
+ "arrow-select 54.3.1",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.5",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash 1.6.3",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -3454,6 +3777,7 @@ name = "rocky-cli"
 version = "1.23.0"
 dependencies = [
  "anyhow",
+ "arrow 54.3.1",
  "async-trait",
  "base64",
  "blake3",
@@ -3464,6 +3788,7 @@ dependencies = [
  "indexmap",
  "miette",
  "notify",
+ "parquet",
  "rocky-adapter-sdk",
  "rocky-ai",
  "rocky-airbyte",
@@ -3801,6 +4126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,6 +4299,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -4186,6 +4526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,6 +4597,12 @@ dependencies = [
  "psm",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4444,6 +4796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -4869,6 +5232,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -5716,4 +6095,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -150,6 +150,7 @@ notify = "8"
 # DataFusion
 datafusion = "45"
 arrow = "54"
+parquet = "54"
 
 # WASM
 wasm-bindgen = "0.2"

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -42,6 +42,8 @@ notify = { workspace = true }
 blake3 = { workspace = true }
 hostname = { workspace = true }
 toml = { workspace = true }
+arrow = { workspace = true }
+parquet = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -1,17 +1,33 @@
 //! `rocky catalog` — emit a project-wide column-level lineage snapshot.
 //!
-//! PR-1 of the catalog rollout: walks the SemanticGraph, builds a
-//! [`CatalogOutput`], and writes it to `./.rocky/catalog/catalog.json`
-//! by default. Stdout is a one-screen summary; the structured payload
-//! is the file. State-store and Parquet emit are deferred to
-//! follow-up PRs.
+//! Walks the SemanticGraph, builds a [`CatalogOutput`], and writes it
+//! to `./.rocky/catalog/` by default. Stdout is a one-screen summary;
+//! the structured payload is the file(s).
+//!
+//! Two artefact families:
+//!
+//! - `catalog.json` — single-file snapshot with assets + edges nested
+//!   together; the "front door" for shell scripts and PR bots.
+//! - `edges.parquet` + `assets.parquet` — flat analytics-friendly
+//!   files, one row per column-lineage edge / one row per asset
+//!   column. Designed to JOIN against warehouse queries.
+//!
+//! Format selection lives behind `--format json|parquet|both`
+//! (default `both`).
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
+use arrow::array::{ArrayRef, BooleanArray, RecordBatch, StringArray, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use chrono::Utc;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
 
 use rocky_compiler::compile::{self, CompilerConfig};
 use rocky_compiler::semantic::{LineageEdge, SemanticGraph};
@@ -24,29 +40,72 @@ use crate::registry::resolve_pipeline;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Which on-disk artefact families to emit.
+///
+/// `Both` is the default: write `catalog.json` plus `edges.parquet` +
+/// `assets.parquet`. The variants are intentionally orthogonal to the
+/// CLI's `--output` meta-format, which only controls what stdout
+/// summarises (table vs JSON mirror of the persisted payload).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CatalogFormat {
+    Json,
+    Parquet,
+    Both,
+}
+
+impl CatalogFormat {
+    fn writes_json(self) -> bool {
+        matches!(self, Self::Json | Self::Both)
+    }
+
+    fn writes_parquet(self) -> bool {
+        matches!(self, Self::Parquet | Self::Both)
+    }
+}
+
 /// Execute `rocky catalog`.
 pub fn run_catalog(
     config_path: &Path,
     state_path: &Path,
     models_dir: &Path,
     out_dir: &Path,
+    format: CatalogFormat,
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
     let started = Instant::now();
     let output = compute_catalog_output(config_path, state_path, models_dir, cache_ttl_override)?;
 
-    // Persist the JSON artifact regardless of stdout format. The file
-    // is the contract; stdout is the human-readable summary.
-    let json_path = out_dir.join("catalog.json");
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
-    let pretty = serde_json::to_string_pretty(&output).context("serializing catalog")?;
-    std::fs::write(&json_path, pretty + "\n")
-        .with_context(|| format!("writing {}", json_path.display()))?;
+
+    // Track every file we write so the human summary can list them.
+    let mut written: Vec<PathBuf> = Vec::new();
+
+    if format.writes_json() {
+        let json_path = out_dir.join("catalog.json");
+        let pretty = serde_json::to_string_pretty(&output).context("serializing catalog")?;
+        std::fs::write(&json_path, pretty + "\n")
+            .with_context(|| format!("writing {}", json_path.display()))?;
+        written.push(json_path);
+    }
+
+    if format.writes_parquet() {
+        let edges_path = out_dir.join("edges.parquet");
+        write_edges_parquet(&edges_path, &output)
+            .with_context(|| format!("writing {}", edges_path.display()))?;
+        written.push(edges_path);
+
+        let assets_path = out_dir.join("assets.parquet");
+        write_assets_parquet(&assets_path, &output)
+            .with_context(|| format!("writing {}", assets_path.display()))?;
+        written.push(assets_path);
+    }
 
     if output_json {
         // Mirror the persisted artifact on stdout so machine consumers
-        // can pipe `rocky catalog --output json` without re-reading the file.
+        // can pipe `rocky catalog --output json` without re-reading the
+        // file. Note the stdout JSON is independent of `--format`; it
+        // is always the same `CatalogOutput` shape.
         crate::output::print_json(&output)?;
     } else {
         let duration_ms = started.elapsed().as_millis();
@@ -64,7 +123,9 @@ pub fn run_catalog(
         if output.stats.orphan_columns > 0 {
             println!("  orphan columns:   {}", output.stats.orphan_columns);
         }
-        println!("  json:             {}", json_path.display());
+        for path in &written {
+            println!("  wrote:            {}", path.display());
+        }
         println!("  duration:         {duration_ms}ms");
     }
 
@@ -245,6 +306,19 @@ pub(crate) fn compute_catalog_output(
     });
     regrade_star_edges(&mut edges, &result.semantic_graph);
 
+    // 9. Sort assets by (fqn, then by name as a tiebreaker for
+    //    same-fqn collisions) and sort columns within each asset by
+    //    name. Both sorts are stable and keep `assets.parquet` /
+    //    `catalog.json` byte-stable across compiles.
+    for asset in &mut assets {
+        asset.columns.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+    assets.sort_by(|a, b| {
+        a.fqn
+            .cmp(&b.fqn)
+            .then_with(|| a.model_name.cmp(&b.model_name))
+    });
+
     let stats = CatalogStats {
         asset_count: assets.len(),
         column_count: total_columns,
@@ -308,6 +382,238 @@ fn regrade_star_edges(edges: &mut [CatalogEdge], graph: &SemanticGraph) {
 /// Default catalog output directory: `./.rocky/catalog/`.
 pub fn default_out_dir() -> PathBuf {
     PathBuf::from(".rocky").join("catalog")
+}
+
+// ---------------------------------------------------------------------------
+// Parquet writers
+// ---------------------------------------------------------------------------
+//
+// Two flat schemas, one row per edge / one row per (asset, column).
+// Both files share `generated_at` and `config_hash` so consumers can
+// JOIN edges to assets without round-tripping through the JSON. All
+// timestamps are encoded as `TIMESTAMP(MICROS, UTC)`; the timezone tag
+// is part of the schema so DuckDB / BigQuery / Spark all treat the
+// column as zoned rather than naive.
+
+const TIMESTAMP_TZ: &str = "UTC";
+
+/// Schema for `edges.parquet`.
+///
+/// Columns mirror the design memo §3.2 verbatim:
+/// `source_model`, `source_column`, `target_model`, `target_column`,
+/// `transform`, `confidence`, `generated_at`, `config_hash`,
+/// `last_run_id` (nullable).
+fn edges_arrow_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("source_model", DataType::Utf8, false),
+        Field::new("source_column", DataType::Utf8, false),
+        Field::new("target_model", DataType::Utf8, false),
+        Field::new("target_column", DataType::Utf8, false),
+        Field::new("transform", DataType::Utf8, false),
+        Field::new("confidence", DataType::Utf8, false),
+        Field::new(
+            "generated_at",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(TIMESTAMP_TZ.into())),
+            false,
+        ),
+        Field::new("config_hash", DataType::Utf8, false),
+        Field::new("last_run_id", DataType::Utf8, true),
+    ]))
+}
+
+/// Schema for `assets.parquet`.
+///
+/// Columns mirror the design memo §3.2 verbatim:
+/// `asset_fqn`, `model_name`, `asset_kind`, `column_name`,
+/// `data_type` (nullable), `is_nullable` (nullable), `has_star`,
+/// `intent` (nullable), `last_materialized_at` (nullable),
+/// `generated_at`, `config_hash`.
+fn assets_arrow_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("asset_fqn", DataType::Utf8, false),
+        Field::new("model_name", DataType::Utf8, false),
+        Field::new("asset_kind", DataType::Utf8, false),
+        Field::new("column_name", DataType::Utf8, false),
+        Field::new("data_type", DataType::Utf8, true),
+        Field::new("is_nullable", DataType::Boolean, true),
+        Field::new("has_star", DataType::Boolean, false),
+        Field::new("intent", DataType::Utf8, true),
+        Field::new(
+            "last_materialized_at",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(TIMESTAMP_TZ.into())),
+            true,
+        ),
+        Field::new(
+            "generated_at",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(TIMESTAMP_TZ.into())),
+            false,
+        ),
+        Field::new("config_hash", DataType::Utf8, false),
+    ]))
+}
+
+/// Write `edges.parquet` (one row per [`CatalogEdge`]).
+///
+/// The output is sorted by
+/// `(source_model, source_column, target_model, target_column)` —
+/// preserves the same order the JSON artifact uses so consumers
+/// JOINing the two see identical row orderings.
+pub fn write_edges_parquet(path: &Path, output: &CatalogOutput) -> Result<()> {
+    let schema = edges_arrow_schema();
+    let n = output.edges.len();
+    let generated_at_micros = output.generated_at.timestamp_micros();
+
+    let mut source_model: Vec<&str> = Vec::with_capacity(n);
+    let mut source_column: Vec<&str> = Vec::with_capacity(n);
+    let mut target_model: Vec<&str> = Vec::with_capacity(n);
+    let mut target_column: Vec<&str> = Vec::with_capacity(n);
+    let mut transform: Vec<&str> = Vec::with_capacity(n);
+    let mut confidence: Vec<&str> = Vec::with_capacity(n);
+
+    for edge in &output.edges {
+        source_model.push(&edge.source_model);
+        source_column.push(&edge.source_column);
+        target_model.push(&edge.target_model);
+        target_column.push(&edge.target_column);
+        transform.push(&edge.transform);
+        confidence.push(confidence_label(&edge.confidence));
+    }
+
+    let last_run_id_arr = StringArray::from(vec![output.last_run_id.as_deref(); n]);
+    let generated_at_arr =
+        TimestampMicrosecondArray::from(vec![generated_at_micros; n]).with_timezone(TIMESTAMP_TZ);
+    let config_hash_arr = StringArray::from(vec![output.config_hash.as_str(); n]);
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from(source_model)),
+        Arc::new(StringArray::from(source_column)),
+        Arc::new(StringArray::from(target_model)),
+        Arc::new(StringArray::from(target_column)),
+        Arc::new(StringArray::from(transform)),
+        Arc::new(StringArray::from(confidence)),
+        Arc::new(generated_at_arr),
+        Arc::new(config_hash_arr),
+        Arc::new(last_run_id_arr),
+    ];
+
+    let batch =
+        RecordBatch::try_new(schema.clone(), columns).context("building edges record batch")?;
+
+    write_record_batch(path, schema, &batch)
+}
+
+/// Write `assets.parquet` (one row per asset column).
+///
+/// Per the design memo, the table is "one row = one column on one
+/// asset" — assets without columns produce zero rows. The output is
+/// sorted by `(asset_fqn, column_name)` because the upstream
+/// `compute_catalog_output` sorts assets by `fqn` and columns by
+/// `name`, and we iterate in that order.
+pub fn write_assets_parquet(path: &Path, output: &CatalogOutput) -> Result<()> {
+    let schema = assets_arrow_schema();
+    let generated_at_micros = output.generated_at.timestamp_micros();
+
+    // Pre-size optimistically: most assets have a handful of columns.
+    let approx_rows: usize = output.assets.iter().map(|a| a.columns.len()).sum();
+
+    let mut asset_fqn: Vec<&str> = Vec::with_capacity(approx_rows);
+    let mut model_name: Vec<&str> = Vec::with_capacity(approx_rows);
+    let mut asset_kind: Vec<&str> = Vec::with_capacity(approx_rows);
+    let mut column_name: Vec<&str> = Vec::with_capacity(approx_rows);
+    let mut data_type: Vec<Option<&str>> = Vec::with_capacity(approx_rows);
+    let mut is_nullable: Vec<Option<bool>> = Vec::with_capacity(approx_rows);
+    let mut has_star: Vec<bool> = Vec::with_capacity(approx_rows);
+    let mut intent: Vec<Option<&str>> = Vec::with_capacity(approx_rows);
+    let mut last_materialized_micros: Vec<Option<i64>> = Vec::with_capacity(approx_rows);
+
+    // Track `has_star` per asset by membership in `upstream_models`
+    // emitted by the regrade pass — but the catalog asset doesn't
+    // carry the bit directly. Recover it from the assets that own
+    // medium-confidence outbound edges. Cheaper: we treat any asset
+    // whose `model_name` matches a Medium target as star-derived.
+    let star_targets: std::collections::HashSet<&str> = output
+        .edges
+        .iter()
+        .filter(|e| matches!(e.confidence, EdgeConfidence::Medium))
+        .map(|e| e.target_model.as_str())
+        .collect();
+
+    for asset in &output.assets {
+        let kind_label = asset_kind_label(&asset.kind);
+        let fqn = asset.fqn.as_str();
+        let m_name = asset.model_name.as_str();
+        let intent_str = asset.intent.as_deref();
+        let asset_has_star = star_targets.contains(m_name);
+        let last_mat = asset.last_materialized_at.map(|t| t.timestamp_micros());
+
+        for col in &asset.columns {
+            asset_fqn.push(fqn);
+            model_name.push(m_name);
+            asset_kind.push(kind_label);
+            column_name.push(col.name.as_str());
+            data_type.push(col.data_type.as_deref());
+            is_nullable.push(col.nullable);
+            has_star.push(asset_has_star);
+            intent.push(intent_str);
+            last_materialized_micros.push(last_mat);
+        }
+    }
+
+    let n = asset_fqn.len();
+
+    let last_materialized_arr =
+        TimestampMicrosecondArray::from(last_materialized_micros).with_timezone(TIMESTAMP_TZ);
+    let generated_at_arr =
+        TimestampMicrosecondArray::from(vec![generated_at_micros; n]).with_timezone(TIMESTAMP_TZ);
+    let config_hash_arr = StringArray::from(vec![output.config_hash.as_str(); n]);
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from(asset_fqn)),
+        Arc::new(StringArray::from(model_name)),
+        Arc::new(StringArray::from(asset_kind)),
+        Arc::new(StringArray::from(column_name)),
+        Arc::new(StringArray::from(data_type)),
+        Arc::new(BooleanArray::from(is_nullable)),
+        Arc::new(BooleanArray::from(has_star)),
+        Arc::new(StringArray::from(intent)),
+        Arc::new(last_materialized_arr),
+        Arc::new(generated_at_arr),
+        Arc::new(config_hash_arr),
+    ];
+
+    let batch =
+        RecordBatch::try_new(schema.clone(), columns).context("building assets record batch")?;
+
+    write_record_batch(path, schema, &batch)
+}
+
+fn write_record_batch(path: &Path, schema: Arc<Schema>, batch: &RecordBatch) -> Result<()> {
+    let file = File::create(path).with_context(|| format!("creating {}", path.display()))?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut writer =
+        ArrowWriter::try_new(file, schema, Some(props)).context("opening parquet writer")?;
+    writer.write(batch).context("writing record batch")?;
+    writer.close().context("closing parquet writer")?;
+    Ok(())
+}
+
+fn confidence_label(c: &EdgeConfidence) -> &'static str {
+    match c {
+        EdgeConfidence::High => "high",
+        EdgeConfidence::Medium => "medium",
+        EdgeConfidence::Low => "low",
+    }
+}
+
+fn asset_kind_label(k: &AssetKind) -> &'static str {
+    match k {
+        AssetKind::Source => "source",
+        AssetKind::Model => "model",
+        AssetKind::View => "view",
+        AssetKind::MaterializedView => "materialized_view",
+    }
 }
 
 #[cfg(test)]
@@ -393,12 +699,169 @@ mod tests {
         sorted_keys.sort();
         assert_eq!(keys, sorted_keys, "edges must be sorted before emit");
 
+        // Assets should be deterministically sorted by (fqn, model_name)
+        // and each asset's columns sorted by name. The artefact is meant
+        // to be diffable in git — non-deterministic ordering would break
+        // that contract for both catalog.json and assets.parquet.
+        let asset_keys: Vec<_> = output.assets.iter().map(|a| a.fqn.as_str()).collect();
+        let mut sorted_asset_keys = asset_keys.clone();
+        sorted_asset_keys.sort();
+        assert_eq!(
+            asset_keys, sorted_asset_keys,
+            "assets must be sorted by fqn"
+        );
+        for asset in &output.assets {
+            let col_names: Vec<&str> = asset.columns.iter().map(|c| c.name.as_str()).collect();
+            let mut sorted_col_names = col_names.clone();
+            sorted_col_names.sort();
+            assert_eq!(
+                col_names, sorted_col_names,
+                "columns must be sorted by name on asset {}",
+                asset.fqn
+            );
+        }
+
         // Two compiles must produce identical structural output (assets,
         // edges, counts) — the catalog is meant to be diffable in git.
         let again = compute_catalog_output(&config_path, &state_path, &models_dir, None)?;
         assert_eq!(output.assets.len(), again.assets.len());
         assert_eq!(output.edges.len(), again.edges.len());
         assert_eq!(output.stats.column_count, again.stats.column_count);
+
+        Ok(())
+    }
+
+    /// Schema-conformance test for the two Parquet artefacts.
+    ///
+    /// Runs the catalog assembler against the playground POC, writes
+    /// both files, then re-opens them with the Arrow Parquet reader
+    /// and asserts (a) the column names match the design memo §3.2
+    /// schema verbatim, (b) the timestamp columns carry the `UTC`
+    /// timezone tag, and (c) the row counts line up with the in-memory
+    /// catalog (one row per edge / one row per asset column).
+    #[cfg(feature = "duckdb")]
+    #[test]
+    fn parquet_files_match_design_memo_schema() -> Result<()> {
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let poc_dir = std::path::Path::new(manifest_dir)
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("examples")
+            .join("playground")
+            .join("pocs")
+            .join("00-foundations")
+            .join("00-playground-default");
+
+        if !poc_dir.is_dir() {
+            eprintln!(
+                "skipping parquet_files_match_design_memo_schema: \
+                 {} not found (running outside the monorepo?)",
+                poc_dir.display()
+            );
+            return Ok(());
+        }
+
+        let config_path = poc_dir.join("rocky.toml");
+        let models_dir = poc_dir.join("models");
+        let state_path = poc_dir.join(".rocky-state.redb");
+
+        let output = compute_catalog_output(&config_path, &state_path, &models_dir, None)?;
+
+        let tmp = tempfile::tempdir()?;
+        let edges_path = tmp.path().join("edges.parquet");
+        let assets_path = tmp.path().join("assets.parquet");
+        write_edges_parquet(&edges_path, &output)?;
+        write_assets_parquet(&assets_path, &output)?;
+
+        // edges.parquet — schema + row count.
+        let file = std::fs::File::open(&edges_path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let mut total_rows = 0usize;
+        let mut observed_schema: Option<arrow::datatypes::SchemaRef> = None;
+        for batch in reader {
+            let batch = batch?;
+            total_rows += batch.num_rows();
+            observed_schema.get_or_insert_with(|| batch.schema());
+        }
+        assert_eq!(
+            total_rows,
+            output.edges.len(),
+            "edges.parquet row count diverged from CatalogOutput.edges"
+        );
+        let schema = observed_schema.expect("edges.parquet had no batches");
+        let edge_cols: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            edge_cols,
+            vec![
+                "source_model",
+                "source_column",
+                "target_model",
+                "target_column",
+                "transform",
+                "confidence",
+                "generated_at",
+                "config_hash",
+                "last_run_id",
+            ],
+            "edges.parquet column names diverged from design memo §3.2"
+        );
+        let generated_at_field = schema.field_with_name("generated_at")?;
+        assert_eq!(
+            generated_at_field.data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some(TIMESTAMP_TZ.into())),
+            "edges.parquet generated_at must be TIMESTAMP(MICROS, UTC)"
+        );
+        assert!(!schema.field_with_name("source_model")?.is_nullable());
+        assert!(schema.field_with_name("last_run_id")?.is_nullable());
+
+        // assets.parquet — schema + row count.
+        let file = std::fs::File::open(&assets_path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let mut total_rows = 0usize;
+        let mut observed_schema: Option<arrow::datatypes::SchemaRef> = None;
+        for batch in reader {
+            let batch = batch?;
+            total_rows += batch.num_rows();
+            observed_schema.get_or_insert_with(|| batch.schema());
+        }
+        let expected_rows: usize = output.assets.iter().map(|a| a.columns.len()).sum();
+        assert_eq!(
+            total_rows, expected_rows,
+            "assets.parquet row count diverged from sum(asset.columns.len())"
+        );
+        let schema = observed_schema.expect("assets.parquet had no batches");
+        let asset_cols: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            asset_cols,
+            vec![
+                "asset_fqn",
+                "model_name",
+                "asset_kind",
+                "column_name",
+                "data_type",
+                "is_nullable",
+                "has_star",
+                "intent",
+                "last_materialized_at",
+                "generated_at",
+                "config_hash",
+            ],
+            "assets.parquet column names diverged from design memo §3.2"
+        );
+        let last_mat_field = schema.field_with_name("last_materialized_at")?;
+        assert_eq!(
+            last_mat_field.data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some(TIMESTAMP_TZ.into())),
+            "assets.parquet last_materialized_at must be TIMESTAMP(MICROS, UTC)"
+        );
+        assert!(last_mat_field.is_nullable());
+        assert!(!schema.field_with_name("has_star")?.is_nullable());
+        assert!(schema.field_with_name("data_type")?.is_nullable());
+        assert!(schema.field_with_name("is_nullable")?.is_nullable());
+        assert!(schema.field_with_name("intent")?.is_nullable());
 
         Ok(())
     }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -62,7 +62,7 @@ pub use bench::run_bench;
 pub use branch::{
     run_branch_compare, run_branch_create, run_branch_delete, run_branch_list, run_branch_show,
 };
-pub use catalog::{default_out_dir as catalog_default_out_dir, run_catalog};
+pub use catalog::{CatalogFormat, default_out_dir as catalog_default_out_dir, run_catalog};
 #[cfg(feature = "duckdb")]
 pub use ci::run_ci;
 pub use ci_diff::run_ci_diff;

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -106,6 +106,28 @@ enum OutputFormat {
     Table,
 }
 
+/// Artefact family selector for `rocky catalog --format`.
+///
+/// Maps 1:1 to [`rocky_cli::commands::CatalogFormat`]. Kept in
+/// `main.rs` so `clap::ValueEnum` does not need to leak into the CLI
+/// library crate.
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum CatalogFormatArg {
+    Json,
+    Parquet,
+    Both,
+}
+
+impl From<CatalogFormatArg> for rocky_cli::commands::CatalogFormat {
+    fn from(value: CatalogFormatArg) -> Self {
+        match value {
+            CatalogFormatArg::Json => Self::Json,
+            CatalogFormatArg::Parquet => Self::Parquet,
+            CatalogFormatArg::Both => Self::Both,
+        }
+    }
+}
+
 /// CLI alias for `rocky compile --target-dialect`. Short names
 /// (`dbx`, `sf`, `bq`, `duckdb`) are the user-facing spelling; they map
 /// 1:1 to `rocky_cli::commands::Dialect`.
@@ -455,20 +477,30 @@ enum Command {
     /// Emit a project-wide column-level lineage snapshot.
     ///
     /// Walks the SemanticGraph and writes a persisted catalog artifact
-    /// (default: `./.rocky/catalog/catalog.json`) so any non-Rocky
-    /// consumer can read column-level lineage without invoking the
-    /// engine. PR-1 emits JSON only; Parquet output and run-history
-    /// enrichment land in follow-up PRs.
+    /// (default: `./.rocky/catalog/`) so any non-Rocky consumer can
+    /// read column-level lineage without invoking the engine. The
+    /// snapshot is emitted as `catalog.json` (single-file front door),
+    /// `edges.parquet` (one row per column-lineage edge), and
+    /// `assets.parquet` (one row per asset column). Use `--format` to
+    /// restrict the output to a single artefact family.
     Catalog {
         /// Models directory.
         #[arg(long, default_value = "models")]
         models: PathBuf,
         /// Output directory for the catalog artifacts.
         ///
-        /// Defaults to `./.rocky/catalog/`. The JSON file is always
-        /// written to `<out>/catalog.json`.
+        /// Defaults to `./.rocky/catalog/`. The JSON file is written
+        /// to `<out>/catalog.json`; the Parquet files to
+        /// `<out>/edges.parquet` and `<out>/assets.parquet`.
         #[arg(long)]
         out: Option<PathBuf>,
+        /// Which artefact family to emit.
+        ///
+        /// `json` writes only `catalog.json`; `parquet` writes only
+        /// `edges.parquet` + `assets.parquet`; `both` (the default)
+        /// writes all three.
+        #[arg(long, value_enum, default_value_t = CatalogFormatArg::Both)]
+        format: CatalogFormatArg,
     },
 
     /// Show column-level lineage for a model
@@ -1613,13 +1645,18 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             json,
             cli.cache_ttl,
         ),
-        Command::Catalog { models, out } => {
+        Command::Catalog {
+            models,
+            out,
+            format,
+        } => {
             let out_dir = out.unwrap_or_else(rocky_cli::commands::catalog_default_out_dir);
             rocky_cli::commands::run_catalog(
                 &cli.config,
                 &state_path,
                 &models,
                 &out_dir,
+                format.into(),
                 json,
                 cli.cache_ttl,
             )


### PR DESCRIPTION
## Summary

Adds two flat Parquet artefacts alongside the existing `catalog.json` front-door file:

- `edges.parquet` — one row per column-lineage edge.
- `assets.parquet` — one row per asset column.

Both share `generated_at` + `config_hash` columns so consumers can JOIN without round-tripping through JSON. Timestamps are `TIMESTAMP(MICROS, UTC)` (timezone tag is part of the schema).

## UX

```
rocky catalog [--format json|parquet|both]   # default: both
```

Default writes all three files to `./.rocky/catalog/`:

- `catalog.json` (single-file front door)
- `edges.parquet` + `assets.parquet` (analytics-friendly)

`--format json` writes only `catalog.json`. `--format parquet` writes only the two Parquet files.

Assets are now sorted `(fqn, model_name)` and columns within each asset by name, so `catalog.json` and `assets.parquet` are byte-stable across compiles. Edges were already sorted.

## Tests

- `parquet_files_match_design_memo_schema` opens each file with the Arrow Parquet reader and asserts column names, types, and the `UTC` timezone tag on timestamp columns. Runs against the playground POC, no credentials required.
- Existing tests still pass (`compute_catalog_output_against_playground_pocs`, `default_out_dir_is_relative_under_dot_rocky`, `regrade_star_edges_marks_star_targets_as_medium`).

`parquet = "54"` added as a workspace dep (sibling of `arrow = "54"`). Codegen cascade is a no-op (no JSON shape change).

## Test plan

- [x] `cargo test -p rocky-cli --lib catalog::` (4 passed)
- [x] `cargo test --workspace --no-fail-fast` (no regressions)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `just codegen` (zero drift)
- [x] Smoke: `rocky catalog --format both/json/parquet` on the playground POC; verified files via DuckDB `DESCRIBE SELECT * FROM '.rocky/catalog/*.parquet'`