### PR TITLE
feat(rocky-iceberg): UniForm writer sync_iceberg_metadata() + full round-trip test

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3954,6 +3954,7 @@ dependencies = [
  "percent-encoding",
  "reqwest",
  "rocky-core",
+ "rocky-databricks",
  "serde",
  "serde_json",
  "thiserror",

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -30,6 +30,10 @@ futures = { workspace = true }
 
 [dev-dependencies]
 wiremock = { workspace = true }
+# Live round-trip test wraps a real DatabricksConnector behind the writer's
+# SqlClient trait. Production wire-up will move to the CLI surface in a
+# follow-up; today this dep is dev-only.
+rocky-databricks = { path = "../rocky-databricks" }
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -213,6 +213,23 @@ impl UniformWriter {
             "exhausted {COND_PUT_RETRY_BUDGET} retries chasing next_commit_version"
         )))
     }
+
+    /// Trigger `MSCK REPAIR TABLE <fqtn> SYNC METADATA` on the warehouse so
+    /// UniForm regenerates the Iceberg metadata next to the table.
+    ///
+    /// Callers should run this after every successful [`Self::write_batch`]
+    /// so cross-engine readers (DuckDB iceberg_scan, Iceberg-aware Trino,
+    /// etc.) see the new commit. Photon reads via the Delta surface
+    /// directly and does not need MSCK.
+    ///
+    /// Phase 1 makes this a separate call so callers can batch multiple
+    /// writes and trigger one MSCK at the end. The default `write_batch`
+    /// path does not call it implicitly.
+    pub async fn sync_iceberg_metadata(&self) -> Result<()> {
+        let sql = format!("MSCK REPAIR TABLE {} SYNC METADATA", self.config.fqtn());
+        tracing::debug!(sql = %sql, "issuing MSCK REPAIR to sync iceberg metadata");
+        self.sql.execute(&sql).await
+    }
 }
 
 #[cfg(test)]
