### PR TITLE
fix(vscode): use relative path as tree/test item ID to prevent duplicates

### DIFF
--- a/editors/vscode/src/testExplorer.ts
+++ b/editors/vscode/src/testExplorer.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import { runRockyJson, RockyCliError } from "./rockyCli";
 import type { TestResult } from "./types/rockyJson";
@@ -112,9 +113,16 @@ async function runHandler(
       controller2.abort(),
     );
 
+    // `item.id` is the workspace-relative path (unique for dedup); the CLI
+    // and `TestFailure.name` use the model basename, so derive that from
+    // `item.uri` for the rocky invocation and the failure-name filter.
+    const modelName = item.uri
+      ? path.basename(item.uri.fsPath, ".rocky")
+      : item.id;
+
     try {
       const result = await runRockyJson<TestResult>(
-        ["test", "--model", item.id, "--output", "json"],
+        ["test", "--model", modelName, "--output", "json"],
         { signal: controller2.signal, timeoutMs: 120000 },
       );
       const elapsed = Date.now() - start;
@@ -123,7 +131,7 @@ async function runHandler(
         run.passed(item, elapsed);
       } else {
         const lines = (result.failures ?? [])
-          .filter((f) => f.name === item.id || f.name === undefined)
+          .filter((f) => f.name === modelName || f.name === undefined)
           .map((f) => f.error);
         const message = new vscode.TestMessage(
           lines.length > 0 ? lines.join("\n") : `${failed} test(s) failed`,

--- a/editors/vscode/src/testExplorer.ts
+++ b/editors/vscode/src/testExplorer.ts
@@ -1,4 +1,3 @@
-import * as path from "path";
 import * as vscode from "vscode";
 import { runRockyJson, RockyCliError } from "./rockyCli";
 import type { TestResult } from "./types/rockyJson";
@@ -67,7 +66,7 @@ function removeModel(
 }
 
 function modelIdFor(uri: vscode.Uri): string {
-  return path.basename(uri.fsPath, ".rocky");
+  return vscode.workspace.asRelativePath(uri);
 }
 
 function makeTestItem(

--- a/editors/vscode/src/views/modelsView.ts
+++ b/editors/vscode/src/views/modelsView.ts
@@ -44,7 +44,7 @@ export class ModelTreeItem extends vscode.TreeItem {
     const label = path.basename(resourceUri.fsPath, ".rocky");
     super(label, vscode.TreeItemCollapsibleState.None);
     this.label = label;
-    this.id = label;
+    this.id = vscode.workspace.asRelativePath(resourceUri);
     this.tooltip = resourceUri.fsPath;
     this.description = vscode.workspace.asRelativePath(resourceUri);
     this.command = {


### PR DESCRIPTION
## Summary
- `ModelTreeItem` (models view) and `modelIdFor()` (test explorer) both use `path.basename(uri.fsPath, ".rocky")` as the tree/test item ID. When two `.rocky` files in different directories share the same basename (e.g., `models/staging/customer.rocky` and `models/marts/customer.rocky`), VS Code deduplicates by ID and silently drops one item.
- Changed both to use `vscode.workspace.asRelativePath(uri)` which is unique per file within a workspace.

## Test plan
- [ ] Create two `.rocky` files with the same name in different directories under `models/` (e.g., `models/staging/customer.rocky` and `models/marts/customer.rocky`)
- [ ] Verify both appear in the Models tree view
- [ ] Verify both appear in the Test Explorer panel