### PR TITLE
feat(rocky-iceberg): schema evolution support (Wave 2 Phase 5)

### DIFF
--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -104,44 +104,11 @@ fn parse_log_jsonl(body: &[u8]) -> Result<Vec<LogAction>> {
     Ok(out)
 }
 
-/// Build a [`UniformTableState`] from the actions of `_delta_log/00…0.json`.
-///
-/// `next_commit_version` is left as 1 on the assumption that bootstrap-only
-/// state has v=0 already written. Callers that read additional commits patch
-/// it from the listing.
-fn state_from_bootstrap_actions(actions: &[LogAction]) -> Result<UniformTableState> {
-    let mut protocol: Option<&Protocol> = None;
-    let mut metadata: Option<&MetaData> = None;
-    for a in actions {
-        match a {
-            LogAction::Protocol(p) => protocol = Some(p),
-            LogAction::MetaData(m) => metadata = Some(m),
-            LogAction::Other => {}
-        }
-    }
-    let protocol = protocol.ok_or_else(|| {
-        UniformWriterError::DeltaLog("bootstrap commit has no protocol action".into())
-    })?;
-    let metadata = metadata.ok_or_else(|| {
-        UniformWriterError::DeltaLog("bootstrap commit has no metaData action".into())
-    })?;
-
-    let row_tracking_enabled = protocol.writer_features.iter().any(|f| f == "rowTracking")
-        || metadata
-            .configuration
-            .get("delta.enableRowTracking")
-            .map(|v| v == "true")
-            .unwrap_or(false);
-    let deletion_vectors_enabled = protocol
-        .writer_features
-        .iter()
-        .any(|f| f == "deletionVectors")
-        || metadata
-            .configuration
-            .get("delta.enableDeletionVectors")
-            .map(|v| v == "true")
-            .unwrap_or(false);
-
+/// Extract `(physical, field_id)` maps from a metaData action's
+/// `schemaString`.
+fn parse_columns_from_metadata(
+    metadata: &MetaData,
+) -> Result<(HashMap<String, String>, HashMap<String, i32>)> {
     let schema: SchemaString = serde_json::from_str(&metadata.schema_string).map_err(|e| {
         UniformWriterError::DeltaLog(format!("malformed metaData.schemaString: {e}"))
     })?;
@@ -181,6 +148,50 @@ fn state_from_bootstrap_actions(actions: &[LogAction]) -> Result<UniformTableSta
             )));
         }
     }
