### PR TITLE
fix(engine/rocky-trino): mark live-coordinator conformance tests #[ignore]

### DIFF
--- a/engine/crates/rocky-trino/README.md
+++ b/engine/crates/rocky-trino/README.md
@@ -207,7 +207,9 @@ The `trino-conformance` Cargo feature gates an opt-in integration test
 at [`tests/conformance.rs`](tests/conformance.rs) that drives the
 adapter against a real Trino coordinator. It's off by default so the
 default `cargo test -p rocky-trino` invocation stays credential- and
-network-free, and CI never tries to reach Docker on its own.
+network-free. The two network-dependent tests are also marked
+`#[ignore]` so they stay skipped under `cargo test --all-features` (as
+CI runs) — execution requires both the feature flag and `-- --ignored`.
 
 What it covers:
 
@@ -243,7 +245,7 @@ docker run -d --rm -p 8080:8080 --name rocky-trino-conformance \
 until curl -fsS http://localhost:8080/v1/info | grep -q '"starting":false'; do
     sleep 2
 done
-cargo test -p rocky-trino --features trino-conformance
+cargo test -p rocky-trino --features trino-conformance -- --ignored
 docker stop rocky-trino-conformance
 ```
 

--- a/engine/crates/rocky-trino/tests/conformance.rs
+++ b/engine/crates/rocky-trino/tests/conformance.rs
@@ -16,7 +16,7 @@
 //! docker run -d --rm -p 8080:8080 --name rocky-trino-conformance \
 //!     trinodb/trino:latest
 //! # wait until /v1/info reports {"starting":false}
-//! cargo test -p rocky-trino --features trino-conformance
+//! cargo test -p rocky-trino --features trino-conformance -- --ignored
 //! ```
 //!
 //! What it covers:
@@ -95,6 +95,7 @@ fn dialect_format_table_ref_matches_trino_quoting() {
 }
 
 #[tokio::test]
+#[ignore = "requires a live Trino coordinator at TRINO_HOST:TRINO_PORT (default localhost:8080); run with `--ignored`"]
 async fn round_trip_select_one() {
     // The simplest possible query — exercises POST /v1/statement +
     // nextUri polling without touching any catalog.
@@ -114,6 +115,7 @@ async fn round_trip_select_one() {
 }
 
 #[tokio::test]
+#[ignore = "requires a live Trino coordinator at TRINO_HOST:TRINO_PORT (default localhost:8080); run with `--ignored`"]
 async fn round_trip_create_insert_select_drop() {
     // Exercises the full `WarehouseAdapter` surface against the writable
     // `memory.default` schema:


### PR DESCRIPTION
## Summary

- engine-ci has been red on main since 495dc5c (#442) — `cargo test --all-features` enables `trino-conformance`, which pulls the two live-coordinator round-trip tests into the default pass; with no Trino at localhost:8080 they fail with ConnectionRefused.
- Adds `#[ignore]` to the two network-dependent tests so the feature flag still gates compilation while `--ignored` gates execution.
- Pure-dialect test (`dialect_format_table_ref_matches_trino_quoting`) stays runnable — it doesn't open a connection.
- README + module-doc invocation strings updated to the new `cargo test -p rocky-trino --features trino-conformance -- --ignored` shape.

## Test plan

- [x] `cargo test -p rocky-trino --all-features` — passes; conformance round-trip tests skipped as `ignored`
- [x] `cargo clippy -p rocky-trino --all-targets --all-features -- -D warnings`