### PR TITLE
docs: refresh top-level READMEs and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Rocky is a monorepo. The four subprojects share one repository, one issue tracke
 
 | Subproject | Path | Language | Build |
 |---|---|---|---|
-| Rocky CLI engine | `engine/` | Rust (20-crate Cargo workspace) | `cargo` |
+| Rocky CLI engine | `engine/` | Rust (21-crate Cargo workspace) | `cargo` |
 | Dagster integration | `integrations/dagster/` | Python | `uv` |
 | VS Code extension | `editors/vscode/` | TypeScript | `npm` |
 | Sample project | `examples/playground/` | TOML / SQL config | none |
@@ -39,7 +39,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 ```
 
-The engine is a Cargo workspace with 20 crates (Rust edition 2024, MSRV 1.85). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
+The engine is a Cargo workspace with 21 members — 19 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.85). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
 
 ### Dagster integration (`integrations/dagster/`)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Tag PII columns in the model sidecar; bind tags to mask strategies in `[mask]` /
 
 | Path | Artifact | Language | Description |
 |---|---|---|---|
-| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine — 20-crate Cargo workspace |
+| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine — 21-crate Cargo workspace |
 | [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component wrapping the Rocky CLI |
 | [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension — LSP client + commands for AI features |
 | [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | Self-contained DuckDB sample pipeline used for smoke tests and benchmarks |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -17,7 +17,7 @@ Language support for the [Rocky](https://github.com/rocky-data/rocky) SQL transf
 ## Requirements
 
 - **[Rocky CLI](https://github.com/rocky-data/rocky/releases?q=engine)** on your `PATH` (or set `rocky.server.path`)
-- **VS Code** 1.85.0+
+- **VS Code** 1.116.0+
 
 ## Install
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -85,6 +85,8 @@ Full reference: [CLI commands](https://rocky-data.dev/reference/cli/).
 | Role | Adapter | Status | Notes |
 |------|---------|--------|-------|
 | Source | Fivetran | Production | REST API discovery of connectors and tables |
+| Source | Airbyte | Beta | Airbyte API discovery of connections and streams |
+| Source | Iceberg | Beta | REST catalog discovery of namespaces and tables |
 | Source | Manual | Production | Schema/table lists inline in `rocky.toml` |
 | Warehouse | Databricks | Production | SQL Statement API + Unity Catalog governance |
 | Warehouse | Snowflake | Beta | SQL execution via Snowflake connector |

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -2,9 +2,9 @@
 
 A curated catalog of small POCs that showcase the distinctive capabilities of [Rocky](https://github.com/rocky-data/rocky), plus the benchmark suite comparing Rocky against dbt-core, dbt-fusion, and PySpark.
 
-This repo is a **learning / reference** companion to the official [rocky/examples/](https://github.com/rocky-data/rocky/tree/main/examples) starter projects. The starters show you the shape of a Rocky project; the POCs here show you *what Rocky can do that other tools can't*.
+This catalog is a **learning / reference** companion to the official [rocky/engine/examples/](https://github.com/rocky-data/rocky/tree/main/engine/examples) starter projects. The starters show you the shape of a Rocky project; the POCs here show you *what Rocky can do that other tools can't*.
 
-## When to look here vs `rocky/examples/`
+## When to look here vs `engine/examples/`
 
 | You want to... | Look at |
 |---|---|


### PR DESCRIPTION
## Summary

Drift sweep of the top-level user-facing READMEs + CONTRIBUTING. Audit-and-fix only — no stylistic rewrites.

## Drift found and fixed

**`README.md` (root)**
- Workspace size: `20-crate` → `21-crate` (workspace currently has 19 library crates + 2 binaries `rocky` and `rocky-lsp`).

**`engine/README.md`**
- Adapter table missing two source adapters now wired through `rocky-cli`'s registry (`registry.rs:31-38`, `error_reporter.rs:49-50`): added Airbyte (Beta) and Iceberg (Beta) rows.

**`editors/vscode/README.md`**
- VS Code minimum: `1.85.0+` → `1.116.0+`. The hard floor is the `engines.vscode` field in `package.json` (`^1.116.0`), and this is exactly the kind of triangle drift that's bitten releases before.

**`examples/playground/README.md`**
- Broken link: text and section heading both pointed at `rocky/examples/` (which is the playground itself); the actual starter projects live at `engine/examples/`. The table directly below already used the correct URLs — header text and intro sentence now match.

**`CONTRIBUTING.md`**
- Two `20-crate` references → `21-crate`, plus a clarifying note that the count is 19 library crates + 2 binaries.

## Untouched and why

- **`integrations/dagster/README.md`** — re-checked end to end against current public API (`RockyResource`, `RockyComponent`, `RockyDagsterTranslator`, `parse_rocky_output`, etc.); no drift.
- **Root README "trust system" intro** — there's an internal note that a more accurate framing would emphasize the typed-program-layer-above-the-warehouse angle. Decided not to force a rewrite during a drift sweep; current intro is correct, just open to sharpening later.
- **Playground "47 of 60 POCs run with no external credentials"** — could not confidently re-derive that count from `run.sh` env-var guards (some POCs need credentials without `${VAR:?...}` patterns), so left as-is.

## Counting basis for "21"

The previous "20" likely matched workspace `members` count at an earlier point. Workspace currently has 21 members (19 in `crates/` + `rocky` + `rocky-lsp`), so kept the same counting basis. Engine `CLAUDE.md` files still say 20 in places — those are agent-facing and out of scope for this sweep.

## Test plan

- [x] Each documented CLI verb still appears in `rocky --help`
- [x] All POC links in the playground README resolve to existing directories
- [x] VS Code engines version matches `package.json`
- [x] Adapter additions backed by primary-source grep in `engine/crates/rocky-cli/src/`