### PR TITLE
docs: document env-var substitution in sidecars, _defaults.toml, and inline frontmatter

### DIFF
--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -152,11 +152,15 @@ Notice several changes:
 
 The importer cannot convert all Jinja patterns. It produces warnings and failures for cases it cannot handle automatically.
 
+:::tip[Per-model env-var injection]
+For migrations that lean on `{{ var() }}` or `{{ target.* }}` to drive per-model `catalog` / `schema` / `table` values from an orchestrator, Rocky's three-layer config (pipeline `rocky.toml` + `models/_defaults.toml` + per-model sidecar `.toml`) supports `${VAR}` / `${VAR:-default}` substitution at every layer. See the worked example at [`examples/playground/pocs/00-foundations/07-config-layering/`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/00-foundations/07-config-layering) — particularly useful for Dagster asset factories that inject targets per asset via subprocess env.
+:::
+
 ### Common warnings
 
 | Pattern | Importer Behavior | Manual Fix |
 |---|---|---|
-| `{{ var('some_var') }}` | Replaced with a `TODO` placeholder | Replace with a hardcoded value or environment variable in `rocky.toml` |
+| `{{ var('some_var') }}` | Replaced with a `TODO` placeholder | Replace with a hardcoded value or `${VAR}` / `${VAR:-default}` substitution. Env vars resolve in `rocky.toml`, in `models/_defaults.toml`, and in per-model sidecar `.toml` files — letting an orchestrator inject `[target]` values per asset without templating. |
 | `{% if target.name == 'prod' %}` | Stripped, keeping the default branch | Remove environment branching or use separate `rocky.toml` files per environment |
 | `{% set ... %}` variable assignments | Stripped with a warning | Inline the value or refactor the query |
 

--- a/docs/src/content/docs/guides/playground.md
+++ b/docs/src/content/docs/guides/playground.md
@@ -380,9 +380,9 @@ Exit code 0 means all checks passed. A non-zero exit code fails the CI job.
 
 ## 8. Explore the POC Catalog
 
-The playground includes a curated catalog of 58 POCs that showcase Rocky's distinctive capabilities. Each POC is self-contained with its own `rocky.toml`, `models/`, and `run.sh`. Most run on local DuckDB with zero credentials.
+The playground includes a curated catalog of 61 POCs that showcase Rocky's distinctive capabilities. Each POC is self-contained with its own `rocky.toml`, `models/`, and `run.sh`. Most run on local DuckDB with zero credentials.
 
-### Foundations (7 POCs)
+### Foundations (8 POCs)
 
 | POC | Feature |
 |---|---|
@@ -393,6 +393,7 @@ The playground includes a curated catalog of 58 POCs that showcase Rocky's disti
 | `04-window-functions` | DSL window syntax with partition + sort + frame |
 | `05-generic-adapter-exercise` | Full generic-adapter trait surface against DuckDB |
 | `06-branches-replay-lineage` | Trust arc 1: branches + replay + column lineage end-to-end |
+| `07-config-layering` | Three-layer config (`rocky.toml` + `_defaults.toml` + sidecar) with `${VAR}` substitution at every layer |
 
 ### Quality (6 POCs)
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -80,6 +80,22 @@ token = "${DATABRICKS_TOKEN}"
 
 If a referenced variable is not set, Rocky returns a parse error listing the missing variable.
 
+The same substitution runs over every TOML config Rocky loads, not just `rocky.toml`:
+
+- **Per-model sidecars** (`models/<name>.toml`) — useful for orchestrator-injected `[target]` overrides.
+- **`models/_defaults.toml`** — directory-level defaults applied to every sibling sidecar.
+- **Inline `---toml` frontmatter** in `.sql` / `.rocky` files — only the frontmatter block is substituted; the SQL body below the closing `---` is left untouched, so `${VAR}` in SQL stays literal.
+
+```toml
+# models/customer_facts.toml — sidecar example
+[target]
+catalog = "${ROCKY_TARGET_CATALOG:-warehouse}"
+schema  = "${ROCKY_TARGET_SCHEMA:-marts}"
+table   = "${ROCKY_TABLE_OVERRIDE:-customer_facts}"
+```
+
+A worked example covering all three layers lives in `examples/playground/pocs/00-foundations/07-config-layering/`.
+
 ### Default Values
 
 Use `${VAR_NAME:-default}` to provide a fallback when a variable is unset or empty:

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -91,6 +91,20 @@ Warehouse-managed table shapes — **Delta tables**, **Iceberg tables**, **mater
 | `schema` | string | Yes | Source schema name. |
 | `table` | string | Yes | Source table name. |
 
+### Environment variables
+
+Sidecar `.toml` files (and `models/_defaults.toml`) go through the same `${VAR}` / `${VAR:-default}` substitution as `rocky.toml`. This lets an orchestrator inject per-model `[target]` values via subprocess env without templating the sidecar:
+
+```toml
+# models/customer_facts.toml
+[target]
+catalog = "${ROCKY_TARGET_CATALOG:-warehouse}"
+schema  = "${ROCKY_TARGET_SCHEMA:-marts}"
+table   = "${ROCKY_TABLE_OVERRIDE:-customer_facts}"
+```
+
+See [Environment Variables](/reference/configuration/#environment-variables) for the canonical syntax reference and [`examples/playground/pocs/00-foundations/07-config-layering/`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/00-foundations/07-config-layering) for a runnable three-layer example.
+
 ### `[classification]`
 
 Per-column classification tags. Keys are column names, values are free-form classification strings. Rocky resolves each value against `[mask]` / `[mask.<env>]` in `rocky.toml` to pick the masking strategy, then applies both the column tag and the mask via the governance adapter after a successful DAG.
@@ -174,6 +188,8 @@ FROM raw_catalog.src__acme__us_west__shopify.orders
 ```
 
 The inline format uses the same fields as the sidecar TOML file. The SQL query follows the closing `---` marker.
+
+The frontmatter block supports the same `${VAR}` / `${VAR:-default}` substitution as sidecar `.toml` files (see [Environment Variables](/reference/configuration/#environment-variables)); the SQL body below the closing `---` is **not** substituted, so any `${VAR}` token in the query stays literal.
 
 This format is supported for backward compatibility. The sidecar format is preferred because it keeps SQL files portable and free of non-SQL syntax.
 


### PR DESCRIPTION
## Summary
Documents env-var substitution capability that landed in #415:
- `reference/configuration.md` — adds sidecar / `_defaults.toml` / inline frontmatter to the env-var section.
- `reference/model-format.md` — adds an env-var subsection to the sidecar format reference; notes the frontmatter-but-not-body distinction for inline format.
- `guides/migrate-from-dbt.md` — updates the Jinja-removal table to mention sidecar env-vars; cross-links to the config-layering POC.
- `guides/playground.md` — adds the new `07-config-layering` POC row to the Foundations table; refreshes catalog count to 61 (was already drifted).

## Why
PR #415 expanded env-var substitution from `rocky.toml` only to per-model sidecars + `_defaults.toml` + inline frontmatter. Until now, the docs didn't reflect that capability — readers would assume rocky.toml-only and miss the dbt-migration use case (Dagster asset-factory injecting `catalog`/`schema`/`table` per asset via subprocess env).

## Test plan
- [x] `cd docs && npm run build` — Astro/Starlight built cleanly (73 pages, 0 broken-link errors).
- [x] `#environment-variables` anchor confirmed present in `configuration.md` rendered output.
- [x] New `#environment-variables` anchor under Sidecar Format renders in `model-format.md`.
- [ ] Manual read-through: a reader new to Rocky understands env-vars work at all three layers.