### PR TITLE
feat(engine): map dbt generic tests in import-dbt

### DIFF
--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -253,7 +253,12 @@ fn run_importer(
 
     if let Some(ref mf) = manifest_file {
         let manifest = dbt_manifest::parse_manifest(mf).map_err(|e| anyhow::anyhow!("{e}"))?;
-        Ok(dbt::import_from_manifest(&manifest, default_target))
+        let mut result = dbt::import_from_manifest(&manifest, default_target);
+        // The manifest path doesn't itself walk schema.yml files for tests.
+        // Apply the dbt-tests pass against the project root so manifest
+        // imports also pick up the four canonical generic tests.
+        dbt::apply_dbt_tests(dbt_project, default_target, &mut result);
+        Ok(result)
     } else {
         dbt::import_dbt_project(dbt_project, default_target).map_err(|e| anyhow::anyhow!("{e}"))
     }

--- a/engine/crates/rocky-cli/tests/fixtures/dbt-rich/models/schema.yml
+++ b/engine/crates/rocky-cli/tests/fixtures/dbt-rich/models/schema.yml
@@ -1,0 +1,35 @@
+version: 2
+
+# Exercises every supported dbt → Rocky generic-test mapping plus one
+# non-canonical test that must be surfaced as a structured warning.
+models:
+  - name: stg_orders
+    description: Staged orders, one row per order line.
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+      - name: customer_id
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_customers')
+              field: customer_id
+      - name: amount
+        tests:
+          # Non-canonical: must surface as a warning, NOT stubbed in the toml.
+          - dbt_utils.accepted_range:
+              min_value: 0
+              max_value: 1000000
+
+  - name: stg_customers
+    columns:
+      - name: customer_id
+        tests:
+          - unique
+          - not_null
+      - name: status
+        tests:
+          - accepted_values:
+              values: ['active', 'inactive', 'pending']

--- a/engine/crates/rocky-cli/tests/import_dbt_emit.rs
+++ b/engine/crates/rocky-cli/tests/import_dbt_emit.rs
@@ -176,4 +176,72 @@ fn emit_runnable_repo_from_rich_fixture() {
     assert!(notes.contains("Not Translated"));
     assert!(notes.contains("Required env vars"));
     assert!(notes.contains("dbt generic tests"));
+
+    // Generic-test mapping: the four canonical built-ins land as
+    // `[[tests]]` blocks on each model sidecar. Non-canonical tests
+    // (e.g. `dbt_utils.accepted_range`) must NOT appear in the toml —
+    // they are surfaced as structured import warnings instead.
+    let stg_orders_toml = std::fs::read_to_string(models_dir.join("stg_orders.toml")).unwrap();
+    assert!(
+        stg_orders_toml.contains("[[tests]]"),
+        "stg_orders.toml should carry generic-test [[tests]] blocks"
+    );
+    assert!(stg_orders_toml.contains("type = \"unique\""));
+    assert!(stg_orders_toml.contains("type = \"not_null\""));
+    assert!(stg_orders_toml.contains("type = \"relationships\""));
+    assert!(stg_orders_toml.contains("to_column = \"customer_id\""));
+    // Relationships FQN should resolve via the imported-target map for
+    // stg_customers (which lives in the default schema).
+    assert!(
+        stg_orders_toml.contains("to_table = \""),
+        "relationships test must include a fully-qualified to_table"
+    );
+    // Non-canonical test must NOT be stubbed in the emitted toml.
+    assert!(
+        !stg_orders_toml.contains("dbt_utils"),
+        "non-canonical tests must not be stubbed as TODO entries; emitted toml should be clean"
+    );
+    assert!(
+        !stg_orders_toml.to_lowercase().contains("accepted_range"),
+        "non-canonical tests must not be stubbed as TODO entries"
+    );
+
+    let stg_customers_toml_again =
+        std::fs::read_to_string(models_dir.join("stg_customers.toml")).unwrap();
+    assert!(stg_customers_toml_again.contains("type = \"accepted_values\""));
+    assert!(stg_customers_toml_again.contains("\"active\""));
+
+    // Loaded via the canonical model loader, the tests round-trip into the
+    // typed TestDecl surface — confirming the emitted [[tests]] toml is
+    // wire-compatible with rocky-core.
+    let stg_orders = models
+        .iter()
+        .find(|m| m.config.name == "stg_orders")
+        .unwrap();
+    assert!(
+        !stg_orders.config.tests.is_empty(),
+        "stg_orders should carry at least one TestDecl after loading"
+    );
+
+    // The non-canonical test must surface as a structured warning whose
+    // category is `UnsupportedTest` (not silently dropped).
+    assert!(
+        result.warnings.iter().any(
+            |w| matches!(w.category, dbt::WarningCategory::UnsupportedTest)
+                && w.message.contains("dbt_utils.accepted_range")
+        ),
+        "expected an UnsupportedTest warning for dbt_utils.accepted_range"
+    );
+
+    // Counter check: the four canonical mappings flow through `tests_converted`
+    // (was misclassified as `tests_converted_custom` in v0). Total tests in
+    // the fixture: order_id × {unique, not_null}, customer_id × {not_null,
+    // relationships}, customer_id × {unique, not_null}, status × accepted_values,
+    // amount × dbt_utils.accepted_range.
+    assert_eq!(result.tests_found, 8, "all schema.yml tests are counted");
+    assert_eq!(result.tests_skipped, 1, "one non-canonical test skipped");
+    assert_eq!(
+        result.tests_converted, 7,
+        "seven canonical tests converted to TestDecls"
+    );
 }

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -54,6 +54,9 @@ pub enum WarningCategory {
     StaleManifest,
     /// `{{ source() }}` reference with no matching source definition.
     MissingSource,
+    /// dbt generic test outside the four canonical built-ins
+    /// (`unique` / `not_null` / `accepted_values` / `relationships`).
+    UnsupportedTest,
 }
 
 /// A warning produced during import.
@@ -152,6 +155,93 @@ pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfi
     }
 
     result
