### PR TITLE
feat(playground): add rocky run --watch inner-loop POC

### DIFF
--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -36,7 +36,7 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**50 of 63 POCs run with no external credentials.** See each POC's README for prerequisites.
+**51 of 64 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
@@ -127,7 +127,7 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [08-circuit-breaker](pocs/05-orchestration/08-circuit-breaker) | **Trust arc 3** — `[adapter.retry]` exponential backoff + three-state `CircuitBreaker` |
 | [09-idempotency-key](pocs/05-orchestration/09-idempotency-key) | `rocky run --idempotency-key` dedup — second run with the same key yields `status = "skipped_idempotent"` |
 
-### 06 — Developer Experience (12 POCs · DuckDB)
+### 06 — Developer Experience (13 POCs · DuckDB)
 
 Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff.
 
@@ -145,6 +145,7 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 | [10-pr-preview-and-data-diff](pocs/06-developer-experience/10-pr-preview-and-data-diff) | `rocky preview create / diff / cost` — column-level pruned re-run + sampled row diff + cost delta on a 5-model DAG |
 | [11-lineage-diff](pocs/06-developer-experience/11-lineage-diff) | `rocky lineage-diff <base_ref>` — per-changed-column downstream blast-radius for PR review (Markdown drops into a PR comment) |
 | [12-catalog-emit](pocs/06-developer-experience/12-catalog-emit) | `rocky catalog --format both` — column-level lineage emitted as `catalog.json` + `edges.parquet` + `assets.parquet`; readable by any Parquet client without going through the engine |
+| [13-run-watch-inner-loop](pocs/06-developer-experience/13-run-watch-inner-loop) | `rocky run --watch` re-materialises on every save; 200 ms debounce window, FSEvents-safe directory watch, NDJSON-stream output, clean SIGINT exit |
 
 ### 07 — Adapters (6 POCs · mixed)
 

