### PR TITLE
feat(rocky-core): env-var substitution in model sidecar TOML

### DIFF
--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::ModelBudgetConfig;
+use crate::config::{ModelBudgetConfig, substitute_env_vars};
 use crate::dag::DagNode;
 use crate::ir::{
     GovernanceConfig, MaterializationStrategy, ModelIr, Plan, SourceRef, TargetRef,
@@ -44,6 +44,13 @@ pub enum ModelError {
         model: String,
         value: String,
         reason: String,
+    },
+
+    #[error("failed to substitute env vars in '{path}': {source}")]
+    EnvSubstitution {
+        path: String,
+        #[source]
+        source: Box<crate::config::ConfigError>,
     },
 }
 
@@ -418,8 +425,18 @@ pub struct DirDefaultsTarget {
 }
 
 /// Validates and loads a `_defaults.toml` file. Rejects per-model fields.
+///
+/// `${VAR}` and `${VAR:-default}` placeholders are resolved before parsing,
+/// matching `rocky.toml` and per-model sidecar behavior. Lets directory-level
+/// defaults (e.g. `target.schema = "${ROCKY_SCHEMA:-public}"`) be set per
+/// orchestrator subprocess.
 pub fn load_dir_defaults(path: &Path) -> Result<DirDefaults, ModelError> {
-    let content = std::fs::read_to_string(path)?;
+    let raw_content = std::fs::read_to_string(path)?;
+    let content =
+        substitute_env_vars(&raw_content).map_err(|source| ModelError::EnvSubstitution {
+            path: path.display().to_string(),
+            source: Box::new(source),
+        })?;
 
     // Check for per-model fields that shouldn't be in defaults
     let raw: toml::Value = toml::from_str(&content).map_err(|e| ModelError::ParseFrontmatter {
@@ -664,6 +681,12 @@ impl Model {
 /// `target.table` (defaults to name), and `target.catalog`/`target.schema`
 /// (inherited from `defaults` if provided).
 ///
+/// `${VAR}` and `${VAR:-default}` placeholders in the sidecar TOML are
+/// resolved before parsing, matching the substitution behavior of
+/// `rocky.toml`. This lets an orchestrator inject per-model
+/// `target.catalog` / `target.schema` / `target.table` via subprocess env
+/// without rewriting source files.
+///
 /// ```text
 /// models/
 /// ├── _defaults.toml      ← optional: target.catalog, target.schema
@@ -684,7 +707,12 @@ pub fn load_model_pair(
             trimmed.to_string()
         }
     };
-    let toml_content = std::fs::read_to_string(toml_path)?;
+    let raw_toml = std::fs::read_to_string(toml_path)?;
+    let toml_content =
+        substitute_env_vars(&raw_toml).map_err(|source| ModelError::EnvSubstitution {
+            path: toml_path.display().to_string(),
+            source: Box::new(source),
+        })?;
     let raw: RawModelConfig =
         toml::from_str(&toml_content).map_err(|e| ModelError::ParseFrontmatter {
             path: toml_path.display().to_string(),
@@ -728,8 +756,14 @@ pub fn parse_model_inline(
             path: file_path.to_string(),
         })?;
 
+    let frontmatter =
+        substitute_env_vars(frontmatter).map_err(|source| ModelError::EnvSubstitution {
+            path: file_path.to_string(),
+            source: Box::new(source),
+        })?;
+
     let raw: RawModelConfig =
-        toml::from_str(frontmatter).map_err(|e| ModelError::ParseFrontmatter {
+        toml::from_str(&frontmatter).map_err(|e| ModelError::ParseFrontmatter {
             path: file_path.to_string(),
             source: e,
         })?;
@@ -1784,5 +1818,140 @@ ssn = "confidential"
             m.config.classification.get("ssn"),
             Some(&"confidential".to_string())
         );
+    }
+
+    /// FR-001 Option A: `${VAR}` and `${VAR:-default}` placeholders in a
+    /// model sidecar `.toml` resolve at load time, mirroring `rocky.toml`.
+    #[test]
+    fn test_sidecar_env_var_substitution() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // SAFETY: test-only, no concurrent reads of these variables.
+        unsafe {
+            std::env::set_var("ROCKY_TEST_SIDECAR_CATALOG", "warehouse_prod");
+            std::env::set_var("ROCKY_TEST_SIDECAR_SCHEMA", "silver");
+        }
+
+        std::fs::write(
+            dir.path().join("stg_events.toml"),
+            r#"
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "${ROCKY_TEST_SIDECAR_CATALOG}"
+schema  = "${ROCKY_TEST_SIDECAR_SCHEMA:-fallback_schema}"
+table   = "${ROCKY_TEST_SIDECAR_TABLE:-stg_events}"
+"#,
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("stg_events.sql"), "SELECT 1 AS id").unwrap();
+
+        let model = load_model_pair(
+            &dir.path().join("stg_events.sql"),
+            &dir.path().join("stg_events.toml"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(model.config.target.catalog, "warehouse_prod");
+        assert_eq!(model.config.target.schema, "silver");
+        // Default branch: ROCKY_TEST_SIDECAR_TABLE not set, fallback wins.
+        assert_eq!(model.config.target.table, "stg_events");
+
+        unsafe {
+            std::env::remove_var("ROCKY_TEST_SIDECAR_CATALOG");
+            std::env::remove_var("ROCKY_TEST_SIDECAR_SCHEMA");
+        }
+    }
+
+    /// Missing `${VAR}` (no default) at sidecar load time surfaces as a
+    /// `ModelError::EnvSubstitution` — same shape `rocky.toml` already has.
+    #[test]
+    fn test_sidecar_env_var_missing_errors() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // SAFETY: test-only.
+        unsafe { std::env::remove_var("ROCKY_TEST_SIDECAR_NEVER_SET") };
+
+        std::fs::write(
+            dir.path().join("bad.toml"),
+            r#"
+[target]
+catalog = "${ROCKY_TEST_SIDECAR_NEVER_SET}"
+schema  = "s"
+"#,
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("bad.sql"), "SELECT 1").unwrap();
+
+        let result = load_model_pair(
+            &dir.path().join("bad.sql"),
+            &dir.path().join("bad.toml"),
+            None,
+        );
+
+        assert!(matches!(result, Err(ModelError::EnvSubstitution { .. })));
+    }
+
+    /// `_defaults.toml` also goes through env-var substitution so the same
+    /// orchestrator-injected env values apply to directory-level defaults.
+    #[test]
+    fn test_dir_defaults_env_var_substitution() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // SAFETY: test-only.
+        unsafe {
+            std::env::set_var("ROCKY_TEST_DEFAULTS_CATALOG", "from_env_default");
+        }
+
+        std::fs::write(
+            dir.path().join("_defaults.toml"),
+            r#"
+[target]
+catalog = "${ROCKY_TEST_DEFAULTS_CATALOG}"
+schema  = "${ROCKY_TEST_DEFAULTS_SCHEMA:-public}"
+"#,
+        )
+        .unwrap();
+
+        let defaults = load_dir_defaults(&dir.path().join("_defaults.toml")).unwrap();
+        let target = defaults.target.expect("target should be set");
+        assert_eq!(target.catalog.as_deref(), Some("from_env_default"));
+        assert_eq!(target.schema.as_deref(), Some("public"));
+
+        unsafe {
+            std::env::remove_var("ROCKY_TEST_DEFAULTS_CATALOG");
+        }
+    }
+
+    /// Inline `---toml` frontmatter format also resolves env vars before
+    /// parsing — mirrors the sidecar path so legacy single-file models
+    /// stay in lockstep.
+    #[test]
+    fn test_inline_frontmatter_env_var_substitution() {
+        // SAFETY: test-only.
+        unsafe {
+            std::env::set_var("ROCKY_TEST_INLINE_CATALOG", "inline_warehouse");
+        }
+
+        let content = r#"---toml
+name = "inline_model"
+[target]
+catalog = "${ROCKY_TEST_INLINE_CATALOG}"
+schema  = "${ROCKY_TEST_INLINE_SCHEMA:-staging}"
+table   = "inline_model"
+---
+
+SELECT 1
+"#;
+
+        let model = parse_model_inline(content, "inline_model.sql", None).unwrap();
+        assert_eq!(model.config.target.catalog, "inline_warehouse");
+        assert_eq!(model.config.target.schema, "staging");
+
+        unsafe {
+            std::env::remove_var("ROCKY_TEST_INLINE_CATALOG");
+        }
     }
 }

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -36,11 +36,11 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**47 of 60 POCs run with no external credentials.** See each POC's README for prerequisites.
+**48 of 61 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
-### 00 — Foundations (7 POCs · DuckDB)
+### 00 — Foundations (8 POCs · DuckDB)
 
 DSL syntax, materialization basics, playground baseline, and the trust-arc 1 storage primitives.
 
@@ -53,6 +53,7 @@ DSL syntax, materialization basics, playground baseline, and the trust-arc 1 sto
 | [04-window-functions](pocs/00-foundations/04-window-functions) | DSL window syntax with partition + sort + frame |
 | [05-generic-adapter-exercise](pocs/00-foundations/05-generic-adapter-exercise) | Generic adapter exercise — building custom adapters via the process protocol |
 | [06-branches-replay-lineage](pocs/00-foundations/06-branches-replay-lineage) | **Trust arc 1** — `rocky branch create/list/show`, `rocky run --branch`, `rocky replay`, `rocky lineage --downstream` |
+| [07-config-layering](pocs/00-foundations/07-config-layering) | Three-layer config: `rocky.toml` + `_defaults.toml` + per-model sidecar, with env-var substitution at every layer |
 
 ### 01 — Quality (6 POCs · DuckDB)
 

--- a/examples/playground/pocs/00-foundations/07-config-layering/README.md
+++ b/examples/playground/pocs/00-foundations/07-config-layering/README.md
@@ -1,0 +1,85 @@
+# 07-config-layering — three-layer config + env-var substitution
+
+> **Category:** 00-foundations
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** env-var substitution, `_defaults.toml` inheritance, model sidecar overrides
+
+## What it shows
+
+Rocky resolves a model's target (`catalog.schema.table`) by walking three
+config layers, with `${VAR}` / `${VAR:-default}` substitution at every layer:
+
+1. **`rocky.toml`** — pipeline-level config (adapter, target template, etc.)
+2. **`models/_defaults.toml`** — directory-level defaults applied to every
+   sibling sidecar.
+3. **`models/<name>.toml`** — per-model sidecar, overrides anything from the
+   layers above.
+
+This POC runs `rocky compile` twice over the same source tree — once with
+no env vars set, once with overrides — and prints the resolved targets so
+the precedence rules are visible side-by-side.
+
+## Why it's distinctive
+
+- Env-var substitution works at **every** config layer — including per-model
+  sidecars, which closes a dbt-migration ergonomics gap (FR-001 Option A).
+  A Dagster asset factory can now point each asset at its own
+  catalog/schema/table by setting env vars on the rocky subprocess.
+- The same source files materialize to different physical tables based on
+  the orchestrator's environment, with no codegen or templating step.
+
+## Layout
+
+```
+.
+├── README.md             this file
+├── rocky.toml            Layer 1 — pipeline + adapter (uses ${ROCKY_DUCKDB_PATH})
+├── run.sh                end-to-end demo: two runs, with/without env vars
+└── models/
+    ├── _defaults.toml    Layer 2 — directory defaults (catalog, schema, strategy)
+    ├── orders_summary.sql + .toml   Demonstrates Layer 2 inheritance
+    └── customer_facts.sql  + .toml  Demonstrates Layer 3 env-var override
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+=== Run 1: NO env vars set — every layer falls back to its default ===
+Resolved model targets (defaults):
+  customer_facts     -> customer_warehouse.marts.customer_facts
+  orders_summary     -> poc_warehouse.public.orders_summary
+
+=== Run 2: env vars set — orchestrator-style overrides flow into every layer ===
+Resolved model targets (overrides):
+  customer_facts     -> customer_prod.gold.customer_facts_v2
+  orders_summary     -> prod_warehouse.silver.orders_summary
+```
+
+## Precedence rules
+
+For a sidecar field (e.g. `target.catalog`):
+
+1. Explicit value in the sidecar (after env-var substitution) wins.
+2. Otherwise, the matching value from `_defaults.toml` (also after env-var
+   substitution).
+3. Otherwise, filename inference for `name` and `target.table` (defaults to
+   the SQL file's stem).
+
+`${VAR}` is **required** — an unset var is a load-time error. `${VAR:-default}`
+falls back to `default` when the var is unset or empty.
+
+## Related
+
+- Canonical config reference: `.claude/skills/rocky-config/SKILL.md` at the
+  monorepo root.
+- The substitution helper lives at
+  `engine/crates/rocky-core/src/config.rs::substitute_env_vars`.
+- The sidecar / `_defaults.toml` loader lives at
+  `engine/crates/rocky-core/src/models.rs`.

--- a/examples/playground/pocs/00-foundations/07-config-layering/models/_defaults.toml
+++ b/examples/playground/pocs/00-foundations/07-config-layering/models/_defaults.toml
@@ -1,0 +1,10 @@
+# Layer 2: directory-level defaults
+#
+# Every sibling sidecar inherits these unless it overrides.
+# Now goes through env-var substitution (FR-001 Option A).
+[target]
+catalog = "${ROCKY_CATALOG:-poc_warehouse}"
+schema  = "${ROCKY_DEFAULT_SCHEMA:-public}"
+
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/00-foundations/07-config-layering/models/customer_facts.sql
+++ b/examples/playground/pocs/00-foundations/07-config-layering/models/customer_facts.sql
@@ -1,0 +1,4 @@
+WITH base AS (
+  SELECT 1 AS customer_id, 'acme' AS name
+)
+SELECT customer_id, name FROM base

--- a/examples/playground/pocs/00-foundations/07-config-layering/models/customer_facts.toml
+++ b/examples/playground/pocs/00-foundations/07-config-layering/models/customer_facts.toml
@@ -1,0 +1,11 @@
+# customer_facts — overrides every target field via env-var substitution.
+#
+# This is the FR-001 Option A capability: ${VAR}/${VAR:-default} placeholders
+# in a per-model sidecar resolve at load time, the same way `rocky.toml`
+# already supports them. A Dagster asset factory can now point each asset
+# at its own catalog/schema/table by setting env vars on the subprocess.
+
+[target]
+catalog = "${ROCKY_CUSTOMER_CATALOG:-customer_warehouse}"
+schema  = "${ROCKY_CUSTOMER_SCHEMA:-marts}"
+table   = "${ROCKY_TABLE_OVERRIDE:-customer_facts}"

--- a/examples/playground/pocs/00-foundations/07-config-layering/models/orders_summary.sql
+++ b/examples/playground/pocs/00-foundations/07-config-layering/models/orders_summary.sql
@@ -1,0 +1,1 @@
+SELECT 1 AS order_id, 100 AS amount

--- a/examples/playground/pocs/00-foundations/07-config-layering/models/orders_summary.toml
+++ b/examples/playground/pocs/00-foundations/07-config-layering/models/orders_summary.toml
@@ -1,0 +1,9 @@
+# orders_summary — minimal sidecar
+#
+# Demonstrates Layer 3 inheritance from Layer 2:
+#   * `target.catalog` / `target.schema` come from `_defaults.toml`
+#     (and resolve from ${ROCKY_CATALOG} / ${ROCKY_DEFAULT_SCHEMA})
+#   * `target.table` defaults to the filename stem (`orders_summary`)
+#   * `name` defaults to the filename stem
+#
+# This file is intentionally empty of overrides — that's the whole point.

--- a/examples/playground/pocs/00-foundations/07-config-layering/rocky.toml
+++ b/examples/playground/pocs/00-foundations/07-config-layering/rocky.toml
@@ -1,0 +1,19 @@
+# 07-config-layering — three-layer env-var substitution demo
+#
+# Layer 1: rocky.toml             — pipeline-level config with ${VAR:-default}
+# Layer 2: models/_defaults.toml  — directory-level model defaults
+# Layer 3: models/<name>.toml     — per-model sidecar overrides
+
+[adapter]
+type = "duckdb"
+# Layer 1 substitution: ${ROCKY_DUCKDB_PATH} flows into the adapter path.
+# (Existing rocky.toml capability — kept here so all three layers are visible
+# in one example.)
+path = "${ROCKY_DUCKDB_PATH:-poc.duckdb}"
+
+[pipeline.layered]
+type = "transformation"
+
+[pipeline.layered.target]
+# Transformation pipelines defer catalog/schema/table to per-model sidecars
+# (Layer 2 + 3). The adapter reference is all that's needed here.

--- a/examples/playground/pocs/00-foundations/07-config-layering/run.sh
+++ b/examples/playground/pocs/00-foundations/07-config-layering/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# 07-config-layering — three-layer config + env-var substitution at every layer
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb run2.duckdb
+
+extract_targets() {
+    # Pull per-model target out of compile JSON. python3 only, no jq.
+    python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data.get('models_detail', []):
+    t = m.get('target', {})
+    print(f\"  {m['name']:18s} -> {t.get('catalog', '?')}.{t.get('schema', '?')}.{t.get('table', '?')}\")
+"
+}
+
+run_compile() {
+    local out=$1
+    rocky -c rocky.toml validate >/dev/null 2>&1
+    rocky compile --models models/ --output json > "$out" 2>/dev/null
+}
+
+echo "=== Run 1: NO env vars set — every layer falls back to its default ==="
+unset ROCKY_DUCKDB_PATH ROCKY_CATALOG ROCKY_DEFAULT_SCHEMA \
+      ROCKY_CUSTOMER_CATALOG ROCKY_CUSTOMER_SCHEMA ROCKY_TABLE_OVERRIDE
+run_compile expected/compile-defaults.json
+echo "Resolved model targets (defaults):"
+extract_targets < expected/compile-defaults.json
+
+echo
+echo "=== Run 2: env vars set — orchestrator-style overrides flow into every layer ==="
+export ROCKY_DUCKDB_PATH="run2.duckdb"
+export ROCKY_CATALOG="prod_warehouse"
+export ROCKY_DEFAULT_SCHEMA="silver"
+export ROCKY_CUSTOMER_CATALOG="customer_prod"
+export ROCKY_CUSTOMER_SCHEMA="gold"
+export ROCKY_TABLE_OVERRIDE="customer_facts_v2"
+run_compile expected/compile-overrides.json
+echo "Resolved model targets (overrides):"
+extract_targets < expected/compile-overrides.json
+
+echo
+echo "POC complete: same source files, two different resolutions."
+echo
+echo "Layer 1 (rocky.toml) — adapter.path"
+echo "  default  : poc.duckdb"
+echo "  override : run2.duckdb              (\$ROCKY_DUCKDB_PATH)"
+echo
+echo "Layer 2 (models/_defaults.toml) — inherited by orders_summary"
+echo "  default  : poc_warehouse.public.orders_summary"
+echo "  override : prod_warehouse.silver.orders_summary"
+echo "             (\$ROCKY_CATALOG, \$ROCKY_DEFAULT_SCHEMA)"
+echo
+echo "Layer 3 (per-model sidecar) — customer_facts (FR-001 Option A)"
+echo "  default  : customer_warehouse.marts.customer_facts"
+echo "  override : customer_prod.gold.customer_facts_v2"

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,10 +1,10 @@
 # POC Catalog
 
-60 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+61 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
-- [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage (7 POCs · DuckDB)
+- [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage + config layering (8 POCs · DuckDB)
 - [01-quality](01-quality/) — Contracts, checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline (6 POCs · DuckDB)
 - [02-performance](02-performance/) — Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, trust-arc 2 cost+budgets (10 POCs · DuckDB)
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
@@ -17,7 +17,7 @@
 
 | POCs | Credentials |
 |---|---|
-| 47 of 60 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
+| 48 of 61 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
 | 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |


### PR DESCRIPTION
## Summary
- `feat(rocky-core)`: model sidecar `.toml` files (and `models/_defaults.toml`, plus inline `---toml` frontmatter) now go through `substitute_env_vars` before parsing — same mechanism `rocky.toml` already supports. Closes the FR-001 Option A ergonomics gap. `_defaults.toml` is bundled in this PR (one-line change in the same loader, mirrors the sidecar path symmetry).
- `docs(playground)`: new POC at `examples/playground/pocs/00-foundations/07-config-layering/` demonstrating `rocky.toml` + `models/_defaults.toml` + per-model sidecars working together with env-var substitution at every layer.

## Why
Orchestration ergonomics gap. dbt users coming from a Dagster asset-factory pattern can't inject per-model `catalog`/`schema`/`table` from env without restructuring the project. After this, a Dagster `RockyResource` can set `ROCKY_CATALOG=...` (and friends) on the subprocess env per asset and per-model sidecars resolve it at load time.

## What's in scope
- `engine/crates/rocky-core/src/models.rs` — `load_model_pair`, `load_dir_defaults`, and `parse_model_inline` route their TOML content through `substitute_env_vars` before `toml::from_str`. New `ModelError::EnvSubstitution` variant boxes the underlying `ConfigError` to keep the error enum small.
- 4 new unit tests in `models.rs::tests` covering: sidecar `${VAR}` + `${VAR:-default}`, missing-var error path, `_defaults.toml` substitution, inline frontmatter substitution.
- New POC: 5 files (`README.md`, `rocky.toml`, `run.sh`, two model sidecars + their SQL) plus `models/_defaults.toml`. The POC's `run.sh` runs `rocky compile --output json` twice (with/without env vars) and prints resolved targets so the precedence is visible side-by-side.

## Out of scope (per the FR)
- Schema-pattern templates (`{tenant}`, `{regions}`, `{source}`) in sidecars — tied to the source-schema-pattern resolver, separate concern.
- CLI overrides on `rocky run` / `rocky compile` (FR-001 Option B) — separate, larger change.
- Dagster integration wiring — engine-side FR only.
- CHANGELOG updates — release-time work.

## Test plan
- [x] `cargo test -p rocky-core` (1198 tests, all pass — 4 new)
- [x] `cargo clippy -p rocky-core --all-targets -- -D warnings` (clean)
- [x] POC `run.sh` exits 0 with env vars set (overrides resolve correctly)
- [x] POC `run.sh` exits 0 with no env vars (defaults take over)