### PR TITLE
feat(rocky-cli): wider RockyType coverage in content_addressed runner (Wave 2 PR 6b)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -7,21 +7,26 @@
 //!    `discover()` reports for the table.
 //! 3. Execute the model SQL via the warehouse adapter to obtain rows.
 //! 4. Convert rows + typed columns into an Arrow `RecordBatch`.
-//! 5. Call `UniformWriter::write_batch` (unpartitioned this PR; partitioned
-//!    follows in a sub-PR after this).
-//! 6. Trigger `MSCK REPAIR TABLE ... SYNC METADATA` via
-//!    [`rocky_iceberg::uniform_writer::UniformWriter::sync_iceberg_metadata`]
-//!    so DuckDB iceberg_scan + Iceberg-aware Trino can see the new commit.
+//! 5. For unpartitioned targets: one `UniformWriter::write_batch` commit.
+//!    For partitioned targets: group rows by partition tuple and emit one
+//!    `write_partitioned_batch` commit per group.
+//! 6. Trigger `MSCK REPAIR TABLE ... SYNC METADATA` directly via the
+//!    warehouse adapter so DuckDB iceberg_scan + Iceberg-aware Trino can
+//!    see the new commit(s).
 //!
-//! Phase 1 + 2 of the writer support `Int64`, `Utf8`, and
-//! `Timestamp(Microsecond, UTC)` columns; other typed-column types return a
-//! `DeltaLog` error from the writer and propagate up as an anyhow.
+//! Supported `typed_columns` types:
+//! - `Boolean`, `Int32`, `Int64`, `Float32`, `Float64`, `Decimal{precision, scale}`
+//! - `String`, `Date`, `Timestamp`, `TimestampNtz`, `Binary`
+//!
+//! Unsupported types (`Array`, `Map`, `Struct`, `Variant`, `Unknown`)
+//! surface a typed error pointing at the limitation.
 
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
 use arrow::array::{
-    ArrayRef, Int32Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
+    ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
+    Int32Array, Int64Array, RecordBatch, StringArray, TimestampMicrosecondArray,
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use object_store::ObjectStore;
@@ -208,6 +213,184 @@ pub(crate) fn query_result_to_record_batch(
                     Arc::new(StringArray::from(values)) as ArrayRef,
                 )
             }
