### PR TITLE
feat(rocky-core): ModelIr + ProjectIr structs

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3522,6 +3522,7 @@ name = "rocky-core"
 version = "1.23.0"
 dependencies = [
  "async-trait",
+ "blake3",
  "bytes",
  "chrono",
  "criterion",

--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -256,7 +256,6 @@ fn bench_sql_generation(c: &mut Criterion) {
                 } else {
                     MaterializationStrategy::Incremental {
                         timestamp_column: "_fivetran_synced".into(),
-                        watermark: None,
                     }
                 },
                 columns: ColumnSelection::All,

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -138,7 +138,6 @@ pub async fn plan(
                 "incremental" => (
                     MaterializationStrategy::Incremental {
                         timestamp_column: pipeline.timestamp_column.clone(),
-                        watermark: None,
                     },
                     "incremental_copy",
                 ),

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4388,7 +4388,6 @@ async fn process_table(
         strategy: if pipeline.strategy == "incremental" {
             MaterializationStrategy::Incremental {
                 timestamp_column: pipeline.timestamp_column.clone(),
-                watermark: None,
             }
         } else {
             MaterializationStrategy::FullRefresh

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -33,6 +33,7 @@ futures = { workspace = true }
 lasso = { version = "0.7", features = ["multi-threaded"] }
 memmap2 = "0.9"
 rayon = "1"
+blake3 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -2,6 +2,16 @@
 //! `partition_by`, `ColumnSelection::Explicit`, `columns_to_drop` — use
 //! `Vec<Arc<str>>` so cloning a plan / drift result is refcount-cheap.
 //! JSON wire format is preserved by serde's `rc` feature.
+//!
+//! ## Canonical-JSON convention for [`ModelIr`] / [`ProjectIr`]
+//!
+//! Recipe-hash determinism requires a single, predictable serialization
+//! shape. Every `Option<T>` field on [`ModelIr`] and [`ProjectIr`] (and on
+//! types they own that are introduced alongside the IR) carries
+//! `#[serde(default, skip_serializing_if = "Option::is_none")]`. `None`
+//! values are absent from the JSON; the recipe-hash never sees an explicit
+//! `null`. Add new optional fields with the same attribute pair so the rule
+//! stays uniform.
 
 use std::sync::Arc;
 
@@ -72,10 +82,14 @@ pub enum MaterializationStrategy {
     /// Drop and recreate the entire table.
     FullRefresh,
     /// Append rows newer than the watermark.
-    Incremental {
-        timestamp_column: String,
-        watermark: Option<WatermarkState>,
-    },
+    ///
+    /// The watermark value itself is not carried on the strategy: it is
+    /// runtime state read from the embedded state store (see
+    /// [`crate::state::StateStore::get_watermark`]) and the SQL generator
+    /// emits a `WHERE ts > (SELECT MAX(ts) FROM target)` subquery that
+    /// resolves the bound at execution time. Keeping the field off the
+    /// strategy means recipe-hash inputs are runtime-state-free.
+    Incremental { timestamp_column: String },
     /// Upsert based on unique key columns.
     Merge {
         unique_key: Vec<Arc<str>>,
@@ -420,6 +434,181 @@ pub struct ResolvedRole {
     pub inherits_from: Vec<String>,
 }
 
+/// A single resolved column-masking instruction.
+///
+/// Policy lives in [`crate::config::RockyConfig`] (workspace-default
+/// `[mask]` block plus optional per-env `[mask.<env>]` overrides). The
+/// resolution-as-applied — column name plus the strategy chosen for the
+/// active environment — is captured here so the recipe-hash reflects what
+/// the warehouse actually sees.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnMask {
+    /// Column name, interned for cheap cloning.
+    pub column: Arc<str>,
+    /// Resolved strategy for the active environment.
+    pub strategy: crate::traits::MaskStrategy,
+}
+
+/// Per-model intermediate representation.
+///
+/// Carries everything Rocky needs to know about a single model to generate
+/// SQL, run governance, and compute a recipe-hash: the SQL itself, the
+/// typed output columns, the lineage edges that target this model, the
+/// materialization strategy, governance metadata, and the resolved
+/// column-masking plan for the active environment.
+///
+/// `ModelIr` is an internal contract. It does not derive `JsonSchema` and
+/// is not part of the public CLI output schema; consumers outside the
+/// engine should depend on the typed `*Output` structs in
+/// `rocky-cli::output` instead.
+///
+/// All `Option` fields follow the canonical-JSON rule documented at the
+/// top of this module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelIr {
+    /// Stable identifier for this model (project-unique).
+    pub name: Arc<str>,
+    /// User-written SQL for this model. The SQL string is the load-bearing
+    /// recipe-hash input: text changes (even comments) hash to a different
+    /// value.
+    pub sql: String,
+    /// Inferred output columns. May be empty when typecheck partial-failed
+    /// or the model uses `SELECT *` against an upstream that hasn't been
+    /// typechecked yet.
+    pub typed_columns: Vec<crate::types::TypedColumn>,
+    /// Column-level lineage edges whose target is this model. Cross-model
+    /// edges that originate elsewhere appear in the consumer's slice.
+    pub lineage_edges: Vec<crate::lineage::LineageEdge>,
+    /// How the warehouse should materialize this model.
+    ///
+    /// Recipe-hash invariant: when this strategy is
+    /// [`MaterializationStrategy::TimeInterval`], the `window` field MUST
+    /// be `None` at hash time. The static plan emits `None`; the runtime
+    /// fills `Some(...)` per partition. Hashing the resolved partition
+    /// would yield a different recipe-hash for every partition of the same
+    /// model, defeating content-addressed write semantics.
+    pub materialization: MaterializationStrategy,
+    /// Governance metadata (catalog/schema lifecycle policy).
+    pub governance: GovernanceConfig,
+    /// Resolved column masks for the active environment. Populated at IR
+    /// construction by reading
+    /// [`crate::config::RockyConfig::resolve_mask_for_env`]. Empty when no
+    /// classifications matched or every resolved strategy was
+    /// [`crate::traits::MaskStrategy::None`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub column_masks: Vec<ColumnMask>,
+}
+
+impl ModelIr {
+    /// Compute the recipe-hash of this model.
+    ///
+    /// The hash is `blake3` over a canonical JSON encoding of `self`: keys
+    /// sorted, no insignificant whitespace, `Option::None` skipped per the
+    /// canonical-JSON rule documented at the top of this module.
+    ///
+    /// Determinism contract: given two byte-identical [`ModelIr`] values
+    /// the returned hash is byte-identical. Mutating any input field
+    /// (SQL, typed columns, lineage edges, materialization, governance,
+    /// resolved masks) changes the hash.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` cannot be serialized to JSON. All fields on
+    /// [`ModelIr`] derive `Serialize` over infallible primitives, so this
+    /// only fires on a programming error (e.g. a `Map` with non-string
+    /// keys introduced after this comment was written).
+    pub fn recipe_hash(&self) -> blake3::Hash {
+        let canonical = canonical_json(self);
+        blake3::hash(canonical.as_bytes())
+    }
+}
+
+/// Project-level intermediate representation.
+///
+/// Thin wrapper that pairs the per-model IRs with the project's DAG and
+/// the cross-model lineage edges. Project-level recipe-hash is *derived*
+/// from the per-model hashes; it is not stored on this struct.
+///
+/// `ProjectIr` is an internal contract and does not derive `JsonSchema`
+/// (see [`ModelIr`] for the rationale).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectIr {
+    /// All models in this project. Ordering is caller-defined; the
+    /// project-level recipe-hash sorts by per-model hash before combining.
+    pub models: Vec<ModelIr>,
+    /// DAG nodes describing model-to-model dependencies. Use
+    /// [`crate::dag::topological_sort`] or
+    /// [`crate::dag::execution_layers`] to derive an execution order.
+    pub dag: Vec<crate::dag::DagNode>,
+    /// Full cross-model column-level lineage. Each [`ModelIr`] also carries
+    /// the slice of edges that target it; this field is the union and is
+    /// the canonical store.
+    pub lineage_edges: Vec<crate::lineage::LineageEdge>,
+}
+
+impl ProjectIr {
+    /// Compute the project-level recipe-hash.
+    ///
+    /// Each model contributes its [`ModelIr::recipe_hash`]; the per-model
+    /// hashes are sorted lexicographically by their hex representation and
+    /// hashed together so the result is independent of `models` ordering.
+    ///
+    /// Project-level fields ([`Self::dag`], [`Self::lineage_edges`]) are
+    /// not folded into the project-level hash — they are derived facts
+    /// about how the per-model recipes relate, not part of any single
+    /// model's recipe. Changes to the DAG or cross-model lineage that do
+    /// not change a model's own recipe leave the per-model hashes (and
+    /// therefore the project-level hash) untouched.
+    pub fn recipe_hash(&self) -> blake3::Hash {
+        let mut per_model: Vec<String> = self
+            .models
+            .iter()
+            .map(|m| m.recipe_hash().to_hex().to_string())
+            .collect();
+        per_model.sort();
+        let mut hasher = blake3::Hasher::new();
+        for h in &per_model {
+            hasher.update(h.as_bytes());
+            // Length-prefix the separator so concatenation is unambiguous.
+            hasher.update(b"\n");
+        }
+        hasher.finalize()
+    }
+}
+
+/// Canonical-JSON encoder used by [`ModelIr::recipe_hash`].
+///
+/// `serde_json` preserves field insertion order on `Map`, which is not
+/// stable enough for content-addressed hashing across different inputs of
+/// the same logical value. This helper round-trips through a
+/// [`serde_json::Value`] and rewrites every nested map into a
+/// [`std::collections::BTreeMap`] (key-sorted). The resulting string has
+/// no insignificant whitespace and skipped-on-`None` fields stay absent
+/// because they were already absent at serialize time.
+fn canonical_json<T: Serialize>(value: &T) -> String {
+    let raw = serde_json::to_value(value)
+        .expect("recipe_hash inputs must be JSON-encodable; programming error");
+    let canonical = canonicalize(raw);
+    serde_json::to_string(&canonical)
+        .expect("BTreeMap-based serde_json::Value is always serializable")
+}
+
+fn canonicalize(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let sorted: std::collections::BTreeMap<String, serde_json::Value> =
+                map.into_iter().map(|(k, v)| (k, canonicalize(v))).collect();
+            // serde_json serializes BTreeMap keys in sorted order; round-trip
+            // back through Value to keep the type uniform.
+            serde_json::to_value(sorted).expect("BTreeMap<String, Value> always converts to Value")
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(canonicalize).collect())
+        }
+        other => other,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -439,7 +628,6 @@ mod tests {
             },
             strategy: MaterializationStrategy::Incremental {
                 timestamp_column: "_fivetran_synced".into(),
-                watermark: None,
             },
             columns: ColumnSelection::All,
             metadata_columns: vec![MetadataColumn {
@@ -573,7 +761,6 @@ mod tests {
             MaterializationStrategy::FullRefresh,
             MaterializationStrategy::Incremental {
                 timestamp_column: "_fivetran_synced".into(),
-                watermark: None,
             },
             MaterializationStrategy::Merge {
                 unique_key: vec!["id".into()],
@@ -602,5 +789,269 @@ mod tests {
             let json = serde_json::to_string(strategy).unwrap();
             let _: MaterializationStrategy = serde_json::from_str(&json).unwrap();
         }
+    }
+
+    // ----- ModelIr / ProjectIr round-trip + recipe-hash tests -----
+
+    use crate::lineage::{LineageEdge, QualifiedColumn};
+    use crate::traits::MaskStrategy;
+    use crate::types::{RockyType, TypedColumn};
+    use rocky_sql::lineage::TransformKind;
+
+    fn sample_replication_model() -> ModelIr {
+        ModelIr {
+            name: Arc::from("orders"),
+            sql: "SELECT * FROM source_catalog.src__acme.shopify.orders".into(),
+            typed_columns: vec![TypedColumn {
+                name: "id".into(),
+                data_type: RockyType::Int64,
+                nullable: false,
+            }],
+            lineage_edges: vec![],
+            materialization: MaterializationStrategy::Incremental {
+                timestamp_column: "_fivetran_synced".into(),
+            },
+            governance: GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: true,
+                auto_create_schemas: true,
+            },
+            column_masks: vec![],
+        }
+    }
+
+    fn sample_transformation_model() -> ModelIr {
+        ModelIr {
+            name: Arc::from("dim_customers"),
+            sql: "SELECT customer_id, email FROM stg_customers".into(),
+            typed_columns: vec![
+                TypedColumn {
+                    name: "customer_id".into(),
+                    data_type: RockyType::Int64,
+                    nullable: false,
+                },
+                TypedColumn {
+                    name: "email".into(),
+                    data_type: RockyType::String,
+                    nullable: true,
+                },
+            ],
+            lineage_edges: vec![LineageEdge {
+                source: QualifiedColumn {
+                    model: Arc::from("stg_customers"),
+                    column: Arc::from("customer_id"),
+                },
+                target: QualifiedColumn {
+                    model: Arc::from("dim_customers"),
+                    column: Arc::from("customer_id"),
+                },
+                transform: TransformKind::Direct,
+            }],
+            materialization: MaterializationStrategy::Merge {
+                unique_key: vec![Arc::from("customer_id")],
+                update_columns: ColumnSelection::All,
+            },
+            governance: GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            column_masks: vec![ColumnMask {
+                column: Arc::from("email"),
+                strategy: MaskStrategy::Hash,
+            }],
+        }
+    }
+
+    fn sample_full_refresh_model() -> ModelIr {
+        // [`ModelIr`] does not yet carry SnapshotPlan-specific fields
+        // (`unique_key`, `updated_at`, `invalidate_hard_deletes`). The third
+        // strategy variant exercised by the round-trip suite is therefore
+        // FullRefresh. SnapshotPlan-style coverage will land alongside the
+        // construction-site migration when source/target refs are threaded
+        // through.
+        ModelIr {
+            name: Arc::from("dim_users_full_refresh"),
+            sql: "SELECT * FROM dim_users".into(),
+            typed_columns: vec![],
+            lineage_edges: vec![],
+            materialization: MaterializationStrategy::FullRefresh,
+            governance: GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            column_masks: vec![],
+        }
+    }
+
+    #[test]
+    fn model_ir_replication_roundtrip_byte_stable() {
+        let m = sample_replication_model();
+        let json1 = serde_json::to_string(&m).unwrap();
+        let back: ModelIr = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json1, json2, "round-trip must be byte-stable");
+    }
+
+    #[test]
+    fn model_ir_transformation_roundtrip_byte_stable() {
+        let m = sample_transformation_model();
+        let json1 = serde_json::to_string(&m).unwrap();
+        let back: ModelIr = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json1, json2, "round-trip must be byte-stable");
+    }
+
+    #[test]
+    fn model_ir_full_refresh_roundtrip_byte_stable() {
+        let m = sample_full_refresh_model();
+        let json1 = serde_json::to_string(&m).unwrap();
+        let back: ModelIr = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json1, json2, "round-trip must be byte-stable");
+    }
+
+    #[test]
+    fn project_ir_roundtrip_with_multiple_models() {
+        let project = ProjectIr {
+            models: vec![
+                sample_replication_model(),
+                sample_transformation_model(),
+                sample_full_refresh_model(),
+            ],
+            dag: vec![
+                crate::dag::DagNode {
+                    name: "orders".into(),
+                    depends_on: vec![],
+                },
+                crate::dag::DagNode {
+                    name: "dim_customers".into(),
+                    depends_on: vec![],
+                },
+                crate::dag::DagNode {
+                    name: "dim_users_full_refresh".into(),
+                    depends_on: vec!["dim_customers".into()],
+                },
+            ],
+            lineage_edges: vec![LineageEdge {
+                source: QualifiedColumn {
+                    model: Arc::from("stg_customers"),
+                    column: Arc::from("customer_id"),
+                },
+                target: QualifiedColumn {
+                    model: Arc::from("dim_customers"),
+                    column: Arc::from("customer_id"),
+                },
+                transform: TransformKind::Direct,
+            }],
+        };
+        let json1 = serde_json::to_string(&project).unwrap();
+        let back: ProjectIr = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json1, json2, "ProjectIr round-trip must be byte-stable");
+        assert_eq!(back.models.len(), 3);
+    }
+
+    #[test]
+    fn model_ir_missing_required_field_fails_noisily() {
+        // The `sql` field has no serde default; dropping it must fail
+        // deserialization rather than silently producing an empty SQL string.
+        let json = r#"{
+            "name": "orders",
+            "typed_columns": [],
+            "lineage_edges": [],
+            "materialization": {"strategy": "FullRefresh"},
+            "governance": {
+                "permissions_file": null,
+                "auto_create_catalogs": false,
+                "auto_create_schemas": false
+            }
+        }"#;
+        let err = serde_json::from_str::<ModelIr>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("sql"),
+            "expected error to mention missing `sql` field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_is_deterministic() {
+        let m1 = sample_transformation_model();
+        let m2 = sample_transformation_model();
+        assert_eq!(
+            m1.recipe_hash(),
+            m2.recipe_hash(),
+            "identical inputs must produce identical hashes"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_sql_changes() {
+        let mut m = sample_transformation_model();
+        let h1 = m.recipe_hash();
+        m.sql.push_str(" -- a comment");
+        let h2 = m.recipe_hash();
+        assert_ne!(
+            h1, h2,
+            "SQL text changes must propagate into the recipe hash"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_column_mask_changes() {
+        let mut m = sample_transformation_model();
+        let h1 = m.recipe_hash();
+        m.column_masks[0].strategy = MaskStrategy::Redact;
+        let h2 = m.recipe_hash();
+        assert_ne!(
+            h1, h2,
+            "resolved-mask changes must propagate into the recipe hash"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_typed_columns_change() {
+        let mut m = sample_transformation_model();
+        let h1 = m.recipe_hash();
+        m.typed_columns.push(TypedColumn {
+            name: "added_at".into(),
+            data_type: RockyType::Timestamp,
+            nullable: true,
+        });
+        let h2 = m.recipe_hash();
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn project_recipe_hash_is_independent_of_model_order() {
+        let a = sample_replication_model();
+        let b = sample_transformation_model();
+        let p1 = ProjectIr {
+            models: vec![a.clone(), b.clone()],
+            dag: vec![],
+            lineage_edges: vec![],
+        };
+        let p2 = ProjectIr {
+            models: vec![b, a],
+            dag: vec![],
+            lineage_edges: vec![],
+        };
+        assert_eq!(
+            p1.recipe_hash(),
+            p2.recipe_hash(),
+            "project hash must sort per-model hashes before combining"
+        );
+    }
+
+    #[test]
+    fn empty_column_masks_omitted_from_serialization() {
+        // Rule A consistency: empty Vec on `column_masks` is skipped.
+        let m = sample_replication_model();
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json.contains("column_masks"),
+            "empty column_masks must be skipped per the canonical-JSON rule, got: {json}"
+        );
     }
 }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -562,7 +562,6 @@ impl Model {
             StrategyConfig::Incremental { timestamp_column } => {
                 MaterializationStrategy::Incremental {
                     timestamp_column: timestamp_column.clone(),
-                    watermark: None,
                 }
             }
             StrategyConfig::Merge {

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -788,7 +788,6 @@ mod tests {
             },
             strategy: MaterializationStrategy::Incremental {
                 timestamp_column: "_fivetran_synced".into(),
-                watermark: None,
             },
             columns: ColumnSelection::All,
             metadata_columns: vec![MetadataColumn {
@@ -1060,7 +1059,6 @@ mod tests {
             },
             strategy: MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
-                watermark: None,
             },
             sql: "SELECT * FROM cat.sch.raw_orders WHERE updated_at > '2026-01-01'".into(),
             governance: GovernanceConfig {
@@ -1609,7 +1607,6 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             LakehouseOptions::default(),
             MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
-                watermark: None,
             },
         );
         let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
@@ -1632,7 +1629,6 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
-                watermark: None,
             },
         );
         let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -262,10 +262,11 @@ fn test_incremental_pipeline_with_watermark() {
         )
         .unwrap();
 
-    // Build an incremental plan using the stored watermark
+    // Build an incremental plan; the watermark itself is read from the
+    // state store at SQL-generation time, not carried on the strategy.
+    let _wm = store.get_watermark(table_key).unwrap();
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
-        watermark: store.get_watermark(table_key).unwrap(),
     });
 
     // Generate INSERT INTO ... SELECT SQL (incremental append)
@@ -578,7 +579,6 @@ fn test_transformation_incremental() {
         },
         strategy: MaterializationStrategy::Incremental {
             timestamp_column: "updated_at".into(),
-            watermark: None,
         },
         sql: "SELECT * FROM cat.raw.events WHERE updated_at > '2026-01-01'".into(),
         governance: GovernanceConfig {
@@ -925,9 +925,11 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     let wm = store.get_watermark(table_key).unwrap();
     assert!(wm.is_some(), "watermark should exist after first run");
 
+    // The watermark value lives in the state store and is consulted by the
+    // SQL generator at execution time; the strategy itself no longer
+    // carries it.
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
-        watermark: wm,
     });
     let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
     assert!(sql.contains("INSERT INTO"));
@@ -1019,7 +1021,6 @@ fn test_exact_incremental_sql_output() {
 
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
-        watermark: None,
     });
 
     let sql = sql_gen::generate_select_sql(&plan, &dialect).unwrap();
