### PR TITLE
feat(engine/rocky-trino): docker conformance harness behind trino-conformance feature

### DIFF
--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -25,10 +25,10 @@ tokio = { workspace = true }
 wiremock = { workspace = true }
 
 [features]
-# Gates the Docker-Trino live test in `tests/docker_live.rs`. Requires a
-# locally running `trinodb/trino` coordinator (the crate's
-# `docker-compose.yml` brings one up). Off by default so unit-test runs
-# stay credential-free.
+# Gates the Docker-Trino conformance harness in `tests/conformance.rs`.
+# Requires a locally running `trinodb/trino` coordinator reachable at
+# `${TRINO_HOST:-localhost}:${TRINO_PORT:-8080}`. Off by default so
+# unit-test runs stay credential- and network-free.
 trino-conformance = []
 
 [lints]

--- a/engine/crates/rocky-trino/README.md
+++ b/engine/crates/rocky-trino/README.md
@@ -148,13 +148,12 @@ DropAndRecreate.
   broken SQL.
 - **OAuth 2.0 / Kerberos / SPNEGO auth.** Basic + JWT only.
 - **`rocky init trino` template** — no scaffold exists yet.
-- **Docker conformance harness.** The crate's `Cargo.toml` reserves a
-  `trino-conformance` feature for a future `tests/docker_live.rs`
-  driver against `trinodb/trino`. The driver and its `docker-compose.yml`
-  are not yet committed.
-- **Playground POC.** No `examples/playground/pocs/07-adapters/*-trino*`
-  POC exists yet — it lands in a separate small PR alongside the
-  Docker harness.
+- **Playground POC** (full `docker compose up` walkthrough with a
+  row-count assertion via the REST API) lives at
+  `examples/playground/pocs/07-adapters/07-trino-docker/`. The
+  feature-gated harness in `tests/conformance.rs` (see below) covers
+  the in-tree adapter contract; the POC covers the end-to-end pipeline
+  shape.
 - **Governance / loader / batch checks.** Trino's `GRANT` semantics
   depend on the underlying connector; deferred until there's a concrete
   ask. The crate exports no `TrinoGovernanceAdapter` /
@@ -170,9 +169,9 @@ DropAndRecreate.
 
 ## Testing
 
