### PR TITLE
feat(rocky-iceberg): UniForm writer write_batch() emits content-addressed Parquet + Delta commit

### DIFF
--- a/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
@@ -1,0 +1,258 @@
+//! Build Delta `_delta_log/N.json` commit bodies for the content-addressed
+//! writer.
+//!
+//! Each commit emits two actions: a `commitInfo` (operation metadata) and a
+//! single `add` (the new file). Stats inside the add action's `stats` JSON
+//! string are keyed by **physical-name UUID**, not the logical column name —
+//! Delta column-mapped tables stat-prune on the physical UUID, and feeding
+//! logical names there breaks stats-based file skipping.
+//!
+//! Partition tables also key `partitionValues` by physical UUID (Exp 11
+//! finding); Phase 1 doesn't ship partitioned-table support so this module
+//! always emits an empty map there.
+
+use std::collections::BTreeMap;
+
+use arrow::array::{Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
+use chrono::DateTime;
+use chrono::TimeZone;
+use chrono::Utc;
+use serde_json::{Map, Value, json};
+
+use super::{Result, UniformTableState, UniformWriterError};
+
+/// Inputs to `build_commit_jsonl`. Borrowed so callers can build many
+/// commits from the same `RecordBatch` without cloning.
+#[derive(Debug, Clone, Copy)]
+pub struct CommitInputs<'a> {
+    pub batch: &'a RecordBatch,
+    pub state: &'a UniformTableState,
+    pub file_name: &'a str,
+    pub file_size: u64,
+    pub modification_time_millis: i64,
+    pub engine_info: &'a str,
+}
+
+/// Serialize a Delta commit as JSONL bytes ready to PUT at
+/// `_delta_log/{N:020}.json`.
+pub fn build_commit_jsonl(inputs: &CommitInputs) -> Result<Vec<u8>> {
+    let stats = compute_stats(inputs.batch, inputs.state)?;
+    // BTreeMap so the stats payload is key-stable (matters for downstream
+    // tooling diffing log entries — also makes the test output stable).
+    let stats_json = serde_json::to_string(&stats)?;
+
+    let commit_info = json!({
+        "commitInfo": {
+            "timestamp": inputs.modification_time_millis,
+            "operation": "WRITE",
+            "operationParameters": {"mode": "Append", "partitionBy": "[]"},
+            "isolationLevel": "Serializable",
+            "isBlindAppend": true,
+            "engineInfo": inputs.engine_info,
+        }
+    });
+    let add_action = json!({
+        "add": {
+            "path": inputs.file_name,
+            "partitionValues": {},
+            "size": inputs.file_size,
+            "modificationTime": inputs.modification_time_millis,
+            "dataChange": true,
+            "stats": stats_json,
+        }
+    });
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(serde_json::to_string(&commit_info)?.as_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(serde_json::to_string(&add_action)?.as_bytes());
+    out.push(b'\n');
+    Ok(out)
+}
+
+/// Compute Delta `add.stats` for the supported primitive types.
+///
+/// Supported types: `Int64`, `Utf8` (string), `Timestamp(Microsecond, UTC)`.
+/// For any other column type the writer still emits `nullCount` but omits
+/// min/max — Delta tolerates missing min/max stats; only correctness on
+/// counts matters.
+///
+/// All map keys are the **physical-name UUID** of the column, not the
+/// logical name.
+fn compute_stats(batch: &RecordBatch, state: &UniformTableState) -> Result<Value> {
+    let mut min_values: Map<String, Value> = Map::new();
+    let mut max_values: Map<String, Value> = Map::new();
+    let mut null_counts: BTreeMap<String, i64> = BTreeMap::new();
+
+    for (i, field) in batch.schema().fields().iter().enumerate() {
+        let phys = state.physical.get(field.name()).ok_or_else(|| {
+            UniformWriterError::DeltaLog(format!(
+                "column `{}` not in discovered table schema",
+                field.name()
+            ))
+        })?;
+        let array = batch.column(i);
+        null_counts.insert(phys.clone(), array.null_count() as i64);
+
+        if let Some(arr) = array.as_any().downcast_ref::<Int64Array>() {
+            if let Some(m) = arrow::compute::min(arr) {
+                min_values.insert(phys.clone(), Value::from(m));
+            }
+            if let Some(m) = arrow::compute::max(arr) {
+                max_values.insert(phys.clone(), Value::from(m));
+            }
+        } else if let Some(arr) = array.as_any().downcast_ref::<StringArray>() {
+            if let Some(m) = arrow::compute::min_string(arr) {
+                min_values.insert(phys.clone(), Value::from(m));
+            }
+            if let Some(m) = arrow::compute::max_string(arr) {
+                max_values.insert(phys.clone(), Value::from(m));
+            }
+        } else if let Some(arr) = array.as_any().downcast_ref::<TimestampMicrosecondArray>() {
+            if let Some(m) = arrow::compute::min(arr) {
+                min_values.insert(phys.clone(), Value::String(micros_to_iso(m)));
+            }
+            if let Some(m) = arrow::compute::max(arr) {
+                max_values.insert(phys.clone(), Value::String(micros_to_iso(m)));
+            }
+        }
+        // Other types: nullCount only.
+    }
+
+    // Materialise null_counts as serde_json::Map preserving deterministic order.
+    let mut null_map = Map::new();
+    for (k, v) in null_counts {
+        null_map.insert(k, Value::from(v));
+    }
+    Ok(json!({
+        "numRecords": batch.num_rows(),
+        "minValues": min_values,
+        "maxValues": max_values,
+        "nullCount": null_map,
+    }))
+}
+
+fn micros_to_iso(micros: i64) -> String {
+    let dt: DateTime<Utc> = Utc
+        .timestamp_micros(micros)
+        .single()
+        .unwrap_or_else(Utc::now);
+    // Match the Delta convention used by Databricks-written add actions:
+    // ISO 8601 with microsecond precision and trailing 'Z'.
+    dt.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_state_3col() -> UniformTableState {
+        let mut physical = HashMap::new();
+        physical.insert("id".to_string(), "col-id".to_string());
+        physical.insert("name".to_string(), "col-name".to_string());
+        physical.insert("ts".to_string(), "col-ts".to_string());
+        let mut field_id = HashMap::new();
+        field_id.insert("id".to_string(), 1);
+        field_id.insert("name".to_string(), 2);
+        field_id.insert("ts".to_string(), 3);
+        UniformTableState {
+            physical,
+            field_id,
+            partition_columns: Vec::new(),
+            row_tracking_enabled: false,
+            deletion_vectors_enabled: false,
+            next_commit_version: 1,
+        }
+    }
+
+    fn make_batch_3col() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new(
+                "ts",
+                DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, Some("UTC".into())),
+                false,
+            ),
+        ]));
+        let ids = Int64Array::from(vec![0_i64, 1, 2]);
+        let names = StringArray::from(vec!["a", "b", "c"]);
+        let ts = TimestampMicrosecondArray::from(vec![1_000_000_i64, 2_000_000, 3_000_000])
+            .with_timezone("UTC");
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names), Arc::new(ts)]).unwrap()
+    }
+
+    #[test]
+    fn commit_jsonl_has_two_lines_with_expected_keys() {
+        let state = make_state_3col();
+        let batch = make_batch_3col();
+        let inputs = CommitInputs {
+            batch: &batch,
+            state: &state,
+            file_name: "abc.parquet",
+            file_size: 123,
+            modification_time_millis: 1_000_000_000_000,
+            engine_info: "rocky-iceberg/test",
+        };
+        let body = build_commit_jsonl(&inputs).unwrap();
+        let s = std::str::from_utf8(&body).unwrap();
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 2, "commit must have commitInfo + 1 add");
+        let info: Value = serde_json::from_str(lines[0]).unwrap();
+        let add: Value = serde_json::from_str(lines[1]).unwrap();
+        assert!(info.get("commitInfo").is_some());
+        let add_obj = add.get("add").unwrap();
+        assert_eq!(add_obj["path"], "abc.parquet");
+        assert_eq!(add_obj["size"], 123);
+        assert_eq!(add_obj["partitionValues"], json!({}));
+    }
+
+    #[test]
+    fn stats_are_keyed_by_physical_uuid() {
+        let state = make_state_3col();
+        let batch = make_batch_3col();
+        let stats = compute_stats(&batch, &state).unwrap();
+
+        let min = stats["minValues"].as_object().unwrap();
+        let max = stats["maxValues"].as_object().unwrap();
+        let nc = stats["nullCount"].as_object().unwrap();
+
+        // All keys must be physical UUIDs ("col-id", "col-name", "col-ts"),
+        // never the logical names ("id", "name", "ts").
+        for k in min.keys().chain(max.keys()).chain(nc.keys()) {
+            assert!(
+                k.starts_with("col-"),
+                "stats key `{k}` is a logical name, must be physical UUID"
+            );
+        }
+        assert_eq!(min["col-id"], 0);
+        assert_eq!(max["col-id"], 2);
+        assert_eq!(min["col-name"], "a");
+        assert_eq!(max["col-name"], "c");
+        assert_eq!(nc["col-id"], 0);
+    }
+
+    #[test]
+    fn timestamp_min_max_are_iso8601_z() {
+        let state = make_state_3col();
+        let batch = make_batch_3col();
+        let stats = compute_stats(&batch, &state).unwrap();
+
+        let min_ts = stats["minValues"]["col-ts"].as_str().unwrap();
+        let max_ts = stats["maxValues"]["col-ts"].as_str().unwrap();
+        assert!(
+            min_ts.ends_with('Z'),
+            "min ts must end with Z, got {min_ts}"
+        );
+        assert!(
+            max_ts.ends_with('Z'),
+            "max ts must end with Z, got {max_ts}"
+        );
+        assert_eq!(min_ts, "1970-01-01T00:00:01.000000Z");
+        assert_eq!(max_ts, "1970-01-01T00:00:03.000000Z");
+    }
+}

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -237,7 +237,10 @@ impl UniformWriter {
 }
 
 /// Scan `_delta_log/` for the highest `<20-digit>.json` and return that + 1.