@@ -242,6 +259,40 @@ mod tests {
         async fn execute(&self, _sql: &str) -> Result<()> {
             panic!("write_batch must not call SqlClient::execute");
         }
+    }
+
+    /// Records every SQL statement issued for assertion in tests.
+    #[derive(Default)]
+    struct RecordingSqlClient {
+        log: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SqlClient for RecordingSqlClient {
+        async fn execute(&self, sql: &str) -> Result<()> {
+            self.log.lock().unwrap().push(sql.to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_iceberg_metadata_issues_msck_repair() {
+        let recorder = Arc::new(RecordingSqlClient::default());
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "cat".into(),
+                schema: "sch".into(),
+                table: "tbl".into(),
+                prefix: "p".into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            Arc::new(InMemory::new()) as Arc<dyn ObjectStore>,
+            recorder.clone(),
+        );
+        writer.sync_iceberg_metadata().await.unwrap();
+        let log = recorder.log.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0], "MSCK REPAIR TABLE cat.sch.tbl SYNC METADATA");
     }
 
     /// Seed an `InMemory` object store with a minimal Phase-1-compatible

--- a/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
+++ b/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
@@ -1,6 +1,7 @@
-//! Live-integration test for `UniformWriter::discover()`.
+//! Live-integration tests for `UniformWriter` against a real Databricks
+//! UniForm table + S3 prefix.
 //!
-//! Gated on `#[ignore]` + env vars so it only fires when the operator
+//! Gated on `#[ignore]` + env vars so they only fire when the operator
 //! deliberately opts in. The pattern matches
 //! `rocky-databricks/tests/integration.rs`.
 //!
@@ -14,14 +15,19 @@
 //! export ROCKY_TEST_CATALOG=<catalog>
 //! export ROCKY_TEST_SCHEMA=<schema>
 //! export ROCKY_TEST_TABLE=<table>
+//! # Databricks creds (only needed for the round_trip test):
+//! export DATABRICKS_HOST=<host>
+//! export DATABRICKS_HTTP_PATH=<http_path>
+//! export DATABRICKS_CLIENT_ID=<oauth_m2m_client_id>
+//! export DATABRICKS_CLIENT_SECRET=<oauth_m2m_client_secret>
 //! cargo test -p rocky-iceberg --test uniform_writer_live -- --ignored
 //! ```
 //!
 //! The target table must be an external Delta UniForm table with
 //! `delta.columnMapping.mode = 'name'`, unpartitioned, no rowTracking, and
 //! no deletion vectors — i.e. the shape this Phase 1 writer can serve. The
-//! test asserts `discover()` returns a `UniformTableState` consistent with
-//! those constraints; it does not write anything to the table.
+//! `round_trip` test additionally requires the canonical
+//! `(id BIGINT, name STRING, ts TIMESTAMP)` schema (id/name/ts).
 //!
 //! `object_store::AmazonS3Builder::from_env()` reads `AWS_ACCESS_KEY_ID` /
 //! `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`) but does NOT
@@ -33,7 +39,11 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
-use rocky_iceberg::uniform_writer::{Result, SqlClient, UniformWriter, UniformWriterConfig};
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+use rocky_iceberg::uniform_writer::{
+    Result, SqlClient, UniformWriter, UniformWriterConfig, UniformWriterError,
+};
 
 /// SQL client that panics if called — discover() never touches SQL, so the
 /// integration test wires this stub in place of the real warehouse client.
@@ -226,5 +236,177 @@ async fn write_batch_phase1_compatible_sandbox() {
         state_after.next_commit_version > before_version,
         "next_commit_version must bump after write_batch (before={before_version}, after={})",
         state_after.next_commit_version,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Full Phase 1 round-trip: discover → write_batch → sync_iceberg_metadata →
+// SELECT COUNT(*) via Photon.
+// ---------------------------------------------------------------------------
+
+/// `SqlClient` impl that wraps a real `DatabricksConnector` for use in the
+/// round-trip test. Production wire-up (e.g. a Rocky CLI command) will host
+/// the equivalent impl in a non-test crate; Phase 1 keeps it here so
+/// `rocky-iceberg` does not need a hard dep on `rocky-databricks`.
+struct DatabricksSqlClient {
+    connector: DatabricksConnector,
+}
+
+#[async_trait::async_trait]
+impl SqlClient for DatabricksSqlClient {
+    async fn execute(&self, sql: &str) -> Result<()> {
+        self.connector
+            .execute_statement(sql)
+            .await
+            .map(|_statement_id| ())
+            .map_err(|e| UniformWriterError::Sql(format!("{e}")))
+    }
+}
+
+fn connector_from_env() -> Option<DatabricksConnector> {
+    let host = std::env::var("DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+    Some(DatabricksConnector::new(
+        ConnectorConfig {
+            host,
+            warehouse_id,
+            timeout: std::time::Duration::from_secs(120),
+            retry: Default::default(),
+        },
+        auth,
+    ))
+}
+
+/// End-to-end Phase 1 round trip: write a content-addressed Parquet via
+/// `write_batch`, trigger MSCK via `sync_iceberg_metadata`, and confirm:
+///   - `SELECT COUNT(*)` via Photon bumped by the number of rows written
+///   - at least one `*.metadata.json` file appears under `metadata/`
+///     (proving MSCK regenerated the Iceberg side of UniForm)
+///
+/// Requires the same `ROCKY_TEST_*` + AWS env as the other live tests,
+/// plus `DATABRICKS_HOST` / `_HTTP_PATH` / `_CLIENT_ID` / `_CLIENT_SECRET`
+/// (or `DATABRICKS_TOKEN`).
+#[tokio::test]
+#[ignore]
+async fn round_trip_phase1_compatible_sandbox() {
+    let Some(cfg) = try_load_config() else {
+        eprintln!("skipping: ROCKY_TEST_* env vars not set");
+        return;
+    };
+    let Some(store) = build_s3_store(&cfg) else {
+        eprintln!("skipping: failed to build S3 store from environment");
+        return;
+    };
+    let Some(connector) = connector_from_env() else {
+        eprintln!("skipping: DATABRICKS_* env vars not set");
+        return;
+    };
+
+    let sql_client = Arc::new(DatabricksSqlClient { connector });
+    let fqtn = format!("{}.{}.{}", cfg.catalog, cfg.schema, cfg.table);
+    let count_sql = format!("SELECT COUNT(*) AS n FROM {fqtn}");
+
+    // Count BEFORE the write — uses the connector directly because the
+    // SqlClient trait only exposes execute (no row return).
+    let count_before = sql_client
+        .connector
+        .execute_sql(&count_sql)
+        .await
+        .expect("count before");
+    let n_before: i64 = count_before.rows[0][0]
+        .as_str()
+        .or_else(|| count_before.rows[0][0].as_i64().map(|_| ""))
+        .and_then(|s| s.parse().ok())
+        .or_else(|| count_before.rows[0][0].as_i64())
+        .expect("parse count as i64");
+
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: cfg.catalog.clone(),
+            schema: cfg.schema.clone(),
+            table: cfg.table.clone(),
+            prefix: cfg.prefix.clone(),
+            engine_info: "rocky-iceberg/round-trip-live-test".into(),
+        },
+        store.clone(),
+        sql_client.clone() as Arc<dyn SqlClient>,
+    );
+
+    let state = writer.discover().await.expect("discover");
+    let expected_cols: std::collections::BTreeSet<&str> =
+        ["id", "name", "ts"].into_iter().collect();
+    let actual_cols: std::collections::BTreeSet<&str> =
+        state.physical.keys().map(String::as_str).collect();
+    if expected_cols != actual_cols {
+        eprintln!("skipping: this test expects schema (id, name, ts); table has {actual_cols:?}");
+        return;
+    }
+
+    // Build a 3-row batch with a fresh ts per run so re-runs don't collide
+    // on blake3.
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        ),
+    ]));
+    let ids = Int64Array::from(vec![900_101_i64, 900_102, 900_103]);
+    let names = StringArray::from(vec!["round-trip-a", "round-trip-b", "round-trip-c"]);
+    let ts = TimestampMicrosecondArray::from(vec![now_micros, now_micros + 1, now_micros + 2])
+        .with_timezone("UTC");
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names), Arc::new(ts)]).unwrap();
+
+    let written = writer.write_batch(batch).await.expect("write_batch");
+    assert_eq!(written.num_records, 3);
+
+    writer
+        .sync_iceberg_metadata()
+        .await
+        .expect("MSCK REPAIR must succeed");
+
+    // Verify Photon sees the new rows.
+    let count_after = sql_client
+        .connector
+        .execute_sql(&count_sql)
+        .await
+        .expect("count after");
+    let n_after: i64 = count_after.rows[0][0]
+        .as_str()
+        .or_else(|| count_after.rows[0][0].as_i64().map(|_| ""))
+        .and_then(|s| s.parse().ok())
+        .or_else(|| count_after.rows[0][0].as_i64())
+        .expect("parse count as i64");
+    assert_eq!(
+        n_after,
+        n_before + 3,
+        "Photon count must bump by 3 (before={n_before}, after={n_after})"
+    );
+
+    // Verify a `metadata/*.metadata.json` exists after MSCK.
+    use futures::TryStreamExt;
+    let metadata_prefix = object_store::path::Path::from(format!("{}/metadata", cfg.prefix));
+    let mut metadata_json_count = 0_usize;
+    let mut stream = store.list(Some(&metadata_prefix));
+    while let Some(item) = stream.try_next().await.expect("list metadata") {
+        if item.location.as_ref().ends_with(".metadata.json") {
+            metadata_json_count += 1;
+        }
+    }
+    assert!(
+        metadata_json_count > 0,
+        "MSCK must have written at least one *.metadata.json file under metadata/"
     );
 }