+}
+
+/// Walk a dbt project's `models/` tree for `schema.yml` files, convert any
+/// `tests:` entries to canonical Rocky [`TestDecl`]s, attach them to the
+/// matching imported model, and emit structured warnings for tests outside
+/// the four canonical built-ins. Counter fields on [`ImportResult`] are
+/// updated in place.
+///
+/// The caller passes the dbt project root (or any directory the YAMLs live
+/// under). Both the `models/` regex path and the manifest path use this
+/// helper so test mapping works whether or not a manifest is present.
+pub fn apply_dbt_tests(yaml_root: &Path, default_target: &TargetConfig, result: &mut ImportResult) {
+    let model_yamls = match super::dbt_tests::parse_model_yamls(yaml_root) {
+        Ok(map) if !map.is_empty() => map,
+        _ => return,
+    };
+
+    // Build a name → (catalog, schema) lookup for relationship FQN resolution.
+    let mut targets: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    for m in &result.imported {
+        targets.insert(
+            m.config.name.clone(),
+            (
+                m.config.target.catalog.clone(),
+                m.config.target.schema.clone(),
+            ),
+        );
+    }
+    let resolver = super::dbt_tests::ImportedTargetResolver {
+        targets: &targets,
+        default_catalog: &default_target.catalog,
+        default_schema: &default_target.schema,
+    };
+
+    for (model_name, model_yaml) in &model_yamls {
+        let total_tests: usize = model_yaml.columns.iter().map(|c| c.tests.len()).sum();
+        if total_tests == 0 {
+            // Still let YAML descriptions seed `intent` for matching imported models.
+            attach_intent(result, model_name, model_yaml.description.as_deref());
+            continue;
+        }
+        result.tests_found += total_tests;
+
+        let (decls, unsupported) = super::dbt_tests::tests_to_test_decls(model_yaml, &resolver);
+
+        result.tests_converted += decls.len();
+        result.tests_skipped += unsupported.len();
+
+        // Attach the decls to the matching imported model (if present).
+        if let Some(imported) = result.imported.iter_mut().find(|m| &m.name == model_name) {
+            imported.config.tests.extend(decls);
+        }
+
+        // Surface every unsupported test as a structured warning. Skip
+        // model-level tests (column == None) — same rule today.
+        for u in unsupported {
+            let where_ = match &u.column {
+                Some(c) => format!("column '{c}'"),
+                None => "model-level".to_string(),
+            };
+            result.warnings.push(ImportWarning {
+                model: u.model.clone(),
+                category: WarningCategory::UnsupportedTest,
+                message: format!(
+                    "dbt test '{name}' on {where_} is outside the v0 canonical set (unique, not_null, accepted_values, relationships) — not translated",
+                    name = u.test_name,
+                ),
+                suggestion: Some(
+                    "rewrite as a Rocky `[[tests]]` of type `expression` or as a custom check in a quality pipeline".to_string(),
+                ),
+            });
+        }
+
+        attach_intent(result, model_name, model_yaml.description.as_deref());
+    }
+}
+
+fn attach_intent(result: &mut ImportResult, model_name: &str, description: Option<&str>) {
+    let Some(desc) = description else {
+        return;
+    };
+    if let Some(imported) = result.imported.iter_mut().find(|m| m.name == model_name) {
+        if imported.config.intent.is_none() {
+            imported.config.intent = Some(desc.to_string());
+        }
+    }
 }
 
 fn import_manifest_node(
@@ -371,36 +461,14 @@ pub fn import_dbt_project(
         }
     }
 