+    Ok((physical, field_id))
+}
+
+/// Build a [`UniformTableState`] from the actions of `_delta_log/00…0.json`.
+///
+/// `next_commit_version` is left as 1 on the assumption that bootstrap-only
+/// state has v=0 already written. Callers that read additional commits patch
+/// it from the listing. Likewise `physical` / `field_id` /
+/// `partition_columns` reflect bootstrap; `discover()` overrides them from
+/// the latest post-bootstrap metaData if a later `ALTER TABLE` has fired.
+fn state_from_bootstrap_actions(actions: &[LogAction]) -> Result<UniformTableState> {
+    let mut protocol: Option<&Protocol> = None;
+    let mut metadata: Option<&MetaData> = None;
+    for a in actions {
+        match a {
+            LogAction::Protocol(p) => protocol = Some(p),
+            LogAction::MetaData(m) => metadata = Some(m),
+            LogAction::Other => {}
+        }
+    }
+    let protocol = protocol.ok_or_else(|| {
+        UniformWriterError::DeltaLog("bootstrap commit has no protocol action".into())
+    })?;
+    let metadata = metadata.ok_or_else(|| {
+        UniformWriterError::DeltaLog("bootstrap commit has no metaData action".into())
+    })?;
+
+    let row_tracking_enabled = protocol.writer_features.iter().any(|f| f == "rowTracking")
+        || metadata
+            .configuration
+            .get("delta.enableRowTracking")
+            .map(|v| v == "true")
+            .unwrap_or(false);
+    let deletion_vectors_enabled = protocol
+        .writer_features
+        .iter()
+        .any(|f| f == "deletionVectors")
+        || metadata
+            .configuration
+            .get("delta.enableDeletionVectors")
+            .map(|v| v == "true")
+            .unwrap_or(false);
+
+    let (physical, field_id) = parse_columns_from_metadata(metadata)?;
 
     Ok(UniformTableState {
         physical,
@@ -196,6 +207,72 @@ fn state_from_bootstrap_actions(actions: &[LogAction]) -> Result<UniformTableSta
         // value.
         row_tracking_next_id: 0,
     })
+}
+
+/// Walk `_delta_log/*.json` newest → oldest looking for the highest commit
+/// version that carries a `metaData` action. Returns the parsed schema +
+/// partition columns from that commit, or `None` if no post-bootstrap
+/// commit has emitted a metaData (i.e. no `ALTER TABLE` since CREATE).
+///
+/// `ALTER ADD COLUMN`, `RENAME COLUMN`, `DROP COLUMN`, and
+/// `SET TBLPROPERTIES` all emit a fresh metaData action. The writer must
+/// reflect the latest one — using the bootstrap schema would silently emit
+/// Parquet files referencing UUIDs that no longer exist (DROP) or missing
+/// new columns (ADD).
+pub(super) async fn discover_latest_metadata<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+    bootstrap_version: u64,
+) -> Result<Option<MetaDataSnapshot>> {
+    use futures::TryStreamExt;
+    let log_prefix = Path::from(format!("{prefix}/_delta_log"));
+    let mut versions: Vec<(u64, Path)> = Vec::new();
+    let mut stream = store.list(Some(&log_prefix));
+    while let Some(meta) = stream.try_next().await? {
+        let key = meta.location.to_string();
+        if let Some((_, last)) = key.rsplit_once('/')
+            && let Some(stem) = last.strip_suffix(".json")
+            && stem.len() == 20
+            && let Ok(v) = stem.parse::<u64>()
+            // Only walk commits AFTER the bootstrap — the bootstrap's
+            // metaData is already in the state.
+            && v > bootstrap_version
+        {
+            versions.push((v, meta.location));
+        }
+    }
+    versions.sort_by_key(|(v, _)| std::cmp::Reverse(*v));
+    for (_, path) in versions {
+        let body = store.get(&path).await?.bytes().await?;
+        let actions = parse_log_jsonl(&body)?;
+        // Take the last metaData in this commit (commits emit at most one
+        // metaData per the Delta protocol; defense in depth).
+        let mut latest = None;
+        for a in &actions {
+            if let LogAction::MetaData(m) = a {
+                latest = Some(m);
+            }
+        }
+        if let Some(metadata) = latest {
+            let (physical, field_id) = parse_columns_from_metadata(metadata)?;
+            return Ok(Some(MetaDataSnapshot {
+                physical,
+                field_id,
+                partition_columns: metadata.partition_columns.clone(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+/// Subset of metaData fields the writer cares about, surfaced by
+/// [`discover_latest_metadata`] for `discover()` to overlay onto the
+/// bootstrap-derived state.
+#[derive(Debug)]
+pub(super) struct MetaDataSnapshot {
+    pub physical: HashMap<String, String>,
+    pub field_id: HashMap<String, i32>,
+    pub partition_columns: Vec<String>,
 }
 
 /// Reject states the writer cannot serve.
@@ -307,6 +384,17 @@ impl UniformWriter {
         // bootstrap's v=0 and append a new versioned JSON.
         state.next_commit_version = next_commit_version(self.store(), &prefix).await?;
 
+        // Phase 5: overlay the latest post-bootstrap metaData if any
+        // `ALTER TABLE` has fired since CREATE. The bootstrap schema is
+        // only authoritative when no schema-changing DDL has run.
+        if let Some(latest) =
+            discover_latest_metadata(self.store(), &prefix, /* bootstrap_version = */ 0).await?
+        {
+            state.physical = latest.physical;
+            state.field_id = latest.field_id;
+            state.partition_columns = latest.partition_columns;
+        }
+
         // For rowTracking-enabled tables, scan the log for the latest
         // watermark. For everything else this stays 0 (and is unused).
         if state.row_tracking_enabled {
@@ -401,6 +489,112 @@ mod tests {
             "partition column physical UUID must appear in the `physical` map",
         );
         enforce_supported(&state).expect("partitioned tables are supported in phase 2");
+    }
+
+    #[tokio::test]
+    async fn discover_latest_metadata_returns_none_for_bootstrap_only() {
+        use bytes::Bytes;
+        use object_store::PutPayload;
+        use object_store::memory::InMemory;
+        let store = InMemory::new();
+        store
+            .put(
+                &Path::from("tbl/_delta_log/00000000000000000000.json"),
+                PutPayload::from(Bytes::copy_from_slice(EXP04_BOOTSTRAP)),
+            )
+            .await
+            .unwrap();
+        let latest = discover_latest_metadata(&store, "tbl", 0).await.unwrap();
+        assert!(latest.is_none(), "no post-bootstrap metaData → None");
+    }
+
+    #[tokio::test]
+    async fn discover_latest_metadata_finds_post_alter_schema() {
+        use bytes::Bytes;
+        use object_store::PutPayload;
+        use object_store::memory::InMemory;
+        let store = InMemory::new();
+        // Bootstrap = exp-04 (id, name, ts).
+        store
+            .put(
+                &Path::from("tbl/_delta_log/00000000000000000000.json"),
+                PutPayload::from(Bytes::copy_from_slice(EXP04_BOOTSTRAP)),
+            )
+            .await
+            .unwrap();
+        // v=1: a WRITE (no metaData) — discover should walk past this.
+        let v1 = "{\"commitInfo\":{\"timestamp\":1,\"operation\":\"WRITE\"}}\n\
+                  {\"add\":{\"path\":\"abc.parquet\",\"partitionValues\":{},\"size\":1,\"modificationTime\":1,\"dataChange\":true,\"stats\":\"{\\\"numRecords\\\":1}\"}}\n";
+        store
+            .put(
+                &Path::from("tbl/_delta_log/00000000000000000001.json"),
+                PutPayload::from(Bytes::from(v1.as_bytes().to_vec())),
+            )
+            .await
+            .unwrap();
+        // v=2: ALTER ADD COLUMN `extra` — emits a new metaData with the
+        // pre-existing UUIDs preserved + a fresh UUID for `extra`.
+        let alter_metadata = serde_json::json!({
+            "metaData": {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": serde_json::to_string(&serde_json::json!({
+                    "type": "struct",
+                    "fields": [
+                        // id + name + ts retain their pre-ALTER UUIDs.
+                        {"name": "id", "type": "long", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 1,
+                            "delta.columnMapping.physicalName": "col-764ab664-41c1-43df-91d3-0a26f1a2804a"
+                        }},
+                        {"name": "name", "type": "string", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 2,
+                            "delta.columnMapping.physicalName": "col-6a00f493-6967-4191-9447-0d19f8db9868"
+                        }},
+                        {"name": "ts", "type": "timestamp", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 3,
+                            "delta.columnMapping.physicalName": "col-a789db88-c380-4a59-87a3-45e324ffa1a8"
+                        }},
+                        // `extra` is brand new; gets a fresh UUID + id=4.
+                        {"name": "extra", "type": "string", "nullable": true, "metadata": {
+                            "delta.columnMapping.id": 4,
+                            "delta.columnMapping.physicalName": "col-a13f2930-65e1-46ce-aec4-224f8e484c43"
+                        }}
+                    ]
+                })).unwrap(),
+                "partitionColumns": [],
+                "configuration": {"delta.columnMapping.mode": "name"},
+                "createdTime": 0
+            }
+        });
+        let v2 = format!(
+            "{}\n{}\n",
+            serde_json::json!({"commitInfo": {"operation": "ADD COLUMNS"}}),
+            serde_json::to_string(&alter_metadata).unwrap(),
+        );
+        store
+            .put(
+                &Path::from("tbl/_delta_log/00000000000000000002.json"),
+                PutPayload::from(Bytes::from(v2.into_bytes())),
+            )
+            .await
+            .unwrap();
+
+        let latest = discover_latest_metadata(&store, "tbl", 0)
+            .await
+            .unwrap()
+            .expect("latest metaData should be the v=2 ALTER commit");
+        // Pre-existing columns kept their UUIDs.
+        assert_eq!(
+            latest.physical.get("id").map(String::as_str),
+            Some("col-764ab664-41c1-43df-91d3-0a26f1a2804a")
+        );
+        // New column appears with its fresh UUID.
+        assert_eq!(
+            latest.physical.get("extra").map(String::as_str),
+            Some("col-a13f2930-65e1-46ce-aec4-224f8e484c43")
+        );
+        assert_eq!(latest.field_id.get("extra"), Some(&4));
+        assert_eq!(latest.physical.len(), 4, "id, name, ts, extra");
     }
 
     #[test]

--- a/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
+++ b/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
@@ -635,3 +635,84 @@ async fn row_tracking_round_trip_phase3_compatible_sandbox() {
         state_after.row_tracking_next_id,
     );
 }
+
+/// Live test for Phase 5 — schema evolution.
+///
+/// Requires the same env vars as the other live tests, except
+/// `ROCKY_TEST_*` should point at a UniForm table that has been
+/// `ALTER TABLE … ADD COLUMN`'d at least once (so the latest schema
+/// lives in a post-bootstrap commit). The test:
+///   - asserts `discover()` returns the post-ALTER schema, not the
+///     bootstrap one
+///   - writes a batch using the new column
+///   - reads back via Photon and confirms the new-column rows are
+///     visible
+///
+/// The canonical sandbox is the Exp 10 `schema_evo_t2` table (id,
+/// name, value, extra) — `extra` was added by ALTER ADD COLUMN.
+#[tokio::test]
+#[ignore]
+async fn schema_evolution_e2e_live_sandbox() {
+    let Some(cfg) = try_load_config() else {
+        eprintln!("skipping: ROCKY_TEST_* env vars not set");
+        return;
+    };
+    let Some(store) = build_s3_store(&cfg) else {
+        eprintln!("skipping: failed to build S3 store from environment");
+        return;
+    };
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: cfg.catalog.clone(),
+            schema: cfg.schema.clone(),
+            table: cfg.table.clone(),
+            prefix: cfg.prefix.clone(),
+            engine_info: "rocky-iceberg/schema-evolution-live-test".into(),
+        },
+        store.clone(),
+        Arc::new(PanicSqlClient),
+    );
+    let state = writer.discover().await.expect("discover");
+
+    // This test targets a Phase-5 sandbox where ALTER ADD COLUMN has
+    // landed. Skip cleanly if the operator points at a different shape.
+    if !state.physical.contains_key("extra") {
+        eprintln!(
+            "skipping: expected the sandbox to have an `extra` column added \
+             via ALTER ADD COLUMN; got cols {:?}",
+            state.physical.keys().collect::<Vec<_>>()
+        );
+        return;
+    }
+    assert!(
+        state.physical.contains_key("id"),
+        "id retained from pre-ALTER schema"
+    );
+
+    let ts_suffix = chrono::Utc::now().timestamp_micros();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+        Field::new("extra", DataType::Utf8, true),
+    ]));
+    let ids = Int64Array::from(vec![900_801_i64, 900_802]);
+    let names = StringArray::from(vec!["evo-a", "evo-b"]);
+    let values = Int64Array::from(vec![ts_suffix, ts_suffix + 1]);
+    let extras = StringArray::from(vec![Some("post-alter-1"), Some("post-alter-2")]);
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(ids),
+            Arc::new(names),
+            Arc::new(values),
+            Arc::new(extras),
+        ],
+    )
+    .unwrap();
+    let result = writer
+        .write_batch(batch)
+        .await
+        .expect("post-ALTER write must succeed");
+    assert_eq!(result.num_records, 2);
+}