-Unit tests live alongside the source — no separate `tests/` directory
-yet. They use [`wiremock`](https://crates.io/crates/wiremock) to stand
-up a coordinator mock and assert against:
+Unit tests live alongside the source. They use
+[`wiremock`](https://crates.io/crates/wiremock) to stand up a
+coordinator mock and assert against:
 
 - the `Authorization: Basic ...` header *structure* (decoded round-trip
   rather than a base64 literal — committing the encoded form trips
@@ -199,9 +198,59 @@ unit-test inputs only.
 cargo test -p rocky-trino
 ```
 
-The `trino-conformance` Cargo feature is reserved for the future Docker
-live test and is off by default — no live Trino is required to run the
-unit suite.
+No live Trino is required for the unit suite. The Docker-backed
+harness lives behind the `trino-conformance` Cargo feature — see
+[Conformance harness](#conformance-harness) below.
+
+## Conformance harness
+
+The `trino-conformance` Cargo feature gates an opt-in integration test
+at [`tests/conformance.rs`](tests/conformance.rs) that drives the
+adapter against a real Trino coordinator. It's off by default so the
+default `cargo test -p rocky-trino` invocation stays credential- and
+network-free, and CI never tries to reach Docker on its own.
+
+What it covers:
+
+- `TrinoDialect::format_table_ref` round-trips against the live
+  coordinator (the dialect's identifier-quoting contract has to match
+  what Trino's parser actually accepts).
+- The full `WarehouseAdapter` round-trip via the writable `memory`
+  connector: `SELECT 1`, then `CREATE TABLE AS` / `INSERT INTO` /
+  `SELECT *` / `DROP TABLE` against `memory.default.<unique_table>`.
+  Every statement flows through the same `/v1/statement` polling state
+  machine the unit tests exercise via `wiremock`, but here it lands on
+  a real coordinator.
+
+The harness reads the coordinator URL from `${TRINO_HOST:-localhost}`
+and `${TRINO_PORT:-8080}` and authenticates via the JWT-bearer path
+with a dummy token. (The upstream `trinodb/trino:latest` image rejects
+non-empty Basic-auth passwords over plain HTTP — *"Password not
+allowed for insecure authentication"* — but doesn't validate JWT
+bearers against a JWKS in the default config, so any non-empty token
+threads through. `X-Trino-User` is supplied explicitly via
+`TrinoClientConfig::with_user` because JWT auth doesn't infer one,
+mirroring the production pattern in [Configuration](#configuration-rockytoml)
+above.) The test table name is salted with `SystemTime::now()` so
+re-runs against a long-lived container don't collide on the previous
+run's `memory.default` table.
+
+To run it locally:
+
+```bash
+docker run -d --rm -p 8080:8080 --name rocky-trino-conformance \
+    trinodb/trino:latest
+# Wait until the coordinator reports ready (~30-45s on a warm pull):
+until curl -fsS http://localhost:8080/v1/info | grep -q '"starting":false'; do
+    sleep 2
+done
+cargo test -p rocky-trino --features trino-conformance
+docker stop rocky-trino-conformance
+```
+
+For the end-to-end pipeline-shape walkthrough (full `docker compose up`
++ `rocky run` + row-count assertion), see
+`examples/playground/pocs/07-adapters/07-trino-docker/`.
 
 ## Crate layout
 

--- a/engine/crates/rocky-trino/tests/conformance.rs
+++ b/engine/crates/rocky-trino/tests/conformance.rs
@@ -1,0 +1,180 @@
+//! Docker-backed conformance harness for the Trino adapter.
+//!
+//! Gated behind the `trino-conformance` Cargo feature so the default
+//! `cargo test -p rocky-trino` run stays credential- and network-free.
+//! When the feature is enabled this file expects a Trino coordinator
+//! reachable at `http://${TRINO_HOST:-localhost}:${TRINO_PORT:-8080}`.
+//! The upstream `trinodb/trino:latest` image works as-is, no auth
+//! configuration required: the harness uses the JWT-bearer path with
+//! a dummy token because Trino refuses non-empty Basic-auth passwords
+//! over plain HTTP, and the default config doesn't validate JWT
+//! bearers against a JWKS.
+//!
+//! Run with:
+//!
+//! ```bash
+//! docker run -d --rm -p 8080:8080 --name rocky-trino-conformance \
+//!     trinodb/trino:latest
+//! # wait until /v1/info reports {"starting":false}
+//! cargo test -p rocky-trino --features trino-conformance
+//! ```
+//!
+//! What it covers:
+//!
+//! - `TrinoDialect::format_table_ref` round-trips against the live
+//!   coordinator (the dialect's identifier-quoting contract has to
+//!   match what Trino's parser actually accepts).
+//! - The full `WarehouseAdapter` round-trip via the writable `memory`
+//!   connector: `CREATE TABLE` (CTAS), `INSERT INTO`, `SELECT *`,
+//!   `DROP TABLE`. Every statement flows through the same
+//!   `/v1/statement` polling state machine the unit tests exercise via
+//!   `wiremock`, but here it lands on a real Trino coordinator.
+//!
+//! The test uses a unique table name per run so re-running the suite
+//! against the same long-lived container doesn't trip on leftover
+//! state from a prior run.
+
+#![cfg(feature = "trino-conformance")]
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::traits::WarehouseAdapter;
+use rocky_trino::{TrinoAdapter, TrinoAuth, TrinoClientConfig};
+
+/// Coordinator URL assembled from `TRINO_HOST` (default `localhost`) +
+/// `TRINO_PORT` (default `8080`). Matches the conventions in
+/// `examples/playground/pocs/07-adapters/07-trino-docker/`.
+fn coordinator_url() -> String {
+    let host = std::env::var("TRINO_HOST").unwrap_or_else(|_| "localhost".into());
+    let port = std::env::var("TRINO_PORT").unwrap_or_else(|_| "8080".into());
+    format!("http://{host}:{port}")
+}
+
+/// Per-run table name in `memory.default` so concurrent / repeat runs
+/// don't collide. Trino's `memory` connector keeps tables for the
+/// container's lifetime, so re-running against the same container
+/// without cleanup would otherwise fail at CTAS.
+fn unique_table_name() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("rocky_conformance_{nanos}")
+}
+
+fn build_adapter() -> TrinoAdapter {
+    // The stock `trinodb/trino` image runs without any
+    // `password-authenticator.properties`, which means Trino refuses
+    // a non-empty Basic-auth password over plain HTTP ("Password not
+    // allowed for insecure authentication"). The JWT-bearer path is
+    // not validated against a JWKS in the default config either, so
+    // a dummy bearer token threads cleanly through the wire-protocol
+    // state machine without needing TLS or a real authenticator.
+    // The `X-Trino-User` header still has to be set explicitly because
+    // JWT auth doesn't infer one — we route the value via
+    // `TrinoClientConfig::with_user`, mirroring the production
+    // recommendation in the README.
+    let auth =
+        TrinoAuth::jwt("rocky-conformance-dummy-token").expect("jwt auth fixture should construct");
+    let cfg = TrinoClientConfig::new(coordinator_url())
+        .with_user("rocky")
+        .with_timeout(Duration::from_secs(30));
+    TrinoAdapter::new(cfg, auth)
+}
+
+#[test]
+fn dialect_format_table_ref_matches_trino_quoting() {
+    let adapter = build_adapter();
+    let formatted = adapter
+        .dialect()
+        .format_table_ref("memory", "default", "rocky_test")
+        .expect("identifiers are valid");
+    // Trino's standard identifier quoting is double-quotes; the dialect
+    // must emit a three-part `"catalog"."schema"."table"` reference.
+    assert_eq!(formatted, "\"memory\".\"default\".\"rocky_test\"");
+}
+
+#[tokio::test]
+async fn round_trip_select_one() {
+    // The simplest possible query — exercises POST /v1/statement +
+    // nextUri polling without touching any catalog.
+    let adapter = build_adapter();
+    let result = adapter
+        .execute_query("SELECT 1 AS n")
+        .await
+        .expect("SELECT 1 should succeed against a live coordinator");
+    assert_eq!(result.columns, vec!["n".to_string()]);
+    assert_eq!(result.rows.len(), 1);
+    let n = result.rows[0]
+        .first()
+        .expect("row has one column")
+        .as_i64()
+        .expect("column is an integer");
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+async fn round_trip_create_insert_select_drop() {
+    // Exercises the full `WarehouseAdapter` surface against the writable
+    // `memory.default` schema:
+    //   1. CREATE TABLE AS (a single-row VALUES seed)
+    //   2. INSERT INTO (append two more rows)
+    //   3. SELECT (read the three rows back)
+    //   4. DROP TABLE IF EXISTS (cleanup)
+    let adapter = build_adapter();
+    let dialect = adapter.dialect();
+    let table = unique_table_name();
+    let table_ref = dialect
+        .format_table_ref("memory", "default", &table)
+        .expect("identifiers are valid");
+
+    // Belt-and-braces: drop first in case a previous run leaked state.
+    adapter
+        .execute_statement(&dialect.drop_table_sql(&table_ref))
+        .await
+        .expect("pre-test DROP should succeed");
+
+    // 1) CREATE TABLE AS — VALUES list seeds one row.
+    let ctas = dialect.create_table_as(&table_ref, "SELECT 1 AS id, 'alice' AS name");
+    adapter
+        .execute_statement(&ctas)
+        .await
+        .expect("CTAS should succeed against memory.default");
+
+    // 2) INSERT INTO — append two rows.
+    let insert = dialect.insert_into(
+        &table_ref,
+        "SELECT * FROM (VALUES (2, 'bob'), (3, 'carol')) AS t(id, name)",
+    );
+    adapter
+        .execute_statement(&insert)
+        .await
+        .expect("INSERT should succeed");
+
+    // 3) SELECT — read all three rows back, ordered for stable assertion.
+    let select_sql = format!("SELECT id, name FROM {table_ref} ORDER BY id");
+    let result = adapter
+        .execute_query(&select_sql)
+        .await
+        .expect("SELECT should succeed");
+    assert_eq!(result.columns, vec!["id".to_string(), "name".to_string()]);
+    assert_eq!(result.rows.len(), 3, "expected 3 rows after CTAS + INSERT");
+    let ids: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|r| r[0].as_i64().expect("id is an integer"))
+        .collect();
+    assert_eq!(ids, vec![1, 2, 3]);
+    let names: Vec<&str> = result
+        .rows
+        .iter()
+        .map(|r| r[1].as_str().expect("name is a string"))
+        .collect();
+    assert_eq!(names, vec!["alice", "bob", "carol"]);
+
+    // 4) DROP — cleanup so the container stays usable for re-runs.
+    adapter
+        .execute_statement(&dialect.drop_table_sql(&table_ref))
+        .await
+        .expect("DROP should succeed");
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in integration test at `engine/crates/rocky-trino/tests/conformance.rs` that drives the Trino adapter against a real `trinodb/trino` coordinator end-to-end through the `/v1/statement` polling state machine. Gated behind the `trino-conformance` Cargo feature (already reserved in `Cargo.toml`) so the default `cargo test -p rocky-trino` run stays credential- and network-free; CI is unchanged.
- Covers `TrinoDialect::format_table_ref` against the live coordinator + a full `WarehouseAdapter` round-trip via the writable `memory` connector: `SELECT 1`, then `CREATE TABLE AS` / `INSERT INTO` / `SELECT *` / `DROP TABLE` against `memory.default.<unique_table>` (table name salted with `SystemTime::now()` so re-runs against a long-lived container don't collide).
- Auth path is JWT-bearer with a dummy token. Trino's upstream image rejects non-empty Basic-auth passwords over plain HTTP (*"Password not allowed for insecure authentication"*), but doesn't validate JWT bearers against a JWKS in the default config — any non-empty token threads through cleanly without TLS or a real authenticator. `X-Trino-User` is supplied via `TrinoClientConfig::with_user` (mirrors the production pattern in the README, since JWT auth doesn't infer a user).
- README gains a `## Conformance harness` section with copy-pasteable run instructions; the stale `Cargo.toml` feature comment naming `tests/docker_live.rs` is corrected and the "Not in v0" bullet about the harness is replaced with a pointer to the playground POC.

The follow-up PR drops `is_experimental: true` now that this self-test path exists. Original v0 adapter shipped in #427.

## Test plan

- [x] `cargo test -p rocky-trino` — 35/35 unit tests pass (default features, no Docker)
- [x] `cargo test -p rocky-trino --features trino-conformance` — 3/3 conformance tests pass against a local `trinodb/trino:latest` container
- [x] `cargo clippy -p rocky-trino --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p rocky-trino -- --check` — clean