### PR TITLE
fix(vscode): show doctor result on exit 2 instead of swallowing it

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.1] — 2026-05-07
+
+Patch release fixing the new "Run Health Check" leaf in the **Extension Info → Logs** sidebar section. Clicking it surfaced "Doctor failed: …" toasts and threw the doctor JSON away — `rocky doctor` exits 2 when any check is `critical` (see `engine/crates/rocky-cli/src/commands/doctor.rs`) and the vscode handler treated any non-zero exit as a hard failure. Same bug existed in 1.14.x but was harder to hit because doctor wasn't exposed in the sidebar.
+
+### Fixed
+
+- **`rocky.doctor` command recovers the JSON payload on exit 2.** `RockyCliError` now captures `stdout` alongside `stderr`, so callers that know certain commands signal status via exit code can re-read the payload from the thrown error. The doctor handler (`src/commands/ops.ts`) checks for `exitCode === 2`, parses `err.stdout` as `DoctorResult`, and renders the doctor webview just as it does on a healthy run — so users see exactly which checks failed instead of a generic "Doctor failed" notification. Falls through to the existing error path when the stdout payload is missing or unparseable (e.g., a true CLI panic).
+
 ## [1.15.0] — 2026-05-07
 
 Activity bar UX overhaul. The Rocky sidebar now leads with a **Get Started** welcome panel and a structured **Extension Info** tree (extension version, Rocky CLI version, language-server status, configuration, detected `rocky.toml`, log shortcuts), and ends with a **Help** panel linking out to docs / issues / marketplace / releases / source. Existing Models, Runs, and Sources panels stay in place but switch their inline empty-state messages to `viewsWelcome` markdown gated by a new `rocky.hasProject` context — so a workspace with no `rocky.toml` shows orientation instead of CLI errors.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/editors/vscode/src/__tests__/rockyCli.test.ts
+++ b/editors/vscode/src/__tests__/rockyCli.test.ts
@@ -100,6 +100,27 @@ describe("runRocky", () => {
     });
   });
 
+  it("captures stdout on RockyCliError so callers can recover JSON payloads", async () => {
+    // `rocky doctor` exits 2 when health is critical but still emits valid
+    // JSON on stdout. Callers (the doctor handler) read err.stdout to recover
+    // the payload instead of dropping it on the floor.
+    const doctorJson =
+      '{"command":"doctor","overall":"critical","checks":[],"suggestions":[]}';
+    execFileMock.mockImplementationOnce(
+      (_cmd: string, _args: string[], _opts: unknown, cb: ExecCallback) => {
+        const err = Object.assign(new Error("exit 2"), { code: 2 });
+        cb(err, doctorJson, "");
+        return fakeChild();
+      },
+    );
+    await expect(
+      runRocky(["doctor", "--output", "json"]),
+    ).rejects.toMatchObject({
+      exitCode: 2,
+      stdout: doctorJson,
+    });
+  });
+
   it("kills the child process when the abort signal fires", async () => {
     const killSpy = vi.fn();
     execFileMock.mockImplementationOnce(

--- a/editors/vscode/src/commands/ops.ts
+++ b/editors/vscode/src/commands/ops.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import {
+  RockyCliError,
   runRockyJsonWithProgress,
   runRockyWithProgress,
   showRockyError,
@@ -19,6 +20,19 @@ export async function doctor(): Promise<void> {
     );
     showDoctorResult(result);
   } catch (err) {
+    // `rocky doctor` exits 2 when any check is `critical` (see
+    // engine/crates/rocky-cli/src/commands/doctor.rs). The JSON payload on
+    // stdout is still valid — surface it so users can see what's wrong
+    // instead of a generic "Doctor failed" toast.
+    if (err instanceof RockyCliError && err.exitCode === 2 && err.stdout) {
+      try {
+        const result = JSON.parse(err.stdout) as DoctorResult;
+        showDoctorResult(result);
+        return;
+      } catch {
+        // Fall through to the generic error path below.
+      }
+    }
     showRockyError("Doctor failed", err);
   }
 }

--- a/editors/vscode/src/rockyCli.ts
+++ b/editors/vscode/src/rockyCli.ts
@@ -21,6 +21,11 @@ export interface RockyResult {
 /**
  * Error thrown by {@link runRocky} on non-zero exit, spawn failure, timeout,
  * or JSON-parse failure (when called via {@link runRockyJson}).
+ *
+ * `stdout` is captured even on non-zero exit because some Rocky commands
+ * (notably `rocky doctor`) signal status via the exit code while still
+ * emitting a valid JSON payload on stdout — callers that know to expect
+ * this can recover the payload from the thrown error.
  */
 export class RockyCliError extends Error {
   constructor(
@@ -28,6 +33,7 @@ export class RockyCliError extends Error {
     public readonly stderr: string,
     public readonly exitCode: number | string | null,
     cause?: Error,
+    public readonly stdout: string = "",
   ) {
     super(message, cause ? { cause } : undefined);
     this.name = "RockyCliError";
@@ -70,7 +76,13 @@ export function runRocky(
             `[${elapsed}ms] command failed (exit ${err.code ?? "?"}): ${err.message}`,
           );
           reject(
-            new RockyCliError(err.message, stderr ?? "", err.code ?? null, err),
+            new RockyCliError(
+              err.message,
+              stderr ?? "",
+              err.code ?? null,
+              err,
+              stdout ?? "",
+            ),
           );
           return;
         }


### PR DESCRIPTION
## Summary

- `rocky doctor` exits 2 on critical health state but still emits valid JSON on stdout. The vscode handler treated any non-zero exit as a hard failure and dropped the payload — users got a generic "Doctor failed" toast instead of the diagnosis.
- The new **Extension Info → Logs → Run Health Check** leaf in 1.15.0 made this very easy to hit; same bug existed in 1.14.x but was harder to trigger because doctor wasn't in the sidebar.

## Fix

- `RockyCliError` now carries `stdout` alongside `stderr`. Defaults to `""` so existing callers compile unchanged; `runRocky` populates it automatically on non-zero exit.
- `doctor()` handler in `src/commands/ops.ts` checks for `exitCode === 2`, parses `err.stdout` as `DoctorResult`, and renders the doctor webview the same way it does on a healthy run. Falls through to the original error path when stdout is missing or unparseable.

Bumps to `1.15.1`.

## Test plan

- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 35 pass (1 new asserts `stdout` capture on the rejected error)
- [ ] Manual: open a workspace with no `rocky.toml`, click Extension Info → Logs → Run Health Check → doctor webview opens with the critical-state report (instead of an error toast).
- [ ] Manual: with the rocky binary uninstalled / bad path, verify the original "Doctor failed" toast still appears (fallthrough path).