### PR TITLE
chore(engine/rocky-trino): drop is_experimental flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ Each subproject has its own README with detailed usage. The [`engine/README.md`]
 | Warehouse | Snowflake | Beta | REST connector · zero-copy `CLONE` for branches · masking policies |
 | Warehouse | BigQuery | Beta | REST connector · `CREATE TABLE … COPY` for branches |
 | Warehouse | DuckDB | Local / Testing | Embedded · powers `rocky playground` (no credentials needed) |
-| Warehouse | Trino | Experimental | REST `/v1/statement` polling client · Basic + JWT auth · `is_experimental: true` until the Docker conformance harness lands |
+| Warehouse | Trino | Beta | REST `/v1/statement` polling client · Basic + JWT auth · Docker conformance harness behind `trino-conformance` feature |
 | Source | Fivetran | Production | REST connector + table discovery |
 | Source | Airbyte | Beta | Catalog discovery |
 | Source | Iceberg | Beta | REST catalog discovery of namespaces and tables |
 | Source | Manual | Production | Schema/table lists inline in `rocky.toml` |
 
-Building a warehouse Rocky doesn't ship in-tree (ClickHouse, Trino, Redshift, …)? See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [Rust-native skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
+Building a warehouse Rocky doesn't ship in-tree (ClickHouse, Redshift, …)? See the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) and the [Rust-native skeleton POC](examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/).
 
 ## Building from source
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`rocky-trino` drops the experimental flag.** With the Docker conformance harness landed (`trino-conformance` cargo feature), the adapter now advertises `is_experimental() == false` (the trait default) and the CLI no longer logs a startup warning when a `type = "trino"` block is registered. Adapter tables in the root and engine READMEs move from `Experimental` to `Beta`. No behavioral change for users beyond the warning suppression.
+
 ## [1.27.0] — 2026-05-07
 
 Feature release on three independent fronts. Headline: **`rocky import-dbt` now emits a runnable Rocky repo** ([#428](https://github.com/rocky-data/rocky/pull/428)) — the command was previously a validation report; it now writes `rocky.toml` (with `${VAR}` placeholders for connection fields, never inlined secrets), per-model `.sql` + `.toml` sidecars, a verbatim copy of `seeds/`, and a `MIGRATION-NOTES.md` under `--output-dir`. **Generic-test mapping** ([#433](https://github.com/rocky-data/rocky/pull/433)) lands in the same window, translating dbt's `unique` / `not_null` / `accepted_values` / `relationships` schema tests into Rocky `[[checks]]` blocks on the per-model sidecar. Bundles **`rocky-trino` v0** ([#427](https://github.com/rocky-data/rocky/pull/427)) — first warehouse adapter built natively against `rocky-adapter-sdk` (the four first-party adapters predated the SDK and were retrofitted), shipping the four core modules (REST connector + dialect + HTTP Basic / JWT auth + `WarehouseAdapter` impl) with v0 limits flagged at validate time (no MERGE, no OAuth/Kerberos, no governance, no checksum bisection). **`rocky run --watch`** ([#423](https://github.com/rocky-data/rocky/pull/423)) wraps the run path in a filesystem-watcher loop for the inner-loop editor workflow; under `--output json`, each iteration emits one `RunOutput` per line (newline-delimited stream).

--- a/engine/README.md
+++ b/engine/README.md
@@ -90,7 +90,7 @@ Full reference: [CLI commands](https://rocky-data.dev/reference/cli/).
 | Warehouse | Snowflake | Beta | SQL execution via Snowflake connector |
 | Warehouse | BigQuery | Beta | SQL execution via BigQuery connector |
 | Warehouse | DuckDB | Local / Testing | Embedded execution for development and CI |
-| Warehouse | Trino | Experimental | REST `/v1/statement` polling client; Basic + JWT auth; `is_experimental: true` until the Docker conformance harness lands |
+| Warehouse | Trino | Beta | REST `/v1/statement` polling client; Basic + JWT auth; Docker conformance harness behind the `trino-conformance` feature |
 
 Build a custom adapter in Rust or any language: [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) — walks through a ClickHouse-shaped skeleton, the trait surface, auth, testing, and distribution. Concepts overview: [Adapter SDK](https://rocky-data.dev/concepts/adapters/).
 

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rocky-trino"
 version = "0.1.0"
-description = "Trino warehouse adapter for Rocky (v0, experimental)"
+description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-trino/README.md
+++ b/engine/crates/rocky-trino/README.md
@@ -8,15 +8,14 @@ Implements `rocky_core::traits::WarehouseAdapter` and
 HTTP API. Hand-rolled over `reqwest` — no high-level Trino client crate
 dependency.
 
-## Status — v0, experimental
+## Status — beta
 
-The adapter advertises `WarehouseAdapter::is_experimental() == true`, so
-the CLI's startup loop logs a warning whenever an `[adapters.<name>]
-type = "trino"` block is registered. Coverage is intentionally narrow:
-the v0 PR exercised `rocky-adapter-sdk` from outside the first-party
-adapters and surfaced gaps. It is not yet ready for production traffic.
-The experimental flag is scheduled to drop once the Docker conformance
-harness exercises the four pipeline strategies end-to-end.
+Coverage is intentionally narrow but the supported surface is exercised
+end-to-end by the Docker conformance harness behind the
+`trino-conformance` cargo feature (see [Conformance harness](#conformance-harness)
+below). Unsupported gaps — MERGE, OAuth/Kerberos, governance, loader,
+batch-checks — fail loudly at validate time rather than emitting broken
+SQL silently.
 
 ## Configuration (`rocky.toml`)
 

--- a/engine/crates/rocky-trino/src/adapter.rs
+++ b/engine/crates/rocky-trino/src/adapter.rs
@@ -1,10 +1,10 @@
 //! Trino warehouse adapter — implements `rocky_core::traits::WarehouseAdapter`.
 //!
-//! v0 surface: `dialect`, `execute_statement`, `execute_query`,
-//! `describe_table`, `is_experimental` (returns `true`). Everything else
-//! falls back to the trait defaults: `merge_into` errors via the dialect
-//! ("v0 doesn't support MERGE"), `checksum_chunks` errors via the
-//! `row_hash_expr` default, governance / batch / loader are absent.
+//! Surface: `dialect`, `execute_statement`, `execute_query`,
+//! `describe_table`. Everything else falls back to the trait defaults:
+//! `merge_into` errors via the dialect ("v0 doesn't support MERGE"),
+//! `checksum_chunks` errors via the `row_hash_expr` default, governance /
+//! batch / loader are absent.
 
 use async_trait::async_trait;
 use rocky_core::ir::{ColumnInfo, TableRef};
@@ -15,9 +15,6 @@ use crate::connector::{TrinoClient, TrinoClientConfig};
 use crate::dialect::TrinoDialect;
 
 /// Trino warehouse adapter.
-///
-/// Marks itself as experimental — the registry's startup loop logs a
-/// warning when this adapter is selected.
 pub struct TrinoAdapter {
     client: TrinoClient,
     dialect: TrinoDialect,
@@ -51,14 +48,6 @@ impl TrinoAdapter {
 impl WarehouseAdapter for TrinoAdapter {
     fn dialect(&self) -> &dyn SqlDialect {
         &self.dialect
-    }
-
-    fn is_experimental(&self) -> bool {
-        // The Trino adapter is v0 / experimental — coverage is intentionally
-        // narrow (no MERGE, no governance, no loader, no Docker-conformance
-        // harness). The registry's startup loop reads this to surface a
-        // warning to the operator.
-        true
     }
 
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
@@ -125,11 +114,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_experimental_is_true() {
+    fn is_not_experimental() {
         let cfg = TrinoClientConfig::new("http://localhost:8080");
         let auth = crate::test_helpers::test_basic_auth();
         let adapter = TrinoAdapter::new(cfg, auth);
-        assert!(adapter.is_experimental());
+        assert!(!adapter.is_experimental());
     }
 
     #[test]

--- a/engine/crates/rocky-trino/src/lib.rs
+++ b/engine/crates/rocky-trino/src/lib.rs
@@ -1,8 +1,9 @@
-//! Trino warehouse adapter for Rocky (v0, experimental).
+//! Trino warehouse adapter for Rocky.
 //!
 //! Implements [`WarehouseAdapter`](rocky_core::traits::WarehouseAdapter)
 //! and [`SqlDialect`](rocky_core::traits::SqlDialect) against Trino's
-//! `POST /v1/statement` HTTP API. v0 is intentionally minimal:
+//! `POST /v1/statement` HTTP API. The supported surface is intentionally
+//! narrow — the gaps below are explicit at validate time, not implicit:
 //!
 //! - **Auth:** HTTP Basic (`X-Trino-User` + `Authorization: Basic ...`)
 //!   and JWT bearer. OAuth and Kerberos are out of scope.
@@ -11,17 +12,16 @@
 //!   supported by OSS Trino, so the adapter returns `None` from
 //!   `create_catalog_sql`. `auto_create_catalogs = true` against this
 //!   adapter trips at validate time.
-//! - **No MERGE in v0** — Trino's MERGE support is connector-dependent
-//!   (Iceberg yes, Hive limited). The dialect's `merge_into` returns an
-//!   explicit "not supported in v0" error so `strategy = "merge"` fails
-//!   loudly rather than emitting broken SQL.
-//! - **No governance / loader / batch-checks** — those are deferred
-//!   follow-ups gated by demand.
+//! - **No MERGE** — Trino's MERGE support is connector-dependent (Iceberg
+//!   yes, Hive limited). The dialect's `merge_into` returns an explicit
+//!   "not supported" error so `strategy = "merge"` fails loudly rather
+//!   than emitting broken SQL.
+//! - **No governance / loader / batch-checks** — deferred follow-ups
+//!   gated by demand.
 //!
-//! The adapter is marked `is_experimental: true` — the runtime logs a
-//! warning when it's selected, and the experimental flag drops in a
-//! follow-up once the Docker sandbox is exercised end-to-end across the
-//! four pipeline strategies.
+//! Conformance against a real Trino coordinator is exercised by the
+//! Docker harness behind the `trino-conformance` feature flag; see
+//! `tests/conformance.rs` and the README for invocation.
 
 pub mod adapter;
 pub mod auth;


### PR DESCRIPTION
## Summary

- Drops the explicit `is_experimental() == true` override on `TrinoAdapter` — the Docker conformance harness behind the `trino-conformance` feature (#442) gives the adapter a self-test path, so the trait default (`false`) is the right answer now.
- Moves the Trino row in the root + engine README adapter tables from `Experimental` to `Beta`.
- Drops the experimental framing from the crate README, Cargo description, and `lib.rs` module doc; renames the unit test to assert the trait default holds.
- One-line `[Unreleased] / Changed` CHANGELOG entry.

## Test plan

- [x] cargo test -p rocky-trino (35 passed)
- [x] cargo clippy -p rocky-trino --all-targets -- -D warnings
- [x] cargo fmt --check