-    // Phase 2: Scan for model YAML test definitions and convert to contracts
+    // Phase 2: Scan model YAML files for test definitions and convert them
+    // to canonical Rocky `[[tests]]` (`TestDecl`) entries on each imported
+    // model. Tests outside the four canonical built-ins emit structured
+    // warnings; we deliberately do NOT stub them as TODO comments in the
+    // generated rocky.toml.
     for dir in &model_dirs {
         if dir.exists() {
-            if let Ok(model_yamls) = super::dbt_tests::parse_model_yamls(dir) {
-                for (model_name, model_yaml) in &model_yamls {
-                    let (checks, skipped) = super::dbt_tests::tests_to_contracts(model_yaml);
-                    let total_tests: usize = model_yaml.columns.iter().map(|c| c.tests.len()).sum();
-                    result.tests_found += total_tests;
-                    result.tests_skipped += skipped;
-
-                    for check in &checks {
-                        if check.custom_sql.is_some() {
-                            result.tests_converted_custom += 1;
-                        } else {
-                            result.tests_converted += 1;
-                        }
-                    }
-
-                    // Set model description as intent if available and model was imported
-                    if let Some(ref desc) = model_yaml.description {
-                        if let Some(imported) =
-                            result.imported.iter_mut().find(|m| &m.name == model_name)
-                        {
-                            if imported.config.intent.is_none() {
-                                imported.config.intent = Some(desc.clone());
-                            }
-                        }
-                    }
-                }
-            }
+            apply_dbt_tests(dir, default_target, &mut result);
         }
     }
 

--- a/engine/crates/rocky-compiler/src/import/dbt_tests.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_tests.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use rocky_core::tests::{TestDecl, TestSeverity, TestType};
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -315,6 +317,191 @@ pub fn tests_to_contracts(model: &DbtModelYaml) -> (Vec<ContractCheck>, usize) {
 
     (checks, skipped)
 }
