### PR TITLE
fix(playground): repair five failing POCs + smoke filter

### DIFF
--- a/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/data/seed.sql
+++ b/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/data/seed.sql
@@ -1,0 +1,24 @@
+-- Seed data for `rocky test` (in-memory DuckDB).
+-- The persistent `rocky run` flow uses `rocky seed --seeds seeds/` instead.
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders (
+    order_id    INTEGER,
+    customer_id INTEGER,
+    product     VARCHAR,
+    amount      DECIMAL(10,2),
+    status      VARCHAR,
+    ordered_at  DATE
+);
+
+INSERT INTO raw__orders.orders VALUES
+    (101, 1, 'Widget A', 29.99, 'shipped',   DATE '2025-08-01'),
+    (102, 2, 'Widget B', 49.50, 'delivered', DATE '2025-08-02'),
+    (103, 1, 'Gadget X', 15.00, 'pending',   DATE '2025-08-03'),
+    (104, 3, 'Widget A', 29.99, 'shipped',   DATE '2025-08-04'),
+    (105, 5, 'Gadget Y', 89.95, 'delivered', DATE '2025-08-05'),
+    (106, 4, 'Widget B', 49.50, 'pending',   DATE '2025-08-06'),
+    (107, 6, 'Gadget X', 15.00, 'shipped',   DATE '2025-08-07'),
+    (108, 2, 'Widget A', 29.99, 'delivered', DATE '2025-08-08'),
+    (109, 7, 'Gadget Y', 89.95, 'pending',   DATE '2025-08-09'),
+    (110, 3, 'Widget B', 49.50, 'shipped',   DATE '2025-08-10');

--- a/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/models/stg_orders.sql
+++ b/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/models/stg_orders.sql
@@ -5,4 +5,4 @@ SELECT
     amount,
     status,
     ordered_at
-FROM poc.staging__orders.orders
+FROM raw__orders.orders

--- a/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/models/stg_orders.sql
+++ b/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/models/stg_orders.sql
@@ -1,3 +1,6 @@
+-- Reads `raw__orders` directly so `rocky test` (in-memory DuckDB) finds the
+-- table via `data/seed.sql`. The replication step in run.sh exercises the
+-- separate raw__→staging__ flow but isn't a dependency of this model.
 SELECT
     order_id,
     customer_id,

--- a/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/rocky.toml
+++ b/examples/playground/pocs/00-foundations/05-generic-adapter-exercise/rocky.toml
@@ -11,6 +11,9 @@ path = "poc.duckdb"
 [pipeline.exercise]
 strategy = "full_refresh"
 
+[pipeline.exercise.source.discovery]
+adapter = "default"
+
 [pipeline.exercise.source.schema_pattern]
 prefix = "raw__"
 separator = "__"

--- a/examples/playground/pocs/00-foundations/06-branches-replay-lineage/run.sh
+++ b/examples/playground/pocs/00-foundations/06-branches-replay-lineage/run.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-rm -f .rocky-state.redb poc.duckdb
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
 mkdir -p expected
 
 echo "==> 1. Compile the 3-model DAG (type-check, no warehouse required)"

--- a/examples/playground/pocs/01-quality/02-inline-checks/rocky.toml
+++ b/examples/playground/pocs/01-quality/02-inline-checks/rocky.toml
@@ -5,6 +5,9 @@ path = "poc.duckdb"
 [pipeline.poc]
 strategy = "full_refresh"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -13,6 +16,9 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
 
 # Inline data quality checks
 [pipeline.poc.checks]

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/rocky.toml
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/rocky.toml
@@ -15,6 +15,9 @@ in_flight_ttl_hours = 24
 [pipeline.poc]
 strategy = "full_refresh"
 
+[pipeline.poc.source.discovery]
+adapter = "default"
+
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"
 separator = "__"
@@ -23,3 +26,6 @@ components = ["source"]
 [pipeline.poc.target]
 catalog_template = "poc"
 schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/05-orchestration/09-idempotency-key/run.sh
+++ b/examples/playground/pocs/05-orchestration/09-idempotency-key/run.sh
@@ -10,10 +10,6 @@ duckdb poc.duckdb < data/seed.sql
 rocky validate
 
 # Scenario 1: fresh key → run claims it, proceeds.
-# Like POC 04, the DuckDB execution path hits "no discovery adapter"
-# before reaching materialization, so the run exits non-zero. The
-# idempotency claim still happens: the key enters `InFlight` state
-# inside the state store.
 KEY="fivetran_sync:demo_connector:2026-04-23T10:00:00Z"
 rocky -c rocky.toml -o json run \
   --filter source=orders \
