### PR TITLE
fix(playground/02-performance/02-merge-upsert): execute end-to-end against DuckDB

### DIFF
--- a/examples/playground/pocs/02-performance/02-merge-upsert/README.md
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/README.md
@@ -1,16 +1,20 @@
-# 02-merge-upsert — Merge strategy via custom MERGE SQL
+# 02-merge-upsert — Model-level MERGE strategy, executed end-to-end
 
 > **Category:** 02-performance
 > **Credentials:** none (DuckDB)
 > **Runtime:** < 5s
-> **Rocky features:** `strategy.type = "merge"` model strategy
+> **Rocky features:** `[strategy] type = "merge"`, `unique_key`, `update_columns`, transformation pipeline, `auto_create_schemas`
 
 ## What it shows
 
-Demonstrates the MERGE materialization strategy declared at the **model**
-level (sidecar `.toml`) rather than at the pipeline replication level.
-Models with `[strategy] type = "merge"` use `unique_key` + `update_columns`
-to upsert rather than truncate-and-reload.
+Two models in one transformation pipeline. `raw_customers` materializes a
+staging copy of `seeds.customers`; `dim_customers` reads from it with
+`[strategy] type = "merge"`, declaring `unique_key = ["customer_id"]` and
+`update_columns = ["name", "email", "tier"]`. The first `rocky run`
+materializes the dim table; between runs we mutate the seed (update one
+row's tier, rename another, insert a new customer); the second `rocky run`
+issues a MERGE that upserts the changes — existing rows updated in place,
+new rows inserted, untouched rows untouched.
 
 ```toml
 [strategy]
@@ -21,24 +25,40 @@ update_columns = ["name", "email", "tier"]
 
 ## Why it's distinctive
 
-- **Model-level MERGE** avoids hand-writing `MERGE INTO` SQL.
-- Update column list is explicit so unrelated columns aren't overwritten.
-- Compile-time validation of `unique_key` ensures the column exists.
+- **Model-level MERGE** — no hand-written `MERGE INTO` SQL. Rocky lowers
+  `[strategy] type = "merge"` to dialect-specific MERGE on the target
+  warehouse.
+- **Update column list is explicit** so unrelated columns aren't
+  overwritten when the source schema grows.
+- **End-to-end against DuckDB.** Every other Rocky strategy POC also
+  materializes against DuckDB; this one closes the loop by exercising
+  MERGE semantics on a real warehouse, not just sql-gen string assertions.
 
 ## Layout
 
 ```
 .
 ├── README.md
-├── rocky.toml
-├── run.sh
-├── models/
-│   ├── raw_customers.sql
-│   ├── raw_customers.toml
-│   ├── dim_customers.sql
-│   └── dim_customers.toml    type = "merge", unique_key, update_columns
-└── data/seed.sql
+├── rocky.toml                        transformation pipeline + auto_create_schemas
+├── run.sh                            seed -> run #1 -> mutate -> run #2 -> verify
+├── data/
+│   ├── seed.sql                      50 customers in seeds.customers
+│   └── delta.sql                     1 update + 1 rename + 1 insert (between runs)
+└── models/
+    ├── raw_customers.{sql,toml}      seeds.customers -> poc.staging.raw_customers (full_refresh)
+    └── dim_customers.{sql,toml}      poc.staging.raw_customers -> poc.demo.dim_customers (merge)
 ```
+
+## Prerequisites
+
+- `rocky` on PATH
+- `duckdb` CLI (`brew install duckdb`) — seeds the source table, applies
+  the delta, and verifies post-MERGE row counts
+- Engine ≥ 1.29 (or this branch). The two enabling fixes shipped in PRs
+  [#448](https://github.com/rocky-data/rocky/pull/448)
+  (`auto_create_schemas` for transformation pipelines) and
+  [#449](https://github.com/rocky-data/rocky/pull/449) (DuckDB MERGE
+  unqualified-LHS).
 
 ## Run
 
@@ -46,10 +66,58 @@ update_columns = ["name", "email", "tier"]
 ./run.sh
 ```
 
-## Status
+## Expected output
 
-The merge strategy is parsed and the model.toml schema is validated by
-`rocky compile`. Local DuckDB execution (`rocky test`) doesn't currently
-generate MERGE SQL — `executor.rs` always emits `CREATE OR REPLACE TABLE AS`.
-This POC is **scaffold + spec**: shows the user-facing config + intended
-behavior. End-to-end MERGE on DuckDB awaits a follow-up to `rocky-engine`.
+```text
+=== first rocky run — initial materialization ===
+  - poc.staging.raw_customers (full_refresh)
+  - poc.demo.dim_customers (merge)
+
+  dim_customers row count after run #1:  50
+
+=== apply delta (UPDATE customer 5 tier, rename customer 7, INSERT customer 51) ===
+
+=== second rocky run — MERGE upsert ===
+  - poc.staging.raw_customers (full_refresh)
+  - poc.demo.dim_customers (merge)
+
+=== verify MERGE semantics ===
+-- row count after MERGE (expect 51 = 50 original + 1 inserted) --
+51
+
+customer_id |     name              |     email                       | tier
+----------- | --------------------- | ------------------------------- | ------
+          5 | Customer 5            | customer5@example.com           | gold     <- tier updated
+          7 | Customer 7 (renamed)  | customer7+renamed@example.com   | bronze   <- name+email updated
+         51 | Customer 51           | customer51@example.com          | bronze   <- newly inserted
+```
+
+## What happened
+
+1. `data/seed.sql` populates `seeds.customers` with 50 rows.
+2. First `rocky run --pipeline transform`:
+   - `auto_create_schemas` materializes `poc.staging` and `poc.demo`.
+   - `raw_customers` runs first (full_refresh CTAS).
+   - `dim_customers` runs second — Rocky sees the target doesn't exist, so
+     it bootstraps an empty `poc.demo.dim_customers` from the model schema
+     and then issues the MERGE (which inserts all 50 rows on the first
+     pass).
+3. `data/delta.sql` mutates `seeds.customers`: update tier on id=5, rename
+   id=7, insert id=51.
+4. Second `rocky run --pipeline transform`:
+   - `raw_customers` rebuilds (full_refresh).
+   - `dim_customers` issues a MERGE. WHEN MATCHED THEN UPDATE updates the
+     two changed rows; WHEN NOT MATCHED THEN INSERT inserts customer 51.
+     Untouched rows stay byte-identical.
+5. The final query proves 51 total rows + the expected per-row deltas.
+
+## Related
+
+- DuckDB MERGE dialect:
+  [`engine/crates/rocky-duckdb/src/dialect.rs`](../../../../engine/crates/rocky-duckdb/src/dialect.rs)
+  (`merge_into`)
+- Transformation MERGE codegen:
+  [`engine/crates/rocky-core/src/sql_gen.rs`](../../../../engine/crates/rocky-core/src/sql_gen.rs)
+  (`generate_transformation_sql` MERGE arm)
+- Sibling: [`01-incremental-watermark`](../01-incremental-watermark) —
+  watermark-based incremental writes (no MERGE, append only)

--- a/examples/playground/pocs/02-performance/02-merge-upsert/data/delta.sql
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/data/delta.sql
@@ -1,0 +1,17 @@
+-- Delta applied between the two rocky runs to exercise MERGE semantics:
+--   * Customer 5 changes tier bronze -> gold (UPDATE)
+--   * Customer 7 changes name + email (UPDATE)
+--   * Customer 51 is brand new (INSERT)
+-- Customer 5 had tier=silver in the seed (i % 5 = 0); we bump it to gold.
+
+UPDATE seeds.customers
+SET tier = 'gold'
+WHERE customer_id = 5;
+
+UPDATE seeds.customers
+SET name = 'Customer 7 (renamed)',
+    email = 'customer7+renamed@example.com'
+WHERE customer_id = 7;
+
+INSERT INTO seeds.customers VALUES
+    (51, 'Customer 51', 'customer51@example.com', 'bronze');

--- a/examples/playground/pocs/02-performance/02-merge-upsert/data/seed.sql
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/data/seed.sql
@@ -1,3 +1,7 @@
+-- Initial customer master: 50 rows.
+-- run.sh applies this once, then mutates the table between rocky runs to
+-- exercise the MERGE upsert path (existing keys updated, new keys inserted).
+
 CREATE SCHEMA IF NOT EXISTS seeds;
 
 CREATE OR REPLACE TABLE seeds.customers AS

--- a/examples/playground/pocs/02-performance/02-merge-upsert/models/dim_customers.sql
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/models/dim_customers.sql
@@ -1,1 +1,1 @@
-SELECT customer_id, name, email, tier FROM raw_customers
+SELECT customer_id, name, email, tier FROM poc.staging.raw_customers

--- a/examples/playground/pocs/02-performance/02-merge-upsert/models/dim_customers.toml
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/models/dim_customers.toml
@@ -1,3 +1,5 @@
+depends_on = ["raw_customers"]
+
 [strategy]
 type = "merge"
 unique_key = ["customer_id"]

--- a/examples/playground/pocs/02-performance/02-merge-upsert/rocky.toml
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/rocky.toml
@@ -1,14 +1,16 @@
+# 02-merge-upsert — model-level MERGE strategy executed end-to-end against DuckDB
+
 [adapter]
 type = "duckdb"
+path = "poc.duckdb"
 
-[pipeline.poc]
-strategy = "full_refresh"
+[pipeline.transform]
+type = "transformation"
 
-[pipeline.poc.source.schema_pattern]
-prefix = "raw__"
-separator = "__"
-components = ["source"]
+[pipeline.transform.target]
+adapter = "default"
 
-[pipeline.poc.target]
-catalog_template = "poc"
-schema_template = "demo"
+# Lets `rocky run` auto-create poc.staging and poc.demo on first invocation
+# so the POC needs no manual `CREATE SCHEMA` step (added in PR #448).
+[pipeline.transform.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/02-performance/02-merge-upsert/run.sh
+++ b/examples/playground/pocs/02-performance/02-merge-upsert/run.sh
@@ -1,13 +1,77 @@
 #!/usr/bin/env bash
+# 02-merge-upsert — model-level MERGE strategy, executed end-to-end against DuckDB
 set -euo pipefail
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
+
+# Clean state from previous runs
+rm -rf .rocky_state poc.duckdb expected
 mkdir -p expected
-rm -f .rocky-state.redb
 
+echo "=== validate ==="
 rocky validate
-rocky compile --models models > expected/compile.json
-rocky test --models models > expected/test.json
 
-echo "POC complete: merge strategy parsed and models compiled."
-echo "(Local DuckDB executor uses CREATE OR REPLACE TABLE for now; see README.)"
+echo ""
+echo "=== seed (50 customers in seeds.customers) ==="
+duckdb poc.duckdb < data/seed.sql
+duckdb poc.duckdb -c "SELECT COUNT(*) AS seed_rows FROM seeds.customers;"
+
+echo ""
+echo "=== first rocky run — initial materialization ==="
+rocky run --pipeline transform --output json > expected/run1.json
+python3 - <<'PY'
+import json, pathlib
+r = json.loads(pathlib.Path("expected/run1.json").read_text())
+for m in r.get("materializations", []):
+    print(f"  - {'.'.join(m['asset_key'])} ({m.get('metadata',{}).get('strategy','?')})")
+PY
+
+echo ""
+echo "  dim_customers row count after run #1:"
+duckdb poc.duckdb -c "SELECT COUNT(*) AS rows FROM poc.demo.dim_customers;"
+
+echo ""
+echo "=== apply delta (UPDATE customer 5 tier, rename customer 7, INSERT customer 51) ==="
+duckdb poc.duckdb < data/delta.sql
+
+echo ""
+echo "=== second rocky run — MERGE upsert ==="
+rocky run --pipeline transform --output json > expected/run2.json
+python3 - <<'PY'
+import json, pathlib
+r = json.loads(pathlib.Path("expected/run2.json").read_text())
+for m in r.get("materializations", []):
+    print(f"  - {'.'.join(m['asset_key'])} ({m.get('metadata',{}).get('strategy','?')})")
+PY
+
+echo ""
+echo "=== verify MERGE semantics ==="
+duckdb poc.duckdb <<'SQL'
+.print
+.print -- row count after MERGE (expect 51 = 50 original + 1 inserted) --
+SELECT COUNT(*) AS rows FROM poc.demo.dim_customers;
+
+.print
+.print -- updated rows (customer 5 should be 'gold'; customer 7 should be renamed) --
+SELECT customer_id, name, email, tier
+FROM poc.demo.dim_customers
+WHERE customer_id IN (5, 7, 51)
+ORDER BY customer_id;
+SQL
+
+echo ""
+echo "=== compiled MERGE SQL (for reference) ==="
+rocky compile --models models/ --output json > expected/compile.json
+python3 - <<'PY'
+import json, pathlib
+c = json.loads(pathlib.Path("expected/compile.json").read_text())
+for m in c.get("models_detail", []):
+    if m.get("strategy", {}).get("type") == "merge":
+        print(f"  model: {m['name']}")
+        print(f"  unique_key: {m['strategy'].get('unique_key')}")
+        print(f"  update_columns: {m['strategy'].get('update_columns')}")
+PY
+
+echo ""
+echo "POC complete: 50 rows on first run, MERGE upserts to 51 rows on second."


### PR DESCRIPTION
## Summary
The POC was scaffold-only — `run.sh` ran `rocky compile` + `rocky test` but never exercised MERGE SQL generation or execution. The README explicitly noted "Local DuckDB execution doesn't currently generate MERGE SQL".

Restructure the POC to drive the full MERGE upsert path against a real DuckDB file:

- Switch `rocky.toml` from a stub replication pipeline to a transformation pipeline with `auto_create_schemas = true` so `poc.staging` and `poc.demo` materialize on first run.
- Make `dim_customers` depend on `raw_customers` (DAG ordering) and reference it as `poc.staging.raw_customers` so the merge bootstrap step can resolve the source table.
- `run.sh` now: seed 50 customers → first `rocky run` (CTAS for staging, bootstrap-then-MERGE for dim) → apply delta (1 update, 1 rename, 1 insert) → second `rocky run` (MERGE upserts) → query verifies 51 rows with the expected per-row deltas.
- `data/delta.sql` is the new mutation script applied between runs.

## Verified output
```
=== verify MERGE semantics ===
-- row count after MERGE (expect 51 = 50 original + 1 inserted) --
51
customer_id |     name              |     email                       | tier
          5 | Customer 5            | customer5@example.com           | gold
          7 | Customer 7 (renamed)  | customer7+renamed@example.com   | bronze
         51 | Customer 51           | customer51@example.com          | bronze
```

## Depends on
- #448 — `auto_create_schemas` for transformation pipelines
- #449 — DuckDB MERGE unqualified-LHS

Once both engine fixes ship in the next release, this POC runs cleanly against a stock binary.

## Test plan
- [x] Smoke-test against a locally-built rocky with both engine fixes applied: row counts match + post-MERGE verifications pass
- [ ] Re-verify after #448 + #449 land in main
- [ ] CI green