### PR TITLE
feat(rocky-core): Typed-IR Phase 2b.1 — construct ModelIr at every Plan site

### DIFF
--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -165,6 +165,9 @@ pub async fn plan(
                 },
             };
 
+            // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
+            let _model_ir = ModelIr::from(&Plan::Replication(plan.clone()));
+
             // Pick the right SQL generator for the materialization strategy.
             // Full refresh uses CREATE OR REPLACE TABLE AS so the target doesn't
             // need to exist; incremental uses INSERT INTO which requires the

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4401,6 +4401,9 @@ async fn process_table(
         },
     };
 
+    // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
+    let _model_ir = ModelIr::from(&Plan::Replication(replication.clone()));
+
     let strategy_name;
     let sql = if use_full_refresh {
         strategy_name = "full_refresh";

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -654,6 +654,9 @@ pub async fn run_snapshot(
         },
     };
 
+    // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
+    let _model_ir = ModelIr::from(&Plan::Snapshot(plan.clone()));
+
     let dialect = warehouse_adapter.dialect();
     let stmts = sql_gen::generate_snapshot_sql(&plan, dialect)?;
 

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 use crate::config::ModelBudgetConfig;
 use crate::dag::DagNode;
 use crate::ir::{
-    GovernanceConfig, MaterializationStrategy, SourceRef, TargetRef, TransformationPlan,
+    GovernanceConfig, MaterializationStrategy, ModelIr, Plan, SourceRef, TargetRef,
+    TransformationPlan,
 };
 use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 use crate::retention::{RetentionParseError, RetentionPolicy};
@@ -637,6 +638,24 @@ impl Model {
             format_options: self.config.format_options.clone(),
         }
     }
+
+    /// Construct the per-model [`ModelIr`] for this transformation model.
+    ///
+    /// Reuses [`Self::to_plan`] so the materialization-strategy lowering
+    /// stays in one place; the resulting [`Plan::Transformation`] is fed to
+    /// [`From<&Plan> for ModelIr`] and the model's own `name` overrides the
+    /// `target.table`-derived default so the IR carries the project-unique
+    /// identifier rather than the warehouse table name.
+    ///
+    /// `typed_columns`, `lineage_edges`, and `column_masks` stay empty here
+    /// — they are populated by the compiler / governance layers downstream
+    /// when richer typed data is available.
+    pub fn to_model_ir(&self) -> ModelIr {
+        let plan = Plan::Transformation(self.to_plan());
+        let mut ir = ModelIr::from(&plan);
+        ir.name = std::sync::Arc::from(self.config.name.as_str());
+        ir
+    }
 }
 
 /// Loads a model from a sidecar pair: `name.sql` + `name.toml`.
@@ -961,6 +980,82 @@ SELECT id, name, status FROM raw.src
         let (fm, sql) = split_frontmatter(content).unwrap();
         assert_eq!(fm, "name = \"test\"");
         assert_eq!(sql, "SELECT 1");
+    }
+
+    #[test]
+    fn test_to_model_ir_carries_model_name_not_target_table() {
+        // The model name (`fct_orders`) and target.table (`fct_orders_v2`)
+        // differ — `to_model_ir` must use the project-unique model name on
+        // `ModelIr::name`, not whatever `From<&Plan>` would default to from
+        // the target table.
+        let model = parse_model_inline(
+            r#"---toml
+name = "fct_orders"
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "fct_orders_v2"
+---
+SELECT 1
+"#,
+            "fct_orders.sql",
+            None,
+        )
+        .unwrap();
+
+        let ir = model.to_model_ir();
+        assert_eq!(&*ir.name, "fct_orders");
+        assert_eq!(ir.target.table, "fct_orders_v2");
+    }
+
+    #[test]
+    fn test_to_model_ir_lowering_matches_to_plan() {
+        // The strategy / sql / sources / governance / format lowering MUST
+        // match `to_plan` exactly — `to_model_ir` reuses `to_plan` internally
+        // and threads it through `From<&Plan> for ModelIr`. This guards the
+        // contract that the two views agree.
+        let model = parse_model_inline(
+            r#"---toml
+name = "dim"
+depends_on = ["raw.src"]
+[strategy]
+type = "merge"
+unique_key = ["id"]
+update_columns = ["name", "status"]
+[[sources]]
+catalog = "raw"
+schema = "ext"
+table = "src"
+[target]
+catalog = "c"
+schema = "s"
+table = "t"
+---
+SELECT id, name, status FROM raw.ext.src
+"#,
+            "dim.sql",
+            None,
+        )
+        .unwrap();
+
+        let plan = model.to_plan();
+        let ir = model.to_model_ir();
+
+        assert_eq!(ir.sql, plan.sql);
+        // SourceRef / TargetRef / MaterializationStrategy do not derive
+        // `PartialEq`; compare by canonical JSON instead.
+        assert_eq!(
+            serde_json::to_value(&ir.sources).unwrap(),
+            serde_json::to_value(&plan.sources).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&ir.target).unwrap(),
+            serde_json::to_value(&plan.target).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_value(&ir.materialization).unwrap(),
+            serde_json::to_value(&plan.strategy).unwrap()
+        );
     }
 
     // --- Sidecar format tests ---