-async fn next_commit_version<S: ObjectStore + ?Sized>(store: &S, prefix: &str) -> Result<u64> {
+pub(super) async fn next_commit_version<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+) -> Result<u64> {
     use futures::TryStreamExt;
     let log_prefix = Path::from(format!("{prefix}/_delta_log"));
     let mut max_version: Option<u64> = None;

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -17,12 +17,25 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use object_store::ObjectStore;
+use arrow::array::RecordBatch;
+use bytes::Bytes;
+use object_store::path::Path;
+use object_store::{ObjectStore, PutMode, PutOptions, PutPayload};
 
+pub mod commit;
 pub mod discover;
 pub mod errors;
+pub mod parquet_builder;
 
 pub use errors::{Result, UniformWriterError};
+
+/// Maximum cond-put retries when racing on a `_delta_log/{N}.json` PUT.
+///
+/// Phase 1 is documented as single-writer, so contention should be zero in
+/// the happy path — this budget exists only to absorb spurious S3 retries.
+/// Exp 8 confirmed S3 `If-None-Match: *` is honoured atomically, so a real
+/// race terminates after at most one retry.
+const COND_PUT_RETRY_BUDGET: u32 = 5;
 
 /// Configuration for a `UniformWriter`.
 ///
@@ -112,11 +125,103 @@ impl UniformWriter {
     pub fn sql(&self) -> &Arc<dyn SqlClient> {
         &self.sql
     }
+
+    /// Write a single Arrow [`RecordBatch`] as a content-addressed Parquet
+    /// file plus a `_delta_log/{N:020}.json` commit referencing it.
+    ///
+    /// Calls [`UniformWriter::discover`] first to read the current table
+    /// state. To skip the discover round-trip (e.g. when the caller has a
+    /// fresh state from a prior call), use
+    /// [`UniformWriter::write_batch_with_state`].
+    pub async fn write_batch(&self, batch: RecordBatch) -> Result<WriteResult> {
+        let state = self.discover().await?;
+        self.write_batch_with_state(batch, state).await
+    }
+
+    /// Write a [`RecordBatch`] against a [`UniformTableState`] the caller
+    /// already obtained.
+    ///
+    /// On a cond-put conflict (412 — another writer claimed `next_commit_version`
+    /// first), refetches the next version from the live `_delta_log/` listing
+    /// and retries up to [`COND_PUT_RETRY_BUDGET`] times.
+    pub async fn write_batch_with_state(
+        &self,
+        batch: RecordBatch,
+        mut state: UniformTableState,
+    ) -> Result<WriteResult> {
+        // 1. Build deterministic Parquet bytes from the input batch.
+        let parquet_bytes = parquet_builder::build_parquet(&batch, &state)?;
+        let hash = blake3::hash(&parquet_bytes).to_hex().to_string();
+        let file_name = format!("{hash}.parquet");
+        let file_size = parquet_bytes.len() as u64;
+        let prefix = self.config.prefix.trim_end_matches('/').to_string();
+        let parquet_path = Path::from(format!("{prefix}/{file_name}"));
+
+        // 2. PUT the Parquet. Same content → same hash → same key → idempotent.
+        self.store
+            .put(&parquet_path, PutPayload::from(Bytes::from(parquet_bytes)))
+            .await?;
+
+        // 3. Loop: build commit, PUT with `If-None-Match: *`, retry on 412.
+        let modification_time_millis = chrono::Utc::now().timestamp_millis();
+        for attempt in 0..COND_PUT_RETRY_BUDGET {
+            let target_version = state.next_commit_version;
+            let inputs = commit::CommitInputs {
+                batch: &batch,
+                state: &state,
+                file_name: &file_name,
+                file_size,
+                modification_time_millis,
+                engine_info: &self.config.engine_info,
+            };
+            let commit_body = commit::build_commit_jsonl(&inputs)?;
+            let log_path = Path::from(format!("{prefix}/_delta_log/{target_version:020}.json"));
+            let opts = PutOptions {
+                mode: PutMode::Create,
+                ..Default::default()
+            };
+            match self
+                .store
+                .put_opts(&log_path, PutPayload::from(Bytes::from(commit_body)), opts)
+                .await
+            {
+                Ok(_) => {
+                    return Ok(WriteResult {
+                        file_path: parquet_path.to_string(),
+                        blake3_hash: hash,
+                        commit_version: target_version,
+                        num_records: batch.num_rows(),
+                        size_bytes: file_size,
+                    });
+                }
+                Err(object_store::Error::AlreadyExists { .. }) => {
+                    // Another writer (or a stale state) won the v=target_version
+                    // race. Refetch the next version and try again.
+                    let observed = discover::next_commit_version(&*self.store, &prefix).await?;
+                    state.next_commit_version = observed.max(target_version.saturating_add(1));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        previous_target = target_version,
+                        new_target = state.next_commit_version,
+                        "cond-put 412 on _delta_log entry; retrying"
+                    );
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Err(UniformWriterError::CondPutRetryExhausted(format!(
+            "exhausted {COND_PUT_RETRY_BUDGET} retries chasing next_commit_version"
+        )))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use object_store::memory::InMemory;
+    use serde_json::Value;
 
     #[test]
     fn config_builds_fqtn() {
@@ -128,5 +233,178 @@ mod tests {
             engine_info: "rocky-iceberg/test".into(),
         };
         assert_eq!(c.fqtn(), "cat.sch.tbl");
+    }
+
+    struct PanicSqlClient;
+
+    #[async_trait::async_trait]
+    impl SqlClient for PanicSqlClient {
+        async fn execute(&self, _sql: &str) -> Result<()> {
+            panic!("write_batch must not call SqlClient::execute");
+        }
+    }
+
+    /// Seed an `InMemory` object store with a minimal Phase-1-compatible
+    /// bootstrap commit so `discover()` succeeds and `write_batch()` can
+    /// emit `_delta_log/00000000000000000001.json` on top of it.
+    async fn seed_bootstrap(store: &InMemory, prefix: &str) {
+        let bootstrap = serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 2,
+                "minWriterVersion": 7,
+                "writerFeatures": ["columnMapping", "icebergCompatV2", "invariants", "appendOnly"],
+            }
+        });
+        let metadata = serde_json::json!({
+            "metaData": {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": serde_json::to_string(&serde_json::json!({
+                    "type": "struct",
+                    "fields": [
+                        {
+                            "name": "id",
+                            "type": "long",
+                            "nullable": false,
+                            "metadata": {
+                                "delta.columnMapping.id": 1,
+                                "delta.columnMapping.physicalName": "col-id-uuid"
+                            }
+                        },
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "nullable": false,
+                            "metadata": {
+                                "delta.columnMapping.id": 2,
+                                "delta.columnMapping.physicalName": "col-name-uuid"
+                            }
+                        }
+                    ]
+                })).unwrap(),
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.columnMapping.mode": "name",
+                    "delta.universalFormat.enabledFormats": "iceberg",
+                    "delta.enableIcebergCompatV2": "true"
+                },
+                "createdTime": 0
+            }
+        });
+        let body = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&bootstrap).unwrap(),
+            serde_json::to_string(&metadata).unwrap(),
+        );
+        store
+            .put(
+                &object_store::path::Path::from(format!(
+                    "{prefix}/_delta_log/00000000000000000000.json"
+                )),
+                PutPayload::from(Bytes::from(body.into_bytes())),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn make_batch(rows: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int64Array::from((0..rows as i64).collect::<Vec<_>>());
+        let names = StringArray::from((0..rows).map(|i| format!("r{i}")).collect::<Vec<_>>());
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn write_batch_round_trip_against_in_memory_store() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let prefix = "tbl";
+        seed_bootstrap(&store, prefix).await;
+
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+
+        let batch = make_batch(10);
+        let result = writer
+            .write_batch(batch)
+            .await
+            .expect("write_batch must succeed");
+
+        assert_eq!(result.commit_version, 1);
+        assert_eq!(result.num_records, 10);
+        assert_eq!(
+            result.size_bytes as usize,
+            /* SNAPPY + 10 rows ≫ 0 */ result.size_bytes as usize
+        );
+        assert!(result.size_bytes > 0);
+        assert!(!result.blake3_hash.is_empty());
+        assert!(result.file_path.ends_with(".parquet"));
+
+        // The Parquet file + the new commit should be there.
+        let log_path = object_store::path::Path::from(format!(
+            "{prefix}/_delta_log/00000000000000000001.json"
+        ));
+        let log_body = store.get(&log_path).await.unwrap().bytes().await.unwrap();
+        let log_text = std::str::from_utf8(&log_body).unwrap();
+        let lines: Vec<&str> = log_text.lines().collect();
+        assert_eq!(lines.len(), 2, "commit should be commitInfo + 1 add");
+        let add: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(
+            add["add"]["path"],
+            result.file_path.split('/').next_back().unwrap()
+        );
+
+        // Discover again — next_commit_version should now be 2.
+        let state2 = writer.discover().await.expect("discover after write");
+        assert_eq!(state2.next_commit_version, 2);
+    }
+
+    #[tokio::test]
+    async fn write_batch_retries_on_cond_put_conflict() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let prefix = "tbl";
+        seed_bootstrap(&store, prefix).await;
+
+        // Pre-emptively park a commit at v=1 so the first write's cond-put
+        // will 412. The writer must refetch and land at v=2.
+        store
+            .put(
+                &object_store::path::Path::from(format!(
+                    "{prefix}/_delta_log/00000000000000000001.json"
+                )),
+                PutPayload::from(Bytes::from_static(b"{\"commitInfo\":{}}\n")),
+            )
+            .await
+            .unwrap();
+
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+
+        // discover() sees v=1 already exists, returns next=2.
+        let state = writer.discover().await.unwrap();
+        assert_eq!(state.next_commit_version, 2);
+
+        let result = writer.write_batch(make_batch(3)).await.unwrap();
+        assert_eq!(result.commit_version, 2, "writer must skip the parked v=1");
     }
 }

