### PR TITLE
feat(rocky-iceberg): UniForm writer supports partitioned tables (Phase 2)

### DIFF
--- a/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
@@ -8,10 +8,11 @@
 //! logical names there breaks stats-based file skipping.
 //!
 //! Partition tables also key `partitionValues` by physical UUID (Exp 11
-//! finding); Phase 1 doesn't ship partitioned-table support so this module
-//! always emits an empty map there.
+//! finding). Callers writing to a partitioned table pass a non-empty
+//! `partition_values` map keyed by logical name; this module translates to
+//! physical UUIDs before emitting the `add` action.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use arrow::array::{Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray};
 use chrono::DateTime;
@@ -23,29 +24,45 @@ use super::{Result, UniformTableState, UniformWriterError};
 
 /// Inputs to `build_commit_jsonl`. Borrowed so callers can build many
 /// commits from the same `RecordBatch` without cloning.
+///
+/// For unpartitioned tables, pass `partition_values: &HashMap::new()` and
+/// `add_file_path: "<hash>.parquet"`. For partitioned tables, pass a map
+/// keyed by logical partition-column name with stringified values and an
+/// `add_file_path` like `<col>=<value>/<hash>.parquet`.
 #[derive(Debug, Clone, Copy)]
 pub struct CommitInputs<'a> {
     pub batch: &'a RecordBatch,
     pub state: &'a UniformTableState,
-    pub file_name: &'a str,
+    pub add_file_path: &'a str,
     pub file_size: u64,
     pub modification_time_millis: i64,
     pub engine_info: &'a str,
+    /// Logical-name → stringified partition value. Empty for unpartitioned
+    /// tables.
+    pub partition_values: &'a HashMap<String, String>,
 }
 
 /// Serialize a Delta commit as JSONL bytes ready to PUT at
 /// `_delta_log/{N:020}.json`.
