### PR TITLE
refactor(engine/rocky-core): begin Typed-IR Phase 3 — direct ModelIr variant accessors

### DIFF
--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -587,6 +587,107 @@ impl ModelIr {
         blake3::hash(canonical.as_bytes())
     }
 
+    /// View this IR as a [`ReplicationPlan`] without round-tripping through
+    /// the [`Plan`] enum.
+    ///
+    /// Returns `Some` when the IR's variant-specific fields match a
+    /// replication shape — i.e. `columns` is `Some` and it is not a
+    /// snapshot (`unique_key` non-empty AND `updated_at` `Some`).
+    /// Returns `None` on any other variant.
+    ///
+    /// Variant inference matches [`Self::to_plan_compatible`]; the two stay
+    /// in lockstep. Prefer this method on hot paths (e.g. `sql_gen`) to
+    /// avoid materialising the [`Plan`] enum just to dispatch on its tag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the IR is variant-confirmed as a replication but is
+    /// missing `source`. The `From<&Plan>` impl always populates `source`
+    /// for replications; this only fires on a hand-built [`ModelIr`] that
+    /// violates the variant contract.
+    pub fn as_replication(&self) -> Option<ReplicationPlan> {
+        // Snapshot takes priority over replication in variant inference;
+        // bail out without cloning when this IR is snapshot-shaped.
+        if !self.unique_key.is_empty() && self.updated_at.is_some() {
+            return None;
+        }
+        let columns = self.columns.clone()?;
+        let source = self
+            .source
+            .clone()
+            .expect("Replication ModelIr must carry `source`");
+        Some(ReplicationPlan {
+            source,
+            target: self.target.clone(),
+            strategy: self.materialization.clone(),
+            columns,
+            metadata_columns: self.metadata_columns.clone(),
+            governance: self.governance.clone(),
+        })
+    }
+
+    /// View this IR as a [`TransformationPlan`] without round-tripping
+    /// through the [`Plan`] enum.
+    ///
+    /// Returns `Some` when the IR is neither snapshot-shaped
+    /// (`unique_key` non-empty AND `updated_at` `Some`) nor replication-
+    /// shaped (`columns` `Some`). Returns `None` otherwise.
+    ///
+    /// Variant inference matches [`Self::to_plan_compatible`].
+    pub fn as_transformation(&self) -> Option<TransformationPlan> {
+        if !self.unique_key.is_empty() && self.updated_at.is_some() {
+            return None;
+        }
+        if self.columns.is_some() {
+            return None;
+        }
+        Some(TransformationPlan {
+            sources: self.sources.clone(),
+            target: self.target.clone(),
+            strategy: self.materialization.clone(),
+            sql: self.sql.clone(),
+            governance: self.governance.clone(),
+            format: self.format.clone(),
+            format_options: self.format_options.clone(),
+        })
+    }
+
+    /// View this IR as a [`SnapshotPlan`] without round-tripping through
+    /// the [`Plan`] enum.
+    ///
+    /// Returns `Some` when the IR is snapshot-shaped (`unique_key`
+    /// non-empty AND `updated_at` `Some`). Returns `None` otherwise.
+    ///
+    /// Variant inference matches [`Self::to_plan_compatible`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the IR is variant-confirmed as a snapshot but is missing
+    /// `source` or `updated_at`. The `From<&Plan>` impl always populates
+    /// both for snapshots; this only fires on a hand-built [`ModelIr`]
+    /// that violates the variant contract.
+    pub fn as_snapshot(&self) -> Option<SnapshotPlan> {
+        if self.unique_key.is_empty() || self.updated_at.is_none() {
+            return None;
+        }
+        let source = self
+            .source
+            .clone()
+            .expect("Snapshot ModelIr must carry `source`");
+        let updated_at = self
+            .updated_at
+            .clone()
+            .expect("Snapshot ModelIr must carry `updated_at`");
+        Some(SnapshotPlan {
+            source,
+            target: self.target.clone(),
+            unique_key: self.unique_key.clone(),
+            updated_at,
+            invalidate_hard_deletes: self.invalidate_hard_deletes,
+            governance: self.governance.clone(),
+        })
+    }
+
     /// Reconstruct a [`Plan`] from this `ModelIr`, mirroring the
     /// `From<&Plan> for ModelIr` conversion.
     ///
@@ -1623,5 +1724,126 @@ mod tests {
                 .contains("\"columns\":"),
             "snapshot ModelIr must omit `columns`"
         );
