### PR TITLE
fix(engine): install.ps1 parses on PowerShell 5.1

### DIFF
--- a/engine/install.ps1
+++ b/engine/install.ps1
@@ -48,10 +48,10 @@ if (-not $ResolvedVersion) {
         # and lexical sort places v1.10.0 before v1.9.0 — cast the stripped
         # version to [version] and sort descending so 1.10.0 wins.
         $Releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -ErrorAction Stop
-        $ResolvedVersion = ($Releases
-            | Where-Object { $_.tag_name -match "^$TagPrefix\d+\.\d+\.\d+$" }
-            | Sort-Object -Property @{Expression = { [version]($_.tag_name -replace "^$TagPrefix", "") }} -Descending
-            | Select-Object -First 1).tag_name
+        $ResolvedVersion = ($Releases |
+            Where-Object { $_.tag_name -match "^$TagPrefix\d+\.\d+\.\d+$" } |
+            Sort-Object -Property @{Expression = { [version]($_.tag_name -replace "^$TagPrefix", "") }} -Descending |
+            Select-Object -First 1).tag_name
         if (-not $ResolvedVersion) {
             Write-Error "Failed to find an engine release (tag prefix '$TagPrefix'). Set ROCKY_VERSION manually."
             exit 1


### PR DESCRIPTION
## Summary
- `engine/install.ps1` crashed at parse time on PowerShell 5.1 with `Missing closing ')' in expression` — the version-resolution pipeline used line-leading `|`, a PowerShell 7+ syntax.
- Switched the four offending lines to trailing-pipe style. Same cmdlets, same arguments, same `.tag_name` projection — only the pipe positioning differs, and it now matches the trailing-`|` style already used elsewhere in the file (e.g., the checksums block).
- Windows 10 / 11 ship PowerShell 5.1 as default `powershell.exe`, so the README's `irm | iex` one-liner needs to parse there.

## Test plan
- [ ] On a PowerShell 5.1 host: `irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex` parses and installs successfully (regression of the reported crash).
- [ ] On PowerShell 7.x: `pwsh -NoProfile -File .\engine\install.ps1` still installs successfully (no regression on the path that already worked).
- [ ] `rocky --version` prints the installed version after each.