+///
+/// Single `commitInfo` + single `add` action. Multi-`add` commits (e.g.
+/// writing several partitions atomically) are not Phase 2 — callers issue
+/// one commit per partition write.
 pub fn build_commit_jsonl(inputs: &CommitInputs) -> Result<Vec<u8>> {
     let stats = compute_stats(inputs.batch, inputs.state)?;
-    // BTreeMap so the stats payload is key-stable (matters for downstream
-    // tooling diffing log entries — also makes the test output stable).
     let stats_json = serde_json::to_string(&stats)?;
+
+    // Translate logical-name → physical-UUID for partitionValues. Sanity-
+    // check that the provided keys cover exactly the table's partition
+    // columns and nothing else.
+    let partition_values_physical = translate_partition_values(inputs)?;
+    let partition_by_json = serde_json::to_string(&inputs.state.partition_columns)?;
 
     let commit_info = json!({
         "commitInfo": {
             "timestamp": inputs.modification_time_millis,
             "operation": "WRITE",
-            "operationParameters": {"mode": "Append", "partitionBy": "[]"},
+            "operationParameters": {"mode": "Append", "partitionBy": partition_by_json},
             "isolationLevel": "Serializable",
             "isBlindAppend": true,
             "engineInfo": inputs.engine_info,
@@ -53,8 +70,8 @@ pub fn build_commit_jsonl(inputs: &CommitInputs) -> Result<Vec<u8>> {
     });
     let add_action = json!({
         "add": {
-            "path": inputs.file_name,
-            "partitionValues": {},
+            "path": inputs.add_file_path,
+            "partitionValues": partition_values_physical,
             "size": inputs.file_size,
             "modificationTime": inputs.modification_time_millis,
             "dataChange": true,
@@ -67,6 +84,43 @@ pub fn build_commit_jsonl(inputs: &CommitInputs) -> Result<Vec<u8>> {
     out.push(b'\n');
     out.extend_from_slice(serde_json::to_string(&add_action)?.as_bytes());
     out.push(b'\n');
+    Ok(out)
+}
+
+fn translate_partition_values(inputs: &CommitInputs) -> Result<Map<String, Value>> {
+    let table_partitions: HashSet<&str> = inputs
+        .state
+        .partition_columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    // Caller must provide values for exactly the table's partition columns.
+    for col in &inputs.state.partition_columns {
+        if !inputs.partition_values.contains_key(col) {
+            return Err(UniformWriterError::DeltaLog(format!(
+                "missing partition value for column `{col}` (table partition columns: {:?})",
+                inputs.state.partition_columns
+            )));
+        }
+    }
+    for col in inputs.partition_values.keys() {
+        if !table_partitions.contains(col.as_str()) {
+            return Err(UniformWriterError::DeltaLog(format!(
+                "unexpected partition value for column `{col}` (table partition columns: {:?})",
+                inputs.state.partition_columns
+            )));
+        }
+    }
+
+    let mut out: Map<String, Value> = Map::new();
+    for col in &inputs.state.partition_columns {
+        let phys = inputs.state.physical.get(col).ok_or_else(|| {
+            UniformWriterError::DeltaLog(format!("partition column `{col}` is not in PHYSICAL map"))
+        })?;
+        let v = inputs.partition_values.get(col).expect("checked above");
+        out.insert(phys.clone(), Value::String(v.clone()));
+    }
     Ok(out)
 }
 
@@ -83,8 +137,14 @@ fn compute_stats(batch: &RecordBatch, state: &UniformTableState) -> Result<Value
     let mut min_values: Map<String, Value> = Map::new();
     let mut max_values: Map<String, Value> = Map::new();
     let mut null_counts: BTreeMap<String, i64> = BTreeMap::new();
+    let partitions: HashSet<&str> = state.partition_columns.iter().map(String::as_str).collect();
 
     for (i, field) in batch.schema().fields().iter().enumerate() {
+        // Partition columns are NOT in the Parquet file, so they don't
+        // belong in `stats` either.
+        if partitions.contains(field.name().as_str()) {
+            continue;
+        }
         let phys = state.physical.get(field.name()).ok_or_else(|| {
             UniformWriterError::DeltaLog(format!(
                 "column `{}` not in discovered table schema",
@@ -190,13 +250,15 @@ mod tests {
     fn commit_jsonl_has_two_lines_with_expected_keys() {
         let state = make_state_3col();
         let batch = make_batch_3col();
+        let pv = HashMap::new();
         let inputs = CommitInputs {
             batch: &batch,
             state: &state,
-            file_name: "abc.parquet",
+            add_file_path: "abc.parquet",
             file_size: 123,
             modification_time_millis: 1_000_000_000_000,
             engine_info: "rocky-iceberg/test",
+            partition_values: &pv,
         };
         let body = build_commit_jsonl(&inputs).unwrap();
         let s = std::str::from_utf8(&body).unwrap();
@@ -209,6 +271,133 @@ mod tests {
         assert_eq!(add_obj["path"], "abc.parquet");
         assert_eq!(add_obj["size"], 123);
         assert_eq!(add_obj["partitionValues"], json!({}));
+    }
+
+    fn make_partitioned_state() -> UniformTableState {
+        let mut physical = HashMap::new();
+        physical.insert("id".to_string(), "col-id".to_string());
+        physical.insert("payload".to_string(), "col-payload".to_string());
+        physical.insert("region".to_string(), "col-region".to_string());
+        let mut field_id = HashMap::new();
+        field_id.insert("id".to_string(), 1);
+        field_id.insert("payload".to_string(), 2);
+        field_id.insert("region".to_string(), 3);
+        UniformTableState {
+            physical,
+            field_id,
+            partition_columns: vec!["region".to_string()],
+            row_tracking_enabled: false,
+            deletion_vectors_enabled: false,
+            next_commit_version: 1,
+        }
+    }
+
+    fn make_partitioned_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, false),
+            Field::new("region", DataType::Utf8, false),
+        ]));
+        let ids = Int64Array::from(vec![0_i64, 1, 2]);
+        let payload = StringArray::from(vec!["a", "b", "c"]);
+        let region = StringArray::from(vec!["eu", "eu", "eu"]);
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(ids), Arc::new(payload), Arc::new(region)],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn partitioned_commit_keys_partition_values_by_physical_uuid() {
+        let state = make_partitioned_state();
+        let batch = make_partitioned_batch();
+        let mut pv = HashMap::new();
+        pv.insert("region".to_string(), "eu".to_string());
+        let inputs = CommitInputs {
+            batch: &batch,
+            state: &state,
+            add_file_path: "region=eu/abc.parquet",
+            file_size: 100,
+            modification_time_millis: 0,
+            engine_info: "rocky-iceberg/test",
+            partition_values: &pv,
+        };
+        let body = build_commit_jsonl(&inputs).unwrap();
+        let lines: Vec<&str> = std::str::from_utf8(&body).unwrap().lines().collect();
+        let add: Value = serde_json::from_str(lines[1]).unwrap();
+        let add_obj = add.get("add").unwrap();
+        // Exp 11 — partitionValues MUST be keyed by physical UUID, not logical name.
+        assert_eq!(add_obj["partitionValues"], json!({"col-region": "eu"}));
+        assert_eq!(add_obj["path"], "region=eu/abc.parquet");
+    }
+
+    #[test]
+    fn partitioned_stats_omit_partition_column() {
+        let state = make_partitioned_state();
+        let batch = make_partitioned_batch();
+        let stats = compute_stats(&batch, &state).unwrap();
+        for k in stats["minValues"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .chain(stats["maxValues"].as_object().unwrap().keys())
+            .chain(stats["nullCount"].as_object().unwrap().keys())
+        {
+            assert_ne!(k, "col-region", "partition column must not appear in stats");
+        }
+    }
+
+    #[test]
+    fn partitioned_commit_rejects_missing_partition_value() {
+        let state = make_partitioned_state();
+        let batch = make_partitioned_batch();
+        let pv = HashMap::new();
+        let inputs = CommitInputs {
+            batch: &batch,
+            state: &state,
+            add_file_path: "x.parquet",
+            file_size: 0,
+            modification_time_millis: 0,
+            engine_info: "t",
+            partition_values: &pv,
+        };
+        match build_commit_jsonl(&inputs) {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("`region`"),
+                    "must name the missing column: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn partitioned_commit_rejects_extra_partition_value() {
+        let state = make_partitioned_state();
+        let batch = make_partitioned_batch();
+        let mut pv = HashMap::new();
+        pv.insert("region".to_string(), "eu".to_string());
+        pv.insert("unknown".to_string(), "x".to_string());
+        let inputs = CommitInputs {
+            batch: &batch,
+            state: &state,
+            add_file_path: "x.parquet",
+            file_size: 0,
+            modification_time_millis: 0,
+            engine_info: "t",
+            partition_values: &pv,
+        };
+        match build_commit_jsonl(&inputs) {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("`unknown`"),
+                    "must name the extra column: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -194,21 +194,20 @@ fn state_from_bootstrap_actions(actions: &[LogAction]) -> Result<UniformTableSta
     })
 }
 
-/// Reject states the Phase 1 writer cannot serve.
+/// Reject states the writer cannot serve.
 ///
 /// Each branch surfaces a typed error pointing at the wave 2 phase that
 /// will eventually lift the restriction.
-fn enforce_phase1_constraints(state: &UniformTableState) -> Result<()> {
+///
+/// As of Phase 2, partitioned tables are supported (callers route through
+/// [`UniformWriter::write_partitioned_batch`]); the partitioned check has
+/// been lifted from discover.
+fn enforce_supported(state: &UniformTableState) -> Result<()> {
     if state.deletion_vectors_enabled {
         return Err(UniformWriterError::DeletionVectorsUnsupported);
     }
     if state.row_tracking_enabled {
         return Err(UniformWriterError::RowTrackingUnsupported);
-    }
-    if !state.partition_columns.is_empty() {
-        return Err(UniformWriterError::PartitionedUnsupported(
-            state.partition_columns.clone(),
-        ));
     }
     Ok(())
 }
@@ -217,9 +216,9 @@ impl UniformWriter {
     /// Read `_delta_log/00…0.json` from the configured prefix, parse it, and
     /// list `_delta_log/` to compute the next commit version.
     ///
-    /// Returns an error if Phase 1 cannot serve the table (DV, rowTracking,
-    /// partitioned). The error names the wave 2 phase that will lift the
-    /// restriction.
+    /// Returns an error if the writer cannot serve the table (DV or
+    /// rowTracking). The error names the wave 2 phase that will lift the
+    /// restriction. Partitioned tables are supported as of Phase 2.
     pub async fn discover(&self) -> Result<UniformTableState> {
         let prefix = self.config().prefix.trim_end_matches('/').to_string();
         let bootstrap_path = Path::from(format!("{prefix}/_delta_log/{BOOTSTRAP_COMMIT_FILENAME}"));
@@ -227,11 +226,11 @@ impl UniformWriter {
         let actions = parse_log_jsonl(&body)?;
         let mut state = state_from_bootstrap_actions(&actions)?;
 
-        // Compute next_commit_version from the log listing. Phase 1 writers
-        // skip bootstrap's v=0 and append a new versioned JSON.
+        // Compute next_commit_version from the log listing. Writers skip
+        // bootstrap's v=0 and append a new versioned JSON.
         state.next_commit_version = next_commit_version(self.store(), &prefix).await?;
 
-        enforce_phase1_constraints(&state)?;
+        enforce_supported(&state)?;
         Ok(state)
     }
 }
@@ -285,7 +284,7 @@ mod tests {
         assert!(!state.row_tracking_enabled);
         assert!(!state.deletion_vectors_enabled);
 
-        enforce_phase1_constraints(&state).expect("exp 4 must satisfy phase 1");
+        enforce_supported(&state).expect("exp 4 must satisfy phase 1");
     }
 
     #[test]
@@ -298,26 +297,25 @@ mod tests {
         );
         assert!(!state.deletion_vectors_enabled);
 
-        match enforce_phase1_constraints(&state) {
+        match enforce_supported(&state) {
             Err(UniformWriterError::RowTrackingUnsupported) => {}
             other => panic!("expected RowTrackingUnsupported, got {other:?}"),
         }
     }
 
     #[test]
-    fn exp11_partitioned_is_rejected() {
+    fn exp11_partitioned_is_accepted() {
+        // As of Phase 2 partitioned tables are supported. discover() must
+        // surface partition_columns + the partition column's physical UUID
+        // alongside the non-partition column UUIDs.
         let actions = parse_log_jsonl(EXP11_PARTITIONED_BOOTSTRAP).unwrap();
         let state = state_from_bootstrap_actions(&actions).unwrap();
         assert_eq!(state.partition_columns, vec!["region"]);
-        // Partition column UUIDs land in `physical` like any other column.
-        assert!(state.physical.contains_key("region"));
-
-        match enforce_phase1_constraints(&state) {
-            Err(UniformWriterError::PartitionedUnsupported(cols)) => {
-                assert_eq!(cols, vec!["region"]);
-            }
-            other => panic!("expected PartitionedUnsupported, got {other:?}"),
-        }
+        assert!(
+            state.physical.contains_key("region"),
+            "partition column physical UUID must appear in the `physical` map",
+        );
+        enforce_supported(&state).expect("partitioned tables are supported in phase 2");
     }
 
     #[test]
@@ -339,7 +337,7 @@ mod tests {
         let state = state_from_bootstrap_actions(&actions).unwrap();
         assert!(state.deletion_vectors_enabled);
 
-        match enforce_phase1_constraints(&state) {
+        match enforce_supported(&state) {
             Err(UniformWriterError::DeletionVectorsUnsupported) => {}
             other => panic!("expected DeletionVectorsUnsupported, got {other:?}"),
         }

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -6,15 +6,18 @@
 //! `MSCK REPAIR TABLE ... SYNC METADATA` via the warehouse SQL surface so
 //! UniForm regenerates the corresponding Iceberg metadata.
 //!
-//! Phase 1 scope (locked, see `rocky-arc1-wave2-phase1-uniform-writer.md`):
-//! - Single writer (no cross-writer coordination beyond conditional-put on
-//!   the log entry).
+//! Scope today (Phase 1 + Phase 2):
+//! - Single writer; conditional-put on the log entry covers contention.
 //! - External Delta UniForm table on an object store the writer can `PUT`.
-//! - Unpartitioned, no schema evolution, no rowTracking, no deletion
-//!   vectors. The writer errors loudly if it discovers any of those at
-//!   table-init time; later phases lift each restriction.
+//! - Unpartitioned tables via [`UniformWriter::write_batch`].
+//! - Partitioned tables via [`UniformWriter::write_partitioned_batch`]
+//!   (caller pre-groups rows per partition tuple). `add.partitionValues`
+//!   is keyed by physical-name UUID, not logical name (Exp 11).
+//! - No schema evolution, no rowTracking, no deletion vectors. The writer
+//!   errors loudly if it discovers any of those at table-init time; later
+//!   phases lift each restriction.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
@@ -129,6 +132,12 @@ impl UniformWriter {
     /// Write a single Arrow [`RecordBatch`] as a content-addressed Parquet
     /// file plus a `_delta_log/{N:020}.json` commit referencing it.
     ///
+    /// **Unpartitioned tables only.** For partitioned tables, callers
+    /// pre-group rows by partition tuple and invoke
+    /// [`UniformWriter::write_partitioned_batch`] once per partition.
+    /// Mixing this entry point with a partitioned target returns
+    /// [`UniformWriterError::PartitionedUnsupported`].
+    ///
     /// Calls [`UniformWriter::discover`] first to read the current table
     /// state. To skip the discover round-trip (e.g. when the caller has a
     /// fresh state from a prior call), use
@@ -147,15 +156,112 @@ impl UniformWriter {
     pub async fn write_batch_with_state(
         &self,
         batch: RecordBatch,
+        state: UniformTableState,
+    ) -> Result<WriteResult> {
+        if !state.partition_columns.is_empty() {
+            return Err(UniformWriterError::PartitionedUnsupported(
+                state.partition_columns.clone(),
+            ));
+        }
+        let empty = HashMap::new();
+        self.write_internal(batch, state, &empty, |hash| format!("{hash}.parquet"))
+            .await
+    }
+
+    /// Write a single Arrow [`RecordBatch`] to a partitioned UniForm table.
+    ///
+    /// The caller has pre-grouped rows so that every row in `batch`
+    /// belongs to the same partition tuple, and supplies that tuple as
+    /// `partition_values` keyed by logical column name. Stringification is
+    /// the caller's responsibility (Delta partition values are always
+    /// strings on the wire).
+    ///
+    /// The Parquet file is uploaded to a Hive-style prefix
+    /// (`<col1>=<val1>/<col2>=<val2>/.../<hash>.parquet`); the emitted
+    /// `add.partitionValues` is keyed by **physical** column name UUID, as
+    /// required by Delta column-mapping (Exp 11 finding).
+    ///
+    /// Errors:
+    /// - the target is unpartitioned → `DeltaLog` (caller should use
+    ///   [`Self::write_batch`])
+    /// - `partition_values` is missing a column or carries an unknown key
+    ///   → `DeltaLog`
+    pub async fn write_partitioned_batch(
+        &self,
+        batch: RecordBatch,
+        partition_values: HashMap<String, String>,
+    ) -> Result<WriteResult> {
+        let state = self.discover().await?;
+        self.write_partitioned_batch_with_state(batch, partition_values, state)
+            .await
+    }
+
+    /// [`Self::write_partitioned_batch`] against a state the caller
+    /// already obtained.
+    pub async fn write_partitioned_batch_with_state(
+        &self,
+        batch: RecordBatch,
+        partition_values: HashMap<String, String>,
+        state: UniformTableState,
+    ) -> Result<WriteResult> {
+        if state.partition_columns.is_empty() {
+            return Err(UniformWriterError::DeltaLog(
+                "write_partitioned_batch called against unpartitioned table; \
+                 use write_batch instead"
+                    .to_string(),
+            ));
+        }
+        // Validate keys match the table's partition columns.
+        let table_partitions: HashSet<&str> =
+            state.partition_columns.iter().map(String::as_str).collect();
+        for col in &state.partition_columns {
+            if !partition_values.contains_key(col) {
+                return Err(UniformWriterError::DeltaLog(format!(
+                    "missing partition value for column `{col}` (table partition columns: {:?})",
+                    state.partition_columns
+                )));
+            }
+        }
+        for k in partition_values.keys() {
+            if !table_partitions.contains(k.as_str()) {
+                return Err(UniformWriterError::DeltaLog(format!(
+                    "unexpected partition value for column `{k}` (table partition columns: {:?})",
+                    state.partition_columns
+                )));
+            }
+        }
+
+        // Pre-compute the Hive-style partition path prefix; iteration in
+        // table's partition_columns order keeps it deterministic.
+        let mut partition_prefix = String::new();
+        for col in &state.partition_columns {
+            let v = partition_values.get(col).expect("checked above");
+            partition_prefix.push_str(&format!("{col}={v}/"));
+        }
+        let pv_for_closure = partition_values.clone();
+        self.write_internal(batch, state, &pv_for_closure, move |hash| {
+            format!("{partition_prefix}{hash}.parquet")
+        })
+        .await
+    }
+
+    /// Shared write pipeline used by both unpartitioned and partitioned
+    /// entry points. `path_for_hash` produces the `add.path` (relative to
+    /// the table prefix) given the blake3 hash of the Parquet bytes.
+    async fn write_internal(
+        &self,
+        batch: RecordBatch,
         mut state: UniformTableState,
+        partition_values: &HashMap<String, String>,
+        path_for_hash: impl FnOnce(&str) -> String,
     ) -> Result<WriteResult> {
         // 1. Build deterministic Parquet bytes from the input batch.
         let parquet_bytes = parquet_builder::build_parquet(&batch, &state)?;
         let hash = blake3::hash(&parquet_bytes).to_hex().to_string();
-        let file_name = format!("{hash}.parquet");
+        let add_file_path = path_for_hash(&hash);
         let file_size = parquet_bytes.len() as u64;
         let prefix = self.config.prefix.trim_end_matches('/').to_string();
-        let parquet_path = Path::from(format!("{prefix}/{file_name}"));
+        let parquet_path = Path::from(format!("{prefix}/{add_file_path}"));
 
         // 2. PUT the Parquet. Same content → same hash → same key → idempotent.
         self.store
@@ -169,10 +275,11 @@ impl UniformWriter {
             let inputs = commit::CommitInputs {
                 batch: &batch,
                 state: &state,
-                file_name: &file_name,
+                add_file_path: &add_file_path,
                 file_size,
                 modification_time_millis,
                 engine_info: &self.config.engine_info,
+                partition_values,
             };
             let commit_body = commit::build_commit_jsonl(&inputs)?;
             let log_path = Path::from(format!("{prefix}/_delta_log/{target_version:020}.json"));
@@ -195,8 +302,6 @@ impl UniformWriter {
                     });
                 }
                 Err(object_store::Error::AlreadyExists { .. }) => {
-                    // Another writer (or a stale state) won the v=target_version
-                    // race. Refetch the next version and try again.
                     let observed = discover::next_commit_version(&*self.store, &prefix).await?;
                     state.next_commit_version = observed.max(target_version.saturating_add(1));
                     tracing::warn!(
@@ -272,6 +377,183 @@ mod tests {
         async fn execute(&self, sql: &str) -> Result<()> {
             self.log.lock().unwrap().push(sql.to_string());
             Ok(())
+        }
+    }
+
+    /// Seed an `InMemory` object store with a partitioned bootstrap commit
+    /// (`region` as the lone partition column).
+    async fn seed_partitioned_bootstrap(store: &InMemory, prefix: &str) {
+        let bootstrap = serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 2,
+                "minWriterVersion": 7,
+                "writerFeatures": ["columnMapping", "icebergCompatV2", "invariants", "appendOnly"],
+            }
+        });
+        let metadata = serde_json::json!({
+            "metaData": {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": serde_json::to_string(&serde_json::json!({
+                    "type": "struct",
+                    "fields": [
+                        {"name": "id", "type": "long", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 1,
+                            "delta.columnMapping.physicalName": "col-id-uuid"
+                        }},
+                        {"name": "payload", "type": "string", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 2,
+                            "delta.columnMapping.physicalName": "col-payload-uuid"
+                        }},
+                        {"name": "region", "type": "string", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 3,
+                            "delta.columnMapping.physicalName": "col-region-uuid"
+                        }}
+                    ]
+                })).unwrap(),
+                "partitionColumns": ["region"],
+                "configuration": {
+                    "delta.columnMapping.mode": "name",
+                    "delta.universalFormat.enabledFormats": "iceberg",
+                    "delta.enableIcebergCompatV2": "true"
+                },
+                "createdTime": 0
+            }
+        });
+        let body = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&bootstrap).unwrap(),
+            serde_json::to_string(&metadata).unwrap(),
+        );
+        store
+            .put(
+                &object_store::path::Path::from(format!(
+                    "{prefix}/_delta_log/00000000000000000000.json"
+                )),
+                PutPayload::from(Bytes::from(body.into_bytes())),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn make_partitioned_batch(region: &str, rows: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, false),
+            Field::new("region", DataType::Utf8, false),
+        ]));
+        let ids = Int64Array::from((0..rows as i64).collect::<Vec<_>>());
+        let payload = StringArray::from(
+            (0..rows)
+                .map(|i| format!("{region}-{i}"))
+                .collect::<Vec<_>>(),
+        );
+        let region_col = StringArray::from(vec![region; rows]);
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(ids), Arc::new(payload), Arc::new(region_col)],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn write_partitioned_batch_round_trip_against_in_memory_store() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let prefix = "tbl";
+        seed_partitioned_bootstrap(&store, prefix).await;
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+
+        let batch = make_partitioned_batch("eu", 5);
+        let mut pv = HashMap::new();
+        pv.insert("region".to_string(), "eu".to_string());
+        let result = writer
+            .write_partitioned_batch(batch, pv)
+            .await
+            .expect("partitioned write must succeed");
+
+        assert_eq!(result.commit_version, 1);
+        assert_eq!(result.num_records, 5);
+        // Hive-style path includes the partition column.
+        assert!(
+            result.file_path.contains("/region=eu/"),
+            "file path must carry partition prefix: {}",
+            result.file_path
+        );
+
+        // The commit must encode partitionValues by physical UUID.
+        let log_path = object_store::path::Path::from(format!(
+            "{prefix}/_delta_log/00000000000000000001.json"
+        ));
+        let log = store.get(&log_path).await.unwrap().bytes().await.unwrap();
+        let log_text = std::str::from_utf8(&log).unwrap();
+        let add_line = log_text.lines().nth(1).unwrap();
+        let add: Value = serde_json::from_str(add_line).unwrap();
+        assert_eq!(
+            add["add"]["partitionValues"],
+            serde_json::json!({"col-region-uuid": "eu"})
+        );
+    }
+
+    #[tokio::test]
+    async fn write_batch_rejects_partitioned_table() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let prefix = "tbl";
+        seed_partitioned_bootstrap(&store, prefix).await;
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+        match writer.write_batch(make_partitioned_batch("eu", 1)).await {
+            Err(UniformWriterError::PartitionedUnsupported(cols)) => {
+                assert_eq!(cols, vec!["region".to_string()]);
+            }
+            other => panic!("expected PartitionedUnsupported, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_partitioned_batch_rejects_unpartitioned_table() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        let prefix = "tbl";
+        seed_bootstrap(&store, prefix).await;
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(PanicSqlClient),
+        );
+        let mut pv = HashMap::new();
+        pv.insert("region".to_string(), "eu".to_string());
+        match writer.write_partitioned_batch(make_batch(1), pv).await {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("unpartitioned"),
+                    "error must mention unpartitioned table: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog error, got {other:?}"),
         }
     }
 

--- a/engine/crates/rocky-iceberg/src/uniform_writer/parquet_builder.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/parquet_builder.rs
@@ -17,11 +17,19 @@
 //! schema; this module rebuilds the schema with each column renamed to its
 //! `delta.columnMapping.physicalName` UUID + a `PARQUET:field_id` metadata
 //! entry, then writes that batch to a buffer.
+//!
+//! Partition columns (members of `state.partition_columns`) are skipped —
+//! they are NOT physically present in the Parquet file. Delta + Iceberg
+//! reconstruct the partition column from `add.partitionValues` + the file's
+//! Hive-style path prefix; storing them in the file would be redundant and
+//! breaks the partition-aware reader contract.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use std::collections::HashSet;
+
+use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{Field, Schema};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -29,10 +37,20 @@ use parquet::file::properties::{EnabledStatistics, WriterProperties, WriterVersi
 
 use super::{Result, UniformTableState, UniformWriterError};
 
-/// Rebuild the schema with physical-UUID column names + field-id metadata.
-fn rebuild_schema(logical_schema: &Schema, state: &UniformTableState) -> Result<Arc<Schema>> {
-    let mut fields = Vec::with_capacity(logical_schema.fields().len());
-    for f in logical_schema.fields() {
+/// Project + rename the batch: drop partition columns, rename the remaining
+/// columns to their physical UUIDs, attach `PARQUET:field_id` metadata.
+fn project_to_physical(
+    batch: &RecordBatch,
+    state: &UniformTableState,
+) -> Result<(Arc<Schema>, Vec<ArrayRef>)> {
+    let partitions: HashSet<&str> = state.partition_columns.iter().map(String::as_str).collect();
+    let logical_schema = batch.schema();
+    let mut fields: Vec<Field> = Vec::with_capacity(logical_schema.fields().len());
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(logical_schema.fields().len());
+    for (i, f) in logical_schema.fields().iter().enumerate() {
+        if partitions.contains(f.name().as_str()) {
+            continue;
+        }
         let physical = state.physical.get(f.name()).ok_or_else(|| {
             UniformWriterError::DeltaLog(format!(
                 "column `{}` not in discovered table schema",
@@ -47,17 +65,22 @@ fn rebuild_schema(logical_schema: &Schema, state: &UniformTableState) -> Result<
         })?;
         let mut metadata = HashMap::new();
         metadata.insert("PARQUET:field_id".to_string(), field_id.to_string());
-        let new_field =
-            Field::new(physical, f.data_type().clone(), f.is_nullable()).with_metadata(metadata);
-        fields.push(new_field);
+        fields.push(
+            Field::new(physical, f.data_type().clone(), f.is_nullable()).with_metadata(metadata),
+        );
+        columns.push(batch.column(i).clone());
     }
-    Ok(Arc::new(Schema::new(fields)))
+    Ok((Arc::new(Schema::new(fields)), columns))
 }
 
 /// Build Parquet bytes from an Arrow `RecordBatch`.
+///
+/// Any columns whose name is in `state.partition_columns` are dropped from
+/// the Parquet output (partition values live in `add.partitionValues` +
+/// the file's Hive-style path prefix, not the file itself).
 pub fn build_parquet(batch: &RecordBatch, state: &UniformTableState) -> Result<Vec<u8>> {
-    let new_schema = rebuild_schema(&batch.schema(), state)?;
-    let new_batch = RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec())?;
+    let (new_schema, columns) = project_to_physical(batch, state)?;
+    let new_batch = RecordBatch::try_new(new_schema.clone(), columns)?;
 
     let props = WriterProperties::builder()
         .set_writer_version(WriterVersion::PARQUET_2_0)

--- a/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
+++ b/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
@@ -410,3 +410,109 @@ async fn round_trip_phase1_compatible_sandbox() {
         "MSCK must have written at least one *.metadata.json file under metadata/"
     );
 }
+
+/// Live test for `write_partitioned_batch()`.
+///
+/// Requires the same env vars as the other live tests, except
+/// `ROCKY_TEST_*` should point at a **partitioned** UniForm table with
+/// the canonical `(id BIGINT, payload STRING, region STRING)` schema and
+/// `region` as the partition column. The test writes 3 rows into the
+/// `region=eu` partition and verifies the new Parquet appears at
+/// `<prefix>/region=eu/<hash>.parquet`.
+#[tokio::test]
+#[ignore]
+async fn write_partitioned_batch_phase2_compatible_sandbox() {
+    let Some(cfg) = try_load_config() else {
+        eprintln!("skipping: ROCKY_TEST_* env vars not set");
+        return;
+    };
+    let Some(store) = build_s3_store(&cfg) else {
+        eprintln!("skipping: failed to build S3 store from environment");
+        return;
+    };
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: cfg.catalog.clone(),
+            schema: cfg.schema.clone(),
+            table: cfg.table.clone(),
+            prefix: cfg.prefix.clone(),
+            engine_info: "rocky-iceberg/write-partitioned-live-test".into(),
+        },
+        store.clone(),
+        Arc::new(PanicSqlClient),
+    );
+    let state = writer.discover().await.expect("discover");
+
+    if state.partition_columns.is_empty() {
+        eprintln!(
+            "skipping: this test expects a partitioned table; the target table is unpartitioned"
+        );
+        return;
+    }
+    let expected_cols: std::collections::BTreeSet<&str> =
+        ["id", "payload", "region"].into_iter().collect();
+    let actual_cols: std::collections::BTreeSet<&str> =
+        state.physical.keys().map(String::as_str).collect();
+    if expected_cols != actual_cols || state.partition_columns != vec!["region".to_string()] {
+        eprintln!(
+            "skipping: this test expects (id, payload, region) PARTITIONED BY (region); \
+             got cols={actual_cols:?}, partitions={:?}",
+            state.partition_columns,
+        );
+        return;
+    }
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("payload", DataType::Utf8, false),
+        Field::new("region", DataType::Utf8, false),
+    ]));
+    let ts_suffix = chrono::Utc::now().timestamp_micros();
+    let ids = Int64Array::from(vec![900_201_i64, 900_202, 900_203]);
+    let payload = StringArray::from(vec![
+        format!("part-a-{ts_suffix}"),
+        format!("part-b-{ts_suffix}"),
+        format!("part-c-{ts_suffix}"),
+    ]);
+    let region = StringArray::from(vec!["eu", "eu", "eu"]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(ids), Arc::new(payload), Arc::new(region)],
+    )
+    .unwrap();
+
+    let mut pv = std::collections::HashMap::new();
+    pv.insert("region".to_string(), "eu".to_string());
+    let result = writer
+        .write_partitioned_batch(batch, pv)
+        .await
+        .expect("partitioned write must succeed");
+
+    assert_eq!(result.num_records, 3);
+    assert!(
+        result.file_path.contains("/region=eu/"),
+        "file path must carry partition prefix: {}",
+        result.file_path
+    );
+
+    // Verify the Parquet landed in S3 at the Hive-style key.
+    use futures::TryStreamExt;
+    let part_prefix = object_store::path::Path::from(format!("{}/region=eu", cfg.prefix));
+    let mut found = false;
+    let mut stream = store.list(Some(&part_prefix));
+    while let Some(item) = stream.try_next().await.expect("list partition prefix") {
+        if item
+            .location
+            .as_ref()
+            .ends_with(&format!("{}.parquet", result.blake3_hash))
+        {
+            found = true;
+            break;
+        }
+    }
+    assert!(
+        found,
+        "Parquet must exist at <prefix>/region=eu/{}.parquet",
+        result.blake3_hash
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the wave 2 content-addressed writer (follows Phase 1 series #488/#489/#491/#492). Lifts the `PartitionedUnsupported` restriction by adding `UniformWriter::write_partitioned_batch(batch, partition_values)` for partitioned UniForm tables.

API shape:
- `write_batch(batch)` — unpartitioned tables only. Errors with `PartitionedUnsupported` against a partitioned target.
- `write_partitioned_batch(batch, partition_values)` — partitioned tables only. Caller pre-groups rows so every row in `batch` belongs to one partition tuple and supplies the tuple as a logical-name → stringified-value map. Returns `DeltaLog` against an unpartitioned target.

A new `write_internal()` helper backs both entry points so the cond-put + retry-on-412 + idempotent Parquet PUT logic isn't duplicated.

## Phase 0 findings honoured

- **Exp 11** — `add.partitionValues` keys are the **physical** column UUID, not the logical name. Databricks' own INSERT confirms the format; the Delta protocol spec is misleading on this point. The writer translates logical → physical inside `build_commit_jsonl`.
- Partition columns are dropped from the Parquet output (readers reconstruct them from `add.partitionValues` + the file's Hive-style path) and excluded from `add.stats`.

## Tests

**Unit:**
- 4 new tests in `commit.rs` (partitionValues keyed by physical UUID, stats omit partition column, missing/extra partition value errors).
- 3 new module-level tests against `InMemory` (partitioned round-trip, write_batch rejects partitioned, write_partitioned_batch rejects unpartitioned).

**Live (env-gated):**
- 1 new test `write_partitioned_batch_phase2_compatible_sandbox` hits a partitioned UniForm table with the canonical `(id, payload, region) PARTITIONED BY (region)` schema.

**Live round-trip verified:** 3 rows written to `region=eu` → Photon `SELECT region, COUNT(*) GROUP BY region` shows `eu=336` (333 prior + 3 new), with the partition column correctly reconstructed from `partitionValues`.

## Test plan

- [x] `cargo build -p rocky-iceberg` clean
- [x] `cargo clippy -p rocky-iceberg --all-targets -- -D warnings` clean
- [x] `cargo test -p rocky-iceberg --lib` — 49 passed (7 new for partitioned support + 42 prior)
- [x] `cargo test -p rocky-iceberg --test uniform_writer_live write_partitioned_batch_phase2 -- --ignored` against a partitioned sandbox — passes
- [x] `cargo fmt -p rocky-iceberg -- --check` clean