### PR TITLE
feat(rocky-ai,rocky-cli): emit model sidecar from rocky ai generate

### DIFF
--- a/editors/vscode/src/types/generated/ai.ts
+++ b/editors/vscode/src/types/generated/ai.ts
@@ -10,10 +10,18 @@
  */
 export interface AiGenerateOutput {
   attempts: number;
+  /**
+   * Path of the body file (`.rocky` or `.sql`) written to the models directory, when emission succeeded.
+   */
+  body_path?: string | null;
   command: string;
   format: string;
   intent: string;
   name: string;
+  /**
+   * Path of the `.toml` sidecar written next to the body, when emission succeeded. The sidecar carries the materialization strategy and target coordinates so Rocky's model loader picks the generated model up without manual editing.
+   */
+  sidecar_path?: string | null;
   source: string;
   version: string;
   [k: string]: unknown;

--- a/engine/crates/rocky-ai/src/lib.rs
+++ b/engine/crates/rocky-ai/src/lib.rs
@@ -8,5 +8,6 @@ pub mod client;
 pub mod explain;
 pub mod generate;
 pub mod prompt;
+pub mod sidecar;
 pub mod sync;
 pub mod testgen;

--- a/engine/crates/rocky-ai/src/sidecar.rs
+++ b/engine/crates/rocky-ai/src/sidecar.rs
@@ -1,0 +1,460 @@
+//! TOML sidecar emission for AI-generated models.
+//!
+//! `rocky ai` historically emitted only the body source (`.sql` or `.rocky`)
+//! and printed it to stdout; the user then had to author a matching `.toml`
+//! sidecar by hand for Rocky's model loader to pick the model up. This
+//! module renders the sidecar from a small CLI-driven config so a single
+//! `rocky ai` invocation produces a complete, loadable model package.
+//!
+//! The shape mirrors a subset of [`rocky_core::models::ModelConfig`] that's
+//! authorable from the CLI today: name + strategy + target. Other fields
+//! (intent, freshness, classification, retention, budget, …) are out of
+//! scope for the first cut and inherit defaults from the Rocky loader.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// Errors emitted while writing the body + sidecar files.
+#[derive(Debug, Error)]
+pub enum SidecarError {
+    #[error("file already exists at {path} (pass --overwrite to replace)")]
+    AlreadyExists { path: String },
+
+    #[error("failed to write {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to serialize sidecar TOML: {0}")]
+    Serialize(#[from] toml::ser::Error),
+
+    #[error(
+        "unknown materialization '{value}'; expected one of: full_refresh, incremental, merge, ephemeral"
+    )]
+    UnknownMaterialization { value: String },
+
+    #[error("--watermark is required when --materialization=incremental")]
+    MissingWatermark,
+
+    #[error("invalid --target '{value}': expected catalog.schema.table")]
+    InvalidTarget { value: String },
+}
+
+/// Materialization strategy authorable from the `rocky ai --materialization`
+/// flag. A deliberately narrow subset of [`rocky_core::models::StrategyConfig`]:
+/// the four shapes a generated model is most likely to want today.
+///
+/// `time_interval`, `delete_insert`, and `microbatch` exist in the engine's
+/// strategy enum but require richer flag plumbing (granularity, partition
+/// columns) than this first cut bothers with — adding them is a follow-up.
+#[derive(Debug, Clone)]
+pub enum SidecarMaterialization {
+    FullRefresh,
+    Incremental { watermark: String },
+    Merge,
+    Ephemeral,
+}
+
+impl SidecarMaterialization {
+    /// Parse the `--materialization` CLI value. The optional `watermark` is
+    /// only consumed when `value == "incremental"` — it's required there
+    /// and ignored otherwise.
+    pub fn parse(value: &str, watermark: Option<&str>) -> Result<Self, SidecarError> {
+        match value {
+            "full_refresh" => Ok(Self::FullRefresh),
+            "incremental" => {
+                let w = watermark.ok_or(SidecarError::MissingWatermark)?;
+                Ok(Self::Incremental {
+                    watermark: w.to_string(),
+                })
+            }
+            "merge" => Ok(Self::Merge),
+            "ephemeral" => Ok(Self::Ephemeral),
+            other => Err(SidecarError::UnknownMaterialization {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// `catalog.schema.table` triple. Parsed from the `--target` CLI flag or
+/// derived from the model name (default: `generated.ai.<name>`).
+#[derive(Debug, Clone)]
+pub struct SidecarTarget {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+}
+
+impl SidecarTarget {
+    /// Default target when `--target` is omitted. Mirrors the in-memory
+    /// default in `rocky_ai::generate::build_generated_model`.
+    pub fn default_for(name: &str) -> Self {
+        Self {
+            catalog: "generated".to_string(),
+            schema: "ai".to_string(),
+            table: name.to_string(),
+        }
+    }
+
+    /// Parse the `--target` CLI value as `catalog.schema.table`. Each
+    /// component must be non-empty; anything else is rejected.
+    pub fn parse(value: &str) -> Result<Self, SidecarError> {
+        let parts: Vec<&str> = value.split('.').collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            return Err(SidecarError::InvalidTarget {
+                value: value.to_string(),
+            });
+        }
+        Ok(Self {
+            catalog: parts[0].to_string(),
+            schema: parts[1].to_string(),
+            table: parts[2].to_string(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// On-the-wire sidecar TOML
+// ---------------------------------------------------------------------------
+
+/// Lean serialization-only mirror of the on-disk sidecar shape. Keeping
+/// this struct local rather than reusing `rocky_core::models::ModelConfig`
+/// lets us emit a compact file (no empty `depends_on = []`, no empty
+/// `sources = []`, no `classification = {}` block) that Rocky's loader
+/// still accepts cleanly via field-default inference.
+#[derive(Debug, Serialize)]
+struct SidecarToml<'a> {
+    name: &'a str,
+    strategy: SidecarStrategyToml<'a>,
+    target: SidecarTargetToml<'a>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum SidecarStrategyToml<'a> {
+    #[serde(rename = "full_refresh")]
+    FullRefresh,
+    #[serde(rename = "incremental")]
+    Incremental { timestamp_column: &'a str },
+    #[serde(rename = "merge")]
+    Merge,
+    #[serde(rename = "ephemeral")]
+    Ephemeral,
+}
+
+#[derive(Debug, Serialize)]
+struct SidecarTargetToml<'a> {
+    catalog: &'a str,
+    schema: &'a str,
+    table: &'a str,
+}
+
+/// Render the sidecar TOML body for the given (name, strategy, target).
+///
+/// The `Merge` variant intentionally serializes without a `unique_key`
+/// list — Rocky's `StrategyConfig::Merge` requires `unique_key`, so the
+/// emitted TOML for `--materialization merge` is **incomplete on its own**.
+/// The user is expected to fill in the unique key before running
+/// `rocky run`. This is consistent with the brief's "first cut" scope:
+/// the AI doesn't know the unique key, and we don't have a flag to capture
+/// it yet. A future iteration can add `--unique-key`.
+pub fn render_sidecar_toml(
+    name: &str,
+    materialization: &SidecarMaterialization,
+    target: &SidecarTarget,
+) -> Result<String, SidecarError> {
+    let strategy = match materialization {
+        SidecarMaterialization::FullRefresh => SidecarStrategyToml::FullRefresh,
+        SidecarMaterialization::Incremental { watermark } => SidecarStrategyToml::Incremental {
+            timestamp_column: watermark,
+        },
+        SidecarMaterialization::Merge => SidecarStrategyToml::Merge,
+        SidecarMaterialization::Ephemeral => SidecarStrategyToml::Ephemeral,
+    };
+
+    let toml = SidecarToml {
+        name,
+        strategy,
+        target: SidecarTargetToml {
+            catalog: &target.catalog,
+            schema: &target.schema,
+            table: &target.table,
+        },
+    };
+
+    Ok(toml::to_string(&toml)?)
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem write
+// ---------------------------------------------------------------------------
+
+/// Result of [`write_model_files`] — the absolute paths written so the CLI
+/// can surface them in `--output json` and the human-readable summary.
+#[derive(Debug, Clone)]
+pub struct WrittenFiles {
+    pub body_path: PathBuf,
+    pub sidecar_path: PathBuf,
+}
+
+/// Write the generated body + sidecar TOML to `<dir>/<name>.<ext>` and
+/// `<dir>/<name>.toml`. `format` is `"rocky"` or `"sql"` and dictates the
+/// body extension; the sidecar is always `.toml`.
+///
+/// Pre-existing files trigger [`SidecarError::AlreadyExists`] unless
+/// `overwrite` is true. The check is performed before any write so a
+/// failed precondition leaves the filesystem untouched.
+///
+/// The parent directory is created if it doesn't already exist.
+pub fn write_model_files(
+    dir: &Path,
+    name: &str,
+    format: &str,
+    body: &str,
+    materialization: &SidecarMaterialization,
+    target: &SidecarTarget,
+    overwrite: bool,
+) -> Result<WrittenFiles, SidecarError> {
+    let ext = match format {
+        "rocky" => "rocky",
+        // Anything that isn't the Rocky DSL is treated as raw SQL — the
+        // generate pipeline only ever produces "rocky" or "sql" today.
+        _ => "sql",
+    };
+
+    let body_path = dir.join(format!("{name}.{ext}"));
+    let sidecar_path = dir.join(format!("{name}.toml"));
+
+    if !overwrite {
+        if body_path.exists() {
+            return Err(SidecarError::AlreadyExists {
+                path: body_path.display().to_string(),
+            });
+        }
+        if sidecar_path.exists() {
+            return Err(SidecarError::AlreadyExists {
+                path: sidecar_path.display().to_string(),
+            });
+        }
+    }
+
+    if !dir.exists() {
+        std::fs::create_dir_all(dir).map_err(|e| SidecarError::Io {
+            path: dir.display().to_string(),
+            source: e,
+        })?;
+    }
+
+    let sidecar_toml = render_sidecar_toml(name, materialization, target)?;
+
+    std::fs::write(&body_path, body).map_err(|e| SidecarError::Io {
+        path: body_path.display().to_string(),
+        source: e,
+    })?;
+    std::fs::write(&sidecar_path, &sidecar_toml).map_err(|e| SidecarError::Io {
+        path: sidecar_path.display().to_string(),
+        source: e,
+    })?;
+
+    Ok(WrittenFiles {
+        body_path,
+        sidecar_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rocky_core::models::{StrategyConfig, parse_model_inline};
+
+    #[test]
+    fn render_full_refresh_default_target() {
+        let target = SidecarTarget::default_for("fct_orders");
+        let toml = render_sidecar_toml("fct_orders", &SidecarMaterialization::FullRefresh, &target)
+            .unwrap();
+
+        assert!(toml.contains("name = \"fct_orders\""));
+        assert!(toml.contains("[strategy]"));
+        assert!(toml.contains("type = \"full_refresh\""));
+        assert!(toml.contains("[target]"));
+        assert!(toml.contains("catalog = \"generated\""));
+        assert!(toml.contains("schema = \"ai\""));
+        assert!(toml.contains("table = \"fct_orders\""));
+    }
+
+    #[test]
+    fn render_incremental_carries_watermark_as_timestamp_column() {
+        let target = SidecarTarget::default_for("events");
+        let toml = render_sidecar_toml(
+            "events",
+            &SidecarMaterialization::Incremental {
+                watermark: "_synced_at".to_string(),
+            },
+            &target,
+        )
+        .unwrap();
+        assert!(toml.contains("type = \"incremental\""));
+        assert!(toml.contains("timestamp_column = \"_synced_at\""));
+    }
+
+    #[test]
+    fn parse_target_rejects_two_part() {
+        let err = SidecarTarget::parse("schema.table").unwrap_err();
+        assert!(matches!(err, SidecarError::InvalidTarget { .. }));
+    }
+
+    #[test]
+    fn parse_target_rejects_empty_segment() {
+        let err = SidecarTarget::parse("a..c").unwrap_err();
+        assert!(matches!(err, SidecarError::InvalidTarget { .. }));
+    }
+
+    #[test]
+    fn parse_materialization_unknown_rejected() {
+        let err = SidecarMaterialization::parse("materialized_view", None).unwrap_err();
+        assert!(matches!(err, SidecarError::UnknownMaterialization { .. }));
+    }
+
+    #[test]
+    fn parse_incremental_requires_watermark() {
+        let err = SidecarMaterialization::parse("incremental", None).unwrap_err();
+        assert!(matches!(err, SidecarError::MissingWatermark));
+    }
+
+    #[test]
+    fn write_creates_body_and_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = SidecarTarget::default_for("fct_orders");
+
+        let written = write_model_files(
+            dir.path(),
+            "fct_orders",
+            "rocky",
+            "from orders\nselect { id }",
+            &SidecarMaterialization::FullRefresh,
+            &target,
+            false,
+        )
+        .unwrap();
+
+        assert!(written.body_path.exists());
+        assert!(written.sidecar_path.exists());
+        assert!(written.body_path.ends_with("fct_orders.rocky"));
+        assert!(written.sidecar_path.ends_with("fct_orders.toml"));
+    }
+
+    #[test]
+    fn write_refuses_existing_files_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = SidecarTarget::default_for("fct_orders");
+        // Pre-create the sidecar file
+        std::fs::write(dir.path().join("fct_orders.toml"), "name = \"old\"\n").unwrap();
+
+        let err = write_model_files(
+            dir.path(),
+            "fct_orders",
+            "sql",
+            "SELECT 1",
+            &SidecarMaterialization::FullRefresh,
+            &target,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, SidecarError::AlreadyExists { .. }));
+
+        // Body should not have been written either — precondition fails before
+        // any disk mutation.
+        assert!(!dir.path().join("fct_orders.sql").exists());
+    }
+
+    #[test]
+    fn write_overwrites_when_flag_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = SidecarTarget::default_for("m");
+        std::fs::write(dir.path().join("m.toml"), "stale\n").unwrap();
+        std::fs::write(dir.path().join("m.sql"), "stale\n").unwrap();
+
+        write_model_files(
+            dir.path(),
+            "m",
+            "sql",
+            "SELECT 42",
+            &SidecarMaterialization::FullRefresh,
+            &target,
+            true,
+        )
+        .unwrap();
+
+        let body = std::fs::read_to_string(dir.path().join("m.sql")).unwrap();
+        assert_eq!(body, "SELECT 42");
+        let sidecar = std::fs::read_to_string(dir.path().join("m.toml")).unwrap();
+        assert!(sidecar.contains("type = \"full_refresh\""));
+    }
+
+    #[test]
+    fn emitted_sidecar_loads_via_rocky_core_full_refresh() {
+        // Smoke-check: the TOML we emit deserializes through rocky-core's
+        // model loader. Use `parse_model_inline` with synthetic frontmatter
+        // to exercise `RawModelConfig` → `ModelConfig` resolution against
+        // our emitted TOML body.
+        let target = SidecarTarget::default_for("fct_orders");
+        let sidecar =
+            render_sidecar_toml("fct_orders", &SidecarMaterialization::FullRefresh, &target)
+                .unwrap();
+
+        let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
+        let model = parse_model_inline(&inline, "fct_orders.sql", None).unwrap();
+
+        assert_eq!(model.config.name, "fct_orders");
+        assert_eq!(model.config.target.catalog, "generated");
+        assert_eq!(model.config.target.schema, "ai");
+        assert_eq!(model.config.target.table, "fct_orders");
+        assert!(matches!(model.config.strategy, StrategyConfig::FullRefresh));
+    }
+
+    #[test]
+    fn emitted_sidecar_loads_via_rocky_core_incremental() {
+        let target = SidecarTarget {
+            catalog: "warehouse".to_string(),
+            schema: "raw".to_string(),
+            table: "events".to_string(),
+        };
+        let sidecar = render_sidecar_toml(
+            "events",
+            &SidecarMaterialization::Incremental {
+                watermark: "_synced_at".to_string(),
+            },
+            &target,
+        )
+        .unwrap();
+
+        let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
+        let model = parse_model_inline(&inline, "events.sql", None).unwrap();
+
+        match model.config.strategy {
+            StrategyConfig::Incremental { timestamp_column } => {
+                assert_eq!(timestamp_column, "_synced_at");
+            }
+            other => panic!("expected Incremental, got {other:?}"),
+        }
+        assert_eq!(model.config.target.catalog, "warehouse");
+    }
+
+    #[test]
+    fn emitted_sidecar_loads_via_rocky_core_ephemeral() {
+        let target = SidecarTarget::default_for("staging_users");
+        let sidecar =
+            render_sidecar_toml("staging_users", &SidecarMaterialization::Ephemeral, &target)
+                .unwrap();
+
+        let inline = format!("---toml\n{sidecar}---\n\nSELECT 1\n");
+        let model = parse_model_inline(&inline, "staging_users.sql", None).unwrap();
+        assert!(matches!(model.config.strategy, StrategyConfig::Ephemeral));
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 
 use rocky_ai::client::{AiConfig, DEFAULT_MAX_TOKENS, LlmClient};
 use rocky_ai::generate;
+use rocky_ai::sidecar::{SidecarMaterialization, SidecarTarget, write_model_files};
 use rocky_compiler::compile::{CompileResult, CompilerConfig, compile};
 use rocky_compiler::types::TypedColumn;
 use rocky_core::redacted::RedactedString;
@@ -115,6 +116,7 @@ fn build_schema_context(result: &CompileResult) -> SchemaBuckets {
 /// matters for downstream models and contract validation. Rocky's
 /// typechecker is lenient on unresolved columns today, so schema grounding
 /// in the prompt is the primary mechanism preventing hallucinated columns.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_ai(
     config_path: &Path,
     state_path: &Path,
@@ -123,9 +125,23 @@ pub async fn run_ai(
     models_dir: &str,
     output_json: bool,
     cache_ttl_override: Option<u64>,
+    materialization: &str,
+    watermark: Option<&str>,
+    target: Option<&str>,
+    overwrite: bool,
 ) -> Result<()> {
     let client = make_client(config_path)?;
     let fmt = format.unwrap_or("rocky");
+
+    // Validate sidecar inputs up-front — failing here costs no LLM tokens.
+    // Materialization parsing also enforces the `--watermark` requirement
+    // for `incremental` before we make the API call.
+    let parsed_materialization = SidecarMaterialization::parse(materialization, watermark)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let parsed_target_override = match target {
+        Some(value) => Some(SidecarTarget::parse(value).map_err(|e| anyhow::anyhow!("{e}"))?),
+        None => None,
+    };
 
     // Best-effort compile of the project to ground the prompt.
     // If it fails (missing dir, parse errors, etc.) we degrade to unschema'd
@@ -166,6 +182,28 @@ pub async fn run_ai(
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
+    // Resolve target. `--target` overrides the default; otherwise we
+    // mirror the in-memory default from `build_generated_model`
+    // (`generated.ai.<name>`) so the on-disk sidecar matches what AI
+    // validation already typechecked against.
+    let resolved_target =
+        parsed_target_override.unwrap_or_else(|| SidecarTarget::default_for(&result.name));
+
+    let dir = std::path::Path::new(models_dir);
+    let written = write_model_files(
+        dir,
+        &result.name,
+        &result.format,
+        &result.source,
+        &parsed_materialization,
+        &resolved_target,
+        overwrite,
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let body_path = written.body_path.display().to_string();
+    let sidecar_path = written.sidecar_path.display().to_string();
+
     if output_json {
         let output = AiGenerateOutput {
             version: VERSION.to_string(),
@@ -175,11 +213,15 @@ pub async fn run_ai(
             name: result.name.clone(),
             source: result.source.clone(),
             attempts: result.attempts,
+            body_path: Some(body_path),
+            sidecar_path: Some(sidecar_path),
         };
         print_json(&output)?;
     } else {
         println!("Generated model: {} ({})", result.name, result.format);
         println!("Attempts: {}", result.attempts);
+        println!("Wrote: {body_path}");
+        println!("Wrote: {sidecar_path}");
         println!();
         println!("{}", result.source);
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1347,6 +1347,16 @@ pub struct AiGenerateOutput {
     pub name: String,
     pub source: String,
     pub attempts: usize,
+    /// Path of the body file (`.rocky` or `.sql`) written to the models
+    /// directory, when emission succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_path: Option<String>,
+    /// Path of the `.toml` sidecar written next to the body, when emission
+    /// succeeded. The sidecar carries the materialization strategy and
+    /// target coordinates so Rocky's model loader picks the generated
+    /// model up without manual editing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sidecar_path: Option<String>,
 }
 
 /// JSON output for `rocky ai sync`.

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -540,11 +540,39 @@ enum Command {
         /// Output format: "rocky" or "sql"
         #[arg(long)]
         format: Option<String>,
-        /// Models directory (compiled to ground the prompt in real schemas).
+        /// Models directory (compiled to ground the prompt in real schemas,
+        /// and the destination directory for the generated body + sidecar).
         /// If the directory doesn't exist or fails to compile, generation
         /// proceeds without schema context.
         #[arg(long, default_value = "models")]
         models: String,
+        /// Materialization strategy for the generated model. Written into
+        /// the emitted `.toml` sidecar's `[strategy]` block.
+        ///
+        /// Accepted: `full_refresh` (default), `incremental`, `merge`,
+        /// `ephemeral`. Other strategies in `StrategyConfig`
+        /// (`time_interval`, `delete_insert`, `microbatch`) require richer
+        /// flag plumbing and are deliberately out of scope for this first
+        /// cut.
+        #[arg(long, default_value = "full_refresh")]
+        materialization: String,
+        /// Watermark column for `--materialization=incremental`. Maps to
+        /// `[strategy] timestamp_column` in the emitted sidecar TOML.
+        /// Required when materialization is `incremental`; ignored
+        /// otherwise.
+        #[arg(long)]
+        watermark: Option<String>,
+        /// Target table coordinates as `catalog.schema.table`. Defaults to
+        /// `generated.ai.<model_name>`, matching the in-memory default
+        /// used during AI compile-verify.
+        #[arg(long)]
+        target: Option<String>,
+        /// Overwrite an existing body or sidecar file at the destination
+        /// path. Without this flag, an existing file fails the command
+        /// loudly so generated output never silently clobbers user-authored
+        /// models.
+        #[arg(long)]
+        overwrite: bool,
     },
 
     /// Detect schema changes and propose intent-guided model updates
@@ -1737,6 +1765,10 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             intent,
             format,
             models,
+            materialization,
+            watermark,
+            target,
+            overwrite,
         } => {
             rocky_cli::commands::run_ai(
                 &cli.config,
@@ -1746,6 +1778,10 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 &models,
                 json,
                 cli.cache_ttl,
+                &materialization,
+                watermark.as_deref(),
+                target.as_deref(),
+                overwrite,
             )
             .await
         }

--- a/integrations/dagster/src/dagster_rocky/types_generated/ai_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/ai_schema.py
@@ -12,9 +12,17 @@ class AiGenerateOutput(BaseModel):
     """
 
     attempts: conint(ge=0)
+    body_path: str | None = None
+    """
+    Path of the body file (`.rocky` or `.sql`) written to the models directory, when emission succeeded.
+    """
     command: str
     format: str
     intent: str
     name: str
+    sidecar_path: str | None = None
+    """
+    Path of the `.toml` sidecar written next to the body, when emission succeeded. The sidecar carries the materialization strategy and target coordinates so Rocky's model loader picks the generated model up without manual editing.
+    """
     source: str
     version: str

--- a/schemas/ai.schema.json
+++ b/schemas/ai.schema.json
@@ -7,6 +7,13 @@
       "minimum": 0.0,
       "type": "integer"
     },
+    "body_path": {
+      "description": "Path of the body file (`.rocky` or `.sql`) written to the models directory, when emission succeeded.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "command": {
       "type": "string"
     },
@@ -18,6 +25,13 @@
     },
     "name": {
       "type": "string"
+    },
+    "sidecar_path": {
+      "description": "Path of the `.toml` sidecar written next to the body, when emission succeeded. The sidecar carries the materialization strategy and target coordinates so Rocky's model loader picks the generated model up without manual editing.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "source": {
       "type": "string"


### PR DESCRIPTION
## Summary
- New flags on `rocky ai`: `--materialization`, `--watermark`, `--target`, `--overwrite`.
- Writes a `.toml` sidecar next to the generated `.sql`/`.rocky` body, containing target + strategy. (Body is also persisted to the models directory now — previously only printed to stdout.)
- `AiGenerateOutput.body_path` + `sidecar_path` expose the new files in `--output json`.

## Why
`rocky ai generate` previously emitted the generated body source to stdout only — no body file, no sidecar. Rocky's model loader needs both, so users had to manually author the sidecar (and save the body) after every run. This makes a single `rocky ai` invocation produce a complete, loadable model package.

## Design notes
- Accepted materializations are `full_refresh`, `incremental`, `merge`, `ephemeral`. `materialized_view` / `dynamic_table` were in the brief but aren't variants of `StrategyConfig` — they live in the IR layer only and would emit invalid sidecar TOML. `time_interval` / `delete_insert` / `microbatch` need richer flag plumbing and are deliberately out of scope for this first cut.
- `--watermark` maps to `[strategy] timestamp_column` (the actual sidecar field name); the flag uses the more familiar "watermark" wording.
- `merge` emits without `unique_key` — the AI doesn't know the key. Resulting sidecar is incomplete on its own; user fills the key in before `rocky run`. Follow-up: `--unique-key`.
- Sidecar is rendered from a lean local serializer (`SidecarToml`) rather than reusing `ModelConfig`, so the on-disk file stays compact. Three loader-roundtrip tests confirm the emitted TOML deserializes cleanly through `parse_model_inline` for full_refresh / incremental / ephemeral.
- Existing files trigger `SidecarError::AlreadyExists` unless `--overwrite` is set; the precondition runs before any disk write so a failed check leaves the filesystem untouched.

## Test plan
- [x] `cargo test -p rocky-ai -p rocky-cli` (rocky-ai 41 tests incl. 11 new sidecar tests; rocky-cli 366 tests)
- [x] `cargo clippy -p rocky-ai -p rocky-cli -- -D warnings`
- [x] `cargo fmt`
- [x] `just codegen` — `AiGenerateOutput` gained `body_path` + `sidecar_path`; schema + dagster Pydantic + vscode TypeScript bindings regenerated and committed
- [ ] Manual: `rocky ai "build a fct_orders model" --materialization full_refresh --target warehouse.marts.fct_orders` produces both files (LLM-dependent, deferred)