### PR TITLE
feat(engine): run adapter conformance dialect check

### DIFF
--- a/docs/src/content/docs/guides/adapter-sdk.md
+++ b/docs/src/content/docs/guides/adapter-sdk.md
@@ -185,7 +185,7 @@ For adapters that talk to a REST API, the in-tree pattern is `wiremock`-based â€
 
 ### The conformance harness
 
-`rocky-adapter-sdk::conformance::run_conformance(&manifest)` returns a `ConformanceResult` describing which tests apply (based on declared capabilities) and which were skipped. Today this is a test plan, not a live runner â€” it prints the matrix but does not yet execute trait calls against your adapter. Treat it as a checklist of behaviors your unit tests should cover. Live execution will land in a future SDK release.
+`rocky-adapter-sdk::conformance::run_conformance(&manifest, adapter.dialect())` returns a `ConformanceResult` describing which tests apply (based on declared capabilities) and which were skipped. The harness now exercises one real dialect call, `SqlDialect::format_table_ref`, as the first incremental step toward live execution. The remaining checks are still plan entries rather than warehouse calls, so treat the result as a checklist of behaviors your unit tests should cover while broader trait execution lands in future SDK releases.
 
 ## Distributing your adapter
 

--- a/docs/src/content/docs/guides/adapter-sdk.md
+++ b/docs/src/content/docs/guides/adapter-sdk.md
@@ -185,7 +185,7 @@ For adapters that talk to a REST API, the in-tree pattern is `wiremock`-based �
 
 ### The conformance harness
 
-`rocky-adapter-sdk::conformance::run_conformance(&manifest, adapter.dialect())` returns a `ConformanceResult` describing which tests apply (based on declared capabilities) and which were skipped. The harness now exercises one real dialect call, `SqlDialect::format_table_ref`, as the first incremental step toward live execution. The remaining checks are still plan entries rather than warehouse calls, so treat the result as a checklist of behaviors your unit tests should cover while broader trait execution lands in future SDK releases.
+`rocky-adapter-sdk::conformance::run_conformance(&manifest, Some(adapter.dialect()))` returns a `ConformanceResult` describing which tests apply (based on declared capabilities) and which were skipped. When a live dialect is supplied, the harness exercises one real trait call, `SqlDialect::format_table_ref`, as the first incremental step toward live execution. Pass `None` when no live adapter is available — for example, `rocky test-adapter --builtin <name>`, which validates the test plan without a warehouse — and dialect-category checks are reported as skipped rather than run against a stub. The remaining checks are still plan entries rather than warehouse calls, so treat the result as a checklist of behaviors your unit tests should cover while broader trait execution lands in future SDK releases.
 
 ## Distributing your adapter
 

--- a/engine/crates/rocky-adapter-sdk/src/conformance.rs
+++ b/engine/crates/rocky-adapter-sdk/src/conformance.rs
@@ -7,7 +7,7 @@
 //! # Usage
 //!
 //! ```ignore
-//! let result = run_conformance(&adapter, &manifest, adapter.dialect()).await;
+//! let result = run_conformance(&manifest, adapter.dialect());
 //! assert_eq!(result.tests_failed, 0);
 //! ```
 
@@ -16,6 +16,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::AdapterManifest;
+use crate::traits::{SqlDialect, TableRef};
 
 /// Result of running the conformance test suite against an adapter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -303,14 +304,13 @@ fn test_specs() -> Vec<TestSpec> {
 /// This builds the test plan based on the adapter's manifest, runs each test,
 /// and collects results. Tests for unsupported capabilities are skipped.
 ///
