### PR TITLE
feat(rocky-iceberg): scaffold UniForm writer module

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3981,8 +3981,13 @@ dependencies = [
 name = "rocky-iceberg"
 version = "1.29.0"
 dependencies = [
+ "arrow 58.3.0",
  "async-trait",
+ "blake3",
+ "bytes",
  "chrono",
+ "object_store",
+ "parquet",
  "percent-encoding",
  "reqwest",
  "rocky-core",

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -18,6 +18,15 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 percent-encoding = { workspace = true }
 
+# Wave 2 — content-addressed UniForm writer. Storage abstraction (portable
+# across S3 / GCS / Azure), in-memory Arrow / Parquet construction, and
+# blake3 for content-addressing the Parquet bytes.
+arrow = { workspace = true }
+parquet = { workspace = true }
+object_store = { workspace = true }
+blake3 = { workspace = true }
+bytes = { workspace = true }
+
 [dev-dependencies]
 wiremock = { workspace = true }
 

--- a/engine/crates/rocky-iceberg/src/lib.rs
+++ b/engine/crates/rocky-iceberg/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod adapter;
 pub mod client;
+pub mod uniform_writer;

--- a/engine/crates/rocky-iceberg/src/uniform_writer/errors.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/errors.rs
@@ -1,0 +1,48 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum UniformWriterError {
+    #[error("object store: {0}")]
+    ObjectStore(#[from] object_store::Error),
+
+    #[error("parquet: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+
+    #[error("arrow: {0}")]
+    Arrow(#[from] arrow::error::ArrowError),
+
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("delta log parse: {0}")]
+    DeltaLog(String),
+
+    #[error("sql client: {0}")]
+    Sql(String),
+
+    #[error(
+        "row tracking is enabled on this table; phase 1 writer does not support it. \
+         See arc 1 wave 2 phase 3 for the rowTracking-aware writer surface."
+    )]
+    RowTrackingUnsupported,
+
+    #[error(
+        "partitioned tables are not supported by phase 1; partition columns: {0:?}. \
+         See arc 1 wave 2 phase 2 for partitioned-table support."
+    )]
+    PartitionedUnsupported(Vec<String>),
+
+    #[error(
+        "deletion vectors are enabled on this table; UniForm + deletionVectors is rejected by \
+         Delta itself. This writer requires UniForm and so cannot operate on a DV table."
+    )]
+    DeletionVectorsUnsupported,
+
+    #[error("retry budget exhausted on conditional log put: {0}")]
+    CondPutRetryExhausted(String),
+}
+
+pub type Result<T> = std::result::Result<T, UniformWriterError>;

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -1,0 +1,131 @@
+//! Content-addressed writer for Delta UniForm tables.
+//!
+//! Reads a Delta UniForm table's `_delta_log` state, writes deterministic
+//! Parquet files keyed by their blake3 hash, and emits Delta commit JSONL
+//! that references those files. After each commit, callers must trigger
+//! `MSCK REPAIR TABLE ... SYNC METADATA` via the warehouse SQL surface so
+//! UniForm regenerates the corresponding Iceberg metadata.
+//!
+//! Phase 1 scope (locked, see `rocky-arc1-wave2-phase1-uniform-writer.md`):
+//! - Single writer (no cross-writer coordination beyond conditional-put on
+//!   the log entry).
+//! - External Delta UniForm table on an object store the writer can `PUT`.
+//! - Unpartitioned, no schema evolution, no rowTracking, no deletion
+//!   vectors. The writer errors loudly if it discovers any of those at
+//!   table-init time; later phases lift each restriction.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+
+pub mod errors;
+
+pub use errors::{Result, UniformWriterError};
+
+/// Configuration for a `UniformWriter`.
+///
+/// The triple `(catalog, schema, table)` identifies the table in the
+/// warehouse SQL surface; `prefix` is the object-store key prefix under
+/// which `_delta_log/` and the table's Parquet files live. `engine_info`
+/// is recorded in every commit's `commitInfo.engineInfo` so observers can
+/// trace writes back to the Rocky version that emitted them.
+#[derive(Debug, Clone)]
+pub struct UniformWriterConfig {
+    pub catalog: String,
+    pub schema: String,
+    pub table: String,
+    pub prefix: String,
+    pub engine_info: String,
+}
+
+impl UniformWriterConfig {
+    pub fn fqtn(&self) -> String {
+        format!("{}.{}.{}", self.catalog, self.schema, self.table)
+    }
+}
+
+/// Snapshot of a Delta UniForm table's state as observed by `discover()`.
+///
+/// `physical` and `field_id` are keyed by the logical column name and
+/// return the Delta column-mapping UUID + numeric id, respectively. Stats
+/// and `partitionValues` in `add` actions must be keyed by these UUIDs,
+/// not the logical names (see Exp 11 — column-mapped Delta tables use
+/// physical UUIDs for partition key lookup, not the logical name the
+/// protocol spec implies).
+#[derive(Debug, Clone)]
+pub struct UniformTableState {
+    pub physical: HashMap<String, String>,
+    pub field_id: HashMap<String, i32>,
+    pub partition_columns: Vec<String>,
+    pub row_tracking_enabled: bool,
+    pub deletion_vectors_enabled: bool,
+    pub next_commit_version: u64,
+}
+
+/// Result of a successful `write_batch()` call.
+#[derive(Debug, Clone)]
+pub struct WriteResult {
+    pub file_path: String,
+    pub blake3_hash: String,
+    pub commit_version: u64,
+    pub num_records: usize,
+    pub size_bytes: u64,
+}
+
+/// Minimal SQL execution surface the writer needs.
+///
+/// Phase 1 only uses this for `MSCK REPAIR TABLE ... SYNC METADATA` after
+/// a successful commit. Implementations live next to the existing
+/// warehouse adapters (e.g. `rocky-databricks` wraps its Statement
+/// Execution API behind this trait in PR 4).
+#[async_trait::async_trait]
+pub trait SqlClient: Send + Sync {
+    async fn execute(&self, sql: &str) -> Result<()>;
+}
+
+/// Content-addressed writer for a single Delta UniForm table.
+pub struct UniformWriter {
+    config: UniformWriterConfig,
+    store: Arc<dyn ObjectStore>,
+    sql: Arc<dyn SqlClient>,
+}
+
+impl UniformWriter {
+    pub fn new(
+        config: UniformWriterConfig,
+        store: Arc<dyn ObjectStore>,
+        sql: Arc<dyn SqlClient>,
+    ) -> Self {
+        Self { config, store, sql }
+    }
+
+    pub fn config(&self) -> &UniformWriterConfig {
+        &self.config
+    }
+
+    pub fn store(&self) -> &Arc<dyn ObjectStore> {
+        &self.store
+    }
+
+    pub fn sql(&self) -> &Arc<dyn SqlClient> {
+        &self.sql
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_builds_fqtn() {
+        let c = UniformWriterConfig {
+            catalog: "cat".into(),
+            schema: "sch".into(),
+            table: "tbl".into(),
+            prefix: "p/".into(),
+            engine_info: "rocky-iceberg/test".into(),
+        };
+        assert_eq!(c.fqtn(), "cat.sch.tbl");
+    }
+}


### PR DESCRIPTION
## Summary

First PR of the wave 2 content-addressed-writer series. Type-only scaffold for `rocky-iceberg::uniform_writer` — no business logic yet; `discover()` + `write_batch()` + `sync_iceberg_metadata()` land in PRs 2–4.

- Adds parquet / arrow / object_store / blake3 / bytes as `rocky-iceberg` dependencies (all already at the workspace level).
- New module `rocky-iceberg::uniform_writer` with `UniformWriterConfig`, `UniformTableState`, `WriteResult`, the `SqlClient` trait surface (used only for MSCK REPAIR after a commit), and the `UniformWriterError` enum.
- Errors are explicit about what the writer refuses on day one: rowTracking, deletion vectors, and partitioned tables each surface a typed error pointing at the later phase that will ship support. DV is rejected outright because Delta itself forbids `enableDeletionVectors=true` on UniForm tables.

The writer targets a single external Delta UniForm table with column-mapping `mode=name`, no schema evolution, no rowTracking, no deletion vectors. Later phases lift each of those.

## Test plan

- [x] `cargo build -p rocky-iceberg` clean
- [x] `cargo clippy -p rocky-iceberg -- -D warnings` clean
- [x] `cargo test -p rocky-iceberg --lib` — 29 passed (28 pre-existing + new `config_builds_fqtn`)
- [x] `cargo fmt -p rocky-iceberg -- --check` clean
- [x] Full-workspace `cargo build` clean