+
+// ---------------------------------------------------------------------------
+// Test -> TestDecl conversion (canonical Rocky model `[[tests]]` mapping)
+// ---------------------------------------------------------------------------
+
+/// A dbt test that did not map to a canonical Rocky [`TestDecl`].
+///
+/// Surfaced as a structured import warning so callers can act on the
+/// long tail (e.g. `dbt_utils.*`, `dbt_expectations.*`, project-defined
+/// generic tests) without losing visibility.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedTest {
+    /// The dbt model name the test was attached to.
+    pub model: String,
+    /// The column the test was attached to. `None` means the test was
+    /// declared at model level (Rocky's canonical four are all
+    /// column-level; model-level tests always land here).
+    pub column: Option<String>,
+    /// Test name as it appeared in `schema.yml` (e.g. `dbt_utils.accepted_range`).
+    pub test_name: String,
+}
+
+/// How [`tests_to_test_decls`] resolves a `relationships.to: ref('m')`
+/// reference to a Rocky FQN (`catalog.schema.table`).
+pub trait RelationshipResolver {
+    /// Return the fully-qualified Rocky table name for `model_name`.
+    fn resolve(&self, model_name: &str) -> String;
+}
+
+/// Resolve via an explicit lookup map of imported model targets, with
+/// a default fallback for cross-project refs the importer didn't see.
+pub struct ImportedTargetResolver<'a> {
+    pub targets: &'a HashMap<String, (String, String)>,
+    pub default_catalog: &'a str,
+    pub default_schema: &'a str,
+}
+
+impl RelationshipResolver for ImportedTargetResolver<'_> {
+    fn resolve(&self, model_name: &str) -> String {
+        match self.targets.get(model_name) {
+            Some((catalog, schema)) => format!("{catalog}.{schema}.{model_name}"),
+            None => format!(
+                "{}.{}.{}",
+                self.default_catalog, self.default_schema, model_name
+            ),
+        }
+    }
+}
+
+/// Convert dbt model tests to canonical Rocky [`TestDecl`]s.
+///
+/// Mapping (v0 — the four canonical dbt built-ins only):
+///
+/// | dbt test | Rocky [`TestType`] |
+/// |---|---|
+/// | `not_null` | [`TestType::NotNull`] |
+/// | `unique` | [`TestType::Unique`] |
+/// | `accepted_values: { values: [...] }` | [`TestType::AcceptedValues`] |
+/// | `relationships: { to: ref('m'), field: 'c' }` | [`TestType::Relationships`] |
+///
+/// Anything else (`dbt_utils.*`, `dbt_expectations.*`, project-defined
+/// generic tests, model-level tests) is returned in the [`UnsupportedTest`]
+/// list. The caller is expected to surface those as import warnings —
+/// the v0 emitter does **not** stub them as TODO comments in the
+/// generated rocky.toml.
+pub fn tests_to_test_decls(
+    model: &DbtModelYaml,
+    resolver: &dyn RelationshipResolver,
+) -> (Vec<TestDecl>, Vec<UnsupportedTest>) {
+    let mut decls = Vec::new();
+    let mut unsupported = Vec::new();
+
+    for col in &model.columns {
+        for test in &col.tests {
+            match test {
+                DbtTestDef::Simple(name) => match name.as_str() {
+                    "not_null" => {
+                        decls.push(TestDecl {
+                            test_type: TestType::NotNull,
+                            column: Some(col.name.clone()),
+                            severity: TestSeverity::Error,
+                            filter: None,
+                        });
+                    }
+                    "unique" => {
+                        decls.push(TestDecl {
+                            test_type: TestType::Unique,
+                            column: Some(col.name.clone()),
+                            severity: TestSeverity::Error,
+                            filter: None,
+                        });
+                    }
+                    other => {
+                        unsupported.push(UnsupportedTest {
+                            model: model.name.clone(),
+                            column: Some(col.name.clone()),
+                            test_name: other.to_string(),
+                        });
+                    }
+                },
+                DbtTestDef::Configured { name, config } => match name.as_str() {
+                    "accepted_values" => match accepted_values_decl(&col.name, config) {
+                        Some(decl) => decls.push(decl),
+                        None => unsupported.push(UnsupportedTest {
+                            model: model.name.clone(),
+                            column: Some(col.name.clone()),
+                            test_name: "accepted_values".to_string(),
+                        }),
+                    },
+                    "relationships" => match relationships_decl(&col.name, config, resolver) {
+                        Some(decl) => decls.push(decl),
+                        None => unsupported.push(UnsupportedTest {
+                            model: model.name.clone(),
+                            column: Some(col.name.clone()),
+                            test_name: "relationships".to_string(),
+                        }),
+                    },
+                    other => {
+                        unsupported.push(UnsupportedTest {
+                            model: model.name.clone(),
+                            column: Some(col.name.clone()),
+                            test_name: other.to_string(),
+                        });
+                    }
+                },
+            }
+        }
+    }
+
+    (decls, unsupported)
+}
+
+fn accepted_values_decl(
+    col_name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> Option<TestDecl> {
+    let raw = config.get("values")?;
+    let values: Vec<String> = match raw {
+        serde_yaml::Value::Sequence(seq) => seq
+            .iter()
+            .filter_map(|v| match v {
+                serde_yaml::Value::String(s) => Some(s.clone()),
+                serde_yaml::Value::Number(n) => Some(n.to_string()),
+                serde_yaml::Value::Bool(b) => Some(b.to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => return None,
+    };
+
+    if values.is_empty() {
+        return None;
+    }
+
+    Some(TestDecl {
+        test_type: TestType::AcceptedValues { values },
+        column: Some(col_name.to_string()),
+        severity: TestSeverity::Error,
+        filter: None,
+    })
+}
+
+fn relationships_decl(
+    col_name: &str,
+    config: &HashMap<String, serde_yaml::Value>,
+    resolver: &dyn RelationshipResolver,
+) -> Option<TestDecl> {
+    let to_raw = config.get("to")?.as_str()?;
+    let field = config.get("field")?.as_str()?;
+    let ref_model = extract_ref_model(to_raw).unwrap_or(to_raw);
+
+    Some(TestDecl {
+        test_type: TestType::Relationships {
+            to_table: resolver.resolve(ref_model),
+            to_column: field.to_string(),
+        },
+        column: Some(col_name.to_string()),
+        severity: TestSeverity::Error,
+        filter: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Legacy ContractCheck conversion (kept for `validate-migration`)
+// ---------------------------------------------------------------------------
 
 fn convert_accepted_values(
     model_name: &str,
@@ -956,6 +1143,273 @@ models:
     #[test]
     fn test_extract_ref_model_not_ref() {
         assert_eq!(extract_ref_model("dim_customers"), None);
+    }
+
+    // --- TestDecl mapper tests (canonical four built-ins) ---
+
+    fn default_resolver() -> ImportedTargetResolver<'static> {
+        // Empty target map — every relationships ref falls back to defaults.
+        // Use Box::leak to keep the lifetime simple in tests.
+        let map: &'static HashMap<String, (String, String)> = Box::leak(Box::new(HashMap::new()));
+        ImportedTargetResolver {
+            targets: map,
+            default_catalog: "warehouse",
+            default_schema: "main",
+        }
+    }
+
+    #[test]
+    fn test_decl_simple_unique_and_not_null() {
+        let model = DbtModelYaml {
+            name: "fct_orders".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "order_id".to_string(),
+                description: None,
+                tests: vec![
+                    DbtTestDef::Simple("unique".to_string()),
+                    DbtTestDef::Simple("not_null".to_string()),
+                ],
+            }],
+        };
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 2);
+        assert!(
+            decls.iter().any(|d| matches!(d.test_type, TestType::Unique)
+                && d.column.as_deref() == Some("order_id"))
+        );
+        assert!(
+            decls
+                .iter()
+                .any(|d| matches!(d.test_type, TestType::NotNull)
+                    && d.column.as_deref() == Some("order_id"))
+        );
+    }
+
+    #[test]
+    fn test_decl_accepted_values_string_and_number() {
+        let mut config = HashMap::new();
+        config.insert(
+            "values".to_string(),
+            serde_yaml::Value::Sequence(vec![
+                serde_yaml::Value::String("active".to_string()),
+                serde_yaml::Value::String("inactive".to_string()),
+                serde_yaml::Value::Number(serde_yaml::Number::from(7)),
+            ]),
+        );
+        let model = DbtModelYaml {
+            name: "users".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "status".to_string(),
+                description: None,
+                tests: vec![DbtTestDef::Configured {
+                    name: "accepted_values".to_string(),
+                    config,
+                }],
+            }],
+        };
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::AcceptedValues { values } => {
+                assert_eq!(values, &["active", "inactive", "7"]);
+            }
+            _ => panic!("expected AcceptedValues"),
+        }
+    }
+
+    #[test]
+    fn test_decl_relationships_uses_resolver() {
+        let mut config = HashMap::new();
+        config.insert(
+            "to".to_string(),
+            serde_yaml::Value::String("ref('dim_customers')".to_string()),
+        );
+        config.insert(
+            "field".to_string(),
+            serde_yaml::Value::String("customer_id".to_string()),
+        );
+        let model = DbtModelYaml {
+            name: "fct_orders".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "customer_id".to_string(),
+                description: None,
+                tests: vec![DbtTestDef::Configured {
+                    name: "relationships".to_string(),
+                    config,
+                }],
+            }],
+        };
+
+        // Build a resolver that knows where dim_customers lives.
+        let mut targets = HashMap::new();
+        targets.insert(
+            "dim_customers".to_string(),
+            ("analytics".to_string(), "marts".to_string()),
+        );
+        let resolver = ImportedTargetResolver {
+            targets: &targets,
+            default_catalog: "warehouse",
+            default_schema: "main",
+        };
+
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert!(unsupported.is_empty());
+        assert_eq!(decls.len(), 1);
+        match &decls[0].test_type {
+            TestType::Relationships {
+                to_table,
+                to_column,
+            } => {
+                assert_eq!(to_table, "analytics.marts.dim_customers");
+                assert_eq!(to_column, "customer_id");
+            }
+            _ => panic!("expected Relationships"),
+        }
+    }
+
+    #[test]
+    fn test_decl_relationships_falls_back_to_defaults_for_unknown_ref() {
+        let mut config = HashMap::new();
+        config.insert(
+            "to".to_string(),
+            serde_yaml::Value::String("ref('external_dim')".to_string()),
+        );
+        config.insert(
+            "field".to_string(),
+            serde_yaml::Value::String("id".to_string()),
+        );
+        let model = DbtModelYaml {
+            name: "fct".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "external_id".to_string(),
+                description: None,
+                tests: vec![DbtTestDef::Configured {
+                    name: "relationships".to_string(),
+                    config,
+                }],
+            }],
+        };
+        let resolver = default_resolver();
+        let (decls, _) = tests_to_test_decls(&model, &resolver);
+        match &decls[0].test_type {
+            TestType::Relationships { to_table, .. } => {
+                assert_eq!(to_table, "warehouse.main.external_dim");
+            }
+            _ => panic!("expected Relationships"),
+        }
+    }
+
+    #[test]
+    fn test_decl_unsupported_simple_and_configured() {
+        let mut config = HashMap::new();
+        config.insert(
+            "min_value".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(0)),
+        );
+        let model = DbtModelYaml {
+            name: "model".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "amount".to_string(),
+                description: None,
+                tests: vec![
+                    DbtTestDef::Simple("project_macro_test".to_string()),
+                    DbtTestDef::Configured {
+                        name: "dbt_utils.accepted_range".to_string(),
+                        config,
+                    },
+                ],
+            }],
+        };
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert!(decls.is_empty());
+        assert_eq!(unsupported.len(), 2);
+        assert!(
+            unsupported
+                .iter()
+                .any(|u| u.test_name == "project_macro_test")
+        );
+        assert!(
+            unsupported
+                .iter()
+                .any(|u| u.test_name == "dbt_utils.accepted_range")
+        );
+        for u in &unsupported {
+            assert_eq!(u.model, "model");
+            assert_eq!(u.column.as_deref(), Some("amount"));
+        }
+    }
+
+    #[test]
+    fn test_decl_accepted_values_empty_or_malformed_unsupported() {
+        // Empty list — unsupported.
+        let mut config = HashMap::new();
+        config.insert("values".to_string(), serde_yaml::Value::Sequence(vec![]));
+        let model = DbtModelYaml {
+            name: "m".to_string(),
+            description: None,
+            columns: vec![DbtColumnYaml {
+                name: "c".to_string(),
+                description: None,
+                tests: vec![DbtTestDef::Configured {
+                    name: "accepted_values".to_string(),
+                    config,
+                }],
+            }],
+        };
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert!(decls.is_empty());
+        assert_eq!(unsupported.len(), 1);
+        assert_eq!(unsupported[0].test_name, "accepted_values");
+    }
+
+    #[test]
+    fn test_decl_mixed_canonical_and_unsupported() {
+        let mut av_cfg = HashMap::new();
+        av_cfg.insert(
+            "values".to_string(),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("a".to_string())]),
+        );
+        let model = DbtModelYaml {
+            name: "users".to_string(),
+            description: None,
+            columns: vec![
+                DbtColumnYaml {
+                    name: "id".to_string(),
+                    description: None,
+                    tests: vec![
+                        DbtTestDef::Simple("unique".to_string()),
+                        DbtTestDef::Simple("not_null".to_string()),
+                    ],
+                },
+                DbtColumnYaml {
+                    name: "status".to_string(),
+                    description: None,
+                    tests: vec![
+                        DbtTestDef::Configured {
+                            name: "accepted_values".to_string(),
+                            config: av_cfg,
+                        },
+                        DbtTestDef::Simple("custom_check".to_string()),
+                    ],
+                },
+            ],
+        };
+        let resolver = default_resolver();
+        let (decls, unsupported) = tests_to_test_decls(&model, &resolver);
+        assert_eq!(decls.len(), 3);
+        assert_eq!(unsupported.len(), 1);
+        assert_eq!(unsupported[0].test_name, "custom_check");
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use rocky_core::models::{ModelConfig, StrategyConfig};
+use rocky_core::tests::{TestDecl, TestSeverity, TestType};
 
 use super::dbt::{ImportResult, ImportedModel, WarningCategory};
 use super::dbt_profiles::ProfileResolution;
