### PR TITLE
fix(engine,vscode,docs): unbreak rocky import-dbt --output clash

### DIFF
--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -22,7 +22,7 @@ Rocky does not require dbt to be installed. The importer reads `.sql` files dire
 Run `rocky import-dbt` pointing at your dbt project directory:
 
 ```bash
-rocky import-dbt --dbt-project ./my-dbt-project --output ./rocky-models
+rocky import-dbt --dbt-project ./my-dbt-project --output-dir ./rocky-models
 ```
 
 This scans `my-dbt-project/models/` for `.sql` files and produces Rocky sidecar files in `./rocky-models/`:
@@ -52,10 +52,10 @@ The importer handles these dbt patterns:
 
 ### JSON output
 
-For programmatic use, add `--output json`:
+For programmatic use, request JSON via the global `-o json` flag:
 
 ```bash
-rocky import-dbt --dbt-project ./my-dbt-project --output ./rocky-models -o json
+rocky -o json import-dbt --dbt-project ./my-dbt-project --output-dir ./rocky-models
 ```
 
 ```json

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -129,7 +129,7 @@ rocky import-dbt --dbt-project ~/projects/acme-dbt
 Import to a custom output directory:
 
 ```bash
-rocky import-dbt --dbt-project ~/projects/acme-dbt --output src/models
+rocky import-dbt --dbt-project ~/projects/acme-dbt --output-dir src/models
 ```
 
 Same shape. Import and then compile to verify in one step:

--- a/editors/vscode/src/commands/migration.ts
+++ b/editors/vscode/src/commands/migration.ts
@@ -119,9 +119,8 @@ export async function importDbt(): Promise<void> {
     "import-dbt",
     "--dbt-project",
     dbtPath,
-    "--output",
+    "--output-dir",
     output,
-    "--json",
   ];
   if (modePick.value === "regex") args.push("--no-manifest");
   if (manifestPath) args.push("--manifest", manifestPath);

--- a/editors/vscode/src/commands/migration.ts
+++ b/editors/vscode/src/commands/migration.ts
@@ -121,8 +121,7 @@ export async function importDbt(): Promise<void> {
     dbtPath,
     "--output",
     output,
-    "--output",
-    "json",
+    "--json",
   ];
   if (modePick.value === "regex") args.push("--no-manifest");
   if (manifestPath) args.push("--manifest", manifestPath);

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -622,8 +622,8 @@ enum Command {
         #[arg(long)]
         dbt_project: PathBuf,
         /// Output directory for Rocky models
-        #[arg(long, default_value = "models")]
-        output: PathBuf,
+        #[arg(long = "output-dir", default_value = "models")]
+        output_dir: PathBuf,
         /// Path to manifest.json (auto-detected from target/ if omitted)
         #[arg(long)]
         manifest: Option<PathBuf>,
@@ -1783,12 +1783,12 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         ),
         Command::ImportDbt {
             dbt_project,
-            output,
+            output_dir,
             manifest,
             no_manifest,
         } => rocky_cli::commands::run_import_dbt(
             &dbt_project,
-            &output,
+            &output_dir,
             manifest.as_deref(),
             no_manifest,
             json,


### PR DESCRIPTION
## Summary
- The `importDbt` command in the VS Code extension passes `--output` twice: once for the user-selected output directory and once with value `"json"`. Since `--output` expects a directory path, the second value overwrites the first, causing the imported models to be written to a directory literally named `json` instead of the user's chosen path.
- The JSON output format should be requested via the global `--json` flag (as used by all other commands in the extension), not `--output json`.

## Test plan
- [ ] Run the "Rocky: Import dbt project" command from the VS Code command palette
- [ ] Select a dbt project, specify a custom output directory (e.g., "my-models"), and run the import
- [ ] Verify models are written to the specified directory, not to a directory named "json"