### PR DESCRIPTION
## Summary

Lifts the bootstrap-only schema discovery so \`UniformWriter::discover()\` returns the table's current schema after \`ALTER TABLE … ADD COLUMN\` / \`RENAME COLUMN\` / \`DROP COLUMN\` / \`SET TBLPROPERTIES\`. Before this, the writer used only the bootstrap commit's schema, which would silently emit Parquet files referencing UUIDs that no longer exist (DROP) or missing new columns the user expected (ADD) on any schema-evolved table.

## How it works

1. **\`discover_latest_metadata()\`** walks \`_delta_log/*.json\` newest → oldest, returns the first \`metaData\` action it finds (Delta emits one per ALTER). Returns \`None\` for tables that have never been ALTER'd.
2. **\`discover()\`** parses the bootstrap commit for the initial state (protocol + bootstrap metaData), then overlays the latest post-bootstrap metaData if one exists. The overlay replaces \`physical\` / \`field_id\` / \`partition_columns\` — protocol features (rowTracking, DV) stay sourced from bootstrap, matching the Delta convention that protocol actions are bootstrap-only in practice.

Per **Exp 10's finding**, ALTER ADD COLUMN preserves existing column UUIDs and only allocates a fresh UUID for the new column — Rocky's writer re-reads the entire schema on each \`discover()\` rather than incrementally patching, which is correct for ADD / DROP / RENAME.

## Performance note

The walk is bounded by the number of commits. For tables with many commits and only a bootstrap metaData, the walk inspects every entry; a future PR can cap or use Delta checkpoint files. For Rocky's current workloads (small dev tables, occasional ALTERs) this is fine.

## Tests

- **Unit** \`discover_latest_metadata_returns_none_for_bootstrap_only\` — fresh table returns \`None\`.
- **Unit** \`discover_latest_metadata_finds_post_alter_schema\` — bootstrap (id, name, ts) + WRITE commit (no metaData) + ALTER ADD COLUMN commit (metaData with id, name, ts, extra). discover walks past the WRITE and finds the ALTER's metaData. UUIDs preserved for pre-ALTER columns; \`extra\` carries its fresh UUID.
- **Live** \`schema_evolution_e2e_live_sandbox\` — writes a 2-row batch including the new \`extra\` column against an ALTER'd UniForm sandbox. The write would fail with "column not in discovered table schema" if discover() were still bootstrap-only.

## Live verification

Passes against a Phase-5 sandbox (id, name, value, extra) where the \`extra\` column was added via \`ALTER ADD COLUMN\` after CREATE.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p rocky-iceberg --lib\` — 54 passed (2 new + 52 prior)
- [x] Live schema-evolution test passes against an ALTER'd sandbox
- [x] \`cargo fmt --all -- --check\` clean