@@ -295,6 +296,69 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
             out.push_str(&format!("table = \"{}\"\n", src.table));
         }
     }
+
+    if !config.tests.is_empty() {
+        for test in &config.tests {
+            out.push('\n');
+            out.push_str(&render_test_decl(test));
+        }
+    }
+    out
+}
+
+/// Serialise a [`TestDecl`] as a `[[tests]]` block matching the canonical
+/// Rocky model sidecar shape (`type = "..."`, `column = "..."`, plus
+/// type-specific fields). Mirrors the derived serde untagged shape used
+/// by `rocky-core::tests` so the emitted TOML round-trips through the
+/// model loader.
+fn render_test_decl(test: &TestDecl) -> String {
+    let mut out = String::new();
+    out.push_str("[[tests]]\n");
+    match &test.test_type {
+        TestType::NotNull => {
+            out.push_str("type = \"not_null\"\n");
+        }
+        TestType::Unique => {
+            out.push_str("type = \"unique\"\n");
+        }
+        TestType::AcceptedValues { values } => {
+            out.push_str("type = \"accepted_values\"\n");
+            let escaped: Vec<String> = values
+                .iter()
+                .map(|v| format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\"")))
+                .collect();
+            out.push_str(&format!("values = [{}]\n", escaped.join(", ")));
+        }
+        TestType::Relationships {
+            to_table,
+            to_column,
+        } => {
+            out.push_str("type = \"relationships\"\n");
+            out.push_str(&format!("to_table = \"{to_table}\"\n"));
+            out.push_str(&format!("to_column = \"{to_column}\"\n"));
+        }
+        // The v0 dbt importer maps only the four canonical built-ins to
+        // `TestDecl`. Anything else here would be programmer error — emit
+        // toml that won't load is worse than a panic, so refuse to render.
+        other => {
+            unreachable!(
+                "rocky import-dbt only produces NotNull/Unique/AcceptedValues/Relationships TestDecls; got {:?}",
+                std::mem::discriminant(other)
+            );
+        }
+    }
+    if let Some(col) = &test.column {
+        out.push_str(&format!("column = \"{col}\"\n"));
+    }
+    if test.severity != TestSeverity::Error {
+        out.push_str("severity = \"warning\"\n");
+    }
+    if let Some(filter) = &test.filter {
+        out.push_str(&format!(
+            "filter = \"{}\"\n",
+            filter.replace('\\', "\\\\").replace('"', "\\\"")
+        ));
+    }
     out
 }
 
