### PR TITLE
fix(rocky-cli): propagate state-store open errors on model-only run

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -844,7 +844,16 @@ pub async fn run(
             .unwrap_or_else(|| "default".to_string());
 
         let warehouse = adapter_registry.warehouse_adapter(&target_adapter_name)?;
-        let state_store = rocky_core::state::StateStore::open(state_path).ok();
+        // Propagate state-store open errors with context, matching the
+        // full-pipeline run path below. The previous `.ok()` silently
+        // disabled state persistence (lost watermarks, missing run history)
+        // whenever the state file was corrupted or unreadable.
+        let state_store =
+            rocky_core::state::StateStore::open(state_path).context(format!(
+                "failed to open state store at {}",
+                state_path.display()
+            ))?;
+        let state_store = Some(state_store);
         // `run_id` minted at the top of `run()` — model-only, replication,
         // and idempotency-claim paths all share one identifier.
         let mut output = RunOutput::new(

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -848,12 +848,12 @@ pub async fn run(
         // full-pipeline run path below. The previous `.ok()` silently
         // disabled state persistence (lost watermarks, missing run history)
         // whenever the state file was corrupted or unreadable.
-        let state_store =
+        let state_store = Some(
             rocky_core::state::StateStore::open(state_path).context(format!(
                 "failed to open state store at {}",
                 state_path.display()
-            ))?;
-        let state_store = Some(state_store);
+            ))?,
+        );
         // `run_id` minted at the top of `run()` — model-only, replication,
         // and idempotency-claim paths all share one identifier.
         let mut output = RunOutput::new(

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -300,7 +300,9 @@ impl Auth {
 
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
+                    .map_err(|e| {
+                        AuthError::KeyPairInvalid(format!("system clock before unix epoch: {e}"))
+                    })?
                     .as_secs();
 
                 #[derive(serde::Serialize)]

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -300,9 +300,7 @@ impl Auth {
 
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|e| {
-                        AuthError::KeyPairInvalid(format!("system clock before unix epoch: {e}"))
-                    })?
+                    .unwrap()
                     .as_secs();
 
                 #[derive(serde::Serialize)]


### PR DESCRIPTION
## Summary

Replace `.ok()` with `?`-propagation on `StateStore::open(state_path)` in the model-only `rocky run --model X` path. The previous code silently disabled state persistence whenever the state file was corrupted or unreadable, masking the underlying problem and diverging from the full-pipeline run path which already uses `?` with `.context(...)`. Bring the two paths to parity so corrupted state surfaces loudly instead of degrading silently.

## Behavior change

Pre-fix: `rocky run --model X` against a corrupted state file ran to completion without persisting new state.
Post-fix: same scenario errors with `failed to open state store at <path>`.

This is the right call (corrupted state should be surfaced, not silently masked). Worth a changelog mention on the next engine cut.

## Subproject(s) touched

- [x] `engine/` (`rocky-cli`)

## Test plan

- [x] `cargo build -p rocky-cli`
- [x] `cargo clippy -p rocky-cli --lib -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI green

## History

Originally bundled with an unrelated `rocky-snowflake` auth change (`SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` -> `.map_err(...)`). That change was reverted in 0e39adbb on review: it created an outlier vs ~14 other sites in the engine workspace that consistently use `.unwrap()` for this pattern, and `AuthError::KeyPairInvalid` misclassifies what's really a system-clock issue. If we want to harden those, do it as a project-wide consistent pass.