@@ -23,15 +19,8 @@ KEY1=$(jq -r '.idempotency_key // "none"' expected/run1_fresh.json)
 echo "Run 1 (fresh key, orders)      status = $STATUS1  (key echoed: $KEY1)"
 
 # Scenario 2: same key again → idempotency short-circuit.
-# The claim step inspects the prior entry (InFlight from Run 1 since
-# the DuckDB path didn't finalize). The second caller sees an in-flight
-# claim that's still within TTL and exits with skipped_in_flight plus
-# the prior run_id.
-#
-# On a fully-successful Run 1 (tiered/valkey backend or real pipeline)
-# the entry would transition to Succeeded, and Run 2 would see
-# skipped_idempotent instead. The mechanism is identical; only the
-# state transition differs.
+# Run 1's entry transitioned to Succeeded, so the second caller sees a
+# completed claim and exits with skipped_idempotent plus the prior run_id.
 rocky -c rocky.toml -o json run \
   --filter source=orders \
   --idempotency-key "$KEY" > expected/run2_repeat.json || true

--- a/examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/08-portability-lint/rocky.toml
@@ -5,8 +5,9 @@ type = "duckdb"
 path = "poc.duckdb"
 
 # Project-wide portability settings. Per-model overrides via `-- rocky-allow` pragma.
+# Baseline compile (no `--target-dialect`) emits no portability lints; pass
+# `--target-dialect bq` on the CLI to fire P001 on the non-portable model.
 [portability]
-target_dialect = "bigquery"
 allow = ["QUALIFY"]  # QUALIFY is BigQuery-supported, so allow it project-wide
 
 [pipeline.poc]

--- a/examples/playground/pocs/06-developer-experience/08-portability-lint/run.sh
+++ b/examples/playground/pocs/06-developer-experience/08-portability-lint/run.sh
@@ -34,6 +34,6 @@ echo "==> 4. Summary"
 echo "  portable.sql              — portable; clean under every dialect"
 echo "  non_portable_nvl.sql      — fires P001 under --target-dialect=bq"
 echo "  suppressed_via_pragma.sql — same NVL, suppressed per-file via '-- rocky-allow: NVL'"
-echo "  rocky.toml [portability]  — project-wide target + allowlist for 'QUALIFY'"
+echo "  rocky.toml [portability]  — project-wide allowlist for 'QUALIFY'"
 echo
 echo "POC complete."

--- a/examples/playground/scripts/_poc-template/run.sh
+++ b/examples/playground/scripts/_poc-template/run.sh
@@ -5,8 +5,13 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-# Clean state from previous runs
-rm -f .rocky-state.redb poc.duckdb
+# Clean state from previous runs. `models/.rocky-state.redb` is the canonical
+# location since the LSP↔CLI unification (rocky-core::state::resolve_state_path);
+# the bare CWD path is the deprecated legacy fallback. Wipe both so re-runs
+# of POCs that create named state entries (branches, idempotency keys) don't
+# trip "already exists" on the second invocation.
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
 mkdir -p expected
 
 # Optional: load seed data into the persistent DuckDB

--- a/examples/playground/scripts/run-all-duckdb.sh
+++ b/examples/playground/scripts/run-all-duckdb.sh
@@ -47,7 +47,8 @@ for run in pocs/*/*/run.sh; do
     # standalone POC crate (resolving deps from crates.io and compiling
     # tokio/serde/etc.) consistently exceeds the 60s smoke timeout. These
     # POCs are still verified by their own `cargo test` invocation.
-    if grep -qE 'cargo\s+(check|build|test|run)' "$run" 2>/dev/null; then
+    # Anchor at line start so `echo "=== cargo check ..."` doesn't match.
+    if grep -qE '^[[:space:]]*cargo[[:space:]]+(check|build|test|run)\b' "$run" 2>/dev/null; then
         echo "--- SKIP $poc_dir (Rust toolchain — cold cargo build exceeds smoke timeout)"
         skipped=$((skipped + 1))
         continue

--- a/examples/playground/scripts/run-all-duckdb.sh
+++ b/examples/playground/scripts/run-all-duckdb.sh
@@ -25,8 +25,12 @@ for run in pocs/*/*/run.sh; do
     poc_dir=$(dirname "$run")
     readme="$poc_dir/README.md"
 