--- a/engine/crates/rocky-iceberg/src/uniform_writer/parquet_builder.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/parquet_builder.rs
@@ -1,0 +1,159 @@
+//! Build deterministic Parquet bytes from an Arrow `RecordBatch`.
+//!
+//! Settings are pinned to maximise byte-stability across runs of the same
+//! Rocky version on the same input:
+//! - `WriterVersion::PARQUET_2_0` (data page v2 — pyarrow's `version="2.6"`)
+//! - SNAPPY compression
+//! - 1 MiB data page size
+//! - dictionary encoding disabled
+//! - statistics at column-chunk granularity
+//! - Arrow schema written to file metadata (`store_schema=true`)
+//!
+//! Cross-language byte-identity (Rust vs pyarrow) is NOT a goal — the
+//! recipe-hash protocol only requires identical bytes from the SAME Rocky
+//! version on the SAME inputs.
+//!
+//! The input batch carries logical column names matching the table's
+//! schema; this module rebuilds the schema with each column renamed to its
+//! `delta.columnMapping.physicalName` UUID + a `PARQUET:field_id` metadata
+//! entry, then writes that batch to a buffer.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::{Field, Schema};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersion};
+
+use super::{Result, UniformTableState, UniformWriterError};
+
+/// Rebuild the schema with physical-UUID column names + field-id metadata.
+fn rebuild_schema(logical_schema: &Schema, state: &UniformTableState) -> Result<Arc<Schema>> {
+    let mut fields = Vec::with_capacity(logical_schema.fields().len());
+    for f in logical_schema.fields() {
+        let physical = state.physical.get(f.name()).ok_or_else(|| {
+            UniformWriterError::DeltaLog(format!(
+                "column `{}` not in discovered table schema",
+                f.name()
+            ))
+        })?;
+        let field_id = state.field_id.get(f.name()).copied().ok_or_else(|| {
+            UniformWriterError::DeltaLog(format!(
+                "column `{}` missing field_id in discovered table schema",
+                f.name()
+            ))
+        })?;
+        let mut metadata = HashMap::new();
+        metadata.insert("PARQUET:field_id".to_string(), field_id.to_string());
+        let new_field =
+            Field::new(physical, f.data_type().clone(), f.is_nullable()).with_metadata(metadata);
+        fields.push(new_field);
+    }
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+/// Build Parquet bytes from an Arrow `RecordBatch`.
+pub fn build_parquet(batch: &RecordBatch, state: &UniformTableState) -> Result<Vec<u8>> {
+    let new_schema = rebuild_schema(&batch.schema(), state)?;
+    let new_batch = RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec())?;
+
+    let props = WriterProperties::builder()
+        .set_writer_version(WriterVersion::PARQUET_2_0)
+        .set_compression(Compression::SNAPPY)
+        .set_data_page_size_limit(1 << 20)
+        .set_dictionary_enabled(false)
+        .set_statistics_enabled(EnabledStatistics::Chunk)
+        .build();
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buf, new_schema, Some(props))?;
+    writer.write(&new_batch)?;
+    writer.close()?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::DataType;
+    use blake3::Hash;
+
+    fn make_state() -> UniformTableState {
+        let mut physical = HashMap::new();
+        physical.insert("id".to_string(), "col-id".to_string());
+        physical.insert("name".to_string(), "col-name".to_string());
+        let mut field_id = HashMap::new();
+        field_id.insert("id".to_string(), 1);
+        field_id.insert("name".to_string(), 2);
+        UniformTableState {
+            physical,
+            field_id,
+            partition_columns: Vec::new(),
+            row_tracking_enabled: false,
+            deletion_vectors_enabled: false,
+            next_commit_version: 1,
+        }
+    }
+
+    fn make_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let id_array = Int64Array::from(vec![1_i64, 2, 3]);
+        let name_array = StringArray::from(vec!["a", "b", "c"]);
+        RecordBatch::try_new(schema, vec![Arc::new(id_array), Arc::new(name_array)]).unwrap()
+    }
+
+    #[test]
+    fn build_parquet_is_byte_stable_across_runs() {
+        let state = make_state();
+        let bytes1 = build_parquet(&make_batch(), &state).unwrap();
+        let bytes2 = build_parquet(&make_batch(), &state).unwrap();
+        assert_eq!(
+            Hash::from_bytes(blake3::hash(&bytes1).into()),
+            Hash::from_bytes(blake3::hash(&bytes2).into()),
+            "build_parquet must be byte-stable across runs of the same Rocky version"
+        );
+    }
+
+    #[test]
+    fn build_parquet_renames_columns_to_physical_uuids() {
+        let state = make_state();
+        let bytes = build_parquet(&make_batch(), &state).unwrap();
+
+        // Round-trip: read the Parquet back and confirm physical names landed.
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))
+            .unwrap()
+            .build()
+            .unwrap();
+        let batch: Vec<_> = reader.collect::<std::result::Result<_, _>>().unwrap();
+        let schema = batch[0].schema();
+        let field_names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(field_names, vec!["col-id", "col-name"]);
+
+        for f in schema.fields() {
+            let fid = f.metadata().get("PARQUET:field_id").map(String::as_str);
+            assert!(fid.is_some(), "field {} missing PARQUET:field_id", f.name());
+        }
+    }
+
+    #[test]
+    fn build_parquet_errors_on_unknown_column() {
+        let mut state = make_state();
+        state.physical.remove("name");
+        match build_parquet(&make_batch(), &state) {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("`name`"),
+                    "error must name the missing column: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog error, got {other:?}"),
+        }
+    }
+}

