### PR TITLE
refactor(engine): drive validate known-types from registry

### DIFF
--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -419,14 +419,31 @@ fn validate_adapter(
             });
         }
         other => {
-            ok = false;
-            msgs.push(ValidateMessage {
-                severity: "warn".into(),
-                code: "V017".into(),
-                message: format!("adapter.{name}: unknown type '{other}'"),
-                file: None,
-                field: Some(format!("adapter.{name}.type")),
-            });
+            // Catchall: types the registry knows how to construct but
+            // for which `validate_adapter` has no per-type credential
+            // checks (V011-V016) emit a generic V010 ok rather than a
+            // cosmetic V017. Genuinely unrecognised types still warn.
+            // Driving this off `AdapterRegistry::is_known` keeps V017
+            // drift-proof against future adapter additions — adding a
+            // new dispatch arm in `registry.rs` is enough.
+            if crate::registry::AdapterRegistry::is_known(other) {
+                msgs.push(ValidateMessage {
+                    severity: "ok".into(),
+                    code: "V010".into(),
+                    message: format!("adapter.{name}: {other}"),
+                    file: None,
+                    field: None,
+                });
+            } else {
+                ok = false;
+                msgs.push(ValidateMessage {
+                    severity: "warn".into(),
+                    code: "V017".into(),
+                    message: format!("adapter.{name}: unknown type '{other}'"),
+                    file: None,
+                    field: Some(format!("adapter.{name}.type")),
+                });
+            }
         }
     }
 
