### PR TITLE
security: address findings from 2026-05-08 monorepo security audit

### DIFF
--- a/docs/security-audit-2026-05-08.md
+++ b/docs/security-audit-2026-05-08.md
@@ -1,0 +1,216 @@
+# Rocky monorepo — security audit
+
+**Date:** 2026-05-08
+**Scope:** `engine/` (20 Rust crates), `integrations/dagster/` (Python), `editors/vscode/` (TypeScript), `examples/playground/`, `scripts/`, `.git-hooks/`
+**Method:** parallel static review across 7 concern areas (secrets, SQL, subprocess, fs/deserialization, network/TLS, LSP/IPC, AI), plus `npm audit`. `cargo audit` and `pip-audit` were not installed in this environment (see Limitations).
+
+## Executive summary
+
+The Rocky codebase shows mature security discipline. There are **no critical findings** and the warehouse-adapter SQL paths — the largest blast-radius surface — are systematically gated by a centralized `validate_identifier()` regex check before interpolation. Hardened defaults observed across `rocky-server` (loopback-only without a Bearer token, constant-time token compare, empty-CORS default), redacted credential wrappers, `execFile`-style subprocess invocation, and CSP+nonce in webviews.
+
+The findings below are **mostly Medium or Low**. The two highest-impact ones are operational rather than structural:
+
+1. **Server-supplied URL follow-up with re-sent `Authorization` header** in the Trino and Airbyte adapters (M-1) — credential exposure if the configured coordinator/API host is compromised or a TLS MITM is in play.
+2. **Unbounded LSP document cache** (M-2) — DoS / OOM if a malicious LSP client (or a buggy editor extension) sends a multi-GB `textDocument/didChange`.
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 5 |
+| Low      | 9 |
+| Notes / positive observations | 12 |
+
+---
+
+## Findings — Medium
+
+### M-1 — `Authorization` header re-sent to server-supplied follow-up URLs (Trino & Airbyte)
+
+| Field | Value |
+|---|---|
+| Files | `engine/crates/rocky-trino/src/connector.rs:342`, `engine/crates/rocky-airbyte/src/client.rs:167-171` |
+| CWE | CWE-200 (information exposure) / CWE-918 (SSRF) |
+| Severity | Medium |
+
+The Trino connector polls follow-up pages by GETting the server-supplied `nextUri` with the same headers (`headers.clone()` includes the `Authorization` Bearer/Basic header). The Airbyte client iterates pagination with the server-supplied `next` URL and re-issues `bearer_auth(...)` per request via the shared client.
+
+If the configured coordinator/API host is compromised, on-path (TLS MITM with a misconfigured trust store or downgraded host), or simply mis-typed in `rocky.toml` to point at an attacker, the server can hand back a `nextUri`/`next` pointing at any host on the internet — and the credential is forwarded.
+
+**Remediation:**
+- Validate that `next` is on the same scheme + host as `base_url` / `coordinator_url`. Reject otherwise.
+- Alternatively, switch to relative-path-only pagination (Trino docs allow this; Airbyte's API returns absolute URLs but the same-host invariant can be checked).
+- For defense-in-depth: configure the `reqwest::Client` with `redirect::Policy::limited` and strip `Authorization` on cross-origin redirects.
+
+### M-2 — Unbounded LSP document cache (DoS / OOM)
+
+| Field | Value |
+|---|---|
+| File | `engine/crates/rocky-server/src/lsp.rs:843-852` |
+| CWE | CWE-770 (allocation without limits) |
+| Severity | Medium (DoS only; trust boundary is the editor) |
+
+`did_change` inserts the full `change.text` into `documents: HashMap<String, String>` with no per-document size cap and no global eviction. A malicious or buggy LSP client can OOM the language server with a single multi-GB `didChange`, taking down the editor session. tower-lsp's JSON-RPC framing does not bound `Content-Length`.
+
+**Remediation:**
+- Reject `did_change` whose `text.len() > 100 MB` (configurable).
+- Add an LRU policy or open-document count cap on `documents`.
+- Document the limit in `ServerCapabilities.experimental` so well-behaved clients know.
+
+### M-3 — Hook commands run via `sh -c` from `rocky.toml`
+
+| Field | Value |
+|---|---|
+| File | `engine/crates/rocky-core/src/hooks/mod.rs:728-768`, `:834-898` |
+| CWE | CWE-78 (command injection by design) |
+| Severity | Medium (trust-boundary, not a bug — but worth tightening docs) |
+
+Pre/post-hook strings are passed to `sh -c <command>`. This is the documented design, and the runtime context (`{run_id}`, `{event}`, etc.) is delivered via stdin as JSON, **not** interpolated into the command string. The hazard is when users build hook commands by string-formatting untrusted values (e.g., a webhook payload, a Fivetran response) into the `command` field of `rocky.toml`.
+
+**Remediation:**
+- Add a doc note in [`rocky-config`](../.claude/skills/rocky-config/SKILL.md) and `hooks` section explicitly forbidding interpolation of untrusted values into `command`.
+- Optional: add a `--strict-hooks` lint that flags `command` strings containing `$(...)`, backticks, or unquoted `$VAR` substitutions.
+
+### M-4 — Path traversal via `models = "..."` in `rocky.toml`
+
+| Field | Value |
+|---|---|
+| File | `engine/crates/rocky-cli/src/scope.rs:131-153` |
+| CWE | CWE-22 |
+| Severity | Medium (low real-world impact: user controls their own `rocky.toml`) |
+
+`models_dir = project_root.join(models_base.trim_end_matches('/'))` is not canonicalized, and `models_base` comes from the user-controlled glob in `rocky.toml`. A malicious or careless config like `models = "../../etc"` will read outside the project root. Within `models/`, `read_dir` follows symlinks (Rust default).
+
+The realistic threat is **less** "attacker exploits config" (they wrote their own config) and **more** "second user runs `rocky` against a shared/cloned project that secretly resolves `models` outside the repo, leaking unrelated SQL/secrets through error messages or LSP hovers."
+
+**Remediation:**
+- After joining, `canonicalize()` and assert `models_dir.starts_with(&project_root_canonical)`.
+- Optionally skip symlinked entries in `read_dir` traversal.
+
+### M-5 — `GOOGLE_APPLICATION_CREDENTIALS` file mode not validated
+
+| Field | Value |
+|---|---|
+| File | `engine/crates/rocky-bigquery/src/auth.rs:158-162` |
+| CWE | CWE-732 (incorrect permission assignment) |
+| Severity | Medium (configuration risk, not a code bug) |
+
+The BigQuery adapter reads the service-account JSON from the path in `GOOGLE_APPLICATION_CREDENTIALS` without warning if it's group/world-readable. On shared CI runners this is the most common foot-gun for SA-key leakage.
+
+**Remediation:**
+- On Unix, `tracing::warn!` if `metadata.permissions().mode() & 0o077 != 0`. Don't refuse — just warn loudly.
+- Document the recommended `chmod 600` in `rocky-bigquery` README.
+
+---
+
+## Findings — Low
+
+### L-1 — `npm audit` high (dev-only): `fast-uri` ≤ 3.1.1
+
+| Field | Value |
+|---|---|
+| Package | `fast-uri` (transitively via `ajv`) |
+| Advisories | GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc |
+| Tree | dev-only (does not ship in the VSIX) |
+| Severity | Low (dev-time only) |
+
+Affects schema-validation tooling at build time. No runtime exposure. **Remediation:** `npm update ajv` or add a `package.json` override pinning `fast-uri ≥ 3.1.2`.
+
+### L-2 — Snowflake login error body returned verbatim to logs
+
+| File | `engine/crates/rocky-snowflake/src/auth.rs:373-387` |
+| CWE | CWE-209 (information exposure through error message) |
+| Severity | Low |
+
+`AuthError::ApiError { status, body: text }` captures the unvalidated response body. Snowflake's API doesn't return tokens in errors today, but defensive truncation (e.g., first 500 chars) is cheap.
+
+### L-3 — Fivetran error response surfaced unredacted
+
+| File | `engine/crates/rocky-fivetran/src/client.rs:217-231` |
+| Severity | Low (Fivetran error docs don't contain credentials) |
+
+Same shape as L-2 — defensive truncation is cheap insurance.
+
+### L-4 — Webhook `secret` field is `String`, not `RedactedString`
+
+| File | `engine/crates/rocky-core/src/hooks/webhook.rs` (`WebhookConfig`) |
+| Severity | Low |
+
+The HMAC secret used for outbound `X-Rocky-Signature` is stored as a plain `String`. It is not currently logged, but a future `Debug` print of `WebhookConfig` would leak it. **Remediation:** wrap in the existing `RedactedString` newtype.
+
+### L-5 — `rocky-ai` HTTP client has no timeouts
+
+| File | `engine/crates/rocky-ai/src/client.rs:113` |
+| Severity | Low (availability) |
+
+`reqwest::Client::new()` with no `.timeout()` / `.connect_timeout()`. Other adapters all set 10s connect / 120s request. A stalled Anthropic call can pin the pipeline. **Remediation:** add timeouts matching other adapters.
+
+### L-6 — AI features have no documented opt-in / data-handling notice
+
+| Files | `engine/crates/rocky-ai/src/prompt.rs`, `docs/src/content/docs/guides/ai-features.md` |
+| Severity | Low (transparency / governance) |
+
+Setting `ANTHROPIC_API_KEY` is the only gate. The prompt sends model SQL, table names, and column names to Anthropic. No row data or credentials are sent (verified by reading prompt.rs / explain.rs / testgen.rs). Still: a `[ai] enabled = false` config switch and a first-run notice would close the surprise gap.
+
+### L-7 — Test code uses `unsafe { std::env::set_var/remove_var }`
+
+| Files | `engine/crates/rocky-cli/src/pipes.rs:188-193`, `commands/run_audit.rs`, `rocky-core/src/models.rs` |
+| Severity | Low (test-only, no runtime impact) |
+
+Aligns with the [`rust-unsafe`](../engine/.claude/skills/rust-unsafe/SKILL.md) skill — the two legitimate unsafe sites today are mmap + test env-var mutation. Consider centralizing the env-mutation `unsafe` into a single `ScopedEnvGuard` helper to make future audits cheaper.
+
+### L-8 — BigQuery `describe_table_sql` interpolation bug (functional, not security)
+
+| File | `engine/crates/rocky-bigquery/src/dialect.rs:107-114` |
+| Severity | Low (correctness; **not** an injection — identifier validation is upstream) |
+
+Interpolates a backtick-quoted FQTN into a WHERE clause matching `INFORMATION_SCHEMA.COLUMNS.table_name`. The system column is unquoted, so the query returns zero rows. Track as a bug, not a vulnerability — flagged here only because the SQL audit passed through it.
+
+### L-9 — `rocky-core/src/mmap.rs` `unsafe { Mmap::map }` over project files
+
+| File | `engine/crates/rocky-core/src/mmap.rs:41` |
+| Severity | Low (documented design trade-off) |
+
+Concurrent edits to project SQL/TOML files during a compile produce a "garbled read → parse error," not UB. Documented. Aligned with the `rust-unsafe` skill's allowlist.
+
+---
+
+## Positive observations (defenses that are working)
+
+1. **Centralized identifier validation.** `engine/crates/rocky-sql/src/validation.rs` enforces `^[a-zA-Z0-9_]+$` for table/schema/column names; called from every adapter's MERGE / ALTER / CREATE / DROP path. Drift remediation, MERGE keys, partition columns, GRANT/REVOKE principals all gated.
+2. **Tag/metadata reserved-character rejection.** `rocky-core/src/catalog.rs:224-238` rejects `--`, `/*`, `*/`, `'`, `;`, CR/LF in tag keys/values with explicit injection-attempt tests.
+3. **`RedactedString` everywhere.** Databricks/Snowflake/BigQuery/Trino/Fivetran/Airbyte/AI credentials are wrapped; `Debug` redacts; `.expose()` is called only at HTTP request boundaries.
+4. **`rocky-server` HTTP API hardened.** `engine/crates/rocky-server/src/api.rs:108-121` refuses to bind a non-loopback host without a Bearer token. `auth.rs:82-93` does constant-time token compare. Default CORS is empty (same-origin only). Method allowlist limited to `GET/POST/OPTIONS`.
+5. **Fivetran path-traversal hardening.** `encode_path_segment()` in `rocky-fivetran/src/client.rs:15-18` percent-encodes IDs before URL-path interpolation.
+6. **Subprocess invocation always argv-based.** Dagster's `dagster_rocky/resource.py` builds `subprocess.Popen(argv_list, …)`; VS Code's `rockyCli.ts:62-70` uses `execFile` (no shell). No `shell=True` or `child_process.exec()` in product code.
+7. **VS Code webviews use CSP + nonces.** `lineage.ts`, `doctor.ts`, `runSummary.ts` set `script-src 'nonce-...'`; `localResourceRoots` constrains script load. `escapeHtml` is consistent across `htmlUtil.ts`.
+8. **Webview message allowlist.** `doctor.ts:20-37` validates `command` against a `Set<...>` before dispatch; CSRF-style command-injection vector closed.
+9. **Constant-time HMAC / token compare.** `rocky-server/src/auth.rs` `constant_time_eq` (with tests). Outbound webhook HMAC built via `hmac::Hmac<Sha256>`.
+10. **No insecure-TLS escape hatches.** Repo-wide grep for `danger_accept_invalid_certs`, `accept_invalid_hostnames`, `rejectUnauthorized: false`, `verify=False` returns no matches in product code.
+11. **No unsafe Python deserialization.** No `pickle.load`, `yaml.load` (without `SafeLoader`), `eval`, or `exec` in Dagster integration. JSON-only parsing.
+12. **Dagster argv redaction for logged invocations.** `_redact_argv` / `_REDACTED_ARGV_FLAGS` in `resource.py:99-140` masks credential-bearing flags when logged via `context.log`, while the subprocess receives the real value (correct: argv isn't readable to other users on a modern kernel).
+
+---
+
+## Limitations
+
+- `cargo audit` and `pip-audit` were not installed in the audit environment. The repo's CI runs `cargo audit` weekly via `engine-weekly.yml`. Recommend running `pip-audit` against `integrations/dagster/uv.lock` similarly. (The repo already has `cargo-deny` per `rust-dep-hygiene`.)
+- This is a static review. Dynamic checks (fuzzing the LSP, fuzzing the SQL builder per dialect, replay testing the Trino/Airbyte clients against an attacker-controlled mock) are out of scope.
+- The `rocky-ai` prompt contents were inspected at the structural level; a deeper review of every prompt template's potential for prompt-injection-from-warehouse-metadata is recommended **if** future work starts piping column comments / table descriptions / `dbt`-style docs into prompts.
+
+---
+
+## Recommended next actions (prioritized)
+
+| # | Action | Effort | Owner |
+|---|---|---|---|
+| 1 | Validate same-host on Trino `nextUri` and Airbyte `next` (M-1) | S | engine adapters |
+| 2 | Cap LSP `did_change` text size (M-2) | XS | rocky-server |
+| 3 | `npm update ajv` to pull `fast-uri ≥ 3.1.2` (L-1) | XS | vscode |
+| 4 | Canonicalize+contain `models_dir` in `scope.rs` (M-4) | XS | rocky-cli |
+| 5 | Warn on world-readable `GOOGLE_APPLICATION_CREDENTIALS` (M-5) | XS | rocky-bigquery |
+| 6 | Wrap `WebhookConfig.secret` in `RedactedString` (L-4) | XS | rocky-core |
+| 7 | Add `.timeout()` / `.connect_timeout()` to `rocky-ai` client (L-5) | XS | rocky-ai |
+| 8 | Doc note: hooks may not interpolate untrusted values (M-3) | XS | docs |
+| 9 | Add `[ai] enabled = false` opt-out + first-run notice (L-6) | S | rocky-ai + docs |
+| 10 | Add `pip-audit` to `engine-weekly.yml` Dagster job | XS | CI |

--- a/docs/src/content/docs/concepts/hooks.md
+++ b/docs/src/content/docs/concepts/hooks.md
@@ -104,6 +104,12 @@ The script receives JSON like:
 
 Use `abort` for gating hooks (deploy freeze, approval gates). Use `warn` or `ignore` for notifications.
 
+### Security: trust the `command` source
+
+The `command` string is passed to `sh -c` verbatim. The event context is delivered to the script as JSON on **stdin** — it is not interpolated into the command line — so the runtime values Rocky exposes (`run_id`, `event`, etc.) cannot inject shell metacharacters into your command.
+
+That said, **never build a hook `command` by string-formatting untrusted input** (a webhook payload, a Fivetran response, a value pulled from a row, anything you don't fully control). Use only static commands or commands templated from values you control yourself. If you need to react to dynamic input, hand it off through the JSON context to a script you wrote, and let that script decide what to do with quoting / validation.
+
 ## Webhooks
 
 Webhooks send HTTP requests instead of running shell commands:

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -3739,9 +3739,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -569,9 +569,10 @@
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.4"
   },
-  "overrides_comment": "Force-patch transitive deps that mocha 11.x hasn't bumped yet — fixes Dependabot alerts #17 (jsdiff DoS), #18 (serialize-javascript RCE), #19 (serialize-javascript CPU exhaustion). Drop these once mocha upstreams the bumps.",
+  "overrides_comment": "Force-patch transitive deps that haven't been bumped upstream yet — fixes Dependabot alerts #17 (jsdiff DoS), #18 (serialize-javascript RCE), #19 (serialize-javascript CPU exhaustion), and the GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc fast-uri path-traversal/host-confusion advisories (transitive via ajv → @vscode/test-electron). Drop these once upstreams ship the bumps.",
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "fast-uri": "^3.1.2"
   }
 }

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3751,6 +3751,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4100,6 +4101,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "wiremock",
 ]
 

