### PR TITLE
fix(dagster): avoid sticky dag_mode mutation on missing DAG state

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -675,8 +675,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         raw = json.loads(state_path.read_text(encoding="utf-8"))
         if "dag" not in raw:
             # Graceful fallback: re-enter the non-DAG path.
-            self.dag_mode = False
-            return self.build_defs_from_state(context, state_path)
+            return self.build_defs_from_state(context, state_path, _skip_dag=True)
 
         # Use model_validate_json to correctly handle Pydantic field aliases
         # (e.g., "from" → from_, "schema" → schema_).
@@ -842,6 +841,8 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         self,
         context: dg.ComponentLoadContext,
         state_path: Path | None,
+        *,
+        _skip_dag: bool = False,
     ) -> dg.Definitions:
         """Build materializable assets from the cached discover/compile state."""
         if state_path is None:
@@ -856,7 +857,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             return dg.Definitions()
 
         # DAG-mode: build the full connected asset graph from ``rocky dag``.
-        if self.dag_mode:
+        if self.dag_mode and not _skip_dag:
             return self._build_defs_from_dag(context, state_path)
 
         discover, compile_result, optimize_result = _load_state(state_path)

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -674,8 +674,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
 
         raw = json.loads(state_path.read_text(encoding="utf-8"))
         if "dag" not in raw:
-            # Graceful fallback: re-enter the non-DAG path.
-            return self.build_defs_from_state(context, state_path, _skip_dag=True)
+            # Graceful fallback: re-enter the non-DAG path. Call the helper
+            # directly rather than `build_defs_from_state` to avoid mutating
+            # `self.dag_mode` — that would persist across code-server reloads
+            # and poison subsequent `write_state_to_path` calls (line 564).
+            return self._build_defs_from_discover(context, state_path)
 
         # Use model_validate_json to correctly handle Pydantic field aliases
         # (e.g., "from" → from_, "schema" → schema_).
@@ -841,8 +844,6 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         self,
         context: dg.ComponentLoadContext,
         state_path: Path | None,
-        *,
-        _skip_dag: bool = False,
     ) -> dg.Definitions:
         """Build materializable assets from the cached discover/compile state."""
         if state_path is None:
@@ -857,9 +858,22 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             return dg.Definitions()
 
         # DAG-mode: build the full connected asset graph from ``rocky dag``.
-        if self.dag_mode and not _skip_dag:
+        if self.dag_mode:
             return self._build_defs_from_dag(context, state_path)
 
+        return self._build_defs_from_discover(context, state_path)
+
+    def _build_defs_from_discover(
+        self,
+        context: dg.ComponentLoadContext,
+        state_path: Path,
+    ) -> dg.Definitions:
+        """Build assets from the legacy discover/compile/optimize state shape.
+
+        Reached either when ``dag_mode`` is off, or via the
+        :meth:`_build_defs_from_dag` fallback when the cached state predates
+        DAG mode (no ``"dag"`` key).
+        """
         discover, compile_result, optimize_result = _load_state(state_path)
         if self.strict_build and not discover.sources:
             raise dg.Failure(

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -60,6 +60,26 @@ def test_build_defs_from_none_state():
     assert list(defs.assets or []) == []
 
 
+def test_dag_mode_fallback_does_not_mutate_config(discover_json: str, tmp_path: Path):
+    """When ``dag_mode=True`` but the cached state predates DAG mode (no ``dag``
+    key), ``build_defs_from_state`` must fall back without mutating
+    ``self.dag_mode`` — the mutation persists across code-server reloads and
+    poisons subsequent ``write_state_to_path`` calls (the dag payload skip at
+    component.py:564), permanently degrading the cache.
+    """
+    state = {"discover": json.loads(discover_json)}  # deliberately no "dag" key
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(state))
+
+    component = RockyComponent(config_path="rocky.toml", dag_mode=True)
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    # Fallback returned a populated definitions tree (matches the legacy path).
+    assert len(list(defs.assets or [])) > 0
+    # Crucially: the config attribute is unchanged after the fallback.
+    assert component.dag_mode is True
+
+
 def test_defs_state_config_key():
     """Test that the state key includes the config path."""
     component = RockyComponent(config_path="config/rocky.toml")


### PR DESCRIPTION
## Summary
- `_build_defs_from_dag` mutates `self.dag_mode = False` when the `"dag"` key is missing from cached state, then calls `build_defs_from_state` which checks `self.dag_mode` to decide the code path. This mutation is sticky — it permanently downgrades the component instance to non-DAG mode, persisting across code-server reloads even after valid DAG state becomes available.
- Replaced the mutation with a `_skip_dag=True` keyword argument on the fallback call. This avoids the DAG path for the fallback invocation only, without altering the component's config state.

## Test plan
- [ ] Run `uv run pytest -v` in `integrations/dagster/` — all existing tests should pass
- [ ] Test with a component where `dag_mode=True` but state is missing the `"dag"` key — verify it falls back gracefully
- [ ] Test that a subsequent state write with valid DAG data restores DAG-mode behavior (no longer stuck in non-DAG mode)