### PR TITLE
refactor(engine/rocky-core): migrate test fixtures off From<&Plan>

### DIFF
--- a/engine/crates/rocky-cli/tests/ir_golden.rs
+++ b/engine/crates/rocky-cli/tests/ir_golden.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 
 use rocky_core::ir::{
     ColumnMask, ColumnSelection, GovernanceConfig, MaterializationStrategy, MetadataColumn,
-    ModelIr, Plan, ReplicationPlan, SnapshotPlan, SourceRef, TargetRef, TransformationPlan,
+    ModelIr, SourceRef, TargetRef,
 };
 use rocky_core::lakehouse::{LakehouseFormat, LakehouseOptions};
 use rocky_core::lineage::{LineageEdge, QualifiedColumn};
@@ -339,40 +339,38 @@ fn raw_source(table: &str) -> SourceRef {
 }
 
 fn build_01_replication_full_refresh() -> ModelIr {
-    let plan = Plan::Replication(ReplicationPlan {
-        source: raw_source("orders"),
-        target: raw_target("orders"),
-        strategy: MaterializationStrategy::FullRefresh,
-        columns: ColumnSelection::All,
-        metadata_columns: vec![],
-        governance: baseline_governance(),
-    });
-    let mut ir = ModelIr::from(&plan);
+    let mut ir = ModelIr::replication(
+        raw_target("orders"),
+        MaterializationStrategy::FullRefresh,
+        raw_source("orders"),
+        ColumnSelection::All,
+        vec![],
+        baseline_governance(),
+    );
     ir.name = Arc::from("orders");
     ir
 }
 
 fn build_02_replication_incremental() -> ModelIr {
-    let plan = Plan::Replication(ReplicationPlan {
-        source: raw_source("events"),
-        target: raw_target("events"),
-        strategy: MaterializationStrategy::Incremental {
+    let mut ir = ModelIr::replication(
+        raw_target("events"),
+        MaterializationStrategy::Incremental {
             timestamp_column: "_synced_at".into(),
         },
-        columns: ColumnSelection::Explicit(vec![
+        raw_source("events"),
+        ColumnSelection::Explicit(vec![
             Arc::from("id"),
             Arc::from("event_type"),
             Arc::from("payload"),
             Arc::from("_synced_at"),
         ]),
-        metadata_columns: vec![MetadataColumn {
+        vec![MetadataColumn {
             name: "_loaded_by".into(),
             data_type: "STRING".into(),
             value: "'rocky'".into(),
         }],
-        governance: baseline_governance(),
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+    );
     ir.name = Arc::from("events");
     ir
 }
@@ -386,10 +384,9 @@ fn build_03_replication_merge() -> ModelIr {
     // `update_columns` is explicit (not `ColumnSelection::All`) so the
     // DuckDB dialect produces a valid `UPDATE SET name = source.name, ...`
     // — DuckDB MERGE rejects the `UPDATE SET *` shorthand.
-    let plan = Plan::Replication(ReplicationPlan {
-        source: raw_source("customers"),
-        target: raw_target("customers"),
-        strategy: MaterializationStrategy::Merge {
+    let mut ir = ModelIr::replication(
+        raw_target("customers"),
+        MaterializationStrategy::Merge {
             unique_key: vec![Arc::from("customer_id")],
             update_columns: ColumnSelection::Explicit(vec![
                 Arc::from("name"),
@@ -397,30 +394,29 @@ fn build_03_replication_merge() -> ModelIr {
                 Arc::from("updated_at"),
             ]),
         },
-        columns: ColumnSelection::All,
-        metadata_columns: vec![],
-        governance: baseline_governance(),
-    });
-    let mut ir = ModelIr::from(&plan);
+        raw_source("customers"),
+        ColumnSelection::All,
+        vec![],
+        baseline_governance(),
+    );
     ir.name = Arc::from("customers");
     ir
 }
 
 fn build_04_transformation_full_refresh() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
+    let mut ir = ModelIr::transformation(
+        marts_target("fct_orders"),
+        MaterializationStrategy::FullRefresh,
+        vec![SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "raw__demo".into(),
             table: "orders".into(),
         }],
-        target: marts_target("fct_orders"),
-        strategy: MaterializationStrategy::FullRefresh,
-        sql: "SELECT id, customer_id, total FROM tgtwarehouse.raw__demo.orders".into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        "SELECT id, customer_id, total FROM tgtwarehouse.raw__demo.orders".into(),
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("fct_orders");
     ir.typed_columns = vec![
         TypedColumn {
@@ -443,14 +439,9 @@ fn build_04_transformation_full_refresh() -> ModelIr {
 }
 
 fn build_05_transformation_merge() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
-            catalog: TGT_CATALOG.into(),
-            schema: "raw__demo".into(),
-            table: "customers".into(),
-        }],
-        target: marts_target("dim_customers"),
-        strategy: MaterializationStrategy::Merge {
+    let mut ir = ModelIr::transformation(
+        marts_target("dim_customers"),
+        MaterializationStrategy::Merge {
             unique_key: vec![Arc::from("customer_id")],
             update_columns: ColumnSelection::Explicit(vec![
                 Arc::from("name"),
@@ -458,14 +449,18 @@ fn build_05_transformation_merge() -> ModelIr {
                 Arc::from("updated_at"),
             ]),
         },
-        sql: "SELECT customer_id, name, email, updated_at \
+        vec![SourceRef {
+            catalog: TGT_CATALOG.into(),
+            schema: "raw__demo".into(),
+            table: "customers".into(),
+        }],
+        "SELECT customer_id, name, email, updated_at \
               FROM tgtwarehouse.raw__demo.customers"
             .into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("dim_customers");
     // Resolved column mask: email gets HASH for the active env.
     ir.column_masks = vec![ColumnMask {
@@ -488,67 +483,64 @@ fn build_05_transformation_merge() -> ModelIr {
 }
 
 fn build_06_transformation_ephemeral() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
+    let mut ir = ModelIr::transformation(
+        marts_target("active_orders"),
+        MaterializationStrategy::Ephemeral,
+        vec![SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "marts__demo".into(),
             table: "fct_orders".into(),
         }],
-        target: marts_target("active_orders"),
-        strategy: MaterializationStrategy::Ephemeral,
-        sql: "SELECT * FROM tgtwarehouse.marts__demo.fct_orders WHERE status = 'active'".into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        "SELECT * FROM tgtwarehouse.marts__demo.fct_orders WHERE status = 'active'".into(),
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("active_orders");
     ir
 }
 
 fn build_07_transformation_materialized_view() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
+    let mut ir = ModelIr::transformation(
+        marts_target("mv_orders_daily"),
+        MaterializationStrategy::MaterializedView,
+        vec![SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "marts__demo".into(),
             table: "fct_orders".into(),
         }],
-        target: marts_target("mv_orders_daily"),
-        strategy: MaterializationStrategy::MaterializedView,
-        sql: "SELECT DATE(created_at) AS day, COUNT(*) AS order_count, SUM(total) AS revenue \
+        "SELECT DATE(created_at) AS day, COUNT(*) AS order_count, SUM(total) AS revenue \
               FROM tgtwarehouse.marts__demo.fct_orders GROUP BY 1"
             .into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("mv_orders_daily");
     ir
 }
 
 fn build_08_transformation_dynamic_table() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
+    // Note: target_lag also sits on the strategy enum, but
+    // generate_dynamic_table_sql consumes it from the call args (see Entry::DynamicTable).
+    let mut ir = ModelIr::transformation(
+        marts_target("dt_orders_recent"),
+        MaterializationStrategy::DynamicTable {
+            target_lag: "1 hour".into(),
+        },
+        vec![SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "marts__demo".into(),
             table: "fct_orders".into(),
         }],
-        target: marts_target("dt_orders_recent"),
-        // Note: target_lag also sits on the strategy enum, but
-        // generate_dynamic_table_sql consumes it from the call args (see Entry::DynamicTable).
-        strategy: MaterializationStrategy::DynamicTable {
-            target_lag: "1 hour".into(),
-        },
-        sql: "SELECT id, customer_id, total \
+        "SELECT id, customer_id, total \
               FROM tgtwarehouse.marts__demo.fct_orders \
               WHERE created_at > CURRENT_DATE - INTERVAL '7' DAY"
             .into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("dt_orders_recent");
     ir
 }
@@ -556,59 +548,59 @@ fn build_08_transformation_dynamic_table() -> ModelIr {
 fn build_09_transformation_time_interval_bootstrap() -> ModelIr {
     // Static plan emits window=None per the recipe-hash invariant
     // documented in SPEC.md §5.
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
-            catalog: TGT_CATALOG.into(),
-            schema: "raw__demo".into(),
-            table: "events".into(),
-        }],
-        target: marts_target("events_daily"),
-        strategy: MaterializationStrategy::TimeInterval {
+    let mut ir = ModelIr::transformation(
+        marts_target("events_daily"),
+        MaterializationStrategy::TimeInterval {
             time_column: "event_date".into(),
             granularity: TimeGrain::Day,
             window: None,
         },
-        sql: "SELECT event_date, COUNT(*) AS event_count \
+        vec![SourceRef {
+            catalog: TGT_CATALOG.into(),
+            schema: "raw__demo".into(),
+            table: "events".into(),
+        }],
+        "SELECT event_date, COUNT(*) AS event_count \
               FROM tgtwarehouse.raw__demo.events \
               WHERE event_date >= '@start_date' AND event_date < '@end_date' \
               GROUP BY 1"
             .into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("events_daily");
     ir
 }
 
 fn build_10_transformation_lakehouse_delta() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![SourceRef {
+    let mut ir = ModelIr::transformation(
+        marts_target("fct_events_delta"),
+        MaterializationStrategy::FullRefresh,
+        vec![SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "raw__demo".into(),
             table: "events".into(),
         }],
-        target: marts_target("fct_events_delta"),
-        strategy: MaterializationStrategy::FullRefresh,
-        sql: "SELECT id, event_type, event_date, payload \
+        "SELECT id, event_type, event_date, payload \
               FROM tgtwarehouse.raw__demo.events"
             .into(),
-        governance: baseline_governance(),
-        format: Some(LakehouseFormat::DeltaTable),
-        format_options: Some(LakehouseOptions {
+        baseline_governance(),
+        Some(LakehouseFormat::DeltaTable),
+        Some(LakehouseOptions {
             partition_by: vec!["event_date".into()],
             ..Default::default()
         }),
-    });
-    let mut ir = ModelIr::from(&plan);
+    );
     ir.name = Arc::from("fct_events_delta");
     ir
 }
 
 fn build_11_transformation_multi_source_join() -> ModelIr {
-    let plan = Plan::Transformation(TransformationPlan {
-        sources: vec![
+    let mut ir = ModelIr::transformation(
+        marts_target("fct_order_lines"),
+        MaterializationStrategy::FullRefresh,
+        vec![
             SourceRef {
                 catalog: TGT_CATALOG.into(),
                 schema: "raw__demo".into(),
@@ -625,36 +617,32 @@ fn build_11_transformation_multi_source_join() -> ModelIr {
                 table: "products".into(),
             },
         ],
-        target: marts_target("fct_order_lines"),
-        strategy: MaterializationStrategy::FullRefresh,
-        sql: "SELECT o.id AS order_id, c.name AS customer_name, p.sku, o.total \
+        "SELECT o.id AS order_id, c.name AS customer_name, p.sku, o.total \
               FROM tgtwarehouse.raw__demo.orders o \
               JOIN tgtwarehouse.raw__demo.customers c ON o.customer_id = c.id \
               JOIN tgtwarehouse.raw__demo.products p ON o.product_id = p.id"
             .into(),
-        governance: baseline_governance(),
-        format: None,
-        format_options: None,
-    });
-    let mut ir = ModelIr::from(&plan);
+        baseline_governance(),
+        None,
+        None,
+    );
     ir.name = Arc::from("fct_order_lines");
     ir
 }
 
 fn build_12_snapshot_scd2() -> ModelIr {
-    let plan = Plan::Snapshot(SnapshotPlan {
-        source: SourceRef {
+    let mut ir = ModelIr::snapshot(
+        snapshot_target("dim_customers_history"),
+        SourceRef {
             catalog: TGT_CATALOG.into(),
             schema: "marts__demo".into(),
             table: "dim_customers".into(),
         },
-        target: snapshot_target("dim_customers_history"),
-        unique_key: vec![Arc::from("customer_id")],
-        updated_at: "updated_at".into(),
-        invalidate_hard_deletes: true,
-        governance: baseline_governance(),
-    });
-    let mut ir = ModelIr::from(&plan);
+        vec![Arc::from("customer_id")],
+        "updated_at".into(),
+        true,
+        baseline_governance(),
+    );
     ir.name = Arc::from("dim_customers_history");
     ir
 }

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -642,6 +642,50 @@ impl ModelIr {
         }
     }
 
+    /// Construct a transformation-shaped [`ModelIr`] directly, bypassing
+    /// the [`Plan`] enum.
+    ///
+    /// Variant inference (see [`Self::variant`]) returns
+    /// [`ModelIrVariant::Transformation`] for any IR built by this
+    /// constructor — `columns` stays `None` and snapshot-shape fields
+    /// stay empty.
+    ///
+    /// `name` defaults to `target.table`. Callers that have a richer
+    /// project-unique identifier (e.g. the compiler-side
+    /// [`crate::models::Model::to_model_ir`]) should mutate `name` after
+    /// construction. `typed_columns`, `lineage_edges`, `column_masks`,
+    /// `source`, `metadata_columns`, `unique_key`, `updated_at`, and
+    /// `invalidate_hard_deletes` default to their zero values.
+    pub fn transformation(
+        target: TargetRef,
+        strategy: MaterializationStrategy,
+        sources: Vec<SourceRef>,
+        sql: String,
+        governance: GovernanceConfig,
+        format: Option<LakehouseFormat>,
+        format_options: Option<LakehouseOptions>,
+    ) -> Self {
+        Self {
+            name: Arc::from(target.table.as_str()),
+            sql,
+            typed_columns: Vec::new(),
+            lineage_edges: Vec::new(),
+            materialization: strategy,
+            governance,
+            target,
+            column_masks: Vec::new(),
+            source: None,
+            sources,
+            columns: None,
+            metadata_columns: Vec::new(),
+            unique_key: Vec::new(),
+            updated_at: None,
+            invalidate_hard_deletes: false,
+            format,
+            format_options,
+        }
+    }
+
     /// Construct a snapshot-shaped [`ModelIr`] directly, bypassing the
     /// [`Plan`] enum.
     ///

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -902,18 +902,40 @@ mod tests {
 
     /// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
     fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
-        ModelIr::from(&Plan::Replication(plan.clone()))
+        ModelIr::replication(
+            plan.target.clone(),
+            plan.strategy.clone(),
+            plan.source.clone(),
+            plan.columns.clone(),
+            plan.metadata_columns.clone(),
+            plan.governance.clone(),
+        )
     }
 
     /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
     fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-        ModelIr::from(&Plan::Transformation(plan.clone()))
+        ModelIr::transformation(
+            plan.target.clone(),
+            plan.strategy.clone(),
+            plan.sources.clone(),
+            plan.sql.clone(),
+            plan.governance.clone(),
+            plan.format.clone(),
+            plan.format_options.clone(),
+        )
     }
 
     /// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
     #[allow(dead_code)]
     fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-        ModelIr::from(&Plan::Snapshot(plan.clone()))
+        ModelIr::snapshot(
+            plan.target.clone(),
+            plan.source.clone(),
+            plan.unique_key.clone(),
+            plan.updated_at.clone(),
+            plan.invalidate_hard_deletes,
+            plan.governance.clone(),
+        )
     }
 
     fn sample_incremental_plan() -> ReplicationPlan {

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -5,7 +5,7 @@
 
 use rocky_core::ir::{
     ColumnInfo, ColumnSelection, DriftAction, GovernanceConfig, MaterializationStrategy,
-    MetadataColumn, ModelIr, Plan, ReplicationPlan, SnapshotPlan, SourceRef, TableRef, TargetRef,
+    MetadataColumn, ModelIr, ReplicationPlan, SnapshotPlan, SourceRef, TableRef, TargetRef,
     TransformationPlan, WatermarkState,
 };
 use rocky_core::state::StateStore;
@@ -15,18 +15,40 @@ use tempfile::TempDir;
 
 /// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
 fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
-    ModelIr::from(&Plan::Replication(plan.clone()))
+    ModelIr::replication(
+        plan.target.clone(),
+        plan.strategy.clone(),
+        plan.source.clone(),
+        plan.columns.clone(),
+        plan.metadata_columns.clone(),
+        plan.governance.clone(),
+    )
 }
 
 /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
 fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-    ModelIr::from(&Plan::Transformation(plan.clone()))
+    ModelIr::transformation(
+        plan.target.clone(),
+        plan.strategy.clone(),
+        plan.sources.clone(),
+        plan.sql.clone(),
+        plan.governance.clone(),
+        plan.format.clone(),
+        plan.format_options.clone(),
+    )
 }
 
 /// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
 #[allow(dead_code)]
 fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-    ModelIr::from(&Plan::Snapshot(plan.clone()))
+    ModelIr::snapshot(
+        plan.target.clone(),
+        plan.source.clone(),
+        plan.unique_key.clone(),
+        plan.updated_at.clone(),
+        plan.invalidate_hard_deletes,
+        plan.governance.clone(),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1126,7 +1148,7 @@ WHERE _fivetran_synced > (
 mod time_interval_e2e {
     use rocky_core::incremental::{PartitionRecord, PartitionStatus, partition_key_to_window};
     use rocky_core::ir::{
-        GovernanceConfig, MaterializationStrategy, ModelIr, Plan, SourceRef, TargetRef,
+        GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef,
         TransformationPlan,
     };
     use rocky_core::models::TimeGrain;
@@ -1138,7 +1160,15 @@ mod time_interval_e2e {
 
     /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
     fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-        ModelIr::from(&Plan::Transformation(plan.clone()))
+        ModelIr::transformation(
+            plan.target.clone(),
+            plan.strategy.clone(),
+            plan.sources.clone(),
+            plan.sql.clone(),
+            plan.governance.clone(),
+            plan.format.clone(),
+            plan.format_options.clone(),
+        )
     }
 
     /// SQL to seed a stg_orders table with rows across 5 partitions

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -23,19 +23,41 @@ use tempfile::TempDir;
 
 /// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
 fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
-    ModelIr::from(&Plan::Replication(plan.clone()))
+    ModelIr::replication(
+        plan.target.clone(),
+        plan.strategy.clone(),
+        plan.source.clone(),
+        plan.columns.clone(),
+        plan.metadata_columns.clone(),
+        plan.governance.clone(),
+    )
 }
 
 /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
 #[allow(dead_code)]
 fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-    ModelIr::from(&Plan::Transformation(plan.clone()))
+    ModelIr::transformation(
+        plan.target.clone(),
+        plan.strategy.clone(),
+        plan.sources.clone(),
+        plan.sql.clone(),
+        plan.governance.clone(),
+        plan.format.clone(),
+        plan.format_options.clone(),
+    )
 }
 
 /// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
 #[allow(dead_code)]
 fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-    ModelIr::from(&Plan::Snapshot(plan.clone()))
+    ModelIr::snapshot(
+        plan.target.clone(),
+        plan.source.clone(),
+        plan.unique_key.clone(),
+        plan.updated_at.clone(),
+        plan.invalidate_hard_deletes,
+        plan.governance.clone(),
+    )
 }
 
 fn dialect() -> DuckDbSqlDialect {


### PR DESCRIPTION
## Summary

Continues the Typed-IR migration from #485. Removes the last production-code consumers of `From<&Plan> for ModelIr` outside of the `Plan` enum itself.

After this PR, `From<&Plan> for ModelIr` is referenced only inside `ir.rs`:
- The `impl` block itself
- `ModelIr::to_plan_compatible` (delegates to accessors)
- Round-trip unit tests in `ir.rs`'s test module

All three are slated for deletion in the next sub-PR, which also drops `Plan`, `ReplicationPlan`, `TransformationPlan`, and `SnapshotPlan`.

## Changes

**`rocky-core/src/ir.rs`**
- New `pub fn ModelIr::transformation(target, strategy, sources, sql, governance, format, format_options) -> Self`. Body mirrors the `From<&Plan::Transformation>` arm. Completes the trio of named constructors started in #485 (replication + snapshot already landed).

**Test-side migrations**
- `rocky-core/src/sql_gen.rs` test helpers `rep_ir` / `xform_ir` / `snap_ir` now call the named constructors instead of `ModelIr::from(&Plan::X)`. Signatures unchanged so the ~50 call sites in the sql_gen test module are untouched.
- `rocky-core/tests/e2e.rs` `rep_ir` / `xform_ir` / `snap_ir` migrated. The inner `time_interval_e2e` module's `xform_ir` migrated too. `Plan` no longer imported.
- `rocky-core/tests/integration.rs` `rep_ir` / `xform_ir` / `snap_ir` migrated.
- `rocky-cli/tests/ir_golden.rs` — all 12 `build_*` fixture functions rewritten to call the named constructors directly: `build_01_replication_full_refresh` through `build_12_snapshot_scd2`. The pattern `let plan = Plan::X(XPlan { ... }); let mut ir = ModelIr::from(&plan); ir.name = ...` collapses to `let mut ir = ModelIr::X(...); ir.name = ...`. Unused `Plan`, `ReplicationPlan`, `TransformationPlan`, `SnapshotPlan` imports dropped.

## Byte-stability invariant

The `ir_golden` snapshot fixtures (`ir.json` and `<dialect>.sql` files in `tests/fixtures/`) are byte-stable across this refactor — verified by the four `ir_golden` integration tests:
- `ir_round_trip_byte_stable`
- `ir_recipe_hash_pinned`
- `ir_json_matches_snapshot`
- `ir_sql_per_dialect`

The named constructors produce ModelIrs that canonical-JSON-equal the equivalent `From<&Plan>` path, so recipe hashes and SQL snapshots are unchanged.

## Test plan

- [x] `cargo test -p rocky-core --lib` — 1213 passed
- [x] `cargo test -p rocky-core --test e2e` — 30 passed
- [x] `cargo test -p rocky-core --test integration` — 20 passed
- [x] `cargo test -p rocky-cli --test ir_golden` — 4 passed (snapshot byte-stability + recipe-hash pin)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `examples/playground/pocs/00-foundations/00-playground-default/run.sh` — green

## Scope

- No `Plan` / `*Plan` struct changes (deletion next)
- No `From<&Plan>` deletion (next sub-PR)
- No `to_plan_compatible` change (next sub-PR)
- No `schemas/` or generated-bindings changes — `just codegen` not required