### PR TITLE
feat(vscode): activity bar UX overhaul (Get Started / Info / Help)

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] — 2026-05-07
+
+Activity bar UX overhaul. The Rocky sidebar now leads with a **Get Started** welcome panel and a structured **Extension Info** tree (extension version, Rocky CLI version, language-server status, configuration, detected `rocky.toml`, log shortcuts), and ends with a **Help** panel linking out to docs / issues / marketplace / releases / source. Existing Models, Runs, and Sources panels stay in place but switch their inline empty-state messages to `viewsWelcome` markdown gated by a new `rocky.hasProject` context — so a workspace with no `rocky.toml` shows orientation instead of CLI errors.
+
+### Added
+
+- **Activity bar — `Get Started` panel** (markdown via `viewsWelcome`). Three context variants: empty workspace prompts to open a folder; workspace without `rocky.toml` shows `Initialize Rocky Project` / `Try Playground` / `Open Documentation`; workspace with a Rocky project shows quick actions (`Compile`, `Plan`, `Run`, `Discover Sources`, `Run Health Check`).
+- **Activity bar — `Extension Info` panel** (`src/views/extensionInfoView.ts`). Four sections: About (extension + CLI version, LSP status), Configuration (server path, inlay hints, extra args — each leaf opens its setting), Project (detected `rocky.toml` paths, workspace folder), Logs & Diagnostics (Show Output Channel / Run Doctor / Restart Language Server). LSP status updates live via a new lifecycle emitter; CLI version cached for 60s.
+- **Activity bar — `Help` panel** (`src/views/helpView.ts`). Five fixed leaves: Documentation, Report a Bug, View on Marketplace, Releases & Changelog, Source Code. Each opens the URL via the built-in `vscode.open` command.
+- **Empty-state `viewsWelcome` for Models / Runs / Sources** — gated by `rocky.hasProject` so the copy and CTAs match whether a workspace has a Rocky project. `rocky.runs` and `rocky.sources` no longer shell out to the CLI on workspaces with no `rocky.toml`.
+- **New commands**: `rocky.openOutputChannel`, `rocky.openDocumentation`, `rocky.reportBug`, `rocky.viewMarketplace`, `rocky.refreshInfo`, `rocky.init`, `rocky.playground`. The last two open an integrated terminal at the workspace root and run `rocky init` / `rocky playground`.
+- **`getCliVersion()` helper** (`src/rockyCli.ts`) — runs `rocky --version`, caches for 60s, swallows errors. Used by the Extension Info panel's About section.
+- **`onDidChangeLspState` emitter + `getLspState()`** (`src/lspClient.ts`). New `LspStatus` (`Starting | Restarting | Ready | Stopped | Failed`) fired from the actual lifecycle transitions (start, restart, stop, startup-failure) — independent of the diagnostic-driven status bar updates.
+
+### Changed
+
+- **`rocky.models` file watcher** debounced to 500ms; `onDidChange` removed (saves no longer trigger a refresh) since the file list is unaffected by content changes.
+- **Activity bar order**: `Get Started → Extension Info → Models → Runs → Sources → Help`. New informational panels start collapsed; Models stays expanded as the default landing target.
+
 ## [1.14.2] — 2026-05-05
 
 Patch release fixing a broken brand image on the VS Code Marketplace listing. v1.14.1 shipped successfully but rendered a broken image because `vsce` rewrites relative image URLs in the extension README to `<repo>/raw/HEAD/<README-relative-path>` and ignores `package.json`'s `repository.directory` field — so `media/rocky-readme-light.png` resolved to `https://github.com/rocky-data/rocky/raw/HEAD/media/rocky-readme-light.png` (404) instead of the actual file at `https://github.com/rocky-data/rocky/raw/HEAD/editors/vscode/media/rocky-readme-light.png`. Replaced the relative paths in `<picture>` with absolute `raw.githubusercontent.com` URLs that bypass `vsce`'s rewriter entirely. No extension feature changes.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.14.2",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {
@@ -26,7 +26,10 @@
   "activationEvents": [
     "onLanguage:rocky",
     "workspaceContains:**/*.rocky",
-    "workspaceContains:rocky.toml"
+    "workspaceContains:rocky.toml",
+    "onView:rocky.getStarted",
+    "onView:rocky.info",
+    "onView:rocky.help"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -271,6 +274,42 @@
         "title": "Refresh Sources",
         "category": "Rocky",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "rocky.refreshInfo",
+        "title": "Refresh Extension Info",
+        "category": "Rocky",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "rocky.openOutputChannel",
+        "title": "Show Output Channel",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.openDocumentation",
+        "title": "Open Documentation",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.reportBug",
+        "title": "Report a Bug",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.viewMarketplace",
+        "title": "View on Marketplace",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.init",
+        "title": "Initialize Project",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.playground",
+        "title": "Open Playground",
+        "category": "Rocky"
       }
     ],
     "semanticTokenScopes": [
@@ -338,6 +377,22 @@
     "views": {
       "rocky": [
         {
+          "id": "rocky.getStarted",
+          "name": "Get Started",
+          "type": "tree",
+          "icon": "icons/rocky-icon.svg",
+          "contextualTitle": "Get Started with Rocky",
+          "visibility": "visible"
+        },
+        {
+          "id": "rocky.info",
+          "name": "Extension Info",
+          "type": "tree",
+          "icon": "icons/rocky-icon.svg",
+          "contextualTitle": "Rocky Extension Info",
+          "visibility": "collapsed"
+        },
+        {
           "id": "rocky.models",
           "name": "Models",
           "icon": "icons/rocky-icon.svg",
@@ -347,16 +402,73 @@
           "id": "rocky.runs",
           "name": "Runs",
           "icon": "icons/rocky-icon.svg",
-          "contextualTitle": "Rocky Run History"
+          "contextualTitle": "Rocky Run History",
+          "visibility": "collapsed"
         },
         {
           "id": "rocky.sources",
           "name": "Sources",
           "icon": "icons/rocky-icon.svg",
-          "contextualTitle": "Rocky Sources"
+          "contextualTitle": "Rocky Sources",
+          "visibility": "collapsed"
+        },
+        {
+          "id": "rocky.help",
+          "name": "Help",
+          "type": "tree",
+          "icon": "icons/rocky-icon.svg",
+          "contextualTitle": "Rocky Help",
+          "visibility": "collapsed"
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "rocky.getStarted",
+        "contents": "Open a folder containing a Rocky project to get started.\n\n[Open Folder](command:vscode.openFolder)\n\nLearn more about Rocky in the [documentation](https://github.com/rocky-data/rocky#readme).",
+        "when": "workbenchState == empty"
+      },
+      {
+        "view": "rocky.getStarted",
+        "contents": "No Rocky project detected in this workspace.\n\n[Initialize Rocky Project](command:rocky.init)\n[Try the Playground](command:rocky.playground)\n[Open Documentation](command:rocky.openDocumentation)",
+        "when": "workbenchState != empty && !rocky.hasProject"
+      },
+      {
+        "view": "rocky.getStarted",
+        "contents": "Quick actions for your Rocky project.\n\n[Compile Models](command:rocky.compile)\n[Plan Pipeline (Dry Run)](command:rocky.plan)\n[Run Pipeline](command:rocky.run)\n[Discover Sources](command:rocky.discover)\n[Run Health Check](command:rocky.doctor)",
+        "when": "rocky.hasProject"
+      },
+      {
+        "view": "rocky.models",
+        "contents": "Open a Rocky project to see your models.\n\n[Initialize Rocky Project](command:rocky.init)\n[Open Documentation](command:rocky.openDocumentation)",
+        "when": "!rocky.hasProject"
+      },
+      {
+        "view": "rocky.models",
+        "contents": "No models found in this workspace.\n\nCreate a `.rocky` file under `models/`, or browse the [documentation](command:rocky.openDocumentation) for examples.",
+        "when": "rocky.hasProject"
+      },
+      {
+        "view": "rocky.runs",
+        "contents": "Open a Rocky project to see run history.",
+        "when": "!rocky.hasProject"
+      },
+      {
+        "view": "rocky.runs",
+        "contents": "No runs yet. Run your pipeline to see history here.\n\n[Run Pipeline](command:rocky.run)\n[Plan (Dry Run)](command:rocky.plan)",
+        "when": "rocky.hasProject"
+      },
+      {
+        "view": "rocky.sources",
+        "contents": "Open a Rocky project to discover sources.",
+        "when": "!rocky.hasProject"
+      },
+      {
+        "view": "rocky.sources",
+        "contents": "Sources are discovered from your configured adapter.\n\n[Discover Sources](command:rocky.discover)",
+        "when": "rocky.hasProject"
+      }
+    ],
     "menus": {
       "view/title": [
         {
@@ -372,6 +484,11 @@
         {
           "command": "rocky.refreshSources",
           "when": "view == rocky.sources",
+          "group": "navigation"
+        },
+        {
+          "command": "rocky.refreshInfo",
+          "when": "view == rocky.info",
           "group": "navigation"
         }
       ],

--- a/editors/vscode/src/__tests__/extensionInfoView.test.ts
+++ b/editors/vscode/src/__tests__/extensionInfoView.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => {
+  class TreeItem {
+    public label: string;
+    public collapsibleState: number;
+    public iconPath: unknown;
+    public tooltip: string | undefined;
+    public command: unknown;
+    public description: string | undefined;
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  }
+
+  class ThemeIcon {
+    constructor(public id: string, public color?: unknown) {}
+  }
+
+  class ThemeColor {
+    constructor(public id: string) {}
+  }
+
+  return {
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon,
+    ThemeColor,
+    EventEmitter: class {
+      private listeners: ((value: unknown) => void)[] = [];
+      event = (listener: (value: unknown) => void): { dispose(): void } => {
+        this.listeners.push(listener);
+        return { dispose: (): void => undefined };
+      };
+      fire(value: unknown): void {
+        for (const l of this.listeners) l(value);
+      }
+    },
+    Uri: { file: (p: string) => ({ fsPath: p, toString: () => p }) },
+    workspace: {
+      findFiles: vi.fn(async () => []),
+      workspaceFolders: undefined,
+      asRelativePath: (uri: { fsPath: string }) => uri.fsPath,
+      getConfiguration: () => ({
+        get: <T,>(_key: string, fallback: T): T => fallback,
+      }),
+      onDidChangeConfiguration: () => ({ dispose: () => undefined }),
+      onDidChangeWorkspaceFolders: () => ({ dispose: () => undefined }),
+    },
+    commands: {
+      registerCommand: () => ({ dispose: () => undefined }),
+    },
+    window: {
+      createTreeView: () => ({ dispose: () => undefined }),
+    },
+  };
+});
+
+vi.mock("../config", () => ({
+  getConfig: () => ({
+    serverPath: "/usr/local/bin/rocky",
+    extraArgs: ["--verbose"],
+    inlayHintsEnabled: true,
+  }),
+  getWorkspaceFolder: () => undefined,
+}));
+
+const lspState = { current: { status: "Ready" as const } };
+vi.mock("../lspClient", () => ({
+  getLspState: () => lspState.current,
+  onDidChangeLspState: () => ({ dispose: () => undefined }),
+}));
+
+const cliVersion = { value: "1.26.0" as string | undefined };
+vi.mock("../rockyCli", () => ({
+  clearCliVersionCache: () => undefined,
+  getCliVersion: async () => cliVersion.value,
+}));
+
+import * as vscode from "vscode";
+import { ExtensionInfoTreeProvider } from "../views/extensionInfoView";
+
+function makeContext(): vscode.ExtensionContext {
+  return {
+    extension: { packageJSON: { version: "1.15.0" } },
+    subscriptions: [],
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe("ExtensionInfoTreeProvider", () => {
+  beforeEach(() => {
+    cliVersion.value = "1.26.0";
+    lspState.current = { status: "Ready" };
+  });
+
+  it("returns four root sections in About → Configuration → Project → Logs order", async () => {
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const sections = await provider.getChildren();
+    expect(sections.map((s) => s.label)).toEqual([
+      "About",
+      "Configuration",
+      "Project",
+      "Logs & Diagnostics",
+    ]);
+  });
+
+  it("About section includes extension version, CLI version, and LSP status", async () => {
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const [aboutSection] = await provider.getChildren();
+    const leaves = await provider.getChildren(aboutSection);
+
+    const labels = leaves.map((l) => l.label);
+    expect(labels).toEqual(["Extension", "Rocky CLI", "Language Server"]);
+
+    expect(leaves[0].description).toBe("1.15.0");
+    expect(leaves[1].description).toBe("1.26.0");
+    expect(leaves[2].description).toBe("Ready");
+  });
+
+  it("About surfaces 'not detected' when the CLI version lookup fails", async () => {
+    cliVersion.value = undefined;
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const [aboutSection] = await provider.getChildren();
+    const leaves = await provider.getChildren(aboutSection);
+    expect(leaves[1].description).toBe("not detected");
+  });
+
+  it("About reflects the latest LSP state on each refresh", async () => {
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const [aboutSection] = await provider.getChildren();
+
+    lspState.current = { status: "Failed", error: "ENOENT" };
+    const leaves = await provider.getChildren(aboutSection);
+    expect(leaves[2].description).toBe("Failed");
+    expect(leaves[2].tooltip).toBe("ENOENT");
+  });
+
+  it("Configuration section reads server path, inlay hints, extra args", async () => {
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const sections = await provider.getChildren();
+    const configSection = sections[1];
+    const leaves = await provider.getChildren(configSection);
+
+    expect(leaves.map((l) => l.label)).toEqual([
+      "Server Path",
+      "Inlay Hints",
+      "Extra Args",
+    ]);
+    expect(leaves[0].description).toBe("/usr/local/bin/rocky");
+    expect(leaves[1].description).toBe("enabled");
+    expect(leaves[2].description).toBe("--verbose");
+  });
+
+  it("Logs section exposes commands for output channel, doctor, restart", async () => {
+    const provider = new ExtensionInfoTreeProvider(makeContext());
+    const sections = await provider.getChildren();
+    const logs = sections[3];
+    const leaves = await provider.getChildren(logs);
+
+    const commands = leaves.map(
+      (l) => (l as { command?: { command: string } }).command?.command,
+    );
+    expect(commands).toEqual([
+      "rocky.openOutputChannel",
+      "rocky.doctor",
+      "rocky.restartServer",
+    ]);
+  });
+});

--- a/editors/vscode/src/__tests__/helpView.test.ts
+++ b/editors/vscode/src/__tests__/helpView.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => {
+  class TreeItem {
+    public label: string;
+    public collapsibleState: number;
+    public iconPath: unknown;
+    public tooltip: string | undefined;
+    public command: unknown;
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  }
+
+  class ThemeIcon {
+    constructor(public id: string) {}
+  }
+
+  return {
+    EventEmitter: class {
+      private listeners: ((value: unknown) => void)[] = [];
+      event = (listener: (value: unknown) => void): { dispose(): void } => {
+        this.listeners.push(listener);
+        return { dispose: (): void => undefined };
+      };
+      fire(value: unknown): void {
+        for (const l of this.listeners) l(value);
+      }
+    },
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon,
+    Uri: { parse: (s: string) => ({ toString: () => s, scheme: "https" }) },
+    window: {
+      createTreeView: () => ({ dispose: () => undefined }),
+    },
+  };
+});
+
+// Import must follow vi.mock so the mocked module is bound.
+import { HelpTreeProvider } from "../views/helpView";
+
+describe("HelpTreeProvider", () => {
+  it("returns five leaf links with stable labels", () => {
+    const provider = new HelpTreeProvider();
+    const items = provider.getChildren();
+    expect(items).toHaveLength(5);
+
+    const labels = items.map((it) => it.label);
+    expect(labels).toEqual([
+      "Documentation",
+      "Report a Bug",
+      "View on Marketplace",
+      "Releases & Changelog",
+      "Source Code",
+    ]);
+  });
+
+  it("attaches a vscode.open command to every leaf", () => {
+    const provider = new HelpTreeProvider();
+    for (const item of provider.getChildren()) {
+      const cmd = (item as {
+        command?: { command: string; arguments: unknown[] };
+      }).command;
+      expect(cmd?.command).toBe("vscode.open");
+      expect(cmd?.arguments).toBeDefined();
+      expect((cmd?.arguments as unknown[])?.length).toBe(1);
+    }
+  });
+
+  it("passes through getTreeItem unchanged", () => {
+    const provider = new HelpTreeProvider();
+    const items = provider.getChildren();
+    expect(provider.getTreeItem(items[0])).toBe(items[0]);
+  });
+});

--- a/editors/vscode/src/__tests__/rockyCli.test.ts
+++ b/editors/vscode/src/__tests__/rockyCli.test.ts
@@ -30,7 +30,13 @@ vi.mock("child_process", () => ({
 
 // Imports must follow vi.mock so the mocked modules are bound.
 import * as cp from "child_process";
-import { runRocky, runRockyJson, RockyCliError } from "../rockyCli";
+import {
+  RockyCliError,
+  clearCliVersionCache,
+  getCliVersion,
+  runRocky,
+  runRockyJson,
+} from "../rockyCli";
 
 type ExecCallback = (
   err: (Error & { code?: number }) | null,
@@ -128,5 +134,50 @@ describe("runRockyJson", () => {
   it("throws RockyCliError on invalid JSON", async () => {
     mockSuccess("not json at all");
     await expect(runRockyJson(["doctor"])).rejects.toBeInstanceOf(RockyCliError);
+  });
+});
+
+describe("getCliVersion", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    clearCliVersionCache();
+  });
+
+  it("parses the version number from `rocky --version` output", async () => {
+    mockSuccess("rocky 1.26.0\n");
+    const v = await getCliVersion();
+    expect(v).toBe("1.26.0");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual(["--version"]);
+  });
+
+  it("caches the result across consecutive calls", async () => {
+    mockSuccess("rocky 1.26.0");
+    const first = await getCliVersion();
+    const second = await getCliVersion();
+    expect(first).toBe("1.26.0");
+    expect(second).toBe("1.26.0");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when the binary is missing", async () => {
+    mockFailure("ENOENT", "spawn rocky ENOENT", 0);
+    const v = await getCliVersion();
+    expect(v).toBeUndefined();
+  });
+
+  it("returns undefined when output has no recognizable version", async () => {
+    mockSuccess("?? something weird ??");
+    const v = await getCliVersion();
+    expect(v).toBeUndefined();
+  });
+
+  it("re-shells after the cache is cleared", async () => {
+    mockSuccess("rocky 1.26.0");
+    expect(await getCliVersion()).toBe("1.26.0");
+    clearCliVersionCache();
+    mockSuccess("rocky 1.27.0");
+    expect(await getCliVersion()).toBe("1.27.0");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -5,6 +5,14 @@ import { branchApprove, branchPromote } from "./branch";
 import { commandPalette } from "./commandPalette";
 import { ci, compile, validate } from "./compile";
 import { hooksList, hooksTest } from "./hooks";
+import {
+  init,
+  openDocumentation,
+  openOutputChannel,
+  playground,
+  reportBug,
+  viewMarketplace,
+} from "./info";
 import { catalog, history, metrics } from "./inspect";
 import { showLineage } from "./lineage";
 import { importDbt, validateMigration } from "./migration";
@@ -80,5 +88,13 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     // Branch approval / promote — gated production writes from a branch
     vscode.commands.registerCommand("rocky.branchApprove", branchApprove),
     vscode.commands.registerCommand("rocky.branchPromote", branchPromote),
+
+    // Sidebar / Get Started utilities
+    vscode.commands.registerCommand("rocky.openOutputChannel", openOutputChannel),
+    vscode.commands.registerCommand("rocky.openDocumentation", openDocumentation),
+    vscode.commands.registerCommand("rocky.reportBug", reportBug),
+    vscode.commands.registerCommand("rocky.viewMarketplace", viewMarketplace),
+    vscode.commands.registerCommand("rocky.init", init),
+    vscode.commands.registerCommand("rocky.playground", playground),
   );
 }

--- a/editors/vscode/src/commands/info.ts
+++ b/editors/vscode/src/commands/info.ts
@@ -1,0 +1,61 @@
+import * as vscode from "vscode";
+import { getWorkspaceFolder } from "../config";
+import { getOutputChannel } from "../output";
+import { clearCliVersionCache } from "../rockyCli";
+
+const URLS = {
+  documentation: "https://github.com/rocky-data/rocky#readme",
+  issues: "https://github.com/rocky-data/rocky/issues/new",
+  marketplace:
+    "https://marketplace.visualstudio.com/items?itemName=rocky-data.rocky",
+} as const;
+
+export function openOutputChannel(): void {
+  getOutputChannel().show(true);
+}
+
+export function openDocumentation(): Thenable<boolean> {
+  return vscode.env.openExternal(vscode.Uri.parse(URLS.documentation));
+}
+
+export function reportBug(): Thenable<boolean> {
+  return vscode.env.openExternal(vscode.Uri.parse(URLS.issues));
+}
+
+export function viewMarketplace(): Thenable<boolean> {
+  return vscode.env.openExternal(vscode.Uri.parse(URLS.marketplace));
+}
+
+/**
+ * Open an integrated terminal in the workspace root and run a Rocky CLI
+ * command. Used by the Get Started panel for `rocky init` and
+ * `rocky playground`. The terminal is shown so the user can watch progress
+ * and answer any prompts the CLI asks.
+ *
+ * The command is sent via {@link vscode.Terminal.sendText} (no shell quoting
+ * required for these argv-free commands).
+ */
+function runInTerminal(name: string, command: string): void {
+  const cwd = getWorkspaceFolder();
+  const terminal = vscode.window.createTerminal({ name, cwd });
+  terminal.show(true);
+  terminal.sendText(command);
+}
+
+export function init(): void {
+  runInTerminal("Rocky: Init", "rocky init");
+}
+
+export function playground(): void {
+  runInTerminal("Rocky: Playground", "rocky playground");
+}
+
+/**
+ * Force the next Extension Info refresh to re-shell `rocky --version`.
+ * Wired up via the registered `rocky.refreshInfo` command in
+ * {@link registerExtensionInfoView}; calling this clears the underlying
+ * cache so the new fetch isn't served from the 60s TTL.
+ */
+export function invalidateInfoCaches(): void {
+  clearCliVersionCache();
+}

--- a/editors/vscode/src/lspClient.ts
+++ b/editors/vscode/src/lspClient.ts
@@ -18,6 +18,40 @@ interface DiagnosticTotals {
   warnings: number;
 }
 
+/**
+ * Current lifecycle state of the Rocky language server. Independent of
+ * diagnostics — those flow separately through the status bar.
+ */
+export type LspStatus =
+  | "Starting"
+  | "Restarting"
+  | "Ready"
+  | "Stopped"
+  | "Failed";
+
+export interface LspState {
+  status: LspStatus;
+  /** Last error message if `status === "Failed"`, otherwise undefined. */
+  error?: string;
+}
+
+let currentLspState: LspState = { status: "Stopped" };
+const lspStateEmitter = new vscode.EventEmitter<LspState>();
+
+/** Fires whenever the language server transitions between lifecycle states. */
+export const onDidChangeLspState: vscode.Event<LspState> =
+  lspStateEmitter.event;
+
+/** Returns the most recent lifecycle state. */
+export function getLspState(): LspState {
+  return currentLspState;
+}
+
+function setLspState(status: LspStatus, error?: string): void {
+  currentLspState = error !== undefined ? { status, error } : { status };
+  lspStateEmitter.fire(currentLspState);
+}
+
 export function getClient(): LanguageClient | undefined {
   return client;
 }
@@ -39,6 +73,8 @@ export function startLspClient(context: vscode.ExtensionContext): void {
   statusBarItem.tooltip = "Click to restart Rocky language server";
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
+
+  setLspState("Starting");
 
   context.subscriptions.push(
     vscode.languages.onDidChangeDiagnostics(updateStatusBarFromDiagnostics),
@@ -115,6 +151,7 @@ async function launchClient(): Promise<void> {
     await client.start();
     statusBarItem.text = "$(check) Rocky: Ready";
     statusBarItem.backgroundColor = undefined;
+    setLspState("Ready");
   } catch (err) {
     handleStartupFailure(err as Error);
   }
@@ -185,6 +222,8 @@ function handleStartupFailure(err: Error): void {
     "statusBarItem.errorBackground",
   );
 
+  setLspState("Failed", err.message);
+
   const isMissingBinary =
     /ENOENT/i.test(err.message) ||
     /not found/i.test(err.message) ||
@@ -212,6 +251,7 @@ function handleStartupFailure(err: Error): void {
 
 export async function restartLspClient(): Promise<void> {
   statusBarItem.text = "$(loading~spin) Rocky: Restarting...";
+  setLspState("Restarting");
   if (client) {
     try {
       await client.stop();
@@ -230,6 +270,7 @@ export async function restartLspClient(): Promise<void> {
 export async function stopLspClient(): Promise<void> {
   await client?.stop();
   client = undefined;
+  setLspState("Stopped");
 }
 
 function updateStatusBarFromDiagnostics(): void {

--- a/editors/vscode/src/rockyCli.ts
+++ b/editors/vscode/src/rockyCli.ts
@@ -155,6 +155,46 @@ export async function runRockyJsonWithProgress<T = unknown>(
   }
 }
 
+interface VersionCache {
+  value: string | undefined;
+  fetchedAt: number;
+}
+
+let versionCache: VersionCache | undefined;
+const VERSION_TTL_MS = 60_000;
+
+/**
+ * Returns the installed Rocky CLI version string (e.g., `"1.26.0"`), or
+ * `undefined` when the binary is missing or fails to respond. The result is
+ * cached for 60 seconds so repeated tree refreshes don't fork+exec on every
+ * tick. Errors are swallowed — this helper is for display only.
+ */
+export async function getCliVersion(): Promise<string | undefined> {
+  const now = Date.now();
+  if (versionCache && now - versionCache.fetchedAt < VERSION_TTL_MS) {
+    return versionCache.value;
+  }
+  let value: string | undefined;
+  try {
+    const { stdout } = await runRocky(["--version"], { timeoutMs: 5_000 });
+    value = parseVersion(stdout);
+  } catch {
+    value = undefined;
+  }
+  versionCache = { value, fetchedAt: now };
+  return value;
+}
+
+/** Force the next {@link getCliVersion} call to re-shell. */
+export function clearCliVersionCache(): void {
+  versionCache = undefined;
+}
+
+function parseVersion(stdout: string): string | undefined {
+  const match = stdout.trim().match(/(\d+\.\d+\.\d+(?:[-.][\w.+-]+)?)/);
+  return match?.[1];
+}
+
 /**
  * Display a Rocky CLI error to the user with a "Show Logs" action that opens
  * the output channel containing the full stderr trace.

--- a/editors/vscode/src/views/extensionInfoView.ts
+++ b/editors/vscode/src/views/extensionInfoView.ts
@@ -1,0 +1,261 @@
+import * as vscode from "vscode";
+import { getConfig } from "../config";
+import { getLspState, onDidChangeLspState } from "../lspClient";
+import type { LspStatus } from "../lspClient";
+import { clearCliVersionCache, getCliVersion } from "../rockyCli";
+
+type Section = "about" | "config" | "project" | "logs";
+
+class SectionItem extends vscode.TreeItem {
+  override readonly contextValue = "rockyInfoSection";
+
+  constructor(
+    public readonly section: Section,
+    label: string,
+    icon: string,
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    this.iconPath = new vscode.ThemeIcon(icon);
+  }
+}
+
+class LeafItem extends vscode.TreeItem {
+  override readonly contextValue = "rockyInfoLeaf";
+
+  constructor(
+    label: string,
+    description: string | undefined,
+    icon: string | vscode.ThemeIcon,
+    command?: vscode.Command,
+    tooltip?: string,
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    if (description !== undefined) this.description = description;
+    this.iconPath = typeof icon === "string" ? new vscode.ThemeIcon(icon) : icon;
+    if (command) this.command = command;
+    if (tooltip) this.tooltip = tooltip;
+  }
+}
+
+type Node = SectionItem | LeafItem;
+
+/**
+ * Tree view backing the "Extension Info" sidebar section. Surfaces extension
+ * version, Rocky CLI version, LSP state, configuration, detected project
+ * paths, and quick links to logs and diagnostics.
+ *
+ * Refreshes on:
+ *  - LSP state transitions (via {@link onDidChangeLspState})
+ *  - Configuration changes under `rocky.*`
+ *  - Workspace folder changes
+ *  - User invoking `rocky.refreshInfo`
+ */
+export class ExtensionInfoTreeProvider implements vscode.TreeDataProvider<Node> {
+  private readonly emitter = new vscode.EventEmitter<Node | undefined | void>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  refresh(): void {
+    this.emitter.fire();
+  }
+
+  getTreeItem(item: Node): vscode.TreeItem {
+    return item;
+  }
+
+  async getChildren(element?: Node): Promise<Node[]> {
+    if (!element) {
+      return [
+        new SectionItem("about", "About", "info"),
+        new SectionItem("config", "Configuration", "settings-gear"),
+        new SectionItem("project", "Project", "folder"),
+        new SectionItem("logs", "Logs & Diagnostics", "output"),
+      ];
+    }
+    if (element instanceof SectionItem) {
+      switch (element.section) {
+        case "about":
+          return await this.aboutLeaves();
+        case "config":
+          return this.configLeaves();
+        case "project":
+          return await this.projectLeaves();
+        case "logs":
+          return this.logsLeaves();
+      }
+    }
+    return [];
+  }
+
+  private async aboutLeaves(): Promise<LeafItem[]> {
+    const extVersion = String(
+      this.context.extension.packageJSON.version ?? "unknown",
+    );
+    const cliVersion = await getCliVersion();
+    const lsp = getLspState();
+    return [
+      new LeafItem("Extension", extVersion, "tag"),
+      new LeafItem(
+        "Rocky CLI",
+        cliVersion ?? "not detected",
+        cliVersion ? "package" : "warning",
+        undefined,
+        cliVersion ? undefined : "Rocky CLI was not found on PATH or at rocky.server.path.",
+      ),
+      new LeafItem(
+        "Language Server",
+        lspStatusLabel(lsp.status),
+        lspIcon(lsp.status),
+        { command: "rocky.restartServer", title: "Restart Language Server" },
+        lsp.error,
+      ),
+    ];
+  }
+
+  private configLeaves(): LeafItem[] {
+    const cfg = getConfig();
+    return [
+      new LeafItem(
+        "Server Path",
+        cfg.serverPath,
+        "terminal",
+        openSettingCommand("rocky.server.path"),
+      ),
+      new LeafItem(
+        "Inlay Hints",
+        cfg.inlayHintsEnabled ? "enabled" : "disabled",
+        "symbol-parameter",
+        openSettingCommand("rocky.inlayHints.enabled"),
+      ),
+      new LeafItem(
+        "Extra Args",
+        cfg.extraArgs.length > 0 ? cfg.extraArgs.join(" ") : "(none)",
+        "symbol-array",
+        openSettingCommand("rocky.server.extraArgs"),
+      ),
+    ];
+  }
+
+  private async projectLeaves(): Promise<LeafItem[]> {
+    const tomls = await vscode.workspace.findFiles(
+      "**/rocky.toml",
+      "**/node_modules/**",
+      5,
+    );
+    const folder =
+      vscode.workspace.workspaceFolders?.[0]?.name ?? "(no folder open)";
+    const items: LeafItem[] = [];
+    if (tomls.length === 0) {
+      items.push(new LeafItem("rocky.toml", "not detected", "warning"));
+    } else {
+      for (const uri of tomls) {
+        const rel = vscode.workspace.asRelativePath(uri);
+        items.push(
+          new LeafItem(
+            "rocky.toml",
+            rel,
+            "file-code",
+            {
+              command: "vscode.open",
+              title: "Open rocky.toml",
+              arguments: [uri],
+            },
+            uri.fsPath,
+          ),
+        );
+      }
+    }
+    items.push(new LeafItem("Workspace", folder, "folder"));
+    return items;
+  }
+
+  private logsLeaves(): LeafItem[] {
+    return [
+      new LeafItem(
+        "Show Output Channel",
+        undefined,
+        "output",
+        { command: "rocky.openOutputChannel", title: "Show Output Channel" },
+      ),
+      new LeafItem(
+        "Run Health Check",
+        undefined,
+        "pulse",
+        { command: "rocky.doctor", title: "Run Doctor" },
+      ),
+      new LeafItem(
+        "Restart Language Server",
+        undefined,
+        "debug-restart",
+        { command: "rocky.restartServer", title: "Restart Language Server" },
+      ),
+    ];
+  }
+}
+
+function openSettingCommand(setting: string): vscode.Command {
+  return {
+    command: "workbench.action.openSettings",
+    title: "Open Setting",
+    arguments: [setting],
+  };
+}
+
+function lspStatusLabel(status: LspStatus): string {
+  return status;
+}
+
+function lspIcon(status: LspStatus): vscode.ThemeIcon {
+  switch (status) {
+    case "Ready":
+      return new vscode.ThemeIcon(
+        "check",
+        new vscode.ThemeColor("testing.iconPassed"),
+      );
+    case "Starting":
+    case "Restarting":
+      return new vscode.ThemeIcon("loading~spin");
+    case "Stopped":
+      return new vscode.ThemeIcon("circle-slash");
+    case "Failed":
+      return new vscode.ThemeIcon(
+        "error",
+        new vscode.ThemeColor("testing.iconFailed"),
+      );
+    default:
+      return new vscode.ThemeIcon("question");
+  }
+}
+
+export function registerExtensionInfoView(
+  context: vscode.ExtensionContext,
+): ExtensionInfoTreeProvider {
+  const provider = new ExtensionInfoTreeProvider(context);
+  const view = vscode.window.createTreeView("rocky.info", {
+    treeDataProvider: provider,
+    showCollapseAll: false,
+  });
+  context.subscriptions.push(view);
+
+  context.subscriptions.push(onDidChangeLspState(() => provider.refresh()));
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("rocky")) provider.refresh();
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(() => provider.refresh()),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("rocky.refreshInfo", () => {
+      clearCliVersionCache();
+      provider.refresh();
+    }),
+  );
+
+  return provider;
+}

--- a/editors/vscode/src/views/getStartedView.ts
+++ b/editors/vscode/src/views/getStartedView.ts
@@ -1,0 +1,98 @@
+import * as vscode from "vscode";
+
+/**
+ * The Get Started panel itself is rendered via `contributes.viewsWelcome` in
+ * package.json — this provider only owns the empty tree (so the welcome
+ * markdown shows) and the `rocky.hasProject` context that gates which welcome
+ * variant is visible.
+ *
+ * `rocky.hasProject` is also consumed by Models / Runs / Sources viewsWelcome
+ * entries so all five sections stay in sync.
+ */
+export class GetStartedTreeProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  private readonly emitter = new vscode.EventEmitter<
+    vscode.TreeItem | undefined | void
+  >();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  refresh(): void {
+    this.emitter.fire();
+  }
+
+  getTreeItem(item: vscode.TreeItem): vscode.TreeItem {
+    return item;
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    return [];
+  }
+}
+
+async function detectProject(): Promise<boolean> {
+  const found = await vscode.workspace.findFiles(
+    "**/rocky.toml",
+    "**/node_modules/**",
+    1,
+  );
+  return found.length > 0;
+}
+
+let cachedHasProject = false;
+
+/**
+ * Synchronous read of whether a Rocky project (`rocky.toml`) was detected in
+ * the workspace. Updated by the file watcher in {@link registerGetStartedView}.
+ *
+ * Other views (Runs, Sources) use this to skip CLI invocations on workspaces
+ * with no Rocky project.
+ */
+export function hasRockyProject(): boolean {
+  return cachedHasProject;
+}
+
+const projectChangeEmitter = new vscode.EventEmitter<boolean>();
+
+/** Fires whenever {@link hasRockyProject} flips. */
+export const onDidChangeRockyProject: vscode.Event<boolean> =
+  projectChangeEmitter.event;
+
+export function registerGetStartedView(
+  context: vscode.ExtensionContext,
+): GetStartedTreeProvider {
+  const provider = new GetStartedTreeProvider();
+  const view = vscode.window.createTreeView("rocky.getStarted", {
+    treeDataProvider: provider,
+    showCollapseAll: false,
+  });
+  context.subscriptions.push(view);
+
+  const refreshContext = async (): Promise<void> => {
+    const has = await detectProject();
+    const changed = has !== cachedHasProject;
+    cachedHasProject = has;
+    await vscode.commands.executeCommand(
+      "setContext",
+      "rocky.hasProject",
+      has,
+    );
+    provider.refresh();
+    if (changed) projectChangeEmitter.fire(has);
+  };
+
+  void refreshContext();
+
+  const watcher = vscode.workspace.createFileSystemWatcher("**/rocky.toml");
+  watcher.onDidCreate(() => void refreshContext());
+  watcher.onDidDelete(() => void refreshContext());
+  context.subscriptions.push(watcher);
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(
+      () => void refreshContext(),
+    ),
+  );
+
+  return provider;
+}

--- a/editors/vscode/src/views/helpView.ts
+++ b/editors/vscode/src/views/helpView.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode";
+
+interface HelpLink {
+  label: string;
+  url: string;
+  icon: string;
+}
+
+const HELP_LINKS: readonly HelpLink[] = [
+  {
+    label: "Documentation",
+    url: "https://github.com/rocky-data/rocky#readme",
+    icon: "book",
+  },
+  {
+    label: "Report a Bug",
+    url: "https://github.com/rocky-data/rocky/issues/new",
+    icon: "bug",
+  },
+  {
+    label: "View on Marketplace",
+    url: "https://marketplace.visualstudio.com/items?itemName=rocky-data.rocky",
+    icon: "extensions",
+  },
+  {
+    label: "Releases & Changelog",
+    url: "https://github.com/rocky-data/rocky/releases?q=engine",
+    icon: "tag",
+  },
+  {
+    label: "Source Code",
+    url: "https://github.com/rocky-data/rocky",
+    icon: "github",
+  },
+];
+
+class HelpItem extends vscode.TreeItem {
+  override readonly contextValue = "rockyHelpItem";
+
+  constructor(link: HelpLink) {
+    super(link.label, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(link.icon);
+    this.tooltip = link.url;
+    this.command = {
+      command: "vscode.open",
+      title: "Open",
+      arguments: [vscode.Uri.parse(link.url)],
+    };
+  }
+}
+
+/**
+ * Static tree of external help links — docs, issue tracker, marketplace,
+ * releases, source code. Each leaf opens a URL via the built-in `vscode.open`
+ * command.
+ */
+export class HelpTreeProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  private readonly emitter = new vscode.EventEmitter<
+    vscode.TreeItem | undefined | void
+  >();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  getTreeItem(item: vscode.TreeItem): vscode.TreeItem {
+    return item;
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    return HELP_LINKS.map((link) => new HelpItem(link));
+  }
+}
+
+export function registerHelpView(
+  context: vscode.ExtensionContext,
+): HelpTreeProvider {
+  const provider = new HelpTreeProvider();
+  const view = vscode.window.createTreeView("rocky.help", {
+    treeDataProvider: provider,
+    showCollapseAll: false,
+  });
+  context.subscriptions.push(view);
+  return provider;
+}

--- a/editors/vscode/src/views/index.ts
+++ b/editors/vscode/src/views/index.ts
@@ -1,15 +1,30 @@
 import * as vscode from "vscode";
+import { registerExtensionInfoView } from "./extensionInfoView";
+import type { ExtensionInfoTreeProvider } from "./extensionInfoView";
+import { registerGetStartedView } from "./getStartedView";
+import { registerHelpView } from "./helpView";
 import { registerModelsView } from "./modelsView";
 import { registerRunsView } from "./runsView";
 import { registerSourcesView } from "./sourcesView";
 
+let infoProvider: ExtensionInfoTreeProvider | undefined;
+
 /**
- * Registers the three Rocky tree views (Models, Runs, Sources) on the
- * activity bar. Each view is self-contained and exposes its own refresh
- * command via package.json menu contributions.
+ * Registers all six Rocky tree views on the activity bar:
+ *   Get Started → Extension Info → Models → Runs → Sources → Help
+ *
+ * The Get Started view also wires the `rocky.hasProject` context that gates
+ * the welcome content of every other view.
  */
 export function registerViews(context: vscode.ExtensionContext): void {
+  registerGetStartedView(context);
+  infoProvider = registerExtensionInfoView(context);
   registerModelsView(context);
   registerRunsView(context);
   registerSourcesView(context);
+  registerHelpView(context);
+}
+
+export function getInfoProvider(): ExtensionInfoTreeProvider | undefined {
+  return infoProvider;
 }

--- a/editors/vscode/src/views/modelsView.ts
+++ b/editors/vscode/src/views/modelsView.ts
@@ -66,11 +66,28 @@ export function registerModelsView(
   });
   context.subscriptions.push(view);
 
+  // Debounce so rapid create/delete bursts (e.g. branch switches) don't
+  // trigger a refresh per file. `onDidChange` is intentionally skipped — the
+  // file list doesn't change on saves and the existing tree items don't
+  // display body contents.
+  let pending: NodeJS.Timeout | undefined;
+  const scheduleRefresh = (): void => {
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = undefined;
+      provider.refresh();
+    }, 500);
+  };
+
   const watcher = vscode.workspace.createFileSystemWatcher(MODELS_GLOB);
-  watcher.onDidCreate(() => provider.refresh());
-  watcher.onDidDelete(() => provider.refresh());
-  watcher.onDidChange(() => provider.refresh());
+  watcher.onDidCreate(scheduleRefresh);
+  watcher.onDidDelete(scheduleRefresh);
   context.subscriptions.push(watcher);
+  context.subscriptions.push({
+    dispose() {
+      if (pending) clearTimeout(pending);
+    },
+  });
 
   context.subscriptions.push(
     vscode.commands.registerCommand("rocky.refreshModels", () =>

--- a/editors/vscode/src/views/runsView.ts
+++ b/editors/vscode/src/views/runsView.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { runRockyJson } from "../rockyCli";
 import type { HistoryResult } from "../types/rockyJson";
 import type { RunModelRecord } from "../types/generated";
+import { hasRockyProject, onDidChangeRockyProject } from "./getStartedView";
 
 type Run = NonNullable<HistoryResult["runs"]>[number];
 
@@ -41,6 +42,13 @@ export class RunsTreeProvider implements vscode.TreeDataProvider<Node> {
     // Leaf nodes have no children
     if (element) return [];
 
+    // Skip the CLI call entirely when there's no Rocky project — the
+    // viewsWelcome handles the empty state and we don't want to flash an
+    // error from `rocky history` complaining about a missing rocky.toml.
+    if (!hasRockyProject()) {
+      return [];
+    }
+
     // Root: fetch runs
     if (this.cache === undefined) {
       try {
@@ -60,10 +68,8 @@ export class RunsTreeProvider implements vscode.TreeDataProvider<Node> {
       return [new MessageItem(`Error: ${this.loadError}`, "error")];
     }
 
-    if (this.cache.length === 0) {
-      return [new MessageItem("No runs found", "info")];
-    }
-
+    // Empty cache: return [] so the package.json viewsWelcome content for
+    // rocky.runs takes over instead of an inline tree row.
     return this.cache.map((run) => new RunTreeItem(run));
   }
 }
@@ -215,6 +221,10 @@ export function registerRunsView(
     vscode.commands.registerCommand("rocky.refreshRuns", () =>
       provider.refresh(),
     ),
+  );
+
+  context.subscriptions.push(
+    onDidChangeRockyProject(() => provider.refresh()),
   );
 
   return provider;

--- a/editors/vscode/src/views/sourcesView.ts
+++ b/editors/vscode/src/views/sourcesView.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { runRockyJson } from "../rockyCli";
 import type { DiscoverResult, DiscoverSource } from "../types/rockyJson";
+import { hasRockyProject, onDidChangeRockyProject } from "./getStartedView";
 
 type Table = NonNullable<DiscoverSource["tables"]>[number];
 
@@ -32,6 +33,12 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<Node> {
 
   async getChildren(node?: Node): Promise<Node[]> {
     if (!node) {
+      // Skip discovery when there's no Rocky project — the viewsWelcome
+      // already prompts the user to open one, and we don't want to flash an
+      // error from the CLI complaining about a missing rocky.toml.
+      if (!hasRockyProject()) {
+        return [];
+      }
       if (this.loading) {
         return [makeMessage("Discovering sources…", "loading~spin")];
       }
@@ -41,10 +48,9 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<Node> {
       if (this.loadError) {
         return [makeMessage(`Error: ${this.loadError}`, "error")];
       }
-      if (!this.cache || this.cache.length === 0) {
-        return [makeMessage("No sources discovered", "info")];
-      }
-      return this.cache.map((s) => new SourceNode(s));
+      // Empty cache: return [] so the viewsWelcome content for rocky.sources
+      // (with its "Discover Sources" CTA) takes over.
+      return (this.cache ?? []).map((s) => new SourceNode(s));
     }
 
     if (node instanceof SourceNode) {
@@ -135,6 +141,10 @@ export function registerSourcesView(
     vscode.commands.registerCommand("rocky.refreshSources", () =>
       provider.refresh(),
     ),
+  );
+
+  context.subscriptions.push(
+    onDidChangeRockyProject(() => provider.refresh()),
   );
 
   return provider;


### PR DESCRIPTION
## Summary

- Adds three new sidebar panels — **Get Started**, **Extension Info**, **Help** — alongside the existing Models / Runs / Sources, ordered intro → tools → support.
- `viewsWelcome` empty states gated by a new `rocky.hasProject` context replace inline tree messages and stop Models / Runs / Sources from shelling out to the CLI on workspaces without a `rocky.toml`.
- New `LspState` lifecycle emitter (independent of diagnostic-driven status bar updates) and a 60s-cached `getCliVersion()` helper feed the Extension Info → About section.

## What's in the new panels

- **Get Started** — markdown via `viewsWelcome`, three context variants (no folder open, workspace without rocky.toml, workspace with a Rocky project). CTAs cover Init Project, Try Playground, Compile, Plan, Run, Discover, Doctor.
- **Extension Info** — 4-section tree: About (extension + CLI versions, LSP status), Configuration (server path, inlay hints, extra args — each leaf opens its setting), Project (detected `rocky.toml`, workspace folder), Logs & Diagnostics (output channel, doctor, restart LSP).
- **Help** — fixed list of external links: Documentation, Report a Bug, Marketplace, Releases & Changelog, Source Code.

## Other changes

- 7 new commands: `rocky.openOutputChannel`, `rocky.openDocumentation`, `rocky.reportBug`, `rocky.viewMarketplace`, `rocky.refreshInfo`, `rocky.init`, `rocky.playground`.
- Models watcher debounced to 500ms; `onDidChange` removed (saves no longer trigger refresh).
- Bump to **1.15.0** + CHANGELOG entry.

## Test plan

- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm run bundle -- --dev` succeeds (881 KB)
- [x] `npm run test:unit` — 34 pass (14 new covering helpView, extensionInfoView, getCliVersion)
- [ ] Manual sidebar matrix in Extension Development Host:
  - [ ] No folder open → Get Started shows "Open Folder" CTA
  - [ ] Folder open without rocky.toml → Init / Playground / Docs CTAs
  - [ ] Folder with rocky.toml → quick-action CTAs; Models / Runs / Sources show normal state
  - [ ] Toggle rocky.toml → viewsWelcome flips within ~500ms
  - [ ] Stop the LSP → Extension Info → About → Language Server reflects "Failed"
- [ ] `npm test` (Electron integration suite)