### PR TITLE
docs: drop trust-system framing from public copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Rocky monorepo
 
-Single repository for the Rocky data platform — a Rust-based control plane for warehouse data pipelines, positioned as "the trust system for your data" — and its first-party integrations.
+Single repository for the Rocky data platform — a Rust-based control plane for warehouse SQL pipelines — and its first-party integrations.
 
 ## Subprojects
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-The **trust system for your data**. A Rust-based control plane for warehouse pipelines: branches, replay, column-level lineage, compile-time safety, per-model cost attribution. Keep Databricks or Snowflake. Bring Rocky for the DAG.
+A Rust-based control plane for warehouse SQL pipelines: branches, replay, column-level lineage, compile-time type safety, per-model cost attribution. Storage and compute stay with your warehouse — Databricks, Snowflake, BigQuery, or DuckDB. Apache 2.0.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart — create a project, compile, and run 3 models in under 15s" width="900" />

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # Rocky
 
-> The trust system for your data. A Rust-based control plane for warehouse-side data pipelines: branches, replay, provable reproducibility, column-level lineage, compile-time safety, per-model cost attribution. Keep Databricks or Snowflake. Bring Rocky for the DAG.
+> A Rust-based control plane for warehouse SQL pipelines: branches, replay, provable reproducibility, column-level lineage, compile-time type safety, per-model cost attribution. Storage and compute stay with the warehouse (Databricks, Snowflake, BigQuery, DuckDB); Rocky owns the DAG.
 
 Rocky is not a warehouse. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, DuckDB); Rocky owns the graph — dependencies, compile-time types, drift, incremental logic, lineage, cost. No Jinja, no manifest, no parse step.
 

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -5,9 +5,7 @@ sidebar:
   order: 1
 ---
 
-Rocky is the **trust system for your data**. Branches, replay, provable reproducibility, complete column-level lineage, compile-time safety, per-model cost attribution — things your current stack can't offer because it doesn't own the DAG.
-
-Keep Databricks or Snowflake. Bring Rocky for the DAG.
+Rocky is a Rust-based control plane for warehouse SQL pipelines. Branches, replay, column-level lineage, compile-time type safety, and per-model cost attribution — primitives delivered through a single static binary that drives Databricks, Snowflake, BigQuery, or DuckDB. Things your current stack can't offer because it doesn't own the DAG.
 
 ## What Rocky is
 
@@ -26,7 +24,7 @@ A Rust-based control plane for warehouse-side data work. Storage and compute sta
 | Quality | ✅ | Inline assertions during `rocky run`; no separate test step |
 | Orchestration | Partial | First-class Dagster integration; `rocky serve` for small standalone teams |
 
-## The seven trust dimensions
+## What Rocky does
 
 1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
 2. **Cost attribution + budgets** — per-model cost on every run. `[budget]` block in `rocky.toml`; `budget_breach` hook event on exceed.

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -1,6 +1,6 @@
 # Rocky — Agent Instructions
 
-Rocky is a Rust-based control plane for warehouse-side data pipelines — the trust system for your data. It owns the DAG: compile-time types, branches + replay, column-level lineage, drift handling, incremental logic, and cost attribution. Storage and compute stay with the warehouse (Databricks, Snowflake, BigQuery, DuckDB).
+Rocky is a Rust-based control plane for warehouse SQL pipelines. It owns the DAG: compile-time types, branches + replay, column-level lineage, drift handling, incremental logic, and per-model cost attribution. Storage and compute stay with the warehouse (Databricks, Snowflake, BigQuery, DuckDB).
 
 ## Key Concepts
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,8 +1,6 @@
 # Rocky
 