### PR DESCRIPTION
Wires `ModelIr` construction at every site that builds a `Plan` today, so the follow-up `sql_gen` migration (Phase 2b.2) is a pure type-swap with no construction-site ambiguity.

## What landed

- **`Model::to_model_ir(&self) -> ModelIr`** in `rocky-core/src/models.rs`. Reuses `to_plan` so the materialization-strategy lowering stays in one place, then threads through `From<&Plan> for ModelIr` and overrides `name` with the model's `config.name` (so the IR carries the project-unique identifier, not the warehouse table name).
- **The 3 bare-handed `Plan` sites** (`commands/plan.rs:147`, `commands/run.rs:4377`, `commands/run_local.rs:632`) now build a `ModelIr` via `ModelIr::from(&Plan::X(plan.clone()))` right after the Plan variant. Bound to `_model_ir` (does not trigger `unused_variables`); inline comment marks it as Phase 2b.1.

## Why two PRs

PR #370's body explicitly deferred the `sql_gen` migration to a separate PR. Reality is even bigger: there are 8+ production callers of `Model::to_plan` and ~25 `sql_gen` test callsites, on top of the 13 `sql_gen` public function signatures. Splitting:

1. Lets this PR be a small, mechanical wiring change with a round-trip test as its consumer (no dead code).
2. Lets PR 2b.2 be a pure type-swap — every callsite swaps \`&plan\` for \`&model_ir\` and \`sql_gen\` sigs change in lockstep, with no overlap with construction-site logic.

## Tests

- \`test_to_model_ir_carries_model_name_not_target_table\` — guards the \`ir.name = config.name\` override.
- \`test_to_model_ir_lowering_matches_to_plan\` — guards that \`to_model_ir\` and \`to_plan\` agree on sql / sources / target / strategy (compared by canonical JSON since none of these derive \`PartialEq\`).
- The 3 bare-handed sites are covered by the existing \`plan_to_model_ir_*_roundtrip\` tests in \`ir.rs\` (Phase 2a) which already prove \`ModelIr::from(&plan).to_plan_compatible()\` is canonical-JSON-equal to \`plan\` for every variant.

## Pre-flight

- \`cargo build -p rocky-core -p rocky-cli\`: clean
- \`cargo test -p rocky-core --lib\`: 1190 passed (was 1188 + 2 new)
- \`cargo test -p rocky-cli --lib\`: 353 passed
- \`cargo clippy -p rocky-cli -p rocky-core --all-targets -- -D warnings\`: clean
- \`cargo fmt --check\`: clean

## Deferred to Phase 2b.2

- \`sql_gen\` public functions accept \`&ModelIr\` instead of \`&ReplicationPlan\` / \`&TransformationPlan\` / \`&SnapshotPlan\`.
- The construction sites stop building \`Plan\` and pass \`&model_ir\` to \`sql_gen\` directly.
- The ~25 \`sql_gen\` test callsites (in \`sql_gen.rs\`, \`tests/e2e.rs\`, \`tests/integration.rs\`, \`benches/compile.rs\`, \`commands/bench.rs\`) swap their plan-construction-then-call pattern.
- **Watermark migration: already complete** — \`MaterializationStrategy::Incremental\` carries only \`timestamp_column\`, and \`WatermarkState\` is read from the state store at SQL-gen time. Nothing to migrate there.