### PR TITLE
feat(rocky-ir): add MaterializationStrategy::ContentAddressed variant (Wave 2 PR 5a)

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -1211,7 +1211,7 @@
       "description": "One entry in the top-level `[mask]` block. A scalar value (`pii = \"hash\"`) binds a classification tag to a default masking strategy; a nested table (`[mask.prod] pii = \"none\"`) overrides strategies for a specific environment.\n\nSerde deserializes the outer `[mask]` map as `BTreeMap<String, MaskEntry>`; scalars are tried first, then the nested table shape. Unknown strategy spellings (e.g., `\"mask\"`) hard-fail at config load time — Rocky never silently accepts something it can't emit SQL for."
     },
     "MaskStrategy": {
-      "description": "Column-masking strategy applied to a classified column at materialization time.\n\nRocky translates a classification tag (e.g., `pii`) into one of these strategies via the `[mask]` / `[mask.<env>]` block in `rocky.toml`. The adapter renders each strategy as a warehouse-native function: Databricks uses `CREATE MASK ... RETURN <expr>` + `SET MASKING POLICY`; other adapters default-unsupported until demand.\n\nSerialized in lowercase to match the TOML spelling (`\"hash\"`, `\"redact\"`, `\"partial\"`, `\"none\"`).",
+      "description": "How a column is masked at apply time.\n\nSerialized in lowercase to match the TOML spelling (`\"hash\"`, `\"redact\"`, `\"partial\"`, `\"none\"`).",
       "oneOf": [
         {
           "description": "SHA-256 hex digest of the column value. Deterministic, one-way.",

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -48,9 +48,7 @@ export type MaskEntry =
       [k: string]: MaskStrategy;
     };
 /**
- * Column-masking strategy applied to a classified column at materialization time.
- *
- * Rocky translates a classification tag (e.g., `pii`) into one of these strategies via the `[mask]` / `[mask.<env>]` block in `rocky.toml`. The adapter renders each strategy as a warehouse-native function: Databricks uses `CREATE MASK ... RETURN <expr>` + `SET MASKING POLICY`; other adapters default-unsupported until demand.
+ * How a column is masked at apply time.
  *
  * Serialized in lowercase to match the TOML spelling (`"hash"`, `"redact"`, `"partial"`, `"none"`).
  */

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3810,6 +3810,7 @@ fn transformation_strategy_name(strategy: &MaterializationStrategy) -> &'static 
         MaterializationStrategy::Ephemeral => "ephemeral",
         MaterializationStrategy::DeleteInsert { .. } => "delete_insert",
         MaterializationStrategy::Microbatch { .. } => "microbatch",
+        MaterializationStrategy::ContentAddressed { .. } => "content_addressed",
     }
 }
 
@@ -4498,6 +4499,15 @@ async fn process_table(
                 strategy_name = "microbatch";
                 // Microbatch on replication tables falls back to incremental insert.
                 sql_gen::generate_insert_sql(&model_ir, dialect)?
+            }
+            MaterializationStrategy::ContentAddressed { .. } => {
+                // content_addressed is a transformation strategy backed by
+                // rocky-iceberg::uniform_writer; the replication pipeline
+                // does not synthesise this variant from rocky.toml.
+                anyhow::bail!(
+                    "content_addressed strategy is not supported on replication tables — \
+                     it only applies to transformation models"
+                );
             }
         }
     };

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -350,6 +350,17 @@ pub fn generate_transformation_sql(
             validation::validate_identifier(timestamp_column)?;
             Ok(vec![dialect.insert_into(&target, &model_ir.sql)])
         }
+        MaterializationStrategy::ContentAddressed { .. } => {
+            // Content-addressed materializations go through the
+            // `rocky-iceberg::uniform_writer` library, not SQL generation.
+            // The runtime detects this strategy in `rocky run` and routes
+            // execution accordingly; sql_gen should never be reached.
+            Err(SqlGenError::InvalidRequest(
+                "ContentAddressed strategy is handled by the runtime via \
+                 rocky-iceberg::uniform_writer; sql_gen does not emit SQL for it"
+                    .to_string(),
+            ))
+        }
     }
 }
 