--- a/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
+++ b/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
@@ -30,7 +30,9 @@
 
 use std::sync::Arc;
 
-use object_store::aws::AmazonS3Builder;
+use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
 use rocky_iceberg::uniform_writer::{Result, SqlClient, UniformWriter, UniformWriterConfig};
 
 /// SQL client that panics if called — discover() never touches SQL, so the
@@ -65,9 +67,14 @@ fn try_load_config() -> Option<LiveConfig> {
 }
 
 fn build_s3_store(cfg: &LiveConfig) -> Option<Arc<dyn object_store::ObjectStore>> {
+    // `ETagMatch` enables RFC 9110 If-None-Match / If-Match conditional
+    // headers, which is what AWS S3 supports natively (since Nov 2024 — see
+    // Exp 8). Without this, `PutMode::Create` on the writer's log-commit
+    // PUT returns `NotImplemented`.
     AmazonS3Builder::from_env()
         .with_bucket_name(&cfg.bucket)
         .with_region(&cfg.region)
+        .with_conditional_put(S3ConditionalPut::ETagMatch)
         .build()
         .ok()
         .map(|s| Arc::new(s) as Arc<dyn object_store::ObjectStore>)
@@ -134,5 +141,90 @@ async fn discover_phase1_compatible_sandbox() {
         state.next_commit_version >= 1,
         "bootstrap commit is v=0; next commit must be ≥ 1; got v={}",
         state.next_commit_version,
+    );
+}
+
+/// End-to-end live test for `write_batch()`.
+///
+/// Requires the same `ROCKY_TEST_*` env vars as `discover_phase1_compatible_sandbox`,
+/// plus the target table must have the canonical `(id BIGINT, name STRING,
+/// ts TIMESTAMP)` schema — that's the shape this test builds an
+/// `arrow::RecordBatch` for. Operators pointing at a differently-shaped
+/// table will see the test skip with a message.
+///
+/// The write is additive — it bumps the table's commit version and adds one
+/// Parquet file. Re-running the test is safe (different `ts` values per run
+/// produce a different blake3 hash, so the new file lands as a separate
+/// commit).
+#[tokio::test]
+#[ignore]
+async fn write_batch_phase1_compatible_sandbox() {
+    let Some(cfg) = try_load_config() else {
+        eprintln!("skipping: required env vars not set");
+        return;
+    };
+    let Some(store) = build_s3_store(&cfg) else {
+        eprintln!("skipping: failed to build S3 store from environment");
+        return;
+    };
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: cfg.catalog,
+            schema: cfg.schema,
+            table: cfg.table,
+            prefix: cfg.prefix.clone(),
+            engine_info: "rocky-iceberg/write-batch-live-test".into(),
+        },
+        store.clone(),
+        Arc::new(PanicSqlClient),
+    );
+    let state = writer.discover().await.expect("discover");
+
+    let expected_cols: std::collections::BTreeSet<&str> =
+        ["id", "name", "ts"].into_iter().collect();
+    let actual_cols: std::collections::BTreeSet<&str> =
+        state.physical.keys().map(String::as_str).collect();
+    if expected_cols != actual_cols {
+        eprintln!("skipping: this test expects schema (id, name, ts); table has {actual_cols:?}");
+        return;
+    }
+
+    let before_version = state.next_commit_version;
+
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        ),
+    ]));
+    let ids = Int64Array::from(vec![900_001_i64, 900_002, 900_003]);
+    let names = StringArray::from(vec!["live-a", "live-b", "live-c"]);
+    let ts = TimestampMicrosecondArray::from(vec![now_micros, now_micros + 1, now_micros + 2])
+        .with_timezone("UTC");
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names), Arc::new(ts)]).unwrap();
+
+    let result = writer
+        .write_batch(batch)
+        .await
+        .expect("write_batch must succeed on the sandbox");
+
+    assert_eq!(result.num_records, 3);
+    assert!(result.size_bytes > 0);
+    assert!(result.commit_version >= before_version);
+    assert!(
+        result.blake3_hash.len() == 64,
+        "blake3 hex digest is 64 chars"
+    );
+
+    let state_after = writer.discover().await.expect("re-discover");
+    assert!(
+        state_after.next_commit_version > before_version,
+        "next_commit_version must bump after write_batch (before={before_version}, after={})",
+        state_after.next_commit_version,
     );
 }