@@ -1343,21 +1360,13 @@ table = "b"
 
     #[test]
     fn test_known_adapter_types_do_not_warn() {
-        // Every adapter type recognized by `registry::AdapterRegistry` must
-        // also be recognized by `validate_adapter`, otherwise a perfectly
-        // valid `rocky.toml` emits a cosmetic V017 warning. Keep this list
-        // in sync with the match arms in `engine/crates/rocky-cli/src/registry.rs`.
-        for adapter_type in [
-            "databricks",
-            "duckdb",
-            "snowflake",
-            "bigquery",
-            "trino",
-            "fivetran",
-            "airbyte",
-            "iceberg",
-            "manual",
-        ] {
+        // Every adapter type recognised by `AdapterRegistry` must also
+        // be recognised by `validate_adapter`, otherwise a perfectly
+        // valid `rocky.toml` emits a cosmetic V017 warning. Driving the
+        // loop directly off `AdapterRegistry::known_types()` keeps this
+        // test drift-proof — adding a new adapter to the registry
+        // automatically adds it to this regression set.
+        for adapter_type in crate::registry::AdapterRegistry::known_types() {
             let toml = format!(
                 r#"
 [adapter.x]

--- a/engine/crates/rocky-cli/src/error_reporter.rs
+++ b/engine/crates/rocky-cli/src/error_reporter.rs
@@ -40,17 +40,11 @@ pub struct ConfigDiagnostic {
 }
 
 /// Known adapter type names for "did you mean?" suggestions.
-pub const KNOWN_ADAPTER_TYPES: &[&str] = &[
-    "databricks",
-    "duckdb",
-    "snowflake",
-    "bigquery",
-    "trino",
-    "fivetran",
-    "airbyte",
-    "iceberg",
-    "manual",
-];
+///
+/// Re-exports the canonical list owned by [`crate::registry`] so the
+/// dispatch arms, the validator's V017 check, and these "did you mean?"
+/// suggestions all read from one source of truth.
+pub use crate::registry::KNOWN_ADAPTER_TYPES;
 
 /// Attempt to convert an `anyhow::Error` into a rich [`ConfigDiagnostic`].
 ///

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -47,6 +47,26 @@ use rocky_bigquery::connector::BigQueryAdapter;
 
 use rocky_trino::{TrinoAdapter, TrinoAuth, TrinoClientConfig};
 
+/// Adapter type strings recognised by [`AdapterRegistry::from_config`].
+///
+/// This is the **single source of truth** for "which adapter types does
+/// Rocky know about?". The dispatch arms in `from_config`, the
+/// "did you mean?" suggestions in [`crate::error_reporter`], and the
+/// `rocky validate` V017 ("unknown adapter type") check all read from
+/// this list — adding a new adapter only requires appending here and
+/// implementing the corresponding dispatch arm.
+pub const KNOWN_ADAPTER_TYPES: &[&str] = &[
+    "databricks",
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "trino",
+    "fivetran",
+    "airbyte",
+    "iceberg",
+    "manual",
+];
+
 /// Holds constructed adapter instances, keyed by name from the config.
 pub struct AdapterRegistry {
     warehouse: HashMap<String, Arc<dyn WarehouseAdapter>>,
@@ -64,6 +84,23 @@ pub struct AdapterRegistry {
 }
 
 impl AdapterRegistry {
+    /// Returns the list of adapter type strings the registry knows how
+    /// to construct.
+    ///
+    /// Drift-proofs callers (e.g. `rocky validate`'s V017 check, the
+    /// "did you mean?" suggester) against future adapter additions:
+    /// append to [`KNOWN_ADAPTER_TYPES`] and every consumer picks it up.
+    pub fn known_types() -> &'static [&'static str] {
+        KNOWN_ADAPTER_TYPES
+    }
+
+    /// Returns `true` if `adapter_type` is a recognised adapter type.
+    ///
+    /// Convenience wrapper over [`Self::known_types`].
+    pub fn is_known(adapter_type: &str) -> bool {
+        KNOWN_ADAPTER_TYPES.contains(&adapter_type)
+    }
+
     /// Build the registry from a `RockyConfig`.
     pub fn from_config(config: &RockyConfig) -> Result<Self> {
         let mut warehouse = HashMap::new();
@@ -363,11 +400,11 @@ impl AdapterRegistry {
                 other => {
                     let mut msg = format!(
                         "adapters.{name}: unsupported adapter type '{other}'. \
-                         Supported: databricks, duckdb, snowflake, bigquery, \
-                         trino, fivetran, airbyte, iceberg, manual"
+                         Supported: {}",
+                        KNOWN_ADAPTER_TYPES.join(", "),
                     );
                     if let Some(suggestion) =
-                        error_reporter::did_you_mean(other, error_reporter::KNOWN_ADAPTER_TYPES)
+                        error_reporter::did_you_mean(other, KNOWN_ADAPTER_TYPES)
                     {
                         msg.push_str(&format!(". Did you mean '{suggestion}'?"));
                     }


### PR DESCRIPTION
## Summary

Successor to #435. That PR fixed a real bug (trino/bigquery/airbyte/iceberg emitting V017 + `valid: false` on perfectly valid configs) by hardcoding the known-types list inside `validate.rs`. Same fix here, made drift-proof.

**Problem:** Two hardcoded copies of the adapter type list (`error_reporter::KNOWN_ADAPTER_TYPES` and an implicit list inside `validate_adapter`'s match arms), kept in sync by a regression test that itself hardcoded the list. Adding a new adapter risked silent regression on all three sites.

**Fix:** `AdapterRegistry` becomes the single source of truth:

- `KNOWN_ADAPTER_TYPES` lives in `registry.rs`; `error_reporter` re-exports it.
- New API: `AdapterRegistry::known_types()` and `is_known()`.
- `validate.rs`'s catchall now branches on `is_known()` — registered types emit V010, only genuinely unknown types still warn V017. Per-type credential checks (V011-V016) untouched.
- Regression test loops directly over `known_types()`, so it can never go stale.
- Bonus: `from_config`'s "unsupported adapter type" bail message now joins the constant instead of hardcoding the supported list.

Adding a new adapter from now on: one entry in `KNOWN_ADAPTER_TYPES` + the dispatch arm in `from_config`. Validate, did-you-mean suggestions, and the regression guard all pick it up automatically.

## Test plan

- [x] `cargo test -p rocky-cli --lib` — 371 pass, 0 fail (including all 13 validate tests; `test_known_adapter_types_do_not_warn` now iterates over the registry)
- [x] `cargo clippy -p rocky-cli --lib --tests -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] End-to-end: `rocky -c examples/playground/pocs/07-adapters/07-trino-docker/rocky.toml validate --output json` → `valid: true`, zero V017 messages