-    # Skip POCs whose README explicitly lists credentials.
-    if grep -qiE '\*\*credentials:\*\*[^n]*(anthropic|databricks|snowflake|fivetran|gcp|google|bigquery)' "$readme" 2>/dev/null; then
+    # Skip credential-gated POCs by detecting the canonical fail-fast guard
+    # `: "${VAR:?...}"` (mandated by examples/playground/CLAUDE.md). Keying
+    # off the guard rather than a platform-name allowlist means new adapters
+    # don't have to update this script — and avoids the brittleness of the
+    # previous `[^n]*` README regex.
+    if grep -qE ': *"\$\{[A-Z_][A-Z0-9_]*:\?' "$run" 2>/dev/null; then
         echo "--- SKIP $poc_dir (credentials required)"
         skipped=$((skipped + 1))
         continue

--- a/examples/playground/scripts/run-all-duckdb.sh
+++ b/examples/playground/scripts/run-all-duckdb.sh
@@ -26,7 +26,7 @@ for run in pocs/*/*/run.sh; do
     readme="$poc_dir/README.md"
 
     # Skip POCs whose README explicitly lists credentials.
-    if grep -qiE '\*\*credentials:\*\*[^n]*(anthropic|databricks|snowflake|fivetran)' "$readme" 2>/dev/null; then
+    if grep -qiE '\*\*credentials:\*\*[^n]*(anthropic|databricks|snowflake|fivetran|gcp|google|bigquery)' "$readme" 2>/dev/null; then
         echo "--- SKIP $poc_dir (credentials required)"
         skipped=$((skipped + 1))
         continue


### PR DESCRIPTION
Smoke run on the current branch: **51 passed, 0 failed, 17 skipped**
(was 45/7/16 on `main`). Two POCs in earlier commits' sandbox
(`09-files-to-duckdb`, `10-route-by-tenant`) needed DuckDB extensions
served from `extensions.duckdb.org` that were blocked there; they
pass in environments that can reach it. The BigQuery POC is now
correctly SKIPPED instead of attempted.

Fixes:

- 00-foundations/05-generic-adapter-exercise: add `[source.discovery]`
  block (required by `rocky discover/plan/run`); point `stg_orders`
  at `raw__orders.orders` so `rocky test` works against the in-memory
  harness; ship `data/seed.sql` for the test path.
- 00-foundations/06-branches-replay-lineage: extend `run.sh` cleanup
  to also delete `models/.rocky-state.redb` so re-runs don't fail
  with `branch already exists`.
- 01-quality/02-inline-checks: add `[source.discovery]` and
  `auto_create_schemas = true` so the run materialises into
  `staging__events`.
- 05-orchestration/09-idempotency-key: same two additions; drop the
  stale "no discovery adapter" comments in `run.sh` now that the run
  reaches Succeeded and Run 2 sees `SkippedIdempotent`.
- 06-developer-experience/08-portability-lint: drop
  `target_dialect = "bigquery"` from `[portability]` so step 1
  ("baseline compile, no dialect gate yet") is actually a baseline.
  P001 still fires on step 2 via `--target-dialect bq`.
- scripts/run-all-duckdb.sh: replace the brittle README regex with
  detection of the canonical fail-fast guard `: "${VAR:?...}"`
  mandated by `examples/playground/CLAUDE.md`. Same 13 POCs match
  (verified against the README-declared credential list); new
  adapters no longer need to touch this script. Cargo-toolchain skip
  regex anchored at line start so `echo "=== cargo check ..."`
  preambles don't match.
- scripts/_poc-template/run.sh: scaffolded cleanup now wipes both
  `.rocky-state.redb` (legacy CWD fallback) and `models/.rocky-state.redb`
  (canonical since the LSP↔CLI unification in
  `rocky-core::state::resolve_state_path`). Comment cites the source
  so the next POC author understands why two paths are wiped.

### Scope of the state-cleanup fix

Only `00-foundations/06-branches-replay-lineage` needed the
`models/.rocky-state.redb` cleanup added to its existing `run.sh`.
Other POCs that exercise named state — `00-foundations/08-branch-approve-promote`
(uses `rocky branch`) and `05-orchestration/09-idempotency-key` (uses
`--idempotency-key`) — have no `models/` directory, so
`resolve_state_path` lands their state in CWD per case 5 ("fall back
to CWD when models_dir is not a real directory"). Their existing
`rm -f .rocky-state.redb` is the right cleanup; re-running them after
this PR PASSes without further changes. The scaffolder template
addition only affects newly-generated POCs that ship with a `models/`
directory.

### Follow-up tracked separately

A minor engine-ergonomics nit surfaced during review — single-adapter
configs should auto-default `source.discovery.adapter` to `"default"`
the same way source/target refs do. Until then every minimal DuckDB
POC has to add `[pipeline.<name>.source.discovery]` explicitly, which
is what three of the fixes above do. Tracked in the Rocky backlog
under "Smaller follow-ups (anytime)".