--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -90,6 +90,33 @@ pub enum MaterializationStrategy {
         /// Batch granularity (default: Hour).
         granularity: TimeGrain,
     },
+    /// Content-addressed write to a Delta UniForm table.
+    ///
+    /// The model's SELECT is executed by the runtime; the resulting rows
+    /// are written as a content-hash-named Parquet file via the
+    /// `rocky_iceberg::uniform_writer` library, and a `_delta_log/{N}.json`
+    /// commit references it. Cross-engine reads (DuckDB iceberg_scan,
+    /// Iceberg-aware Trino, ...) require `MSCK REPAIR TABLE ... SYNC
+    /// METADATA` after each commit; the runtime issues this automatically.
+    ///
+    /// SQL generation does not run for this strategy — `sql_gen` returns
+    /// an error, and the runner takes over the materialization path. See
+    /// `rocky_iceberg::uniform_writer` for the writer surface.
+    ContentAddressed {
+        /// Object-store key prefix containing `_delta_log/` and the
+        /// table's Parquet files. Typically `s3://<bucket>/<path>/<table>`
+        /// for AWS-backed deployments. Resolved at config-parse time; the
+        /// runtime constructs an `ObjectStore` from this.
+        storage_prefix: String,
+        /// If non-empty, the model's SELECT must produce exactly these
+        /// partition columns. The runtime pre-groups rows by partition
+        /// tuple and emits one `add` action per group. Empty means the
+        /// target is unpartitioned.
+        ///
+        /// At runtime, this list is asserted equal to what
+        /// `UniformWriter::discover()` returns; mismatch is a hard error.
+        partition_columns: Vec<String>,
+    },
 }
 
 /// A single partition's time window, used to substitute `@start_date` /