--- a/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/README.md
+++ b/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/README.md
@@ -1,0 +1,73 @@
+# 13-run-watch-inner-loop — `rocky run --watch` reacts to file edits
+
+![rocky run --watch detects a touch, debounces 200 ms, and re-runs the pipeline; Ctrl-C exits cleanly](../../../../../docs/public/demo-run-watch.gif)
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s (background watcher + one synthetic edit, then SIGINT)
+> **Rocky features:** `rocky run --watch`, 200 ms debounce, FSEvents-safe directory watch, NDJSON-stream output
+
+## What it shows
+
+`rocky run --watch` wraps the existing `rocky run` path in a filesystem
+watcher, so an interactive editor session re-materialises the pipeline
+on every save. The POC runs non-interactively by:
+
+1. Launching `rocky run --watch` in the background, redirected to a log.
+2. Waiting for the first run to land (`"command":"run"` in the log).
+3. Touching `rocky.toml` — same shape as a `:w` from vim or a save in
+   VSCode.
+4. Waiting for the second run to land.
+5. Sending SIGINT; the watch loop completes the in-flight run and exits 0.
+
+The log under `expected/watch.log` carries one full `RunOutput` JSON per
+iteration (newline-delimited stream) plus stderr banner + `detected
+change` notices.
+
+## Why it's distinctive
+
+- **The compile-verify loop becomes interactive** — pair this with
+  `rocky lsp` for type-aware authoring + auto-materialise. dbt's
+  `--no-version-check --select <model>` story doesn't survive contact
+  with watching.
+- **Debounce window coalesces editor save bursts** — a quick burst
+  triggers exactly one re-run, not one per `notify` event.
+- **FSEvents-safe on macOS** — the watcher monitors the parent directory
+  with a filename filter, so atomic-rename saves (vim's
+  `set backupcopy=auto`, VSCode's default save) are caught where a
+  file-level watch would miss the new inode.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        DuckDB replication pipeline
+├── run.sh            launch watch → touch → wait → SIGINT
+└── data/seed.sql     50-row synthetic orders table
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.27.0 (the next release after the merge of [#423](https://github.com/rocky-data/rocky/pull/423)) on PATH
+- `duckdb` CLI for seeding (`brew install duckdb`)
+
+## Run
+
+```bash
+./run.sh
+```
+
+## What happened
+
+1. **Seed** `raw__orders.orders` into DuckDB (50 rows).
+2. **Launch watch** — `rocky run --watch -c rocky.toml --filter source=orders` runs in the background, prints a watching banner on stderr, runs the pipeline once on startup.
+3. **Touch `rocky.toml`** — fires a filesystem event; the 200 ms debounce window collects any related events; one re-run is dispatched.
+4. **Two `RunOutput` records** land in `expected/watch.log` — one per iteration, newline-delimited.
+5. **SIGINT** completes the in-flight run, then the watch loop exits 0.
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/run_watch.rs`
+- CLI reference: [`rocky run --watch`](../../../../../docs/src/content/docs/reference/commands/core-pipeline.md#rocky-run)
+- Sibling POC: [`02-rocky-serve-api`](../02-rocky-serve-api/) — `rocky serve --watch` for HTTP-API authoring (different surface; same `--watch` philosophy).

--- a/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/data/seed.sql
+++ b/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/data/seed.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    1 + (i % 20) AS customer_id,
+    ROUND(CAST(10.0 + random() * 90.0 AS DECIMAL(10,2)), 2) AS amount,
+    CASE WHEN i % 11 = 0 THEN 'cancelled' ELSE 'completed' END AS status
+FROM generate_series(1, 50) AS t(i);

--- a/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/rocky.toml
@@ -1,0 +1,27 @@
+# 13-run-watch-inner-loop — `rocky run --watch` inner-loop developer workflow.
+#
+# Replication pipeline so `rocky run` materializes a target on every detected
+# change to a watched file. The watcher monitors the parent directory of
+# rocky.toml + the resolved models directory recursively.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.discovery]
+adapter = "default"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/run.sh
+++ b/examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop/run.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# 13-run-watch-inner-loop — `rocky run --watch` reacts to file edits.
+#
+# This POC is non-interactive by design — `rocky run --watch` blocks until
+# Ctrl-C, so we run it in the background, fire one synthetic edit to
+# rocky.toml after the first run completes, wait for the second run, then
+# send SIGINT and capture the exit code.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+rm -f .rocky-state.redb poc.duckdb
+mkdir -p expected
+
+echo "==> 1. Seed raw__orders.orders into DuckDB"
+duckdb poc.duckdb < data/seed.sql
+
+echo "==> 2. Launch rocky run --watch in the background"
+LOG="$HERE/expected/watch.log"
+: > "$LOG"
+rocky -c rocky.toml run --watch --filter source=orders --output json > "$LOG" 2>&1 &
+WATCH_PID=$!
+trap 'kill -INT "$WATCH_PID" 2>/dev/null || true; wait "$WATCH_PID" 2>/dev/null || true' EXIT
+
+count_runs() {
+    # The watcher prints `[watch] run completed in <ms>` after every successful
+    # iteration — counting these is robust against pretty-printed vs compact
+    # JSON output and language-server log noise.
+    grep -c '^\[watch\] run completed' "$LOG" 2>/dev/null || true
+}
+
+echo "==> 3. Wait for the first run to settle (banner + 1st run completion)"
+for _ in {1..40}; do
+    [[ "$(count_runs)" -ge 1 ]] && break
+    sleep 0.25
+done
+
+echo "==> 4. Touch rocky.toml — debounce window coalesces save bursts; one re-run fires"
+touch rocky.toml
+
+echo "==> 5. Wait for the second run record to land"
+for _ in {1..40}; do
+    [[ "$(count_runs)" -ge 2 ]] && break
+    sleep 0.25
+done
+
+echo "==> 6. Send SIGINT and let the watch loop exit cleanly"
+kill -INT "$WATCH_PID"
+wait "$WATCH_PID" || EXIT_CODE=$?
+trap - EXIT
+EXIT_CODE="${EXIT_CODE:-0}"
+
+echo
+echo "==> Watch loop log (banner + run completions + change notice):"
+grep -E '^\[watch\] ' "$LOG" | head -10
+
+echo
+echo "==> Run records observed: $(count_runs)"
+echo "==> Watch loop exit status: $EXIT_CODE"
+echo
+echo "POC complete: rocky run --watch detected the rocky.toml touch and re-ran the pipeline; SIGINT exited cleanly."

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,6 +1,6 @@
 # POC Catalog
 
-63 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+64 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
@@ -10,14 +10,14 @@
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention (6 POCs · Databricks / DuckDB)
 - [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys (9 POCs · DuckDB / docker)
-- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit (12 POCs · DuckDB)
+- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop (13 POCs · DuckDB)
 - [07-adapters](07-adapters/) — Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native adapter skeleton (6 POCs · mixed)
 
 ## Credentials at a glance
 
 | POCs | Credentials |
 |---|---|
-| 50 of 63 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
+| 51 of 64 | None — local DuckDB (or docker-compose for MinIO/Valkey) |
 | 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |


### PR DESCRIPTION
## Summary

Closes the playground gap left by [#423](https://github.com/rocky-data/rocky/pull/423) (`rocky run --watch`). The new POC at `06-developer-experience/13-run-watch-inner-loop` is a non-interactive harness that exercises the watcher end-to-end:

1. Seeds a tiny `raw__orders.orders` source (50 rows) into DuckDB.
2. Launches `rocky run --watch ... --output json` in the background, redirected to `expected/watch.log`.
3. Waits for the first run to settle.
4. Touches `rocky.toml` — same shape as a `:w` from vim or a save in VSCode.
5. Waits for the debounced re-run.
6. Sends SIGINT; the watch loop completes the in-flight run and exits 0.

## Notes

- The harness counts iterations via the `[watch] run completed in <ms>` banner Rocky writes to stderr after every successful iteration. This is robust against the pretty-printed vs compact JSON output difference (the JSON `RunOutput` has `"command": "run"` with whitespace after the colon, which a naive `grep '"command":"run"'` misses).
- Playground catalog counts bumped 63 → 64; developer-experience 12 → 13.
- The `.gitignore` rule for `.rocky/` from #422 already covers the new POC's runtime artefacts; no .gitignore changes here.

## Test plan

- [ ] `cd examples/playground/pocs/06-developer-experience/13-run-watch-inner-loop && ./run.sh` — exits 0; `expected/watch.log` shows two `[watch] run completed` lines bracketing one `[watch] detected change` line.
- [ ] `./run.sh` re-run is idempotent (state + duckdb torn down at the top).
- [ ] Verify on macOS that the rocky.toml touch fires correctly through FSEvents (the watcher's directory-watch + filename-filter shape was added in #423 specifically to handle atomic-rename saves).