-/// Currently this returns a plan with all tests marked as skipped or with
-/// placeholder timing. Actual test execution will be wired up when adapters
-/// implement the traits against live warehouses.
-pub fn run_conformance(manifest: &AdapterManifest) -> ConformanceResult {
+/// Most tests still return placeholder passes for supported capabilities. The
+/// dialect checks execute against the supplied dialect as they are wired in.
+pub fn run_conformance(manifest: &AdapterManifest, dialect: &dyn SqlDialect) -> ConformanceResult {
     let specs = test_specs();
     let mut results = Vec::with_capacity(specs.len());
     let mut passed = 0usize;
-    let failed = 0usize;
+    let mut failed = 0usize;
     let mut skipped = 0usize;
 
     for spec in &specs {
@@ -334,18 +334,30 @@ pub fn run_conformance(manifest: &AdapterManifest) -> ConformanceResult {
             continue;
         }
 
-        // Placeholder: in a real run, each test would execute against the adapter.
-        // For now, mark all supported tests as passed with zero duration,
-        // indicating the test plan is valid but no live execution occurred.
+        let test_result = run_test_spec(spec, dialect);
         let elapsed = start.elapsed();
-        passed += 1;
-        results.push(TestResult {
-            name: spec.name.to_string(),
-            category: spec.category.clone(),
-            status: TestStatus::Passed,
-            message: None,
-            duration_ms: elapsed.as_millis() as u64,
-        });
+        match test_result {
+            Ok(()) => {
+                passed += 1;
+                results.push(TestResult {
+                    name: spec.name.to_string(),
+                    category: spec.category.clone(),
+                    status: TestStatus::Passed,
+                    message: None,
+                    duration_ms: elapsed.as_millis() as u64,
+                });
+            }
+            Err(message) => {
+                failed += 1;
+                results.push(TestResult {
+                    name: spec.name.to_string(),
+                    category: spec.category.clone(),
+                    status: TestStatus::Failed,
+                    message: Some(message),
+                    duration_ms: elapsed.as_millis() as u64,
+                });
+            }
+        }
     }
 
     ConformanceResult {
@@ -359,10 +371,128 @@ pub fn run_conformance(manifest: &AdapterManifest) -> ConformanceResult {
     }
 }
 
+fn run_test_spec(spec: &TestSpec, dialect: &dyn SqlDialect) -> Result<(), String> {
+    match spec.name {
+        "format_table_ref" => {
+            let table = TableRef {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+            };
+            let formatted = dialect
+                .format_table_ref(&table.catalog, &table.schema, &table.table)
+                .map_err(|e| e.to_string())?;
+            if formatted.trim().is_empty() {
+                return Err("format_table_ref returned an empty table reference".into());
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::manifest::{AdapterCapabilities, AdapterManifest};
+    use crate::traits::{AdapterResult, ColumnSelection, MetadataColumn};
+
+    struct TestDialect;
+
+    impl SqlDialect for TestDialect {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn format_table_ref(
+            &self,
+            catalog: &str,
+            schema: &str,
+            table: &str,
+        ) -> AdapterResult<String> {
+            Ok(format!("{catalog}.{schema}.{table}"))
+        }
+
+        fn create_table_as(&self, target: &str, select_sql: &str) -> String {
+            format!("CREATE TABLE {target} AS {select_sql}")
+        }
+
+        fn insert_into(&self, target: &str, select_sql: &str) -> String {
+            format!("INSERT INTO {target} {select_sql}")
+        }
+
+        fn merge_into(
+            &self,
+            target: &str,
+            source_sql: &str,
+            _keys: &[String],
+            _update_cols: Option<&[String]>,
+        ) -> AdapterResult<String> {
+            Ok(format!("MERGE INTO {target} USING {source_sql}"))
+        }
+
+        fn describe_table_sql(&self, table_ref: &str) -> String {
+            format!("DESCRIBE {table_ref}")
+        }
+
+        fn drop_table_sql(&self, table_ref: &str) -> String {
+            format!("DROP TABLE {table_ref}")
+        }
+
+        fn create_catalog_sql(&self, name: &str) -> Option<AdapterResult<String>> {
+            Some(Ok(format!("CREATE CATALOG {name}")))
+        }
+
+        fn create_schema_sql(&self, catalog: &str, schema: &str) -> Option<AdapterResult<String>> {
+            Some(Ok(format!("CREATE SCHEMA {catalog}.{schema}")))
+        }
+
+        fn row_hash_expr(&self, columns: &[String]) -> String {
+            format!("hash({})", columns.join(", "))
+        }
+
+        fn tablesample_clause(&self, percent: u32) -> Option<String> {
+            Some(format!("TABLESAMPLE ({percent})"))
+        }
+
+        fn select_clause(
+            &self,
+            columns: &ColumnSelection,
+            metadata: &[MetadataColumn],
+        ) -> AdapterResult<String> {
+            let mut sql = match columns {
+                ColumnSelection::All => "SELECT *".to_string(),
+                ColumnSelection::Explicit(cols) => format!("SELECT {}", cols.join(", ")),
+            };
+            for column in metadata {
+                sql.push_str(&format!(", {} AS {}", column.value, column.name));
+            }
+            Ok(sql)
+        }
+
+        fn watermark_where(&self, timestamp_col: &str, target_ref: &str) -> AdapterResult<String> {
+            Ok(format!(
+                "WHERE {timestamp_col} > (SELECT max({timestamp_col}) FROM {target_ref})"
+            ))
+        }
+
+        fn insert_overwrite_partition(
+            &self,
+            target: &str,
+            partition_filter: &str,
+            select_sql: &str,
+        ) -> AdapterResult<Vec<String>> {
+            Ok(vec![format!(
+                "INSERT OVERWRITE {target} WHERE {partition_filter} {select_sql}"
+            )])
+        }
+    }
+
+    static TEST_DIALECT: TestDialect = TestDialect;
+
+    fn run_test_conformance(manifest: &AdapterManifest) -> ConformanceResult {
+        run_conformance(manifest, &TEST_DIALECT)
+    }
 
     fn test_manifest(caps: AdapterCapabilities) -> AdapterManifest {
         AdapterManifest {
@@ -379,7 +509,7 @@ mod tests {
     #[test]
     fn test_conformance_full_capabilities() {
         let manifest = test_manifest(AdapterCapabilities::full());
-        let result = run_conformance(&manifest);
+        let result = run_test_conformance(&manifest);
 
         assert_eq!(result.adapter, "test-adapter");
         assert_eq!(result.tests_skipped, 0);
@@ -389,9 +519,118 @@ mod tests {
     }
 
     #[test]
+    fn test_conformance_executes_format_table_ref() {
+        struct EmptyDialect;
+
+        impl SqlDialect for EmptyDialect {
+            fn name(&self) -> &str {
+                "empty"
+            }
+
+            fn format_table_ref(
+                &self,
+                _catalog: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> AdapterResult<String> {
+                Ok(String::new())
+            }
+
+            fn create_table_as(&self, target: &str, select_sql: &str) -> String {
+                format!("CREATE TABLE {target} AS {select_sql}")
+            }
+
+            fn insert_into(&self, target: &str, select_sql: &str) -> String {
+                format!("INSERT INTO {target} {select_sql}")
+            }
+
+            fn merge_into(
+                &self,
+                target: &str,
+                source_sql: &str,
+                _keys: &[String],
+                _update_cols: Option<&[String]>,
+            ) -> AdapterResult<String> {
+                Ok(format!("MERGE INTO {target} USING {source_sql}"))
+            }
+
+            fn describe_table_sql(&self, table_ref: &str) -> String {
+                format!("DESCRIBE {table_ref}")
+            }
+
+            fn drop_table_sql(&self, table_ref: &str) -> String {
+                format!("DROP TABLE {table_ref}")
+            }
+
+            fn create_catalog_sql(&self, name: &str) -> Option<AdapterResult<String>> {
+                Some(Ok(format!("CREATE CATALOG {name}")))
+            }
+
+            fn create_schema_sql(
+                &self,
+                catalog: &str,
+                schema: &str,
+            ) -> Option<AdapterResult<String>> {
+                Some(Ok(format!("CREATE SCHEMA {catalog}.{schema}")))
+            }
+
+            fn row_hash_expr(&self, columns: &[String]) -> String {
+                format!("hash({})", columns.join(", "))
+            }
+
+            fn tablesample_clause(&self, percent: u32) -> Option<String> {
+                Some(format!("TABLESAMPLE ({percent})"))
+            }
+
+            fn select_clause(
+                &self,
+                columns: &ColumnSelection,
+                _metadata: &[MetadataColumn],
+            ) -> AdapterResult<String> {
+                Ok(match columns {
+                    ColumnSelection::All => "SELECT *".to_string(),
+                    ColumnSelection::Explicit(cols) => format!("SELECT {}", cols.join(", ")),
+                })
+            }
+
+            fn watermark_where(
+                &self,
+                timestamp_col: &str,
+                target_ref: &str,
+            ) -> AdapterResult<String> {
+                Ok(format!(
+                    "WHERE {timestamp_col} > (SELECT max({timestamp_col}) FROM {target_ref})"
+                ))
+            }
+
+            fn insert_overwrite_partition(
+                &self,
+                target: &str,
+                partition_filter: &str,
+                select_sql: &str,
+            ) -> AdapterResult<Vec<String>> {
+                Ok(vec![format!(
+                    "INSERT OVERWRITE {target} WHERE {partition_filter} {select_sql}"
+                )])
+            }
+        }
+
+        let manifest = test_manifest(AdapterCapabilities::warehouse_only());
+        let result = run_conformance(&manifest, &EmptyDialect);
+        let format_result = result
+            .results
+            .iter()
+            .find(|r| r.name == "format_table_ref")
+            .expect("format_table_ref result");
+
+        assert_eq!(format_result.status, TestStatus::Failed);
+        assert_eq!(result.tests_failed, 1);
+    }
+
+    #[test]
     fn test_conformance_warehouse_only() {
         let manifest = test_manifest(AdapterCapabilities::warehouse_only());
-        let result = run_conformance(&manifest);
+        let result = run_test_conformance(&manifest);
 
         // Optional tests should be skipped
         assert!(result.tests_skipped > 0);
@@ -418,7 +657,7 @@ mod tests {
     #[test]
     fn test_conformance_result_serialization() {
         let manifest = test_manifest(AdapterCapabilities::warehouse_only());
-        let result = run_conformance(&manifest);
+        let result = run_test_conformance(&manifest);
 
         let json = serde_json::to_string(&result).unwrap();
         let deserialized: ConformanceResult = serde_json::from_str(&json).unwrap();
@@ -429,7 +668,7 @@ mod tests {
     #[test]
     fn test_conformance_report_formatting() {
         let manifest = test_manifest(AdapterCapabilities::warehouse_only());
-        let result = run_conformance(&manifest);
+        let result = run_test_conformance(&manifest);
         let report = result.report();
 
         assert!(report.contains("Adapter Conformance: test-adapter"));

--- a/engine/crates/rocky-adapter-sdk/src/conformance.rs
+++ b/engine/crates/rocky-adapter-sdk/src/conformance.rs
@@ -7,16 +7,20 @@
 //! # Usage
 //!
 //! ```ignore
-//! let result = run_conformance(&manifest, adapter.dialect());
+//! let result = run_conformance(&manifest, Some(adapter.dialect()));
 //! assert_eq!(result.tests_failed, 0);
 //! ```
+//!
+//! Pass `None` for the dialect when no live adapter is available (for example,
+//! `rocky test-adapter --builtin`). Dialect-category tests are reported as
+//! skipped in that mode rather than executed against a stub.
 
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::AdapterManifest;
-use crate::traits::{SqlDialect, TableRef};
+use crate::traits::SqlDialect;
 
 /// Result of running the conformance test suite against an adapter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -153,6 +157,16 @@ struct TestSpec {
     /// If set, the test is skipped when this capability is false.
     requires_capability: Option<fn(&AdapterManifest) -> bool>,
 }
+
+/// Outcome of a single spec dispatch. Mapped to `TestStatus` by the runner.
+enum TestOutcome {
+    Pass,
+    Fail(String),
+    Skip(String),
+}
+
+/// Message used when a dialect-category spec is asked to run without a dialect.
+const NO_DIALECT_SKIP_MESSAGE: &str = "dialect not available in this run mode";
 
 /// Build the full list of conformance test specifications.
 fn test_specs() -> Vec<TestSpec> {
@@ -301,12 +315,21 @@ fn test_specs() -> Vec<TestSpec> {
 
 /// Run the conformance test suite against an adapter.
 ///
-/// This builds the test plan based on the adapter's manifest, runs each test,
-/// and collects results. Tests for unsupported capabilities are skipped.
+/// Builds the test plan from the adapter's manifest, executes each spec, and
+/// collects results. Specs whose required capability is missing are reported
+/// as `Skipped`.
 ///
-/// Most tests still return placeholder passes for supported capabilities. The
-/// dialect checks execute against the supplied dialect as they are wired in.
-pub fn run_conformance(manifest: &AdapterManifest, dialect: &dyn SqlDialect) -> ConformanceResult {
+/// When `dialect` is `Some`, the harness executes one real trait call
+/// (`SqlDialect::format_table_ref`) as the first incremental live check.
+/// When `dialect` is `None` — for example in `rocky test-adapter --builtin`,
+/// which validates the test plan without a live warehouse — that spec is
+/// reported as `Skipped` rather than executed against a stub. Remaining
+/// specs return placeholder passes; broader live execution lands in future
+/// SDK releases.
+pub fn run_conformance(
+    manifest: &AdapterManifest,
+    dialect: Option<&dyn SqlDialect>,
+) -> ConformanceResult {
     let specs = test_specs();
     let mut results = Vec::with_capacity(specs.len());
     let mut passed = 0usize;
@@ -334,30 +357,29 @@ pub fn run_conformance(manifest: &AdapterManifest, dialect: &dyn SqlDialect) -> 
             continue;
         }
 
-        let test_result = run_test_spec(spec, dialect);
+        let outcome = run_test_spec(spec, dialect);
         let elapsed = start.elapsed();
-        match test_result {
-            Ok(()) => {
+        let (status, message) = match outcome {
+            TestOutcome::Pass => {
                 passed += 1;
-                results.push(TestResult {
-                    name: spec.name.to_string(),
-                    category: spec.category.clone(),
-                    status: TestStatus::Passed,
-                    message: None,
-                    duration_ms: elapsed.as_millis() as u64,
-                });
+                (TestStatus::Passed, None)
             }
-            Err(message) => {
+            TestOutcome::Fail(msg) => {
                 failed += 1;
-                results.push(TestResult {
-                    name: spec.name.to_string(),
-                    category: spec.category.clone(),
-                    status: TestStatus::Failed,
-                    message: Some(message),
-                    duration_ms: elapsed.as_millis() as u64,
-                });
+                (TestStatus::Failed, Some(msg))
             }
-        }
+            TestOutcome::Skip(msg) => {
+                skipped += 1;
+                (TestStatus::Skipped, Some(msg))
+            }
+        };
+        results.push(TestResult {
+            name: spec.name.to_string(),
+            category: spec.category.clone(),
+            status,
+            message,
+            duration_ms: elapsed.as_millis() as u64,
+        });
     }
 
     ConformanceResult {
@@ -371,23 +393,21 @@ pub fn run_conformance(manifest: &AdapterManifest, dialect: &dyn SqlDialect) -> 
     }
 }
 
-fn run_test_spec(spec: &TestSpec, dialect: &dyn SqlDialect) -> Result<(), String> {
+fn run_test_spec(spec: &TestSpec, dialect: Option<&dyn SqlDialect>) -> TestOutcome {
     match spec.name {
         "format_table_ref" => {
-            let table = TableRef {
-                catalog: "c".into(),
-                schema: "s".into(),
-                table: "t".into(),
+            let Some(dialect) = dialect else {
+                return TestOutcome::Skip(NO_DIALECT_SKIP_MESSAGE.into());
             };
-            let formatted = dialect
-                .format_table_ref(&table.catalog, &table.schema, &table.table)
-                .map_err(|e| e.to_string())?;
-            if formatted.trim().is_empty() {
-                return Err("format_table_ref returned an empty table reference".into());
+            match dialect.format_table_ref("c", "s", "t") {
+                Ok(formatted) if formatted.trim().is_empty() => {
+                    TestOutcome::Fail("format_table_ref returned an empty table reference".into())
+                }
+                Ok(_) => TestOutcome::Pass,
+                Err(e) => TestOutcome::Fail(e.to_string()),
             }
-            Ok(())
         }
-        _ => Ok(()),
+        _ => TestOutcome::Pass,
     }
 }
 
@@ -395,9 +415,30 @@ fn run_test_spec(spec: &TestSpec, dialect: &dyn SqlDialect) -> Result<(), String
 mod tests {
     use super::*;
     use crate::manifest::{AdapterCapabilities, AdapterManifest};
-    use crate::traits::{AdapterResult, ColumnSelection, MetadataColumn};
+    use crate::traits::{AdapterError, AdapterResult, ColumnSelection, MetadataColumn};
 
-    struct TestDialect;
+    /// In-crate `SqlDialect` stub. `format_table_ref` is delegated through a
+    /// function pointer so individual tests can swap in empty-string or `Err`
+    /// behavior without duplicating the rest of the trait surface.
+    struct TestDialect {
+        format_table_ref_impl: fn(&str, &str, &str) -> AdapterResult<String>,
+    }
+
+    impl Default for TestDialect {
+        fn default() -> Self {
+            Self {
+                format_table_ref_impl: |c, s, t| Ok(format!("{c}.{s}.{t}")),
+            }
+        }
+    }
+
+    impl TestDialect {
+        fn with_format_table_ref(f: fn(&str, &str, &str) -> AdapterResult<String>) -> Self {
+            Self {
+                format_table_ref_impl: f,
+            }
+        }
+    }
 
     impl SqlDialect for TestDialect {
         fn name(&self) -> &str {
@@ -410,7 +451,7 @@ mod tests {
             schema: &str,
             table: &str,
         ) -> AdapterResult<String> {
-            Ok(format!("{catalog}.{schema}.{table}"))
+            (self.format_table_ref_impl)(catalog, schema, table)
         }
 
         fn create_table_as(&self, target: &str, select_sql: &str) -> String {
@@ -488,10 +529,8 @@ mod tests {
         }
     }
 
-    static TEST_DIALECT: TestDialect = TestDialect;
-
     fn run_test_conformance(manifest: &AdapterManifest) -> ConformanceResult {
-        run_conformance(manifest, &TEST_DIALECT)
+        run_conformance(manifest, Some(&TestDialect::default()))
     }
 
     fn test_manifest(caps: AdapterCapabilities) -> AdapterManifest {
@@ -504,6 +543,14 @@ mod tests {
             auth_methods: vec![],
             config_schema: serde_json::Value::Object(Default::default()),
         }
+    }
+
+    fn find_result<'a>(result: &'a ConformanceResult, name: &str) -> &'a TestResult {
+        result
+            .results
+            .iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("missing {name} result"))
     }
 
     #[test]
@@ -519,112 +566,53 @@ mod tests {
     }
 
     #[test]
-    fn test_conformance_executes_format_table_ref() {
-        struct EmptyDialect;
-
-        impl SqlDialect for EmptyDialect {
-            fn name(&self) -> &str {
-                "empty"
-            }
-
-            fn format_table_ref(
-                &self,
-                _catalog: &str,
-                _schema: &str,
-                _table: &str,
-            ) -> AdapterResult<String> {
-                Ok(String::new())
-            }
-
-            fn create_table_as(&self, target: &str, select_sql: &str) -> String {
-                format!("CREATE TABLE {target} AS {select_sql}")
-            }
-
-            fn insert_into(&self, target: &str, select_sql: &str) -> String {
-                format!("INSERT INTO {target} {select_sql}")
-            }
-
-            fn merge_into(
-                &self,
-                target: &str,
-                source_sql: &str,
-                _keys: &[String],
-                _update_cols: Option<&[String]>,
-            ) -> AdapterResult<String> {
-                Ok(format!("MERGE INTO {target} USING {source_sql}"))
-            }
-
-            fn describe_table_sql(&self, table_ref: &str) -> String {
-                format!("DESCRIBE {table_ref}")
-            }
-
-            fn drop_table_sql(&self, table_ref: &str) -> String {
-                format!("DROP TABLE {table_ref}")
-            }
-
-            fn create_catalog_sql(&self, name: &str) -> Option<AdapterResult<String>> {
-                Some(Ok(format!("CREATE CATALOG {name}")))
-            }
-
-            fn create_schema_sql(
-                &self,
-                catalog: &str,
-                schema: &str,
-            ) -> Option<AdapterResult<String>> {
-                Some(Ok(format!("CREATE SCHEMA {catalog}.{schema}")))
-            }
-
-            fn row_hash_expr(&self, columns: &[String]) -> String {
-                format!("hash({})", columns.join(", "))
-            }
-
-            fn tablesample_clause(&self, percent: u32) -> Option<String> {
-                Some(format!("TABLESAMPLE ({percent})"))
-            }
-
-            fn select_clause(
-                &self,
-                columns: &ColumnSelection,
-                _metadata: &[MetadataColumn],
-            ) -> AdapterResult<String> {
-                Ok(match columns {
-                    ColumnSelection::All => "SELECT *".to_string(),
-                    ColumnSelection::Explicit(cols) => format!("SELECT {}", cols.join(", ")),
-                })
-            }
-
-            fn watermark_where(
-                &self,
-                timestamp_col: &str,
-                target_ref: &str,
-            ) -> AdapterResult<String> {
-                Ok(format!(
-                    "WHERE {timestamp_col} > (SELECT max({timestamp_col}) FROM {target_ref})"
-                ))
-            }
-
-            fn insert_overwrite_partition(
-                &self,
-                target: &str,
-                partition_filter: &str,
-                select_sql: &str,
-            ) -> AdapterResult<Vec<String>> {
-                Ok(vec![format!(
-                    "INSERT OVERWRITE {target} WHERE {partition_filter} {select_sql}"
-                )])
-            }
-        }
-
+    fn test_conformance_executes_format_table_ref_pass() {
         let manifest = test_manifest(AdapterCapabilities::warehouse_only());
-        let result = run_conformance(&manifest, &EmptyDialect);
-        let format_result = result
-            .results
-            .iter()
-            .find(|r| r.name == "format_table_ref")
-            .expect("format_table_ref result");
+        let result = run_conformance(&manifest, Some(&TestDialect::default()));
 
+        let format_result = find_result(&result, "format_table_ref");
+        assert_eq!(format_result.status, TestStatus::Passed);
+    }
+
+    #[test]
+    fn test_conformance_fails_format_table_ref_when_empty() {
+        let dialect = TestDialect::with_format_table_ref(|_, _, _| Ok(String::new()));
+        let manifest = test_manifest(AdapterCapabilities::warehouse_only());
+        let result = run_conformance(&manifest, Some(&dialect));
+
+        let format_result = find_result(&result, "format_table_ref");
         assert_eq!(format_result.status, TestStatus::Failed);
         assert_eq!(result.tests_failed, 1);
+    }
+
+    #[test]
+    fn test_conformance_fails_format_table_ref_on_err() {
+        let dialect =
+            TestDialect::with_format_table_ref(|_, _, _| Err(AdapterError::msg("dialect blew up")));
+        let manifest = test_manifest(AdapterCapabilities::warehouse_only());
+        let result = run_conformance(&manifest, Some(&dialect));
+
+        let format_result = find_result(&result, "format_table_ref");
+        assert_eq!(format_result.status, TestStatus::Failed);
+        assert_eq!(
+            format_result.message.as_deref(),
+            Some("dialect blew up"),
+            "expected the adapter error message to propagate into the test result"
+        );
+    }
+
+    #[test]
+    fn test_conformance_skips_format_table_ref_when_no_dialect() {
+        let manifest = test_manifest(AdapterCapabilities::warehouse_only());
+        let result = run_conformance(&manifest, None);
+
+        let format_result = find_result(&result, "format_table_ref");
+        assert_eq!(format_result.status, TestStatus::Skipped);
+        assert_eq!(
+            format_result.message.as_deref(),
+            Some(NO_DIALECT_SKIP_MESSAGE)
+        );
+        assert_eq!(result.tests_failed, 0);
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/test_adapter.rs
+++ b/engine/crates/rocky-cli/src/commands/test_adapter.rs
@@ -5,10 +5,12 @@
 //! and process-based adapters.
 
 use anyhow::{Context, Result};
-use rocky_adapter_sdk::WarehouseAdapter;
 use rocky_adapter_sdk::conformance::{self, ConformanceResult};
 use rocky_adapter_sdk::manifest::{AdapterCapabilities, AdapterManifest};
 use rocky_adapter_sdk::process::ProcessAdapter;
+use rocky_adapter_sdk::{
+    AdapterResult, ColumnSelection, MetadataColumn, SqlDialect, WarehouseAdapter,
+};
 
 use crate::output::{TestAdapterOutput, TestAdapterTestResult};
 
@@ -34,7 +36,7 @@ pub async fn run_test_adapter(
             let manifest = adapter.manifest().clone();
 
             // Run conformance suite.
-            let result = conformance::run_conformance(&manifest);
+            let result = conformance::run_conformance(&manifest, adapter.dialect());
 
             // Clean up.
             let _ = adapter.close().await;
@@ -56,7 +58,8 @@ pub async fn run_test_adapter(
                 config_schema: serde_json::Value::Null,
             };
 
-            let mut result = conformance::run_conformance(&manifest);
+            let dialect = FallbackDialect::new("unknown");
+            let mut result = conformance::run_conformance(&manifest, &dialect);
             // Override the first test (connect) as failed.
             if let Some(connect_test) = result.results.first_mut() {
                 connect_test.status = conformance::TestStatus::Failed;
@@ -131,10 +134,114 @@ pub async fn run_test_adapter_builtin(
         config_schema: serde_json::Value::Null,
     };
 
-    let result = conformance::run_conformance(&manifest);
+    let dialect = FallbackDialect::new(adapter_name);
+    let result = conformance::run_conformance(&manifest, &dialect);
     output_result(&result, json_output)?;
 
     Ok(())
+}
+
+struct FallbackDialect {
+    name: String,
+}
+
+impl FallbackDialect {
+    fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl SqlDialect for FallbackDialect {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn format_table_ref(&self, catalog: &str, schema: &str, table: &str) -> AdapterResult<String> {
+        Ok(format!("{catalog}.{schema}.{table}"))
+    }
+
+    fn create_table_as(&self, target: &str, select_sql: &str) -> String {
+        format!("CREATE OR REPLACE TABLE {target} AS\n{select_sql}")
+    }
+
+    fn insert_into(&self, target: &str, select_sql: &str) -> String {
+        format!("INSERT INTO {target}\n{select_sql}")
+    }
+
+    fn merge_into(
+        &self,
+        target: &str,
+        source_sql: &str,
+        keys: &[String],
+        _update_cols: Option<&[String]>,
+    ) -> AdapterResult<String> {
+        Ok(format!(
+            "MERGE INTO {target} USING ({source_sql}) ON {}",
+            keys.join(", ")
+        ))
+    }
+
+    fn describe_table_sql(&self, table_ref: &str) -> String {
+        format!("DESCRIBE {table_ref}")
+    }
+
+    fn drop_table_sql(&self, table_ref: &str) -> String {
+        format!("DROP TABLE IF EXISTS {table_ref}")
+    }
+
+    fn create_catalog_sql(&self, name: &str) -> Option<AdapterResult<String>> {
+        Some(Ok(format!("CREATE CATALOG IF NOT EXISTS {name}")))
+    }
+
+    fn create_schema_sql(&self, catalog: &str, schema: &str) -> Option<AdapterResult<String>> {
+        Some(Ok(format!(
+            "CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"
+        )))
+    }
+
+    fn row_hash_expr(&self, columns: &[String]) -> String {
+        format!("MD5(CONCAT({}))", columns.join(", "))
+    }
+
+    fn tablesample_clause(&self, percent: u32) -> Option<String> {
+        Some(format!("TABLESAMPLE ({percent} PERCENT)"))
+    }
+
+    fn select_clause(
+        &self,
+        columns: &ColumnSelection,
+        metadata: &[MetadataColumn],
+    ) -> AdapterResult<String> {
+        let mut sql = match columns {
+            ColumnSelection::All => "SELECT *".to_string(),
+            ColumnSelection::Explicit(cols) => format!("SELECT {}", cols.join(", ")),
+        };
+        for column in metadata {
+            sql.push_str(&format!(
+                ", CAST({} AS {}) AS {}",
+                column.value, column.data_type, column.name
+            ));
+        }
+        Ok(sql)
+    }
+
+    fn watermark_where(&self, timestamp_col: &str, target_ref: &str) -> AdapterResult<String> {
+        Ok(format!(
+            "WHERE {timestamp_col} > (SELECT COALESCE(MAX({timestamp_col}), TIMESTAMP '1970-01-01') FROM {target_ref})"
+        ))
+    }
+
+    fn insert_overwrite_partition(
+        &self,
+        target: &str,
+        partition_filter: &str,
+        select_sql: &str,
+    ) -> AdapterResult<Vec<String>> {
+        Ok(vec![
+            format!("DELETE FROM {target} WHERE {partition_filter}"),
+            format!("INSERT INTO {target}\n{select_sql}"),
+        ])
+    }
 }
 
 fn output_result(result: &ConformanceResult, json_output: bool) -> Result<()> {

--- a/engine/crates/rocky-cli/src/commands/test_adapter.rs
+++ b/engine/crates/rocky-cli/src/commands/test_adapter.rs
@@ -5,12 +5,10 @@
 //! and process-based adapters.
 
 use anyhow::{Context, Result};
+use rocky_adapter_sdk::WarehouseAdapter;
 use rocky_adapter_sdk::conformance::{self, ConformanceResult};
 use rocky_adapter_sdk::manifest::{AdapterCapabilities, AdapterManifest};
 use rocky_adapter_sdk::process::ProcessAdapter;
-use rocky_adapter_sdk::{
-    AdapterResult, ColumnSelection, MetadataColumn, SqlDialect, WarehouseAdapter,
-};
 
 use crate::output::{TestAdapterOutput, TestAdapterTestResult};
 
@@ -36,7 +34,7 @@ pub async fn run_test_adapter(
             let manifest = adapter.manifest().clone();
 
             // Run conformance suite.
-            let result = conformance::run_conformance(&manifest, adapter.dialect());
+            let result = conformance::run_conformance(&manifest, Some(adapter.dialect()));
 
             // Clean up.
             let _ = adapter.close().await;
@@ -58,8 +56,9 @@ pub async fn run_test_adapter(
                 config_schema: serde_json::Value::Null,
             };
 
-            let dialect = FallbackDialect::new("unknown");
-            let mut result = conformance::run_conformance(&manifest, &dialect);
+            // No live dialect available — let the harness skip dialect-category
+            // checks and override `connect` as failed below.
+            let mut result = conformance::run_conformance(&manifest, None);
             // Override the first test (connect) as failed.
             if let Some(connect_test) = result.results.first_mut() {
                 connect_test.status = conformance::TestStatus::Failed;
@@ -134,114 +133,12 @@ pub async fn run_test_adapter_builtin(
         config_schema: serde_json::Value::Null,
     };
 
-    let dialect = FallbackDialect::new(adapter_name);
-    let result = conformance::run_conformance(&manifest, &dialect);
+    // No live adapter is constructed for the builtin path, so the harness
+    // reports dialect-category checks as skipped.
+    let result = conformance::run_conformance(&manifest, None);
     output_result(&result, json_output)?;
 
     Ok(())
-}
-
-struct FallbackDialect {
-    name: String,
-}
-
-impl FallbackDialect {
-    fn new(name: impl Into<String>) -> Self {
-        Self { name: name.into() }
-    }
-}
-
-impl SqlDialect for FallbackDialect {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn format_table_ref(&self, catalog: &str, schema: &str, table: &str) -> AdapterResult<String> {
-        Ok(format!("{catalog}.{schema}.{table}"))
-    }
-
-    fn create_table_as(&self, target: &str, select_sql: &str) -> String {
-        format!("CREATE OR REPLACE TABLE {target} AS\n{select_sql}")
-    }
-
-    fn insert_into(&self, target: &str, select_sql: &str) -> String {
-        format!("INSERT INTO {target}\n{select_sql}")
-    }
-
-    fn merge_into(
-        &self,
-        target: &str,
-        source_sql: &str,
-        keys: &[String],
-        _update_cols: Option<&[String]>,
-    ) -> AdapterResult<String> {
-        Ok(format!(
-            "MERGE INTO {target} USING ({source_sql}) ON {}",
-            keys.join(", ")
-        ))
-    }
-
-    fn describe_table_sql(&self, table_ref: &str) -> String {
-        format!("DESCRIBE {table_ref}")
-    }
-
-    fn drop_table_sql(&self, table_ref: &str) -> String {
-        format!("DROP TABLE IF EXISTS {table_ref}")
-    }
-
-    fn create_catalog_sql(&self, name: &str) -> Option<AdapterResult<String>> {
-        Some(Ok(format!("CREATE CATALOG IF NOT EXISTS {name}")))
-    }
-
-    fn create_schema_sql(&self, catalog: &str, schema: &str) -> Option<AdapterResult<String>> {
-        Some(Ok(format!(
-            "CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"
-        )))
-    }
-
-    fn row_hash_expr(&self, columns: &[String]) -> String {
-        format!("MD5(CONCAT({}))", columns.join(", "))
-    }
-
-    fn tablesample_clause(&self, percent: u32) -> Option<String> {
-        Some(format!("TABLESAMPLE ({percent} PERCENT)"))
-    }
-
-    fn select_clause(
-        &self,
-        columns: &ColumnSelection,
-        metadata: &[MetadataColumn],
-    ) -> AdapterResult<String> {
-        let mut sql = match columns {
-            ColumnSelection::All => "SELECT *".to_string(),
-            ColumnSelection::Explicit(cols) => format!("SELECT {}", cols.join(", ")),
-        };
-        for column in metadata {
-            sql.push_str(&format!(
-                ", CAST({} AS {}) AS {}",
-                column.value, column.data_type, column.name
-            ));
-        }
-        Ok(sql)
-    }
-
-    fn watermark_where(&self, timestamp_col: &str, target_ref: &str) -> AdapterResult<String> {
-        Ok(format!(
-            "WHERE {timestamp_col} > (SELECT COALESCE(MAX({timestamp_col}), TIMESTAMP '1970-01-01') FROM {target_ref})"
-        ))
-    }
-
-    fn insert_overwrite_partition(
-        &self,
-        target: &str,
-        partition_filter: &str,
-        select_sql: &str,
-    ) -> AdapterResult<Vec<String>> {
-        Ok(vec![
-            format!("DELETE FROM {target} WHERE {partition_filter}"),
-            format!("INSERT INTO {target}\n{select_sql}"),
-        ])
-    }
 }
 
 fn output_result(result: &ConformanceResult, json_output: bool) -> Result<()> {


### PR DESCRIPTION
## Summary

Wire the adapter conformance harness into one real dialect call by executing `SqlDialect::format_table_ref` for the existing `format_table_ref` spec.

Fixes #383.

## Subproject(s) touched

- [x] `engine/` (Rust CLI / crates)
- [ ] `integrations/dagster/` (Python package)
- [ ] `editors/vscode/` (TypeScript extension)
- [ ] `examples/playground/` (sample project / benchmarks)
- [ ] `schemas/` (canonical CLI JSON schema)
- [x] Cross-project (CI, scripts, root docs)

## Changes

- Updated `run_conformance` to accept a `&dyn SqlDialect`.
- Executed the `format_table_ref` spec against a stub `TableRef` and failed the result on errors or empty output.
- Updated SDK tests and CLI callers for the new signature.
- Updated the adapter SDK guide to describe the first live dialect check.

## Test Plan

- `cargo test -p rocky-adapter-sdk`
- `cargo check -p rocky-cli --no-default-features`
- `cargo fmt --check`
- `git diff --check`

Note: `cargo check -p rocky-cli --no-default-features` passed with an existing unrelated warning about `default_type_mapper` in `crates/rocky-cli/src/commands/compile.rs`.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant (e.g. `feat(engine/rocky-databricks): ...`, `fix(dagster): ...`)
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers (`integrations/dagster/`, `editors/vscode/`) are updated in this same PR

### Engine (`engine/`)
- [ ] `cargo test --all-targets` passes
- [ ] `cargo clippy --all-targets -- -D warnings` is clean
- [x] `cargo fmt --check` passes

### Dagster (`integrations/dagster/`)
- [ ] `uv run pytest` passes
- [ ] `uv run ruff check` is clean
- [ ] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)
- [ ] `npm run compile` succeeds
- [ ] `npm run test:unit` passes (electron tests run in CI)
- [ ] `npm run lint` is clean