@@ -1070,7 +1071,6 @@ fn test_exact_insert_sql_output() {
 
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
-        watermark: None,
     });
     let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
 

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -172,13 +172,15 @@ async fn test_incremental_pipeline_two_runs() {
     .await
     .unwrap();
 
-    // Run 2: incremental (only new rows)
+    // Run 2: incremental (only new rows). The watermark itself is read
+    // from the state store at SQL-generation time, not carried on the
+    // strategy.
+    let _wm = store.get_watermark("target.events").unwrap();
     let plan2 = duckdb_replication_plan(
         "events",
         "events",
         MaterializationStrategy::Incremental {
             timestamp_column: "_fivetran_synced".into(),
-            watermark: store.get_watermark("target.events").unwrap(),
         },
     );
     let sql2 = sql_gen::generate_insert_sql(&plan2, &d).unwrap();


### PR DESCRIPTION
## Summary

Adds the per-model and per-project intermediate representation types alongside the existing `Plan` enum in `rocky-core::ir`. Both new types are internal contracts (no `JsonSchema` derive); they coexist with `Plan` until Phase 2 migrates the four production construction sites and updates `sql_gen` to consume them.

## Ratified refinements landed in this PR

- **Resolved column masks on `ModelIr`.** `ColumnMask { column, strategy }` lives on `ModelIr.column_masks`, populated at IR construction by reading `RockyConfig::resolve_mask_for_env`. Without this, masking changes the SQL (`SHA256(pii_col)`) but the recipe-hash wouldn't reflect it. Population is wired in Phase 2 alongside the construction-site migration.
- **`WatermarkState` stripped from `MaterializationStrategy::Incremental`.** Watermark values live in the embedded state store (`StateStore::get_watermark`) and the SQL generator already reads them at execution time via the `WHERE ts > (SELECT MAX(ts) FROM target)` subquery. Keeping runtime state off the strategy means recipe-hash inputs are runtime-state-free. All callers updated.
- **`PartitionWindow=None` invariant pinned at hash time** via a doc comment on `ModelIr.materialization`. The runtime fills `Some(...)` per partition; recipe-hash must run on the static form.
- **Canonical-JSON Rule A applied uniformly.** Every `Option<T>` on `ModelIr` and `ProjectIr` uses `#[serde(default, skip_serializing_if = "Option::is_none")]`. The rule is documented at the top of `ir.rs` so new optional fields stay consistent.

## Shape

- `ModelIr { name, sql, typed_columns, lineage_edges, materialization, governance, column_masks }` with `recipe_hash()` returning `blake3` over a key-sorted JSON canonicalization.
- `ProjectIr { models, dag, lineage_edges }` is a thin wrapper. Project-level `recipe_hash()` sorts per-model hashes before combining so the result is independent of `models` ordering.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — all green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] New unit tests in `ir.rs` cover serde round-trip byte-stability for three strategy variants, a multi-model `ProjectIr` round-trip, missing-field deserialization failure, recipe-hash determinism, and recipe-hash sensitivity to SQL / column-mask / typed-column / model-order edits.