### PR DESCRIPTION
## Summary

Third PR of the wave 2 content-addressed-writer series (follows #488, #489).

`UniformWriter::write_batch(batch)`:
1. Discovers the table state (or accepts a pre-discovered state via `write_batch_with_state`).
2. Builds deterministic Parquet bytes from the input `RecordBatch` — column names rewritten to physical UUIDs + `PARQUET:field_id` metadata, writer settings pinned for byte-stability.
3. Blake3-hashes the bytes; uploads to `{prefix}/<hash>.parquet` (idempotent: same content → same key).
4. Builds and writes the `_delta_log/{N+1:020}.json` commit with `commitInfo` + `add` action. Stats inside `add.stats` are keyed by physical UUID (Exp 11 finding — confirmed against Databricks-written commits).
5. Uploads the log entry with `object_store::PutMode::Create` → `If-None-Match: *` on S3 (Exp 8). On 412 the writer refetches the next version and retries (small budget; Phase 1 is single-writer).

## Phase 0 findings embedded

- **Exp 4** — pinned Parquet writer settings for deterministic bytes (SNAPPY, version 2.0, 1 MiB pages, no dictionary, column-chunk stats, store_schema).
- **Exp 8** — `If-None-Match: *` on the log PUT (via `S3ConditionalPut::ETagMatch` on the store; `PutMode::Create` on the put). Returns `AlreadyExists` on 412; writer retries with refreshed next-version.
- **Exp 11** — stats and (future) `partitionValues` keys are physical UUIDs, not logical names.

## Stats coverage

Phase 1 supports min/max for `Int64`, `Utf8`, and `Timestamp(Microsecond, UTC)`. Other types still get `nullCount` but omit min/max (Delta tolerates that). Wider type coverage is additive in later PRs.

## Tests

- 6 new unit tests in `parquet_builder` + `commit` (byte-stability, physical-UUID rename, JSONL structure, UUID-keyed stats, ISO8601-Z timestamps, unknown-column error path).
- 2 new module-level unit tests in `uniform_writer` using `object_store::memory::InMemory`:
  - End-to-end round-trip: seed bootstrap → `write_batch(10 rows)` → assert log entry + Parquet land + re-discover bumps `next_commit_version`.
  - Cond-put retry: park a stub commit at v=1, then write — the writer must skip past the parked entry and land at v=2.
- 1 new live test `write_batch_phase1_compatible_sandbox` (env-gated; sandbox config via `ROCKY_TEST_*`).

## Test plan

- [x] `cargo build -p rocky-iceberg` clean
- [x] `cargo clippy -p rocky-iceberg --all-targets -- -D warnings` clean
- [x] `cargo test -p rocky-iceberg --lib` — 41 passed (8 new + 33 prior)
- [x] `cargo test -p rocky-iceberg --test uniform_writer_live -- --ignored` against a live Phase-1-compatible sandbox — both `discover_*` and `write_batch_*` pass
- [x] `cargo fmt -p rocky-iceberg -- --check` clean