@@ -418,7 +482,7 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
     out.push_str(&format!("- Models skipped: {}\n", ctx.models_skipped));
     out.push_str(&format!("- Seeds copied: {}\n", ctx.seeds_copied));
     out.push_str(&format!(
-        "- dbt tests detected (NOT translated in v0): {}\n",
+        "- dbt tests detected (canonical four mapped to `[[tests]]`; non-canonical surfaced as warnings): {}\n",
         ctx.tests_skipped
     ));
     out.push_str(&format!(
@@ -439,9 +503,15 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
 
     out.push_str("## Not Translated (v0 limitations)\n\n");
     out.push_str(
-        "- **dbt generic tests (`unique`, `not_null`, `accepted_values`, `relationships`)** ",
+        "- **dbt generic tests outside the canonical four** (`unique`, `not_null`, `accepted_values`, ",
     );
-    out.push_str("— map to Rocky `[[checks]]` blocks in a follow-up. Detected count above.\n");
+    out.push_str(
+        "`relationships` are translated to `[[tests]]` on each model sidecar). Anything else ",
+    );
+    out.push_str(
+        "(`dbt_utils.*`, `dbt_expectations.*`, project-defined generic tests, model-level tests) ",
+    );
+    out.push_str("is surfaced under the **Warnings** section below — not stubbed in the SQL.\n");
     out.push_str("- **Singular tests** in `tests/` (custom SQL) — copy and rewrite manually.\n");
     out.push_str("- **dbt macros / `dbt_packages/`** — Rocky has no Jinja runtime. Hand-port any ");
     out.push_str("logic to plain SQL or to a Rocky AI prompt.\n");

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -128,7 +128,9 @@ pub fn generate_report(
         },
         model_count: import_result.imported.len() + import_result.failed.len(),
         source_count: import_result.sources_found,
-        test_count: test_stats.map(|t| t.found).unwrap_or(0),
+        test_count: test_stats
+            .map(|t| t.found)
+            .unwrap_or(import_result.tests_found),
     };
 
     // Count models with warnings
@@ -178,6 +180,10 @@ pub fn generate_report(
             .saturating_sub(import_result.sources_mapped),
     };
 
+    // Prefer caller-supplied stats (richer `by_type` breakdown). Fall back
+    // to the per-import counters populated by the dbt-tests pass so that
+    // `rocky import-dbt` always surfaces test counts in the report, even
+    // when the caller doesn't track stats separately.
     let tests = test_stats
         .map(|t| TestsSummary {
             found: t.found,
@@ -187,10 +193,10 @@ pub fn generate_report(
             by_type: t.by_type.clone(),
         })
         .unwrap_or(TestsSummary {
-            found: 0,
-            converted: 0,
-            converted_custom: 0,
-            skipped: 0,
+            found: import_result.tests_found,
+            converted: import_result.tests_converted,
+            converted_custom: import_result.tests_converted_custom,
+            skipped: import_result.tests_skipped,
             by_type: HashMap::new(),
         });
 

--- a/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/dbt_project/models/schema.yml
+++ b/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/dbt_project/models/schema.yml
@@ -1,0 +1,37 @@
+version: 2
+
+# Demonstrates `rocky import-dbt` mapping each of dbt's four canonical
+# generic tests onto Rocky `[[tests]]` blocks plus surfacing one
+# non-canonical test as a structured warning.
+models:
+  - name: stg_orders
+    description: Staged orders, one row per order, with a normalised status.
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+      - name: customer_id
+        tests:
+          - not_null
+      - name: status
+        tests:
+          - accepted_values:
+              values: ['pending', 'completed', 'shipped']
+
+  - name: fct_revenue
+    description: Per-customer revenue rollup.
+    columns:
+      - name: customer_id
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: customer_id
+      - name: total_revenue
+        tests:
+          # Non-canonical: must surface as an `UnsupportedTest` warning,
+          # not stubbed in the emitted rocky.toml.
+          - dbt_utils.accepted_range:
+              min_value: 0


### PR DESCRIPTION
## Summary

`rocky import-dbt` now translates dbt's four canonical built-in generic tests directly into Rocky model `[[tests]]` blocks, with anything else surfaced as a structured warning rather than dropped or stubbed in the emitted SQL.

## Mappings

| dbt schema.yml test | Rocky `TestDecl` (`[[tests]]` in model sidecar) |
|---|---|
| `unique` | `type = "unique"` + `column = "<col>"` |
| `not_null` | `type = "not_null"` + `column = "<col>"` |
| `accepted_values: { values: [...] }` | `type = "accepted_values"` + `values = [...]` + `column` |
| `relationships: { to: ref('m'), field: 'c' }` | `type = "relationships"` + `to_table = "<catalog>.<schema>.m"` + `to_column = "c"` + `column` |

`relationships.to_table` resolves through a `name → (catalog, schema)` lookup built from the imported model set, so refs to models with overridden targets land at the right FQN. Cross-project refs fall back to the importer defaults.

## Unsupported tests

Tests outside the four canonical built-ins (`dbt_utils.*`, `dbt_expectations.*`, project-defined generics, model-level tests) now raise a new `WarningCategory::UnsupportedTest` per occurrence. They are **not** stubbed as TODO comments in the emitted rocky.toml — the warning carries the model, column, and test name plus a suggestion to rewrite as a Rocky `expression` test or a quality-pipeline check.

## Counter realignment

`accepted_values` and `relationships` previously flowed through `tests_converted_custom` (custom-SQL contract path, never written to disk). They now flow through `tests_converted` and land as first-class typed tests. `tests_converted_custom` stays at 0 for canonical mappings; non-canonical tests move from `tests_converted_custom` to `tests_skipped`.

## Fixture coverage

- `engine/crates/rocky-cli/tests/fixtures/dbt-rich/models/schema.yml` exercises all four built-ins plus one non-canonical (`dbt_utils.accepted_range`) test.
- `examples/playground/pocs/06-developer-experience/03-import-dbt-validate/dbt_project/models/schema.yml` mirrors the same coverage so `./run.sh` (compile + validate-migration) walks the new path end-to-end.

## Codegen

No `*Output` struct fields were changed (`ImportDbtOutput.warnings` already serialises `category` as a free-form string, and the new `UnsupportedTest` variant is just a new value). `cargo run --bin rocky -- export-schemas schemas/` produced no diff — codegen cascade is not required.

## Test plan

- [x] `cargo test -p rocky-compiler --lib import::` (107 passing, 7 new mapper tests)
- [x] `cargo test -p rocky-cli --test import_dbt_emit` (integration: emitted `[[tests]]` shape, structured-warning category, no stubbed TODOs in toml)
- [x] `cargo test -p rocky-cli` (370 passing)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p rocky-compiler -p rocky-cli -- -D warnings` clean
- [x] `./examples/playground/pocs/06-developer-experience/03-import-dbt-validate/run.sh` — emits `[[tests]]` blocks per model, `rocky compile` returns 0 diagnostics, `rocky validate-migration` reports 8 tests / 7 contracts
- [x] `cargo run --bin rocky -- export-schemas schemas/` produces no diff (no codegen cascade needed)

## Boundaries held

- `dbt_utils.*` / `dbt_expectations.*` are demand-gated for a future PR — not scaffolded here.
- The legacy `tests_to_contracts` path is left untouched; `validate-migration` still uses it.
- `MIGRATION-NOTES.md` text updated to reflect that the canonical four are now translated.