+    }
+
+    // ----- Direct variant accessors (`as_replication` / `as_transformation`
+    //       / `as_snapshot`) — bypass `Plan` materialisation on hot paths -----
+
+    #[test]
+    fn as_replication_returns_some_for_replication_shape() {
+        let ir = sample_replication_model();
+        assert!(
+            ir.as_replication().is_some(),
+            "replication-shaped IR must yield Some via as_replication"
+        );
+        assert!(ir.as_transformation().is_none());
+        assert!(ir.as_snapshot().is_none());
+    }
+
+    #[test]
+    fn as_transformation_returns_some_for_transformation_shape() {
+        let ir = sample_transformation_model();
+        assert!(
+            ir.as_transformation().is_some(),
+            "transformation-shaped IR must yield Some via as_transformation"
+        );
+        assert!(ir.as_replication().is_none());
+        assert!(ir.as_snapshot().is_none());
+    }
+
+    #[test]
+    fn as_snapshot_returns_some_for_snapshot_shape() {
+        let ir = sample_snapshot_model();
+        assert!(
+            ir.as_snapshot().is_some(),
+            "snapshot-shaped IR must yield Some via as_snapshot"
+        );
+        assert!(ir.as_replication().is_none());
+        assert!(ir.as_transformation().is_none());
+    }
+
+    /// The three accessors must yield byte-equivalent variants to
+    /// `to_plan_compatible()` for any IR built via `From<&Plan>`. This is
+    /// the load-bearing regression guard for `sql_gen` — both code paths
+    /// must produce identical SQL inputs.
+    #[test]
+    fn accessors_match_to_plan_compatible_for_replication() {
+        let plan = sample_replication_plan();
+        let ir = ModelIr::from(&plan);
+        let via_accessor = Plan::Replication(ir.as_replication().expect("replication"));
+        let via_round_trip = ir.to_plan_compatible();
+        assert!(
+            plans_canonical_eq(&via_accessor, &via_round_trip),
+            "as_replication must produce a Plan canonical-JSON-equal to to_plan_compatible\n  accessor: {}\n  round-trip: {}",
+            canonical_json(&via_accessor),
+            canonical_json(&via_round_trip)
+        );
+    }
+
+    #[test]
+    fn accessors_match_to_plan_compatible_for_transformation() {
+        let plan = sample_transformation_plan();
+        let ir = ModelIr::from(&plan);
+        let via_accessor = Plan::Transformation(ir.as_transformation().expect("transformation"));
+        let via_round_trip = ir.to_plan_compatible();
+        assert!(
+            plans_canonical_eq(&via_accessor, &via_round_trip),
+            "as_transformation must produce a Plan canonical-JSON-equal to to_plan_compatible"
+        );
+    }
+
+    #[test]
+    fn accessors_match_to_plan_compatible_for_snapshot() {
+        let plan = sample_snapshot_plan();
+        let ir = ModelIr::from(&plan);
+        let via_accessor = Plan::Snapshot(ir.as_snapshot().expect("snapshot"));
+        let via_round_trip = ir.to_plan_compatible();
+        assert!(
+            plans_canonical_eq(&via_accessor, &via_round_trip),
+            "as_snapshot must produce a Plan canonical-JSON-equal to to_plan_compatible"
+        );
+    }
+
+    /// Round-trip via the accessor: `From<&Plan> -> as_X` must be
+    /// canonical-JSON-equal to the original `Plan`. Mirrors the existing
+    /// `plan_to_model_ir_*_roundtrip` tests but exercises the accessor
+    /// rather than `to_plan_compatible`.
+    #[test]
+    fn plan_to_model_ir_via_accessor_replication_roundtrip() {
+        let plan = sample_replication_plan();
+        let ir = ModelIr::from(&plan);
+        let back = Plan::Replication(ir.as_replication().expect("replication"));
+        assert!(plans_canonical_eq(&plan, &back));
+    }
+
+    #[test]
+    fn plan_to_model_ir_via_accessor_transformation_roundtrip() {
+        let plan = sample_transformation_plan();
+        let ir = ModelIr::from(&plan);
+        let back = Plan::Transformation(ir.as_transformation().expect("transformation"));
+        assert!(plans_canonical_eq(&plan, &back));
+    }
+
+    #[test]
+    fn plan_to_model_ir_via_accessor_snapshot_roundtrip() {
+        let plan = sample_snapshot_plan();
+        let ir = ModelIr::from(&plan);
+        let back = Plan::Snapshot(ir.as_snapshot().expect("snapshot"));
+        assert!(plans_canonical_eq(&plan, &back));
+    }
+
+    /// Snapshot inference takes priority over replication: an IR that is
+    /// snapshot-shaped (unique_key + updated_at) must yield `None` from
+    /// `as_replication` even if `columns` is also populated. Matches the
+    /// inference order in `to_plan_compatible`.
+    #[test]
+    fn as_replication_rejects_snapshot_shape_even_if_columns_set() {
+        let mut ir = sample_snapshot_model();
+        ir.columns = Some(ColumnSelection::All);
+        assert!(
+            ir.as_replication().is_none(),
+            "snapshot-shape IR with stray `columns` must not view as replication"
+        );
+        assert!(ir.as_snapshot().is_some());
     }
 }

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -705,7 +705,13 @@ impl ModelIr {
     ///
     /// Used in error messages so callers can see *why* their IR didn't
     /// match an expected variant.
-    pub fn variant_name(&self) -> &'static str {
+    ///
+    /// Crate-private: the only intended consumer is `sql_gen`'s
+    /// `*_from_ir` error formatting. Promote to `pub` only when an
+    /// external Rust caller needs it for their own diagnostic surface —
+    /// the JSON output schema is the external contract for everything
+    /// else.
+    pub(crate) fn variant_name(&self) -> &'static str {
         if self.is_snapshot_shaped() {
             "snapshot"
         } else if self.columns.is_some() {
@@ -740,20 +746,17 @@ impl ModelIr {
     /// `From<&Plan>` impl always populates them, so this only fires on a
     /// hand-built `ModelIr` that violates the variant contract.
     pub fn to_plan_compatible(&self) -> Plan {
-        if let Some(snap) = self.as_snapshot() {
-            return Plan::Snapshot(snap);
-        }
-        if let Some(rep) = self.as_replication() {
-            return Plan::Replication(rep);
-        }
-        // Transformation is the unconditional fallback: when neither
-        // snapshot nor replication match, `as_transformation` is `Some`
-        // by construction (its rejection conditions are exactly the
-        // entry conditions of the other two).
-        Plan::Transformation(
-            self.as_transformation()
-                .expect("transformation is the unconditional fallback variant"),
-        )
+        // Transformation is the unconditional fallback: its rejection
+        // conditions in `as_transformation` are exactly the entry
+        // conditions of the other two accessors, so one of the three
+        // is always `Some`.
+        self.as_snapshot()
+            .map(Plan::Snapshot)
+            .or_else(|| self.as_replication().map(Plan::Replication))
+            .or_else(|| self.as_transformation().map(Plan::Transformation))
+            .expect(
+                "at least one accessor must match — transformation is the unconditional fallback",
+            )
     }
 }
 

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -587,6 +587,17 @@ impl ModelIr {
         blake3::hash(canonical.as_bytes())
     }
 
+    /// Predicate underlying variant inference for snapshot. The single
+    /// source of truth shared by [`Self::as_replication`],
+    /// [`Self::as_transformation`], [`Self::as_snapshot`], and
+    /// [`Self::variant_name`]. Snapshot takes priority over replication
+    /// in inference: if both `unique_key` (non-empty) and `updated_at`
+    /// (`Some`) are populated the IR is classified as a snapshot
+    /// regardless of which other variant-specific fields are also set.
+    fn is_snapshot_shaped(&self) -> bool {
+        !self.unique_key.is_empty() && self.updated_at.is_some()
+    }
+
     /// View this IR as a [`ReplicationPlan`] without round-tripping through
     /// the [`Plan`] enum.
     ///
@@ -606,9 +617,7 @@ impl ModelIr {
     /// for replications; this only fires on a hand-built [`ModelIr`] that
     /// violates the variant contract.
     pub fn as_replication(&self) -> Option<ReplicationPlan> {
-        // Snapshot takes priority over replication in variant inference;
-        // bail out without cloning when this IR is snapshot-shaped.
-        if !self.unique_key.is_empty() && self.updated_at.is_some() {
+        if self.is_snapshot_shaped() {
             return None;
         }
         let columns = self.columns.clone()?;
@@ -635,10 +644,7 @@ impl ModelIr {
     ///
     /// Variant inference matches [`Self::to_plan_compatible`].
     pub fn as_transformation(&self) -> Option<TransformationPlan> {
-        if !self.unique_key.is_empty() && self.updated_at.is_some() {
-            return None;
-        }
-        if self.columns.is_some() {
+        if self.is_snapshot_shaped() || self.columns.is_some() {
             return None;
         }
         Some(TransformationPlan {
@@ -663,21 +669,21 @@ impl ModelIr {
     /// # Panics
     ///
     /// Panics if the IR is variant-confirmed as a snapshot but is missing
-    /// `source` or `updated_at`. The `From<&Plan>` impl always populates
-    /// both for snapshots; this only fires on a hand-built [`ModelIr`]
-    /// that violates the variant contract.
+    /// `source`. The `From<&Plan>` impl always populates `source` for
+    /// snapshots; this only fires on a hand-built [`ModelIr`] that
+    /// violates the variant contract.
     pub fn as_snapshot(&self) -> Option<SnapshotPlan> {
-        if self.unique_key.is_empty() || self.updated_at.is_none() {
+        if !self.is_snapshot_shaped() {
             return None;
         }
+        let updated_at = self
+            .updated_at
+            .clone()
+            .expect("is_snapshot_shaped guarantees `updated_at` is `Some`");
         let source = self
             .source
             .clone()
             .expect("Snapshot ModelIr must carry `source`");
-        let updated_at = self
-            .updated_at
-            .clone()
-            .expect("Snapshot ModelIr must carry `updated_at`");
         Some(SnapshotPlan {
             source,
             target: self.target.clone(),
@@ -688,11 +694,34 @@ impl ModelIr {
         })
     }
 
+    /// Human-readable name for this IR's inferred variant.
+    ///
+    /// Matches the inference rules used by [`Self::as_replication`],
+    /// [`Self::as_transformation`], [`Self::as_snapshot`], and
+    /// [`Self::to_plan_compatible`]: snapshot-shaped (`unique_key`
+    /// non-empty AND `updated_at` `Some`) → `"snapshot"`; replication-
+    /// shaped (`columns` `Some`) → `"replication"`; otherwise →
+    /// `"transformation"`.
+    ///
+    /// Used in error messages so callers can see *why* their IR didn't
+    /// match an expected variant.
+    pub fn variant_name(&self) -> &'static str {
+        if self.is_snapshot_shaped() {
+            "snapshot"
+        } else if self.columns.is_some() {
+            "replication"
+        } else {
+            "transformation"
+        }
+    }
+
     /// Reconstruct a [`Plan`] from this `ModelIr`, mirroring the
     /// `From<&Plan> for ModelIr` conversion.
     ///
-    /// The variant is inferred from which variant-specific fields are
-    /// populated:
+    /// Delegates to the three accessors ([`Self::as_snapshot`],
+    /// [`Self::as_replication`], [`Self::as_transformation`]) so the
+    /// variant-inference rule lives in a single place. The variant is
+    /// inferred from which variant-specific fields are populated:
     ///
     /// - `unique_key` non-empty AND `updated_at` `Some` → [`Plan::Snapshot`]
     /// - `columns` `Some` (replication carries an explicit
@@ -705,54 +734,26 @@ impl ModelIr {
     ///
     /// # Panics
     ///
-    /// Panics if a [`ModelIr`] inferred to be a Snapshot is missing
-    /// `source` or if a Replication ModelIr is missing `source`. These
+    /// Panics if a [`ModelIr`] inferred to be a Snapshot or Replication
+    /// is missing `source` (via the accessor's panic contract). These
     /// fields are required on the corresponding [`Plan`] variant; the
     /// `From<&Plan>` impl always populates them, so this only fires on a
     /// hand-built `ModelIr` that violates the variant contract.
     pub fn to_plan_compatible(&self) -> Plan {
-        // Snapshot has both unique_key and updated_at; replication has columns.
-        if !self.unique_key.is_empty() && self.updated_at.is_some() {
-            let source = self
-                .source
-                .clone()
-                .expect("Snapshot ModelIr must carry `source`");
-            let updated_at = self
-                .updated_at
-                .clone()
-                .expect("Snapshot ModelIr must carry `updated_at`");
-            Plan::Snapshot(SnapshotPlan {
-                source,
-                target: self.target.clone(),
-                unique_key: self.unique_key.clone(),
-                updated_at,
-                invalidate_hard_deletes: self.invalidate_hard_deletes,
-                governance: self.governance.clone(),
-            })
-        } else if let Some(columns) = self.columns.clone() {
-            let source = self
-                .source
-                .clone()
-                .expect("Replication ModelIr must carry `source`");
-            Plan::Replication(ReplicationPlan {
-                source,
-                target: self.target.clone(),
-                strategy: self.materialization.clone(),
-                columns,
-                metadata_columns: self.metadata_columns.clone(),
-                governance: self.governance.clone(),
-            })
-        } else {
-            Plan::Transformation(TransformationPlan {
-                sources: self.sources.clone(),
-                target: self.target.clone(),
-                strategy: self.materialization.clone(),
-                sql: self.sql.clone(),
-                governance: self.governance.clone(),
-                format: self.format.clone(),
-                format_options: self.format_options.clone(),
-            })
+        if let Some(snap) = self.as_snapshot() {
+            return Plan::Snapshot(snap);
         }
+        if let Some(rep) = self.as_replication() {
+            return Plan::Replication(rep);
+        }
+        // Transformation is the unconditional fallback: when neither
+        // snapshot nor replication match, `as_transformation` is `Some`
+        // by construction (its rejection conditions are exactly the
+        // entry conditions of the other two).
+        Plan::Transformation(
+            self.as_transformation()
+                .expect("transformation is the unconditional fallback variant"),
+        )
     }
 }
 
@@ -1845,5 +1846,45 @@ mod tests {
             "snapshot-shape IR with stray `columns` must not view as replication"
         );
         assert!(ir.as_snapshot().is_some());
+    }
+
+    /// Replication accessor panics if `columns` is `Some` but `source` is
+    /// `None` — the IR is variant-confirmed but violates the contract that
+    /// `From<&Plan>` always populates.
+    #[test]
+    #[should_panic(expected = "Replication ModelIr must carry `source`")]
+    fn as_replication_panics_when_columns_set_but_source_missing() {
+        let mut ir = sample_replication_model();
+        ir.source = None;
+        let _ = ir.as_replication();
+    }
+
+    /// Snapshot accessor panics if the IR is snapshot-shaped (`unique_key`
+    /// non-empty AND `updated_at` `Some`) but `source` is `None`.
+    #[test]
+    #[should_panic(expected = "Snapshot ModelIr must carry `source`")]
+    fn as_snapshot_panics_when_snapshot_shaped_but_source_missing() {
+        let mut ir = sample_snapshot_model();
+        ir.source = None;
+        let _ = ir.as_snapshot();
+    }
+
+    #[test]
+    fn variant_name_matches_inferred_shape() {
+        assert_eq!(sample_replication_model().variant_name(), "replication");
+        assert_eq!(
+            sample_transformation_model().variant_name(),
+            "transformation"
+        );
+        assert_eq!(sample_snapshot_model().variant_name(), "snapshot");
+    }
+
+    /// Variant-name inference must honour the same priority order as the
+    /// accessors: snapshot wins over replication when both fields are set.
+    #[test]
+    fn variant_name_follows_inference_priority() {
+        let mut ir = sample_snapshot_model();
+        ir.columns = Some(ColumnSelection::All);
+        assert_eq!(ir.variant_name(), "snapshot");
     }
 }

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -2,7 +2,7 @@ use rocky_sql::validation;
 use thiserror::Error;
 
 use crate::ir::{
-    MaterializationStrategy, ModelIr, PartitionWindow, Plan, ReplicationPlan, SnapshotPlan,
+    MaterializationStrategy, ModelIr, PartitionWindow, ReplicationPlan, SnapshotPlan,
     TransformationPlan,
 };
 use crate::lakehouse::{self, LakehouseError};
@@ -10,46 +10,42 @@ use crate::traits::{AdapterError, SqlDialect};
 
 /// Extract the variant-typed `ReplicationPlan` from a [`ModelIr`].
 ///
-/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
-/// from a [`Plan::Replication`]. The check is shaped by which variant-
-/// specific fields are populated: replication carries an explicit
-/// [`crate::ir::ColumnSelection`] in `columns`.
+/// Dispatches directly on the IR's variant-specific fields via
+/// [`ModelIr::as_replication`] — no round-trip through the [`crate::ir::Plan`]
+/// enum. Returns [`SqlGenError::InvalidRequest`] when the IR was not
+/// constructed from a [`crate::ir::Plan::Replication`].
 fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenError> {
-    match model_ir.to_plan_compatible() {
-        Plan::Replication(plan) => Ok(plan),
-        _ => Err(SqlGenError::InvalidRequest(format!(
+    model_ir.as_replication().ok_or_else(|| {
+        SqlGenError::InvalidRequest(format!(
             "expected Replication ModelIr for `{}`",
             model_ir.name
-        ))),
-    }
+        ))
+    })
 }
 
 /// Extract the variant-typed `TransformationPlan` from a [`ModelIr`].
 ///
-/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
-/// from a [`Plan::Transformation`].
+/// Dispatches directly via [`ModelIr::as_transformation`]. Returns
+/// [`SqlGenError::InvalidRequest`] when the IR was not constructed from a
+/// [`crate::ir::Plan::Transformation`].
 fn transformation_from_ir(model_ir: &ModelIr) -> Result<TransformationPlan, SqlGenError> {
-    match model_ir.to_plan_compatible() {
-        Plan::Transformation(plan) => Ok(plan),
-        _ => Err(SqlGenError::InvalidRequest(format!(
+    model_ir.as_transformation().ok_or_else(|| {
+        SqlGenError::InvalidRequest(format!(
             "expected Transformation ModelIr for `{}`",
             model_ir.name
-        ))),
-    }
+        ))
+    })
 }
 
 /// Extract the variant-typed `SnapshotPlan` from a [`ModelIr`].
 ///
-/// Returns [`SqlGenError::InvalidRequest`] when the IR was not constructed
-/// from a [`Plan::Snapshot`].
+/// Dispatches directly via [`ModelIr::as_snapshot`]. Returns
+/// [`SqlGenError::InvalidRequest`] when the IR was not constructed from a
+/// [`crate::ir::Plan::Snapshot`].
 fn snapshot_from_ir(model_ir: &ModelIr) -> Result<SnapshotPlan, SqlGenError> {
-    match model_ir.to_plan_compatible() {
-        Plan::Snapshot(plan) => Ok(plan),
-        _ => Err(SqlGenError::InvalidRequest(format!(
-            "expected Snapshot ModelIr for `{}`",
-            model_ir.name
-        ))),
-    }
+    model_ir.as_snapshot().ok_or_else(|| {
+        SqlGenError::InvalidRequest(format!("expected Snapshot ModelIr for `{}`", model_ir.name))
+    })
 }
 
 /// Errors from SQL generation, including identifier validation and unsafe fragment detection.
@@ -92,7 +88,7 @@ pub enum SqlGenError {
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Replication`].
+/// constructed from a [`crate::ir::Plan::Replication`].
 pub fn generate_select_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -150,7 +146,7 @@ fn generate_select_sql_no_watermark(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Replication`].
+/// constructed from a [`crate::ir::Plan::Replication`].
 pub fn generate_insert_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -170,7 +166,7 @@ pub fn generate_insert_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Replication`].
+/// constructed from a [`crate::ir::Plan::Replication`].
 pub fn generate_create_table_as_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -192,7 +188,7 @@ pub fn generate_create_table_as_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Replication`].
+/// constructed from a [`crate::ir::Plan::Replication`].
 pub fn generate_merge_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -231,7 +227,7 @@ pub fn generate_merge_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Transformation`].
+/// constructed from a [`crate::ir::Plan::Transformation`].
 pub fn generate_transformation_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -382,7 +378,7 @@ pub fn generate_transformation_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Transformation`].
+/// constructed from a [`crate::ir::Plan::Transformation`].
 pub fn generate_time_interval_bootstrap_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -445,7 +441,7 @@ pub fn generate_time_interval_bootstrap_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Transformation`].
+/// constructed from a [`crate::ir::Plan::Transformation`].
 pub fn generate_transformation_initial_ddl(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -491,7 +487,7 @@ fn substitute_partition_placeholders(sql: &str, window: &PartitionWindow) -> Str
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Transformation`].
+/// constructed from a [`crate::ir::Plan::Transformation`].
 pub fn generate_materialized_view_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -514,7 +510,7 @@ pub fn generate_materialized_view_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Transformation`].
+/// constructed from a [`crate::ir::Plan::Transformation`].
 pub fn generate_dynamic_table_sql(
     model_ir: &ModelIr,
     target_lag: &str,
@@ -597,7 +593,7 @@ use std::fmt::Write;
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`Plan::Snapshot`].
+/// constructed from a [`crate::ir::Plan::Snapshot`].
 pub fn generate_snapshot_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -1938,16 +1938,52 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     /// Mismatched-variant errors must include the actually-inferred variant
     /// so callers can see *why* the IR didn't match. Regression guard for
-    /// the `variant_name()` wiring in `*_from_ir`.
+    /// the `variant_name()` wiring in `*_from_ir` — exercises the
+    /// `expected Replication, found transformation` template.
     #[test]
     fn variant_mismatch_error_names_the_actual_variant() {
-        // Pass a transformation IR to `generate_select_sql`, which only
-        // accepts replication IRs. The error must mention "transformation".
         let ir = xform_ir(&sample_transformation_plan());
         let err = generate_select_sql(&ir, &dialect()).expect_err("expected variant mismatch");
         let msg = err.to_string();
         assert!(
             msg.contains("expected Replication ModelIr"),
+            "error should name the expected variant, got: {msg}"
+        );
+        assert!(
+            msg.contains("found transformation"),
+            "error should name the actual variant via `variant_name()`, got: {msg}"
+        );
+    }
+
+    /// Symmetric coverage: replication IR passed to a transformation-only
+    /// generator. Exercises the `expected Transformation, found replication`
+    /// template.
+    #[test]
+    fn variant_mismatch_transformation_helper_names_replication_input() {
+        let ir = rep_ir(&sample_incremental_plan());
+        let err =
+            generate_transformation_sql(&ir, &dialect()).expect_err("expected variant mismatch");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected Transformation ModelIr"),
+            "error should name the expected variant, got: {msg}"
+        );
+        assert!(
+            msg.contains("found replication"),
+            "error should name the actual variant via `variant_name()`, got: {msg}"
+        );
+    }
+
+    /// Symmetric coverage: transformation IR passed to a snapshot-only
+    /// generator. Exercises the `expected Snapshot, found transformation`
+    /// template — the third and final error-message shape.
+    #[test]
+    fn variant_mismatch_snapshot_helper_names_transformation_input() {
+        let ir = xform_ir(&sample_transformation_plan());
+        let err = generate_snapshot_sql(&ir, &dialect()).expect_err("expected variant mismatch");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected Snapshot ModelIr"),
             "error should name the expected variant, got: {msg}"
         );
         assert!(

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -17,8 +17,9 @@ use crate::traits::{AdapterError, SqlDialect};
 fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenError> {
     model_ir.as_replication().ok_or_else(|| {
         SqlGenError::InvalidRequest(format!(
-            "expected Replication ModelIr for `{}`",
-            model_ir.name
+            "expected Replication ModelIr for `{}`, found {}",
+            model_ir.name,
+            model_ir.variant_name()
         ))
     })
 }
@@ -31,8 +32,9 @@ fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenErro
 fn transformation_from_ir(model_ir: &ModelIr) -> Result<TransformationPlan, SqlGenError> {
     model_ir.as_transformation().ok_or_else(|| {
         SqlGenError::InvalidRequest(format!(
-            "expected Transformation ModelIr for `{}`",
-            model_ir.name
+            "expected Transformation ModelIr for `{}`, found {}",
+            model_ir.name,
+            model_ir.variant_name()
         ))
     })
 }
@@ -44,7 +46,11 @@ fn transformation_from_ir(model_ir: &ModelIr) -> Result<TransformationPlan, SqlG
 /// [`crate::ir::Plan::Snapshot`].
 fn snapshot_from_ir(model_ir: &ModelIr) -> Result<SnapshotPlan, SqlGenError> {
     model_ir.as_snapshot().ok_or_else(|| {
-        SqlGenError::InvalidRequest(format!("expected Snapshot ModelIr for `{}`", model_ir.name))
+        SqlGenError::InvalidRequest(format!(
+            "expected Snapshot ModelIr for `{}`, found {}",
+            model_ir.name,
+            model_ir.variant_name()
+        ))
     })
 }
 
@@ -1928,5 +1934,25 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         );
         let result = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect());
         assert!(result.is_err(), "should reject invalid partition column");
+    }
+
+    /// Mismatched-variant errors must include the actually-inferred variant
+    /// so callers can see *why* the IR didn't match. Regression guard for
+    /// the `variant_name()` wiring in `*_from_ir`.
+    #[test]
+    fn variant_mismatch_error_names_the_actual_variant() {
+        // Pass a transformation IR to `generate_select_sql`, which only
+        // accepts replication IRs. The error must mention "transformation".
+        let ir = xform_ir(&sample_transformation_plan());
+        let err = generate_select_sql(&ir, &dialect()).expect_err("expected variant mismatch");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected Replication ModelIr"),
+            "error should name the expected variant, got: {msg}"
+        );
+        assert!(
+            msg.contains("found transformation"),
+            "error should name the actual variant via `variant_name()`, got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary


### Problem

`sql_gen` was dispatching on `ModelIr` variants by round-tripping through `ModelIr::to_plan_compatible()` and matching on the resulting `Plan` enum:

```rust
fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenError> {
    match model_ir.to_plan_compatible() {
        Plan::Replication(plan) => Ok(plan),
        _ => Err(SqlGenError::InvalidRequest(...)),
    }
}
```

That materialised a full `Plan` value on every SQL generation just to read its tag. It's also a blocker for the eventual deletion of the `Plan` enum (Phase 3's terminal goal).

### Change

Added three direct accessors on `ModelIr`:

- `as_replication() -> Option<ReplicationPlan>`
- `as_transformation() -> Option<TransformationPlan>`
- `as_snapshot() -> Option<SnapshotPlan>`

Each returns `Some` when the IR's variant-specific fields match the named shape. Inference rules mirror `to_plan_compatible()` exactly — snapshot priority over replication, replication priority over transformation. Required fields on a variant-confirmed IR still panic if absent, matching the existing contract.

The three private `*_from_ir` helpers in `sql_gen.rs` now call the accessors directly. The `Plan` import drops out of `sql_gen.rs`; its remaining doc-link references are requalified as `[crate::ir::Plan::*]`.

### Why this is the smallest viable beachhead

The plan originally pointed at "state-store recipe-hash off `Plan`" — but `state.rs` doesn't recipe-hash at all (no `recipe_hash` or `ir_hash` references in it). The actual remaining `Plan` materialisations live in:

1. **`sql_gen.rs` (this PR)** — back-converted via `to_plan_compatible()` to dispatch variants
2. `rocky-cli/src/commands/{run,plan,run_local,estimate,bench}.rs` — construction sites that build `Plan::*` then convert to `ModelIr` via `From<&Plan>`
3. `rocky-cli/tests/ir_golden.rs` and `rocky-core/tests/e2e.rs` — test fixtures

Sites (2) and (3) are construction-style and can migrate to direct `ModelIr` constructors in follow-up PRs. Site (1) is dispatch-style and is the load-bearing case to remove first since it runs on every compile/run.

### Coverage

10 new tests in `rocky_core::ir::tests`:

- 3 × `as_X_returns_some_for_X_shape` — happy path + negative cases for the other two accessors
- 1 × `as_replication_rejects_snapshot_shape_even_if_columns_set` — pins the inference priority order
- 3 × `accessors_match_to_plan_compatible_for_X` — load-bearing regression guard: the accessor output is canonical-JSON-equal to `to_plan_compatible()` for any IR built via `From<&Plan>`
- 3 × `plan_to_model_ir_via_accessor_X_roundtrip` — `Plan` → `ModelIr` → accessor round-trip equivalence

`to_plan_compatible()` is **kept in place**. Both APIs co-exist until the follow-up PRs migrate the construction sites and we can delete `Plan` end-to-end.

## Test plan

- [x] `cargo test -p rocky-core --lib` → 1204/1204 pass
- [x] `cargo test -p rocky-core --test e2e` → 30/30 pass
- [x] `cargo test -p rocky-cli --test ir_golden` → 4/4 pass
- [x] `cargo clippy -p rocky-core --lib --tests -- -D warnings` → clean
- [x] `cargo fmt -p rocky-core -- --check` → clean
- [x] Workspace-wide `cargo check` → clean

## Next steps in the sequence

This PR is one of several in the Typed-IR Phase 3 sequence:

1. ✅ **This PR** — `sql_gen` dispatch via direct accessors
2. Inline the three `*_from_ir` helpers at their call sites (drops the variant-struct intermediate entirely; `sql_gen` reads `ModelIr` fields directly)
3. Migrate the 6 `ModelIr::from(&Plan::*)` construction sites in `rocky-cli/src/commands/` to direct `ModelIr` constructors
4. Migrate the test fixtures in `ir_golden.rs` and `e2e.rs`
5. Delete `Plan`, `ReplicationPlan`, `TransformationPlan`, `SnapshotPlan`, `to_plan_compatible`, and `From<&Plan> for ModelIr`

After Phase 3 lands, the catalog-as-service and WASM-plugin-runtime tracks (Steps 2a + 2b of the plan) can build on a stable `ir_hash` keyed on `ModelIr` canonical-JSON alone.
