### PR TITLE
fix(engine): include trino, bigquery, airbyte, iceberg in validate known-types

### DIFF
--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -382,6 +382,42 @@ fn validate_adapter(
                 field: None,
             });
         }
+        "bigquery" => {
+            msgs.push(ValidateMessage {
+                severity: "ok".into(),
+                code: "V010".into(),
+                message: format!("adapter.{name}: bigquery"),
+                file: None,
+                field: None,
+            });
+        }
+        "trino" => {
+            msgs.push(ValidateMessage {
+                severity: "ok".into(),
+                code: "V010".into(),
+                message: format!("adapter.{name}: trino"),
+                file: None,
+                field: None,
+            });
+        }
+        "airbyte" => {
+            msgs.push(ValidateMessage {
+                severity: "ok".into(),
+                code: "V010".into(),
+                message: format!("adapter.{name}: airbyte"),
+                file: None,
+                field: None,
+            });
+        }
+        "iceberg" => {
+            msgs.push(ValidateMessage {
+                severity: "ok".into(),
+                code: "V010".into(),
+                message: format!("adapter.{name}: iceberg"),
+                file: None,
+                field: None,
+            });
+        }
         other => {
             ok = false;
             msgs.push(ValidateMessage {
@@ -1303,6 +1339,54 @@ table = "b"
             .collect();
         assert_eq!(dag_errors.len(), 1);
         assert!(dag_errors[0].message.contains("circular"));
+    }
+
+    #[test]
+    fn test_known_adapter_types_do_not_warn() {
+        // Every adapter type recognized by `registry::AdapterRegistry` must
+        // also be recognized by `validate_adapter`, otherwise a perfectly
+        // valid `rocky.toml` emits a cosmetic V017 warning. Keep this list
+        // in sync with the match arms in `engine/crates/rocky-cli/src/registry.rs`.
+        for adapter_type in [
+            "databricks",
+            "duckdb",
+            "snowflake",
+            "bigquery",
+            "trino",
+            "fivetran",
+            "airbyte",
+            "iceberg",
+            "manual",
+        ] {
+            let toml = format!(
+                r#"
+[adapter.x]
+type = "{adapter_type}"
+
+[pipeline.poc]
+type = "replication"
+
+[pipeline.poc.source]
+adapter = "x"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+adapter = "x"
+catalog_template = "poc"
+schema_template = "demo"
+"#
+            );
+            let out = validate_toml(&toml);
+            let v017: Vec<_> = out.messages.iter().filter(|m| m.code == "V017").collect();
+            assert!(
+                v017.is_empty(),
+                "type '{adapter_type}' unexpectedly emitted V017: {v017:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

`rocky validate` maintains its own hardcoded list of known adapter types in `validate_adapter` (`engine/crates/rocky-cli/src/commands/validate.rs`). That list had drifted from the actual `AdapterRegistry` in `engine/crates/rocky-cli/src/registry.rs`, so a perfectly valid `rocky.toml` using `type = "trino"` emitted a cosmetic `V017: unknown type 'trino'` warning even though the registry happily constructs the adapter. Called out by PR #432 as out-of-scope follow-up.

Three other adapter types were quietly missing too: `bigquery`, `airbyte`, `iceberg`.

## What this PR does

- Adds match arms in `validate_adapter` for `trino`, `bigquery`, `airbyte`, `iceberg` — each emits a `V010` ok message matching the existing pattern.
- Adds `test_known_adapter_types_do_not_warn` that loops every adapter type the registry recognizes and asserts none emits `V017`. Future drift breaks the test.

## Why hardcoded (not registry-driven)

The preferred fix would be querying the registry directly. The registry has no `known_types()` / list-known-adapters API today, and adding one would mean either pulling the type list out of the big match block in `AdapterRegistry::from_config` or threading a static list through the adapter crates — meaningfully bigger than a cosmetic warning fix. The new test plus the doc comment pointing at `registry.rs` are the minimum needed to catch recurrence; promoting to a registry query is a clean follow-up if/when the SDK unification work touches that area.

## Test plan

- [x] `cargo test -p rocky-cli` (13 validate tests pass, including new one)
- [x] `cargo clippy -p rocky-cli --lib --tests -- -D warnings`
- [x] `cargo fmt -- --check`

No `*Output` struct touched, no codegen cascade needed.