### PR TITLE
feat(playground): branch approve/promote + rocky catalog POCs

### DIFF
--- a/examples/playground/.gitignore
+++ b/examples/playground/.gitignore
@@ -2,6 +2,7 @@
 .rocky-state.redb
 .rocky_state
 .rocky_state.redb.lock
+.rocky/
 *.duckdb
 *.duckdb.wal
 *.duckdb.tmp/

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -36,11 +36,11 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**48 of 61 POCs run with no external credentials.** See each POC's README for prerequisites.
+**50 of 63 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
-### 00 — Foundations (8 POCs · DuckDB)
+### 00 — Foundations (9 POCs · DuckDB)
 
 DSL syntax, materialization basics, playground baseline, and the trust-arc 1 storage primitives.
 
@@ -54,6 +54,7 @@ DSL syntax, materialization basics, playground baseline, and the trust-arc 1 sto
 | [05-generic-adapter-exercise](pocs/00-foundations/05-generic-adapter-exercise) | Generic adapter exercise — building custom adapters via the process protocol |
 | [06-branches-replay-lineage](pocs/00-foundations/06-branches-replay-lineage) | **Trust arc 1** — `rocky branch create/list/show`, `rocky run --branch`, `rocky replay`, `rocky lineage --downstream` |
 | [07-config-layering](pocs/00-foundations/07-config-layering) | Three-layer config: `rocky.toml` + `_defaults.toml` + per-model sidecar, with env-var substitution at every layer |
+| [08-branch-approve-promote](pocs/00-foundations/08-branch-approve-promote) | **Trust arc 1** — `[branch.approval] required = true` gates `rocky branch promote`; `rocky branch approve` writes a content-addressed signed artifact bound to the branch state hash |
 
 ### 01 — Quality (6 POCs · DuckDB)
 
@@ -126,7 +127,7 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [08-circuit-breaker](pocs/05-orchestration/08-circuit-breaker) | **Trust arc 3** — `[adapter.retry]` exponential backoff + three-state `CircuitBreaker` |
 | [09-idempotency-key](pocs/05-orchestration/09-idempotency-key) | `rocky run --idempotency-key` dedup — second run with the same key yields `status = "skipped_idempotent"` |
 
-### 06 — Developer Experience (11 POCs · DuckDB)
+### 06 — Developer Experience (12 POCs · DuckDB)
 
 Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff.
 
@@ -143,6 +144,7 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 | [09-sql-types-blast-radius](pocs/06-developer-experience/09-sql-types-blast-radius) | **Trust arc 7** — `rocky compile --with-seed` type grounding + blast-radius `SELECT *` lint |
 | [10-pr-preview-and-data-diff](pocs/06-developer-experience/10-pr-preview-and-data-diff) | `rocky preview create / diff / cost` — column-level pruned re-run + sampled row diff + cost delta on a 5-model DAG |
 | [11-lineage-diff](pocs/06-developer-experience/11-lineage-diff) | `rocky lineage-diff <base_ref>` — per-changed-column downstream blast-radius for PR review (Markdown drops into a PR comment) |
+| [12-catalog-emit](pocs/06-developer-experience/12-catalog-emit) | `rocky catalog --format both` — column-level lineage emitted as `catalog.json` + `edges.parquet` + `assets.parquet`; readable by any Parquet client without going through the engine |
 
 ### 07 — Adapters (6 POCs · mixed)
 