-The **trust system for your data**. A Rust-based control plane for warehouse-side data pipelines: branches, replay, provable reproducibility, column-level lineage, compile-time safety, per-model cost attribution.
-
-Keep Databricks or Snowflake. Bring Rocky for the DAG.
+A Rust-based control plane for warehouse SQL pipelines: branches, replay, column-level lineage, compile-time type safety, per-model cost attribution. Single static binary; storage and compute stay with your warehouse.
 
 **Rocky is not a warehouse.** Storage and compute stay with your warehouse; Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost.
 
@@ -19,7 +17,7 @@ No Jinja. No manifest. No parse step.
 | Quality | ✅ | Inline assertions during `rocky run` |
 | Orchestration | Partial | First-class Dagster integration; `rocky serve` standalone |
 
-## The seven trust dimensions
+## What Rocky does
 
 1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
 2. **Cost attribution + budgets** — per-model cost on every run; `[budget]` block in `rocky.toml`; `budget_breach` hook event.

--- a/examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md
+++ b/examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md
@@ -1,4 +1,4 @@
-# 06-branches-replay-lineage — Trust arc 1: branches, replay, column lineage
+# 06-branches-replay-lineage — branches, replay, column lineage
 
 ![Create a branch, run replication on it, then trace column lineage downstream](../../../../../docs/public/demo-branches-replay.gif)
 
@@ -9,8 +9,8 @@
 
 ## What it shows
 
-The four primitives that make up Rocky's **trust system** storage arc — all
-on a single 3-model DuckDB pipeline:
+The four primitives that make up Rocky's branch / replay / lineage
+surface — all on a single 3-model DuckDB pipeline:
 
 1. **Named branches** — `rocky branch create fix-revenue` registers a
    virtual branch in the state store; runs written against the branch

--- a/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
+++ b/examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md
@@ -8,7 +8,7 @@
 ## What it shows
 
 The end-to-end `rocky preview` workflow that turns a PR into a single
-trust-system surface — *"this PR will change these N rows / these M
+review surface — *"this PR will change these N rows / these M
 columns, costs $X more or less to run, here's the diff"* — on a 5-model
 DuckDB transformation pipeline:
 


### PR DESCRIPTION
## Summary

After the HN launch, the "trust system for your data" framing took flak from multiple commenters as marketing-flavored copy. This sweep drops it from all public-facing surfaces and replaces it with a concrete-primitives lead.

New public lead (everywhere):

> A Rust-based control plane for warehouse SQL pipelines: branches, replay, column-level lineage, compile-time type safety, per-model cost attribution. Storage and compute stay with your warehouse — Databricks, Snowflake, BigQuery, or DuckDB. Apache 2.0.

## What changed

- **`README.md`** — lead replaced; HN-pitch tagline ("Keep Databricks or Snowflake. Bring Rocky for the DAG.") dropped.
- **`engine/README.md`** — same lead change; \`## The seven trust dimensions\` → \`## What Rocky does\` (the seven items preserved verbatim).
- **`docs/public/llms.txt`** — LLM context block lead.
- **`docs/src/content/docs/getting-started/introduction.md`** — public-docs intro lead + same section-header rename.
- **`engine/AGENTS.md`** — agent-context lead.
- **`CLAUDE.md`** — top-level Claude monorepo instruction.
- **2× POC READMEs** — `examples/playground/pocs/00-foundations/06-branches-replay-lineage/README.md` and `examples/playground/pocs/06-developer-experience/10-pr-preview-and-data-diff/README.md` — intro lines that referenced "trust system storage arc" / "trust-system surface".

## What did not change

- **Historical CHANGELOG entries** that name "trust-system arcs" — those describe actual release decisions made under that framing; rewriting them is dishonest to the history.
- **The seven concrete capabilities** — only the section *header* changed; the seven items underneath are unchanged.

## Test plan

- [ ] `docs/` Astro site still builds.
- [ ] `git grep "trust system for your data"` returns zero matches outside `CHANGELOG.md`.
- [ ] llms.txt continues to serve at the expected path.
- [ ] No CI breakage (markdown-only changes; no Rust, no schema, no tests).

8 files changed, +12 / −16.