@@ -1250,6 +1277,79 @@ mod tests {
             !json.contains("column_masks"),
             "empty column_masks must be skipped per the canonical-JSON rule, got: {json}"
         );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_switching_to_content_addressed() {
+        let mut m = sample_transformation_model();
+        let h_before = m.recipe_hash();
+        m.materialization = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset/dim_customers".into(),
+            partition_columns: vec![],
+        };
+        let h_after = m.recipe_hash();
+        assert_ne!(
+            h_before, h_after,
+            "switching to ContentAddressed must change the recipe hash"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_content_addressed_storage_prefix_changes() {
+        let mut m = sample_transformation_model();
+        m.materialization = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset/dim_customers".into(),
+            partition_columns: vec![],
+        };
+        let h1 = m.recipe_hash();
+        m.materialization = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset_v2/dim_customers".into(),
+            partition_columns: vec![],
+        };
+        let h2 = m.recipe_hash();
+        assert_ne!(
+            h1, h2,
+            "changing the content-addressed storage prefix must change the recipe hash"
+        );
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_content_addressed_partition_columns_change() {
+        let mut m = sample_transformation_model();
+        m.materialization = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset/dim_customers".into(),
+            partition_columns: vec![],
+        };
+        let h1 = m.recipe_hash();
+        m.materialization = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset/dim_customers".into(),
+            partition_columns: vec!["region".to_string()],
+        };
+        let h2 = m.recipe_hash();
+        assert_ne!(
+            h1, h2,
+            "adding a partition column must change the recipe hash"
+        );
+    }
+
+    #[test]
+    fn content_addressed_serde_round_trip() {
+        let strategy = MaterializationStrategy::ContentAddressed {
+            storage_prefix: "s3://example-bucket/dataset/t".into(),
+            partition_columns: vec!["region".to_string(), "year".to_string()],
+        };
+        let json = serde_json::to_string(&strategy).unwrap();
+        let back: MaterializationStrategy = serde_json::from_str(&json).unwrap();
+        match back {
+            MaterializationStrategy::ContentAddressed {
+                storage_prefix,
+                partition_columns,
+            } => {
+                assert_eq!(storage_prefix, "s3://example-bucket/dataset/t");
+                assert_eq!(partition_columns, vec!["region", "year"]);
+            }
+            other => panic!("expected ContentAddressed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -1210,7 +1210,7 @@
       "description": "One entry in the top-level `[mask]` block. A scalar value (`pii = \"hash\"`) binds a classification tag to a default masking strategy; a nested table (`[mask.prod] pii = \"none\"`) overrides strategies for a specific environment.\n\nSerde deserializes the outer `[mask]` map as `BTreeMap<String, MaskEntry>`; scalars are tried first, then the nested table shape. Unknown strategy spellings (e.g., `\"mask\"`) hard-fail at config load time — Rocky never silently accepts something it can't emit SQL for."
     },
     "MaskStrategy": {
-      "description": "Column-masking strategy applied to a classified column at materialization time.\n\nRocky translates a classification tag (e.g., `pii`) into one of these strategies via the `[mask]` / `[mask.<env>]` block in `rocky.toml`. The adapter renders each strategy as a warehouse-native function: Databricks uses `CREATE MASK ... RETURN <expr>` + `SET MASKING POLICY`; other adapters default-unsupported until demand.\n\nSerialized in lowercase to match the TOML spelling (`\"hash\"`, `\"redact\"`, `\"partial\"`, `\"none\"`).",
+      "description": "How a column is masked at apply time.\n\nSerialized in lowercase to match the TOML spelling (`\"hash\"`, `\"redact\"`, `\"partial\"`, `\"none\"`).",
       "oneOf": [
         {
           "description": "SHA-256 hex digest of the column value. Deterministic, one-way.",


### PR DESCRIPTION
## Summary

Introduces the IR variant a model declares to materialize itself via the rocky-iceberg content-addressed UniForm writer. **No runner behavior changes** — the variant lands with explicit not-yet-wired stubs in every exhaustive `match` arm. Tests cover recipe-hash sensitivity + serde round-trip.

The variant:

\`\`\`rust
ContentAddressed {
    storage_prefix: String,
    partition_columns: Vec<String>,
}
\`\`\`

\`storage_prefix\` names the object-store key prefix that holds \`_delta_log/\` + Parquet files for the target table; \`partition_columns\` declares the table's partition columns (empty for unpartitioned). A later PR will assert the declared \`partition_columns\` matches what \`UniformWriter::discover()\` returns at runtime; mismatch will be a hard error.

## Cascade stubs

Three exhaustive match arms gained a new branch:
- \`rocky-core::sql_gen::generate_sql_for_strategy\` returns \`SqlGenError::InvalidRequest\` — SQL generation does not run for content-addressed; the runner takes over via \`rocky-iceberg::uniform_writer\`.
- \`rocky-cli::commands::run::transformation_strategy_name\` returns \`"content_addressed"\`.
- The replication path in \`rocky-cli::commands::run\` rejects the variant with \`anyhow::bail!\` — content_addressed is a transformation strategy; it's never synthesised from a replication pipeline.

## Codegen note

\`just codegen\` picked up an unrelated pre-existing drift in \`schemas/rocky_project.schema.json\` (a \`MaskStrategy\` doc-comment edit from an earlier change). Bundled here rather than split into a prep commit since it's a single doc-comment line.

## Tests

- \`recipe_hash_changes_when_switching_to_content_addressed\`
- \`recipe_hash_changes_when_content_addressed_storage_prefix_changes\`
- \`recipe_hash_changes_when_content_addressed_partition_columns_change\`
- \`content_addressed_serde_round_trip\`

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test --workspace\` passes (4 new + all prior)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`just codegen\` regenerated artifacts included; subsequent runs are no-ops

## Follow-ups

Runner integration (TOML acceptance + \`rocky run\` dispatch + live test) lands in subsequent PRs.