--- a/examples/playground/pocs/00-foundations/08-branch-approve-promote/README.md
+++ b/examples/playground/pocs/00-foundations/08-branch-approve-promote/README.md
@@ -1,0 +1,81 @@
+# 08-branch-approve-promote — gated promotion of a branch into prod
+
+![Rocky refuses to promote without a signed approval, then ships once the artifact is on disk](../../../../../docs/public/demo-branch-approve-promote.gif)
+
+> **Category:** 00-foundations
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s
+> **Rocky features:** `rocky branch create`, `rocky run --branch`, `rocky branch approve`, `rocky branch promote`, `[branch.approval]`
+
+## What it shows
+
+The two verbs that gate a branch from "ran fine in isolation" to "live in
+prod":
+
+1. `rocky branch approve <name>` writes a content-addressed approval
+   artifact under `./.rocky/approvals/<branch>/<id>.json`. The artifact
+   binds the approver's git identity to the branch's current
+   `branch_state_hash` (blake3 over canonical JSON).
+2. `rocky branch promote <name>` enumerates the replication pipeline's
+   prod targets, validates the on-disk approvals against the
+   `[branch.approval]` policy, then dispatches one
+   `CREATE OR REPLACE TABLE prod.<x> AS SELECT * FROM branch__<name>.<x>`
+   per target. `PromoteStarted` / `PromoteCompleted` audit events ride
+   along in the JSON output.
+
+## Why it's distinctive
+
+- **Cryptographic gate, not a process gate.** The approval artifact is
+  signed against a state hash; if the branch changes after approval, the
+  hash drifts and `promote` rejects the now-stale signature.
+- **No external service.** Approvals are files on disk — easy to commit,
+  easy to mirror to another store, easy to inspect.
+- **Audit trail in the same JSON output as the operation itself.** No
+  separate event log to wire up.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        DuckDB pipeline + [branch.approval] required = true
+├── run.sh            end-to-end demo
+└── data/seed.sql     5-row synthetic orders table
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.25.0 on PATH
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- A configured git identity (`git config user.email`) — the approver's
+  email is bound into the signed artifact
+
+## Run
+
+```bash
+./run.sh
+```
+
+## What happened
+
+1. **Seed** `raw__orders.orders` into DuckDB (5 rows).
+2. **Run on main** — replication writes `poc.prod__orders.orders`.
+3. **Create branch `fix_orders`** — state-store entry, no warehouse side
+   effects.
+4. **Run on the branch** — replication writes
+   `poc.branch__fix_orders.orders`, leaving prod untouched.
+5. **First promote attempt fails** — `[branch.approval]` requires one
+   approver and the gate finds zero artifacts on disk. Exit 1, error
+   message names the branch.
+6. **Approve** — Rocky signs an artifact bound to the current
+   `branch_state_hash` and the local git identity; the file lands at
+   `.rocky/approvals/fix_orders/<approval_id>.json`.
+7. **Promote** — gate now satisfied. Rocky emits `PromoteStarted`,
+   dispatches the `CREATE OR REPLACE TABLE` per prod target, and emits
+   `PromoteCompleted` with the per-target results.
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/branch.rs`
+- Sibling POC: [`06-branches-replay-lineage`](../06-branches-replay-lineage/) —
+  the branch / replay / lineage primitives without the approval gate.

--- a/examples/playground/pocs/00-foundations/08-branch-approve-promote/data/seed.sql
+++ b/examples/playground/pocs/00-foundations/08-branch-approve-promote/data/seed.sql
@@ -1,0 +1,11 @@
+-- Seed a tiny `orders` source the replication pipeline picks up.
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT * FROM (VALUES
+    (1, 101, 'completed', 49.50,  TIMESTAMP '2026-05-01 10:15:00'),
+    (2, 102, 'completed', 119.00, TIMESTAMP '2026-05-01 10:20:00'),
+    (3, 103, 'cancelled', 0.00,   TIMESTAMP '2026-05-01 10:30:00'),
+    (4, 101, 'completed', 19.99,  TIMESTAMP '2026-05-02 09:05:00'),
+    (5, 104, 'pending',   0.00,   TIMESTAMP '2026-05-02 09:42:00')
+) AS t(order_id, customer_id, status, amount, ordered_at);

--- a/examples/playground/pocs/00-foundations/08-branch-approve-promote/rocky.toml
+++ b/examples/playground/pocs/00-foundations/08-branch-approve-promote/rocky.toml
@@ -1,0 +1,33 @@
+# Branch approve + promote — gated promotion of a branch into prod.
+#
+# `[branch.approval] required = true` flips on the gate; `branch promote` then
+# refuses to run unless at least `min_approvers` valid approval artifacts are
+# on disk (signed by an approver in `allowed_signers`, branch_state_hash still
+# current, signed within `max_age_seconds`).
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.discovery]
+adapter = "default"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "prod__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[branch.approval]
+required = true
+min_approvers = 1
+max_age_seconds = 86400

--- a/examples/playground/pocs/00-foundations/08-branch-approve-promote/run.sh
+++ b/examples/playground/pocs/00-foundations/08-branch-approve-promote/run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# 08-branch-approve-promote — gated promotion of a branch into prod
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+rm -rf .rocky-state.redb poc.duckdb .rocky/approvals
+mkdir -p expected
+
+echo "==> 1. Seed raw__orders.orders into DuckDB"
+duckdb poc.duckdb < data/seed.sql
+
+echo "==> 2. Run replication on main (writes poc.prod__orders.orders)"
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_main.json
+
+echo "==> 3. Create a named branch 'fix_orders'"
+rocky branch create fix_orders \
+    --description "Drop cancelled rows from the orders feed" \
+    > expected/branch_create.json
+
+echo "==> 4. Run replication against the branch (writes poc.branch__fix_orders.orders)"
+rocky -c rocky.toml -o json run --filter source=orders --branch fix_orders \
+    > expected/run_branch.json
+
+echo "==> 5. Try to promote without an approval — gate refuses"
+set +e
+rocky -c rocky.toml branch promote fix_orders > expected/promote_blocked.json 2>&1
+echo "    (exit $?)"
+set -e
+
+echo "==> 6. Sign the branch — git identity binds the artifact"
+rocky -c rocky.toml branch approve fix_orders \
+    --message "verified row counts; safe to ship" \
+    > expected/branch_approve.json
+ls -1 .rocky/approvals/fix_orders/
+
+echo "==> 7. Promote — gate now satisfied; copy branch tables onto prod targets"
+rocky -c rocky.toml branch promote fix_orders > expected/branch_promote.json
+
+echo
+echo "==> Warehouse tables after promotion:"
+duckdb poc.duckdb <<'SQL'
+SELECT table_schema, table_name FROM information_schema.tables
+WHERE table_catalog = 'poc' ORDER BY table_schema, table_name;
+SQL
+
+echo
+echo "POC complete: approval gate refused promote until a signed artifact landed; audit JSON in expected/."

--- a/examples/playground/pocs/03-ai/01-model-generation/README.md
+++ b/examples/playground/pocs/03-ai/01-model-generation/README.md
@@ -1,23 +1,30 @@
 # 01-model-generation — `rocky ai "intent..."` with compile-verify retry loop
 
-![rocky ai generates a .rocky model from natural language intent; Attempts: 2 shows the compile-validate retry loop](../../../../../docs/public/demo-ai-model-generation.gif)
+![rocky ai generates a .rocky body + .toml sidecar from natural language intent; Attempts: 2 shows the compile-validate retry loop](../../../../../docs/public/demo-ai-model-generation.gif)
 
 > **Category:** 03-ai
 > **Credentials:** `ANTHROPIC_API_KEY` required
 > **Runtime:** depends on Anthropic API latency
-> **Rocky features:** `rocky ai`, compile-verify retry, `--format rocky|sql`
+> **Rocky features:** `rocky ai`, compile-verify retry, `--format rocky|sql`, `--materialization`, `--watermark`, `--target`, sidecar emission
 
 ## What it shows
 
 Generate a Rocky model from a natural language description. Rocky sends
 your intent to Claude, receives generated code, and **verifies it compiles**
-before saving. If compile fails, Rocky retries with the error context (up
-to 3 attempts).
+before writing it. If compile fails, Rocky retries with the error context
+(up to 3 attempts).
+
+The output is a pair of files under `models/`:
+
+- `<name>.rocky` — the model body
+- `<name>.toml` — sidecar with `[strategy]` (from `--materialization`) and
+  `[target]` (from `--target`)
 
 ## Why it's distinctive
 
 - **Self-correcting AI** — the compile-verify loop closes the gap between
   "model that looks right" and "model that actually works".
+- **No copy-paste step** — body + sidecar land on disk, ready to `rocky run`.
 - Different from `rocky/examples/ai-intent` (which ships pre-generated tests).
   This POC generates a fresh model live.
 

--- a/examples/playground/pocs/03-ai/01-model-generation/run.sh
+++ b/examples/playground/pocs/03-ai/01-model-generation/run.sh
@@ -5,9 +5,24 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 mkdir -p expected
+rm -f models/monthly_revenue.rocky models/monthly_revenue.toml
 
-# Generate a model from natural language. Rocky compiles + retries if it doesn't parse.
-rocky ai "monthly revenue per customer from raw_orders, only completed orders" --format rocky 2>&1 | tee expected/generation.log
+# Generate a model from natural language. Rocky compiles + retries if it
+# doesn't parse, then writes both the body and a `[strategy]`/`[target]`
+# sidecar alongside it under `models/`.
+rocky ai "monthly revenue per customer from raw_orders, only completed orders" \
+    --format rocky \
+    --target poc.demo.monthly_revenue \
+    --overwrite \
+    2>&1 | tee expected/generation.log
 
 echo
-echo "POC complete: AI-generated model produced (see expected/generation.log)."
+echo "==> Generated artifacts:"
+ls -1 models/monthly_revenue.* | tee expected/generated_files.txt
+
+echo
+echo "==> Sidecar contents:"
+cat models/monthly_revenue.toml | tee expected/monthly_revenue.toml.txt
+
+echo
+echo "POC complete: body + sidecar landed under models/, log at expected/generation.log."

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/README.md
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/README.md
@@ -1,0 +1,88 @@
+# 12-catalog-emit — `rocky catalog`: column-level lineage as JSON + Parquet
+
+![rocky catalog walks the SemanticGraph and writes catalog.json + edges.parquet + assets.parquet under .rocky/catalog/](../../../../../docs/public/demo-rocky-catalog.gif)
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `rocky catalog`, `--format json|parquet|both`, `--out`, state-store enrichment
+
+## What it shows
+
+`rocky catalog` walks the compiler's SemanticGraph and writes a
+self-contained, machine-consumable lineage artefact under
+`./.rocky/catalog/`:
+
+- `catalog.json` — the front door. Project metadata, project-level
+  `last_run_id`, an `assets[]` array (one per model with its columns +
+  upstream/downstream models), and an `edges[]` array of column-level
+  lineage edges including transform kind (`direct`, `aggregation: sum`,
+  …) and confidence.
+- `edges.parquet` — flat table of column-lineage edges. Any Parquet
+  reader (DuckDB, Polars, Spark, BigQuery external table, Athena…) can
+  query it without going through the engine.
+- `assets.parquet` — flat table of asset columns with `last_run_id` /
+  `last_materialized_at` enrichment populated when the state store has a
+  matching successful run.
+
+## Why it's distinctive
+
+- **The catalog is a *queryable artefact*, not a JSON dump.** dbt's
+  `target/manifest.json` is a single 100K+ line monster; Rocky emits
+  a flat Parquet table you can query with `read_parquet('.../edges.parquet')`.
+- **Column-level lineage is compiler-derived, not regex-derived.**
+  Aggregations, joins, and DSL-based group-bys all carry through with
+  semantic transform kinds (`aggregation: sum`, `direct`, …) instead of
+  table-to-table edges only.
+- **No engine on the read path.** Once the catalog is written, lineage
+  consumers (Looker, Superset, custom dashboards) read Parquet directly.
+
+## Layout
+
+```
+.
+├── README.md           this file
+├── rocky.toml          DuckDB transformation pipeline
+├── run.sh              compile → catalog → inspect
+├── data/seed.sql       small `raw__orders.orders` seed (200 rows)
+└── models/
+    ├── _defaults.toml      catalog=poc, schema=demo
+    ├── raw_orders.sql      SELECT … FROM raw__orders.orders
+    ├── stg_orders.sql      filter cancelled
+    └── fct_revenue.sql     group by customer_id → SUM(amount), COUNT(order_id)
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.25.0 on PATH
+- `duckdb` CLI (only used in the demo to read back the Parquet file)
+- `python3` (used to pretty-print the JSON in `run.sh`)
+
+## Run
+
+```bash
+./run.sh
+```
+
+## What happened
+
+1. **Compile** — semantic graph for 3 models; column types propagate
+   from `raw_orders` → `stg_orders` → `fct_revenue`.
+2. **`rocky catalog --format both`** — walks the SemanticGraph and
+   writes the three artefacts under `.rocky/catalog/`.
+3. **Inspect** — the demo prints the first six column-lineage edges,
+   shows each asset's columns + upstream models, then queries
+   `edges.parquet` directly via DuckDB to prove the artefact is
+   tool-agnostic.
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/catalog.rs`
+- Sibling POC:
+  [`01-lineage-column-level/`](../01-lineage-column-level/) — `rocky
+  lineage` for interactive single-model lineage queries (the catalog is
+  the bulk-export equivalent).
+- Sibling POC:
+  [`11-lineage-diff/`](../11-lineage-diff/) — `rocky lineage-diff` for
+  PR-time blast radius (compares two refs at compile time, doesn't
+  persist).

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/data/seed.sql
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/data/seed.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+CREATE SCHEMA IF NOT EXISTS demo;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    1 + (i % 20) AS customer_id,
+    ROUND(CAST(10.0 + random() * 90.0 AS DECIMAL(10,2)), 2) AS amount,
+    CASE WHEN i % 11 = 0 THEN 'cancelled' ELSE 'completed' END AS status
+FROM generate_series(1, 200) AS t(i);

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/_defaults.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/_defaults.toml
@@ -1,0 +1,3 @@
+[target]
+catalog = "poc"
+schema = "demo"

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.sql
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.sql
@@ -1,0 +1,6 @@
+SELECT
+    customer_id,
+    SUM(amount)   AS total,
+    COUNT(order_id) AS orders
+FROM poc.demo.stg_orders
+GROUP BY customer_id

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/fct_revenue.toml
@@ -1,0 +1,2 @@
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/raw_orders.sql
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/raw_orders.sql
@@ -1,0 +1,1 @@
+SELECT order_id, customer_id, amount, status FROM raw__orders.orders

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/raw_orders.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/raw_orders.toml
@@ -1,0 +1,2 @@
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/stg_orders.sql
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/stg_orders.sql
@@ -1,0 +1,3 @@
+SELECT order_id, customer_id, amount, status
+FROM poc.demo.raw_orders
+WHERE status != 'cancelled'

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/stg_orders.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/models/stg_orders.toml
@@ -1,0 +1,2 @@
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/rocky.toml
@@ -1,0 +1,18 @@
+# 12-catalog-emit — emit a column-level lineage catalog with state-store enrichment.
+#
+# Transformation pipeline so `rocky run` actually materialises the three
+# models — that lets `rocky catalog` fill in `last_run_id` /
+# `last_materialized_at` per asset from the state store.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+type = "transformation"
+models = "models/**"
+
+[pipeline.poc.target]
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/06-developer-experience/12-catalog-emit/run.sh
+++ b/examples/playground/pocs/06-developer-experience/12-catalog-emit/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# 12-catalog-emit — emit a column-level catalog from the SemanticGraph
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+rm -rf .rocky-state.redb poc.duckdb .rocky/catalog
+mkdir -p expected
+
+echo "==> 1. Compile the 3-model DAG (the catalog walks the SemanticGraph; no warehouse needed)"
+rocky compile --models models > expected/compile.json
+
+echo "==> 2. Emit the catalog (catalog.json + edges.parquet + assets.parquet)"
+rocky catalog --models models --format both > expected/catalog_summary.json
+ls -1 .rocky/catalog/
+
+echo
+echo "==> First 6 column-lineage edges:"
+python3 -c "
+import json
+with open('.rocky/catalog/catalog.json') as fh:
+    cat = json.load(fh)
+for e in cat['edges'][:6]:
+    print(f\"  {e['source_model']}.{e['source_column']:12s} -> {e['target_model']}.{e['target_column']}\")
+print(f\"  ... ({cat['stats']['edge_count']} edges across {cat['stats']['asset_count']} assets, {cat['stats']['column_count']} columns)\")
+"
+
+echo
+echo "==> Assets and their upstream models:"
+python3 -c "
+import json
+with open('.rocky/catalog/catalog.json') as fh:
+    cat = json.load(fh)
+for a in cat['assets']:
+    cols = ', '.join(c['name'] for c in a['columns'])
+    print(f\"  {a['fqn']:30s} cols=[{cols}]  upstream={a['upstream_models']}\")
+"
+
+echo
+echo "==> Inspecting Parquet companions with DuckDB (any tool that reads Parquet works):"
+duckdb -csv :memory: <<'SQL'
+SELECT source_model, source_column, target_model, target_column, transform
+FROM read_parquet('.rocky/catalog/edges.parquet')
+ORDER BY target_model, target_column
+LIMIT 6;
+SQL
+
+echo
+echo "POC complete: catalog.json + edges.parquet + assets.parquet under .rocky/catalog/."
+echo "(Run \`rocky run\` against a transformation pipeline first to populate state-store"
+echo " enrichment — \`last_run_id\` and \`last_materialized_at\` per asset.)"

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,23 +1,23 @@
 # POC Catalog
 
-61 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+63 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
-- [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage + config layering (8 POCs · DuckDB)
+- [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage + config layering + branch approve/promote (9 POCs · DuckDB)
 - [01-quality](01-quality/) — Contracts, checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline (6 POCs · DuckDB)
 - [02-performance](02-performance/) — Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, trust-arc 2 cost+budgets (10 POCs · DuckDB)
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention (6 POCs · Databricks / DuckDB)
 - [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys (9 POCs · DuckDB / docker)
-- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff (11 POCs · DuckDB)
+- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit (12 POCs · DuckDB)
 - [07-adapters](07-adapters/) — Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native adapter skeleton (6 POCs · mixed)
 
 ## Credentials at a glance
 
 | POCs | Credentials |
 |---|---|
-| 48 of 61 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
+| 50 of 63 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
 | 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |


### PR DESCRIPTION
## Summary

- New POC `00-foundations/08-branch-approve-promote` covering the v1.25 surfaces from #388. Replication pipeline with `[branch.approval] required = true`; `run.sh` walks promote-blocked → approve (signed artifact bound to `branch_state_hash`) → promote-succeeds with `PromoteStarted` / `PromoteCompleted` audit events.
- New POC `06-developer-experience/12-catalog-emit` for `rocky catalog` (#356/#366/#368). 3-model transformation DAG emitting `catalog.json` + `edges.parquet` + `assets.parquet` under `.rocky/catalog/`; the demo queries the Parquet companion directly via DuckDB to show the artefact is engine-free on the read path.
- Refresh `03-ai/01-model-generation` for v1.26 sidecar emission (#414): `run.sh` now passes `--target poc.demo.<name>` and surfaces the body + `.toml` sidecar that land on disk; README updated to match.

## Notes

- Playground catalog counts bumped 61 → 63 (foundations 8 → 9, developer experience 11 → 12) across `examples/playground/README.md` and `examples/playground/pocs/README.md`.
- `examples/playground/.gitignore` now ignores `.rocky/` so catalog and approval runtime artefacts don't get tracked.
- Catalog POC is compile-only — `rocky run` against transformation pipelines with FQN-style `FROM poc.demo.<model>` references currently produces `execution_layers: 1` with no detected upstream dependencies, so per-asset `last_run_id` / `last_materialized_at` enrichment isn't demoed live (mentioned in the README footer).

## Test plan

- [ ] `cd examples/playground/pocs/00-foundations/08-branch-approve-promote && ./run.sh` — exits 0; `expected/promote_blocked.json` records the gate refusal, `expected/branch_promote.json` records the signed approval and the per-target `CREATE OR REPLACE TABLE`.
- [ ] `cd examples/playground/pocs/06-developer-experience/12-catalog-emit && ./run.sh` — exits 0; `.rocky/catalog/{catalog.json,edges.parquet,assets.parquet}` present; first 6 column-lineage edges printed; DuckDB reads back `edges.parquet` directly.
- [ ] `cd examples/playground/pocs/03-ai/01-model-generation && ANTHROPIC_API_KEY=... ./run.sh` — exits 0; emitted body + `.toml` sidecar appear under `models/`; sidecar `[target]` matches `--target` flag.