### PR TITLE
refactor(engine/rocky-core): delete Plan enum + *Plan structs + From<&Plan>

### DIFF
--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -287,12 +287,12 @@ fn populate_governance_actions(
         // Snowflake ALTER TABLE) or `None` on adapters without a
         // first-class retention knob.
         if let Some(retention) = model.config.retention {
-            let plan = model.to_plan();
+            let target = &model.config.target;
             let warehouse_preview = render_retention_preview(
                 adapter_type,
-                &plan.target.catalog,
-                &plan.target.schema,
-                &plan.target.table,
+                &target.catalog,
+                &target.schema,
+                &target.table,
                 retention.duration_days,
             );
             output.retention_actions.push(RetentionAction {

--- a/engine/crates/rocky-cli/src/commands/retention_status.rs
+++ b/engine/crates/rocky-cli/src/commands/retention_status.rs
@@ -182,11 +182,11 @@ async fn probe_model_retention(
         .unwrap_or(&ctx.default_adapter);
     let governance: Box<dyn GovernanceAdapter> = ctx.registry.governance_adapter(adapter_name);
 
-    let plan = model.to_plan();
+    let target = &model.config.target;
     let table = TableRef {
-        catalog: plan.target.catalog,
-        schema: plan.target.schema,
-        table: plan.target.table,
+        catalog: target.catalog.clone(),
+        schema: target.schema.clone(),
+        table: target.table.clone(),
     };
 
     match governance.read_retention_days(&table).await {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2875,11 +2875,10 @@ pub async fn run(
             if let Ok(gov_compile) = governance_compile {
                 let tag_to_strategy = rocky_cfg.resolve_mask_for_env(env);
                 for model in &gov_compile.project.models {
-                    let plan = model.to_plan();
                     let table_ref = TableRef {
-                        catalog: plan.target.catalog.clone(),
-                        schema: plan.target.schema.clone(),
-                        table: plan.target.table.clone(),
+                        catalog: model.config.target.catalog.clone(),
+                        schema: model.config.target.schema.clone(),
+                        table: model.config.target.table.clone(),
                     };
 
                     // --- Classification tags + masking (Wave A) ---

--- a/engine/crates/rocky-core/src/ir.rs
+++ b/engine/crates/rocky-core/src/ir.rs
@@ -31,59 +31,6 @@ use serde::{Deserialize, Serialize};
 use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 use crate::models::TimeGrain;
 
-/// A transformation plan that compiles to warehouse-specific SQL.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum Plan {
-    Replication(ReplicationPlan),
-    Transformation(TransformationPlan),
-    Snapshot(SnapshotPlan),
-}
-
-/// Silver layer: custom SQL transformations with multiple sources.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransformationPlan {
-    /// Multiple input tables (for joins).
-    pub sources: Vec<SourceRef>,
-    pub target: TargetRef,
-    pub strategy: MaterializationStrategy,
-    /// User-written SQL (loaded from file or inline).
-    pub sql: String,
-    pub governance: GovernanceConfig,
-    /// Optional lakehouse table format (Delta, Iceberg, etc.).
-    /// When set, SQL generation uses format-specific DDL.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format: Option<LakehouseFormat>,
-    /// Format-specific options (partitioning, clustering, properties).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub format_options: Option<LakehouseOptions>,
-}
-
-/// Raw layer: 1:1 copy with incremental watermark.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReplicationPlan {
-    pub source: SourceRef,
-    pub target: TargetRef,
-    pub strategy: MaterializationStrategy,
-    pub columns: ColumnSelection,
-    pub metadata_columns: Vec<MetadataColumn>,
-    pub governance: GovernanceConfig,
-}
-
-/// SCD Type 2 snapshot: tracks historical changes via valid_from / valid_to.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SnapshotPlan {
-    pub source: SourceRef,
-    pub target: TargetRef,
-    /// Columns that uniquely identify a row.
-    pub unique_key: Vec<Arc<str>>,
-    /// Column used to detect changes.
-    pub updated_at: String,
-    /// When true, invalidate rows deleted from source.
-    pub invalidate_hard_deletes: bool,
-    pub governance: GovernanceConfig,
-}
-
 /// How to materialize the target table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "strategy")]
@@ -466,8 +413,7 @@ pub struct ColumnMask {
 /// materialization strategy, governance metadata, the resolved
 /// column-masking plan for the active environment, and the source / target
 /// table refs plus variant-specific metadata (column selection, metadata
-/// columns, snapshot key/timestamp, lakehouse format) needed to losslessly
-/// represent any [`Plan`] variant.
+/// columns, snapshot key/timestamp, lakehouse format).
 ///
 /// `ModelIr` is an internal contract. It does not derive `JsonSchema` and
 /// is not part of the public CLI output schema; consumers outside the
@@ -482,9 +428,9 @@ pub struct ColumnMask {
 /// canonical-JSON convention (skip `None`, skip empty `Vec`, skip default
 /// `bool`) keeps the per-variant JSON shape compact, and a single struct
 /// makes the recipe-hash easier to reason about — there is no enum
-/// discriminant to canonicalise. Compile-time variant exhaustiveness is
-/// retained via the still-present [`Plan`] enum, which converts to /
-/// from [`ModelIr`] losslessly.
+/// discriminant to canonicalise. Variant inference happens via
+/// [`Self::variant`], which classifies the IR by which variant-specific
+/// fields are populated.
 ///
 /// All optional fields follow the canonical-JSON rule documented at the
 /// top of this module.
@@ -514,7 +460,7 @@ pub struct ModelIr {
     pub materialization: MaterializationStrategy,
     /// Governance metadata (catalog/schema lifecycle policy).
     pub governance: GovernanceConfig,
-    /// Target table reference. Required on every [`Plan`] variant.
+    /// Target table reference. Required on every variant.
     pub target: TargetRef,
     /// Resolved column masks for the active environment. Populated at IR
     /// construction by reading
@@ -523,52 +469,52 @@ pub struct ModelIr {
     /// [`crate::traits::MaskStrategy::None`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub column_masks: Vec<ColumnMask>,
-    /// Single-source ref. `Some` for [`Plan::Replication`] and
-    /// [`Plan::Snapshot`]; `None` for [`Plan::Transformation`] (which uses
-    /// [`Self::sources`]).
+    /// Single-source ref. `Some` for [`ModelIrVariant::Replication`] and
+    /// [`ModelIrVariant::Snapshot`]; `None` for
+    /// [`ModelIrVariant::Transformation`] (which uses [`Self::sources`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<SourceRef>,
-    /// Multi-source refs (joins). Populated for [`Plan::Transformation`];
-    /// empty for [`Plan::Replication`] and [`Plan::Snapshot`].
+    /// Multi-source refs (joins). Populated for
+    /// [`ModelIrVariant::Transformation`]; empty for
+    /// [`ModelIrVariant::Replication`] and [`ModelIrVariant::Snapshot`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<SourceRef>,
-    /// Column selection. `Some` for [`Plan::Replication`]; `None` for
-    /// other variants (which select via the `sql` field).
+    /// Column selection. `Some` for [`ModelIrVariant::Replication`]; `None`
+    /// for other variants (which select via the `sql` field).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub columns: Option<ColumnSelection>,
     /// Extra columns added during replication (e.g.
     /// `CAST(NULL AS STRING) AS _loaded_by`). Populated for
-    /// [`Plan::Replication`]; empty otherwise.
+    /// [`ModelIrVariant::Replication`]; empty otherwise.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub metadata_columns: Vec<MetadataColumn>,
     /// Columns that uniquely identify a snapshot row. Populated for
-    /// [`Plan::Snapshot`]; empty otherwise.
+    /// [`ModelIrVariant::Snapshot`]; empty otherwise.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub unique_key: Vec<Arc<str>>,
     /// Column used to detect changes for SCD2 snapshots. `Some` for
-    /// [`Plan::Snapshot`]; `None` otherwise.
+    /// [`ModelIrVariant::Snapshot`]; `None` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
     /// When true, invalidate rows deleted from source. Only meaningful
-    /// for [`Plan::Snapshot`]; `false` otherwise.
+    /// for [`ModelIrVariant::Snapshot`]; `false` otherwise.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub invalidate_hard_deletes: bool,
-    /// Optional lakehouse table format (Delta, Iceberg, ...). Lifted from
-    /// [`TransformationPlan::format`]; `None` for non-transformation plans.
+    /// Optional lakehouse table format (Delta, Iceberg, ...). `None` for
+    /// non-transformation models.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format: Option<LakehouseFormat>,
     /// Format-specific options (partitioning, clustering, properties).
-    /// Lifted from [`TransformationPlan::format_options`].
+    /// `None` for non-transformation models.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format_options: Option<LakehouseOptions>,
 }
 
 /// Inferred variant tag for a [`ModelIr`].
 ///
-/// Returned by [`ModelIr::variant`]. The three values mirror the three
-/// [`Plan`] variants; the inference rule (snapshot wins over replication,
-/// replication wins over transformation) is centralised in
-/// [`ModelIr::variant`] and matches [`ModelIr::to_plan_compatible`].
+/// Returned by [`ModelIr::variant`]. The inference rule (snapshot wins
+/// over replication, replication wins over transformation) is centralised
+/// in [`ModelIr::variant`].
 ///
 /// Serialises as lowercase (`"replication"` / `"transformation"` /
 /// `"snapshot"`) so error messages and JSON output stay aligned with the
@@ -600,8 +546,7 @@ impl std::fmt::Display for ModelIrVariant {
 }
 
 impl ModelIr {
-    /// Construct a replication-shaped [`ModelIr`] directly, bypassing the
-    /// [`Plan`] enum.
+    /// Construct a replication-shaped [`ModelIr`] directly.
     ///
     /// Variant inference (see [`Self::variant`]) returns
     /// [`ModelIrVariant::Replication`] for any IR built by this constructor,
@@ -642,8 +587,7 @@ impl ModelIr {
         }
     }
 
-    /// Construct a transformation-shaped [`ModelIr`] directly, bypassing
-    /// the [`Plan`] enum.
+    /// Construct a transformation-shaped [`ModelIr`] directly.
     ///
     /// Variant inference (see [`Self::variant`]) returns
     /// [`ModelIrVariant::Transformation`] for any IR built by this
@@ -686,8 +630,7 @@ impl ModelIr {
         }
     }
 
-    /// Construct a snapshot-shaped [`ModelIr`] directly, bypassing the
-    /// [`Plan`] enum.
+    /// Construct a snapshot-shaped [`ModelIr`] directly.
     ///
     /// `materialization` is fixed at [`MaterializationStrategy::FullRefresh`]
     /// to match the existing snapshot SQL-gen contract — SCD2 logic is
@@ -751,121 +694,21 @@ impl ModelIr {
     }
 
     /// Predicate underlying variant inference for snapshot. The single
-    /// source of truth shared by [`Self::as_replication`],
-    /// [`Self::as_transformation`], [`Self::as_snapshot`], and
-    /// [`Self::variant`]. Snapshot takes priority over replication in
-    /// inference: if both `unique_key` (non-empty) and `updated_at`
-    /// (`Some`) are populated the IR is classified as a snapshot
-    /// regardless of which other variant-specific fields are also set.
+    /// source of truth shared by [`Self::variant`]. Snapshot takes
+    /// priority over replication in inference: if both `unique_key`
+    /// (non-empty) and `updated_at` (`Some`) are populated the IR is
+    /// classified as a snapshot regardless of which other variant-
+    /// specific fields are also set.
     fn is_snapshot_shaped(&self) -> bool {
         !self.unique_key.is_empty() && self.updated_at.is_some()
     }
 
-    /// View this IR as a [`ReplicationPlan`] without round-tripping through
-    /// the [`Plan`] enum.
-    ///
-    /// Returns `Some` when the IR's variant-specific fields match a
-    /// replication shape — i.e. `columns` is `Some` and it is not a
-    /// snapshot (`unique_key` non-empty AND `updated_at` `Some`).
-    /// Returns `None` on any other variant.
-    ///
-    /// Variant inference matches [`Self::to_plan_compatible`]; the two stay
-    /// in lockstep. Prefer this method on hot paths (e.g. `sql_gen`) to
-    /// avoid materialising the [`Plan`] enum just to dispatch on its tag.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the IR is variant-confirmed as a replication but is
-    /// missing `source`. The `From<&Plan>` impl always populates `source`
-    /// for replications; this only fires on a hand-built [`ModelIr`] that
-    /// violates the variant contract.
-    pub fn as_replication(&self) -> Option<ReplicationPlan> {
-        if self.is_snapshot_shaped() {
-            return None;
-        }
-        let columns = self.columns.clone()?;
-        let source = self
-            .source
-            .clone()
-            .expect("Replication ModelIr must carry `source`");
-        Some(ReplicationPlan {
-            source,
-            target: self.target.clone(),
-            strategy: self.materialization.clone(),
-            columns,
-            metadata_columns: self.metadata_columns.clone(),
-            governance: self.governance.clone(),
-        })
-    }
-
-    /// View this IR as a [`TransformationPlan`] without round-tripping
-    /// through the [`Plan`] enum.
-    ///
-    /// Returns `Some` when the IR is neither snapshot-shaped
-    /// (`unique_key` non-empty AND `updated_at` `Some`) nor replication-
-    /// shaped (`columns` `Some`). Returns `None` otherwise.
-    ///
-    /// Variant inference matches [`Self::to_plan_compatible`].
-    pub fn as_transformation(&self) -> Option<TransformationPlan> {
-        if self.is_snapshot_shaped() || self.columns.is_some() {
-            return None;
-        }
-        Some(TransformationPlan {
-            sources: self.sources.clone(),
-            target: self.target.clone(),
-            strategy: self.materialization.clone(),
-            sql: self.sql.clone(),
-            governance: self.governance.clone(),
-            format: self.format.clone(),
-            format_options: self.format_options.clone(),
-        })
-    }
-
-    /// View this IR as a [`SnapshotPlan`] without round-tripping through
-    /// the [`Plan`] enum.
-    ///
-    /// Returns `Some` when the IR is snapshot-shaped (`unique_key`
-    /// non-empty AND `updated_at` `Some`). Returns `None` otherwise.
-    ///
-    /// Variant inference matches [`Self::to_plan_compatible`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if the IR is variant-confirmed as a snapshot but is missing
-    /// `source`. The `From<&Plan>` impl always populates `source` for
-    /// snapshots; this only fires on a hand-built [`ModelIr`] that
-    /// violates the variant contract.
-    pub fn as_snapshot(&self) -> Option<SnapshotPlan> {
-        if !self.is_snapshot_shaped() {
-            return None;
-        }
-        let updated_at = self
-            .updated_at
-            .clone()
-            .expect("is_snapshot_shaped guarantees `updated_at` is `Some`");
-        let source = self
-            .source
-            .clone()
-            .expect("Snapshot ModelIr must carry `source`");
-        Some(SnapshotPlan {
-            source,
-            target: self.target.clone(),
-            unique_key: self.unique_key.clone(),
-            updated_at,
-            invalidate_hard_deletes: self.invalidate_hard_deletes,
-            governance: self.governance.clone(),
-        })
-    }
-
     /// Inferred [`ModelIrVariant`] for this IR.
     ///
-    /// Matches the inference rules used by [`Self::as_replication`],
-    /// [`Self::as_transformation`], [`Self::as_snapshot`], and
-    /// [`Self::to_plan_compatible`]: snapshot-shaped (`unique_key`
-    /// non-empty AND `updated_at` `Some`) →
-    /// [`ModelIrVariant::Snapshot`]; replication-shaped (`columns` `Some`)
-    /// → [`ModelIrVariant::Replication`]; otherwise →
-    /// [`ModelIrVariant::Transformation`].
+    /// Inference rules: snapshot-shaped (`unique_key` non-empty AND
+    /// `updated_at` `Some`) → [`ModelIrVariant::Snapshot`]; replication-
+    /// shaped (`columns` `Some`) → [`ModelIrVariant::Replication`];
+    /// otherwise → [`ModelIrVariant::Transformation`].
     ///
     /// Callers that need just the lowercase string form (e.g. error
     /// message templating, JSON output) reach for [`ModelIrVariant::as_str`]
@@ -877,128 +720,6 @@ impl ModelIr {
             ModelIrVariant::Replication
         } else {
             ModelIrVariant::Transformation
-        }
-    }
-
-    /// Reconstruct a [`Plan`] from this `ModelIr`, mirroring the
-    /// `From<&Plan> for ModelIr` conversion.
-    ///
-    /// Delegates to the three accessors ([`Self::as_snapshot`],
-    /// [`Self::as_replication`], [`Self::as_transformation`]) so the
-    /// variant-inference rule lives in a single place. The variant is
-    /// inferred from which variant-specific fields are populated:
-    ///
-    /// - `unique_key` non-empty AND `updated_at` `Some` → [`Plan::Snapshot`]
-    /// - `columns` `Some` (replication carries an explicit
-    ///   [`ColumnSelection`]) → [`Plan::Replication`]
-    /// - otherwise → [`Plan::Transformation`]
-    ///
-    /// Round-trip property: `ModelIr::from(&plan).to_plan_compatible()` is
-    /// canonical-JSON-equal to `plan` for any well-formed input. Used by
-    /// the test suite to verify the conversion is lossless.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a [`ModelIr`] inferred to be a Snapshot or Replication
-    /// is missing `source` (via the accessor's panic contract). These
-    /// fields are required on the corresponding [`Plan`] variant; the
-    /// `From<&Plan>` impl always populates them, so this only fires on a
-    /// hand-built `ModelIr` that violates the variant contract.
-    pub fn to_plan_compatible(&self) -> Plan {
-        // Transformation is the unconditional fallback: its rejection
-        // conditions in `as_transformation` are exactly the entry
-        // conditions of the other two accessors, so one of the three
-        // is always `Some`.
-        self.as_snapshot()
-            .map(Plan::Snapshot)
-            .or_else(|| self.as_replication().map(Plan::Replication))
-            .or_else(|| self.as_transformation().map(Plan::Transformation))
-            .expect(
-                "at least one accessor must match — transformation is the unconditional fallback",
-            )
-    }
-}
-
-impl From<&Plan> for ModelIr {
-    /// Lossless structural conversion from a [`Plan`] to a [`ModelIr`].
-    ///
-    /// Variant-specific fields are mapped onto the flat [`ModelIr`] shape:
-    ///
-    /// - [`Plan::Replication`] populates `source`, `columns`,
-    ///   `metadata_columns`.
-    /// - [`Plan::Transformation`] populates `sources`, `format`,
-    ///   `format_options`.
-    /// - [`Plan::Snapshot`] populates `source`, `unique_key`, `updated_at`,
-    ///   `invalidate_hard_deletes`.
-    ///
-    /// `name`, `typed_columns`, `lineage_edges`, and `column_masks` are not
-    /// carried by [`Plan`]; they default to the table's own name and empty
-    /// vectors. Callers that have richer typed-column or lineage data
-    /// should populate those fields after construction.
-    fn from(plan: &Plan) -> Self {
-        match plan {
-            Plan::Replication(p) => ModelIr {
-                name: Arc::from(p.target.table.as_str()),
-                sql: String::new(),
-                typed_columns: Vec::new(),
-                lineage_edges: Vec::new(),
-                materialization: p.strategy.clone(),
-                governance: p.governance.clone(),
-                target: p.target.clone(),
-                column_masks: Vec::new(),
-                source: Some(p.source.clone()),
-                sources: Vec::new(),
-                columns: Some(p.columns.clone()),
-                metadata_columns: p.metadata_columns.clone(),
-                unique_key: Vec::new(),
-                updated_at: None,
-                invalidate_hard_deletes: false,
-                format: None,
-                format_options: None,
-            },
-            Plan::Transformation(p) => ModelIr {
-                name: Arc::from(p.target.table.as_str()),
-                sql: p.sql.clone(),
-                typed_columns: Vec::new(),
-                lineage_edges: Vec::new(),
-                materialization: p.strategy.clone(),
-                governance: p.governance.clone(),
-                target: p.target.clone(),
-                column_masks: Vec::new(),
-                source: None,
-                sources: p.sources.clone(),
-                columns: None,
-                metadata_columns: Vec::new(),
-                unique_key: Vec::new(),
-                updated_at: None,
-                invalidate_hard_deletes: false,
-                format: p.format.clone(),
-                format_options: p.format_options.clone(),
-            },
-            Plan::Snapshot(p) => ModelIr {
-                name: Arc::from(p.target.table.as_str()),
-                sql: String::new(),
-                typed_columns: Vec::new(),
-                lineage_edges: Vec::new(),
-                // Snapshots don't have a MaterializationStrategy on the
-                // SnapshotPlan; the SCD2 logic is implicit in
-                // `sql_gen::generate_snapshot_sql`. FullRefresh is the
-                // closest neutral default and matches how snapshot SQL is
-                // generated today.
-                materialization: MaterializationStrategy::FullRefresh,
-                governance: p.governance.clone(),
-                target: p.target.clone(),
-                column_masks: Vec::new(),
-                source: Some(p.source.clone()),
-                sources: Vec::new(),
-                columns: None,
-                metadata_columns: Vec::new(),
-                unique_key: p.unique_key.clone(),
-                updated_at: Some(p.updated_at.clone()),
-                invalidate_hard_deletes: p.invalidate_hard_deletes,
-                format: None,
-                format_options: None,
-            },
         }
     }
 }
@@ -1092,69 +813,6 @@ fn canonicalize(value: serde_json::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_replication_plan_serialization() {
-        let plan = ReplicationPlan {
-            source: SourceRef {
-                catalog: "source_catalog".into(),
-                schema: "src__acme__us_west__shopify".into(),
-                table: "orders".into(),
-            },
-            target: TargetRef {
-                catalog: "acme_warehouse".into(),
-                schema: "staging__us_west__shopify".into(),
-                table: "orders".into(),
-            },
-            strategy: MaterializationStrategy::Incremental {
-                timestamp_column: "_fivetran_synced".into(),
-            },
-            columns: ColumnSelection::All,
-            metadata_columns: vec![MetadataColumn {
-                name: "_loaded_by".into(),
-                data_type: "STRING".into(),
-                value: "NULL".into(),
-            }],
-            governance: GovernanceConfig {
-                permissions_file: Some("config/catalog_permissions.yaml".into()),
-                auto_create_catalogs: true,
-                auto_create_schemas: true,
-            },
-        };
-
-        let json = serde_json::to_string_pretty(&plan).unwrap();
-        let deserialized: ReplicationPlan = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.source.catalog, "source_catalog");
-        assert_eq!(deserialized.target.table, "orders");
-    }
-
-    #[test]
-    fn test_plan_enum_serialization() {
-        let plan = Plan::Replication(ReplicationPlan {
-            source: SourceRef {
-                catalog: "cat".into(),
-                schema: "sch".into(),
-                table: "tbl".into(),
-            },
-            target: TargetRef {
-                catalog: "tcat".into(),
-                schema: "tsch".into(),
-                table: "tbl".into(),
-            },
-            strategy: MaterializationStrategy::FullRefresh,
-            columns: ColumnSelection::All,
-            metadata_columns: vec![],
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
-        });
-
-        let json = serde_json::to_string(&plan).unwrap();
-        let deserialized: Plan = serde_json::from_str(&json).unwrap();
-        assert!(matches!(deserialized, Plan::Replication(_)));
-    }
 
     #[test]
     fn test_table_ref_display() {
@@ -1594,181 +1252,6 @@ mod tests {
         );
     }
 
-    // ----- Plan ↔ ModelIr conversion + variant-coverage tests -----
-
-    fn sample_replication_plan() -> Plan {
-        Plan::Replication(ReplicationPlan {
-            source: SourceRef {
-                catalog: "source_catalog".into(),
-                schema: "src__acme__shopify".into(),
-                table: "orders".into(),
-            },
-            target: TargetRef {
-                catalog: "acme_warehouse".into(),
-                schema: "raw__shopify".into(),
-                table: "orders".into(),
-            },
-            strategy: MaterializationStrategy::Incremental {
-                timestamp_column: "_fivetran_synced".into(),
-            },
-            columns: ColumnSelection::Explicit(vec![Arc::from("id"), Arc::from("customer_id")]),
-            metadata_columns: vec![MetadataColumn {
-                name: "_loaded_by".into(),
-                data_type: "STRING".into(),
-                value: "NULL".into(),
-            }],
-            governance: GovernanceConfig {
-                permissions_file: Some("perms.yaml".into()),
-                auto_create_catalogs: true,
-                auto_create_schemas: true,
-            },
-        })
-    }
-
-    fn sample_transformation_plan() -> Plan {
-        Plan::Transformation(TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: "acme_warehouse".into(),
-                schema: "staging".into(),
-                table: "stg_customers".into(),
-            }],
-            target: TargetRef {
-                catalog: "acme_warehouse".into(),
-                schema: "marts".into(),
-                table: "dim_customers".into(),
-            },
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec![Arc::from("customer_id")],
-                update_columns: ColumnSelection::All,
-            },
-            sql: "SELECT customer_id, email FROM stg_customers".into(),
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
-            format: None,
-            format_options: None,
-        })
-    }
-
-    fn sample_snapshot_plan() -> Plan {
-        Plan::Snapshot(SnapshotPlan {
-            source: SourceRef {
-                catalog: "acme_warehouse".into(),
-                schema: "marts".into(),
-                table: "dim_users".into(),
-            },
-            target: TargetRef {
-                catalog: "acme_warehouse".into(),
-                schema: "snapshots".into(),
-                table: "dim_users_history".into(),
-            },
-            unique_key: vec![Arc::from("user_id")],
-            updated_at: "updated_at".into(),
-            invalidate_hard_deletes: true,
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
-        })
-    }
-
-    /// Canonical-JSON-equality is the equivalence relation used to verify
-    /// the [`Plan`] ↔ [`ModelIr`] round-trip — none of the [`Plan`]
-    /// component types derive `PartialEq`, and adding the derive cascade
-    /// was deemed out of scope for this PR.
-    fn plans_canonical_eq(a: &Plan, b: &Plan) -> bool {
-        canonical_json(a) == canonical_json(b)
-    }
-
-    #[test]
-    fn plan_to_model_ir_replication_roundtrip() {
-        let plan = sample_replication_plan();
-        let ir = ModelIr::from(&plan);
-        let back = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&plan, &back),
-            "replication round-trip must be canonical-JSON-equal\n  before: {}\n  after:  {}",
-            canonical_json(&plan),
-            canonical_json(&back)
-        );
-        assert!(matches!(back, Plan::Replication(_)));
-    }
-
-    #[test]
-    fn plan_to_model_ir_replication_with_merge_strategy_roundtrip() {
-        // Discrimination guardrail: `MaterializationStrategy::Merge` carries
-        // its own `unique_key` field on the strategy enum. The top-level
-        // `ModelIr::unique_key` field must stay empty for a Replication —
-        // otherwise `to_plan_compatible` would mis-classify it as a
-        // [`Plan::Snapshot`] (since updated_at would still be None this
-        // wouldn't actually trigger today, but the test pins the contract).
-        let plan = Plan::Replication(ReplicationPlan {
-            source: SourceRef {
-                catalog: "src".into(),
-                schema: "raw".into(),
-                table: "users".into(),
-            },
-            target: TargetRef {
-                catalog: "tgt".into(),
-                schema: "raw".into(),
-                table: "users".into(),
-            },
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec![Arc::from("id")],
-                update_columns: ColumnSelection::All,
-            },
-            columns: ColumnSelection::All,
-            metadata_columns: vec![],
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
-        });
-        let ir = ModelIr::from(&plan);
-        assert!(
-            ir.unique_key.is_empty(),
-            "Merge-strategy unique_key must NOT leak into top-level ModelIr.unique_key"
-        );
-        let back = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&plan, &back),
-            "replication-with-merge round-trip must be canonical-JSON-equal"
-        );
-        assert!(matches!(back, Plan::Replication(_)));
-    }
-
-    #[test]
-    fn plan_to_model_ir_transformation_roundtrip() {
-        let plan = sample_transformation_plan();
-        let ir = ModelIr::from(&plan);
-        let back = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&plan, &back),
-            "transformation round-trip must be canonical-JSON-equal\n  before: {}\n  after:  {}",
-            canonical_json(&plan),
-            canonical_json(&back)
-        );
-        assert!(matches!(back, Plan::Transformation(_)));
-    }
-
-    #[test]
-    fn plan_to_model_ir_snapshot_roundtrip() {
-        let plan = sample_snapshot_plan();
-        let ir = ModelIr::from(&plan);
-        let back = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&plan, &back),
-            "snapshot round-trip must be canonical-JSON-equal\n  before: {}\n  after:  {}",
-            canonical_json(&plan),
-            canonical_json(&back)
-        );
-        assert!(matches!(back, Plan::Snapshot(_)));
-    }
-
     #[test]
     fn recipe_hash_changes_when_replication_source_changes() {
         let mut m = sample_replication_model();
@@ -1822,12 +1305,11 @@ mod tests {
     }
 
     #[test]
-    fn recipe_hash_replication_plan_round_trips_into_model_ir_deterministically() {
-        // Same plan input → same ModelIr → same recipe-hash.
-        let plan = sample_replication_plan();
-        let h1 = ModelIr::from(&plan).recipe_hash();
-        let h2 = ModelIr::from(&plan).recipe_hash();
-        assert_eq!(h1, h2, "From<&Plan> must produce a deterministic ModelIr");
+    fn recipe_hash_is_deterministic_for_identical_sample_models() {
+        // Same ModelIr inputs → same recipe-hash.
+        let h1 = sample_replication_model().recipe_hash();
+        let h2 = sample_replication_model().recipe_hash();
+        assert_eq!(h1, h2, "identical ModelIr inputs must hash identically");
     }
 
     #[test]
@@ -1889,148 +1371,6 @@ mod tests {
         );
     }
 
-    // ----- Direct variant accessors (`as_replication` / `as_transformation`
-    //       / `as_snapshot`) — bypass `Plan` materialisation on hot paths -----
-
-    #[test]
-    fn as_replication_returns_some_for_replication_shape() {
-        let ir = sample_replication_model();
-        assert!(
-            ir.as_replication().is_some(),
-            "replication-shaped IR must yield Some via as_replication"
-        );
-        assert!(ir.as_transformation().is_none());
-        assert!(ir.as_snapshot().is_none());
-    }
-
-    #[test]
-    fn as_transformation_returns_some_for_transformation_shape() {
-        let ir = sample_transformation_model();
-        assert!(
-            ir.as_transformation().is_some(),
-            "transformation-shaped IR must yield Some via as_transformation"
-        );
-        assert!(ir.as_replication().is_none());
-        assert!(ir.as_snapshot().is_none());
-    }
-
-    #[test]
-    fn as_snapshot_returns_some_for_snapshot_shape() {
-        let ir = sample_snapshot_model();
-        assert!(
-            ir.as_snapshot().is_some(),
-            "snapshot-shaped IR must yield Some via as_snapshot"
-        );
-        assert!(ir.as_replication().is_none());
-        assert!(ir.as_transformation().is_none());
-    }
-
-    /// The three accessors must yield byte-equivalent variants to
-    /// `to_plan_compatible()` for any IR built via `From<&Plan>`. This is
-    /// the load-bearing regression guard for `sql_gen` — both code paths
-    /// must produce identical SQL inputs.
-    #[test]
-    fn accessors_match_to_plan_compatible_for_replication() {
-        let plan = sample_replication_plan();
-        let ir = ModelIr::from(&plan);
-        let via_accessor = Plan::Replication(ir.as_replication().expect("replication"));
-        let via_round_trip = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&via_accessor, &via_round_trip),
-            "as_replication must produce a Plan canonical-JSON-equal to to_plan_compatible\n  accessor: {}\n  round-trip: {}",
-            canonical_json(&via_accessor),
-            canonical_json(&via_round_trip)
-        );
-    }
-
-    #[test]
-    fn accessors_match_to_plan_compatible_for_transformation() {
-        let plan = sample_transformation_plan();
-        let ir = ModelIr::from(&plan);
-        let via_accessor = Plan::Transformation(ir.as_transformation().expect("transformation"));
-        let via_round_trip = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&via_accessor, &via_round_trip),
-            "as_transformation must produce a Plan canonical-JSON-equal to to_plan_compatible"
-        );
-    }
-
-    #[test]
-    fn accessors_match_to_plan_compatible_for_snapshot() {
-        let plan = sample_snapshot_plan();
-        let ir = ModelIr::from(&plan);
-        let via_accessor = Plan::Snapshot(ir.as_snapshot().expect("snapshot"));
-        let via_round_trip = ir.to_plan_compatible();
-        assert!(
-            plans_canonical_eq(&via_accessor, &via_round_trip),
-            "as_snapshot must produce a Plan canonical-JSON-equal to to_plan_compatible"
-        );
-    }
-
-    /// Round-trip via the accessor: `From<&Plan> -> as_X` must be
-    /// canonical-JSON-equal to the original `Plan`. Mirrors the existing
-    /// `plan_to_model_ir_*_roundtrip` tests but exercises the accessor
-    /// rather than `to_plan_compatible`.
-    #[test]
-    fn plan_to_model_ir_via_accessor_replication_roundtrip() {
-        let plan = sample_replication_plan();
-        let ir = ModelIr::from(&plan);
-        let back = Plan::Replication(ir.as_replication().expect("replication"));
-        assert!(plans_canonical_eq(&plan, &back));
-    }
-
-    #[test]
-    fn plan_to_model_ir_via_accessor_transformation_roundtrip() {
-        let plan = sample_transformation_plan();
-        let ir = ModelIr::from(&plan);
-        let back = Plan::Transformation(ir.as_transformation().expect("transformation"));
-        assert!(plans_canonical_eq(&plan, &back));
-    }
-
-    #[test]
-    fn plan_to_model_ir_via_accessor_snapshot_roundtrip() {
-        let plan = sample_snapshot_plan();
-        let ir = ModelIr::from(&plan);
-        let back = Plan::Snapshot(ir.as_snapshot().expect("snapshot"));
-        assert!(plans_canonical_eq(&plan, &back));
-    }
-
-    /// Snapshot inference takes priority over replication: an IR that is
-    /// snapshot-shaped (unique_key + updated_at) must yield `None` from
-    /// `as_replication` even if `columns` is also populated. Matches the
-    /// inference order in `to_plan_compatible`.
-    #[test]
-    fn as_replication_rejects_snapshot_shape_even_if_columns_set() {
-        let mut ir = sample_snapshot_model();
-        ir.columns = Some(ColumnSelection::All);
-        assert!(
-            ir.as_replication().is_none(),
-            "snapshot-shape IR with stray `columns` must not view as replication"
-        );
-        assert!(ir.as_snapshot().is_some());
-    }
-
-    /// Replication accessor panics if `columns` is `Some` but `source` is
-    /// `None` — the IR is variant-confirmed but violates the contract that
-    /// `From<&Plan>` always populates.
-    #[test]
-    #[should_panic(expected = "Replication ModelIr must carry `source`")]
-    fn as_replication_panics_when_columns_set_but_source_missing() {
-        let mut ir = sample_replication_model();
-        ir.source = None;
-        let _ = ir.as_replication();
-    }
-
-    /// Snapshot accessor panics if the IR is snapshot-shaped (`unique_key`
-    /// non-empty AND `updated_at` `Some`) but `source` is `None`.
-    #[test]
-    #[should_panic(expected = "Snapshot ModelIr must carry `source`")]
-    fn as_snapshot_panics_when_snapshot_shaped_but_source_missing() {
-        let mut ir = sample_snapshot_model();
-        ir.source = None;
-        let _ = ir.as_snapshot();
-    }
-
     #[test]
     fn variant_matches_inferred_shape() {
         assert_eq!(
@@ -2053,12 +1393,11 @@ mod tests {
         assert_eq!(ir.variant(), ModelIrVariant::Snapshot);
     }
 
-    /// `variant()` must stay in lockstep with `to_plan_compatible()`: for any
-    /// `ModelIr` built via `From<&Plan>`, the inferred [`ModelIrVariant`]
-    /// matches the originating [`Plan`] tag. Guards against drift in the
-    /// shared [`ModelIr::is_snapshot_shaped`] inference root.
+    /// Sample fixtures must each map to their expected variant — guards
+    /// against drift in the shared [`ModelIr::is_snapshot_shaped`]
+    /// inference root.
     #[test]
-    fn variant_matches_to_plan_compatible_tag() {
+    fn variant_matches_sample_fixtures() {
         let cases = [
             (sample_replication_model(), ModelIrVariant::Replication),
             (
@@ -2069,9 +1408,6 @@ mod tests {
         ];
         for (ir, expected) in cases {
             assert_eq!(ir.variant(), expected);
-            let plan = ir.to_plan_compatible();
-            let roundtripped = ModelIr::from(&plan);
-            assert_eq!(roundtripped.variant(), expected);
         }
     }
 

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -8,9 +8,7 @@ use thiserror::Error;
 
 use crate::config::{ModelBudgetConfig, substitute_env_vars};
 use crate::dag::DagNode;
-use crate::ir::{
-    GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef, TransformationPlan,
-};
+use crate::ir::{GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef};
 use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 use crate::retention::{RetentionParseError, RetentionPolicy};
 use crate::tests::TestDecl;
@@ -572,8 +570,17 @@ impl Model {
         }
     }
 
-    /// Converts to a TransformationPlan for SQL generation.
-    pub fn to_plan(&self) -> TransformationPlan {
+    /// Construct the per-model [`ModelIr`] for this transformation model.
+    ///
+    /// Lowers the [`StrategyConfig`] to a [`MaterializationStrategy`] and
+    /// assembles the IR directly. The model's own `name` overrides the
+    /// `target.table`-derived default so the IR carries the project-unique
+    /// identifier rather than the warehouse table name.
+    ///
+    /// `typed_columns`, `lineage_edges`, and `column_masks` stay empty here
+    /// — they are populated by the compiler / governance layers downstream
+    /// when richer typed data is available.
+    pub fn to_model_ir(&self) -> ModelIr {
         let strategy = match &self.config.strategy {
             StrategyConfig::FullRefresh => MaterializationStrategy::FullRefresh,
             StrategyConfig::Incremental { timestamp_column } => {
@@ -627,7 +634,24 @@ impl Model {
             },
         };
 
-        TransformationPlan {
+        ModelIr {
+            name: std::sync::Arc::from(self.config.name.as_str()),
+            sql: self.sql.clone(),
+            typed_columns: Vec::new(),
+            lineage_edges: Vec::new(),
+            materialization: strategy,
+            governance: GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            target: TargetRef {
+                catalog: self.config.target.catalog.clone(),
+                schema: self.config.target.schema.clone(),
+                table: self.config.target.table.clone(),
+            },
+            column_masks: Vec::new(),
+            source: None,
             sources: self
                 .config
                 .sources
@@ -638,54 +662,13 @@ impl Model {
                     table: s.table.clone(),
                 })
                 .collect(),
-            target: TargetRef {
-                catalog: self.config.target.catalog.clone(),
-                schema: self.config.target.schema.clone(),
-                table: self.config.target.table.clone(),
-            },
-            strategy,
-            sql: self.sql.clone(),
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
-            format: self.config.format.clone(),
-            format_options: self.config.format_options.clone(),
-        }
-    }
-
-    /// Construct the per-model [`ModelIr`] for this transformation model.
-    ///
-    /// Reuses [`Self::to_plan`] to share the materialization-strategy
-    /// lowering, then assembles the IR directly without round-tripping
-    /// through [`Plan`]. The model's own `name` overrides the
-    /// `target.table`-derived default so the IR carries the project-unique
-    /// identifier rather than the warehouse table name.
-    ///
-    /// `typed_columns`, `lineage_edges`, and `column_masks` stay empty here
-    /// — they are populated by the compiler / governance layers downstream
-    /// when richer typed data is available.
-    pub fn to_model_ir(&self) -> ModelIr {
-        let plan = self.to_plan();
-        ModelIr {
-            name: std::sync::Arc::from(self.config.name.as_str()),
-            sql: plan.sql,
-            typed_columns: Vec::new(),
-            lineage_edges: Vec::new(),
-            materialization: plan.strategy,
-            governance: plan.governance,
-            target: plan.target,
-            column_masks: Vec::new(),
-            source: None,
-            sources: plan.sources,
             columns: None,
             metadata_columns: Vec::new(),
             unique_key: Vec::new(),
             updated_at: None,
             invalidate_hard_deletes: false,
-            format: plan.format,
-            format_options: plan.format_options,
+            format: self.config.format.clone(),
+            format_options: self.config.format_options.clone(),
         }
     }
 }
@@ -959,9 +942,9 @@ JOIN analytics.marts.dim_customers c ON o.customer_id = c.customer_id
         assert_eq!(model.config.depends_on.len(), 2);
         assert_eq!(model.config.sources.len(), 2);
 
-        let plan = model.to_plan();
-        assert_eq!(plan.sources.len(), 2);
-        assert!(plan.sql.contains("JOIN"));
+        let ir = model.to_model_ir();
+        assert_eq!(ir.sources.len(), 2);
+        assert!(ir.sql.contains("JOIN"));
     }
 
     #[test]
@@ -1010,12 +993,12 @@ SELECT id, name, status FROM raw.src
             None,
         )
         .unwrap();
-        let plan = model.to_plan();
+        let ir = model.to_model_ir();
         assert!(matches!(
-            plan.strategy,
+            ir.materialization,
             MaterializationStrategy::Merge { .. }
         ));
-        if let MaterializationStrategy::Merge { update_columns, .. } = &plan.strategy {
+        if let MaterializationStrategy::Merge { update_columns, .. } = &ir.materialization {
             assert!(matches!(
                 update_columns,
                 crate::ir::ColumnSelection::Explicit(_)
@@ -1055,56 +1038,6 @@ SELECT 1
         let ir = model.to_model_ir();
         assert_eq!(&*ir.name, "fct_orders");
         assert_eq!(ir.target.table, "fct_orders_v2");
-    }
-
-    #[test]
-    fn test_to_model_ir_lowering_matches_to_plan() {
-        // The strategy / sql / sources / governance / format lowering MUST
-        // match `to_plan` exactly — `to_model_ir` reuses `to_plan` internally
-        // and threads it through `From<&Plan> for ModelIr`. This guards the
-        // contract that the two views agree.
-        let model = parse_model_inline(
-            r#"---toml
-name = "dim"
-depends_on = ["raw.src"]
-[strategy]
-type = "merge"
-unique_key = ["id"]
-update_columns = ["name", "status"]
-[[sources]]
-catalog = "raw"
-schema = "ext"
-table = "src"
-[target]
-catalog = "c"
-schema = "s"
-table = "t"
----
-SELECT id, name, status FROM raw.ext.src
-"#,
-            "dim.sql",
-            None,
-        )
-        .unwrap();
-
-        let plan = model.to_plan();
-        let ir = model.to_model_ir();
-
-        assert_eq!(ir.sql, plan.sql);
-        // SourceRef / TargetRef / MaterializationStrategy do not derive
-        // `PartialEq`; compare by canonical JSON instead.
-        assert_eq!(
-            serde_json::to_value(&ir.sources).unwrap(),
-            serde_json::to_value(&plan.sources).unwrap()
-        );
-        assert_eq!(
-            serde_json::to_value(&ir.target).unwrap(),
-            serde_json::to_value(&plan.target).unwrap()
-        );
-        assert_eq!(
-            serde_json::to_value(&ir.materialization).unwrap(),
-            serde_json::to_value(&plan.strategy).unwrap()
-        );
     }
 
     // --- Sidecar format tests ---
@@ -1406,8 +1339,8 @@ granularity = "day"
             file_path: "fake.sql".into(),
             contract_path: None,
         };
-        let plan = model.to_plan();
-        match plan.strategy {
+        let ir = model.to_model_ir();
+        match ir.materialization {
             MaterializationStrategy::TimeInterval {
                 time_column,
                 granularity,

--- a/engine/crates/rocky-core/src/snapshots.rs
+++ b/engine/crates/rocky-core/src/snapshots.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::config::SnapshotPipelineConfig;
-use crate::ir::{GovernanceConfig, SnapshotPlan, SourceRef, TargetRef};
+use crate::ir::{SourceRef, TargetRef};
 use crate::sql_gen::SqlGenError;
 use crate::traits::SqlDialect;
 
@@ -54,9 +54,9 @@ pub enum SnapshotStrategy {
 
 /// Parsed snapshot configuration ready for SQL generation.
 ///
-/// Bridges [`SnapshotPipelineConfig`] (TOML-level) to [`SnapshotPlan`]
-/// (IR-level) and carries the additional metadata needed by the SQL
-/// generators in this module.
+/// Bridges [`SnapshotPipelineConfig`] (TOML-level) to the SQL generators
+/// in this module, carrying the additional metadata they need
+/// (`unique_key`, change-detection strategy, hard-delete handling).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotConfig {
     /// Source table (three-part reference).
@@ -94,33 +94,6 @@ impl SnapshotConfig {
                 updated_at: cfg.updated_at.clone(),
             },
             invalidate_hard_deletes: cfg.invalidate_hard_deletes,
-        }
-    }
-
-    /// Convert to the IR-level [`SnapshotPlan`] consumed by the existing
-    /// `sql_gen::generate_snapshot_sql` path.
-    pub fn to_plan(&self) -> SnapshotPlan {
-        let updated_at = match &self.strategy {
-            SnapshotStrategy::Timestamp { updated_at } => updated_at.clone(),
-            // For check strategy, the updated_at field in SnapshotPlan is
-            // unused — the check-strategy SQL generator bypasses it.
-            SnapshotStrategy::Check { .. } => String::new(),
-        };
-        SnapshotPlan {
-            source: self.source.clone(),
-            target: self.target.clone(),
-            unique_key: self
-                .unique_key
-                .iter()
-                .map(|s| std::sync::Arc::from(s.as_str()))
-                .collect(),
-            updated_at,
-            invalidate_hard_deletes: self.invalidate_hard_deletes,
-            governance: GovernanceConfig {
-                permissions_file: None,
-                auto_create_catalogs: false,
-                auto_create_schemas: false,
-            },
         }
     }
 }

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -57,7 +57,7 @@ pub enum SqlGenError {
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Replication`].
+/// a replication-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_select_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -102,7 +102,7 @@ pub fn generate_select_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Replication`].
+/// a replication-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_insert_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -124,7 +124,7 @@ pub fn generate_insert_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Replication`].
+/// a replication-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_create_table_as_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -159,7 +159,7 @@ pub fn generate_create_table_as_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Replication`].
+/// a replication-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_merge_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -212,7 +212,7 @@ pub fn generate_merge_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Transformation`].
+/// a transformation-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_transformation_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -376,7 +376,7 @@ pub fn generate_transformation_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Transformation`].
+/// a transformation-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_time_interval_bootstrap_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -445,7 +445,7 @@ pub fn generate_time_interval_bootstrap_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Transformation`].
+/// a transformation-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_transformation_initial_ddl(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -501,7 +501,7 @@ fn substitute_partition_placeholders(sql: &str, window: &PartitionWindow) -> Str
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Transformation`].
+/// a transformation-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_materialized_view_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -526,7 +526,7 @@ pub fn generate_materialized_view_sql(
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Transformation`].
+/// a transformation-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_dynamic_table_sql(
     model_ir: &ModelIr,
     target_lag: &str,
@@ -611,7 +611,7 @@ use std::fmt::Write;
 /// # Errors
 ///
 /// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
-/// constructed from a [`crate::ir::Plan::Snapshot`].
+/// a snapshot-variant [`ModelIr`] (see [`crate::ir::ModelIrVariant`]).
 pub fn generate_snapshot_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
@@ -900,84 +900,44 @@ mod tests {
         TestDialect
     }
 
-    /// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
-    fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
+    fn sample_incremental_ir() -> ModelIr {
         ModelIr::replication(
-            plan.target.clone(),
-            plan.strategy.clone(),
-            plan.source.clone(),
-            plan.columns.clone(),
-            plan.metadata_columns.clone(),
-            plan.governance.clone(),
-        )
-    }
-
-    /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
-    fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-        ModelIr::transformation(
-            plan.target.clone(),
-            plan.strategy.clone(),
-            plan.sources.clone(),
-            plan.sql.clone(),
-            plan.governance.clone(),
-            plan.format.clone(),
-            plan.format_options.clone(),
-        )
-    }
-
-    /// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
-    #[allow(dead_code)]
-    fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-        ModelIr::snapshot(
-            plan.target.clone(),
-            plan.source.clone(),
-            plan.unique_key.clone(),
-            plan.updated_at.clone(),
-            plan.invalidate_hard_deletes,
-            plan.governance.clone(),
-        )
-    }
-
-    fn sample_incremental_plan() -> ReplicationPlan {
-        ReplicationPlan {
-            source: SourceRef {
-                catalog: "source_catalog".into(),
-                schema: "src__acme__us_west__shopify".into(),
-                table: "orders".into(),
-            },
-            target: TargetRef {
+            TargetRef {
                 catalog: "acme_warehouse".into(),
                 schema: "staging__us_west__shopify".into(),
                 table: "orders".into(),
             },
-            strategy: MaterializationStrategy::Incremental {
+            MaterializationStrategy::Incremental {
                 timestamp_column: "_fivetran_synced".into(),
             },
-            columns: ColumnSelection::All,
-            metadata_columns: vec![MetadataColumn {
+            SourceRef {
+                catalog: "source_catalog".into(),
+                schema: "src__acme__us_west__shopify".into(),
+                table: "orders".into(),
+            },
+            ColumnSelection::All,
+            vec![MetadataColumn {
                 name: "_loaded_by".into(),
                 data_type: "STRING".into(),
                 value: "NULL".into(),
             }],
-            governance: GovernanceConfig {
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: true,
                 auto_create_schemas: true,
             },
-        }
+        )
     }
 
-    fn sample_full_refresh_plan() -> ReplicationPlan {
-        ReplicationPlan {
-            strategy: MaterializationStrategy::FullRefresh,
-            ..sample_incremental_plan()
-        }
+    fn sample_full_refresh_ir() -> ModelIr {
+        let mut ir = sample_incremental_ir();
+        ir.materialization = MaterializationStrategy::FullRefresh;
+        ir
     }
 
     #[test]
     fn test_incremental_select() {
-        let plan = sample_incremental_plan();
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_select_sql(&sample_incremental_ir(), &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("FROM source_catalog.src__acme__us_west__shopify.orders"));
@@ -988,8 +948,7 @@ mod tests {
 
     #[test]
     fn test_full_refresh_select() {
-        let plan = sample_full_refresh_plan();
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_select_sql(&sample_full_refresh_ir(), &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("FROM source_catalog"));
@@ -998,8 +957,7 @@ mod tests {
 
     #[test]
     fn test_insert_into_sql() {
-        let plan = sample_incremental_plan();
-        let sql = generate_insert_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_insert_sql(&sample_incremental_ir(), &dialect()).unwrap();
 
         assert!(sql.starts_with("INSERT INTO acme_warehouse.staging__us_west__shopify.orders"));
         assert!(sql.contains("SELECT *, CAST(NULL AS STRING) AS _loaded_by"));
@@ -1008,8 +966,7 @@ mod tests {
 
     #[test]
     fn test_create_table_as_sql() {
-        let plan = sample_incremental_plan();
-        let sql = generate_create_table_as_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_create_table_as_sql(&sample_incremental_ir(), &dialect()).unwrap();
 
         // CTAS always does full refresh (no WHERE clause)
         assert!(sql.starts_with(
@@ -1021,12 +978,14 @@ mod tests {
 
     #[test]
     fn test_explicit_columns() {
-        let plan = ReplicationPlan {
-            columns: ColumnSelection::Explicit(vec!["id".into(), "name".into(), "status".into()]),
-            metadata_columns: vec![],
-            ..sample_full_refresh_plan()
-        };
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let mut ir = sample_full_refresh_ir();
+        ir.columns = Some(ColumnSelection::Explicit(vec![
+            "id".into(),
+            "name".into(),
+            "status".into(),
+        ]));
+        ir.metadata_columns = vec![];
+        let sql = generate_select_sql(&ir, &dialect()).unwrap();
 
         assert!(sql.starts_with("SELECT id, name, status"));
         assert!(!sql.contains("*"));
@@ -1034,11 +993,9 @@ mod tests {
 
     #[test]
     fn test_no_metadata_columns() {
-        let plan = ReplicationPlan {
-            metadata_columns: vec![],
-            ..sample_full_refresh_plan()
-        };
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let mut ir = sample_full_refresh_ir();
+        ir.metadata_columns = vec![];
+        let sql = generate_select_sql(&ir, &dialect()).unwrap();
 
         assert_eq!(sql.lines().next().unwrap().trim(), "SELECT *");
         assert!(!sql.contains("CAST"));
@@ -1046,22 +1003,20 @@ mod tests {
 
     #[test]
     fn test_multiple_metadata_columns() {
-        let plan = ReplicationPlan {
-            metadata_columns: vec![
-                MetadataColumn {
-                    name: "_loaded_by".into(),
-                    data_type: "STRING".into(),
-                    value: "NULL".into(),
-                },
-                MetadataColumn {
-                    name: "load_id".into(),
-                    data_type: "INT".into(),
-                    value: "42".into(),
-                },
-            ],
-            ..sample_full_refresh_plan()
-        };
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let mut ir = sample_full_refresh_ir();
+        ir.metadata_columns = vec![
+            MetadataColumn {
+                name: "_loaded_by".into(),
+                data_type: "STRING".into(),
+                value: "NULL".into(),
+            },
+            MetadataColumn {
+                name: "load_id".into(),
+                data_type: "INT".into(),
+                value: "42".into(),
+            },
+        ];
+        let sql = generate_select_sql(&ir, &dialect()).unwrap();
 
         assert!(sql.contains("CAST(NULL AS STRING) AS _loaded_by"));
         assert!(sql.contains("CAST(42 AS INT) AS load_id"));
@@ -1069,86 +1024,74 @@ mod tests {
 
     #[test]
     fn test_rejects_unsafe_identifier_in_source() {
-        let plan = ReplicationPlan {
-            source: SourceRef {
-                catalog: "catalog; DROP TABLE".into(),
-                schema: "schema".into(),
-                table: "table".into(),
-            },
-            ..sample_full_refresh_plan()
-        };
-        assert!(generate_select_sql(&rep_ir(&plan), &dialect()).is_err());
+        let mut ir = sample_full_refresh_ir();
+        ir.source = Some(SourceRef {
+            catalog: "catalog; DROP TABLE".into(),
+            schema: "schema".into(),
+            table: "table".into(),
+        });
+        assert!(generate_select_sql(&ir, &dialect()).is_err());
     }
 
     #[test]
     fn test_rejects_unsafe_metadata_name() {
-        let plan = ReplicationPlan {
-            metadata_columns: vec![MetadataColumn {
-                name: "col; DROP TABLE".into(),
-                data_type: "STRING".into(),
-                value: "NULL".into(),
-            }],
-            ..sample_full_refresh_plan()
-        };
-        assert!(generate_select_sql(&rep_ir(&plan), &dialect()).is_err());
+        let mut ir = sample_full_refresh_ir();
+        ir.metadata_columns = vec![MetadataColumn {
+            name: "col; DROP TABLE".into(),
+            data_type: "STRING".into(),
+            value: "NULL".into(),
+        }];
+        assert!(generate_select_sql(&ir, &dialect()).is_err());
     }
 
     #[test]
     fn test_rejects_unsafe_metadata_value() {
-        let plan = ReplicationPlan {
-            metadata_columns: vec![MetadataColumn {
-                name: "col".into(),
-                data_type: "STRING".into(),
-                value: "1; DROP TABLE users".into(),
-            }],
-            ..sample_full_refresh_plan()
-        };
+        let mut ir = sample_full_refresh_ir();
+        ir.metadata_columns = vec![MetadataColumn {
+            name: "col".into(),
+            data_type: "STRING".into(),
+            value: "1; DROP TABLE users".into(),
+        }];
         // Note: metadata value validation is delegated to the dialect's select_clause.
         // The test dialect writes the value verbatim. The SQL gen layer itself does not
         // validate literal values anymore (that was in the removed non-dialect code).
         // This test now checks that the dialect produces output (it does, since TestDialect
         // doesn't validate literal values). In production, the DatabricksSqlDialect should
         // validate literal values.
-        let _ = generate_select_sql(&rep_ir(&plan), &dialect());
+        let _ = generate_select_sql(&ir, &dialect());
     }
 
     #[test]
     fn test_rejects_unsafe_data_type() {
-        let plan = ReplicationPlan {
-            metadata_columns: vec![MetadataColumn {
-                name: "col".into(),
-                data_type: "STRING); DROP TABLE users--".into(),
-                value: "NULL".into(),
-            }],
-            ..sample_full_refresh_plan()
-        };
+        let mut ir = sample_full_refresh_ir();
+        ir.metadata_columns = vec![MetadataColumn {
+            name: "col".into(),
+            data_type: "STRING); DROP TABLE users--".into(),
+            value: "NULL".into(),
+        }];
         // Same as above: data type validation is delegated to the dialect.
-        let _ = generate_select_sql(&rep_ir(&plan), &dialect());
+        let _ = generate_select_sql(&ir, &dialect());
     }
 
     #[test]
     fn test_merge_select_is_full_scan() {
-        let plan = ReplicationPlan {
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec!["id".into()],
-                update_columns: ColumnSelection::All,
-            },
-            ..sample_full_refresh_plan()
+        let mut ir = sample_full_refresh_ir();
+        ir.materialization = MaterializationStrategy::Merge {
+            unique_key: vec!["id".into()],
+            update_columns: ColumnSelection::All,
         };
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_select_sql(&ir, &dialect()).unwrap();
         assert!(!sql.contains("WHERE")); // merge SELECT is a full scan
     }
 
     #[test]
     fn test_merge_sql() {
-        let plan = ReplicationPlan {
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec!["id".into()],
-                update_columns: ColumnSelection::All,
-            },
-            ..sample_full_refresh_plan()
+        let mut ir = sample_full_refresh_ir();
+        ir.materialization = MaterializationStrategy::Merge {
+            unique_key: vec!["id".into()],
+            update_columns: ColumnSelection::All,
         };
-        let sql = generate_merge_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_merge_sql(&ir, &dialect()).unwrap();
         assert!(sql.contains("MERGE INTO"));
         assert!(sql.contains("ON t.id = s.id"));
         assert!(sql.contains("WHEN MATCHED THEN UPDATE SET *"));
@@ -1157,55 +1100,51 @@ mod tests {
 
     #[test]
     fn test_merge_composite_key() {
-        let plan = ReplicationPlan {
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec!["id".into(), "date".into()],
-                update_columns: ColumnSelection::Explicit(vec!["status".into(), "amount".into()]),
-            },
-            ..sample_full_refresh_plan()
+        let mut ir = sample_full_refresh_ir();
+        ir.materialization = MaterializationStrategy::Merge {
+            unique_key: vec!["id".into(), "date".into()],
+            update_columns: ColumnSelection::Explicit(vec!["status".into(), "amount".into()]),
         };
-        let sql = generate_merge_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_merge_sql(&ir, &dialect()).unwrap();
         assert!(sql.contains("ON t.id = s.id AND t.date = s.date"));
         assert!(sql.contains("UPDATE SET t.status = s.status, t.amount = s.amount"));
     }
 
     #[test]
     fn test_merge_no_key_fails() {
-        let plan = ReplicationPlan {
-            strategy: MaterializationStrategy::Merge {
-                unique_key: vec![],
-                update_columns: ColumnSelection::All,
-            },
-            ..sample_full_refresh_plan()
+        let mut ir = sample_full_refresh_ir();
+        ir.materialization = MaterializationStrategy::Merge {
+            unique_key: vec![],
+            update_columns: ColumnSelection::All,
         };
         // The dialect returns an error for empty keys, which sql_gen maps to UnsafeFragment
-        assert!(generate_merge_sql(&rep_ir(&plan), &dialect()).is_err());
+        assert!(generate_merge_sql(&ir, &dialect()).is_err());
     }
 
     #[test]
     fn test_transformation_full_refresh() {
-        let plan = TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: "cat".into(),
-                schema: "sch".into(),
-                table: "src".into(),
-            }],
-            target: TargetRef {
+        let ir = ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "silver".into(),
                 table: "dim_accounts".into(),
             },
-            strategy: MaterializationStrategy::FullRefresh,
-            sql: "SELECT id, name, email FROM cat.sch.src WHERE active = true".into(),
-            governance: GovernanceConfig {
+            MaterializationStrategy::FullRefresh,
+            vec![SourceRef {
+                catalog: "cat".into(),
+                schema: "sch".into(),
+                table: "src".into(),
+            }],
+            "SELECT id, name, email FROM cat.sch.src WHERE active = true".into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        };
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+            None,
+            None,
+        );
+        let stmts = generate_transformation_sql(&ir, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.starts_with("CREATE OR REPLACE TABLE cat.silver.dim_accounts AS"));
@@ -1214,53 +1153,53 @@ mod tests {
 
     #[test]
     fn test_transformation_incremental() {
-        let plan = TransformationPlan {
-            sources: vec![],
-            target: TargetRef {
+        let ir = ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "silver".into(),
                 table: "fct_orders".into(),
             },
-            strategy: MaterializationStrategy::Incremental {
+            MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
             },
-            sql: "SELECT * FROM cat.sch.raw_orders WHERE updated_at > '2026-01-01'".into(),
-            governance: GovernanceConfig {
+            vec![],
+            "SELECT * FROM cat.sch.raw_orders WHERE updated_at > '2026-01-01'".into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        };
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+            None,
+            None,
+        );
+        let stmts = generate_transformation_sql(&ir, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(stmts[0].starts_with("INSERT INTO cat.silver.fct_orders"));
     }
 
     #[test]
     fn test_transformation_merge() {
-        let plan = TransformationPlan {
-            sources: vec![],
-            target: TargetRef {
+        let ir = ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "silver".into(),
                 table: "dim_users".into(),
             },
-            strategy: MaterializationStrategy::Merge {
+            MaterializationStrategy::Merge {
                 unique_key: vec!["user_id".into()],
                 update_columns: ColumnSelection::All,
             },
-            sql: "SELECT user_id, name, email FROM cat.sch.raw_users".into(),
-            governance: GovernanceConfig {
+            vec![],
+            "SELECT user_id, name, email FROM cat.sch.raw_users".into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        };
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+            None,
+            None,
+        );
+        let stmts = generate_transformation_sql(&ir, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.contains("MERGE INTO cat.silver.dim_users AS t"));
@@ -1294,8 +1233,7 @@ mod tests {
 
     #[test]
     fn test_sample_incremental_sql_matches_expected() {
-        let plan = sample_incremental_plan();
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_select_sql(&sample_incremental_ir(), &dialect()).unwrap();
 
         let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1310,8 +1248,7 @@ WHERE _fivetran_synced > (
 
     #[test]
     fn test_sample_full_refresh_sql_matches_expected() {
-        let plan = sample_full_refresh_plan();
-        let sql = generate_select_sql(&rep_ir(&plan), &dialect()).unwrap();
+        let sql = generate_select_sql(&sample_full_refresh_ir(), &dialect()).unwrap();
 
         let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1320,37 +1257,35 @@ FROM source_catalog.src__acme__us_west__shopify.orders";
         assert_eq!(sql, expected);
     }
 
-    fn sample_transformation_plan() -> TransformationPlan {
-        TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: "cat".into(),
-                schema: "sch".into(),
-                table: "src".into(),
-            }],
-            target: TargetRef {
+    fn sample_transformation_ir() -> ModelIr {
+        ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "silver".into(),
                 table: "dim_accounts".into(),
             },
-            strategy: MaterializationStrategy::FullRefresh,
-            sql: "SELECT id, name, email FROM cat.sch.src WHERE active = true".into(),
-            governance: GovernanceConfig {
+            MaterializationStrategy::FullRefresh,
+            vec![SourceRef {
+                catalog: "cat".into(),
+                schema: "sch".into(),
+                table: "src".into(),
+            }],
+            "SELECT id, name, email FROM cat.sch.src WHERE active = true".into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        }
+            None,
+            None,
+        )
     }
 
     #[test]
     fn test_generate_materialized_view_sql() {
-        let plan = TransformationPlan {
-            strategy: MaterializationStrategy::MaterializedView,
-            ..sample_transformation_plan()
-        };
-        let sql = generate_materialized_view_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let mut ir = sample_transformation_ir();
+        ir.materialization = MaterializationStrategy::MaterializedView;
+        let sql = generate_materialized_view_sql(&ir, &dialect()).unwrap();
 
         let expected = "\
 CREATE OR REPLACE MATERIALIZED VIEW cat.silver.dim_accounts AS
@@ -1361,11 +1296,9 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_generate_materialized_view_via_transformation() {
-        let plan = TransformationPlan {
-            strategy: MaterializationStrategy::MaterializedView,
-            ..sample_transformation_plan()
-        };
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let mut ir = sample_transformation_ir();
+        ir.materialization = MaterializationStrategy::MaterializedView;
+        let stmts = generate_transformation_sql(&ir, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("CREATE OR REPLACE MATERIALIZED VIEW cat.silver.dim_accounts AS")
@@ -1374,14 +1307,11 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_generate_dynamic_table_sql() {
-        let plan = TransformationPlan {
-            strategy: MaterializationStrategy::DynamicTable {
-                target_lag: "1 hour".into(),
-            },
-            ..sample_transformation_plan()
+        let mut ir = sample_transformation_ir();
+        ir.materialization = MaterializationStrategy::DynamicTable {
+            target_lag: "1 hour".into(),
         };
-        let sql = generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "COMPUTE_WH", &dialect())
-            .unwrap();
+        let sql = generate_dynamic_table_sql(&ir, "1 hour", "COMPUTE_WH", &dialect()).unwrap();
 
         let expected = "\
 CREATE OR REPLACE DYNAMIC TABLE cat.silver.dim_accounts
@@ -1395,31 +1325,21 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_dynamic_table_rejects_bad_warehouse() {
-        let plan = TransformationPlan {
-            strategy: MaterializationStrategy::DynamicTable {
-                target_lag: "1 hour".into(),
-            },
-            ..sample_transformation_plan()
+        let mut ir = sample_transformation_ir();
+        ir.materialization = MaterializationStrategy::DynamicTable {
+            target_lag: "1 hour".into(),
         };
-        let result =
-            generate_dynamic_table_sql(&xform_ir(&plan), "1 hour", "WH; DROP TABLE", &dialect());
+        let result = generate_dynamic_table_sql(&ir, "1 hour", "WH; DROP TABLE", &dialect());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_dynamic_table_rejects_bad_target_lag() {
-        let plan = TransformationPlan {
-            strategy: MaterializationStrategy::DynamicTable {
-                target_lag: "1 hour".into(),
-            },
-            ..sample_transformation_plan()
+        let mut ir = sample_transformation_ir();
+        ir.materialization = MaterializationStrategy::DynamicTable {
+            target_lag: "1 hour".into(),
         };
-        let result = generate_dynamic_table_sql(
-            &xform_ir(&plan),
-            "1'; DROP TABLE --",
-            "COMPUTE_WH",
-            &dialect(),
-        );
+        let result = generate_dynamic_table_sql(&ir, "1'; DROP TABLE --", "COMPUTE_WH", &dialect());
         assert!(result.is_err());
     }
 
@@ -1429,36 +1349,32 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     use crate::models::TimeGrain;
     use chrono::TimeZone;
 
-    fn time_interval_plan(
-        time_column: &str,
-        sql: &str,
-        window: Option<PartitionWindow>,
-    ) -> TransformationPlan {
-        TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: "cat".into(),
-                schema: "raw".into(),
-                table: "stg_orders".into(),
-            }],
-            target: TargetRef {
+    fn time_interval_ir(time_column: &str, sql: &str, window: Option<PartitionWindow>) -> ModelIr {
+        ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "marts".into(),
                 table: "fct_daily_orders".into(),
             },
-            strategy: MaterializationStrategy::TimeInterval {
+            MaterializationStrategy::TimeInterval {
                 time_column: time_column.into(),
                 granularity: TimeGrain::Day,
                 window,
             },
-            sql: sql.into(),
-            governance: GovernanceConfig {
+            vec![SourceRef {
+                catalog: "cat".into(),
+                schema: "raw".into(),
+                table: "stg_orders".into(),
+            }],
+            sql.into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        }
+            None,
+            None,
+        )
     }
 
     fn april_7_window() -> PartitionWindow {
@@ -1474,23 +1390,23 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // Static planning leaves window=None; calling generate_transformation_sql
         // without populating it must fail loudly so the runtime executor isn't
         // confused into emitting an unbounded statement.
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order_date",
             "SELECT order_date FROM cat.raw.stg_orders WHERE order_date >= @start_date AND order_date < @end_date",
             None,
         );
-        let result = generate_transformation_sql(&xform_ir(&plan), &dialect());
+        let result = generate_transformation_sql(&plan, &dialect());
         assert!(matches!(result, Err(SqlGenError::MissingPartitionWindow)));
     }
 
     #[test]
     fn test_time_interval_substitutes_placeholders() {
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order_date",
             "SELECT order_date FROM cat.raw.stg_orders WHERE order_date >= @start_date AND order_date < @end_date",
             Some(april_7_window()),
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1, "test dialect emits a single REPLACE WHERE");
         let sql = &stmts[0];
         // Both placeholders substituted with quoted timestamp literals.
@@ -1519,12 +1435,12 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // SECURITY: even though the compiler validates time_column at
         // typecheck time (E023), sql_gen re-validates at the planning
         // boundary so a bad column name can never reach format!().
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order date", // contains a space → invalid identifier
             "SELECT 1 FROM cat.raw.stg_orders WHERE 1=1 AND @start_date < @end_date",
             Some(april_7_window()),
         );
-        let result = generate_transformation_sql(&xform_ir(&plan), &dialect());
+        let result = generate_transformation_sql(&plan, &dialect());
         assert!(matches!(result, Err(SqlGenError::UnsafeFragment { .. })));
     }
 
@@ -1546,13 +1462,13 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // AS statement with both placeholders substituted to the same
         // sentinel timestamp ('1900-01-01 00:00:00'), making the half-open
         // [start, end) window empty so the model SELECT returns zero rows.
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order_date",
             "SELECT order_date FROM cat.raw.stg_orders \
              WHERE order_at >= @start_date AND order_at < @end_date",
             None,
         );
-        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
 
         // Wrapped in CREATE OR REPLACE TABLE AS by the test dialect.
         assert!(
@@ -1580,12 +1496,12 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // The bootstrap helper does NOT need PartitionWindow to be populated
         // on the plan — it ignores plan.strategy entirely and just uses the
         // model SQL + target. Verify that a plan with window=None still works.
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order_date",
             "SELECT order_date FROM cat.raw.x WHERE x.t >= @start_date AND x.t < @end_date",
             None, // window = None
         );
-        let result = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect());
+        let result = generate_time_interval_bootstrap_sql(&plan, &dialect());
         assert!(
             result.is_ok(),
             "bootstrap should not error on missing window: {result:?}"
@@ -1596,37 +1512,37 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     use crate::lakehouse::{LakehouseFormat, LakehouseOptions};
 
-    fn lakehouse_plan(
+    fn lakehouse_ir(
         format: LakehouseFormat,
         options: LakehouseOptions,
         strategy: MaterializationStrategy,
-    ) -> TransformationPlan {
-        TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: "cat".into(),
-                schema: "raw".into(),
-                table: "stg_orders".into(),
-            }],
-            target: TargetRef {
+    ) -> ModelIr {
+        ModelIr::transformation(
+            TargetRef {
                 catalog: "cat".into(),
                 schema: "silver".into(),
                 table: "fct_orders".into(),
             },
             strategy,
-            sql: "SELECT id, amount, region FROM cat.raw.stg_orders".into(),
-            governance: GovernanceConfig {
+            vec![SourceRef {
+                catalog: "cat".into(),
+                schema: "raw".into(),
+                table: "stg_orders".into(),
+            }],
+            "SELECT id, amount, region FROM cat.raw.stg_orders".into(),
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: Some(format),
-            format_options: Some(options),
-        }
+            Some(format),
+            Some(options),
+        )
     }
 
     #[test]
     fn test_lakehouse_full_refresh_delta() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::DeltaTable,
             LakehouseOptions {
                 partition_by: vec!["region".into()],
@@ -1636,7 +1552,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(sql.contains("USING DELTA"), "expected USING DELTA: {sql}");
@@ -1664,7 +1580,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_full_refresh_iceberg() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::IcebergTable,
             LakehouseOptions {
                 partition_by: vec!["region".into()],
@@ -1672,7 +1588,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1687,12 +1603,12 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_full_refresh_streaming_table() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::StreamingTable,
             LakehouseOptions::default(),
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].contains("CREATE OR REPLACE STREAMING TABLE"),
@@ -1703,12 +1619,12 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_full_refresh_view() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::View,
             LakehouseOptions::default(),
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].contains("CREATE OR REPLACE VIEW"),
@@ -1719,7 +1635,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_full_refresh_materialized_view() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::MaterializedView,
             LakehouseOptions {
                 comment: Some("MV test".into()),
@@ -1727,7 +1643,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1741,7 +1657,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     fn test_lakehouse_full_refresh_plain_table() {
         // LakehouseFormat::Table with options should still apply partitioning
         // and properties even though it's a "plain" table.
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::Table,
             LakehouseOptions {
                 cluster_by: vec!["id".into()],
@@ -1749,7 +1665,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1772,14 +1688,14 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         // Incremental INSERT should not emit lakehouse DDL — that's for
         // initial table creation. The format field is silently ignored for
         // the INSERT path, since the table already exists.
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::DeltaTable,
             LakehouseOptions::default(),
             MaterializationStrategy::Incremental {
                 timestamp_column: "updated_at".into(),
             },
         );
-        let stmts = generate_transformation_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_sql(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("INSERT INTO"),
@@ -1790,7 +1706,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_initial_ddl_delta() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::DeltaTable,
             LakehouseOptions {
                 partition_by: vec!["region".into()],
@@ -1801,7 +1717,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 timestamp_column: "updated_at".into(),
             },
         );
-        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1820,7 +1736,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
 
     #[test]
     fn test_lakehouse_initial_ddl_iceberg() {
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::IcebergTable,
             LakehouseOptions {
                 cluster_by: vec!["user_id".into()],
@@ -1831,7 +1747,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 update_columns: ColumnSelection::All,
             },
         );
-        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1848,16 +1764,14 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     fn test_lakehouse_initial_ddl_fallback_no_format() {
         // When format is None, generate_transformation_initial_ddl should
         // fall back to the plain dialect.create_table_as.
-        let plan = TransformationPlan {
-            format: None,
-            format_options: None,
-            ..lakehouse_plan(
-                LakehouseFormat::DeltaTable,
-                LakehouseOptions::default(),
-                MaterializationStrategy::FullRefresh,
-            )
-        };
-        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
+        let mut plan = lakehouse_ir(
+            LakehouseFormat::DeltaTable,
+            LakehouseOptions::default(),
+            MaterializationStrategy::FullRefresh,
+        );
+        plan.format = None;
+        plan.format_options = None;
+        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         assert!(
             stmts[0].starts_with("CREATE OR REPLACE TABLE"),
@@ -1874,7 +1788,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     #[test]
     fn test_lakehouse_time_interval_bootstrap_with_delta_format() {
         // Time-interval bootstrap should use lakehouse DDL when format is set.
-        let mut plan = time_interval_plan(
+        let mut plan = time_interval_ir(
             "order_date",
             "SELECT order_date, amount FROM cat.raw.stg_orders \
              WHERE order_date >= @start_date AND order_date < @end_date",
@@ -1887,7 +1801,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             ..LakehouseOptions::default()
         });
 
-        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
         assert!(
             sql.contains("USING DELTA"),
             "bootstrap should use DELTA: {sql}"
@@ -1919,13 +1833,13 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     #[test]
     fn test_lakehouse_time_interval_bootstrap_without_format() {
         // Without format, bootstrap should use plain CTAS as before.
-        let plan = time_interval_plan(
+        let plan = time_interval_ir(
             "order_date",
             "SELECT order_date FROM cat.raw.stg_orders \
              WHERE order_date >= @start_date AND order_date < @end_date",
             None,
         );
-        let sql = generate_time_interval_bootstrap_sql(&xform_ir(&plan), &dialect()).unwrap();
+        let sql = generate_time_interval_bootstrap_sql(&plan, &dialect()).unwrap();
         assert!(
             sql.starts_with("CREATE OR REPLACE TABLE"),
             "should use plain CTAS: {sql}"
@@ -1939,7 +1853,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     #[test]
     fn test_lakehouse_initial_ddl_with_delete_insert_strategy() {
         // DeleteInsert strategy should also get lakehouse DDL on initial creation.
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::DeltaTable,
             LakehouseOptions {
                 partition_by: vec!["date_key".into()],
@@ -1949,7 +1863,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
                 partition_by: vec!["date_key".into()],
             },
         );
-        let stmts = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect()).unwrap();
+        let stmts = generate_transformation_initial_ddl(&plan, &dialect()).unwrap();
         assert_eq!(stmts.len(), 1);
         let sql = &stmts[0];
         assert!(
@@ -1965,7 +1879,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     #[test]
     fn test_lakehouse_initial_ddl_invalid_option_rejected() {
         // Ensure invalid lakehouse options propagate as LakehouseError.
-        let plan = lakehouse_plan(
+        let plan = lakehouse_ir(
             LakehouseFormat::DeltaTable,
             LakehouseOptions {
                 partition_by: vec!["DROP TABLE --".into()],
@@ -1973,7 +1887,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
             },
             MaterializationStrategy::FullRefresh,
         );
-        let result = generate_transformation_initial_ddl(&xform_ir(&plan), &dialect());
+        let result = generate_transformation_initial_ddl(&plan, &dialect());
         assert!(result.is_err(), "should reject invalid partition column");
     }
 
@@ -1983,7 +1897,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     /// `expected Replication, found transformation` template.
     #[test]
     fn variant_mismatch_error_names_the_actual_variant() {
-        let ir = xform_ir(&sample_transformation_plan());
+        let ir = sample_transformation_ir();
         let err = generate_select_sql(&ir, &dialect()).expect_err("expected variant mismatch");
         let msg = err.to_string();
         assert!(
@@ -1992,7 +1906,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         );
         assert!(
             msg.contains("found transformation"),
-            "error should name the actual variant via `variant_name()`, got: {msg}"
+            "error should name the actual variant via `variant()`, got: {msg}"
         );
     }
 
@@ -2001,7 +1915,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     /// template.
     #[test]
     fn variant_mismatch_transformation_helper_names_replication_input() {
-        let ir = rep_ir(&sample_incremental_plan());
+        let ir = sample_incremental_ir();
         let err =
             generate_transformation_sql(&ir, &dialect()).expect_err("expected variant mismatch");
         let msg = err.to_string();
@@ -2011,7 +1925,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         );
         assert!(
             msg.contains("found replication"),
-            "error should name the actual variant via `variant_name()`, got: {msg}"
+            "error should name the actual variant via `variant()`, got: {msg}"
         );
     }
 
@@ -2020,7 +1934,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
     /// template — the third and final error-message shape.
     #[test]
     fn variant_mismatch_snapshot_helper_names_transformation_input() {
-        let ir = xform_ir(&sample_transformation_plan());
+        let ir = sample_transformation_ir();
         let err = generate_snapshot_sql(&ir, &dialect()).expect_err("expected variant mismatch");
         let msg = err.to_string();
         assert!(
@@ -2029,7 +1943,7 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         );
         assert!(
             msg.contains("found transformation"),
-            "error should name the actual variant via `variant_name()`, got: {msg}"
+            "error should name the actual variant via `variant()`, got: {msg}"
         );
     }
 }

--- a/engine/crates/rocky-core/tests/e2e.rs
+++ b/engine/crates/rocky-core/tests/e2e.rs
@@ -5,51 +5,12 @@
 
 use rocky_core::ir::{
     ColumnInfo, ColumnSelection, DriftAction, GovernanceConfig, MaterializationStrategy,
-    MetadataColumn, ModelIr, ReplicationPlan, SnapshotPlan, SourceRef, TableRef, TargetRef,
-    TransformationPlan, WatermarkState,
+    MetadataColumn, ModelIr, SourceRef, TableRef, TargetRef, WatermarkState,
 };
 use rocky_core::state::StateStore;
 use rocky_core::traits::{AdapterError, AdapterResult, SqlDialect};
 use rocky_core::{drift, sql_gen};
 use tempfile::TempDir;
-
-/// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
-fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
-    ModelIr::replication(
-        plan.target.clone(),
-        plan.strategy.clone(),
-        plan.source.clone(),
-        plan.columns.clone(),
-        plan.metadata_columns.clone(),
-        plan.governance.clone(),
-    )
-}
-
-/// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
-fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-    ModelIr::transformation(
-        plan.target.clone(),
-        plan.strategy.clone(),
-        plan.sources.clone(),
-        plan.sql.clone(),
-        plan.governance.clone(),
-        plan.format.clone(),
-        plan.format_options.clone(),
-    )
-}
-
-/// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
-#[allow(dead_code)]
-fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-    ModelIr::snapshot(
-        plan.target.clone(),
-        plan.source.clone(),
-        plan.unique_key.clone(),
-        plan.updated_at.clone(),
-        plan.invalidate_hard_deletes,
-        plan.governance.clone(),
-    )
-}
 
 // ---------------------------------------------------------------------------
 // Test dialect (mirrors Databricks behavior for integration tests)
@@ -208,32 +169,32 @@ fn temp_state() -> (StateStore, TempDir) {
     (store, dir)
 }
 
-/// Returns a standard replication plan for testing.
-fn sample_replication_plan(strategy: MaterializationStrategy) -> ReplicationPlan {
-    ReplicationPlan {
-        source: SourceRef {
-            catalog: "source_catalog".into(),
-            schema: "src__acme__us_west__shopify".into(),
-            table: "orders".into(),
-        },
-        target: TargetRef {
+/// Returns a standard replication [`ModelIr`] for testing.
+fn sample_replication_ir(strategy: MaterializationStrategy) -> ModelIr {
+    ModelIr::replication(
+        TargetRef {
             catalog: "acme_warehouse".into(),
             schema: "staging__us_west__shopify".into(),
             table: "orders".into(),
         },
         strategy,
-        columns: ColumnSelection::All,
-        metadata_columns: vec![MetadataColumn {
+        SourceRef {
+            catalog: "source_catalog".into(),
+            schema: "src__acme__us_west__shopify".into(),
+            table: "orders".into(),
+        },
+        ColumnSelection::All,
+        vec![MetadataColumn {
             name: "_loaded_by".into(),
             data_type: "STRING".into(),
             value: "NULL".into(),
         }],
-        governance: GovernanceConfig {
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-    }
+    )
 }
 
 // ===========================================================================
@@ -245,10 +206,10 @@ fn test_full_refresh_pipeline() {
     let (store, _dir) = temp_state();
     let dialect = TestDialect;
 
-    let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
+    let plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
 
     // Generate CREATE TABLE AS SELECT SQL (full refresh)
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
 
     // Verify SQL structure
     assert!(
@@ -303,12 +264,12 @@ fn test_incremental_pipeline_with_watermark() {
     // Build an incremental plan; the watermark itself is read from the
     // state store at SQL-generation time, not carried on the strategy.
     let _wm = store.get_watermark(table_key).unwrap();
-    let plan = sample_replication_plan(MaterializationStrategy::Incremental {
+    let plan = sample_replication_ir(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
 
     // Generate INSERT INTO ... SELECT SQL (incremental append)
-    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
 
     // Verify incremental SQL structure
     assert!(
@@ -559,29 +520,30 @@ fn test_run_history_flow() {
 fn test_transformation_full_refresh() {
     let dialect = TestDialect;
 
-    let plan = TransformationPlan {
-        sources: vec![SourceRef {
-            catalog: "source".into(),
-            schema: "raw".into(),
-            table: "orders".into(),
-        }],
-        target: TargetRef {
+    let plan = ModelIr::transformation(
+        TargetRef {
             catalog: "analytics".into(),
             schema: "marts".into(),
             table: "order_summary".into(),
         },
-        strategy: MaterializationStrategy::FullRefresh,
-        sql: "SELECT customer_id, COUNT(*) as order_count FROM source.raw.orders GROUP BY customer_id".into(),
-        governance: GovernanceConfig {
+        MaterializationStrategy::FullRefresh,
+        vec![SourceRef {
+            catalog: "source".into(),
+            schema: "raw".into(),
+            table: "orders".into(),
+        }],
+        "SELECT customer_id, COUNT(*) as order_count FROM source.raw.orders GROUP BY customer_id"
+            .into(),
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-        format: None,
-        format_options: None,
-    };
+        None,
+        None,
+    );
 
-    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
 
@@ -604,31 +566,31 @@ fn test_transformation_full_refresh() {
 fn test_transformation_incremental() {
     let dialect = TestDialect;
 
-    let plan = TransformationPlan {
-        sources: vec![SourceRef {
-            catalog: "cat".into(),
-            schema: "raw".into(),
-            table: "events".into(),
-        }],
-        target: TargetRef {
+    let plan = ModelIr::transformation(
+        TargetRef {
             catalog: "cat".into(),
             schema: "silver".into(),
             table: "fct_events".into(),
         },
-        strategy: MaterializationStrategy::Incremental {
+        MaterializationStrategy::Incremental {
             timestamp_column: "updated_at".into(),
         },
-        sql: "SELECT * FROM cat.raw.events WHERE updated_at > '2026-01-01'".into(),
-        governance: GovernanceConfig {
+        vec![SourceRef {
+            catalog: "cat".into(),
+            schema: "raw".into(),
+            table: "events".into(),
+        }],
+        "SELECT * FROM cat.raw.events WHERE updated_at > '2026-01-01'".into(),
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-        format: None,
-        format_options: None,
-    };
+        None,
+        None,
+    );
 
-    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
     assert!(
@@ -641,32 +603,32 @@ fn test_transformation_incremental() {
 fn test_transformation_merge() {
     let dialect = TestDialect;
 
-    let plan = TransformationPlan {
-        sources: vec![SourceRef {
-            catalog: "cat".into(),
-            schema: "raw".into(),
-            table: "users".into(),
-        }],
-        target: TargetRef {
+    let plan = ModelIr::transformation(
+        TargetRef {
             catalog: "cat".into(),
             schema: "silver".into(),
             table: "dim_users".into(),
         },
-        strategy: MaterializationStrategy::Merge {
+        MaterializationStrategy::Merge {
             unique_key: vec!["user_id".into()],
             update_columns: ColumnSelection::All,
         },
-        sql: "SELECT user_id, name, email FROM cat.raw.users".into(),
-        governance: GovernanceConfig {
+        vec![SourceRef {
+            catalog: "cat".into(),
+            schema: "raw".into(),
+            table: "users".into(),
+        }],
+        "SELECT user_id, name, email FROM cat.raw.users".into(),
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-        format: None,
-        format_options: None,
-    };
+        None,
+        None,
+    );
 
-    let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), &dialect).unwrap();
+    let stmts = sql_gen::generate_transformation_sql(&plan, &dialect).unwrap();
     assert_eq!(stmts.len(), 1);
     let sql = &stmts[0];
     assert!(
@@ -687,31 +649,31 @@ fn test_transformation_merge() {
 fn test_merge_sql_generation() {
     let dialect = TestDialect;
 
-    let plan = ReplicationPlan {
-        source: SourceRef {
-            catalog: "source_catalog".into(),
-            schema: "src__acme__us_west__shopify".into(),
-            table: "customers".into(),
-        },
-        target: TargetRef {
+    let plan = ModelIr::replication(
+        TargetRef {
             catalog: "acme_warehouse".into(),
             schema: "staging__us_west__shopify".into(),
             table: "customers".into(),
         },
-        strategy: MaterializationStrategy::Merge {
+        MaterializationStrategy::Merge {
             unique_key: vec!["customer_id".into()],
             update_columns: ColumnSelection::All,
         },
-        columns: ColumnSelection::All,
-        metadata_columns: vec![],
-        governance: GovernanceConfig {
+        SourceRef {
+            catalog: "source_catalog".into(),
+            schema: "src__acme__us_west__shopify".into(),
+            table: "customers".into(),
+        },
+        ColumnSelection::All,
+        vec![],
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-    };
+    );
 
-    let sql = sql_gen::generate_merge_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_merge_sql(&plan, &dialect).unwrap();
 
     assert!(sql.contains("MERGE INTO"), "expected MERGE INTO: {sql}");
     assert!(
@@ -732,31 +694,31 @@ fn test_merge_sql_generation() {
 fn test_merge_composite_key() {
     let dialect = TestDialect;
 
-    let plan = ReplicationPlan {
-        source: SourceRef {
-            catalog: "source_catalog".into(),
-            schema: "src__acme__us_west__shopify".into(),
-            table: "order_items".into(),
-        },
-        target: TargetRef {
+    let plan = ModelIr::replication(
+        TargetRef {
             catalog: "acme_warehouse".into(),
             schema: "staging__us_west__shopify".into(),
             table: "order_items".into(),
         },
-        strategy: MaterializationStrategy::Merge {
+        MaterializationStrategy::Merge {
             unique_key: vec!["order_id".into(), "line_id".into()],
             update_columns: ColumnSelection::Explicit(vec!["status".into(), "amount".into()]),
         },
-        columns: ColumnSelection::All,
-        metadata_columns: vec![],
-        governance: GovernanceConfig {
+        SourceRef {
+            catalog: "source_catalog".into(),
+            schema: "src__acme__us_west__shopify".into(),
+            table: "order_items".into(),
+        },
+        ColumnSelection::All,
+        vec![],
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-    };
+    );
 
-    let sql = sql_gen::generate_merge_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_merge_sql(&plan, &dialect).unwrap();
     assert!(
         sql.contains("ON t.order_id = s.order_id AND t.line_id = s.line_id"),
         "expected composite ON clause: {sql}"
@@ -871,44 +833,38 @@ fn test_sql_injection_prevention() {
     let dialect = TestDialect;
 
     // Unsafe catalog name
-    let bad_plan = ReplicationPlan {
-        source: SourceRef {
-            catalog: "catalog; DROP TABLE users--".into(),
-            schema: "schema".into(),
-            table: "table".into(),
-        },
-        ..sample_replication_plan(MaterializationStrategy::FullRefresh)
-    };
+    let mut bad_plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    bad_plan.source = Some(SourceRef {
+        catalog: "catalog; DROP TABLE users--".into(),
+        schema: "schema".into(),
+        table: "table".into(),
+    });
     assert!(
-        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
+        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
         "should reject SQL injection in catalog name"
     );
 
     // Unsafe schema name
-    let bad_plan = ReplicationPlan {
-        source: SourceRef {
-            catalog: "cat".into(),
-            schema: "sch' OR '1'='1".into(),
-            table: "tbl".into(),
-        },
-        ..sample_replication_plan(MaterializationStrategy::FullRefresh)
-    };
+    let mut bad_plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    bad_plan.source = Some(SourceRef {
+        catalog: "cat".into(),
+        schema: "sch' OR '1'='1".into(),
+        table: "tbl".into(),
+    });
     assert!(
-        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
+        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
         "should reject SQL injection in schema name"
     );
 
     // Unsafe metadata column name
-    let bad_plan = ReplicationPlan {
-        metadata_columns: vec![MetadataColumn {
-            name: "col; DROP TABLE".into(),
-            data_type: "STRING".into(),
-            value: "NULL".into(),
-        }],
-        ..sample_replication_plan(MaterializationStrategy::FullRefresh)
-    };
+    let mut bad_plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    bad_plan.metadata_columns = vec![MetadataColumn {
+        name: "col; DROP TABLE".into(),
+        data_type: "STRING".into(),
+        value: "NULL".into(),
+    }];
     assert!(
-        sql_gen::generate_select_sql(&rep_ir(&bad_plan), &dialect).is_err(),
+        sql_gen::generate_select_sql(&bad_plan, &dialect).is_err(),
         "should reject SQL injection in metadata column name"
     );
 
@@ -942,8 +898,8 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     let wm = store.get_watermark(table_key).unwrap();
     assert!(wm.is_none(), "no watermark on first run");
 
-    let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
+    let plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
     assert!(sql.contains("CREATE OR REPLACE TABLE"));
     assert!(!sql.contains("WHERE"));
 
@@ -966,10 +922,10 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     // The watermark value lives in the state store and is consulted by the
     // SQL generator at execution time; the strategy itself no longer
     // carries it.
-    let plan = sample_replication_plan(MaterializationStrategy::Incremental {
+    let plan = sample_replication_ir(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
-    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
     assert!(sql.contains("INSERT INTO"));
     assert!(sql.contains("WHERE _fivetran_synced > ("));
 
@@ -1012,8 +968,8 @@ fn test_full_pipeline_flow_incremental_to_full_refresh() {
     let drop_sql = drift::generate_drop_table_sql(&table, &dialect).unwrap();
     assert!(drop_sql.contains("DROP TABLE IF EXISTS"));
 
-    let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let ctas_sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
+    let plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    let ctas_sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
     assert!(ctas_sql.contains("CREATE OR REPLACE TABLE"));
 }
 
@@ -1057,11 +1013,11 @@ fn test_anomaly_detection_with_state() {
 fn test_exact_incremental_sql_output() {
     let dialect = TestDialect;
 
-    let plan = sample_replication_plan(MaterializationStrategy::Incremental {
+    let plan = sample_replication_ir(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
 
-    let sql = sql_gen::generate_select_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_select_sql(&plan, &dialect).unwrap();
 
     let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1078,8 +1034,8 @@ WHERE _fivetran_synced > (
 fn test_exact_full_refresh_sql_output() {
     let dialect = TestDialect;
 
-    let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_select_sql(&rep_ir(&plan), &dialect).unwrap();
+    let plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    let sql = sql_gen::generate_select_sql(&plan, &dialect).unwrap();
 
     let expected = "\
 SELECT *, CAST(NULL AS STRING) AS _loaded_by
@@ -1092,8 +1048,8 @@ FROM source_catalog.src__acme__us_west__shopify.orders";
 fn test_exact_ctas_sql_output() {
     let dialect = TestDialect;
 
-    let plan = sample_replication_plan(MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &dialect).unwrap();
+    let plan = sample_replication_ir(MaterializationStrategy::FullRefresh);
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &dialect).unwrap();
 
     let expected = "\
 CREATE OR REPLACE TABLE acme_warehouse.staging__us_west__shopify.orders AS
@@ -1107,10 +1063,10 @@ FROM source_catalog.src__acme__us_west__shopify.orders";
 fn test_exact_insert_sql_output() {
     let dialect = TestDialect;
 
-    let plan = sample_replication_plan(MaterializationStrategy::Incremental {
+    let plan = sample_replication_ir(MaterializationStrategy::Incremental {
         timestamp_column: "_fivetran_synced".into(),
     });
-    let sql = sql_gen::generate_insert_sql(&rep_ir(&plan), &dialect).unwrap();
+    let sql = sql_gen::generate_insert_sql(&plan, &dialect).unwrap();
 
     let expected = "\
 INSERT INTO acme_warehouse.staging__us_west__shopify.orders
@@ -1149,7 +1105,6 @@ mod time_interval_e2e {
     use rocky_core::incremental::{PartitionRecord, PartitionStatus, partition_key_to_window};
     use rocky_core::ir::{
         GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef,
-        TransformationPlan,
     };
     use rocky_core::models::TimeGrain;
     use rocky_core::sql_gen;
@@ -1157,19 +1112,6 @@ mod time_interval_e2e {
     use rocky_core::traits::{SqlDialect, WarehouseAdapter};
     use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
     use tempfile::TempDir;
-
-    /// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
-    fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-        ModelIr::transformation(
-            plan.target.clone(),
-            plan.strategy.clone(),
-            plan.sources.clone(),
-            plan.sql.clone(),
-            plan.governance.clone(),
-            plan.format.clone(),
-            plan.format_options.clone(),
-        )
-    }
 
     /// SQL to seed a stg_orders table with rows across 5 partitions
     /// (2026-04-04 through 2026-04-08), 2 customers, varying revenue.
@@ -1222,29 +1164,29 @@ mod time_interval_e2e {
         adapter
     }
 
-    /// Build the TransformationPlan for the fct_daily_orders model with the
+    /// Build the [`ModelIr`] for the fct_daily_orders model with the
     /// given partition window populated.
-    fn time_interval_plan(window_key: &str) -> TransformationPlan {
+    fn time_interval_ir(window_key: &str) -> ModelIr {
         let window = partition_key_to_window(TimeGrain::Day, window_key).expect("valid daily key");
-        TransformationPlan {
-            sources: vec![SourceRef {
-                catalog: String::new(),
-                schema: "main".into(),
-                table: "stg_orders".into(),
-            }],
-            target: TargetRef {
+        ModelIr::transformation(
+            TargetRef {
                 catalog: String::new(),
                 schema: "main".into(),
                 table: "fct_daily_orders".into(),
             },
-            strategy: MaterializationStrategy::TimeInterval {
+            MaterializationStrategy::TimeInterval {
                 time_column: "order_date".into(),
                 granularity: TimeGrain::Day,
                 window: Some(window),
             },
+            vec![SourceRef {
+                catalog: String::new(),
+                schema: "main".into(),
+                table: "stg_orders".into(),
+            }],
             // The model SQL: aggregate by date + customer, with the
             // @start_date / @end_date placeholders gating the upstream scan.
-            sql: "SELECT \
+            "SELECT \
                 CAST(order_at AS DATE) AS order_date, \
                 customer_id, \
                 COUNT(*) AS order_count, \
@@ -1253,14 +1195,14 @@ mod time_interval_e2e {
               WHERE order_at >= @start_date AND order_at < @end_date \
               GROUP BY 1, 2"
                 .into(),
-            governance: GovernanceConfig {
+            GovernanceConfig {
                 permissions_file: None,
                 auto_create_catalogs: false,
                 auto_create_schemas: false,
             },
-            format: None,
-            format_options: None,
-        }
+            None,
+            None,
+        )
     }
 
     /// Extract a JSON value as u64. Used to parse COUNT(*) results, which
@@ -1287,9 +1229,9 @@ mod time_interval_e2e {
 
     /// Execute the Vec<String> from generate_transformation_sql against the
     /// adapter, in order. Returns the number of rows in the target afterward.
-    async fn execute_partition(adapter: &DuckDbWarehouseAdapter, plan: &TransformationPlan) -> u64 {
+    async fn execute_partition(adapter: &DuckDbWarehouseAdapter, plan: &ModelIr) -> u64 {
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let stmts = sql_gen::generate_transformation_sql(&xform_ir(plan), dialect)
+        let stmts = sql_gen::generate_transformation_sql(plan, dialect)
             .expect("generate time_interval SQL");
         // Sanity: the duckdb dialect emits 4 statements
         // (BEGIN/DELETE/INSERT/COMMIT) per Phase 2C.
@@ -1310,7 +1252,7 @@ mod time_interval_e2e {
     #[tokio::test]
     async fn test_time_interval_single_partition_writes_only_window() {
         let adapter = setup_with_seeds().await;
-        let plan = time_interval_plan("2026-04-07");
+        let plan = time_interval_ir("2026-04-07");
         let total_rows = execute_partition(&adapter, &plan).await;
 
         // 04-07 has 3 raw rows: customer 1 at 08:00 + 13:00 → 1 group,
@@ -1344,7 +1286,7 @@ mod time_interval_e2e {
     #[tokio::test]
     async fn test_time_interval_idempotent_rerun() {
         let adapter = setup_with_seeds().await;
-        let plan = time_interval_plan("2026-04-07");
+        let plan = time_interval_ir("2026-04-07");
 
         // Run partition 04-07 twice. Idempotency: row count must NOT
         // double on the second run.
@@ -1365,7 +1307,7 @@ mod time_interval_e2e {
         // partition's rows without disturbing the others.
         let mut total = 0u64;
         for key in ["2026-04-04", "2026-04-05", "2026-04-06", "2026-04-07"] {
-            let plan = time_interval_plan(key);
+            let plan = time_interval_ir(key);
             total = execute_partition(&adapter, &plan).await;
         }
 
@@ -1393,7 +1335,7 @@ mod time_interval_e2e {
     #[tokio::test]
     async fn test_time_interval_rerun_with_new_upstream_data_picks_up_changes() {
         let adapter = setup_with_seeds().await;
-        let plan = time_interval_plan("2026-04-07");
+        let plan = time_interval_ir("2026-04-07");
 
         // First run with the original seed → 2 output rows.
         let count_before = execute_partition(&adapter, &plan).await;
@@ -1486,10 +1428,10 @@ mod time_interval_e2e {
         // is the SQL-level proof that the placeholder substitution from
         // Phase 2D works against a real warehouse.
         let adapter = setup_with_seeds().await;
-        let plan = time_interval_plan("2026-04-05"); // expect 1 customer, 1 order
+        let plan = time_interval_ir("2026-04-05"); // expect 1 customer, 1 order
 
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let stmts = sql_gen::generate_transformation_sql(&xform_ir(&plan), dialect).unwrap();
+        let stmts = sql_gen::generate_transformation_sql(&plan, dialect).unwrap();
 
         // The INSERT statement (index 2 in the BEGIN/DELETE/INSERT/COMMIT vec)
         // should contain the substituted timestamp literals, not the
@@ -1552,11 +1494,10 @@ mod time_interval_e2e {
             .expect("insert seeds");
 
         // Step 1: render the bootstrap SQL and execute it.
-        let plan = time_interval_plan("2026-04-07");
+        let plan = time_interval_ir("2026-04-07");
         let dialect: &dyn SqlDialect = adapter.dialect();
-        let bootstrap_sql =
-            sql_gen::generate_time_interval_bootstrap_sql(&xform_ir(&plan), dialect)
-                .expect("bootstrap render");
+        let bootstrap_sql = sql_gen::generate_time_interval_bootstrap_sql(&plan, dialect)
+            .expect("bootstrap render");
         adapter
             .execute_statement(&bootstrap_sql)
             .await
@@ -1620,7 +1561,7 @@ mod time_interval_e2e {
             .await
             .unwrap();
 
-        let plan = time_interval_plan("2026-04-07");
+        let plan = time_interval_ir("2026-04-07");
         execute_partition(&adapter, &plan).await;
 
         // The 04-07 00:00:00 row is INSIDE the window. The 04-08 00:00:00

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -21,45 +21,6 @@ use tempfile::TempDir;
 // Helpers
 // ===========================================================================
 
-/// Lift a [`ReplicationPlan`] into a [`ModelIr`] for testing.
-fn rep_ir(plan: &ReplicationPlan) -> ModelIr {
-    ModelIr::replication(
-        plan.target.clone(),
-        plan.strategy.clone(),
-        plan.source.clone(),
-        plan.columns.clone(),
-        plan.metadata_columns.clone(),
-        plan.governance.clone(),
-    )
-}
-
-/// Lift a [`TransformationPlan`] into a [`ModelIr`] for testing.
-#[allow(dead_code)]
-fn xform_ir(plan: &TransformationPlan) -> ModelIr {
-    ModelIr::transformation(
-        plan.target.clone(),
-        plan.strategy.clone(),
-        plan.sources.clone(),
-        plan.sql.clone(),
-        plan.governance.clone(),
-        plan.format.clone(),
-        plan.format_options.clone(),
-    )
-}
-
-/// Lift a [`SnapshotPlan`] into a [`ModelIr`] for testing.
-#[allow(dead_code)]
-fn snap_ir(plan: &SnapshotPlan) -> ModelIr {
-    ModelIr::snapshot(
-        plan.target.clone(),
-        plan.source.clone(),
-        plan.unique_key.clone(),
-        plan.updated_at.clone(),
-        plan.invalidate_hard_deletes,
-        plan.governance.clone(),
-    )
-}
-
 fn dialect() -> DuckDbSqlDialect {
     DuckDbSqlDialect
 }
@@ -71,36 +32,36 @@ fn temp_state() -> (StateStore, TempDir) {
     (store, dir)
 }
 
-/// Build a replication plan for DuckDB (flat tables, no catalog prefixes).
-fn duckdb_replication_plan(
+/// Build a replication [`ModelIr`] for DuckDB (flat tables, no catalog prefixes).
+fn duckdb_replication_ir(
     source_table: &str,
     target_table: &str,
     strategy: MaterializationStrategy,
-) -> ReplicationPlan {
-    ReplicationPlan {
-        source: SourceRef {
-            catalog: String::new(),
-            schema: "source".into(),
-            table: source_table.into(),
-        },
-        target: TargetRef {
+) -> ModelIr {
+    ModelIr::replication(
+        TargetRef {
             catalog: String::new(),
             schema: "target".into(),
             table: target_table.into(),
         },
         strategy,
-        columns: ColumnSelection::All,
-        metadata_columns: vec![MetadataColumn {
+        SourceRef {
+            catalog: String::new(),
+            schema: "source".into(),
+            table: source_table.into(),
+        },
+        ColumnSelection::All,
+        vec![MetadataColumn {
             name: "_loaded_by".into(),
             data_type: "VARCHAR".into(),
             value: "NULL".into(),
         }],
-        governance: GovernanceConfig {
+        GovernanceConfig {
             permissions_file: None,
             auto_create_catalogs: false,
             auto_create_schemas: false,
         },
-    }
+    )
 }
 
 // ===========================================================================
@@ -137,8 +98,8 @@ async fn test_full_pipeline_lifecycle() {
     .unwrap();
 
     // Generate and execute full refresh SQL
-    let plan = duckdb_replication_plan("orders", "orders", MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
+    let plan = duckdb_replication_ir("orders", "orders", MaterializationStrategy::FullRefresh);
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     // Verify data was copied
@@ -188,8 +149,8 @@ async fn test_incremental_pipeline_two_runs() {
     .unwrap();
 
     // Run 1: full refresh (no watermark)
-    let plan1 = duckdb_replication_plan("events", "events", MaterializationStrategy::FullRefresh);
-    let sql1 = sql_gen::generate_create_table_as_sql(&rep_ir(&plan1), &d).unwrap();
+    let plan1 = duckdb_replication_ir("events", "events", MaterializationStrategy::FullRefresh);
+    let sql1 = sql_gen::generate_create_table_as_sql(&plan1, &d).unwrap();
     p.execute(&sql1).await.unwrap();
     assert_eq!(p.row_count("target.events").await.unwrap(), 2);
 
@@ -215,14 +176,14 @@ async fn test_incremental_pipeline_two_runs() {
     // from the state store at SQL-generation time, not carried on the
     // strategy.
     let _wm = store.get_watermark("target.events").unwrap();
-    let plan2 = duckdb_replication_plan(
+    let plan2 = duckdb_replication_ir(
         "events",
         "events",
         MaterializationStrategy::Incremental {
             timestamp_column: "_fivetran_synced".into(),
         },
     );
-    let sql2 = sql_gen::generate_insert_sql(&rep_ir(&plan2), &d).unwrap();
+    let sql2 = sql_gen::generate_insert_sql(&plan2, &d).unwrap();
     p.execute(&sql2).await.unwrap();
 
     // Should now have 4 rows (2 original + 2 new)
@@ -337,8 +298,8 @@ async fn test_pipeline_with_metadata_columns() {
         .await
         .unwrap();
 
-    let plan = duckdb_replication_plan("items", "items", MaterializationStrategy::FullRefresh);
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
+    let plan = duckdb_replication_ir("items", "items", MaterializationStrategy::FullRefresh);
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     // Verify _loaded_by column exists and is NULL
@@ -795,12 +756,12 @@ async fn test_full_refresh_on_seeded_data() {
         .unwrap();
 
     // Full refresh from seeded source
-    let plan = duckdb_replication_plan(
+    let plan = duckdb_replication_ir(
         "raw_orders",
         "raw_orders",
         MaterializationStrategy::FullRefresh,
     );
-    let sql = sql_gen::generate_create_table_as_sql(&rep_ir(&plan), &d).unwrap();
+    let sql = sql_gen::generate_create_table_as_sql(&plan, &d).unwrap();
     p.execute(&sql).await.unwrap();
 
     let source_count = p.row_count("source.raw_orders").await.unwrap();


### PR DESCRIPTION
## Summary

Final sub-PR of the Typed-IR migration. Removes the deprecated `Plan` materialisation layer entirely. `ModelIr` is now the sole transformation intermediate; `ir_hash` can be keyed on its canonical-JSON alone.

**Net diff: −1464 / +521 lines.**

## Why

Removing `Plan` unblocks content-addressed caching, deterministic replay, and the catalog-as-service / WASM-plugin tracks. All consumers were migrated off `Plan` in earlier sub-PRs; this PR removes the type and its associated scaffolding.

## Deletions

**`rocky-core/src/ir.rs`**
- `pub enum Plan { Replication, Transformation, Snapshot }`
- `pub struct ReplicationPlan`
- `pub struct TransformationPlan`
- `pub struct SnapshotPlan`
- `pub fn ModelIr::as_replication() -> Option<ReplicationPlan>`
- `pub fn ModelIr::as_transformation() -> Option<TransformationPlan>`
- `pub fn ModelIr::as_snapshot() -> Option<SnapshotPlan>`
- `pub fn ModelIr::to_plan_compatible() -> Plan`
- `impl From<&Plan> for ModelIr`
- 9 round-trip / accessor-equivalence unit tests
- All `[Plan]` / `[*Plan]` doc-link references; replaced with `[ModelIrVariant::*]` where appropriate

**Production helpers**
- `Model::to_plan() -> TransformationPlan` deleted; its strategy-lowering logic inlined into `Model::to_model_ir()`, which now builds `ModelIr` directly from `self.config` and `self.sql`.
- `SnapshotConfig::to_plan() -> SnapshotPlan` deleted (had no callers — was a vestigial bridge for the now-gone `Plan` path). `SnapshotConfig` itself stays (parsed-pipeline-config for SCD2 snapshot generation).
- Three CLI call sites that used `model.to_plan().target` for table refs migrated to direct `model.config.target.X` reads (`commands/plan.rs`, `commands/run.rs`, `commands/retention_status.rs`).

## Surface that survives

- `ModelIr` (unchanged shape)
- `ModelIr::replication / transformation / snapshot` direct constructors (introduced PRs #485, #486)
- `ModelIr::variant()` + `ModelIrVariant` enum (introduced PR #483)
- `ModelIr::is_snapshot_shaped()` (private; sole inference-rule source)

## Test fixture migration

| File | Tests | Pattern |
|---|---|---|
| `rocky-core/src/sql_gen.rs` (test module) | 51 | `sample_*_plan` → `sample_*_ir`. Struct-update syntax `..sample_full_refresh_plan()` → `let mut ir = sample_full_refresh_ir(); ir.X = ...`. `rep_ir/xform_ir/snap_ir` lifters deleted. |
| `rocky-core/tests/e2e.rs` | 30 | Same. The inner `time_interval_e2e` module's helpers (`xform_ir`, `time_interval_plan`) collapse to `time_interval_ir` returning `ModelIr` directly. |
| `rocky-core/tests/integration.rs` | 20 | Same; `duckdb_replication_plan` → `duckdb_replication_ir`. |

## Byte-stability invariant preserved

The named constructors (added in earlier sub-PRs) produce ModelIrs that are canonical-JSON-equal to the `From<&Plan>`-built equivalents. The four `ir_golden` integration tests continue to pass:
- `ir_round_trip_byte_stable`
- `ir_recipe_hash_pinned`
- `ir_json_matches_snapshot`
- `ir_sql_per_dialect`

The snapshot fixtures (`ir.json`, `<dialect>.sql`) are byte-identical across this refactor.

## Test plan

- [x] `cargo test -p rocky-core --lib` — 1194 passed
- [x] `cargo test -p rocky-core --test e2e` — 30 passed
- [x] `cargo test -p rocky-core --test integration` — 20 passed
- [x] `cargo test -p rocky-cli --lib` — 376 passed
- [x] `cargo test -p rocky-cli --test ir_golden` — 4 passed (snapshot byte-stability + recipe-hash pin)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --workspace` — clean
- [x] `examples/playground/pocs/00-foundations/00-playground-default/run.sh` — green

## No external API changes

`Plan` and the `*Plan` structs never derived `JsonSchema`. No `schemas/*.schema.json`, Pydantic, or TypeScript bindings change. `just codegen` not required.