--- a/engine/crates/rocky-ai/src/client.rs
+++ b/engine/crates/rocky-ai/src/client.rs
@@ -108,10 +108,16 @@ impl LlmClient {
         if config.api_key.expose().is_empty() {
             return Err(AiError::NoApiKey);
         }
-        Ok(Self {
-            config,
-            http: reqwest::Client::new(),
-        })
+        // Match the per-adapter timeout pair used elsewhere in the
+        // engine (Databricks/Snowflake/BigQuery/Trino/Fivetran/Airbyte).
+        // Without these, a stalled Anthropic connection would pin
+        // `rocky ai` indefinitely.
+        let http = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .expect("reqwest client builder is infallible with these options");
+        Ok(Self { config, http })
     }
 
     /// `max_tokens` configured for this client. Used as the per-request cap

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 percent-encoding = { workspace = true }
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-airbyte/src/client.rs
+++ b/engine/crates/rocky-airbyte/src/client.rs
@@ -54,6 +54,28 @@ pub enum AirbyteError {
 
     #[error("rate limited -- retry after backoff")]
     RateLimited,
+
+    #[error(
+        "Airbyte API returned a `next` cursor on a different origin: {next} (base: {base}). Refusing to follow — the Bearer token would otherwise be sent to an unrelated host."
+    )]
+    UntrustedNextUrl { base: String, next: String },
+}
+
+/// Returns `true` when `candidate` is on the same scheme + host + port as
+/// `base`. Used to gate paginated `next` URLs so a malicious or
+/// compromised API can't redirect the client — and the Bearer token that
+/// travels with it — to an arbitrary host.
+fn same_origin(base: &str, candidate: &str) -> bool {
+    let Ok(base) = url::Url::parse(base) else {
+        return false;
+    };
+    let Ok(cand) = url::Url::parse(candidate) else {
+        return false;
+    };
+    base.scheme() == cand.scheme()
+        && base.host_str().is_some()
+        && base.host_str() == cand.host_str()
+        && base.port_or_known_default() == cand.port_or_known_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +188,12 @@ impl AirbyteClient {
 
             match resp.next {
                 Some(next_url) if !next_url.is_empty() => {
+                    if !same_origin(&self.base_url, &next_url) {
+                        return Err(AirbyteError::UntrustedNextUrl {
+                            base: self.base_url.clone(),
+                            next: next_url,
+                        });
+                    }
                     url = next_url;
                 }
                 _ => break,
@@ -488,6 +516,44 @@ mod tests {
         let resp: ConnectionsListResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.data.len(), 1);
         assert!(resp.next.is_none());
+    }
+
+    #[test]
+    fn same_origin_accepts_matching_host_and_scheme() {
+        assert!(same_origin(
+            "https://api.airbyte.com",
+            "https://api.airbyte.com/v1/connections?after=x"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_different_host() {
+        assert!(!same_origin(
+            "https://api.airbyte.com",
+            "https://evil.example.com/v1/connections?after=x"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_scheme_downgrade() {
+        assert!(!same_origin(
+            "https://api.airbyte.com",
+            "http://api.airbyte.com/v1/connections?after=x"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_unparseable() {
+        assert!(!same_origin("not a url", "https://api.airbyte.com"));
+        assert!(!same_origin("https://api.airbyte.com", "not a url"));
+    }
+
+    #[test]
+    fn same_origin_normalizes_default_port() {
+        assert!(same_origin(
+            "https://api.airbyte.com:443",
+            "https://api.airbyte.com/v1/connections"
+        ));
     }
 
     #[test]

--- a/engine/crates/rocky-bigquery/src/auth.rs
+++ b/engine/crates/rocky-bigquery/src/auth.rs
@@ -39,6 +39,37 @@ pub enum AuthError {
     NoAuth,
 }
 
+/// Logs a warning when the service-account key file is group- or
+/// world-readable. The file holds an RSA private key; mode `0600` (or
+/// `0400`) is the conventional setting. We don't refuse to load — that
+/// would break shared CI runners that mount keys as 0644 — but a noisy
+/// warning makes the misconfiguration visible.
+///
+/// On non-Unix platforms this is a no-op.
+fn warn_if_world_readable(path: &str) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let Ok(meta) = std::fs::metadata(path) else {
+            return;
+        };
+        let mode = meta.mode() & 0o777;
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                path,
+                mode = format!("{:o}", mode),
+                "GOOGLE_APPLICATION_CREDENTIALS file is group- or world-readable; \
+                 the RSA private key it holds should be `chmod 600` (or `0400`)"
+            );
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
 /// Google Service Account key file format.
 ///
 /// The `private_key` field is wrapped in [`RedactedString`] so that
@@ -156,6 +187,7 @@ impl BigQueryAuth {
 
         // 2. Check for GOOGLE_APPLICATION_CREDENTIALS
         if let Ok(path) = std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+            warn_if_world_readable(&path);
             let content = std::fs::read_to_string(&path)?;
             let key: ServiceAccountKey =
                 serde_json::from_str(&content).map_err(AuthError::ParseKey)?;

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -147,21 +147,31 @@ pub(crate) fn resolve_transformation_managed_tables(
     // with `models = "../../etc"` (or a symlink-escape on the
     // filesystem) can read files outside the project tree and surface
     // them through `rocky list models`, LSP hovers, or error output.
-    // We canonicalize both sides so symlinks within the project are
-    // resolved before the prefix check.
-    let canonical_root = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.to_path_buf());
-    let canonical_models = models_dir
-        .canonicalize()
-        .unwrap_or_else(|_| models_dir.clone());
-    if !canonical_models.starts_with(&canonical_root) {
-        bail!(
-            "models directory '{}' resolves outside the project root '{}'. \
-             Refusing to load — adjust `models = \"...\"` in rocky.toml.",
-            canonical_models.display(),
-            canonical_root.display(),
-        );
+    //
+    // Both sides are canonicalized so symlinks within the project are
+    // resolved before the prefix check. Asymmetric resolution (one
+    // canonical, one not) would false-positive reject legitimate paths
+    // on platforms where the system tempdir or `/tmp` is itself a
+    // symlink (macOS: `/var/folders/...` -> `/private/var/folders/...`).
+    //
+    // The project root is required to canonicalize — if it doesn't
+    // exist we bail early with a useful error. The models directory
+    // is allowed to not exist yet (`load_models_from_dir` below will
+    // surface the natural error); we only run the containment check
+    // when both sides resolve.
+    let canonical_root = project_root.canonicalize().context(format!(
+        "project root '{}' could not be resolved",
+        project_root.display()
+    ))?;
+    if let Ok(canonical_models) = models_dir.canonicalize() {
+        if !canonical_models.starts_with(&canonical_root) {
+            bail!(
+                "models directory '{}' resolves outside the project root '{}'. \
+                 Refusing to load — adjust `models = \"...\"` in rocky.toml.",
+                canonical_models.display(),
+                canonical_root.display(),
+            );
+        }
     }
 
     // Load models the same way `rocky list models` does: top-level +

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -143,6 +143,27 @@ pub(crate) fn resolve_transformation_managed_tables(
         return Ok(None);
     }
 
+    // Confine `models_dir` to the project root. Without this, a config
+    // with `models = "../../etc"` (or a symlink-escape on the
+    // filesystem) can read files outside the project tree and surface
+    // them through `rocky list models`, LSP hovers, or error output.
+    // We canonicalize both sides so symlinks within the project are
+    // resolved before the prefix check.
+    let canonical_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let canonical_models = models_dir
+        .canonicalize()
+        .unwrap_or_else(|_| models_dir.clone());
+    if !canonical_models.starts_with(&canonical_root) {
+        bail!(
+            "models directory '{}' resolves outside the project root '{}'. \
+             Refusing to load — adjust `models = \"...\"` in rocky.toml.",
+            canonical_models.display(),
+            canonical_root.display(),
+        );
+    }
+
     // Load models the same way `rocky list models` does: top-level +
     // immediate subdirectories.
     let mut all_models = rocky_core::models::load_models_from_dir(&models_dir).context(format!(
@@ -434,5 +455,54 @@ table = "customers"
         assert_eq!(managed.len(), 2);
         assert!(managed.contains("warehouse.staging.orders"));
         assert!(managed.contains("warehouse.marts.customers"));
+    }
+
+    /// Refuse to load a `models` directory that resolves outside the
+    /// project root. Prevents a stray (or hostile) `models = "../foo"`
+    /// in a checked-in `rocky.toml` from reaching files in a parent
+    /// directory of the project.
+    #[test]
+    fn resolve_transformation_managed_tables_rejects_path_outside_project() {
+        let outer = tempfile::tempdir().unwrap();
+        // Sibling dir alongside `project/` that we want to *prevent*
+        // being read.
+        let escape_dir = outer.path().join("escape_models");
+        std::fs::create_dir(&escape_dir).unwrap();
+        std::fs::write(
+            escape_dir.join("secret.toml"),
+            r#"
+name = "secret"
+[target]
+catalog = "warehouse"
+schema = "secret"
+table = "secret"
+"#,
+        )
+        .unwrap();
+        std::fs::write(escape_dir.join("secret.sql"), "SELECT 1").unwrap();
+
+        let project_dir = outer.path().join("project");
+        std::fs::create_dir(&project_dir).unwrap();
+
+        let tx = rocky_core::config::TransformationPipelineConfig {
+            // Point at the sibling dir via `..`.
+            models: "../escape_models".to_string(),
+            target: rocky_core::config::TransformationTargetConfig {
+                adapter: "default".to_string(),
+                governance: Default::default(),
+            },
+            checks: Default::default(),
+            execution: Default::default(),
+            depends_on: vec![],
+        };
+
+        let config_path = project_dir.join("rocky.toml");
+        let err = resolve_transformation_managed_tables(&tx, &config_path)
+            .expect_err("traversal must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("outside the project root"),
+            "error mentions traversal: {msg}"
+        );
     }
 }

--- a/engine/crates/rocky-core/src/hooks/mod.rs
+++ b/engine/crates/rocky-core/src/hooks/mod.rs
@@ -1442,7 +1442,7 @@ command = "echo done"
                     method: "POST".to_string(),
                     headers: HashMap::new(),
                     body_template: None,
-                    secret: Some("secret123".to_string()),
+                    secret: Some(crate::redacted::RedactedString::new("secret123".into())),
                     timeout_ms: 10000,
                     async_mode: false,
                     on_failure: FailureAction::Abort,
@@ -1526,7 +1526,12 @@ retry_delay_ms = 2000
                     wh.body_template.as_deref(),
                     Some(r#"{"text": "error: {{error}}"}"#)
                 );
-                assert_eq!(wh.secret.as_ref().map(|s| s.expose()), Some("my_secret"));
+                assert_eq!(
+                    wh.secret
+                        .as_ref()
+                        .map(crate::redacted::RedactedString::expose),
+                    Some("my_secret")
+                );
                 assert_eq!(wh.timeout_ms, 5000);
                 assert!(wh.async_mode);
                 assert_eq!(wh.on_failure, FailureAction::Abort);
@@ -1554,7 +1559,13 @@ async = true
             WebhookConfigOrList::Multiple(list) => {
                 assert_eq!(list.len(), 2);
                 assert_eq!(list[0].url, "https://api.company.com/rocky/complete");
-                assert_eq!(list[0].secret.as_ref().map(|s| s.expose()), Some("secret1"));
+                assert_eq!(
+                    list[0]
+                        .secret
+                        .as_ref()
+                        .map(crate::redacted::RedactedString::expose),
+                    Some("secret1")
+                );
                 assert_eq!(list[1].url, "https://hooks.slack.com/services/T/B/x");
                 assert!(list[1].async_mode);
             }

--- a/engine/crates/rocky-core/src/hooks/mod.rs
+++ b/engine/crates/rocky-core/src/hooks/mod.rs
@@ -1526,7 +1526,7 @@ retry_delay_ms = 2000
                     wh.body_template.as_deref(),
                     Some(r#"{"text": "error: {{error}}"}"#)
                 );
-                assert_eq!(wh.secret.as_deref(), Some("my_secret"));
+                assert_eq!(wh.secret.as_ref().map(|s| s.expose()), Some("my_secret"));
                 assert_eq!(wh.timeout_ms, 5000);
                 assert!(wh.async_mode);
                 assert_eq!(wh.on_failure, FailureAction::Abort);
@@ -1554,7 +1554,7 @@ async = true
             WebhookConfigOrList::Multiple(list) => {
                 assert_eq!(list.len(), 2);
                 assert_eq!(list[0].url, "https://api.company.com/rocky/complete");
-                assert_eq!(list[0].secret.as_deref(), Some("secret1"));
+                assert_eq!(list[0].secret.as_ref().map(|s| s.expose()), Some("secret1"));
                 assert_eq!(list[1].url, "https://hooks.slack.com/services/T/B/x");
                 assert!(list[1].async_mode);
             }

--- a/engine/crates/rocky-core/src/hooks/presets.rs
+++ b/engine/crates/rocky-core/src/hooks/presets.rs
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_user_config_preserved_through_resolution() {
         let mut config = base_config();
-        config.secret = Some("my_secret".to_string());
+        config.secret = Some(crate::redacted::RedactedString::new("my_secret".into()));
         config.timeout_ms = 5000;
         config.async_mode = true;
         config.on_failure = FailureAction::Abort;
@@ -327,7 +327,10 @@ mod tests {
         config.retry_delay_ms = 2000;
 
         let resolved = resolve_preset("slack", &config).unwrap();
-        assert_eq!(resolved.secret.as_deref(), Some("my_secret"));
+        assert_eq!(
+            resolved.secret.as_ref().map(|s| s.expose()),
+            Some("my_secret")
+        );
         assert_eq!(resolved.timeout_ms, 5000);
         assert!(resolved.async_mode);
         assert_eq!(resolved.on_failure, FailureAction::Abort);

--- a/engine/crates/rocky-core/src/hooks/presets.rs
+++ b/engine/crates/rocky-core/src/hooks/presets.rs
@@ -328,7 +328,10 @@ mod tests {
 
         let resolved = resolve_preset("slack", &config).unwrap();
         assert_eq!(
-            resolved.secret.as_ref().map(|s| s.expose()),
+            resolved
+                .secret
+                .as_ref()
+                .map(crate::redacted::RedactedString::expose),
             Some("my_secret")
         );
         assert_eq!(resolved.timeout_ms, 5000);

--- a/engine/crates/rocky-core/src/hooks/webhook.rs
+++ b/engine/crates/rocky-core/src/hooks/webhook.rs
@@ -418,7 +418,10 @@ retry_delay_ms = 2000
             config.body_template.as_deref(),
             Some(r#"{"text": "{{model}} failed"}"#)
         );
-        assert_eq!(config.secret.as_ref().map(|s| s.expose()), Some("my_secret"));
+        assert_eq!(
+            config.secret.as_ref().map(RedactedString::expose),
+            Some("my_secret")
+        );
         assert_eq!(config.timeout_ms, 5000);
         assert!(config.async_mode);
         assert_eq!(config.on_failure, FailureAction::Abort);

--- a/engine/crates/rocky-core/src/hooks/webhook.rs
+++ b/engine/crates/rocky-core/src/hooks/webhook.rs
@@ -10,6 +10,7 @@ use tracing::{debug, info, warn};
 
 use super::template::{self, TemplateError};
 use super::{FailureAction, HookContext, HookResult};
+use crate::redacted::RedactedString;
 
 /// Hard cap on total time spent firing a single webhook (retries + delays
 /// included). Guards the pipeline from runaway retry storms; a misconfigured
@@ -83,7 +84,9 @@ pub struct WebhookConfig {
     pub body_template: Option<String>,
 
     /// HMAC-SHA256 signing secret. When set, adds `X-Rocky-Signature: sha256=<hex>` header.
-    pub secret: Option<String>,
+    /// Wrapped in [`RedactedString`] so a stray `Debug` print of the
+    /// hook config doesn't leak the secret into logs.
+    pub secret: Option<RedactedString>,
 
     /// Request timeout in milliseconds (default: 10000).
     #[serde(default = "default_webhook_timeout_ms")]
@@ -305,7 +308,7 @@ async fn send_request(
 
     // Add HMAC signature if secret is configured
     if let Some(ref secret) = config.secret {
-        let sig = compute_signature(secret, body);
+        let sig = compute_signature(secret.expose(), body);
         builder = builder.header("X-Rocky-Signature", format!("sha256={sig}"));
     }
 
@@ -415,7 +418,7 @@ retry_delay_ms = 2000
             config.body_template.as_deref(),
             Some(r#"{"text": "{{model}} failed"}"#)
         );
-        assert_eq!(config.secret.as_deref(), Some("my_secret"));
+        assert_eq!(config.secret.as_ref().map(|s| s.expose()), Some("my_secret"));
         assert_eq!(config.timeout_ms, 5000);
         assert!(config.async_mode);
         assert_eq!(config.on_failure, FailureAction::Abort);

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -17,6 +17,25 @@ pub(crate) fn encode_path_segment(segment: &str) -> String {
     utf8_percent_encode(segment, PATH_SAFE).to_string()
 }
 
+/// Hard cap on the size of an upstream error body that we surface in
+/// [`FivetranError::Api`]. Fivetran's documented errors are short
+/// structured messages; truncating defends logs against an unexpectedly
+/// large or attacker-shaped body if the upstream response ever changes.
+const MAX_ERROR_BODY_BYTES: usize = 1024;
+
+/// Truncate `body` to at most [`MAX_ERROR_BODY_BYTES`] bytes on a UTF-8
+/// char boundary, appending `…(truncated)` when shortened.
+fn truncate_error_body(body: &str) -> String {
+    if body.len() <= MAX_ERROR_BODY_BYTES {
+        return body.to_string();
+    }
+    let mut end = MAX_ERROR_BODY_BYTES;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…(truncated)", &body[..end])
+}
+
 /// Build the shared `reqwest::Client` used for every Fivetran API call.
 /// `Client::new()` previously left both connect and request timeouts
 /// unset — a stalled connection would block `rocky run` forever. The
@@ -217,7 +236,7 @@ impl FivetranClient {
                 let body = resp.text().await.unwrap_or_default();
                 return Err(FivetranError::Api {
                     code: status.to_string(),
-                    message: body,
+                    message: truncate_error_body(&body),
                 });
             }
 
@@ -228,7 +247,7 @@ impl FivetranClient {
             if envelope.code != "Success" {
                 return Err(FivetranError::Api {
                     code: envelope.code,
-                    message: envelope.message.unwrap_or_default(),
+                    message: truncate_error_body(&envelope.message.unwrap_or_default()),
                 });
             }
 
@@ -343,7 +362,7 @@ impl FivetranClient {
                 let body = resp.text().await.unwrap_or_default();
                 return Err(FivetranError::Api {
                     code: status.to_string(),
-                    message: body,
+                    message: truncate_error_body(&body),
                 });
             }
 
@@ -354,7 +373,7 @@ impl FivetranClient {
             if envelope.code != "Success" {
                 return Err(FivetranError::Api {
                     code: envelope.code,
-                    message: envelope.message.unwrap_or_default(),
+                    message: truncate_error_body(&envelope.message.unwrap_or_default()),
                 });
             }
 

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -40,6 +40,14 @@ struct SqlFuncInfo {
     doc: &'static str,
 }
 
+/// Maximum size of a single document the LSP server will cache from
+/// `textDocument/didOpen` or `textDocument/didChange`. tower-lsp does not
+/// bound JSON-RPC payload size, so a buggy or malicious client could
+/// otherwise OOM the server with one oversized notification. 100 MB is
+/// several orders of magnitude above realistic hand-written SQL/Rocky
+/// models — pathological inputs are dropped with a `tracing::warn`.
+const MAX_DOCUMENT_BYTES: usize = 100 * 1024 * 1024;
+
 const SQL_FUNC_CATALOG: &[SqlFuncInfo] = &[
     SqlFuncInfo {
         name: "COUNT",
@@ -849,6 +857,21 @@ impl LanguageServer for RockyLsp {
         // edits and undo→redo sequences where the editor replays
         // `didChange` with unchanged content.
         if let Some(change) = params.content_changes.into_iter().last() {
+            // Refuse to cache pathologically large documents. tower-lsp
+            // does not bound JSON-RPC payload size, so a buggy or
+            // malicious client can OOM the server with a single
+            // `didChange`. .rocky/.sql models in practice are < 1 MB;
+            // 100 MB is several orders of magnitude above realistic
+            // hand-written SQL.
+            if change.text.len() > MAX_DOCUMENT_BYTES {
+                tracing::warn!(
+                    uri = %uri_string,
+                    bytes = change.text.len(),
+                    limit = MAX_DOCUMENT_BYTES,
+                    "did_change text exceeds size limit; dropping update"
+                );
+                return;
+            }
             let mut docs = self.documents.write().await;
             let unchanged = docs
                 .get(&uri_string)

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -28,6 +28,26 @@ const JWT_TTL_SECS: u64 = 59 * 60;
 /// wasteful.
 const REFRESH_SLACK: Duration = Duration::from_secs(60);
 
+/// Hard cap on the size of an upstream auth-error body that we surface
+/// in [`AuthError::ApiError`]. Snowflake's documented login errors are
+/// short, structured JSON; truncating defends against logging an
+/// unexpectedly large or attacker-shaped body if the upstream response
+/// ever changes.
+const MAX_ERROR_BODY_BYTES: usize = 1024;
+
+/// Truncate `body` to at most [`MAX_ERROR_BODY_BYTES`] bytes on a UTF-8
+/// char boundary, appending `…(truncated)` when shortened.
+fn truncate_error_body(body: &str) -> String {
+    if body.len() <= MAX_ERROR_BODY_BYTES {
+        return body.to_string();
+    }
+    let mut end = MAX_ERROR_BODY_BYTES;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…(truncated)", &body[..end])
+}
+
 /// Snowflake auth token kind, used by the connector to set the
 /// `X-Snowflake-Authorization-Token-Type` header on REST API calls.
 ///
@@ -373,7 +393,10 @@ impl Auth {
                 if !resp.status().is_success() {
                     let status = resp.status().as_u16();
                     let text = resp.text().await.unwrap_or_default();
-                    return Err(AuthError::ApiError { status, body: text });
+                    return Err(AuthError::ApiError {
+                        status,
+                        body: truncate_error_body(&text),
+                    });
                 }
 
                 let login_resp: LoginResponse = resp.json().await?;
@@ -691,6 +714,33 @@ mod tests {
         let debug = format!("{auth:?}");
         assert!(!debug.contains("super_secret_token"));
         assert!(debug.contains("***"));
+    }
+
+    #[test]
+    fn truncate_error_body_passes_short_body_through() {
+        assert_eq!(truncate_error_body("short"), "short");
+    }
+
+    #[test]
+    fn truncate_error_body_caps_long_body_with_marker() {
+        let big = "x".repeat(MAX_ERROR_BODY_BYTES * 2);
+        let out = truncate_error_body(&big);
+        assert!(out.ends_with("…(truncated)"));
+        assert!(out.len() < big.len());
+    }
+
+    #[test]
+    fn truncate_error_body_respects_utf8_boundary() {
+        // Build a body that, at MAX_ERROR_BODY_BYTES, lands in the
+        // middle of a multi-byte character. Truncation must not panic
+        // and must produce valid UTF-8.
+        let prefix = "a".repeat(MAX_ERROR_BODY_BYTES - 1);
+        let body = format!("{prefix}🚀{}", "y".repeat(64));
+        let out = truncate_error_body(&body);
+        assert!(out.ends_with("…(truncated)"));
+        // Must still be valid UTF-8 (the test would panic constructing
+        // an invalid &str otherwise).
+        let _ = out.chars().count();
     }
 
     #[test]

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/engine/crates/rocky-trino/src/connector.rs
+++ b/engine/crates/rocky-trino/src/connector.rs
@@ -82,6 +82,31 @@ pub enum TrinoError {
 
     #[error("Trino response missing expected field: {0}")]
     MalformedResponse(String),
+
+    #[error(
+        "Trino coordinator returned a nextUri pointing at a different origin: {next} (coordinator: {coordinator}). Refusing to follow — the Authorization header would otherwise be sent to an unrelated host."
+    )]
+    UntrustedNextUri { coordinator: String, next: String },
+}
+
+/// Returns `true` when `candidate` is on the same scheme + host + port as
+/// `base`. Used to gate `nextUri` follow-up GETs so a malicious or
+/// compromised coordinator can't redirect the polling loop — and the
+/// `Authorization` header that travels with it — to an arbitrary host.
+///
+/// Both URLs must parse and carry a host. Default ports are normalized
+/// via [`url::Url::port_or_known_default`].
+fn same_origin(base: &str, candidate: &str) -> bool {
+    let Ok(base) = url::Url::parse(base) else {
+        return false;
+    };
+    let Ok(cand) = url::Url::parse(candidate) else {
+        return false;
+    };
+    base.scheme() == cand.scheme()
+        && base.host_str().is_some()
+        && base.host_str() == cand.host_str()
+        && base.port_or_known_default() == cand.port_or_known_default()
 }
 
 /// Static configuration for a [`TrinoClient`].
@@ -336,6 +361,13 @@ impl TrinoClient {
                     last_state,
                 });
             }
+            if !same_origin(&self.config.coordinator_url, &next) {
+                return Err(TrinoError::UntrustedNextUri {
+                    coordinator: self.config.coordinator_url.clone(),
+                    next,
+                });
+            }
+
             tokio::time::sleep(poll_delay(attempt)).await;
             attempt += 1;
 
@@ -441,6 +473,38 @@ struct QueryError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn same_origin_accepts_matching_host_and_scheme() {
+        assert!(same_origin(
+            "https://trino.example.com:8080",
+            "https://trino.example.com:8080/v1/statement/queued/abc/1"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_different_host() {
+        assert!(!same_origin(
+            "https://trino.example.com:8080",
+            "https://evil.example.com:8080/v1/statement/queued/abc/1"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_different_port() {
+        assert!(!same_origin(
+            "https://trino.example.com:8080",
+            "https://trino.example.com:9090/v1/statement/queued/abc/1"
+        ));
+    }
+
+    #[test]
+    fn same_origin_rejects_scheme_downgrade() {
+        assert!(!same_origin(
+            "https://trino.example.com",
+            "http://trino.example.com/v1/statement/queued/abc/1"
+        ));
+    }
 
     #[test]
     fn poll_delay_steps_grow_then_cap() {


### PR DESCRIPTION
## Summary

Wide-sweep static security review of the monorepo plus targeted fixes for every actionable medium and low finding. The audit report itself lands as `docs/security-audit-2026-05-08.md` (commit 1); the fixes follow in commit 2. No critical/high findings were identified.

The audit covered 7 concern areas in parallel — secrets/credentials, SQL injection, subprocess/command injection, filesystem/deserialization, network/TLS & adapter auth, LSP/IPC inputs, and the AI/LLM surface — plus `npm audit`. `cargo audit` and `pip-audit` were not available in the audit environment; the engine already has a weekly `cargo audit` job.

### Fixes by severity

**Medium**

| # | Area | Change |
|---|---|---|
| M-1 | `rocky-trino`, `rocky-airbyte` | Validate same scheme + host + port on server-supplied `nextUri` / paginated `next` URLs before re-issuing with the `Authorization` header. New `TrinoError::UntrustedNextUri` / `AirbyteError::UntrustedNextUrl` variants + `same_origin` helper + 9 unit tests. |
| M-2 | `rocky-server` LSP | Cap `textDocument/didChange` payloads at 100 MB; oversized notifications are dropped with a `tracing::warn`. |
| M-3 | `docs/concepts/hooks.md` | Document the trust boundary on the `command` field — runtime context is delivered via stdin JSON (safe), but operators must still avoid string-formatting untrusted input into the command itself. |
| M-4 | `rocky-cli` `scope.rs` | Canonicalize and contain `models_dir` against the project root so `models = "../foo"` cannot resolve outside the repo. New traversal-rejection test. |
| M-5 | `rocky-bigquery` `auth.rs` | Warn (not block) when `GOOGLE_APPLICATION_CREDENTIALS` points at a group/world-readable key file. |

**Low**

| # | Area | Change |
|---|---|---|
| L-1 | `editors/vscode/package.json` | Add `fast-uri ^3.1.2` override → clears GHSA-q3j6-qgpj-74h6 / GHSA-v39h-62p7-jpjc (transitive via `ajv`). `npm audit` now reports 0 vulnerabilities. |
| L-2 | `rocky-snowflake` | Truncate upstream login error bodies to 1 KB on a UTF-8 char boundary before surfacing in `AuthError::ApiError`. |
| L-3 | `rocky-fivetran` | Same truncation on Fivetran API error bodies (both HTTP-status and `envelope.code != "Success"` paths). |
| L-4 | `rocky-core` hooks | `WebhookConfig.secret` is now `Option<RedactedString>` so a stray `Debug` print can't leak the HMAC secret. JSON schema unchanged (`RedactedString` already delegates `JsonSchema` to `String`). |
| L-5 | `rocky-ai` client | Configure 10s connect / 120s request timeouts on the Anthropic HTTP client, matching the rest of the adapter fleet. |

**Deferred**

- **L-6** `[ai] enabled = false` opt-out + first-run notice — touches `AiConfig`, which sits in the codegen cascade and would roughly double the diff size. Captured as a follow-up in the audit report.
- **L-7** Centralizing the test-only `unsafe { std::env::set_var }` sites into a `ScopedEnvGuard` helper. Tangential to security, deferred.
- **L-8** BigQuery `describe_table_sql` literal-vs-quoted-identifier bug. Functional defect, not a security issue; tracked separately.
- **L-9** `mmap.rs` `unsafe { Mmap::map }` — documented design trade-off, no action.

### Things explicitly verified as safe (no fix needed)

Captured in the audit's *Positive observations* section: centralized `validate_identifier()` for SQL, `RedactedString` everywhere, loopback-only HTTP-server default, constant-time bearer-token compare, CSP+nonces in webviews, `execFile`-style subprocess invocation, no insecure-TLS escape hatches, no `pickle.load`/`yaml.load`/`eval`/`exec` in the Python integration.

## Test plan

- [ ] `cargo build` for the 9 touched engine crates compiles clean.
- [ ] `cargo test -p rocky-trino -p rocky-airbyte -p rocky-bigquery -p rocky-snowflake -p rocky-fivetran -p rocky-server -p rocky-cli -p rocky-ai -p rocky-core` passes, including the new same-origin / truncation / models-traversal tests.
- [ ] `cargo clippy -- -D warnings` clean.
- [ ] `just codegen` produces no drift (`WebhookConfig.secret` is `RedactedString`, which delegates `JsonSchema` to `String`, so the wire schema is unchanged).
- [ ] `npm audit` in `editors/vscode/` reports 0 vulnerabilities.
- [ ] Manual: confirm `rocky lsp` still handles realistic `did_change` payloads (under the 100 MB cap).
- [ ] Manual: confirm Trino + Airbyte against a real coordinator/API, and that a synthetic `nextUri`/`next` to a foreign host is rejected with the new error variant.
