### PR TITLE
docs: replace nav title with logo, descriptive landing tab

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
         dark: "./src/assets/rocky-logo-dark.svg",
         light: "./src/assets/rocky-logo-light.svg",
         alt: "Rocky",
+        replacesTitle: true,
       },
       favicon: "/favicon.svg",
       social: [

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Rocky
-description: A SQL transformation engine built in Rust. Type-safe compilation, column-level lineage, AI-powered intent.
+title: Rocky — Rust control plane for warehouse SQL pipelines
+description: Rust-based control plane for warehouse SQL pipelines — branches, replay, column-level lineage, compile-time type safety, per-model cost attribution.
 template: splash
 hero:
   tagline: A compiled SQL transformation engine in Rust. Type-safe compilation, column-level lineage, and an AI intent layer — for data pipelines that don't break.


### PR DESCRIPTION
## Summary
- The new top-nav logo lockup already contains the \"Rocky\" wordmark, so the default Starlight \`title\` text was rendering \"Rocky\" twice. \`logo.replacesTitle: true\` drops the redundant text.
- Landing page \`<title>\` was just \"Rocky\" (same as the site title), so the browser tab collapsed to a single \"Rocky\". Expanded to the public positioning line so the tab is more descriptive on first visit.

Favicon was already swapped to the new SVG in #409 (cached in browsers — hard-refresh to see it).

## Test plan
- [ ] \`cd docs && npm run dev\` — landing page browser tab reads \"Rocky — Rust control plane for warehouse SQL pipelines | Rocky\".
- [ ] Top nav renders only the logo lockup (no extra \"Rocky\" text next to it).
- [ ] Hard-refresh in a browser → favicon shows the new rounded-square dark + orange boulder.