### PR DESCRIPTION
## Summary

Fourth (and final) PR of the Phase 1 wave 2 series (follows #488, #489, #491). Closes the loop: `write_batch()` now has a companion `sync_iceberg_metadata()` that issues `MSCK REPAIR TABLE <fqtn> SYNC METADATA` via the writer's `SqlClient` trait, so UniForm regenerates the Iceberg side for cross-engine reads (DuckDB iceberg_scan, Iceberg-aware Trino, etc.).

Phase 1 keeps `sync_iceberg_metadata()` separate from `write_batch()` so callers can batch multiple writes and trigger one MSCK at the end. Photon reads via the Delta surface directly and does not need MSCK.

## Tests

**Unit (always runs):**
- `RecordingSqlClient` mock asserts the writer issues exactly `MSCK REPAIR TABLE <fqtn> SYNC METADATA` with no extra calls.

**Live (env-gated `#[ignore]`):**
- `round_trip_phase1_compatible_sandbox` wraps a real `DatabricksConnector` behind the `SqlClient` trait, runs the full pipeline (`discover` → `write_batch(3 rows)` → `sync_iceberg_metadata`) on a Phase-1-compatible UniForm table, and asserts:
  - `SELECT COUNT(*)` via Photon bumps by 3,
  - at least one `metadata/*.metadata.json` appears after MSCK.

## Crate coupling

The round-trip test wraps `DatabricksConnector` as `SqlClient`, so this PR adds `rocky-databricks` as a **dev-dependency** of `rocky-iceberg`. The production-side wire-up (a Rocky CLI command that materialises a model via this writer) is the deferred PR 5 of the Phase 1 plan; `rocky-iceberg`'s **public** surface stays free of any warehouse coupling.

## Test plan

- [x] `cargo build -p rocky-iceberg` clean
- [x] `cargo clippy -p rocky-iceberg --all-targets -- -D warnings` clean
- [x] `cargo test -p rocky-iceberg --lib` — 42 passed (1 new MSCK unit test + 41 prior)
- [x] `cargo test -p rocky-iceberg --test uniform_writer_live -- --ignored` against a live sandbox — 3 passed (discover + write_batch + round_trip)
- [x] `cargo fmt -p rocky-iceberg -- --check` clean