### PR TITLE
feat(rocky-core): typed-IR Phase 2b — sql_gen consumes &ModelIr

### DIFF
--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -272,27 +272,36 @@ fn bench_sql_generation(c: &mut Criterion) {
             })
             .collect();
 
-        group.bench_with_input(BenchmarkId::new("ctas", size), &plans, |b, plans| {
-            b.iter(|| {
-                for plan in plans {
-                    sql_gen::generate_create_table_as_sql(plan, &dialect).unwrap();
-                }
-            });
-        });
-
-        // Only bench incremental plans
-        let inc_plans: Vec<&ReplicationPlan> = plans
+        let model_irs: Vec<ModelIr> = plans
             .iter()
-            .filter(|p| matches!(p.strategy, MaterializationStrategy::Incremental { .. }))
+            .map(|plan| ModelIr::from(&Plan::Replication(plan.clone())))
             .collect();
 
         group.bench_with_input(
-            BenchmarkId::new("incremental", inc_plans.len()),
-            &inc_plans,
-            |b, plans| {
+            BenchmarkId::new("ctas", size),
+            &model_irs,
+            |b, model_irs| {
                 b.iter(|| {
-                    for plan in plans.iter() {
-                        sql_gen::generate_insert_sql(plan, &dialect).unwrap();
+                    for model_ir in model_irs {
+                        sql_gen::generate_create_table_as_sql(model_ir, &dialect).unwrap();
+                    }
+                });
+            },
+        );
+
+        // Only bench incremental plans
+        let inc_irs: Vec<&ModelIr> = model_irs
+            .iter()
+            .filter(|ir| matches!(ir.materialization, MaterializationStrategy::Incremental { .. }))
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("incremental", inc_irs.len()),
+            &inc_irs,
+            |b, irs| {
+                b.iter(|| {
+                    for ir in irs.iter() {
+                        sql_gen::generate_insert_sql(ir, &dialect).unwrap();
                     }
                 });
             },

--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -292,7 +292,12 @@ fn bench_sql_generation(c: &mut Criterion) {
         // Only bench incremental plans
         let inc_irs: Vec<&ModelIr> = model_irs
             .iter()
-            .filter(|ir| matches!(ir.materialization, MaterializationStrategy::Incremental { .. }))
+            .filter(|ir| {
+                matches!(
+                    ir.materialization,
+                    MaterializationStrategy::Incremental { .. }
+                )
+            })
             .collect();
 
         group.bench_with_input(

--- a/engine/crates/rocky-cli/src/commands/bench.rs
+++ b/engine/crates/rocky-cli/src/commands/bench.rs
@@ -376,9 +376,15 @@ fn bench_sql_gen(iterations: usize) -> Vec<BenchResult> {
             })
             .collect();
 
+        let model_irs: Vec<_> = plans
+            .iter()
+            .map(|plan| {
+                rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Replication(plan.clone()))
+            })
+            .collect();
         let times = measure(iterations, || {
-            for plan in &plans {
-                sql_gen::generate_create_table_as_sql(plan, &dialect).unwrap();
+            for model_ir in &model_irs {
+                sql_gen::generate_create_table_as_sql(model_ir, &dialect).unwrap();
             }
         });
         let mean_ms =

--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -66,9 +66,11 @@ pub async fn run_estimate(
     let mut estimates = Vec::new();
     for model in &models_to_estimate {
         let plan = model.to_plan();
+        let model_ir =
+            rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(plan.clone()));
         let dialect = warehouse_adapter.dialect();
 
-        let sql_result = rocky_core::sql_gen::generate_transformation_sql(&plan, dialect);
+        let sql_result = rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect);
 
         let sql = match sql_result {
             Ok(stmts) => stmts.join(";\n"),

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -165,8 +165,8 @@ pub async fn plan(
                 },
             };
 
-            // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
-            let _model_ir = ModelIr::from(&Plan::Replication(plan.clone()));
+            // sql_gen consumes the typed IR directly.
+            let model_ir = ModelIr::from(&Plan::Replication(plan.clone()));
 
             // Pick the right SQL generator for the materialization strategy.
             // Full refresh uses CREATE OR REPLACE TABLE AS so the target doesn't
@@ -174,12 +174,12 @@ pub async fn plan(
             // target to already exist (created on the first full-refresh run).
             let sql = match &strategy {
                 MaterializationStrategy::FullRefresh => {
-                    sql_gen::generate_create_table_as_sql(&plan, dialect)?
+                    sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
                 }
                 MaterializationStrategy::Incremental { .. } => {
-                    sql_gen::generate_insert_sql(&plan, dialect)?
+                    sql_gen::generate_insert_sql(&model_ir, dialect)?
                 }
-                _ => sql_gen::generate_insert_sql(&plan, dialect)?,
+                _ => sql_gen::generate_insert_sql(&model_ir, dialect)?,
             };
 
             let target_label = if effective_target_catalog.is_empty() {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3601,6 +3601,9 @@ pub(crate) async fn execute_models(
             }
 
             let plan = model.to_plan();
+            let model_ir = rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(
+                plan.clone(),
+            ));
             let target_ref = dialect
                 .format_table_ref(
                     &plan.target.catalog,
@@ -3636,7 +3639,9 @@ pub(crate) async fn execute_models(
                     .is_err()
                 {
                     let initial_ddls =
-                        rocky_core::sql_gen::generate_transformation_initial_ddl(&plan, dialect)?;
+                        rocky_core::sql_gen::generate_transformation_initial_ddl(
+                            &model_ir, dialect,
+                        )?;
                     info!(
                         model = model_name.as_str(),
                         target = target_ref.as_str(),
@@ -3653,7 +3658,8 @@ pub(crate) async fn execute_models(
                 }
             }
 
-            let exec_stmts = rocky_core::sql_gen::generate_transformation_sql(&plan, dialect)?;
+            let exec_stmts =
+                rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect)?;
 
             info!(
                 model = model_name.as_str(),
@@ -3891,7 +3897,10 @@ async fn execute_time_interval_model(
     let target_exists = warehouse.describe_table(&target_ref_struct).await.is_ok();
     if !target_exists {
         let bootstrap_plan = model.to_plan();
-        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&bootstrap_plan, dialect)
+        let bootstrap_ir = rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(
+            bootstrap_plan.clone(),
+        ));
+        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&bootstrap_ir, dialect)
             .with_context(|| format!("failed to render bootstrap SQL for model '{model_name}'"))?;
         info!(
             model = model_name,
@@ -4063,7 +4072,9 @@ async fn run_one_partition(
     // Generate SQL — this is where dialect.insert_overwrite_partition() gets
     // called and the @start_date / @end_date placeholders are substituted
     // (Phase 2D).
-    let stmts = match sql_gen::generate_transformation_sql(&tplan, dialect) {
+    let tplan_ir =
+        rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(tplan.clone()));
+    let stmts = match sql_gen::generate_transformation_sql(&tplan_ir, dialect) {
         Ok(s) => s,
         Err(e) => {
             return PartitionExecutionResult {
@@ -4401,34 +4412,34 @@ async fn process_table(
         },
     };
 
-    // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
-    let _model_ir = ModelIr::from(&Plan::Replication(replication.clone()));
+    // sql_gen consumes the typed IR directly.
+    let model_ir = ModelIr::from(&Plan::Replication(replication.clone()));
 
     let strategy_name;
     let sql = if use_full_refresh {
         strategy_name = "full_refresh";
-        sql_gen::generate_create_table_as_sql(&replication, dialect)?
+        sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
     } else {
         match &replication.strategy {
             MaterializationStrategy::FullRefresh => {
                 strategy_name = "full_refresh";
-                sql_gen::generate_create_table_as_sql(&replication, dialect)?
+                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::Incremental { .. } => {
                 strategy_name = "incremental";
-                sql_gen::generate_insert_sql(&replication, dialect)?
+                sql_gen::generate_insert_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::Merge { .. } => {
                 strategy_name = "merge";
-                sql_gen::generate_merge_sql(&replication, dialect)?
+                sql_gen::generate_merge_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::MaterializedView => {
                 strategy_name = "materialized_view";
-                sql_gen::generate_create_table_as_sql(&replication, dialect)?
+                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::DynamicTable { .. } => {
                 strategy_name = "dynamic_table";
-                sql_gen::generate_create_table_as_sql(&replication, dialect)?
+                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::TimeInterval { .. } => {
                 // time_interval is a transformation strategy (silver-layer
@@ -4449,12 +4460,12 @@ async fn process_table(
             MaterializationStrategy::DeleteInsert { .. } => {
                 strategy_name = "delete_insert";
                 // For replication, delete+insert falls back to full refresh.
-                sql_gen::generate_create_table_as_sql(&replication, dialect)?
+                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
             }
             MaterializationStrategy::Microbatch { .. } => {
                 strategy_name = "microbatch";
                 // Microbatch on replication tables falls back to incremental insert.
-                sql_gen::generate_insert_sql(&replication, dialect)?
+                sql_gen::generate_insert_sql(&model_ir, dialect)?
             }
         }
     };

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3601,9 +3601,8 @@ pub(crate) async fn execute_models(
             }
 
             let plan = model.to_plan();
-            let model_ir = rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(
-                plan.clone(),
-            ));
+            let model_ir =
+                rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(plan.clone()));
             let target_ref = dialect
                 .format_table_ref(
                     &plan.target.catalog,
@@ -3638,10 +3637,9 @@ pub(crate) async fn execute_models(
                     .await
                     .is_err()
                 {
-                    let initial_ddls =
-                        rocky_core::sql_gen::generate_transformation_initial_ddl(
-                            &model_ir, dialect,
-                        )?;
+                    let initial_ddls = rocky_core::sql_gen::generate_transformation_initial_ddl(
+                        &model_ir, dialect,
+                    )?;
                     info!(
                         model = model_name.as_str(),
                         target = target_ref.as_str(),
@@ -3658,8 +3656,7 @@ pub(crate) async fn execute_models(
                 }
             }
 
-            let exec_stmts =
-                rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect)?;
+            let exec_stmts = rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect)?;
 
             info!(
                 model = model_name.as_str(),
@@ -3901,7 +3898,9 @@ async fn execute_time_interval_model(
             bootstrap_plan.clone(),
         ));
         let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&bootstrap_ir, dialect)
-            .with_context(|| format!("failed to render bootstrap SQL for model '{model_name}'"))?;
+            .with_context(|| {
+            format!("failed to render bootstrap SQL for model '{model_name}'")
+        })?;
         info!(
             model = model_name,
             target = target_table.as_str(),

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -654,11 +654,11 @@ pub async fn run_snapshot(
         },
     };
 
-    // Phase 2b.1: ModelIr built alongside Plan; sql_gen consumes it in 2b.2.
-    let _model_ir = ModelIr::from(&Plan::Snapshot(plan.clone()));
+    // sql_gen consumes the typed IR directly.
+    let model_ir = ModelIr::from(&Plan::Snapshot(plan.clone()));
 
     let dialect = warehouse_adapter.dialect();
-    let stmts = sql_gen::generate_snapshot_sql(&plan, dialect)?;
+    let stmts = sql_gen::generate_snapshot_sql(&model_ir, dialect)?;
 
     let mut tables_failed = 0usize;
     for stmt in &stmts {

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -2,10 +2,55 @@ use rocky_sql::validation;
 use thiserror::Error;
 
 use crate::ir::{
-    MaterializationStrategy, PartitionWindow, ReplicationPlan, SnapshotPlan, TransformationPlan,
+    MaterializationStrategy, ModelIr, PartitionWindow, Plan, ReplicationPlan, SnapshotPlan,
+    TransformationPlan,
 };
 use crate::lakehouse::{self, LakehouseError};
 use crate::traits::{AdapterError, SqlDialect};
+
+/// Extract the variant-typed `ReplicationPlan` from a [`ModelIr`].
+///
+/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
+/// from a [`Plan::Replication`]. The check is shaped by which variant-
+/// specific fields are populated: replication carries an explicit
+/// [`crate::ir::ColumnSelection`] in `columns`.
+fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenError> {
+    match model_ir.to_plan_compatible() {
+        Plan::Replication(plan) => Ok(plan),
+        _ => Err(SqlGenError::InvalidRequest(format!(
+            "expected Replication ModelIr for `{}`",
+            model_ir.name
+        ))),
+    }
+}
+
+/// Extract the variant-typed `TransformationPlan` from a [`ModelIr`].
+///
+/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
+/// from a [`Plan::Transformation`].
+fn transformation_from_ir(model_ir: &ModelIr) -> Result<TransformationPlan, SqlGenError> {
+    match model_ir.to_plan_compatible() {
+        Plan::Transformation(plan) => Ok(plan),
+        _ => Err(SqlGenError::InvalidRequest(format!(
+            "expected Transformation ModelIr for `{}`",
+            model_ir.name
+        ))),
+    }
+}
+
+/// Extract the variant-typed `SnapshotPlan` from a [`ModelIr`].
+///
+/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
+/// from a [`Plan::Snapshot`].
+fn snapshot_from_ir(model_ir: &ModelIr) -> Result<SnapshotPlan, SqlGenError> {
+    match model_ir.to_plan_compatible() {
+        Plan::Snapshot(plan) => Ok(plan),
+        _ => Err(SqlGenError::InvalidRequest(format!(
+            "expected Snapshot ModelIr for `{}`",
+            model_ir.name
+        ))),
+    }
+}
 
 /// Errors from SQL generation, including identifier validation and unsafe fragment detection.
 #[derive(Debug, Error)]
@@ -42,11 +87,17 @@ pub enum SqlGenError {
     InvalidRequest(String),
 }
 
-/// Generates the SELECT SQL for a replication plan using the given dialect.
+/// Generates the SELECT SQL for a replication model using the given dialect.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Replication`].
 pub fn generate_select_sql(
-    plan: &ReplicationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = replication_from_ir(model_ir)?;
     let select = dialect.select_clause(&plan.columns, &plan.metadata_columns)?;
 
     let source = dialect.format_table_ref(
@@ -95,40 +146,58 @@ fn generate_select_sql_no_watermark(
 }
 
 /// Generates `INSERT INTO <target> SELECT ...` using the given dialect.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Replication`].
 pub fn generate_insert_sql(
-    plan: &ReplicationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = replication_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
         &plan.target.table,
     )?;
-    let select = generate_select_sql(plan, dialect)?;
+    let select = generate_select_sql(model_ir, dialect)?;
     Ok(dialect.insert_into(&target, &select))
 }
 
 /// Generates CREATE TABLE AS SELECT using the given dialect (full refresh).
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Replication`].
 pub fn generate_create_table_as_sql(
-    plan: &ReplicationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = replication_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
         &plan.target.table,
     )?;
 
-    let select = generate_select_sql_no_watermark(plan, dialect)?;
+    let select = generate_select_sql_no_watermark(&plan, dialect)?;
 
     Ok(dialect.create_table_as(&target, &select))
 }
 
 /// Generates a MERGE INTO statement using the given dialect.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Replication`].
 pub fn generate_merge_sql(
-    plan: &ReplicationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = replication_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -141,11 +210,11 @@ pub fn generate_merge_sql(
             update_columns,
         } => (unique_key, update_columns),
         _ => {
-            return generate_create_table_as_sql(plan, dialect);
+            return generate_create_table_as_sql(model_ir, dialect);
         }
     };
 
-    let select = generate_select_sql_no_watermark(plan, dialect)?;
+    let select = generate_select_sql_no_watermark(&plan, dialect)?;
 
     Ok(dialect.merge_into(&target, &select, unique_key, update_columns)?)
 }
@@ -158,10 +227,16 @@ pub fn generate_merge_sql(
 /// (`FullRefresh`, `Incremental`, `Merge`, `MaterializedView`) the vec
 /// contains exactly one entry; callers that need a single string can pattern-
 /// match `&[only]` or call `.join("\n")` if cosmetic concatenation is fine.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Transformation`].
 pub fn generate_transformation_sql(
-    plan: &TransformationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
+    let plan = transformation_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -204,7 +279,7 @@ pub fn generate_transformation_sql(
             Ok(vec![stmt])
         }
         MaterializationStrategy::MaterializedView => {
-            Ok(vec![generate_materialized_view_sql(plan, dialect)?])
+            Ok(vec![generate_materialized_view_sql(model_ir, dialect)?])
         }
         MaterializationStrategy::DynamicTable { .. } => {
             // Dynamic tables require a warehouse parameter not available in the plan.
@@ -303,10 +378,16 @@ pub fn generate_transformation_sql(
 ///
 /// Once the table exists, subsequent partition runs use the regular
 /// `insert_overwrite_partition` DELETE+INSERT cycle.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Transformation`].
 pub fn generate_time_interval_bootstrap_sql(
-    plan: &TransformationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = transformation_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -360,10 +441,16 @@ pub fn generate_time_interval_bootstrap_sql(
 /// This is complementary to `generate_transformation_sql` — the runtime
 /// calls this once on first run, then switches to the regular strategy
 /// for subsequent runs.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Transformation`].
 pub fn generate_transformation_initial_ddl(
-    plan: &TransformationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
+    let plan = transformation_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -399,11 +486,17 @@ fn substitute_partition_placeholders(sql: &str, window: &PartitionWindow) -> Str
     )
 }
 
-/// Generates CREATE MATERIALIZED VIEW SQL for a transformation plan.
+/// Generates CREATE MATERIALIZED VIEW SQL for a transformation model.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Transformation`].
 pub fn generate_materialized_view_sql(
-    plan: &TransformationPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = transformation_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -416,13 +509,19 @@ pub fn generate_materialized_view_sql(
     ))
 }
 
-/// Generates CREATE DYNAMIC TABLE SQL for a transformation plan (Snowflake).
+/// Generates CREATE DYNAMIC TABLE SQL for a transformation model (Snowflake).
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Transformation`].
 pub fn generate_dynamic_table_sql(
-    plan: &TransformationPlan,
+    model_ir: &ModelIr,
     target_lag: &str,
     warehouse: &str,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
+    let plan = transformation_from_ir(model_ir)?;
     let target = dialect.format_table_ref(
         &plan.target.catalog,
         &plan.target.schema,
@@ -494,10 +593,16 @@ use std::fmt::Write;
 ///    the `updated_at` column has changed.
 /// 2. Inserts new versions with `valid_from = CURRENT_TIMESTAMP, valid_to = NULL`.
 /// 3. Optionally invalidates hard-deleted rows (source rows that no longer exist).
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// constructed from a [`Plan::Snapshot`].
 pub fn generate_snapshot_sql(
-    plan: &SnapshotPlan,
+    model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
+    let plan = snapshot_from_ir(model_ir)?;
     let source = dialect.format_table_ref(
         &plan.source.catalog,
         &plan.source.schema,
@@ -604,13 +709,13 @@ pub fn generate_snapshot_sql(
 /// Each model's SQL generation is independent, making this embarrassingly
 /// parallel. At 50k models, this reduces SQL gen time from ~1.2s to <200ms.
 pub fn generate_transformations_parallel(
-    plans: &[TransformationPlan],
+    model_irs: &[ModelIr],
     dialect: &(dyn SqlDialect + Sync),
 ) -> Vec<Result<Vec<String>, SqlGenError>> {
     use rayon::prelude::*;
-    plans
+    model_irs
         .par_iter()
-        .map(|plan| generate_transformation_sql(plan, dialect))
+        .map(|model_ir| generate_transformation_sql(model_ir, dialect))
         .collect()
 }
 
@@ -774,6 +879,22 @@ mod tests {
         TestDialect
     }
 
+    /// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
+    fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
+        ModelIr::from(&Plan::Replication(plan.clone()))
+    }
+
+    /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
+    fn xform_ir(plan: &TransformationPlan) -> ModelIr {
+        ModelIr::from(&Plan::Transformation(plan.clone()))
+    }
+
+    /// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
+    #[allow(dead_code)]
+    fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
+        ModelIr::from(&Plan::Snapshot(plan.clone()))
+    }
+
     fn sample_incremental_plan() -> ReplicationPlan {
         ReplicationPlan {
             source: SourceRef {
@@ -813,7 +934,7 @@ mod tests {
     #[test]
     fn test_incremental_select() {
         let plan = sample_incremental_plan();
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("FROM source_catalog.src__acme__us_west__shopify.orders"));
@@ -825,7 +946,7 @@ mod tests {
     #[test]
     fn test_full_refresh_select() {
         let plan = sample_full_refresh_plan();
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("FROM source_catalog"));
@@ -835,7 +956,7 @@ mod tests {
     #[test]
     fn test_insert_into_sql() {
         let plan = sample_incremental_plan();
-        let sql = generate_insert_sql(&plan, &dialect()).unwrap();
+        let sql = generate_insert_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert!(sql.starts_with("INSERT INTO acme_warehouse.staging__us_west__shopify.orders"));
         assert!(sql.contains("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
@@ -845,7 +966,7 @@ mod tests {
     #[test]
     fn test_create_table_as_sql() {
         let plan = sample_incremental_plan();
-        let sql = generate_create_table_as_sql(&plan, &dialect()).unwrap();
+        let sql = generate_create_table_as_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         // CTAS always does full refresh (no WHERE clause)
         assert!(sql.starts_with(
@@ -862,7 +983,7 @@ mod tests {
             metadata_columns: vec![],
             ..sample_full_refresh_plan()
         };
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT id, name, status"));
         assert!(!sql.contains("*"));
@@ -874,7 +995,7 @@ mod tests {
             metadata_columns: vec![],
             ..sample_full_refresh_plan()
         };
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert_eq!(sql.lines().next().unwrap().trim(), "SELECT *");
         assert!(!sql.contains("CAST"));
@@ -897,7 +1018,7 @@ mod tests {
             ],
             ..sample_full_refresh_plan()
         };
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         assert!(sql.contains("CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("CAST(42 AS INT) AS load_id"));
@@ -913,7 +1034,7 @@ mod tests {
             },
             ..sample_full_refresh_plan()
         };
-        assert!(generate_select_sql(&plan, &dialect()).is_err());
+        assert!(generate_select_sql(&rep_ir(&plan), &dialect()).is_err());
     }
 
     #[test]
@@ -926,7 +1047,7 @@ mod tests {
             }],
             ..sample_full_refresh_plan()
         };
-        assert!(generate_select_sql(&plan, &dialect()).is_err());
+        assert!(generate_select_sql(&rep_ir(&plan), &dialect()).is_err());
     }
 
     #[test]
@@ -945,7 +1066,7 @@ mod tests {
         // This test now checks that the dialect produces output (it does, since TestDialect
         // doesn't validate literal values). In production, the DatabricksSqlDialect should
         // validate literal values.
-        let _ = generate_select_sql(&plan, &dialect());
+        let _ = generate_select_sql(&rep_ir(&plan), &dialect());
     }
 
     #[test]
@@ -959,7 +1080,7 @@ mod tests {
             ..sample_full_refresh_plan()
         };
         // Same as above: data type validation is delegated to the dialect.
-        let _ = generate_select_sql(&plan, &dialect());
+        let _ = generate_select_sql(&rep_ir(&plan), &dialect());
     }
 
     #[test]
@@ -971,7 +1092,7 @@ mod tests {
             },
             ..sample_full_refresh_plan()
         };
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
         assert!(!sql.contains("WHERE")); // merge SELECT is a full scan
     }
 
@@ -984,7 +1105,7 @@ mod tests {
             },
             ..sample_full_refresh_plan()
         };
-        let sql = generate_merge_sql(&plan, &dialect()).unwrap();
+        let sql = generate_merge_sql(&rep_ir(&plan), &dialect()).unwrap();
         assert!(sql.contains("MERGE INTO"));
         assert!(sql.contains("ON t.id = s.id"));
         assert!(sql.contains("WHEN MATCHED THEN UPDATE SET *"));
@@ -1000,7 +1121,7 @@ mod tests {
             },
             ..sample_full_refresh_plan()
         };
-        let sql = generate_merge_sql(&plan, &dialect()).unwrap();
+        let sql = generate_merge_sql(&rep_ir(&plan), &dialect()).unwrap();
         assert!(sql.contains("ON t.id = s.id AND t.date = s.date"));
         assert!(sql.contains("UPDATE SET t.status = s.status, t.amount = s.amount"));
     }
@@ -1015,7 +1136,7 @@ mod tests {
             ..sample_full_refresh_plan()
         };
         // The dialect returns an error for empty keys, which sql_gen maps to UnsafeFragment
-        assert!(generate_merge_sql(&plan, &dialect()).is_err());
+        assert!(generate_merge_sql(&rep_ir(&plan), &dialect()).is_err());
     }
 
     #[test]
@@ -1041,7 +1162,7 @@ mod tests {
             format: None,
             format_options: None,
         };
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.starts_with("CREATE OR REPLACE TABLE cat.silver.dim_accounts AS"));
@@ -1069,7 +1190,7 @@ mod tests {
             format: None,
             format_options: None,
         };
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(stmts[0].starts_with("INSERT INTO cat.silver.fct_orders"));
     }
@@ -1096,7 +1217,7 @@ mod tests {
             format: None,
             format_options: None,
         };
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.contains("MERGE INTO cat.silver.dim_users AS t"));
@@ -1131,7 +1252,7 @@ mod tests {
     #[test]
     fn test_sample_incremental_sql_matches_expected() {
         let plan = sample_incremental_plan();
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1147,7 +1268,7 @@ WHERE _fivetran_synced > (
     #[test]
     fn test_sample_full_refresh_sql_matches_expected() {
         let plan = sample_full_refresh_plan();
-        let sql = generate_select_sql(&plan, &dialect()).unwrap();
+        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
 
         let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1186,7 +1307,7 @@ FROM source_catalog.src__acme__us_west__shopify.orders";
             strategy: MaterializationStrategy::MaterializedView,
             ..sample_transformation_plan()
         };
-        let sql = generate_materialized_view_sql(&plan, &dialect()).unwrap();
+        let sql = generate_materialized_view_sql(&xform_ir(&plan), &dialect()).unwrap();
 
         let expected = "\
 CREATE OR REPLACE MATERIALIZED VIEW cat.silver.dim_accounts AS
@@ -1201,7 +1322,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             strategy: MaterializationStrategy::MaterializedView,
             ..sample_transformation_plan()
         };
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("CREATE OR REPLACE MATERIALIZED VIEW cat.silver.dim_accounts AS")
@@ -1216,7 +1337,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             ..sample_transformation_plan()
         };
-        let sql = generate_dynamic_table_sql(&plan, "1 hour", "COMPUTE_WH", &dialect()).unwrap();
+        let sql = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "COMPUTE_WH", &dialect()).unwrap();
 
         let expected = "\
 CREATE OR REPLACE DYNAMIC TABLE cat.silver.dim_accounts
@@ -1236,7 +1357,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             ..sample_transformation_plan()
         };
-        let result = generate_dynamic_table_sql(&plan, "1 hour", "WH; DROP TABLE", &dialect());
+        let result = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "WH; DROP TABLE", &dialect());
         assert!(result.is_err());
     }
 
@@ -1249,7 +1370,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             ..sample_transformation_plan()
         };
         let result =
-            generate_dynamic_table_sql(&plan, "1'; DROP TABLE --", "COMPUTE_WH", &dialect());
+            generate_dynamic_table_sql(&xform_ir(&plan), "1'; DROP TABLE --", "COMPUTE_WH", &dialect());
         assert!(result.is_err());
     }
 
@@ -1309,7 +1430,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             "SELECT order_date FROM cat.raw.stg_orders WHERE order_date >= @start_date AND order_date < @end_date",
             None,
         );
-        let result = generate_transformation_sql(&plan, &dialect());
+        let result = generate_transformation_sql(&xform_ir(&plan), &dialect());
         assert!(matches!(result, Err(SqlGenError::MissingPartitionWindow)));
     }
 
@@ -1320,7 +1441,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             "SELECT order_date FROM cat.raw.stg_orders WHERE order_date >= @start_date AND order_date < @end_date",
             Some(april_7_window()),
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1, "test dialect emits a single REPLACE WHERE");
         let sql = &stmts[0];
         // Both placeholders substituted with quoted timestamp literals.
@@ -1354,7 +1475,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             "SELECT 1 FROM cat.raw.stg_orders WHERE 1=1 AND @start_date < @end_date",
             Some(april_7_window()),
         );
-        let result = generate_transformation_sql(&plan, &dialect());
+        let result = generate_transformation_sql(&xform_ir(&plan), &dialect());
         assert!(matches!(result, Err(SqlGenError::UnsafeFragment { .. })));
     }
 
@@ -1382,7 +1503,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
              WHERE order_at >= @start_date AND order_at < @end_date",
             None,
         );
-        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
 
         // Wrapped in CREATE OR REPLACE TABLE AS by the test dialect.
         assert!(
@@ -1415,7 +1536,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             "SELECT order_date FROM cat.raw.x WHERE x.t >= @start_date AND x.t < @end_date",
             None, // window = None
         );
-        let result = generate_time_interval_bootstrap_sql(&plan, &dialect());
+        let result = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect());
         assert!(
             result.is_ok(),
             "bootstrap should not error on missing window: {result:?}"
@@ -1466,7 +1587,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.contains("USING DELTA"), "expected USING DELTA: {sql}");
@@ -1502,7 +1623,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1522,7 +1643,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             LakehouseOptions::default(),
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].contains("CREATE OR REPLACE STREAMING TABLE"),
@@ -1538,7 +1659,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             LakehouseOptions::default(),
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].contains("CREATE OR REPLACE VIEW"),
@@ -1557,7 +1678,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1579,7 +1700,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1609,7 +1730,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 timestamp_column: "updated_at".into(),
             },
         );
-        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("INSERT INTO"),
@@ -1631,7 +1752,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 timestamp_column: "updated_at".into(),
             },
         );
-        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1661,7 +1782,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 update_columns: ColumnSelection::All,
             },
         );
-        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1687,7 +1808,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 MaterializationStrategy::FullRefresh,
             )
         };
-        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("CREATE OR REPLACE TABLE"),
@@ -1717,7 +1838,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             ..LakehouseOptions::default()
         });
 
-        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert!(
             sql.contains("USING DELTA"),
             "bootstrap should use DELTA: {sql}"
@@ -1755,7 +1876,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
              WHERE order_date >= @start_date AND order_date < @end_date",
             None,
         );
-        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
         assert!(
             sql.starts_with("CREATE OR REPLACE TABLE"),
             "should use plain CTAS: {sql}"
@@ -1779,7 +1900,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 partition_by: vec!["date_key".into()],
             },
         );
-        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1803,7 +1924,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let result = generate_transformation_initial_ddl(&plan, &dialect());
+        let result = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect());
         assert!(result.is_err(), "should reject invalid partition column");
     }
 }

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -1337,7 +1337,8 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             ..sample_transformation_plan()
         };
-        let sql = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "COMPUTE_WH", &dialect()).unwrap();
+        let sql = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "COMPUTE_WH", &dialect())
+            .unwrap();
 
         let expected = "\
 CREATE OR REPLACE DYNAMIC TABLE cat.silver.dim_accounts
@@ -1357,7 +1358,8 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             ..sample_transformation_plan()
         };
-        let result = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "WH; DROP TABLE", &dialect());
+        let result =
+            generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "WH; DROP TABLE", &dialect());
         assert!(result.is_err());
     }
 
@@ -1369,8 +1371,12 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             ..sample_transformation_plan()
         };
-        let result =
-            generate_dynamic_table_sql(&xform_ir(&plan), "1'; DROP TABLE --", "COMPUTE_WH", &dialect());
+        let result = generate_dynamic_table_sql(
+            &xform_ir(&plan),
+            "1'; DROP TABLE --",
+            "COMPUTE_WH",
+            &dialect(),
+        );
         assert!(result.is_err());
     }
 

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -1524,8 +1524,9 @@ mod time_interval_e2e {
         // Step 1: render the bootstrap SQL and execute it.
         let plan = time_interval_plan("2026-04-07");
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&xform_ir(&plan), dialect)
-            .expect("bootstrap render");
+        let bootstrap_sql =
+            sql_gen::generate_time_interval_bootstrap_sql(&xform_ir(&plan), dialect)
+                .expect("bootstrap render");
         adapter
             .execute_statement(&bootstrap_sql)
             .await

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -5,13 +5,29 @@
 
 use rocky_core::ir::{
     ColumnInfo, ColumnSelection, DriftAction, GovernanceConfig, MaterializationStrategy,
-    MetadataColumn, ReplicationPlan, SourceRef, TableRef, TargetRef, TransformationPlan,
-    WatermarkState,
+    MetadataColumn, ModelIr, Plan, ReplicationPlan, SnapshotPlan, SourceRef, TableRef, TargetRef,
+    TransformationPlan, WatermarkState,
 };
 use rocky_core::state::StateStore;
 use rocky_core::traits::{AdapterError, AdapterResult, SqlDialect};
 use rocky_core::{drift, sql_gen};
 use tempfile::TempDir;
+
+/// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
+fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
+    ModelIr::from(&Plan::Replication(plan.clone()))
+}
+
+/// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
+fn xform_ir(plan: &TransformationPlan) -> ModelIr {
+    ModelIr::from(&Plan::Transformation(plan.clone()))
+}
+
+/// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
+#[allow(dead_code)]
+fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
+    ModelIr::from(&Plan::Snapshot(plan.clone()))
+}
 
 // ---------------------------------------------------------------------------
 // Test dialect (mirrors Databricks behavior for integration tests)
@@ -210,7 +226,7 @@ fn test_full_refresh_pipeline() {
     let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
 
     // Generate CREATE TABLE AS SELECT SQL (full refresh)
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
 
     // Verify SQL structure
     assert!(
@@ -270,7 +286,7 @@ fn test_incremental_pipeline_with_watermark() {
     });
 
     // Generate INSERT INTO ... SELECT SQL (incremental append)
-    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
 
     // Verify incremental SQL structure
     assert!(
@@ -543,7 +559,7 @@ fn test_transformation_full_refresh() {
         format_options: None,
     };
 
-    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
 
@@ -590,7 +606,7 @@ fn test_transformation_incremental() {
         format_options: None,
     };
 
-    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
     assert!(
@@ -628,7 +644,7 @@ fn test_transformation_merge() {
         format_options: None,
     };
 
-    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
     assert!(
@@ -673,7 +689,7 @@ fn test_merge_sql_generation() {
         },
     };
 
-    let sql = sql_gen::generate_merge_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_merge_sql(&rep_ir(&plan), &dialect).unwrap();
 
     assert!(sql.contains("MERGE INTO"), "expected MERGE INTO: {sql}");
     assert!(
@@ -718,7 +734,7 @@ fn test_merge_composite_key() {
         },
     };
 
-    let sql = sql_gen::generate_merge_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_merge_sql(&rep_ir(&plan), &dialect).unwrap();
     assert!(
         sql.contains("ON t.order_id = s.order_id AND t.line_id = s.line_id"),
         "expected composite ON clause: {sql}"
@@ -842,7 +858,7 @@ fn test_sql_injection_prevention() {
         ..sample_replication_plan(MaterializationStrategy::FullRefresh)
     };
     assert!(
-        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
+        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
         "should reject SQL injection in catalog name"
     );
 
@@ -856,7 +872,7 @@ fn test_sql_injection_prevention() {
         ..sample_replication_plan(MaterializationStrategy::FullRefresh)
     };
     assert!(
-        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
+        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
         "should reject SQL injection in schema name"
     );
 
@@ -870,7 +886,7 @@ fn test_sql_injection_prevention() {
         ..sample_replication_plan(MaterializationStrategy::FullRefresh)
     };
     assert!(
-        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
+        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
         "should reject SQL injection in metadata column name"
     );
 
@@ -905,7 +921,7 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     assert!(wm.is_none(), "no watermark on first run");
 
     let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
     assert!(sql.contains("CREATE OR REPLACE TABLE"));
     assert!(!sql.contains("WHERE"));
 
@@ -931,7 +947,7 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
-    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
     assert!(sql.contains("INSERT INTO"));
     assert!(sql.contains("WHERE _fivetran_synced > ("));
 
@@ -975,7 +991,7 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     assert!(drop_sql.contains("DROP TABLE IF EXISTS"));
 
     let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let ctas_sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
+    let ctas_sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
     assert!(ctas_sql.contains("CREATE OR REPLACE TABLE"));
 }
 
@@ -1023,7 +1039,7 @@ fn test_exact_incremental_sql_output() {
         timestamp_column: "_fivetran_synced".into(),
     });
 
-    let sql = sql_gen::generate_select_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_select_sql(&rep_ir(&plan), &dialect).unwrap();
 
     let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1041,7 +1057,7 @@ fn test_exact_full_refresh_sql_output() {
     let dialect = TestDialect;
 
     let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_select_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_select_sql(&rep_ir(&plan), &dialect).unwrap();
 
     let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1055,7 +1071,7 @@ fn test_exact_ctas_sql_output() {
     let dialect = TestDialect;
 
     let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
 
     let expected = "\
 CREATE OR REPLACE TABLE acme_warehouse.staging__us_west__shopify.orders AS
@@ -1072,7 +1088,7 @@ fn test_exact_insert_sql_output() {
     let plan = sample_replication_plan(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
-    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
 
     let expected = "\
 INSERT INTO acme_warehouse.staging__us_west__shopify.orders
@@ -1110,7 +1126,8 @@ WHERE _fivetran_synced > (
 mod time_interval_e2e {
     use rocky_core::incremental::{PartitionRecord, PartitionStatus, partition_key_to_window};
     use rocky_core::ir::{
-        GovernanceConfig, MaterializationStrategy, SourceRef, TargetRef, TransformationPlan,
+        GovernanceConfig, MaterializationStrategy, ModelIr, Plan, SourceRef, TargetRef,
+        TransformationPlan,
     };
     use rocky_core::models::TimeGrain;
     use rocky_core::sql_gen;
@@ -1118,6 +1135,11 @@ mod time_interval_e2e {
     use rocky_core::traits::{SqlDialect, WarehouseAdapter};
     use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
     use tempfile::TempDir;
+
+    /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
+    fn xform_ir(plan: &TransformationPlan) -> ModelIr {
+        ModelIr::from(&Plan::Transformation(plan.clone()))
+    }
 
     /// SQL to seed a stg_orders table with rows across 5 partitions
     /// (2026-04-04 through 2026-04-08), 2 customers, varying revenue.
@@ -1237,7 +1259,7 @@ mod time_interval_e2e {
     /// adapter, in order. Returns the number of rows in the target afterward.
     async fn execute_partition(adapter: &DuckDbWarehouseAdapter, plan: &TransformationPlan) -> u64 {
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let stmts = sql_gen::generate_transformation_sql(plan, dialect)
+        let stmts = sql_gen::generate_transformation_sql(&xform_ir(plan), dialect)
             .expect("generate time_interval SQL");
         // Sanity: the duckdb dialect emits 4 statements
         // (BEGIN/DELETE/INSERT/COMMIT) per Phase 2C.
@@ -1437,7 +1459,7 @@ mod time_interval_e2e {
         let plan = time_interval_plan("2026-04-05"); // expect 1 customer, 1 order
 
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let stmts = sql_gen::generate_transformation_sql(&plan, dialect).unwrap();
+        let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), dialect).unwrap();
 
         // The INSERT statement (index 2 in the BEGIN/DELETE/INSERT/COMMIT vec)
         // should contain the substituted timestamp literals, not the
@@ -1502,7 +1524,7 @@ mod time_interval_e2e {
         // Step 1: render the bootstrap SQL and execute it.
         let plan = time_interval_plan("2026-04-07");
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&plan, dialect)
+        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&xform_ir(&plan), dialect)
             .expect("bootstrap render");
         adapter
             .execute_statement(&bootstrap_sql)

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -21,6 +21,23 @@ use tempfile::TempDir;
 // Helpers
 // ===========================================================================
 
+/// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
+fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
+    ModelIr::from(&Plan::Replication(plan.clone()))
+}
+
+/// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
+#[allow(dead_code)]
+fn xform_ir(plan: &TransformationPlan) -> ModelIr {
+    ModelIr::from(&Plan::Transformation(plan.clone()))
+}
+
+/// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
+#[allow(dead_code)]
+fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
+    ModelIr::from(&Plan::Snapshot(plan.clone()))
+}
+
 fn dialect() -> DuckDbSqlDialect {
     DuckDbSqlDialect
 }
@@ -99,7 +116,7 @@ async fn test_full_pipeline_lifecycle() {
 
     // Generate and execute full refresh SQL
     let plan = duckdb_replication_plan("orders", "orders", MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     // Verify data was copied
@@ -150,7 +167,7 @@ async fn test_incremental_pipeline_two_runs() {
 
     // Run 1: full refresh (no watermark)
     let plan1 = duckdb_replication_plan("events", "events", MaterializationStrategy::FullRefresh);
-    let sql1 = sql_gen::generate_create_table_as_sql(&plan1, &d).unwrap();
+    let sql1 = sql_gen::generate_create_table_as_sql(&rep_ir(&plan1), &d).unwrap();
     p.execute(&sql1).await.unwrap();
     assert_eq!(p.row_count("target.events").await.unwrap(), 2);
 
@@ -183,7 +200,7 @@ async fn test_incremental_pipeline_two_runs() {
             timestamp_column: "_fivetran_synced".into(),
         },
     );
-    let sql2 = sql_gen::generate_insert_sql(&plan2, &d).unwrap();
+    let sql2 = sql_gen::generate_insert_sql(&rep_ir(&plan2), &d).unwrap();
     p.execute(&sql2).await.unwrap();
 
     // Should now have 4 rows (2 original + 2 new)
@@ -299,7 +316,7 @@ async fn test_pipeline_with_metadata_columns() {
         .unwrap();
 
     let plan = duckdb_replication_plan("items", "items", MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     // Verify _loaded_by column exists and is NULL
@@ -761,7 +778,7 @@ async fn test_full_refresh_on_seeded_data() {
         "raw_orders",
         MaterializationStrategy::FullRefresh,
     );
-    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     let source_count = p.row_count("source.raw_orders").await.unwrap();


### PR DESCRIPTION
## Summary

- Flips the 11 public `sql_gen` entry points to accept `&ModelIr` (or `&[ModelIr]`) instead of variant-typed `&{Replication,Transformation,Snapshot}Plan` references. Each fn opens with a private variant-extraction helper that maps `model_ir.to_plan_compatible()` back to the typed plan, preserving every existing function body and SQL output byte-for-byte.
- Wires the production construction sites in `plan.rs`, `run.rs` (replication, transformation, time-interval bootstrap, partition path), `run_local.rs` (snapshot), `estimate.rs`, `bench.rs`, and the `compile.rs` criterion bench so they build a `ModelIr` and pass it directly into `sql_gen` — the placeholder `_model_ir` bindings staged in Phase 2a are now load-bearing.
- Updates the test callsites in `sql_gen.rs` (~46 internal), `tests/e2e.rs`, and `tests/integration.rs` via thin per-file `rep_ir` / `xform_ir` / `snap_ir` helpers that lift a typed plan into a `ModelIr`.

The watermark migration was completed earlier — `MaterializationStrategy::Incremental` carries only `timestamp_column`, runtime reads `WatermarkState` from the state store. No further plumbing in this PR.

### Scope

- 11 public `sql_gen` fns flipped (the 2 `validate_*` helpers take `&str` and were already IR-agnostic).
- 5 production construction sites wired up (`plan.rs`, `run.rs` x3, `run_local.rs`, `estimate.rs`).
- 2 benchmark sites updated (`commands/bench.rs`, `benches/compile.rs`).
- ~50 test callsites swapped (sql_gen unit tests + e2e + integration).

### New error mode

A runtime `SqlGenError::InvalidRequest` now fires if a caller hands a `ModelIr` of the wrong variant to a sql_gen fn (e.g. a `Plan::Snapshot`-derived IR into `generate_select_sql`). The type system used to prevent this; the IR doesn't tag variant. The existing call sites all pass IRs constructed from the matching `Plan::X(_)`, so this is dead code in practice — it exists as a tripwire for future construction-site drift.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace --no-fail-fast` — all suites green (sql_gen unit tests, rocky-core e2e + integration, full workspace)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `rocky run` against the playground default POC (`examples/playground/pocs/00-foundations/00-playground-default/`) — `status: Success`