### PR TITLE
feat(rocky-core): TOML sidecar accepts materialization "content_addressed" (Wave 2 PR 5b)

### DIFF
--- a/editors/vscode/src/types/generated/compile.ts
+++ b/editors/vscode/src/types/generated/compile.ts
@@ -81,6 +81,18 @@ export type StrategyConfig =
       timestamp_column: string;
       type: "microbatch";
       [k: string]: unknown;
+    }
+  | {
+      /**
+       * Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
+       */
+      partition_columns?: string[];
+      /**
+       * Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
+       */
+      storage_prefix: string;
+      type: "content_addressed";
+      [k: string]: unknown;
     };
 /**
  * Partition granularity for `time_interval` materialization.

--- a/editors/vscode/src/types/generated/dag.ts
+++ b/editors/vscode/src/types/generated/dag.ts
@@ -71,6 +71,18 @@ export type StrategyConfig =
       timestamp_column: string;
       type: "microbatch";
       [k: string]: unknown;
+    }
+  | {
+      /**
+       * Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
+       */
+      partition_columns?: string[];
+      /**
+       * Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
+       */
+      storage_prefix: string;
+      type: "content_addressed";
+      [k: string]: unknown;
     };
 /**
  * Partition granularity for `time_interval` materialization.

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -115,6 +115,7 @@ pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
                 rocky_core::models::StrategyConfig::DeleteInsert { .. } => "delete_insert",
                 rocky_core::models::StrategyConfig::Ephemeral => "ephemeral",
                 rocky_core::models::StrategyConfig::Microbatch { .. } => "microbatch",
+                rocky_core::models::StrategyConfig::ContentAddressed { .. } => "content_addressed",
             }
             .to_string();
             ListModelEntry {

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -153,6 +153,7 @@ pub fn generate_report(
             rocky_core::models::StrategyConfig::Ephemeral => "ephemeral",
             rocky_core::models::StrategyConfig::DeleteInsert { .. } => "delete_insert",
             rocky_core::models::StrategyConfig::Microbatch { .. } => "microbatch",
+            rocky_core::models::StrategyConfig::ContentAddressed { .. } => "content_addressed",
         };
         *by_materialization.entry(mat.to_string()).or_default() += 1;
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -74,6 +74,7 @@ fn strategy_label(strategy: &StrategyConfig) -> String {
         StrategyConfig::Ephemeral => "ephemeral".into(),
         StrategyConfig::DeleteInsert { .. } => "delete_insert".into(),
         StrategyConfig::Microbatch { .. } => "microbatch".into(),
+        StrategyConfig::ContentAddressed { .. } => "content_addressed".into(),
     }
 }
 

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -251,6 +251,24 @@ pub enum StrategyConfig {
         #[serde(default = "default_microbatch_granularity")]
         granularity: TimeGrain,
     },
+    /// Content-addressed write to a Delta UniForm table via the
+    /// `rocky-iceberg` writer. The runtime executes the model SQL,
+    /// converts the result to Arrow, blake3-hashes the Parquet bytes,
+    /// uploads to `storage_prefix`, and emits a Delta log commit.
+    /// Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK
+    /// REPAIR after each commit; the runtime issues this automatically.
+    #[serde(rename = "content_addressed")]
+    ContentAddressed {
+        /// Object-store key prefix that holds `_delta_log/` + Parquet
+        /// files for the target table. Typically
+        /// `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
+        storage_prefix: String,
+        /// Logical partition column names. Empty for unpartitioned
+        /// tables. The runtime asserts this matches the table's
+        /// declared partition columns at materialization time.
+        #[serde(default)]
+        partition_columns: Vec<String>,
+    },
 }
 
 fn default_batch_size() -> NonZeroU32 {
@@ -555,6 +573,13 @@ impl Model {
                 timestamp_column: timestamp_column.clone(),
                 granularity: *granularity,
             },
+            StrategyConfig::ContentAddressed {
+                storage_prefix,
+                partition_columns,
+            } => MaterializationStrategy::ContentAddressed {
+                storage_prefix: storage_prefix.clone(),
+                partition_columns: partition_columns.clone(),
+            },
         };
 
         ModelIr {
@@ -828,6 +853,81 @@ FROM analytics.staging.customers
             model.config.strategy,
             StrategyConfig::Merge { .. }
         ));
+    }
+
+    #[test]
+    fn test_parse_model_content_addressed() {
+        let content = r#"---toml
+name = "fct_events"
+
+[strategy]
+type = "content_addressed"
+storage_prefix = "s3://example-bucket/dataset/fct_events"
+partition_columns = ["region"]
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "fct_events"
+---
+
+SELECT id, payload, region FROM raw.events
+"#;
+        let model = parse_model_inline(content, "fct_events.sql", None).unwrap();
+        match &model.config.strategy {
+            StrategyConfig::ContentAddressed {
+                storage_prefix,
+                partition_columns,
+            } => {
+                assert_eq!(storage_prefix, "s3://example-bucket/dataset/fct_events");
+                assert_eq!(partition_columns, &vec!["region".to_string()]);
+            }
+            other => panic!("expected ContentAddressed, got {other:?}"),
+        }
+
+        // Lowering must produce the IR variant with the same fields.
+        let ir = model.to_model_ir();
+        match &ir.materialization {
+            rocky_ir::MaterializationStrategy::ContentAddressed {
+                storage_prefix,
+                partition_columns,
+            } => {
+                assert_eq!(storage_prefix, "s3://example-bucket/dataset/fct_events");
+                assert_eq!(partition_columns, &vec!["region".to_string()]);
+            }
+            other => panic!("expected IR ContentAddressed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_model_content_addressed_unpartitioned() {
+        // partition_columns is optional in the TOML; default is an empty vec.
+        let content = r#"---toml
+name = "fct_events"
+
+[strategy]
+type = "content_addressed"
+storage_prefix = "s3://example-bucket/dataset/fct_events"
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "fct_events"
+---
+
+SELECT id, payload FROM raw.events
+"#;
+        let model = parse_model_inline(content, "fct_events.sql", None).unwrap();
+        match &model.config.strategy {
+            StrategyConfig::ContentAddressed {
+                storage_prefix,
+                partition_columns,
+            } => {
+                assert_eq!(storage_prefix, "s3://example-bucket/dataset/fct_events");
+                assert!(partition_columns.is_empty());
+            }
+            other => panic!("expected ContentAddressed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/plan_partition.rs
+++ b/engine/crates/rocky-core/src/plan_partition.rs
@@ -379,6 +379,7 @@ fn strategy_label(s: &StrategyConfig) -> &'static str {
         StrategyConfig::Ephemeral => "ephemeral",
         StrategyConfig::DeleteInsert { .. } => "delete_insert",
         StrategyConfig::Microbatch { .. } => "microbatch",
+        StrategyConfig::ContentAddressed { .. } => "content_addressed",
     }
 }
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/compile_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/compile_schema.py
@@ -210,6 +210,26 @@ class Type6(StrEnum):
     microbatch = "microbatch"
 
 
+class Type7(StrEnum):
+    content_addressed = "content_addressed"
+
+
+class StrategyConfig8(BaseModel):
+    """
+    Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.
+    """
+
+    partition_columns: list[str] | None = []
+    """
+    Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
+    """
+    storage_prefix: str
+    """
+    Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
+    """
+    type: Type7
+
+
 class TargetConfig(BaseModel):
     """
     Target table coordinates for a model.
@@ -348,6 +368,7 @@ class ModelDetail(BaseModel):
         | StrategyConfig5
         | StrategyConfig6
         | StrategyConfig7
+        | StrategyConfig8
     )
     """
     Materialization strategy as the wire-shape `StrategyConfig` (`{"type": "...", ...}`).

--- a/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
@@ -75,7 +75,7 @@ class Type(StrEnum):
     full_refresh = "full_refresh"
 
 
-class StrategyConfig8(BaseModel):
+class StrategyConfig9(BaseModel):
     """
     Materialization strategy for a model, defaulting to full refresh.
     """
@@ -83,21 +83,8 @@ class StrategyConfig8(BaseModel):
     type: Type
 
 
-class Type8(StrEnum):
-    incremental = "incremental"
-
-
-class StrategyConfig9(BaseModel):
-    """
-    Materialization strategy for a model, defaulting to full refresh.
-    """
-
-    timestamp_column: str
-    type: Type8
-
-
 class Type9(StrEnum):
-    merge = "merge"
+    incremental = "incremental"
 
 
 class StrategyConfig10(BaseModel):
@@ -105,32 +92,45 @@ class StrategyConfig10(BaseModel):
     Materialization strategy for a model, defaulting to full refresh.
     """
 
+    timestamp_column: str
     type: Type9
+
+
+class Type10(StrEnum):
+    merge = "merge"
+
+
+class StrategyConfig11(BaseModel):
+    """
+    Materialization strategy for a model, defaulting to full refresh.
+    """
+
+    type: Type10
     unique_key: list[str]
     update_columns: list[str] | None = None
 
 
-class Type10(StrEnum):
+class Type11(StrEnum):
     time_interval = "time_interval"
 
 
-class Type11(StrEnum):
+class Type12(StrEnum):
     ephemeral = "ephemeral"
 
 
-class StrategyConfig12(BaseModel):
+class StrategyConfig13(BaseModel):
     """
     Ephemeral model — inlined as CTE in downstream queries, no table created.
     """
 
-    type: Type11
+    type: Type12
 
 
-class Type12(StrEnum):
+class Type13(StrEnum):
     delete_insert = "delete_insert"
 
 
-class StrategyConfig13(BaseModel):
+class StrategyConfig14(BaseModel):
     """
     Delete+Insert: delete matching rows by partition key, then insert.
     """
@@ -139,11 +139,31 @@ class StrategyConfig13(BaseModel):
     """
     Column(s) used to identify the partition to delete.
     """
-    type: Type12
+    type: Type13
 
 
-class Type13(StrEnum):
+class Type14(StrEnum):
     microbatch = "microbatch"
+
+
+class Type15(StrEnum):
+    content_addressed = "content_addressed"
+
+
+class StrategyConfig16(BaseModel):
+    """
+    Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.
+    """
+
+    partition_columns: list[str] | None = []
+    """
+    Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
+    """
+    storage_prefix: str
+    """
+    Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
+    """
+    type: Type15
 
 
 class TargetConfig(BaseModel):
@@ -178,7 +198,7 @@ class LineageEdgeRecord(BaseModel):
     """
 
 
-class StrategyConfig11(BaseModel):
+class StrategyConfig12(BaseModel):
     """
     Partition-keyed materialization. Each run targets specific partitions rather than appending past a watermark. Idempotent and backfill-friendly.
 
@@ -205,10 +225,10 @@ class StrategyConfig11(BaseModel):
     """
     Column on the model output that holds the partition value. Must be a non-nullable date or timestamp column. Validated by the compiler against the typed output schema.
     """
-    type: Type10
+    type: Type11
 
 
-class StrategyConfig14(BaseModel):
+class StrategyConfig15(BaseModel):
     """
     Microbatch: alias for time_interval with hourly defaults. dbt-compatible naming for partition-based incremental processing.
     """
@@ -221,7 +241,7 @@ class StrategyConfig14(BaseModel):
     """
     Timestamp column for micro-batch boundaries.
     """
-    type: Type13
+    type: Type14
 
 
 class DagNodeOutput(BaseModel):
@@ -260,13 +280,14 @@ class DagNodeOutput(BaseModel):
     Pipeline name from `rocky.toml`, if applicable.
     """
     strategy: (
-        StrategyConfig8
-        | StrategyConfig9
+        StrategyConfig9
         | StrategyConfig10
         | StrategyConfig11
         | StrategyConfig12
         | StrategyConfig13
         | StrategyConfig14
+        | StrategyConfig15
+        | StrategyConfig16
         | None
     ) = None
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -526,19 +526,19 @@ class Type(StrEnum):
     replication = "replication"
 
 
-class Type15(StrEnum):
+class Type17(StrEnum):
     transformation = "transformation"
 
 
-class Type16(StrEnum):
+class Type18(StrEnum):
     quality = "quality"
 
 
-class Type17(StrEnum):
+class Type19(StrEnum):
     snapshot = "snapshot"
 
 
-class Type18(StrEnum):
+class Type20(StrEnum):
     load = "load"
 
 
@@ -562,51 +562,51 @@ class PortabilityConfig(BaseModel):
     """
 
 
-class Type19(StrEnum):
+class Type21(StrEnum):
     not_null = "not_null"
 
 
-class Type20(StrEnum):
+class Type22(StrEnum):
     unique = "unique"
 
 
-class Type21(StrEnum):
+class Type23(StrEnum):
     accepted_values = "accepted_values"
 
 
-class Type22(StrEnum):
+class Type24(StrEnum):
     relationships = "relationships"
 
 
-class Type23(StrEnum):
+class Type25(StrEnum):
     expression = "expression"
 
 
-class Type24(StrEnum):
+class Type26(StrEnum):
     row_count_range = "row_count_range"
 
 
-class Type25(StrEnum):
+class Type27(StrEnum):
     in_range = "in_range"
 
 
-class Type26(StrEnum):
+class Type28(StrEnum):
     regex_match = "regex_match"
 
 
-class Type27(StrEnum):
+class Type29(StrEnum):
     aggregate = "aggregate"
 
 
-class Type28(StrEnum):
+class Type30(StrEnum):
     composite = "composite"
 
 
-class Type29(StrEnum):
+class Type31(StrEnum):
     not_in_future = "not_in_future"
 
 
-class Type30(StrEnum):
+class Type32(StrEnum):
     older_than_n_days = "older_than_n_days"
 
 
@@ -1255,7 +1255,7 @@ class QualityAssertion1(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type19
+    type: Type21
 
 
 class QualityAssertion2(BaseModel):
@@ -1287,7 +1287,7 @@ class QualityAssertion2(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type20
+    type: Type22
 
 
 class QualityAssertion3(BaseModel):
@@ -1319,7 +1319,7 @@ class QualityAssertion3(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type21
+    type: Type23
     values: list[str]
     """
     The allowed values. Compared as string literals.
@@ -1363,7 +1363,7 @@ class QualityAssertion4(BaseModel):
     """
     Fully-qualified target table (`catalog.schema.table`).
     """
-    type: Type22
+    type: Type24
 
 
 class QualityAssertion5(BaseModel):
@@ -1399,7 +1399,7 @@ class QualityAssertion5(BaseModel):
     """
     A SQL boolean expression. Rows where `NOT (expression)` are failures.
     """
-    type: Type23
+    type: Type25
 
 
 class QualityAssertion6(BaseModel):
@@ -1439,7 +1439,7 @@ class QualityAssertion6(BaseModel):
     """
     Minimum row count (inclusive). `None` means no lower bound.
     """
-    type: Type24
+    type: Type26
 
 
 class QualityAssertion7(BaseModel):
@@ -1481,7 +1481,7 @@ class QualityAssertion7(BaseModel):
     """
     Minimum value (inclusive). `None` means no lower bound.
     """
-    type: Type25
+    type: Type27
 
 
 class QualityAssertion8(BaseModel):
@@ -1521,7 +1521,7 @@ class QualityAssertion8(BaseModel):
     """
     The regex pattern. Dialect-specific syntax — stick to the portable subset (character classes, anchors, quantifiers).
     """
-    type: Type26
+    type: Type28
 
 
 class QualityAssertion9(BaseModel):
@@ -1563,7 +1563,7 @@ class QualityAssertion9(BaseModel):
     """
     Aggregate operator.
     """
-    type: Type27
+    type: Type29
     value: str
     """
     Threshold to compare against. Parsed as `f64`.
@@ -1609,7 +1609,7 @@ class QualityAssertion10(BaseModel):
     """
     The kind of composite assertion. Currently `unique` only — kept as an enum to leave room for `not_null_any` / `not_null_all` in a later phase without another TestType.
     """
-    type: Type28
+    type: Type30
 
 
 class QualityAssertion11(BaseModel):
@@ -1641,7 +1641,7 @@ class QualityAssertion11(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type29
+    type: Type31
 
 
 class QualityAssertion12(BaseModel):
@@ -1677,7 +1677,7 @@ class QualityAssertion12(BaseModel):
     """
     N — days in the past. Must be > 0.
     """
-    type: Type30
+    type: Type32
 
 
 class QuarantineConfig(BaseModel):
@@ -2279,7 +2279,7 @@ class PipelineConfig3(QualityPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type16
+    type: Type18
 
 
 class PipelineConfig5(LoadPipelineConfig):
@@ -2287,7 +2287,7 @@ class PipelineConfig5(LoadPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type18
+    type: Type20
 
 
 class SnapshotPipelineConfig(BaseModel):
@@ -2421,7 +2421,7 @@ class PipelineConfig2(TransformationPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type15
+    type: Type17
 
 
 class PipelineConfig4(SnapshotPipelineConfig):
@@ -2429,7 +2429,7 @@ class PipelineConfig4(SnapshotPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type17
+    type: Type19
 
 
 class RockyConfig(BaseModel):

--- a/schemas/compile.schema.json
+++ b/schemas/compile.schema.json
@@ -498,6 +498,34 @@
             "type"
           ],
           "type": "object"
+        },
+        {
+          "description": "Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.",
+          "properties": {
+            "partition_columns": {
+              "default": [],
+              "description": "Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "storage_prefix": {
+              "description": "Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "content_addressed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "storage_prefix",
+            "type"
+          ],
+          "type": "object"
         }
       ]
     },

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -393,6 +393,34 @@
             "type"
           ],
           "type": "object"
+        },
+        {
+          "description": "Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.",
+          "properties": {
+            "partition_columns": {
+              "default": [],
+              "description": "Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "storage_prefix": {
+              "description": "Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "content_addressed"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "storage_prefix",
+            "type"
+          ],
+          "type": "object"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Wave 2 PR 5b. Model `.toml` sidecars can now declare:

\`\`\`toml
[strategy]
type = "content_addressed"
storage_prefix = "s3://bucket/dataset/table"
partition_columns = ["region"]   # optional; defaults to []
\`\`\`

The compiler lowers this to \`MaterializationStrategy::ContentAddressed\` (the IR variant from #496). **No runner behavior yet** — the existing \`sql_gen\` stub still returns \`InvalidRequest\`, and \`rocky run\` does not dispatch on the variant. PR 5c wires the runner.

## Cascade

Four \`match\` arms gain a new branch returning \`"content_addressed"\` so all crates compile clean:
- \`rocky-core::docs::strategy_label\`
- \`rocky-core::plan_partition::strategy_label\`
- \`rocky-compiler::import::report\` materialization breakdown
- \`rocky-cli::commands::list::list_models\`

## Tests

- \`test_parse_model_content_addressed\` — full strategy block parses; lowering to IR preserves \`storage_prefix\` + \`partition_columns\`.
- \`test_parse_model_content_addressed_unpartitioned\` — \`partition_columns\` is optional; default is \`[]\`.

## Codegen

\`just codegen\` propagated the new variant through:
- \`schemas/{compile,dag}.schema.json\`
- \`editors/vscode/src/types/generated/{compile,dag}.ts\`
- \`integrations/dagster/src/dagster_rocky/types_generated/{compile_schema,dag_schema}.py\`

## Out of scope

Validation that \`storage_prefix\` is a usable object-store URL + that \`partition_columns\` matches the table's discovered partition columns happens at runtime in PR 5c.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test -p rocky-core --lib test_parse_model_content_addressed\` — both new tests pass
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`just codegen\` produces only the artifacts in this commit