+            RockyType::Boolean => {
+                let values: Vec<Option<bool>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else if let Some(b) = v.as_bool() {
+                            Ok(Some(b))
+                        } else if let Some(s) = v.as_str() {
+                            // Some adapters serialize booleans as "true" / "false".
+                            match s {
+                                "true" | "TRUE" | "True" | "1" => Ok(Some(true)),
+                                "false" | "FALSE" | "False" | "0" => Ok(Some(false)),
+                                _ => Err(anyhow!(
+                                    "column {:?}: boolean value {s:?} not recognised",
+                                    tc.name
+                                )),
+                            }
+                        } else {
+                            Err(anyhow!("column {:?}: value {v} not a Boolean", tc.name))
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Boolean, tc.nullable),
+                    Arc::new(BooleanArray::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Float32 => {
+                let values: Vec<Option<f32>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else {
+                            v.as_f64()
+                                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                                .map(|x| x as f32)
+                                .map(Some)
+                                .ok_or_else(|| {
+                                    anyhow!("column {:?}: value {v} not Float32", tc.name)
+                                })
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Float32, tc.nullable),
+                    Arc::new(Float32Array::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Float64 => {
+                let values: Vec<Option<f64>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            Ok(None)
+                        } else {
+                            v.as_f64()
+                                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                                .map(Some)
+                                .ok_or_else(|| {
+                                    anyhow!("column {:?}: value {v} not Float64", tc.name)
+                                })
+                        }
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Float64, tc.nullable),
+                    Arc::new(Float64Array::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Decimal { precision, scale } => {
+                // Decimals come back from most warehouses as JSON strings
+                // (Databricks, Snowflake) — preserves the full precision
+                // that JS numbers can't hold. Parse them to i128 by
+                // dropping the decimal point, then convert to
+                // Decimal128Array with the table's precision + scale.
+                let prec = *precision;
+                let scl = *scale;
+                let values: Vec<Option<i128>> =
+                    result
+                        .rows
+                        .iter()
+                        .map(|r| {
+                            let v = &r[col_idx];
+                            if v.is_null() {
+                                return Ok(None);
+                            }
+                            let raw = match v.as_str() {
+                                Some(s) => s.to_string(),
+                                None => v.as_f64().map(|f| f.to_string()).ok_or_else(|| {
+                                    anyhow!(
+                                        "column {:?}: decimal value {v} not a string/number",
+                                        tc.name
+                                    )
+                                })?,
+                            };
+                            Ok(Some(parse_decimal_to_i128(&raw, scl).with_context(|| {
+                            format!(
+                                "column {:?}: cannot parse {raw:?} as Decimal({prec}, {scl})",
+                                tc.name
+                            )
+                        })?))
+                        })
+                        .collect::<Result<_>>()?;
+                let arr = Decimal128Array::from(values)
+                    .with_precision_and_scale(prec, scl as i8)
+                    .map_err(|e| {
+                        anyhow!(
+                            "column {:?}: Decimal128Array::with_precision_and_scale failed: {e}",
+                            tc.name
+                        )
+                    })?;
+                (
+                    Field::new(&tc.name, DataType::Decimal128(prec, scl as i8), tc.nullable),
+                    Arc::new(arr) as ArrayRef,
+                )
+            }
+            RockyType::Date => {
+                let values: Vec<Option<i32>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            return Ok(None);
+                        }
+                        let s = v.as_str().ok_or_else(|| {
+                            anyhow!("column {:?}: date value {v} not a string", tc.name)
+                        })?;
+                        let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").with_context(
+                            || format!("column {:?}: failed to parse date {s:?}", tc.name),
+                        )?;
+                        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                        Ok(Some((date - epoch).num_days() as i32))
+                    })
+                    .collect::<Result<_>>()?;
+                (
+                    Field::new(&tc.name, DataType::Date32, tc.nullable),
+                    Arc::new(Date32Array::from(values)) as ArrayRef,
+                )
+            }
+            RockyType::Binary => {
+                // Warehouses typically base64-encode binary columns in
+                // JSON. Decode each row.
+                use base64::Engine;
+                let values: Vec<Option<Vec<u8>>> = result
+                    .rows
+                    .iter()
+                    .map(|r| {
+                        let v = &r[col_idx];
+                        if v.is_null() {
+                            return Ok(None);
+                        }
+                        let s = v.as_str().ok_or_else(|| {
+                            anyhow!("column {:?}: binary value {v} not a base64 string", tc.name)
+                        })?;
+                        Ok(Some(
+                            base64::engine::general_purpose::STANDARD
+                                .decode(s)
+                                .with_context(|| {
+                                    format!("column {:?}: failed to decode base64 {s:?}", tc.name)
+                                })?,
+                        ))
+                    })
+                    .collect::<Result<_>>()?;
+                let refs: Vec<Option<&[u8]>> = values.iter().map(|v| v.as_deref()).collect();
+                (
+                    Field::new(&tc.name, DataType::Binary, tc.nullable),
+                    Arc::new(BinaryArray::from(refs)) as ArrayRef,
+                )
+            }
             RockyType::Timestamp | RockyType::TimestampNtz => {
                 let values: Vec<Option<i64>> = result
                     .rows
@@ -248,7 +431,8 @@ pub(crate) fn query_result_to_record_batch(
             other => {
                 return Err(anyhow!(
                     "column {:?} has type {other:?}; the content-addressed writer supports \
-                     Int32 / Int64 / String / Timestamp / TimestampNtz in this slice",
+                     Int32 / Int64 / Boolean / Float32 / Float64 / Decimal / String / Date / \
+                     Timestamp / TimestampNtz / Binary in this slice",
                     tc.name
                 ));
             }
@@ -259,6 +443,38 @@ pub(crate) fn query_result_to_record_batch(
 
     let schema = Arc::new(Schema::new(fields));
     RecordBatch::try_new(schema, columns).map_err(|e| anyhow!("RecordBatch::try_new: {e}"))
+}
+
+/// Parse a decimal string (e.g. `"123.45"`) into an `i128` scaled by the
+/// table's declared `scale`. Returns an error if the value has more
+/// fractional digits than the column's scale (the writer would silently
+/// truncate, which is the wrong thing).
+fn parse_decimal_to_i128(s: &str, scale: u8) -> Result<i128> {
+    let trimmed = s.trim();
+    let (sign, rest) = match trimmed.strip_prefix('-') {
+        Some(r) => (-1_i128, r),
+        None => (1_i128, trimmed.strip_prefix('+').unwrap_or(trimmed)),
+    };
+    let (int_part, frac_part) = match rest.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (rest, ""),
+    };
+    if frac_part.len() > scale as usize {
+        return Err(anyhow!(
+            "value {s:?} has {} fractional digits but column scale is {scale}",
+            frac_part.len()
+        ));
+    }
+    let mut int_only = String::with_capacity(int_part.len() + scale as usize);
+    int_only.push_str(int_part);
+    int_only.push_str(frac_part);
+    for _ in frac_part.len()..scale as usize {
+        int_only.push('0');
+    }
+    let magnitude: i128 = int_only
+        .parse()
+        .with_context(|| format!("decimal {s:?} could not be parsed to i128"))?;
+    Ok(sign * magnitude)
 }
 
 /// Materialize a single model whose strategy is
@@ -651,13 +867,18 @@ mod tests {
 
     #[test]
     fn convert_errors_on_unsupported_type() {
-        let typed_cols = vec![col("v", RockyType::Boolean, false)];
+        // Array(Int64) is unsupported in the current slice.
+        let typed_cols = vec![col(
+            "v",
+            RockyType::Array(Box::new(RockyType::Int64)),
+            false,
+        )];
         let result = QueryResult {
             columns: vec!["v".into()],
-            rows: vec![vec![serde_json::json!(true)]],
+            rows: vec![vec![serde_json::json!([1, 2, 3])]],
         };
         let err = query_result_to_record_batch(&typed_cols, &result).unwrap_err();
-        assert!(format!("{err}").contains("Int32 / Int64 / String / Timestamp"));
+        assert!(format!("{err}").contains("Int32 / Int64"));
     }
 
     fn make_partitioned_batch_3rows() -> RecordBatch {
@@ -792,6 +1013,156 @@ mod tests {
         let err =
             group_batch_by_partition_tuple(&batch, &["nope".to_string()], &pcols()).unwrap_err();
         assert!(format!("{err}").contains("not in the model's typed_columns"));
+    }
+
+    #[test]
+    fn convert_boolean_from_bool_and_string() {
+        let typed_cols = vec![col("flag", RockyType::Boolean, true)];
+        let result = QueryResult {
+            columns: vec!["flag".into()],
+            rows: vec![
+                vec![serde_json::json!(true)],
+                vec![serde_json::json!("false")],
+                vec![serde_json::json!("TRUE")],
+                vec![serde_json::Value::Null],
+            ],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(arr.value(0));
+        assert!(!arr.value(1));
+        assert!(arr.value(2));
+        assert!(arr.is_null(3));
+    }
+
+    #[test]
+    fn convert_float64_from_number_and_string() {
+        let typed_cols = vec![col("x", RockyType::Float64, false)];
+        let result = QueryResult {
+            columns: vec!["x".into()],
+            rows: vec![vec![serde_json::json!(1.5)], vec![serde_json::json!("2.5")]],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!((arr.value(0) - 1.5).abs() < 1e-9);
+        assert!((arr.value(1) - 2.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn convert_decimal_from_string() {
+        let typed_cols = vec![col(
+            "price",
+            RockyType::Decimal {
+                precision: 10,
+                scale: 2,
+            },
+            false,
+        )];
+        let result = QueryResult {
+            columns: vec!["price".into()],
+            rows: vec![
+                vec![serde_json::json!("123.45")],
+                vec![serde_json::json!("-99.99")],
+                vec![serde_json::json!("0.01")],
+                vec![serde_json::json!("100")], // no decimal point
+            ],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap();
+        assert_eq!(arr.value(0), 12345_i128);
+        assert_eq!(arr.value(1), -9999_i128);
+        assert_eq!(arr.value(2), 1_i128);
+        assert_eq!(arr.value(3), 10000_i128);
+    }
+
+    #[test]
+    fn convert_decimal_rejects_overflowing_scale() {
+        let typed_cols = vec![col(
+            "x",
+            RockyType::Decimal {
+                precision: 10,
+                scale: 2,
+            },
+            false,
+        )];
+        let result = QueryResult {
+            columns: vec!["x".into()],
+            rows: vec![vec![serde_json::json!("1.234")]], // 3 fractional digits, scale=2
+        };
+        let err = query_result_to_record_batch(&typed_cols, &result).unwrap_err();
+        // The "fractional digits" detail comes from the underlying
+        // `parse_decimal_to_i128` error, which is attached as a source on
+        // the outer "cannot parse ... as Decimal(...)" context wrapper.
+        // `{err:#}` prints the full chain.
+        let full = format!("{err:#}");
+        assert!(
+            full.contains("fractional digits"),
+            "expected error chain to mention fractional digits, got: {full}"
+        );
+    }
+
+    #[test]
+    fn convert_date_from_iso_string() {
+        let typed_cols = vec![col("d", RockyType::Date, false)];
+        let result = QueryResult {
+            columns: vec!["d".into()],
+            rows: vec![
+                vec![serde_json::json!("2026-05-12")],
+                vec![serde_json::json!("1970-01-01")],
+                vec![serde_json::json!("1969-12-31")],
+            ],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Date32Array>()
+            .unwrap();
+        let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+        let may_12_2026 = chrono::NaiveDate::from_ymd_opt(2026, 5, 12).unwrap();
+        assert_eq!(arr.value(0) as i64, (may_12_2026 - epoch).num_days());
+        assert_eq!(arr.value(1), 0);
+        assert_eq!(arr.value(2), -1);
+    }
+
+    #[test]
+    fn convert_binary_from_base64() {
+        let typed_cols = vec![col("payload", RockyType::Binary, false)];
+        // Base64 of bytes [1, 2, 3] is "AQID".
+        let result = QueryResult {
+            columns: vec!["payload".into()],
+            rows: vec![vec![serde_json::json!("AQID")]],
+        };
+        let batch = query_result_to_record_batch(&typed_cols, &result).unwrap();
+        let arr = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        assert_eq!(arr.value(0), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn parse_decimal_to_i128_basics() {
+        assert_eq!(parse_decimal_to_i128("0", 2).unwrap(), 0);
+        assert_eq!(parse_decimal_to_i128("1.00", 2).unwrap(), 100);
+        assert_eq!(parse_decimal_to_i128("-1.50", 2).unwrap(), -150);
+        assert_eq!(parse_decimal_to_i128("1", 2).unwrap(), 100);
+        assert_eq!(parse_decimal_to_i128("0.01", 2).unwrap(), 1);
+        // Trailing zeros vs scale.
+        assert_eq!(parse_decimal_to_i128("1.5", 4).unwrap(), 15000);
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -264,9 +264,9 @@ pub(crate) fn query_result_to_record_batch(
 /// Materialize a single model whose strategy is
 /// [`MaterializationStrategy::ContentAddressed`].
 ///
-/// **Phase 1 of the runner integration:** unpartitioned tables only. If
-/// the model declares `partition_columns`, the function returns an error
-/// pointing at the follow-up PR that will add partitioned support.
+/// Handles both unpartitioned (single `write_batch` commit) and
+/// partitioned (one `write_partitioned_batch` commit per partition tuple)
+/// targets.
 pub async fn execute_content_addressed_model(
     model_ir: &ModelIr,
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
@@ -281,24 +281,14 @@ pub async fn execute_content_addressed_model(
         ));
     };
 
-    if !partition_columns.is_empty() {
-        return Err(anyhow!(
-            "content_addressed strategy with partition_columns={:?} is not yet implemented \
-             in the runner; partitioned support lands in a follow-up PR. The writer library \
-             already exposes UniformWriter::write_partitioned_batch — the work is wiring the \
-             row-grouping step here.",
-            partition_columns
-        ));
-    }
-
     // 1. Build the object store.
     let store = build_object_store(storage_prefix)?;
 
     // 2. Build the writer. SqlClient is a NoOp because the runner calls
-    // MSCK directly via the warehouse adapter (see step 7) — wrapping a
-    // borrowed `&dyn WarehouseAdapter` as `Arc<dyn SqlClient + 'static>`
-    // would force a `'static` lifetime on the borrow which the caller
-    // cannot satisfy.
+    // MSCK directly via the warehouse adapter (see the MSCK call below) —
+    // wrapping a borrowed `&dyn WarehouseAdapter` as
+    // `Arc<dyn SqlClient + 'static>` would force a `'static` lifetime on
+    // the borrow which the caller cannot satisfy.
     let sql_client: Arc<dyn SqlClient> = Arc::new(NoOpSqlClient);
     // Strip the bucket from the storage_prefix to derive the key prefix
     // the writer uses for `_delta_log/` etc.
@@ -316,7 +306,7 @@ pub async fn execute_content_addressed_model(
     );
 
     // 3. Discover state + assert partition_columns match.
-    let state = writer
+    let mut state = writer
         .discover()
         .await
         .with_context(|| format!("discover() failed for {:?}", model_ir.target))?;
@@ -336,19 +326,64 @@ pub async fn execute_content_addressed_model(
 
     // 5. Convert rows → Arrow.
     let batch = query_result_to_record_batch(&model_ir.typed_columns, &result)?;
-    let num_rows = batch.num_rows();
+    let total_rows = batch.num_rows();
 
-    // 6. Write the batch.
-    let write_result = writer
-        .write_batch_with_state(batch, state)
-        .await
-        .map_err(|e| anyhow!("write_batch failed: {e}"))?;
+    // 6. Write — split path on partitioned vs unpartitioned.
+    let (last_blake3, last_commit_version, last_file_path, total_size_bytes) =
+        if partition_columns.is_empty() {
+            let write_result = writer
+                .write_batch_with_state(batch, state)
+                .await
+                .map_err(|e| anyhow!("write_batch failed: {e}"))?;
+            (
+                write_result.blake3_hash,
+                write_result.commit_version,
+                write_result.file_path,
+                write_result.size_bytes,
+            )
+        } else {
+            // Partitioned: group rows by partition tuple and emit one
+            // commit per group. Bump `state.next_commit_version` manually
+            // between groups so the cond-put loop in the writer doesn't
+            // burn a retry per group on the already-claimed version.
+            let groups =
+                group_batch_by_partition_tuple(&batch, partition_columns, &model_ir.typed_columns)?;
+            if groups.is_empty() {
+                return Err(anyhow!(
+                    "partitioned content_addressed: model SQL returned 0 rows; \
+                     no commits emitted (this is likely a bug in the model — fail loud rather \
+                     than silent no-op)"
+                ));
+            }
+            let mut last_blake3 = String::new();
+            let mut last_commit_version = 0_u64;
+            let mut last_file_path = String::new();
+            let mut total_size_bytes = 0_u64;
+            for (pv_map, sub_batch) in groups {
+                let write_result = writer
+                    .write_partitioned_batch_with_state(sub_batch, pv_map, state.clone())
+                    .await
+                    .map_err(|e| anyhow!("write_partitioned_batch failed: {e}"))?;
+                state.next_commit_version = write_result.commit_version + 1;
+                last_blake3 = write_result.blake3_hash;
+                last_commit_version = write_result.commit_version;
+                last_file_path = write_result.file_path;
+                total_size_bytes = total_size_bytes.saturating_add(write_result.size_bytes);
+            }
+            (
+                last_blake3,
+                last_commit_version,
+                last_file_path,
+                total_size_bytes,
+            )
+        };
 
     // 7. Sync iceberg metadata so cross-engine readers see the new
-    // commit. Issued directly via the warehouse adapter rather than
+    // commit(s). Issued directly via the warehouse adapter rather than
     // through `UniformWriter::sync_iceberg_metadata` to avoid the
     // `'static` lifetime requirement on `Arc<dyn SqlClient>` (see the
-    // NoOpSqlClient docstring above).
+    // NoOpSqlClient docstring above). One MSCK call covers all the
+    // commits the partitioned loop just emitted.
     let msck_sql = format!(
         "MSCK REPAIR TABLE {}.{}.{} SYNC METADATA",
         model_ir.target.catalog, model_ir.target.schema, model_ir.target.table,
@@ -359,12 +394,144 @@ pub async fn execute_content_addressed_model(
         .map_err(|e| anyhow!("MSCK REPAIR failed: {e}"))?;
 
     Ok(ContentAddressedRunSummary {
-        num_rows,
-        blake3_hash: write_result.blake3_hash,
-        commit_version: write_result.commit_version,
-        file_path: write_result.file_path,
-        size_bytes: write_result.size_bytes,
+        num_rows: total_rows,
+        blake3_hash: last_blake3,
+        commit_version: last_commit_version,
+        file_path: last_file_path,
+        size_bytes: total_size_bytes,
     })
+}
+
+/// Group a `RecordBatch` by partition tuple.
+///
+/// Returns a `Vec` of `(partition_values_map, sub_batch)` pairs where each
+/// `sub_batch` contains only the rows whose partition values match
+/// `partition_values_map`. The map is keyed by logical partition column
+/// name with stringified values, the shape
+/// [`UniformWriter::write_partitioned_batch`] expects.
+///
+/// Partition columns stay in the sub-batch — `write_partitioned_batch`'s
+/// internal `build_parquet` drops them before writing the Parquet file.
+fn group_batch_by_partition_tuple(
+    batch: &RecordBatch,
+    partition_columns: &[String],
+    typed_columns: &[TypedColumn],
+) -> Result<Vec<(std::collections::HashMap<String, String>, RecordBatch)>> {
+    use arrow::compute::take;
+    use std::collections::HashMap;
+
+    // Map each partition column name → its index in the batch + its type.
+    let mut partition_meta: Vec<(usize, &RockyType)> = Vec::with_capacity(partition_columns.len());
+    for pcol in partition_columns {
+        let (idx, tc) = typed_columns
+            .iter()
+            .enumerate()
+            .find(|(_, tc)| &tc.name == pcol)
+            .ok_or_else(|| {
+                anyhow!(
+                    "partition column {:?} is not in the model's typed_columns",
+                    pcol
+                )
+            })?;
+        partition_meta.push((idx, &tc.data_type));
+    }
+
+    // Bucket row indices by partition tuple. Use a Vec of (key, indices)
+    // pairs instead of a HashMap so iteration order is deterministic
+    // across runs (matters for `next_commit_version` allocation and for
+    // golden-test outputs in downstream consumers).
+    let mut buckets: Vec<(Vec<String>, Vec<u32>)> = Vec::new();
+    for row in 0..batch.num_rows() {
+        let mut key: Vec<String> = Vec::with_capacity(partition_columns.len());
+        for &(col_idx, ty) in &partition_meta {
+            let array = batch.column(col_idx);
+            let s = stringify_partition_value(array.as_ref(), row, ty, partition_columns)?;
+            key.push(s);
+        }
+        let row_u32 = u32::try_from(row).map_err(|_| anyhow!("batch too large for u32 index"))?;
+        match buckets.iter_mut().find(|(k, _)| *k == key) {
+            Some((_, idxs)) => idxs.push(row_u32),
+            None => buckets.push((key, vec![row_u32])),
+        }
+    }
+
+    // For each bucket, build the partition-values map + the sub-batch.
+    let mut out: Vec<(HashMap<String, String>, RecordBatch)> = Vec::with_capacity(buckets.len());
+    for (key, indices) in buckets {
+        let indices_array = arrow::array::UInt32Array::from(indices);
+        let mut new_columns: Vec<arrow::array::ArrayRef> = Vec::with_capacity(batch.num_columns());
+        for col in batch.columns() {
+            let taken = take(col.as_ref(), &indices_array, None)
+                .map_err(|e| anyhow!("arrow::compute::take failed: {e}"))?;
+            new_columns.push(taken);
+        }
+        let sub_batch = RecordBatch::try_new(batch.schema(), new_columns)
+            .map_err(|e| anyhow!("RecordBatch::try_new for partition sub-batch: {e}"))?;
+        let mut pv_map: HashMap<String, String> = HashMap::with_capacity(partition_columns.len());
+        for (pcol, value) in partition_columns.iter().zip(key) {
+            pv_map.insert(pcol.clone(), value);
+        }
+        out.push((pv_map, sub_batch));
+    }
+    Ok(out)
+}
+
+/// Stringify a single Arrow scalar value for use as a Delta partition value.
+///
+/// Delta partition values are always strings on the wire. The
+/// stringification is RockyType-aware so reads + diffs are stable
+/// (numerics formatted canonically, timestamps in ISO 8601 with `Z`).
+fn stringify_partition_value(
+    array: &dyn arrow::array::Array,
+    row: usize,
+    ty: &RockyType,
+    partition_columns: &[String],
+) -> Result<String> {
+    if array.is_null(row) {
+        return Err(anyhow!(
+            "partition columns {:?} cannot contain NULL values (row {row})",
+            partition_columns
+        ));
+    }
+    match ty {
+        RockyType::Int32 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::Int32Array>()
+                .ok_or_else(|| anyhow!("partition column type mismatch: expected Int32"))?;
+            Ok(arr.value(row).to_string())
+        }
+        RockyType::Int64 => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .ok_or_else(|| anyhow!("partition column type mismatch: expected Int64"))?;
+            Ok(arr.value(row).to_string())
+        }
+        RockyType::String => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .ok_or_else(|| anyhow!("partition column type mismatch: expected Utf8"))?;
+            Ok(arr.value(row).to_string())
+        }
+        RockyType::Timestamp | RockyType::TimestampNtz => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
+                .ok_or_else(|| {
+                    anyhow!("partition column type mismatch: expected Timestamp(Microsecond)")
+                })?;
+            let micros = arr.value(row);
+            let dt = chrono::DateTime::from_timestamp_micros(micros)
+                .ok_or_else(|| anyhow!("timestamp {micros} out of range"))?;
+            Ok(dt.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string())
+        }
+        other => Err(anyhow!(
+            "partition column type {other:?} is not supported as a partition key (Phase 6a \
+             supports Int32 / Int64 / String / Timestamp / TimestampNtz)"
+        )),
+    }
 }
 
 /// Summary returned by [`execute_content_addressed_model`].
@@ -493,6 +660,140 @@ mod tests {
         assert!(format!("{err}").contains("Int32 / Int64 / String / Timestamp"));
     }
 
+    fn make_partitioned_batch_3rows() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::Utf8, false),
+            Field::new("region", DataType::Utf8, false),
+        ]));
+        let ids = Int64Array::from(vec![1_i64, 2, 3]);
+        let payload = StringArray::from(vec!["a", "b", "c"]);
+        let region = StringArray::from(vec!["eu", "us", "eu"]);
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(ids), Arc::new(payload), Arc::new(region)],
+        )
+        .unwrap()
+    }
+
+    fn pcols() -> Vec<TypedColumn> {
+        vec![
+            col("id", RockyType::Int64, false),
+            col("payload", RockyType::String, false),
+            col("region", RockyType::String, false),
+        ]
+    }
+
+    #[test]
+    fn group_single_column_partition_splits_into_two_buckets() {
+        let batch = make_partitioned_batch_3rows();
+        let groups =
+            group_batch_by_partition_tuple(&batch, &["region".to_string()], &pcols()).unwrap();
+        assert_eq!(groups.len(), 2, "two distinct region values → two buckets");
+
+        // Bucket order is the first-seen order (eu then us).
+        let (pv0, b0) = &groups[0];
+        let (pv1, b1) = &groups[1];
+        assert_eq!(pv0.get("region").map(String::as_str), Some("eu"));
+        assert_eq!(pv1.get("region").map(String::as_str), Some("us"));
+        assert_eq!(b0.num_rows(), 2);
+        assert_eq!(b1.num_rows(), 1);
+        assert_eq!(b0.num_columns(), 3);
+    }
+
+    #[test]
+    fn group_preserves_first_seen_partition_order() {
+        // Rows order: us, eu, us, eu — buckets should be us-first, then eu.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("region", DataType::Utf8, false),
+        ]));
+        let ids = Int64Array::from(vec![1_i64, 2, 3, 4]);
+        let region = StringArray::from(vec!["us", "eu", "us", "eu"]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(region)]).unwrap();
+        let typed = vec![
+            col("id", RockyType::Int64, false),
+            col("region", RockyType::String, false),
+        ];
+        let groups =
+            group_batch_by_partition_tuple(&batch, &["region".to_string()], &typed).unwrap();
+        assert_eq!(groups[0].0.get("region").map(String::as_str), Some("us"));
+        assert_eq!(groups[1].0.get("region").map(String::as_str), Some("eu"));
+    }
+
+    #[test]
+    fn group_int64_partition_stringifies_correctly() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("payload", DataType::Utf8, false),
+            Field::new("year", DataType::Int64, false),
+        ]));
+        let payload = StringArray::from(vec!["a", "b", "c"]);
+        let year = Int64Array::from(vec![2024_i64, 2025, 2024]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(payload), Arc::new(year)]).unwrap();
+        let typed = vec![
+            col("payload", RockyType::String, false),
+            col("year", RockyType::Int64, false),
+        ];
+        let groups = group_batch_by_partition_tuple(&batch, &["year".to_string()], &typed).unwrap();
+        assert_eq!(groups.len(), 2);
+        // First-seen year=2024 → bucket 0.
+        assert_eq!(groups[0].0.get("year").map(String::as_str), Some("2024"));
+        assert_eq!(groups[1].0.get("year").map(String::as_str), Some("2025"));
+    }
+
+    #[test]
+    fn group_multi_column_partition() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("payload", DataType::Utf8, false),
+            Field::new("region", DataType::Utf8, false),
+            Field::new("year", DataType::Int64, false),
+        ]));
+        let payload = StringArray::from(vec!["a", "b", "c", "d"]);
+        let region = StringArray::from(vec!["eu", "us", "eu", "eu"]);
+        let year = Int64Array::from(vec![2024_i64, 2024, 2025, 2024]);
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(payload), Arc::new(region), Arc::new(year)],
+        )
+        .unwrap();
+        let typed = vec![
+            col("payload", RockyType::String, false),
+            col("region", RockyType::String, false),
+            col("year", RockyType::Int64, false),
+        ];
+        let groups = group_batch_by_partition_tuple(
+            &batch,
+            &["region".to_string(), "year".to_string()],
+            &typed,
+        )
+        .unwrap();
+        // 3 distinct (region, year) tuples: (eu, 2024), (us, 2024), (eu, 2025).
+        assert_eq!(groups.len(), 3);
+    }
+
+    #[test]
+    fn group_rejects_null_partition_value() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "region",
+            DataType::Utf8,
+            true,
+        )]));
+        let region = StringArray::from(vec![Some("eu"), None]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(region)]).unwrap();
+        let typed = vec![col("region", RockyType::String, true)];
+        let err =
+            group_batch_by_partition_tuple(&batch, &["region".to_string()], &typed).unwrap_err();
+        assert!(format!("{err}").contains("cannot contain NULL"));
+    }
+
+    #[test]
+    fn group_rejects_unknown_partition_column() {
+        let batch = make_partitioned_batch_3rows();
+        let err =
+            group_batch_by_partition_tuple(&batch, &["nope".to_string()], &pcols()).unwrap_err();
+        assert!(format!("{err}").contains("not in the model's typed_columns"));
+    }
+
     #[test]
     fn convert_nullable_columns_carry_nulls() {
         let typed_cols = vec![col("name", RockyType::String, true)];
@@ -603,6 +904,110 @@ mod live_tests {
         cell.as_i64()
             .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
             .expect("count parses as i64")
+    }
+
+    /// Live end-to-end test for partitioned content-addressed materialization.
+    ///
+    /// Requires the same env vars as `content_addressed_e2e_live_sandbox`,
+    /// except `ROCKY_TEST_*` should point at a **partitioned** UniForm
+    /// table with the `(id BIGINT, payload STRING, region STRING)`
+    /// PARTITIONED BY (region) shape. The test writes 3 rows split across
+    /// `region='eu'` (2) + `region='us'` (1) and asserts Photon GROUP BY
+    /// counts bump by the right amounts.
+    #[tokio::test]
+    #[ignore]
+    async fn content_addressed_partitioned_e2e_live_sandbox() {
+        let Some(env) = try_load_env() else {
+            eprintln!("skipping: ROCKY_TEST_* env vars not set");
+            return;
+        };
+        let Some(connector) = try_load_connector() else {
+            eprintln!("skipping: DATABRICKS_* env vars not set");
+            return;
+        };
+        let warehouse = DatabricksWarehouseAdapter::new(connector);
+        let warehouse_dyn: &dyn WarehouseAdapter = &warehouse;
+        let fqtn = format!("{}.{}.{}", env.catalog, env.schema, env.table);
+
+        // Group-by counts BEFORE the write.
+        let count_eu_before = read_region_count(warehouse_dyn, &fqtn, "eu").await;
+        let count_us_before = read_region_count(warehouse_dyn, &fqtn, "us").await;
+
+        let model_sql = "SELECT * FROM VALUES \
+             (CAST(900501 AS BIGINT), CAST('runner-eu-1' AS STRING), CAST('eu' AS STRING)), \
+             (CAST(900502 AS BIGINT), CAST('runner-eu-2' AS STRING), CAST('eu' AS STRING)), \
+             (CAST(900503 AS BIGINT), CAST('runner-us-1' AS STRING), CAST('us' AS STRING)) \
+             AS t(id, payload, region)"
+            .to_string();
+
+        let mut model_ir = ModelIr::transformation(
+            TargetRef {
+                catalog: env.catalog.clone(),
+                schema: env.schema.clone(),
+                table: env.table.clone(),
+            },
+            MaterializationStrategy::ContentAddressed {
+                storage_prefix: env.storage_prefix.clone(),
+                partition_columns: vec!["region".to_string()],
+            },
+            vec![],
+            model_sql,
+            GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            None,
+            None,
+        );
+        model_ir.name = Arc::from("live_runner_partitioned_test");
+        model_ir.typed_columns = vec![
+            TypedColumn {
+                name: "id".into(),
+                data_type: RockyType::Int64,
+                nullable: false,
+            },
+            TypedColumn {
+                name: "payload".into(),
+                data_type: RockyType::String,
+                nullable: false,
+            },
+            TypedColumn {
+                name: "region".into(),
+                data_type: RockyType::String,
+                nullable: false,
+            },
+        ];
+
+        let summary = execute_content_addressed_model(&model_ir, warehouse_dyn)
+            .await
+            .expect("partitioned end-to-end must succeed");
+        assert_eq!(
+            summary.num_rows, 3,
+            "total rows across all partition groups"
+        );
+
+        let count_eu_after = read_region_count(warehouse_dyn, &fqtn, "eu").await;
+        let count_us_after = read_region_count(warehouse_dyn, &fqtn, "us").await;
+        assert_eq!(
+            count_eu_after,
+            count_eu_before + 2,
+            "eu partition must bump by 2 (before={count_eu_before}, after={count_eu_after})"
+        );
+        assert_eq!(
+            count_us_after,
+            count_us_before + 1,
+            "us partition must bump by 1 (before={count_us_before}, after={count_us_after})"
+        );
+    }
+
+    async fn read_region_count(warehouse: &dyn WarehouseAdapter, fqtn: &str, region: &str) -> i64 {
+        let sql = format!("SELECT COUNT(*) FROM {fqtn} WHERE region = '{region}'");
+        let result = warehouse.execute_query(&sql).await.expect("count query");
+        result.rows[0][0]
+            .as_i64()
+            .or_else(|| result.rows[0][0].as_str().and_then(|s| s.parse().ok()))
+            .expect("count i64")
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Extends \`query_result_to_record_batch\` to convert warehouse rows for five more \`RockyType\` variants. Stacks on #500.

| Type | Source | Arrow target |
|---|---|---|
| \`Boolean\` | \`Value::Bool\` or string "true"/"false"/"TRUE"/"FALSE"/"1"/"0" | \`BooleanArray\` |
| \`Float32\` | \`Value::Number\` or JSON-string fallback | \`Float32Array\` |
| \`Float64\` | same | \`Float64Array\` |
| \`Decimal {precision, scale}\` | string-encoded decimal | \`Decimal128Array\` |
| \`Date\` | ISO 8601 \`YYYY-MM-DD\` | \`Date32Array\` (days since epoch) |
| \`Binary\` | base64 string (Databricks convention) | \`BinaryArray\` |

Existing \`Int32\` / \`Int64\` / \`String\` / \`Timestamp\` / \`TimestampNtz\` unchanged.

## Decimal handling

A new \`parse_decimal_to_i128(s, scale)\` helper does the sign/integer/fraction split, validates fractional-digit count against the column's declared scale (rejects \`"1.234"\` against a \`Decimal(10, 2)\` column — silent truncation would be the wrong default), and returns an \`i128\` scaled by \`10^scale\`. Negative values, sub-unit values, and integer-only values all round-trip correctly.

## Out of scope

\`Array\`, \`Map\`, \`Struct\`, \`Variant\`, and \`Unknown\` still surface a typed error. Those types interact with the writer's stats + Parquet layout in non-trivial ways and need their own design pass.

## Tests

6 new unit tests:
- \`convert_boolean_from_bool_and_string\` (mixed input forms + null)
- \`convert_float64_from_number_and_string\`
- \`convert_decimal_from_string\` (positive / negative / sub-unit / no-decimal)
- \`convert_decimal_rejects_overflowing_scale\` (3 fractional digits against scale=2)
- \`convert_date_from_iso_string\` (epoch / post-epoch / pre-epoch)
- \`convert_binary_from_base64\` (round-trip)
- \`parse_decimal_to_i128_basics\` (helper edge cases)

Total \`query_result_to_record_batch\` test count is now 22 (was 15).

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p rocky-cli --lib commands::run_content_addressed\` — 22 passed (6 new + 15 prior + 1 prior live ignored)
- [x] \`cargo fmt --all -- --check\` clean