### PR TITLE
feat(rocky-cli): wire content_addressed strategy through rocky run (Wave 2 PR 5c)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3766,6 +3766,7 @@ dependencies = [
  "async-trait",
  "base64",
  "blake3",
+ "bytes",
  "chrono",
  "clap",
  "clap_complete",
@@ -3775,6 +3776,7 @@ dependencies = [
  "indexmap",
  "miette",
  "notify",
+ "object_store",
  "parquet",
  "rocky-adapter-sdk",
  "rocky-ai",
@@ -3804,6 +3806,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -48,6 +48,10 @@ hostname = { workspace = true }
 toml = { workspace = true }
 arrow = { workspace = true }
 parquet = { workspace = true }
+object_store = { workspace = true }
+bytes = { workspace = true }
+url = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ mod replay;
 mod retention_status;
 mod run;
 mod run_audit;
+mod run_content_addressed;
 mod run_dag_exec;
 mod run_local;
 mod run_watch;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3594,11 +3594,98 @@ pub(crate) async fn execute_models(
             }
             let model_start = Instant::now();
 
-            // Dispatch on the materialization strategy. time_interval models
-            // take the per-partition path so the runtime can iterate
-            // partitions, populate the window per partition, and record
-            // state-store rows. Other strategies use the single-statement
-            // path via generate_transformation_sql.
+            // Dispatch on the materialization strategy. Three special
+            // paths:
+            //
+            // - `time_interval` takes the per-partition path so the
+            //   runtime can iterate partitions, populate the window per
+            //   partition, and record state-store rows.
+            // - `content_addressed` writes the model's SELECT result
+            //   through `rocky_iceberg::uniform_writer` (content-hash
+            //   Parquet + Delta log commit) instead of generating SQL.
+            // - All other strategies use the single-statement path via
+            //   `generate_transformation_sql`.
+            if matches!(
+                model.config.strategy,
+                rocky_core::models::StrategyConfig::ContentAddressed { .. }
+            ) {
+                let model_ir = model.to_model_ir();
+                let model_started_at = Utc::now();
+                let target_table_full_name = format!(
+                    "{}.{}.{}",
+                    model_ir.target.catalog, model_ir.target.schema, model_ir.target.table,
+                );
+                let asset_key = vec![
+                    model_ir.target.catalog.clone(),
+                    model_ir.target.schema.clone(),
+                    model_ir.target.table.clone(),
+                ];
+                let summary = super::run_content_addressed::execute_content_addressed_model(
+                    &model_ir, warehouse,
+                )
+                .await
+                .with_context(|| format!("model '{model_name}' failed"));
+                match summary {
+                    Ok(summary) => {
+                        let duration_ms = model_start.elapsed().as_millis() as u64;
+                        output.materializations.push(MaterializationOutput {
+                            asset_key,
+                            rows_copied: Some(summary.num_rows as u64),
+                            duration_ms,
+                            started_at: model_started_at,
+                            metadata: MaterializationMetadata {
+                                strategy: "content_addressed".to_string(),
+                                watermark: None,
+                                target_table_full_name: Some(target_table_full_name.clone()),
+                                sql_hash: Some(crate::output::sql_fingerprint(
+                                    std::slice::from_ref(&model_ir.sql),
+                                )),
+                                column_count: exec_ctx.column_count_for(model_name),
+                                compile_time_ms: exec_ctx.compile_time_ms_for(model_name),
+                            },
+                            partition: None,
+                            cost_usd: None,
+                            bytes_scanned: None,
+                            bytes_written: Some(summary.size_bytes),
+                            job_ids: vec![],
+                        });
+                        info!(
+                            model = model_name.as_str(),
+                            target = target_table_full_name.as_str(),
+                            num_rows = summary.num_rows,
+                            commit_version = summary.commit_version,
+                            blake3 = summary.blake3_hash.as_str(),
+                            file_path = summary.file_path.as_str(),
+                            "content_addressed model materialized"
+                        );
+                        if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                            let _ = reg
+                                .fire(&HookContext::after_model_run(
+                                    run_id,
+                                    pipe,
+                                    model_name,
+                                    duration_ms,
+                                ))
+                                .await;
+                        }
+                        models_executed += 1;
+                        continue;
+                    }
+                    Err(e) => {
+                        if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
+                            let _ = reg
+                                .fire(&HookContext::model_error(
+                                    run_id,
+                                    pipe,
+                                    model_name,
+                                    &format!("{e:#}"),
+                                ))
+                                .await;
+                        }
+                        return Err(e);
+                    }
+                }
+            }
             if matches!(
                 model.config.strategy,
                 rocky_core::models::StrategyConfig::TimeInterval { .. }

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -1,0 +1,517 @@
+//! Runner integration for `MaterializationStrategy::ContentAddressed`.
+//!
+//! The runtime path for content-addressed models:
+//! 1. Discover the table's `UniformTableState` via
+//!    [`rocky_iceberg::uniform_writer::UniformWriter::discover`].
+//! 2. Assert the model's declared `partition_columns` matches what
+//!    `discover()` reports for the table.
+//! 3. Execute the model SQL via the warehouse adapter to obtain rows.
+//! 4. Convert rows + typed columns into an Arrow `RecordBatch`.
+//! 5. Call `UniformWriter::write_batch` (unpartitioned this PR; partitioned
+//!    follows in a sub-PR after this).
+//! 6. Trigger `MSCK REPAIR TABLE ... SYNC METADATA` via
+//!    [`rocky_iceberg::uniform_writer::UniformWriter::sync_iceberg_metadata`]
+//!    so DuckDB iceberg_scan + Iceberg-aware Trino can see the new commit.
+//!
+//! Phase 1 + 2 of the writer support `Int64`, `Utf8`, and
+//! `Timestamp(Microsecond, UTC)` columns; other typed-column types return a
+//! `DeltaLog` error from the writer and propagate up as an anyhow.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow};
+use arrow::array::{
+    ArrayRef, Int32Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
+};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use object_store::ObjectStore;
+use object_store::aws::{AmazonS3Builder, S3ConditionalPut};
+use rocky_iceberg::uniform_writer::{
+    Result as UfResult, SqlClient, UniformWriter, UniformWriterConfig, UniformWriterError,
+};
+use rocky_ir::{MaterializationStrategy, ModelIr, RockyType, TypedColumn};
+use url::Url;
+
+/// Placeholder SqlClient used at writer construction time.
+///
+/// The runner does not call `UniformWriter::sync_iceberg_metadata` — it
+/// issues the MSCK REPAIR directly via the warehouse adapter — so this
+/// `SqlClient` is never invoked. Wrapping the borrowed `&dyn
+/// WarehouseAdapter` as an `Arc<dyn SqlClient>` would force a `'static`
+/// lifetime which the runner cannot satisfy; sidestepping the
+/// indirection keeps the runner ergonomic.
+struct NoOpSqlClient;
+
+#[async_trait::async_trait]
+impl SqlClient for NoOpSqlClient {
+    async fn execute(&self, _sql: &str) -> UfResult<()> {
+        Err(UniformWriterError::Sql(
+            "internal: NoOpSqlClient::execute called — the runner issues MSCK directly via \
+             the warehouse adapter; UniformWriter::sync_iceberg_metadata must not be called \
+             through this client"
+                .into(),
+        ))
+    }
+}
+
+/// Parse `s3://bucket/path/to/table` into `(bucket, key_prefix)`.
+fn parse_s3_url(storage_prefix: &str) -> Result<(String, String)> {
+    let url = Url::parse(storage_prefix)
+        .with_context(|| format!("could not parse storage_prefix as a URL: {storage_prefix:?}"))?;
+    if url.scheme() != "s3" {
+        return Err(anyhow!(
+            "only s3:// URLs are supported in this slice; got scheme {:?} in storage_prefix {:?}",
+            url.scheme(),
+            storage_prefix
+        ));
+    }
+    let bucket = url
+        .host_str()
+        .ok_or_else(|| anyhow!("storage_prefix {storage_prefix:?} has no bucket host"))?
+        .to_string();
+    let prefix = url
+        .path()
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .to_string();
+    Ok((bucket, prefix))
+}
+
+/// Build an [`ObjectStore`] for the given `storage_prefix` URL.
+///
+/// `s3://<bucket>/<prefix>` → an `AmazonS3` store with conditional-put
+/// enabled (RFC 9110 `If-None-Match: *` headers, which AWS S3 supports
+/// natively — see Exp 8). Credentials are sourced from the standard
+/// `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
+/// env vars; profile-style auth (via `AWS_PROFILE`) is not honoured by
+/// `object_store` directly — operators must resolve a profile to the
+/// underlying env vars beforehand.
+pub(crate) fn build_object_store(storage_prefix: &str) -> Result<Arc<dyn ObjectStore>> {
+    let (bucket, _prefix) = parse_s3_url(storage_prefix)?;
+    let region = std::env::var("AWS_DEFAULT_REGION")
+        .or_else(|_| std::env::var("AWS_REGION"))
+        .unwrap_or_else(|_| "us-east-1".to_string());
+    let store = AmazonS3Builder::from_env()
+        .with_bucket_name(&bucket)
+        .with_region(&region)
+        .with_conditional_put(S3ConditionalPut::ETagMatch)
+        .build()
+        .with_context(|| format!("failed to build S3 store for {storage_prefix:?}"))?;
+    Ok(Arc::new(store))
+}
+
+/// Convert a `QueryResult` plus the model's `typed_columns` into an Arrow
+/// `RecordBatch`.
+///
+/// Supported column types (Phase 1 + 2 of the writer): `Int64`, `Int32`,
+/// `String`, `Timestamp`, `TimestampNtz`. Any other `RockyType` returns an
+/// error pointing at the limitation; widening lands in a follow-up PR.
+pub(crate) fn query_result_to_record_batch(
+    typed_columns: &[TypedColumn],
+    result: &rocky_core::traits::QueryResult,
+) -> Result<RecordBatch> {
+    // The warehouse adapter and the model's typed_columns must agree on
+    // column order. Most adapters preserve the SELECT's column order, but
+    // we validate by name to fail loudly on a mismatch.
+    if result.columns.len() != typed_columns.len() {
+        return Err(anyhow!(
+            "column-count mismatch: model declares {} typed columns; warehouse returned {}",
+            typed_columns.len(),
+            result.columns.len()
+        ));
+    }
+    for (i, (tc, name)) in typed_columns.iter().zip(result.columns.iter()).enumerate() {
+        if tc.name != *name {
+            return Err(anyhow!(
+                "column-name mismatch at position {i}: model declares {:?}, warehouse returned {:?}",
+                tc.name,
+                name
+            ));
+        }
+    }
+
+    let mut fields: Vec<Field> = Vec::with_capacity(typed_columns.len());
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(typed_columns.len());
+
+    for (col_idx, tc) in typed_columns.iter().enumerate() {
+        let (field, array): (Field, ArrayRef) = match &tc.data_type {
+            RockyType::Int32 => {
+                let values: Vec<Option<i32>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else {
+                            v.as_i64()
+                                .and_then(|n| i32::try_from(n).ok())
+                                .map(Some)
+                                .ok_or_else(|| {
+                                    anyhow!(
+                                        "column {:?}: value {v} not representable as Int32",
+                                        tc.name
+                                    )
+                                })
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Int32, tc.nullable),
+                    Arc::new(Int32Array::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Int64 => {
+                let values: Vec<Option<i64>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else {
+                            v.as_i64()
+                                .or_else(|| {
+                                    // Some adapters return integers as JSON
+                                    // strings (Databricks' Statement
+                                    // Execution API does this for BIGINT to
+                                    // avoid JS-number precision loss).
+                                    v.as_str().and_then(|s| s.parse().ok())
+                                })
+                                .map(Some)
+                                .ok_or_else(|| anyhow!("column {:?}: value {v} not Int64", tc.name))
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Int64, tc.nullable),
+                    Arc::new(Int64Array::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::String => {
+                let values: Vec<Option<String>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else if let Some(s) = v.as_str() {
+                            Ok(Some(s.to_string()))
+                        } else {
+                            Err(anyhow!("column {:?}: value {v} not a String", tc.name))
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Utf8, tc.nullable),
+                    Arc::new(StringArray::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Timestamp | RockyType::TimestampNtz => {
+                let values: Vec<Option<i64>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            return Ok(None);
+                        }
+                        // Adapters typically return timestamps as
+                        // ISO-8601 strings ("2026-05-12T10:23:45.123456Z");
+                        // parse to micros-since-epoch.
+                        let s = v.as_str().ok_or_else(|| {
+                            anyhow!("column {:?}: timestamp value {v} not a string", tc.name)
+                        })?;
+                        let parsed = chrono::DateTime::parse_from_rfc3339(s)
+                            .map(|dt| dt.with_timezone(&chrono::Utc))
+                            .or_else(|_| {
+                                chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
+                                    .map(|ndt| ndt.and_utc())
+                            })
+                            .with_context(|| {
+                                format!("column {:?}: failed to parse timestamp {s:?}", tc.name)
+                            })?;
+                        Ok(Some(parsed.timestamp_micros()))
+                    })
+                    .collect::<Result<_>>()?;
+                let arr = TimestampMicrosecondArray::from(values).with_timezone("UTC");
+                (
+                    Field::new(
+                        &tc.name,
+                        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                        tc.nullable,
+                    ),
+                    Arc::new(arr) as ArrayRef,
+                )
+            }
+            other => {
+                return Err(anyhow!(
+                    "column {:?} has type {other:?}; the content-addressed writer supports \
+                     Int32 / Int64 / String / Timestamp / TimestampNtz in this slice",
+                    tc.name
+                ));
+            }
+        };
+        fields.push(field);
+        columns.push(array);
+    }
+
+    let schema = Arc::new(Schema::new(fields));
+    RecordBatch::try_new(schema, columns).map_err(|e| anyhow!("RecordBatch::try_new: {e}"))
+}
+
+/// Materialize a single model whose strategy is
+/// [`MaterializationStrategy::ContentAddressed`].
+///
+/// **Phase 1 of the runner integration:** unpartitioned tables only. If
+/// the model declares `partition_columns`, the function returns an error
+/// pointing at the follow-up PR that will add partitioned support.
+pub async fn execute_content_addressed_model(
+    model_ir: &ModelIr,
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+) -> Result<ContentAddressedRunSummary> {
+    let MaterializationStrategy::ContentAddressed {
+        storage_prefix,
+        partition_columns,
+    } = &model_ir.materialization
+    else {
+        return Err(anyhow!(
+            "execute_content_addressed_model called on a non-ContentAddressed model"
+        ));
+    };
+
+    if !partition_columns.is_empty() {
+        return Err(anyhow!(
+            "content_addressed strategy with partition_columns={:?} is not yet implemented \
+             in the runner; partitioned support lands in a follow-up PR. The writer library \
+             already exposes UniformWriter::write_partitioned_batch — the work is wiring the \
+             row-grouping step here.",
+            partition_columns
+        ));
+    }
+
+    // 1. Build the object store.
+    let store = build_object_store(storage_prefix)?;
+
+    // 2. Build the writer. SqlClient is a NoOp because the runner calls
+    // MSCK directly via the warehouse adapter (see step 7) — wrapping a
+    // borrowed `&dyn WarehouseAdapter` as `Arc<dyn SqlClient + 'static>`
+    // would force a `'static` lifetime on the borrow which the caller
+    // cannot satisfy.
+    let sql_client: Arc<dyn SqlClient> = Arc::new(NoOpSqlClient);
+    // Strip the bucket from the storage_prefix to derive the key prefix
+    // the writer uses for `_delta_log/` etc.
+    let (_bucket, key_prefix) = parse_s3_url(storage_prefix)?;
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: model_ir.target.catalog.clone(),
+            schema: model_ir.target.schema.clone(),
+            table: model_ir.target.table.clone(),
+            prefix: key_prefix,
+            engine_info: format!("rocky-cli/{}", env!("CARGO_PKG_VERSION")),
+        },
+        store,
+        sql_client,
+    );
+
+    // 3. Discover state + assert partition_columns match.
+    let state = writer
+        .discover()
+        .await
+        .with_context(|| format!("discover() failed for {:?}", model_ir.target))?;
+    if state.partition_columns != *partition_columns {
+        return Err(anyhow!(
+            "partition columns mismatch: model declares {:?}, table has {:?}",
+            partition_columns,
+            state.partition_columns
+        ));
+    }
+
+    // 4. Execute the model SQL.
+    let result = warehouse
+        .execute_query(&model_ir.sql)
+        .await
+        .map_err(|e| anyhow!("execute_query failed: {e}"))?;
+
+    // 5. Convert rows → Arrow.
+    let batch = query_result_to_record_batch(&model_ir.typed_columns, &result)?;
+    let num_rows = batch.num_rows();
+
+    // 6. Write the batch.
+    let write_result = writer
+        .write_batch_with_state(batch, state)
+        .await
+        .map_err(|e| anyhow!("write_batch failed: {e}"))?;
+
+    // 7. Sync iceberg metadata so cross-engine readers see the new
+    // commit. Issued directly via the warehouse adapter rather than
+    // through `UniformWriter::sync_iceberg_metadata` to avoid the
+    // `'static` lifetime requirement on `Arc<dyn SqlClient>` (see the
+    // NoOpSqlClient docstring above).
+    let msck_sql = format!(
+        "MSCK REPAIR TABLE {}.{}.{} SYNC METADATA",
+        model_ir.target.catalog, model_ir.target.schema, model_ir.target.table,
+    );
+    warehouse
+        .execute_statement(&msck_sql)
+        .await
+        .map_err(|e| anyhow!("MSCK REPAIR failed: {e}"))?;
+
+    Ok(ContentAddressedRunSummary {
+        num_rows,
+        blake3_hash: write_result.blake3_hash,
+        commit_version: write_result.commit_version,
+        file_path: write_result.file_path,
+        size_bytes: write_result.size_bytes,
+    })
+}
+
+/// Summary returned by [`execute_content_addressed_model`].
+#[derive(Debug, Clone)]
+pub struct ContentAddressedRunSummary {
+    pub num_rows: usize,
+    pub blake3_hash: String,
+    pub commit_version: u64,
+    pub file_path: String,
+    pub size_bytes: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Array;
+    use rocky_core::traits::QueryResult;
+
+    fn col(name: &str, ty: RockyType, nullable: bool) -> TypedColumn {
+        TypedColumn {
+            name: name.into(),
+            data_type: ty,
+            nullable,
+        }
+    }
+
+    #[test]
+    fn parse_s3_url_basic() {
+        let (bucket, prefix) = parse_s3_url("s3://my-bucket/path/to/table").unwrap();
+        assert_eq!(bucket, "my-bucket");
+        assert_eq!(prefix, "path/to/table");
+    }
+
+    #[test]
+    fn parse_s3_url_strips_trailing_slash() {
+        let (bucket, prefix) = parse_s3_url("s3://my-bucket/path/to/table/").unwrap();
+        assert_eq!(bucket, "my-bucket");
+        assert_eq!(prefix, "path/to/table");
+    }
+
+    #[test]
+    fn parse_s3_url_rejects_non_s3_scheme() {
+        let err = parse_s3_url("http://my-bucket/path").unwrap_err();
+        assert!(format!("{err}").contains("only s3://"));
+    }
+
+    #[test]
+    fn convert_int64_string_timestamp_columns() {
+        let typed_cols = vec![
+            col("id", RockyType::Int64, false),
+            col("name", RockyType::String, false),
+            col("ts", RockyType::Timestamp, false),
+        ];
+        let result = QueryResult {
+            columns: vec!["id".into(), "name".into(), "ts".into()],
+            rows: vec![
+                vec![
+                    serde_json::json!(1_i64),
+                    serde_json::json!("a"),
+                    serde_json::json!("2026-05-12T10:23:45.123456Z"),
+                ],
+                vec![
+                    serde_json::json!(2_i64),
+                    serde_json::json!("b"),
+                    serde_json::json!("2026-05-12T10:23:46Z"),
+                ],
+            ],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 3);
+        assert_eq!(batch.schema().field(0).name(), "id");
+        assert_eq!(batch.schema().field(1).name(), "name");
+        assert_eq!(batch.schema().field(2).name(), "ts");
+    }
+
+    #[test]
+    fn convert_int64_from_json_string_value() {
+        // Databricks Statement Execution API returns BIGINT as JSON
+        // strings to avoid JS-number precision loss; the converter must
+        // accept that.
+        let typed_cols = vec![col("id", RockyType::Int64, false)];
+        let result = QueryResult {
+            columns: vec!["id".into()],
+            rows: vec![vec![serde_json::json!("12345")]],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 12345);
+    }
+
+    #[test]
+    fn convert_errors_on_column_count_mismatch() {
+        let typed_cols = vec![col("id", RockyType::Int64, false)];
+        let result = QueryResult {
+            columns: vec!["id".into(), "extra".into()],
+            rows: vec![vec![serde_json::json!(1), serde_json::json!(2)]],
+        };
+        let err = query_result_to_record_batch(&typed_cols, &result).unwrap_err();
+        assert!(format!("{err}").contains("column-count mismatch"));
+    }
+
+    #[test]
+    fn convert_errors_on_column_name_mismatch() {
+        let typed_cols = vec![col("id", RockyType::Int64, false)];
+        let result = QueryResult {
+            columns: vec!["whatever".into()],
+            rows: vec![vec![serde_json::json!(1)]],
+        };
+        let err = query_result_to_record_batch(&typed_cols, &result).unwrap_err();
+        assert!(format!("{err}").contains("column-name mismatch"));
+    }
+
+    #[test]
+    fn convert_errors_on_unsupported_type() {
+        let typed_cols = vec![col("v", RockyType::Boolean, false)];
+        let result = QueryResult {
+            columns: vec!["v".into()],
+            rows: vec![vec![serde_json::json!(true)]],
+        };
+        let err = query_result_to_record_batch(&typed_cols, &result).unwrap_err();
+        assert!(format!("{err}").contains("Int32 / Int64 / String / Timestamp"));
+    }
+
+    #[test]
+    fn convert_nullable_columns_carry_nulls() {
+        let typed_cols = vec![col("name", RockyType::String, true)];
+        let result = QueryResult {
+            columns: vec!["name".into()],
+            rows: vec![
+                vec![serde_json::json!("a")],
+                vec![serde_json::Value::Null],
+                vec![serde_json::json!("c")],
+            ],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(!arr.is_null(0));
+        assert!(arr.is_null(1));
+        assert!(!arr.is_null(2));
+    }
+}


### PR DESCRIPTION
## Summary

Wave 2 PR 5c. \`rocky run\` now routes \`MaterializationStrategy::ContentAddressed\` through \`rocky_iceberg::uniform_writer\` end-to-end:

1. Discover the table's \`UniformTableState\` via the writer.
2. Assert the model's declared \`partition_columns\` matches the table's actual partition columns; mismatch is a hard error.
3. Execute the model SQL via the warehouse adapter (\`execute_query\`).
4. Convert row results + the model's \`typed_columns\` into an Arrow \`RecordBatch\`.
5. Call \`UniformWriter::write_batch_with_state\` (unpartitioned this PR; \`write_partitioned_batch\` lands in a follow-up).
6. Trigger \`MSCK REPAIR TABLE <fqtn> SYNC METADATA\` directly via the warehouse adapter so cross-engine readers (DuckDB iceberg_scan, Iceberg-aware Trino) see the new commit.
7. Push a \`MaterializationOutput\` so \`rocky run --output json\` surfaces the strategy, file size, and row count.

## Supported column types

Phase 1 + 2 of the writer support \`Int64\`, \`Int32\`, \`Utf8\`, \`Timestamp(Microsecond, UTC)\`, \`TimestampNtz\`. Other typed-column types return an explicit error citing the limitation; widening lands in a follow-up.

## Lifetime note

The runner sidesteps \`UniformWriter::sync_iceberg_metadata\` because wrapping the borrowed \`&dyn WarehouseAdapter\` as \`Arc<dyn SqlClient + 'static>\` would force a \`'static\` lifetime the caller cannot satisfy. The runner issues MSCK directly via the warehouse adapter; the writer holds a \`NoOpSqlClient\` placeholder that errors loudly if invoked.

## Tests

9 unit tests in \`run_content_addressed\`:
- URL parsing (basic, trailing slash, non-s3 rejection)
- Arrow conversion (Int64/String/Timestamp happy path, Int64 from a JSON-string value, nullable-column null handling)
- Error paths (column-count mismatch, column-name mismatch, unsupported type)

## Out of scope

- Partitioned content-addressed materializations (\`write_partitioned_batch\` integration in the runner). Sub-PR follow.
- Wider \`RockyType\` support (Boolean, Float, Decimal, Date, Binary, complex types).
- Live integration test against a real Databricks UniForm table — PR 5d.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test -p rocky-cli --lib\` — 385 passed (9 new + 376 prior)
- [x] \`cargo fmt --all -- --check\` clean