### PR TITLE
refactor(engine/rocky-core): inline sql_gen variant guards (Typed-IR Phase 3 PR-2)

### DIFF
--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -563,6 +563,42 @@ pub struct ModelIr {
     pub format_options: Option<LakehouseOptions>,
 }
 
+/// Inferred variant tag for a [`ModelIr`].
+///
+/// Returned by [`ModelIr::variant`]. The three values mirror the three
+/// [`Plan`] variants; the inference rule (snapshot wins over replication,
+/// replication wins over transformation) is centralised in
+/// [`ModelIr::variant`] and matches [`ModelIr::to_plan_compatible`].
+///
+/// Serialises as lowercase (`"replication"` / `"transformation"` /
+/// `"snapshot"`) so error messages and JSON output stay aligned with the
+/// pre-typed-enum string convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelIrVariant {
+    Replication,
+    Transformation,
+    Snapshot,
+}
+
+impl ModelIrVariant {
+    /// Lowercase wire name. Used by [`std::fmt::Display`] and by callers
+    /// that need the raw `&'static str` (e.g. error-template assertions).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Replication => "replication",
+            Self::Transformation => "transformation",
+            Self::Snapshot => "snapshot",
+        }
+    }
+}
+
+impl std::fmt::Display for ModelIrVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl ModelIr {
     /// Compute the recipe-hash of this model.
     ///
@@ -590,8 +626,8 @@ impl ModelIr {
     /// Predicate underlying variant inference for snapshot. The single
     /// source of truth shared by [`Self::as_replication`],
     /// [`Self::as_transformation`], [`Self::as_snapshot`], and
-    /// [`Self::variant_name`]. Snapshot takes priority over replication
-    /// in inference: if both `unique_key` (non-empty) and `updated_at`
+    /// [`Self::variant`]. Snapshot takes priority over replication in
+    /// inference: if both `unique_key` (non-empty) and `updated_at`
     /// (`Some`) are populated the IR is classified as a snapshot
     /// regardless of which other variant-specific fields are also set.
     fn is_snapshot_shaped(&self) -> bool {
@@ -694,30 +730,26 @@ impl ModelIr {
         })
     }
 
-    /// Human-readable name for this IR's inferred variant.
+    /// Inferred [`ModelIrVariant`] for this IR.
     ///
     /// Matches the inference rules used by [`Self::as_replication`],
     /// [`Self::as_transformation`], [`Self::as_snapshot`], and
     /// [`Self::to_plan_compatible`]: snapshot-shaped (`unique_key`
-    /// non-empty AND `updated_at` `Some`) → `"snapshot"`; replication-
-    /// shaped (`columns` `Some`) → `"replication"`; otherwise →
-    /// `"transformation"`.
+    /// non-empty AND `updated_at` `Some`) →
+    /// [`ModelIrVariant::Snapshot`]; replication-shaped (`columns` `Some`)
+    /// → [`ModelIrVariant::Replication`]; otherwise →
+    /// [`ModelIrVariant::Transformation`].
     ///
-    /// Used in error messages so callers can see *why* their IR didn't
-    /// match an expected variant.
-    ///
-    /// Crate-private: the only intended consumer is `sql_gen`'s
-    /// `*_from_ir` error formatting. Promote to `pub` only when an
-    /// external Rust caller needs it for their own diagnostic surface —
-    /// the JSON output schema is the external contract for everything
-    /// else.
-    pub(crate) fn variant_name(&self) -> &'static str {
+    /// Callers that need just the lowercase string form (e.g. error
+    /// message templating, JSON output) reach for [`ModelIrVariant::as_str`]
+    /// or the `Display` impl.
+    pub fn variant(&self) -> ModelIrVariant {
         if self.is_snapshot_shaped() {
-            "snapshot"
+            ModelIrVariant::Snapshot
         } else if self.columns.is_some() {
-            "replication"
+            ModelIrVariant::Replication
         } else {
-            "transformation"
+            ModelIrVariant::Transformation
         }
     }
 
@@ -1873,21 +1905,54 @@ mod tests {
     }
 
     #[test]
-    fn variant_name_matches_inferred_shape() {
-        assert_eq!(sample_replication_model().variant_name(), "replication");
+    fn variant_matches_inferred_shape() {
         assert_eq!(
-            sample_transformation_model().variant_name(),
-            "transformation"
+            sample_replication_model().variant(),
+            ModelIrVariant::Replication
         );
-        assert_eq!(sample_snapshot_model().variant_name(), "snapshot");
+        assert_eq!(
+            sample_transformation_model().variant(),
+            ModelIrVariant::Transformation
+        );
+        assert_eq!(sample_snapshot_model().variant(), ModelIrVariant::Snapshot);
     }
 
-    /// Variant-name inference must honour the same priority order as the
+    /// Variant inference must honour the same priority order as the
     /// accessors: snapshot wins over replication when both fields are set.
     #[test]
-    fn variant_name_follows_inference_priority() {
+    fn variant_follows_inference_priority() {
         let mut ir = sample_snapshot_model();
         ir.columns = Some(ColumnSelection::All);
-        assert_eq!(ir.variant_name(), "snapshot");
+        assert_eq!(ir.variant(), ModelIrVariant::Snapshot);
+    }
+
+    /// `variant()` must stay in lockstep with `to_plan_compatible()`: for any
+    /// `ModelIr` built via `From<&Plan>`, the inferred [`ModelIrVariant`]
+    /// matches the originating [`Plan`] tag. Guards against drift in the
+    /// shared [`ModelIr::is_snapshot_shaped`] inference root.
+    #[test]
+    fn variant_matches_to_plan_compatible_tag() {
+        let cases = [
+            (sample_replication_model(), ModelIrVariant::Replication),
+            (
+                sample_transformation_model(),
+                ModelIrVariant::Transformation,
+            ),
+            (sample_snapshot_model(), ModelIrVariant::Snapshot),
+        ];
+        for (ir, expected) in cases {
+            assert_eq!(ir.variant(), expected);
+            let plan = ir.to_plan_compatible();
+            let roundtripped = ModelIr::from(&plan);
+            assert_eq!(roundtripped.variant(), expected);
+        }
+    }
+
+    #[test]
+    fn variant_as_str_matches_display() {
+        assert_eq!(ModelIrVariant::Replication.as_str(), "replication");
+        assert_eq!(ModelIrVariant::Transformation.as_str(), "transformation");
+        assert_eq!(ModelIrVariant::Snapshot.as_str(), "snapshot");
+        assert_eq!(format!("{}", ModelIrVariant::Replication), "replication");
     }
 }

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -1,57 +1,20 @@
 use rocky_sql::validation;
 use thiserror::Error;
 
-use crate::ir::{
-    MaterializationStrategy, ModelIr, PartitionWindow, ReplicationPlan, SnapshotPlan,
-    TransformationPlan,
-};
+use crate::ir::{MaterializationStrategy, ModelIr, ModelIrVariant, PartitionWindow};
 use crate::lakehouse::{self, LakehouseError};
 use crate::traits::{AdapterError, SqlDialect};
 
-/// Extract the variant-typed `ReplicationPlan` from a [`ModelIr`].
-///
-/// Dispatches directly on the IR's variant-specific fields via
-/// [`ModelIr::as_replication`] — no round-trip through the [`crate::ir::Plan`]
-/// enum. Returns [`SqlGenError::InvalidRequest`] when the IR was not
-/// constructed from a [`crate::ir::Plan::Replication`].
-fn replication_from_ir(model_ir: &ModelIr) -> Result<ReplicationPlan, SqlGenError> {
-    model_ir.as_replication().ok_or_else(|| {
-        SqlGenError::InvalidRequest(format!(
-            "expected Replication ModelIr for `{}`, found {}",
-            model_ir.name,
-            model_ir.variant_name()
-        ))
-    })
-}
-
-/// Extract the variant-typed `TransformationPlan` from a [`ModelIr`].
-///
-/// Dispatches directly via [`ModelIr::as_transformation`]. Returns
-/// [`SqlGenError::InvalidRequest`] when the IR was not constructed from a
-/// [`crate::ir::Plan::Transformation`].
-fn transformation_from_ir(model_ir: &ModelIr) -> Result<TransformationPlan, SqlGenError> {
-    model_ir.as_transformation().ok_or_else(|| {
-        SqlGenError::InvalidRequest(format!(
-            "expected Transformation ModelIr for `{}`, found {}",
-            model_ir.name,
-            model_ir.variant_name()
-        ))
-    })
-}
-
-/// Extract the variant-typed `SnapshotPlan` from a [`ModelIr`].
-///
-/// Dispatches directly via [`ModelIr::as_snapshot`]. Returns
-/// [`SqlGenError::InvalidRequest`] when the IR was not constructed from a
-/// [`crate::ir::Plan::Snapshot`].
-fn snapshot_from_ir(model_ir: &ModelIr) -> Result<SnapshotPlan, SqlGenError> {
-    model_ir.as_snapshot().ok_or_else(|| {
-        SqlGenError::InvalidRequest(format!(
-            "expected Snapshot ModelIr for `{}`, found {}",
-            model_ir.name,
-            model_ir.variant_name()
-        ))
-    })
+/// Build the canonical `expected X ModelIr for \`name\`, found <actual>` error
+/// returned by every `generate_*` entry point when its variant guard rejects
+/// the input. Centralising the template keeps the three regression tests in
+/// this file's test module asserting one canonical string shape.
+fn variant_mismatch(model_ir: &ModelIr, expected: &'static str) -> SqlGenError {
+    SqlGenError::InvalidRequest(format!(
+        "expected {expected} ModelIr for `{}`, found {}",
+        model_ir.name,
+        model_ir.variant()
+    ))
 }
 
 /// Errors from SQL generation, including identifier validation and unsafe fragment detection.
@@ -99,25 +62,31 @@ pub fn generate_select_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = replication_from_ir(model_ir)?;
-    let select = dialect.select_clause(&plan.columns, &plan.metadata_columns)?;
+    if model_ir.variant() != ModelIrVariant::Replication {
+        return Err(variant_mismatch(model_ir, "Replication"));
+    }
+    let columns = model_ir
+        .columns
+        .as_ref()
+        .expect("Replication variant guarantees `columns` is Some");
+    let source = model_ir
+        .source
+        .as_ref()
+        .expect("Replication variant guarantees `source` is Some");
 
-    let source = dialect.format_table_ref(
-        &plan.source.catalog,
-        &plan.source.schema,
-        &plan.source.table,
-    )?;
+    let select = dialect.select_clause(columns, &model_ir.metadata_columns)?;
+    let source_ref = dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
 
-    let mut sql = format!("{select}\nFROM {source}");
+    let mut sql = format!("{select}\nFROM {source_ref}");
 
     if let MaterializationStrategy::Incremental {
         timestamp_column, ..
-    } = &plan.strategy
+    } = &model_ir.materialization
     {
         let target = dialect.format_table_ref(
-            &plan.target.catalog,
-            &plan.target.schema,
-            &plan.target.table,
+            &model_ir.target.catalog,
+            &model_ir.target.schema,
+            &model_ir.target.table,
         )?;
 
         let where_clause = dialect.watermark_where(timestamp_column, &target)?;
@@ -126,25 +95,6 @@ pub fn generate_select_sql(
     }
 
     Ok(sql)
-}
-
-/// Generate SELECT SQL without any watermark filter (full refresh semantics).
-///
-/// Used by `generate_create_table_as_sql` and `generate_merge_sql` to avoid
-/// cloning the entire `ReplicationPlan` just to override the strategy.
-fn generate_select_sql_no_watermark(
-    plan: &ReplicationPlan,
-    dialect: &dyn SqlDialect,
-) -> Result<String, SqlGenError> {
-    let select = dialect.select_clause(&plan.columns, &plan.metadata_columns)?;
-
-    let source = dialect.format_table_ref(
-        &plan.source.catalog,
-        &plan.source.schema,
-        &plan.source.table,
-    )?;
-
-    Ok(format!("{select}\nFROM {source}"))
 }
 
 /// Generates `INSERT INTO <target> SELECT ...` using the given dialect.
@@ -157,11 +107,13 @@ pub fn generate_insert_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = replication_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Replication {
+        return Err(variant_mismatch(model_ir, "Replication"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
     let select = generate_select_sql(model_ir, dialect)?;
     Ok(dialect.insert_into(&target, &select))
@@ -177,14 +129,27 @@ pub fn generate_create_table_as_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = replication_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Replication {
+        return Err(variant_mismatch(model_ir, "Replication"));
+    }
+    let columns = model_ir
+        .columns
+        .as_ref()
+        .expect("Replication variant guarantees `columns` is Some");
+    let source = model_ir
+        .source
+        .as_ref()
+        .expect("Replication variant guarantees `source` is Some");
+
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
-    let select = generate_select_sql_no_watermark(&plan, dialect)?;
+    let select_clause = dialect.select_clause(columns, &model_ir.metadata_columns)?;
+    let source_ref = dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+    let select = format!("{select_clause}\nFROM {source_ref}");
 
     Ok(dialect.create_table_as(&target, &select))
 }
@@ -199,14 +164,11 @@ pub fn generate_merge_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = replication_from_ir(model_ir)?;
-    let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
-    )?;
+    if model_ir.variant() != ModelIrVariant::Replication {
+        return Err(variant_mismatch(model_ir, "Replication"));
+    }
 
-    let (unique_key, update_columns) = match &plan.strategy {
+    let (unique_key, update_columns) = match &model_ir.materialization {
         MaterializationStrategy::Merge {
             unique_key,
             update_columns,
@@ -216,7 +178,24 @@ pub fn generate_merge_sql(
         }
     };
 
-    let select = generate_select_sql_no_watermark(&plan, dialect)?;
+    let columns = model_ir
+        .columns
+        .as_ref()
+        .expect("Replication variant guarantees `columns` is Some");
+    let source = model_ir
+        .source
+        .as_ref()
+        .expect("Replication variant guarantees `source` is Some");
+
+    let target = dialect.format_table_ref(
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
+    )?;
+
+    let select_clause = dialect.select_clause(columns, &model_ir.metadata_columns)?;
+    let source_ref = dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+    let select = format!("{select_clause}\nFROM {source_ref}");
 
     Ok(dialect.merge_into(&target, &select, unique_key, update_columns)?)
 }
@@ -238,15 +217,17 @@ pub fn generate_transformation_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let plan = transformation_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
     // Validate all source references
-    for source in &plan.sources {
+    for source in &model_ir.sources {
         dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
     }
 
@@ -257,27 +238,38 @@ pub fn generate_transformation_sql(
     // `generate_transformation_initial_ddl` when missing (Merge today;
     // Incremental / DeleteInsert / Microbatch wired in as their live smoke
     // tests land). Here we handle FullRefresh which always does CTAS.
-    if let Some(ref format) = plan.format {
-        if matches!(plan.strategy, MaterializationStrategy::FullRefresh) {
-            let opts = plan.format_options.as_ref().cloned().unwrap_or_default();
+    if let Some(ref format) = model_ir.format {
+        if matches!(
+            model_ir.materialization,
+            MaterializationStrategy::FullRefresh
+        ) {
+            let opts = model_ir
+                .format_options
+                .as_ref()
+                .cloned()
+                .unwrap_or_default();
             return Ok(lakehouse::generate_lakehouse_ddl(
-                format, &target, &plan.sql, &opts, dialect,
+                format,
+                &target,
+                &model_ir.sql,
+                &opts,
+                dialect,
             )?);
         }
     }
 
-    match &plan.strategy {
+    match &model_ir.materialization {
         MaterializationStrategy::FullRefresh => {
-            Ok(vec![dialect.create_table_as(&target, &plan.sql)])
+            Ok(vec![dialect.create_table_as(&target, &model_ir.sql)])
         }
         MaterializationStrategy::Incremental { .. } => {
-            Ok(vec![dialect.insert_into(&target, &plan.sql)])
+            Ok(vec![dialect.insert_into(&target, &model_ir.sql)])
         }
         MaterializationStrategy::Merge {
             unique_key,
             update_columns,
         } => {
-            let stmt = dialect.merge_into(&target, &plan.sql, unique_key, update_columns)?;
+            let stmt = dialect.merge_into(&target, &model_ir.sql, unique_key, update_columns)?;
             Ok(vec![stmt])
         }
         MaterializationStrategy::MaterializedView => {
@@ -322,7 +314,7 @@ pub fn generate_transformation_sql(
                 end = window.end.format("%Y-%m-%d %H:%M:%S"),
             );
 
-            let substituted = substitute_partition_placeholders(&plan.sql, window);
+            let substituted = substitute_partition_placeholders(&model_ir.sql, window);
 
             Ok(dialect.insert_overwrite_partition(&target, &filter, &substituted)?)
         }
@@ -344,9 +336,9 @@ pub fn generate_transformation_sql(
                 "DELETE FROM {target} WHERE ({partition_cols}) IN (\
                  SELECT DISTINCT {partition_cols} FROM ({source_sql}) AS _rocky_incoming\
                  )",
-                source_sql = plan.sql,
+                source_sql = model_ir.sql,
             );
-            let insert_sql = dialect.insert_into(&target, &plan.sql);
+            let insert_sql = dialect.insert_into(&target, &model_ir.sql);
             Ok(vec![delete_sql, insert_sql])
         }
         MaterializationStrategy::Microbatch {
@@ -356,7 +348,7 @@ pub fn generate_transformation_sql(
             // the timestamp column. The runtime handles batch windowing;
             // SQL gen emits a simple INSERT with watermark filter.
             validation::validate_identifier(timestamp_column)?;
-            Ok(vec![dialect.insert_into(&target, &plan.sql)])
+            Ok(vec![dialect.insert_into(&target, &model_ir.sql)])
         }
     }
 }
@@ -389,11 +381,13 @@ pub fn generate_time_interval_bootstrap_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = transformation_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
     // Sentinel window: start == end → half-open [start, end) is empty.
@@ -411,14 +405,18 @@ pub fn generate_time_interval_bootstrap_sql(
         end: sentinel,
     };
 
-    let body = substitute_partition_placeholders(&plan.sql, &bootstrap_window);
+    let body = substitute_partition_placeholders(&model_ir.sql, &bootstrap_window);
 
     // When a lakehouse format is specified, the bootstrap table must be
     // created using format-specific DDL (e.g., USING DELTA / USING ICEBERG)
     // so the partitioning, clustering, and table properties are applied from
     // the very first creation.
-    if let Some(ref format) = plan.format {
-        let opts = plan.format_options.as_ref().cloned().unwrap_or_default();
+    if let Some(ref format) = model_ir.format {
+        let opts = model_ir
+            .format_options
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
         let stmts = lakehouse::generate_lakehouse_ddl(format, &target, &body, &opts, dialect)?;
         // generate_lakehouse_ddl returns Vec<String>; join into a single
         // statement since the bootstrap function returns String.
@@ -452,21 +450,31 @@ pub fn generate_transformation_initial_ddl(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let plan = transformation_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
-    if let Some(ref format) = plan.format {
-        let opts = plan.format_options.as_ref().cloned().unwrap_or_default();
+    if let Some(ref format) = model_ir.format {
+        let opts = model_ir
+            .format_options
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
         return Ok(lakehouse::generate_lakehouse_ddl(
-            format, &target, &plan.sql, &opts, dialect,
+            format,
+            &target,
+            &model_ir.sql,
+            &opts,
+            dialect,
         )?);
     }
 
-    Ok(vec![dialect.create_table_as(&target, &plan.sql)])
+    Ok(vec![dialect.create_table_as(&target, &model_ir.sql)])
 }
 
 /// Substitute `@start_date` / `@end_date` placeholders in the model SQL with
@@ -498,16 +506,18 @@ pub fn generate_materialized_view_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = transformation_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
     Ok(format!(
         "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{sql}",
-        sql = plan.sql
+        sql = model_ir.sql
     ))
 }
 
@@ -523,11 +533,13 @@ pub fn generate_dynamic_table_sql(
     warehouse: &str,
     dialect: &dyn SqlDialect,
 ) -> Result<String, SqlGenError> {
-    let plan = transformation_from_ir(model_ir)?;
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
     // Validate target_lag and warehouse to prevent injection
@@ -536,7 +548,7 @@ pub fn generate_dynamic_table_sql(
 
     Ok(format!(
         "CREATE OR REPLACE DYNAMIC TABLE {target}\n  TARGET_LAG = '{target_lag}'\n  WAREHOUSE = {warehouse}\nAS\n{sql}",
-        sql = plan.sql
+        sql = model_ir.sql
     ))
 }
 
@@ -604,29 +616,37 @@ pub fn generate_snapshot_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
 ) -> Result<Vec<String>, SqlGenError> {
-    let plan = snapshot_from_ir(model_ir)?;
-    let source = dialect.format_table_ref(
-        &plan.source.catalog,
-        &plan.source.schema,
-        &plan.source.table,
-    )?;
+    if model_ir.variant() != ModelIrVariant::Snapshot {
+        return Err(variant_mismatch(model_ir, "Snapshot"));
+    }
+    let source_ref = model_ir
+        .source
+        .as_ref()
+        .expect("Snapshot variant guarantees `source` is Some");
+    let updated_at = model_ir
+        .updated_at
+        .as_ref()
+        .expect("Snapshot variant guarantees `updated_at` is Some");
+
+    let source =
+        dialect.format_table_ref(&source_ref.catalog, &source_ref.schema, &source_ref.table)?;
     let target = dialect.format_table_ref(
-        &plan.target.catalog,
-        &plan.target.schema,
-        &plan.target.table,
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
     )?;
 
-    if plan.unique_key.is_empty() {
+    if model_ir.unique_key.is_empty() {
         return Err(SqlGenError::MergeNoKey);
     }
 
     // Validate identifiers
-    for k in &plan.unique_key {
+    for k in &model_ir.unique_key {
         validation::validate_identifier(k)?;
     }
-    validation::validate_identifier(&plan.updated_at)?;
+    validation::validate_identifier(updated_at)?;
 
-    let join_cond = plan
+    let join_cond = model_ir
         .unique_key
         .iter()
         .map(|k| format!("target.{k} = source.{k}"))
@@ -654,7 +674,6 @@ pub fn generate_snapshot_sql(
            UPDATE SET valid_to = CURRENT_TIMESTAMP \
          WHEN NOT MATCHED THEN \
            INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)",
-        updated_at = plan.updated_at,
     );
     stmts.push(merge);
 
@@ -675,13 +694,13 @@ pub fn generate_snapshot_sql(
            SELECT 1 FROM {target} AS existing \
            WHERE {existing_join_cond} AND existing.valid_to IS NULL\
          )",
-        self_join_cond = plan
+        self_join_cond = model_ir
             .unique_key
             .iter()
             .map(|k| format!("t2.{k} = source.{k}"))
             .collect::<Vec<_>>()
             .join(" AND "),
-        existing_join_cond = plan
+        existing_join_cond = model_ir
             .unique_key
             .iter()
             .map(|k| format!("existing.{k} = source.{k}"))
@@ -691,7 +710,7 @@ pub fn generate_snapshot_sql(
     stmts.push(insert_new);
 
     // Statement 4 (optional): Invalidate hard-deleted rows
-    if plan.invalidate_hard_deletes {
+    if model_ir.invalidate_hard_deletes {
         let invalidate = format!(
             "UPDATE {target} SET valid_to = CURRENT_TIMESTAMP \
              WHERE valid_to IS NULL \


### PR DESCRIPTION
## Summary

Second sub-PR of Typed-IR Phase 3, continuing from #457. `sql_gen.rs` no longer constructs `ReplicationPlan`, `TransformationPlan`, or `SnapshotPlan` intermediates — every entry point now opens with a one-line variant guard against the new `ModelIrVariant` enum and reads `ModelIr` fields directly. The three private `*_from_ir` wrappers and the private `generate_select_sql_no_watermark` helper are gone; the `*Plan` structs survive only inside `ir.rs::to_plan_compatible()` (PR-5 deletes them).

PR #457 added the direct `ModelIr::as_replication / as_transformation / as_snapshot` accessors but they still cloned fields into the variant `*Plan` structs on every SQL gen. This PR completes the move to direct field reads.

## Why

`ir_hash` becomes keyed on `ModelIr` canonical-JSON alone once `Plan` is gone, which unlocks content-addressed caching, deterministic replay, and the catalog-as-service / WASM-plugin tracks. PR-3 next migrates the 6 `ModelIr::from(&Plan::*)` construction sites in `rocky-cli/src/commands/{run,plan,run_local,estimate,bench}.rs`; PR-4 migrates test fixtures; PR-5 deletes `Plan` + `to_plan_compatible`.

## Changes

**`ir.rs`**
- New `pub enum ModelIrVariant { Replication, Transformation, Snapshot }` with `as_str`, `Display`, and `#[serde(rename_all = \"lowercase\")]` so the wire form matches the pre-existing `\"replication\" / \"transformation\" / \"snapshot\"` string convention.
- `pub(crate) fn variant_name -> &'static str` replaced by `pub fn variant -> ModelIrVariant`. Same inference rule, still delegating to the private `is_snapshot_shaped` predicate (the single source of truth shared with all three accessors and `to_plan_compatible`).
- 4 unit tests cover `variant()`, `as_str()`, `Display`, the inference-priority rule, and a `variant_matches_to_plan_compatible_tag` regression guard that asserts `variant()` and `to_plan_compatible()` agree for every `From<&Plan>`-built IR.

`as_replication`, `as_transformation`, `as_snapshot`, `is_snapshot_shaped`, and `to_plan_compatible` are untouched — PR-5 owns their deletion.

**`sql_gen.rs`**
- Deleted `replication_from_ir`, `transformation_from_ir`, `snapshot_from_ir`, and `generate_select_sql_no_watermark`.
- New private `variant_mismatch(model_ir, expected)` centralises the `expected X ModelIr for `name`, found <actual>` error template — the three regression tests in this file's test module continue to assert the same substrings.
- 10 entry points rewritten to gate on `model_ir.variant()` and read `model_ir.{source, columns, target, materialization, sql, sources, unique_key, updated_at, invalidate_hard_deletes, metadata_columns, format, format_options}` directly.
- `.expect()` count: 8 replication-site + 2 snapshot-site + 0 transformation-site = 10 total, each annotated `\"X variant guarantees Y is Some\"`. Workspace clippy doesn't enable `expect_used` (verified `engine/Cargo.toml:35-43` is `correctness = deny` + 3 style warns), so no `#[allow]` attributes needed.

## Error-template invariant

The three regression tests at `sql_gen.rs` (`variant_mismatch_error_names_the_actual_variant`, `variant_mismatch_transformation_helper_names_replication_input`, `variant_mismatch_snapshot_helper_names_transformation_input`) assert substrings of the form `expected Replication ModelIr` and `found transformation`. The new `variant_mismatch()` helper emits the byte-for-byte identical template, and `ModelIrVariant::Display` renders lowercase via `as_str()`. All three tests pass.

## Test plan

- [x] `cargo test -p rocky-core --lib` — 1213 passed, 0 failed
- [x] `cargo test -p rocky-core --test e2e` — 30 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace` — builds end-to-end (confirms no external callers of `variant_name` or the deleted helpers)
- [x] `examples/playground/pocs/00-foundations/00-playground-default/run.sh` — green

## Scope confined to `rocky-core`

- No `Plan`, `*Plan`, `From<&Plan>`, or `to_plan_compatible` changes
- No `rocky-cli` changes
- No `schemas/` or generated-bindings changes (`just codegen` not required)