### PR TITLE
refactor(engine): migrate cli construction sites off Plan (Typed-IR Phase 3 PR-3)

### DIFF
--- a/engine/crates/rocky-cli/benches/compile.rs
+++ b/engine/crates/rocky-cli/benches/compile.rs
@@ -238,43 +238,40 @@ fn bench_sql_generation(c: &mut Criterion) {
     let dialect = DuckDbSqlDialect;
 
     for size in [10, 100, 500] {
-        // Pre-build replication plans
-        let plans: Vec<ReplicationPlan> = (0..size)
-            .map(|i| ReplicationPlan {
-                source: SourceRef {
-                    catalog: String::new(),
-                    schema: "source".into(),
-                    table: format!("table_{i}"),
-                },
-                target: TargetRef {
-                    catalog: String::new(),
-                    schema: "target".into(),
-                    table: format!("table_{i}"),
-                },
-                strategy: if i % 3 == 0 {
-                    MaterializationStrategy::FullRefresh
-                } else {
-                    MaterializationStrategy::Incremental {
-                        timestamp_column: "_fivetran_synced".into(),
-                    }
-                },
-                columns: ColumnSelection::All,
-                metadata_columns: vec![MetadataColumn {
-                    name: "_loaded_by".into(),
-                    data_type: "VARCHAR".into(),
-                    value: "NULL".into(),
-                }],
-                governance: GovernanceConfig {
-                    permissions_file: None,
-                    auto_create_catalogs: false,
-                    auto_create_schemas: false,
-                },
+        // Pre-build replication IRs directly (no Plan intermediate).
+        let model_irs: Vec<ModelIr> = (0..size)
+            .map(|i| {
+                ModelIr::replication(
+                    TargetRef {
+                        catalog: String::new(),
+                        schema: "target".into(),
+                        table: format!("table_{i}"),
+                    },
+                    if i % 3 == 0 {
+                        MaterializationStrategy::FullRefresh
+                    } else {
+                        MaterializationStrategy::Incremental {
+                            timestamp_column: "_fivetran_synced".into(),
+                        }
+                    },
+                    SourceRef {
+                        catalog: String::new(),
+                        schema: "source".into(),
+                        table: format!("table_{i}"),
+                    },
+                    ColumnSelection::All,
+                    vec![MetadataColumn {
+                        name: "_loaded_by".into(),
+                        data_type: "VARCHAR".into(),
+                        value: "NULL".into(),
+                    }],
+                    GovernanceConfig {
+                        permissions_file: None,
+                        auto_create_catalogs: false,
+                        auto_create_schemas: false,
+                    },
+                )
             })
-            .collect();
-
-        let model_irs: Vec<ModelIr> = plans
-            .iter()
-            .map(|plan| ModelIr::from(&Plan::Replication(plan.clone())))
             .collect();
 
         group.bench_with_input(

--- a/engine/crates/rocky-cli/src/commands/bench.rs
+++ b/engine/crates/rocky-cli/src/commands/bench.rs
@@ -349,37 +349,32 @@ fn bench_sql_gen(iterations: usize) -> Vec<BenchResult> {
     let mut results = Vec::new();
 
     for size in [10, 100, 500, 1000, 5000, 10000] {
-        let plans: Vec<ReplicationPlan> = (0..size)
-            .map(|i| ReplicationPlan {
-                source: SourceRef {
-                    catalog: String::new(),
-                    schema: "source".into(),
-                    table: format!("table_{i}"),
-                },
-                target: TargetRef {
-                    catalog: String::new(),
-                    schema: "target".into(),
-                    table: format!("table_{i}"),
-                },
-                strategy: MaterializationStrategy::FullRefresh,
-                columns: ColumnSelection::All,
-                metadata_columns: vec![MetadataColumn {
-                    name: "_loaded_by".into(),
-                    data_type: "VARCHAR".into(),
-                    value: "NULL".into(),
-                }],
-                governance: GovernanceConfig {
-                    permissions_file: None,
-                    auto_create_catalogs: false,
-                    auto_create_schemas: false,
-                },
-            })
-            .collect();
-
-        let model_irs: Vec<_> = plans
-            .iter()
-            .map(|plan| {
-                rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Replication(plan.clone()))
+        let model_irs: Vec<_> = (0..size)
+            .map(|i| {
+                rocky_core::ir::ModelIr::replication(
+                    TargetRef {
+                        catalog: String::new(),
+                        schema: "target".into(),
+                        table: format!("table_{i}"),
+                    },
+                    MaterializationStrategy::FullRefresh,
+                    SourceRef {
+                        catalog: String::new(),
+                        schema: "source".into(),
+                        table: format!("table_{i}"),
+                    },
+                    ColumnSelection::All,
+                    vec![MetadataColumn {
+                        name: "_loaded_by".into(),
+                        data_type: "VARCHAR".into(),
+                        value: "NULL".into(),
+                    }],
+                    GovernanceConfig {
+                        permissions_file: None,
+                        auto_create_catalogs: false,
+                        auto_create_schemas: false,
+                    },
+                )
             })
             .collect();
         let times = measure(iterations, || {

--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -65,9 +65,7 @@ pub async fn run_estimate(
     // 3. For each model, generate SQL and run EXPLAIN.
     let mut estimates = Vec::new();
     for model in &models_to_estimate {
-        let plan = model.to_plan();
-        let model_ir =
-            rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(plan.clone()));
+        let model_ir = model.to_model_ir();
         let dialect = warehouse_adapter.dialect();
 
         let sql_result = rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect);

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -144,29 +144,27 @@ pub async fn plan(
                 _ => (MaterializationStrategy::FullRefresh, "full_refresh_copy"),
             };
 
-            let plan = ReplicationPlan {
-                source: SourceRef {
-                    catalog: effective_source_catalog.clone(),
-                    schema: conn.schema.clone(),
-                    table: table.name.clone(),
-                },
-                target: TargetRef {
+            // sql_gen consumes the typed IR directly.
+            let model_ir = ModelIr::replication(
+                TargetRef {
                     catalog: effective_target_catalog.clone(),
                     schema: target_schema.clone(),
                     table: table.name.clone(),
                 },
-                strategy: strategy.clone(),
-                columns: ColumnSelection::All,
+                strategy.clone(),
+                SourceRef {
+                    catalog: effective_source_catalog.clone(),
+                    schema: conn.schema.clone(),
+                    table: table.name.clone(),
+                },
+                ColumnSelection::All,
                 metadata_columns,
-                governance: GovernanceConfig {
+                GovernanceConfig {
                     permissions_file: None,
                     auto_create_catalogs: pipeline.target.governance.auto_create_catalogs,
                     auto_create_schemas: pipeline.target.governance.auto_create_schemas,
                 },
-            };
-
-            // sql_gen consumes the typed IR directly.
-            let model_ir = ModelIr::from(&Plan::Replication(plan.clone()));
+            );
 
             // Pick the right SQL generator for the materialization strategy.
             // Full refresh uses CREATE OR REPLACE TABLE AS so the target doesn't

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3643,14 +3643,12 @@ pub(crate) async fn execute_models(
                 continue;
             }
 
-            let plan = model.to_plan();
-            let model_ir =
-                rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(plan.clone()));
+            let model_ir = model.to_model_ir();
             let target_ref = dialect
                 .format_table_ref(
-                    &plan.target.catalog,
-                    &plan.target.schema,
-                    &plan.target.table,
+                    &model_ir.target.catalog,
+                    &model_ir.target.schema,
+                    &model_ir.target.table,
                 )
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -3667,13 +3665,13 @@ pub(crate) async fn execute_models(
             // gets bootstrapped only when a live smoke test for that
             // strategy lands and verifies the fix end-to-end.
             if matches!(
-                plan.strategy,
+                model_ir.materialization,
                 rocky_core::ir::MaterializationStrategy::Merge { .. }
             ) {
                 let target_table_struct = rocky_core::ir::TableRef {
-                    catalog: plan.target.catalog.clone(),
-                    schema: plan.target.schema.clone(),
-                    table: plan.target.table.clone(),
+                    catalog: model_ir.target.catalog.clone(),
+                    schema: model_ir.target.schema.clone(),
+                    table: model_ir.target.table.clone(),
                 };
                 if warehouse
                     .describe_table(&target_table_struct)
@@ -3755,12 +3753,12 @@ pub(crate) async fn execute_models(
             let model_duration_ms = model_start.elapsed().as_millis() as u64;
             let target_table_full_name = format!(
                 "{}.{}.{}",
-                plan.target.catalog, plan.target.schema, plan.target.table
+                model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
             );
             let asset_key = vec![
-                plan.target.catalog.clone(),
-                plan.target.schema.clone(),
-                plan.target.table.clone(),
+                model_ir.target.catalog.clone(),
+                model_ir.target.schema.clone(),
+                model_ir.target.table.clone(),
             ];
             output.materializations.push(MaterializationOutput {
                 asset_key,
@@ -3768,7 +3766,7 @@ pub(crate) async fn execute_models(
                 duration_ms: model_duration_ms,
                 started_at: model_started_at,
                 metadata: MaterializationMetadata {
-                    strategy: transformation_strategy_name(&plan.strategy).to_string(),
+                    strategy: transformation_strategy_name(&model_ir.materialization).to_string(),
                     watermark: None,
                     target_table_full_name: Some(target_table_full_name),
                     sql_hash: Some(crate::output::sql_fingerprint(&exec_stmts)),
@@ -3936,10 +3934,7 @@ async fn execute_time_interval_model(
     };
     let target_exists = warehouse.describe_table(&target_ref_struct).await.is_ok();
     if !target_exists {
-        let bootstrap_plan = model.to_plan();
-        let bootstrap_ir = rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(
-            bootstrap_plan.clone(),
-        ));
+        let bootstrap_ir = model.to_model_ir();
         let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&bootstrap_ir, dialect)
             .with_context(|| {
             format!("failed to render bootstrap SQL for model '{model_name}'")
@@ -4104,18 +4099,16 @@ async fn run_one_partition(
         };
     }
 
-    // Build the per-partition plan: clone the base TransformationPlan and
-    // inject the PartitionWindow into the strategy.
-    let mut tplan = model.to_plan();
-    if let MaterializationStrategy::TimeInterval { window, .. } = &mut tplan.strategy {
+    // Build the per-partition IR: take the base ModelIr and inject the
+    // PartitionWindow into the TimeInterval strategy.
+    let mut tplan_ir = model.to_model_ir();
+    if let MaterializationStrategy::TimeInterval { window, .. } = &mut tplan_ir.materialization {
         *window = Some(partition_plan.window.clone());
     }
 
     // Generate SQL — this is where dialect.insert_overwrite_partition() gets
     // called and the @start_date / @end_date placeholders are substituted
     // (Phase 2D).
-    let tplan_ir =
-        rocky_core::ir::ModelIr::from(&rocky_core::ir::Plan::Transformation(tplan.clone()));
     let stmts = match sql_gen::generate_transformation_sql(&tplan_ir, dialect) {
         Ok(s) => s,
         Err(e) => {
@@ -4426,43 +4419,41 @@ async fn process_table(
         }
     }
 
-    // Build replication plan
-    let replication = ReplicationPlan {
-        source: SourceRef {
-            catalog: task.source_catalog.clone(),
-            schema: task.source_schema.clone(),
-            table: task.table_name.clone(),
-        },
-        target: TargetRef {
+    // Build replication IR directly.
+    let strategy = if pipeline.strategy == "incremental" {
+        MaterializationStrategy::Incremental {
+            timestamp_column: pipeline.timestamp_column.clone(),
+        }
+    } else {
+        MaterializationStrategy::FullRefresh
+    };
+    let model_ir = ModelIr::replication(
+        TargetRef {
             catalog: task.target_catalog.clone(),
             schema: task.target_schema.clone(),
             table: task.table_name.clone(),
         },
-        strategy: if pipeline.strategy == "incremental" {
-            MaterializationStrategy::Incremental {
-                timestamp_column: pipeline.timestamp_column.clone(),
-            }
-        } else {
-            MaterializationStrategy::FullRefresh
+        strategy.clone(),
+        SourceRef {
+            catalog: task.source_catalog.clone(),
+            schema: task.source_schema.clone(),
+            table: task.table_name.clone(),
         },
-        columns: ColumnSelection::All,
-        metadata_columns: task.metadata_columns.clone(),
-        governance: GovernanceConfig {
+        ColumnSelection::All,
+        task.metadata_columns.clone(),
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: pipeline.target.governance.auto_create_catalogs,
             auto_create_schemas: pipeline.target.governance.auto_create_schemas,
         },
-    };
-
-    // sql_gen consumes the typed IR directly.
-    let model_ir = ModelIr::from(&Plan::Replication(replication.clone()));
+    );
 
     let strategy_name;
     let sql = if use_full_refresh {
         strategy_name = "full_refresh";
         sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
     } else {
-        match &replication.strategy {
+        match &strategy {
             MaterializationStrategy::FullRefresh => {
                 strategy_name = "full_refresh";
                 sql_gen::generate_create_table_as_sql(&model_ir, dialect)?

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -630,33 +630,31 @@ pub async fn run_snapshot(
     let mut output = RunOutput::new(String::new(), 0, 1);
     output.pipeline_type = Some("snapshot".to_string());
 
-    let plan = rocky_core::ir::SnapshotPlan {
-        source: SourceRef {
-            catalog: pipeline.source.catalog.clone(),
-            schema: pipeline.source.schema.clone(),
-            table: pipeline.source.table.clone(),
-        },
-        target: TargetRef {
+    // sql_gen consumes the typed IR directly.
+    let model_ir = ModelIr::snapshot(
+        TargetRef {
             catalog: pipeline.target.catalog.clone(),
             schema: pipeline.target.schema.clone(),
             table: pipeline.target.table.clone(),
         },
-        unique_key: pipeline
+        SourceRef {
+            catalog: pipeline.source.catalog.clone(),
+            schema: pipeline.source.schema.clone(),
+            table: pipeline.source.table.clone(),
+        },
+        pipeline
             .unique_key
             .iter()
             .map(|s| std::sync::Arc::from(s.as_str()))
             .collect(),
-        updated_at: pipeline.updated_at.clone(),
-        invalidate_hard_deletes: pipeline.invalidate_hard_deletes,
-        governance: rocky_core::ir::GovernanceConfig {
+        pipeline.updated_at.clone(),
+        pipeline.invalidate_hard_deletes,
+        rocky_core::ir::GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: pipeline.target.governance.auto_create_catalogs,
             auto_create_schemas: pipeline.target.governance.auto_create_schemas,
         },
-    };
-
-    // sql_gen consumes the typed IR directly.
-    let model_ir = ModelIr::from(&Plan::Snapshot(plan.clone()));
+    );
 
     let dialect = warehouse_adapter.dialect();
     let stmts = sql_gen::generate_snapshot_sql(&model_ir, dialect)?;

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -600,6 +600,89 @@ impl std::fmt::Display for ModelIrVariant {
 }
 
 impl ModelIr {
+    /// Construct a replication-shaped [`ModelIr`] directly, bypassing the
+    /// [`Plan`] enum.
+    ///
+    /// Variant inference (see [`Self::variant`]) returns
+    /// [`ModelIrVariant::Replication`] for any IR built by this constructor,
+    /// since `columns` is `Some` and snapshot-shape fields stay empty.
+    ///
+    /// `name` defaults to `target.table`; `sql`, `typed_columns`,
+    /// `lineage_edges`, `sources`, `column_masks`, `unique_key`,
+    /// `updated_at`, `invalidate_hard_deletes`, `format`, and
+    /// `format_options` default to their zero values. Callers that need
+    /// richer typed-column or lineage data should mutate those fields
+    /// after construction.
+    pub fn replication(
+        target: TargetRef,
+        strategy: MaterializationStrategy,
+        source: SourceRef,
+        columns: ColumnSelection,
+        metadata_columns: Vec<MetadataColumn>,
+        governance: GovernanceConfig,
+    ) -> Self {
+        Self {
+            name: Arc::from(target.table.as_str()),
+            sql: String::new(),
+            typed_columns: Vec::new(),
+            lineage_edges: Vec::new(),
+            materialization: strategy,
+            governance,
+            target,
+            column_masks: Vec::new(),
+            source: Some(source),
+            sources: Vec::new(),
+            columns: Some(columns),
+            metadata_columns,
+            unique_key: Vec::new(),
+            updated_at: None,
+            invalidate_hard_deletes: false,
+            format: None,
+            format_options: None,
+        }
+    }
+
+    /// Construct a snapshot-shaped [`ModelIr`] directly, bypassing the
+    /// [`Plan`] enum.
+    ///
+    /// `materialization` is fixed at [`MaterializationStrategy::FullRefresh`]
+    /// to match the existing snapshot SQL-gen contract — SCD2 logic is
+    /// implicit in [`crate::sql_gen::generate_snapshot_sql`] and does not
+    /// depend on a strategy variant.
+    ///
+    /// `name` defaults to `target.table`. `sql`, `typed_columns`,
+    /// `lineage_edges`, `sources`, `column_masks`, `columns`,
+    /// `metadata_columns`, `format`, and `format_options` default to their
+    /// zero values.
+    pub fn snapshot(
+        target: TargetRef,
+        source: SourceRef,
+        unique_key: Vec<Arc<str>>,
+        updated_at: String,
+        invalidate_hard_deletes: bool,
+        governance: GovernanceConfig,
+    ) -> Self {
+        Self {
+            name: Arc::from(target.table.as_str()),
+            sql: String::new(),
+            typed_columns: Vec::new(),
+            lineage_edges: Vec::new(),
+            materialization: MaterializationStrategy::FullRefresh,
+            governance,
+            target,
+            column_masks: Vec::new(),
+            source: Some(source),
+            sources: Vec::new(),
+            columns: None,
+            metadata_columns: Vec::new(),
+            unique_key,
+            updated_at: Some(updated_at),
+            invalidate_hard_deletes,
+            format: None,
+            format_options: None,
+        }
+    }
+
     /// Compute the recipe-hash of this model.
     ///
     /// The hash is `blake3` over a canonical JSON encoding of `self`: keys

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -9,8 +9,7 @@ use thiserror::Error;
 use crate::config::{ModelBudgetConfig, substitute_env_vars};
 use crate::dag::DagNode;
 use crate::ir::{
-    GovernanceConfig, MaterializationStrategy, ModelIr, Plan, SourceRef, TargetRef,
-    TransformationPlan,
+    GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef, TransformationPlan,
 };
 use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 use crate::retention::{RetentionParseError, RetentionPolicy};
@@ -658,9 +657,9 @@ impl Model {
 
     /// Construct the per-model [`ModelIr`] for this transformation model.
     ///
-    /// Reuses [`Self::to_plan`] so the materialization-strategy lowering
-    /// stays in one place; the resulting [`Plan::Transformation`] is fed to
-    /// [`From<&Plan> for ModelIr`] and the model's own `name` overrides the
+    /// Reuses [`Self::to_plan`] to share the materialization-strategy
+    /// lowering, then assembles the IR directly without round-tripping
+    /// through [`Plan`]. The model's own `name` overrides the
     /// `target.table`-derived default so the IR carries the project-unique
     /// identifier rather than the warehouse table name.
     ///
@@ -668,10 +667,26 @@ impl Model {
     /// — they are populated by the compiler / governance layers downstream
     /// when richer typed data is available.
     pub fn to_model_ir(&self) -> ModelIr {
-        let plan = Plan::Transformation(self.to_plan());
-        let mut ir = ModelIr::from(&plan);
-        ir.name = std::sync::Arc::from(self.config.name.as_str());
-        ir
+        let plan = self.to_plan();
+        ModelIr {
+            name: std::sync::Arc::from(self.config.name.as_str()),
+            sql: plan.sql,
+            typed_columns: Vec::new(),
+            lineage_edges: Vec::new(),
+            materialization: plan.strategy,
+            governance: plan.governance,
+            target: plan.target,
+            column_masks: Vec::new(),
+            source: None,
+            sources: plan.sources,
+            columns: None,
+            metadata_columns: Vec::new(),
+            unique_key: Vec::new(),
+            updated_at: None,
+            invalidate_hard_deletes: false,
+            format: plan.format,
+            format_options: plan.format_options,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Third sub-PR of Typed-IR Phase 3. Continues from #483 (which removed `Plan` from `sql_gen.rs`'s consumption path). This PR migrates all remaining CLI construction sites off `ModelIr::from(&Plan::*)` and onto direct `ModelIr` constructors.

After this PR, `From<&Plan> for ModelIr` is consumed only by:
- `ModelIr::to_plan_compatible` (round-trip; delegates to accessors)
- 3 test helpers in `sql_gen.rs` (`rep_ir`, `xform_ir`, `snap_ir`)

PR-4 cleans up the test helpers; PR-5 deletes `Plan` + the `*Plan` family entirely.

## Why

Removes the last `Plan` materialisations from the runtime execution path, leaving `Plan` as a deprecated test-time intermediate. Brings `ir_hash` one step closer to being keyed on `ModelIr` canonical-JSON alone.

## Changes

**`rocky-core/src/ir.rs`**
- New `pub fn ModelIr::replication(target, strategy, source, columns, metadata_columns, governance) -> Self` — body mirrors the `From<&Plan::Replication>` arm.
- New `pub fn ModelIr::snapshot(target, source, unique_key, updated_at, invalidate_hard_deletes, governance) -> Self` — body mirrors the `From<&Plan::Snapshot>` arm; materialization fixed at `FullRefresh` (SCD2 logic is implicit in `generate_snapshot_sql`, not strategy-driven).
- No `ModelIr::transformation()` constructor — `Model::to_model_ir()` already covers all transformation construction sites and is the canonical compiler-to-IR converter.

**`rocky-core/src/models.rs`**
- `Model::to_model_ir()` refactored to construct `ModelIr` inline from `self.to_plan()` instead of via `ModelIr::from(&Plan::Transformation(self.to_plan()))`. Same observable behaviour; one less allocation per model.
- Dropped now-unused `Plan` from the `crate::ir::*` import.

**CLI site migrations (6 + 2 benches)**

| Site | Variant | Migration |
|---|---|---|
| `commands/plan.rs:169` | Replication | `ModelIr::replication(...)` |
| `commands/run.rs:3646` | Transformation | `model.to_model_ir()`; downstream `plan.target` / `plan.strategy` refs rewired to `model_ir.target` / `model_ir.materialization` |
| `commands/run.rs:3939` | Transformation (bootstrap) | `model.to_model_ir()` |
| `commands/run.rs:4109` | Transformation (per-partition mutation) | `let mut tplan_ir = model.to_model_ir();` then mutate `tplan_ir.materialization` instead of `tplan.strategy` |
| `commands/run.rs:4429` | Replication | `ModelIr::replication(...)`; `strategy` hoisted into a local so the subsequent match works |
| `commands/run_local.rs:633` | Snapshot | `ModelIr::snapshot(...)` |
| `commands/estimate.rs:68` | Transformation | `model.to_model_ir()` |
| `commands/bench.rs:352` | Replication (fixture) | Direct `ModelIr::replication` in the loop, no intermediate `Vec<ReplicationPlan>` |
| `benches/compile.rs:242` | Replication (fixture) | Direct `ModelIr::replication` in the loop |

## Test plan

- [x] `cargo test -p rocky-core --lib` — 1213 passed
- [x] `cargo test -p rocky-core --test e2e` — 30 passed
- [x] `cargo test -p rocky-cli --lib` — 376 passed
- [x] `cargo test -p rocky-cli --tests` — 4 `ir_golden` tests passed (`ir_round_trip_byte_stable`, `ir_recipe_hash_pinned`, `ir_json_matches_snapshot`, `ir_sql_per_dialect`) — these directly verify that `Model::to_model_ir()` still produces canonical-JSON-byte-stable IR after the inline refactor
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `examples/playground/pocs/00-foundations/00-playground-default/run.sh` — green (exercises replication + transformation paths through the migrated call sites)

## Scope

- No `Plan` / `*Plan` struct changes
- No `From<&Plan>` deletion (PR-5)
- No `to_plan_compatible` change (PR-5)
- No `schemas/` or generated-bindings changes — `just codegen` not required