### PR TITLE
docs: bring docs site current with engine v1.26.0–v1.30.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Rocky is a monorepo. The four subprojects share one repository, one issue tracke
 
 | Subproject | Path | Language | Build |
 |---|---|---|---|
-| Rocky CLI engine | `engine/` | Rust (21-crate Cargo workspace) | `cargo` |
+| Rocky CLI engine | `engine/` | Rust (23-crate Cargo workspace) | `cargo` |
 | Dagster integration | `integrations/dagster/` | Python | `uv` |
 | VS Code extension | `editors/vscode/` | TypeScript | `npm` |
 | Sample project | `examples/playground/` | TOML / SQL config | none |
@@ -39,7 +39,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 ```
 
-The engine is a Cargo workspace with 21 members — 19 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.85). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
+The engine is a Cargo workspace with 23 members — 21 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.85). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
 
 ### Dagster integration (`integrations/dagster/`)
 

--- a/docs/src/content/docs/concepts/architecture.mdx
+++ b/docs/src/content/docs/concepts/architecture.mdx
@@ -23,11 +23,15 @@ Rocky separates concerns through two adapter types:
 
 - `rocky-databricks` — Executes via the Databricks SQL Statement API and manages Unity Catalog, with adaptive concurrency (AIMD algorithm)
 - `rocky-snowflake` — Executes via the Snowflake REST API with OAuth, key-pair JWT, and password auth
+- `rocky-bigquery` — Executes via the BigQuery REST API with service account / ADC auth
+- `rocky-trino` — Executes via Trino's `/v1/statement` REST polling state machine with HTTP Basic / JWT bearer auth (Beta as of engine v1.28.0)
 - `rocky-duckdb` — Local in-process execution for development, testing, and CI
 
-**rocky-core** sits between them. It defines the Intermediate Representation (IR) and all warehouse-agnostic logic (DAG resolution, schema pattern parsing, SQL generation templates, checks, contracts, state management). rocky-core has no knowledge of Databricks, Fivetran, or any specific system.
+**rocky-ir** defines the typed Intermediate Representation (`ModelIr`, `MaterializationStrategy`, source/target descriptors). It was extracted from `rocky-core` in engine v1.30.0 so adapter crates can depend on the IR without pulling in the SQL-generation surface.
 
-This architecture means adding a new warehouse (e.g., Snowflake) or a new source (e.g., Airbyte) requires implementing an adapter crate without modifying the core engine.
+**rocky-core** sits between adapters and IR. It owns warehouse-agnostic logic (DAG resolution, schema pattern parsing, SQL generation templates, checks, contracts, state management) and depends on `rocky-ir`. rocky-core has no knowledge of Databricks, Fivetran, or any specific system.
+
+This architecture means adding a new warehouse (e.g., Snowflake, Trino) or a new source (e.g., Airbyte) requires implementing an adapter crate without modifying the core engine.
 
 ## Monorepo
 
@@ -49,7 +53,8 @@ The playground catalog currently ships {pocCounts.total} POCs across {pocCounts.
 ```
 engine/
 ├── crates/
-│   ├── rocky-core/          # Generic SQL transformation engine
+│   ├── rocky-ir/            # Typed Intermediate Representation (ModelIr, MaterializationStrategy)
+│   ├── rocky-core/          # Generic SQL transformation engine (depends on rocky-ir)
 │   ├── rocky-sql/           # SQL parsing + typed AST
 │   ├── rocky-lang/          # Rocky DSL parser (.rocky files)
 │   ├── rocky-compiler/      # Type checking + semantic analysis
@@ -57,9 +62,10 @@ engine/
 │   ├── rocky-databricks/    # Databricks warehouse adapter
 │   ├── rocky-snowflake/     # Snowflake warehouse adapter
 │   ├── rocky-bigquery/      # BigQuery warehouse adapter (Beta)
+│   ├── rocky-trino/         # Trino warehouse adapter (Beta as of v1.28.0)
 │   ├── rocky-fivetran/      # Fivetran source adapter
 │   ├── rocky-airbyte/       # Airbyte source adapter
-│   ├── rocky-iceberg/       # Apache Iceberg table format adapter
+│   ├── rocky-iceberg/       # Iceberg + content-addressed Delta UniForm writer
 │   ├── rocky-duckdb/        # DuckDB local execution adapter
 │   ├── rocky-engine/        # Local query engine (DataFusion + Arrow)
 │   ├── rocky-server/        # HTTP API + LSP server
@@ -71,13 +77,20 @@ engine/
 └── rocky/                   # Binary crate
 ```
 
+### rocky-ir
+
+The typed Intermediate Representation. Extracted from `rocky-core` in engine v1.30.0 (Phase G1) so adapter crates can depend on the IR without pulling in the SQL-generation surface.
+
+- **`ModelIr`** — single in-memory plan representation; replaced the legacy `Plan` enum + `ReplicationPlan` / `TransformationPlan` structs (deleted in v1.30.0).
+- **`MaterializationStrategy`** — `FullRefresh`, `Incremental`, `Merge`, `MaterializedView`, `DynamicTable`, `TimeInterval`, `Ephemeral`, `DeleteInsert`, `Microbatch`, `ContentAddressed`.
+- Source / target descriptors and partition windows.
+
 ### rocky-core
 
-The warehouse-agnostic transformation engine. This crate has no knowledge of specific warehouses or sources — it works entirely through adapter abstractions, producing IR that warehouse adapters consume.
+The warehouse-agnostic transformation engine. This crate has no knowledge of specific warehouses or sources — it works entirely through adapter abstractions, consuming IR from `rocky-ir` and producing dialect-specific SQL.
 
 Key modules:
 
-- **ir.rs** — Intermediate Representation types: `Plan`, `ReplicationPlan`, `TransformationPlan`, `MaterializationStrategy`
 - **schema.rs** — Configurable schema pattern parsing (e.g., `src__acme__us_west__shopify` into structured components)
 - **drift.rs** — Schema drift detection (compares column types between source and target)
 - **sql_gen.rs** — IR to dialect-specific SQL generation
@@ -175,6 +188,30 @@ Snowflake warehouse adapter.
 - **connector.rs** — Snowflake REST API client
 - **dialect.rs** — Snowflake SQL dialect (dynamic tables, multi-statement transactions)
 
+### rocky-trino
+
+Trino warehouse adapter (Beta as of engine v1.28.0). First first-party warehouse adapter built natively against `rocky-adapter-sdk`.
+
+- **connector.rs** — Async REST client driving Trino's `POST /v1/statement` + `nextUri` polling state machine. Same-origin guard on every `nextUri` follow-up (same scheme + host + port as the configured coordinator).
+- **dialect.rs** — Double-quoted identifiers, three-part `<catalog>.<schema>.<table>` references, `DESCRIBE <table>` column introspection, ANSI `INSERT INTO` / `CREATE TABLE AS`, `TABLESAMPLE BERNOULLI`.
+- **auth.rs** — HTTP Basic + JWT bearer with `RedactedString`-wrapped credentials.
+- **adapter.rs** — `WarehouseAdapter` impl: `dialect`, `execute_statement`, `execute_query`, `describe_table`.
+
+A Docker conformance harness is gated behind the `trino-conformance` cargo feature: `cargo test -p rocky-trino --features trino-conformance -- --ignored` drives the adapter end-to-end against a real `trinodb/trino` coordinator. The default `cargo test -p rocky-trino` run stays credential- and network-free.
+
+v0 limitations: no MERGE (Trino's MERGE is connector-dependent), no OAuth/Kerberos, no governance, no checksum-bisection support.
+
+### rocky-iceberg
+
+Apache Iceberg + Delta UniForm writer surface. Powers `materialization = "content_addressed"` (engine v1.30.0, Phases 1–5):
+
+- `discover()` reads the bootstrap Delta commit and surfaces schema + partition spec + rowTracking config.
+- `write_batch()` emits content-addressed Parquet files (blake3-hashed file names) and a Delta log commit referencing them.
+- `sync_iceberg_metadata()` keeps Iceberg-compatible readers in sync after each commit.
+- Partitioned + rowTracking + post-ALTER schema evolution all supported.
+
+See [Content-Addressed Materialization](/concepts/content-addressed/) for the user-facing model.
+
 ### rocky-engine
 
 Local query engine built on DataFusion + Arrow. Powers `rocky test` and type inference without a warehouse connection.
@@ -207,59 +244,28 @@ The `rocky` binary crate. Contains only `main.rs`, which wires all the library c
 
 ## Intermediate Representation (IR)
 
-Rocky compiles configuration and SQL into an intermediate representation before generating executable SQL. This separation means the core engine never deals with raw strings — everything is typed and validated.
+Rocky compiles configuration and SQL into an intermediate representation before generating executable SQL. This separation means the core engine never deals with raw strings — everything is typed and validated. The IR lives in the [`rocky-ir`](#rocky-ir) crate.
 
-### Plan
+### ModelIr
 
-The top-level `Plan` enum represents what Rocky will execute:
-
-```rust
-enum Plan {
-    Replication(ReplicationPlan),
-    Transformation(TransformationPlan),
-}
-```
-
-- **ReplicationPlan** — A config-driven copy from source to target (the bronze layer). Contains source/target table references, the incremental strategy, metadata columns, and quality checks.
-- **TransformationPlan** — A user-written SQL model (the silver layer). Contains the parsed SQL, target table, materialization strategy, and dependency references.
+`ModelIr` is the single in-memory plan representation. As of engine v1.30.0, the legacy `Plan` enum (and the `ReplicationPlan` / `TransformationPlan` / `From<&Plan>` bridge layer) is gone — `ModelIr` directly carries the source/target descriptors, the materialization strategy, and any dependency / sources / contracts / checks the model declares. Both replication and transformation pipelines compile to the same `ModelIr` shape, with the kind discriminated by which descriptors are populated.
 
 ### MaterializationStrategy
 
-Controls how data is written to the target table:
-
-```rust
-enum MaterializationStrategy {
-    FullRefresh,
-    Incremental {
-        timestamp_column: String,
-        watermark: Option<DateTime>,
-    },
-    Merge {
-        unique_key: Vec<String>,
-        update_columns: Option<Vec<String>>,
-    },
-    MaterializedView,
-    DynamicTable {
-        target_lag: String,
-    },
-    TimeInterval {
-        time_column: String,
-        granularity: String,  // hour, day, month, year
-        lookback: Option<u32>,
-        batch_size: Option<u32>,
-        first_partition: Option<String>,
-    },
-}
-```
+Controls how data is written to the target table. Variants:
 
 - **FullRefresh** — `CREATE OR REPLACE TABLE ... AS SELECT ...`. Rebuilds the entire table on every run.
-- **Incremental** — `INSERT INTO ... SELECT ... WHERE ts > watermark`. Only processes new rows. The watermark is read from the embedded state store.
+- **Incremental** — `INSERT INTO ... SELECT ... WHERE ts > watermark`. Only processes new rows. The watermark is read from the embedded state store at SQL-generation time (not carried on the strategy itself, so recipe-hash inputs stay runtime-state-free).
 - **Merge** — `MERGE INTO ... USING (...) ON key WHEN MATCHED THEN UPDATE WHEN NOT MATCHED THEN INSERT`. Upserts based on a unique key.
 - **MaterializedView** — `CREATE OR REPLACE MATERIALIZED VIEW ... AS SELECT ...`. Databricks-specific.
 - **DynamicTable** — `CREATE OR REPLACE DYNAMIC TABLE ... TARGET_LAG = '...' AS SELECT ...`. Snowflake-specific.
 - **TimeInterval** — Partition-keyed materialization. The model SQL uses `@start_date` and `@end_date` placeholders; the runtime substitutes per-partition timestamps. Supports `--partition`, `--from/--to`, `--latest`, `--missing` CLI flags.
+- **Ephemeral** — Not materialized; inlined as a CTE in downstream consumers.
+- **DeleteInsert** — Delete rows matching the partition key, then insert fresh data. Cheaper alternative to `Merge` when the partition key identifies the rows being rewritten.
+- **Microbatch** — Alias for `TimeInterval` with `hour`-granularity defaults; dbt-compatible naming.
+- **ContentAddressed** — Content-addressed Parquet + Delta log commit via the `rocky-iceberg` writer. Designed for cross-engine reads (DuckDB `iceberg_scan`, Trino, Spark). SQL generation does not run for this strategy — the runtime drives `rocky-iceberg::uniform_writer` directly. See [Content-Addressed Materialization](/concepts/content-addressed/).
 
-The IR is generated by rocky-core and consumed by `sql_gen.rs`, which produces dialect-specific SQL strings ready for execution.
+The full enum lives in `rocky-ir::ir::MaterializationStrategy`. SQL generation (where applicable) lives in `rocky-core::sql_gen`.
 
 ### Adapter SDK
 

--- a/docs/src/content/docs/concepts/content-addressed.md
+++ b/docs/src/content/docs/concepts/content-addressed.md
@@ -1,0 +1,71 @@
+---
+title: Content-Addressed Materialization
+description: Cross-engine Delta + UniForm writes with content-hashed Parquet files
+sidebar:
+  order: 16
+---
+
+`materialization = "content_addressed"` is a write strategy that lands the model's SELECT result as **content-addressed Parquet files plus a Delta log commit** under an object-store prefix you control. Cross-engine readers — DuckDB `iceberg_scan`, Trino, Spark, anything that reads Iceberg or Delta — read the same files directly without going through Rocky.
+
+Shipped end-to-end in engine v1.30.0 across Phases 1–5 of the `rocky-iceberg` writer: scaffold, bootstrap-commit discovery, `write_batch()`, `sync_iceberg_metadata()`, partitioned tables, rowTracking, and post-ALTER schema evolution.
+
+## When to use it
+
+Use content-addressed materialization when you want Rocky to own the *writer* but explicitly **not** own the readers. Typical fits:
+
+- **Multiple query engines read the same table.** DuckDB analysts, Trino dashboards, and Spark batch jobs all need to read the marts your pipeline writes. Pointing each engine at object storage avoids round-tripping every read through one warehouse.
+- **You're committing into a managed Delta or Iceberg catalog.** Unity Catalog managed tables with UniForm exposed, Iceberg REST catalogs, etc.
+- **You want stable, deduplicatable file names.** Content-hashing the Parquet bytes means the same logical batch produces the same physical file name — useful for replay, audit, and storage de-dup against an external lake.
+
+Stick with `full_refresh` / `incremental` / `merge` when there's a single warehouse, or when you don't have direct object-store access from the runner.
+
+## How it works
+
+On each run, the runtime:
+
+1. Executes the model SQL against the configured adapter and pulls the result into Arrow.
+2. blake3-hashes the Parquet-encoded bytes to derive each file's name.
+3. Uploads files under `storage_prefix` (e.g. `s3://bucket/path/<table>/`).
+4. Emits a Delta log commit referencing the new files. Existing Delta protocol features — partitioning, rowTracking — are honored when the underlying table declares them.
+5. Calls `sync_iceberg_metadata()` so Iceberg-compatible readers see the new snapshot.
+
+The writer's `discover()` step reads the bootstrap Delta commit to pick up the table's schema, partition spec, and rowTracking configuration. Subsequent writes adapt to schema changes (added columns, type widening) applied to the underlying Delta table between runs — that's Phase 5 schema evolution.
+
+## Configuration
+
+A content-addressed sidecar carries the strategy plus `storage_prefix` and an optional `partition_columns` list:
+
+```toml
+# models/fct_events.toml
+name = "fct_events"
+
+[strategy]
+type = "content_addressed"
+storage_prefix = "s3://${ROCKY_BUCKET}/marts/fct_events"
+partition_columns = ["event_date"]
+
+[target]
+catalog = "analytics"
+schema  = "marts"
+table   = "fct_events"
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `storage_prefix` | Yes | Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. The runtime requires write access to this prefix. Env-var substitution applies (see [Environment Variables](/reference/configuration/#environment-variables)). |
+| `partition_columns` | No | Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time. |
+
+For partitioned tables, `partitionValues` in the Delta log are keyed by physical UUID (column-mapping mode), not the logical column name. The writer handles this internally — you only declare the logical names.
+
+## Constraints + things to know
+
+- **UniForm and Deletion Vectors are mutually exclusive.** The writer surfaces a clear error if the target table has DVs enabled. Use one or the other.
+- **rowTracking writers need `baseRowId`.** The Phase 3 writer surface for rowTracking carries `baseRowId` + `rowCommitVersion`; Rocky handles assignment.
+- **Replication tables don't accept this strategy.** Content-addressed is a *transformation* strategy. Pointing a replication pipeline target at a content-addressed model returns a "not supported on replication tables" error at validate time.
+- **No DuckDB POC yet.** The strategy requires real Delta + object storage; it's exercised via live-verify tests against a sandbox rather than a playground POC. See `engine/crates/rocky-cli/src/commands/run_content_addressed.rs` for the e2e test if you want the reference invocation.
+
+## Related
+
+- [Model Format](/reference/model-format/#content-addressed) — the sidecar field reference, including the full Strategy Examples block.
+- [Silver Layer](/concepts/silver-layer/) — where content-addressed models sit in the lakehouse mental model.
+- [Adapters](/concepts/adapters/) — adapter contracts for the writer side of the contract.

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -59,7 +59,7 @@ Full side-by-side comparison: [features/comparison](/features/comparison/).
 
 ## Design principles
 
-1. **Adapter-based.** Source adapters (Fivetran, DuckDB, manual) handle discovery. Warehouse adapters (Databricks, Snowflake, BigQuery, DuckDB) handle execution. The core engine is warehouse-agnostic.
+1. **Adapter-based.** Source adapters (Fivetran, Airbyte, DuckDB, Iceberg, manual) handle discovery. Warehouse adapters (Databricks, Snowflake, BigQuery, Trino, DuckDB) handle execution. The core engine is warehouse-agnostic.
 2. **Config over code.** Bronze layer replication needs no SQL — just TOML.
 3. **Pure SQL models.** Silver-layer transformations use standard SQL plus a `.toml` sidecar.
 4. **Inline quality checks.** Data checks run during replication, not as a separate step.
@@ -70,11 +70,14 @@ Full side-by-side comparison: [features/comparison](/features/comparison/).
 | Role | Adapter | Notes |
 |---|---|---|
 | Source | Fivetran | REST API discovery; metadata only |
+| Source | Airbyte | REST API discovery; metadata only |
 | Source | DuckDB | `information_schema` discovery |
+| Source | Iceberg | Catalog/manifest discovery for content-addressed reads |
 | Source | Manual | Tables declared in `rocky.toml` |
 | Warehouse | Databricks | SQL Statement API, Unity Catalog, adaptive concurrency |
 | Warehouse | Snowflake | REST API; OAuth / JWT / password (Beta) |
 | Warehouse | BigQuery | REST API; service account / ADC (Beta) |
+| Warehouse | Trino | `/v1/statement` REST polling; HTTP Basic / JWT (Beta) |
 | Warehouse | DuckDB | In-process; powers the playground and `rocky test` |
 
 Source adapters are metadata-only — they identify what exists. Actual data already lives in the warehouse, or is loaded via `rocky load` for files. A single DuckDB instance can serve as both source and warehouse, which is how the credential-free playground works end-to-end.
@@ -85,7 +88,7 @@ New adapters plug in via the [Adapter SDK](/concepts/adapters/) without modifyin
 
 | Path | Artifact | Language |
 |---|---|---|
-| `engine/` | `rocky` CLI | Rust (20-crate workspace) |
+| `engine/` | `rocky` CLI | Rust (21-crate workspace) |
 | `integrations/dagster/` | `dagster-rocky` wheel | Python |
 | `editors/vscode/` | Rocky VSIX | TypeScript |
 | `examples/playground/` | POC catalog | TOML / SQL |

--- a/docs/src/content/docs/guides/adapter-sdk.md
+++ b/docs/src/content/docs/guides/adapter-sdk.md
@@ -5,9 +5,9 @@ sidebar:
   order: 9
 ---
 
-Rocky talks to warehouses through a small set of traits in the `rocky-adapter-sdk` crate. Implementing those traits gives you a working warehouse adapter — the same way `rocky-databricks`, `rocky-snowflake`, `rocky-bigquery`, and `rocky-duckdb` are wired today.
+Rocky talks to warehouses through a small set of traits in the `rocky-adapter-sdk` crate. Implementing those traits gives you a working warehouse adapter — the same way `rocky-databricks`, `rocky-snowflake`, `rocky-bigquery`, `rocky-trino`, and `rocky-duckdb` are wired today.
 
-This guide walks a Rust developer from "I want a ClickHouse adapter" to a compiling skeleton with passing tests in roughly fifteen minutes. The runnable skeleton lives at [`examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton) and is shaped after ClickHouse, but the same shape works for Trino, Redshift, StarRocks, MotherDuck, or any SQL warehouse Rocky doesn't ship in-tree.
+This guide walks a Rust developer from "I want a ClickHouse adapter" to a compiling skeleton with passing tests in roughly fifteen minutes. The runnable skeleton lives at [`examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton/`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/07-adapters/06-rust-native-adapter-skeleton) and is shaped after ClickHouse, but the same shape works for Redshift, StarRocks, MotherDuck, or any SQL warehouse Rocky doesn't ship in-tree. (Trino is in-tree as of engine v1.28.0 — see the [`rocky-trino` crate](/concepts/architecture/#rocky-trino).)
 
 ## When to reach for the SDK
 

--- a/docs/src/content/docs/guides/ai-features.md
+++ b/docs/src/content/docs/guides/ai-features.md
@@ -49,7 +49,7 @@ Error: ANTHROPIC_API_KEY not set. Set it to use `rocky ai`.
 
 ## 2. Generate a Model from Intent
 
-The `rocky ai` command generates a model from a natural language description:
+The `rocky ai` command generates a model from a natural language description and **writes both the body file and a matching `.toml` sidecar to the models directory**. The emitted sidecar carries the materialization strategy + target coordinates, so Rocky's loader picks the generated model up on the next `rocky run` without manual editing.
 
 ```bash
 rocky ai "monthly revenue by product category from orders and products, completed orders only"
@@ -60,21 +60,15 @@ Output:
 ```
 Generated model: monthly_category_revenue (rocky)
 Attempts: 1
-
-from orders
-join products on orders.product_id = products.product_id
-where status = "completed"
-group extract(month from order_date), category {
-    month: extract(month from order_date),
-    category: category,
-    total_revenue: sum(quantity * unit_price),
-    order_count: count()
-}
+Wrote: models/monthly_category_revenue.rocky
+Wrote: models/monthly_category_revenue.toml
 ```
+
+The emitted sidecar defaults to `[strategy] type = "full_refresh"` and `[target] = generated.ai.<model_name>`. Override either with the flags below.
 
 ### Choose the output format
 
-By default, Rocky generates Rocky DSL. Use `--format sql` for standard SQL:
+By default, Rocky generates Rocky DSL. Use `--format sql` for standard SQL (still emits both a `.sql` body and a `.toml` sidecar):
 
 ```bash
 rocky ai "monthly revenue by product category" --format sql
@@ -92,6 +86,33 @@ WHERE o.status = 'completed'
 GROUP BY DATE_TRUNC('month', o.order_date), p.category
 ```
 
+### Pick a materialization + target
+
+Pair `--materialization` with `--watermark` for incremental models, and `--target` to land the output in a real catalog/schema rather than the `generated.ai.*` default:
+
+```bash
+rocky ai "daily order facts from stg_orders" \
+  --materialization incremental --watermark order_date \
+  --target analytics.marts.fct_orders_daily
+```
+
+The emitted sidecar (`models/fct_orders_daily.toml`) then carries the parsed materialization, watermark, and target:
+
+```toml
+name = "fct_orders_daily"
+
+[strategy]
+type = "incremental"
+timestamp_column = "order_date"
+
+[target]
+catalog = "analytics"
+schema  = "marts"
+table   = "fct_orders_daily"
+```
+
+Pass `--overwrite` to replace an existing body or sidecar at the destination — without it, the command fails loudly rather than silently clobber user-authored models. See [`rocky ai`](/reference/commands/ai/#rocky-ai) for the full flag table, including the v1 `--materialization merge` limitation.
+
 ### JSON output
 
 For programmatic use:
@@ -102,13 +123,15 @@ rocky ai "monthly revenue by category" -o json
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai",
   "intent": "monthly revenue by category",
   "format": "rocky",
   "name": "monthly_category_revenue",
   "source": "from orders\njoin products on ...",
-  "attempts": 1
+  "attempts": 1,
+  "body_path": "models/monthly_category_revenue.rocky",
+  "sidecar_path": "models/monthly_category_revenue.toml"
 }
 ```
 

--- a/docs/src/content/docs/reference/commands/ai.md
+++ b/docs/src/content/docs/reference/commands/ai.md
@@ -11,7 +11,7 @@ The AI commands use large language models to generate Rocky models from natural 
 
 ## `rocky ai`
 
-Generate a model from a natural language description. Produces a complete Rocky model (SQL + TOML sidecar) or raw SQL.
+Generate a model from a natural language description and write **both the body file and a matching `.toml` sidecar** to the models directory. The emitted sidecar carries the materialization strategy and target coordinates, so Rocky's model loader picks the generated model up on the next `rocky run` without manual editing.
 
 ```bash
 rocky ai <intent> [flags]
@@ -27,7 +27,16 @@ rocky ai <intent> [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--format <FORMAT>` | `string` | | Output format: `rocky` (SQL + TOML) or `sql` (raw SQL only). |
+| `--format <FORMAT>` | `string` | `rocky` | Output format: `rocky` (`.rocky` body + `.toml` sidecar) or `sql` (`.sql` body + `.toml` sidecar). |
+| `--models <PATH>` | `string` | `models` | Models directory. Used both to ground the prompt in real schemas and as the destination directory for the emitted body + sidecar. |
+| `--materialization <STRATEGY>` | `string` | `full_refresh` | Materialization strategy written into the sidecar `[strategy]` block. One of `full_refresh`, `incremental`, `merge`, `ephemeral`. |
+| `--watermark <COLUMN>` | `string` | | Watermark column for `--materialization=incremental`. Maps to `[strategy].timestamp_column` in the sidecar. Required when materialization is `incremental`; ignored otherwise. |
+| `--target <FQN>` | `string` | `generated.ai.<name>` | Target table coordinates as `catalog.schema.table`. Written into the sidecar `[target]` block. |
+| `--overwrite` | `bool` | `false` | Overwrite an existing body or sidecar file at the destination. Without this flag, the command fails loudly rather than silently clobber user-authored models. |
+
+:::note[Merge limitation]
+`--materialization merge` v1 is incomplete: there is no `--unique-key` flag yet, so the emitted sidecar is missing the merge key and must be hand-edited before `rocky run` will accept it. `time_interval`, `delete_insert`, `microbatch`, `materialized_view`, `dynamic_table`, and `content_addressed` are intentionally not exposed by `--materialization` — they need richer flag plumbing or live in the IR-only surface.
+:::
 
 ### Examples
 
@@ -39,17 +48,42 @@ rocky ai "monthly revenue by customer, joining orders and refunds"
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai",
   "intent": "monthly revenue by customer, joining orders and refunds",
   "format": "rocky",
   "name": "fct_monthly_revenue_by_customer",
   "source": "from stg_orders\njoin stg_refunds on order_id {\n    keep stg_refunds.refund_amount\n}\nderive {\n    revenue_month: date_trunc('month', order_date),\n    net_revenue: total_amount - coalesce(refund_amount, 0)\n}\ngroup customer_id, revenue_month {\n    customer_id,\n    revenue_month,\n    net_revenue: sum(net_revenue)\n}",
-  "attempts": 1
+  "attempts": 1,
+  "body_path": "models/fct_monthly_revenue_by_customer.rocky",
+  "sidecar_path": "models/fct_monthly_revenue_by_customer.toml"
 }
 ```
 
-Generate raw SQL instead:
+Generate an incremental model with a watermark, into a non-default target:
+
+```bash
+rocky ai "daily order facts from stg_orders" \
+  --materialization incremental --watermark order_date \
+  --target analytics.marts.fct_orders_daily
+```
+
+The emitted sidecar (`models/fct_orders_daily.toml`) carries the parsed materialization + watermark + target:
+
+```toml
+name = "fct_orders_daily"
+
+[strategy]
+type = "incremental"
+timestamp_column = "order_date"
+
+[target]
+catalog = "analytics"
+schema  = "marts"
+table   = "fct_orders_daily"
+```
+
+Generate raw SQL instead (still emits both `.sql` body and `.toml` sidecar):
 
 ```bash
 rocky ai "top 10 customers by lifetime value" --format sql
@@ -107,7 +141,7 @@ rocky ai-sync
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai-sync",
   "proposals": [
     {
@@ -176,7 +210,7 @@ rocky ai-explain fct_revenue
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai-explain",
   "explanations": [
     {
@@ -196,7 +230,7 @@ rocky ai-explain --all --save
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai-explain",
   "explanations": [
     { "model": "fct_revenue",   "intent": "Calculates monthly net revenue per customer by joining orders with refunds.", "saved": true },
@@ -252,7 +286,7 @@ rocky ai-test fct_revenue
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai-test",
   "results": [
     {
@@ -290,7 +324,7 @@ rocky ai-test --all --save
 
 ```json
 {
-  "version": "1.6.0",
+  "version": "1.30.0",
   "command": "ai-test",
   "results": [
     { "model": "fct_revenue",   "saved": true, "tests": [ /* 3 assertions */ ] },

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -24,7 +24,7 @@ These flags apply to all commands and are documented in the [CLI Reference](/ref
 Initialize a new Rocky project with starter configuration and directory structure.
 
 ```bash
-rocky init [path]
+rocky init [path] [flags]
 ```
 
 ### Arguments
@@ -33,9 +33,15 @@ rocky init [path]
 |----------|------|---------|-------------|
 | `path` | `string` | `.` | Directory where the project will be created. |
 
+### Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--template <NAME>` | `string` | `duckdb` | Scaffold template. One of `duckdb`, `databricks-fivetran`, `snowflake`, `bigquery`, `trino`. Each template emits a runnable `rocky.toml` with the matching adapter wired up via `${VAR}` env-var placeholders (never inline secrets) plus a `models/welcome.{sql,toml}` that compiles with no source tables. |
+
 ### Examples
 
-Create a project in the current directory:
+Create a project in the current directory (default DuckDB template):
 
 ```bash
 rocky init
@@ -47,17 +53,13 @@ Created models/
 Rocky project initialized.
 ```
 
-Create a project in a new directory:
+Create a Trino-targeted project in a new directory:
 
 ```bash
-rocky init acme-pipeline
+rocky init acme-trino --template trino
 ```
 
-```
-Created acme-pipeline/rocky.toml
-Created acme-pipeline/models/
-Rocky project initialized in acme-pipeline/
-```
+The emitted `rocky.toml` wires the `trino` adapter to `${TRINO_HOST}` / `${TRINO_USER}` / `${TRINO_PASSWORD}` (HTTP Basic) or `${TRINO_JWT}` (JWT bearer), with inline TOML comments documenting both auth modes.
 
 ### Related Commands
 
@@ -83,7 +85,7 @@ No command-specific flags. Uses [global flags](#global-flags) only.
 | Check | Description |
 |-------|-------------|
 | TOML syntax | The config file parses without errors as v2 (named adapters + named pipelines). |
-| Adapters | Each `[adapter.NAME]` is a recognized type (`databricks`, `snowflake`, `duckdb`, `fivetran`, `manual`) with the required fields populated. For Databricks, at least one of `token` or `client_id`/`client_secret` must be set. |
+| Adapters | Each `[adapter.NAME]` is a recognized type (`databricks`, `snowflake`, `duckdb`, `fivetran`, `bigquery`, `trino`, `airbyte`, `iceberg`, `manual`) with the required fields populated. For Databricks, at least one of `token` or `client_id`/`client_secret` must be set. The known-types list is driven directly off the adapter registry, so new first-party adapters propagate without a follow-up edit. |
 | Pipelines | Each `[pipeline.NAME]` references existing adapters for source, target, and (optional) discovery, and its `schema_pattern` parses. |
 | DAG validation | If `models/` exists, loads all models and checks for dependency cycles. |
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -100,20 +100,21 @@ rocky import-dbt --dbt-project <PATH> [flags]
 │   ├── <name>.sql              translated dbt model body (Jinja stripped or commented)
 │   └── <name>.toml             [strategy] + [target] sidecar
 ├── seeds/                      verbatim copy of <dbt_project>/seeds/
-└── MIGRATION-NOTES.md          summary: counts, v0 limitations, required env vars
+└── MIGRATION-NOTES.md          summary: counts, known limitations, required env vars
 ```
 
 Connection secrets (passwords, API tokens, service-account JSON) are emitted as `${VAR}` env-var placeholders in `rocky.toml`; they are **never inlined**. The required env vars are listed in `MIGRATION-NOTES.md` so users know what to export before `rocky run`.
 
 `materialized` mapping: `view → ephemeral`, `table → full_refresh`, `incremental` (with `unique_key`) → `merge`, `incremental` (without) → `incremental`. Anything else falls back to `full_refresh` with a TODO line in `MIGRATION-NOTES.md`. Profile types Rocky doesn't natively support stub a DuckDB `[adapter]` so the project still compiles, with the original type preserved under "Not Translated".
 
-### v0 limitations
+### Known limitations
 
-Deferred to follow-up PRs and listed in every emitted `MIGRATION-NOTES.md`:
+Listed in every emitted `MIGRATION-NOTES.md`:
 
-- Generic-test mapping (`unique`, `not_null`, `accepted_values`, `relationships` → `[[checks]]`).
-- Singular dbt tests (custom SQL files in `tests/`).
-- Macros and `dbt_packages/` (skipped; the [hybrid-dbt-packages POC](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/06-hybrid-dbt-packages) is the documented escape hatch for now).
+- Singular dbt tests (custom SQL files in `tests/`) — not translated.
+- Macros and `dbt_packages/` — skipped. The [hybrid-dbt-packages POC](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/06-hybrid-dbt-packages) is the documented escape hatch.
+
+The four built-in dbt generic tests (`unique`, `not_null`, `accepted_values`, `relationships`) translate to native Rocky `[[checks]]` on the matching per-model sidecar (shipped in engine v1.27.0). Tests referencing columns Rocky didn't translate are listed in `MIGRATION-NOTES.md` under "Not Translated" rather than silently dropped.
 
 ### Examples
 
@@ -125,7 +126,7 @@ rocky import-dbt --dbt-project ~/projects/acme-dbt
 
 ```json
 {
-  "version": "1.27.0",
+  "version": "1.30.0",
   "command": "import-dbt",
   "import_method": "regex",
   "project_name": "demo_project",

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -368,12 +368,12 @@ For multi-tenant setups with per-tenant catalogs, use `{component}` placeholders
 
 ### `[pipeline.NAME.target.governance]`
 
-Catalog/schema lifecycle, tagging, grants, and isolation. These features are implemented against Databricks Unity Catalog APIs and apply only when the target adapter is Databricks.
+Catalog/schema lifecycle, tagging, grants, and isolation. Tagging, grants, and workspace isolation are implemented against Databricks Unity Catalog APIs and apply only when the target adapter is Databricks. The two `auto_create_*` lifecycle flags work on every adapter that emits `CREATE SCHEMA` SQL.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `auto_create_catalogs` | bool | `false` | Create target catalogs if they do not exist. |
-| `auto_create_schemas` | bool | `false` | Create target schemas if they do not exist. |
+| `auto_create_schemas` | bool | `false` | Create target schemas if they do not exist. Honored on **both** replication and transformation pipeline targets (transformation parity landed in engine v1.29.0 — prior versions silently no-op'd on transformation pipelines, surfacing as a "Schema with name X does not exist" execute-time error). |
 | `tags` | table | `{}` | Tags applied to managed catalogs, schemas, and tables. |
 | `grants` | list | `[]` | Catalog-level grants. Each entry has `principal` (string) and `permissions` (list of strings). |
 | `schema_grants` | list | `[]` | Schema-level grants. Same format as `grants`. |

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -60,7 +60,7 @@ The `.toml` file specifies the model name, dependencies, materialization strateg
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `type` | string | `"full_refresh"` | Materialization type. One of `"full_refresh"`, `"incremental"`, `"merge"`, `"time_interval"`, `"ephemeral"`, `"delete_insert"`, `"microbatch"`. |
+| `type` | string | `"full_refresh"` | Materialization type. One of `"full_refresh"`, `"incremental"`, `"merge"`, `"time_interval"`, `"ephemeral"`, `"delete_insert"`, `"microbatch"`, `"content_addressed"`. |
 | `timestamp_column` | string | | Column used as the incremental watermark. Required when `type = "incremental"` or `type = "microbatch"`. |
 | `unique_key` | list of strings | | Key columns for merge matching. Required when `type = "merge"`. |
 | `update_columns` | list of strings | | Columns to update on merge match. Defaults to all non-key columns if omitted. |
@@ -70,6 +70,8 @@ The `.toml` file specifies the model name, dependencies, materialization strateg
 | `lookback` | integer | `0` | Number of past partitions to reprocess. Optional for `"time_interval"`. |
 | `batch_size` | integer | `1` | Max partitions per batch. Optional for `"time_interval"`. |
 | `first_partition` | string | | Earliest partition key (e.g., `"2024-01-01"`). Optional for `"time_interval"`. |
+| `storage_prefix` | string | | Object-store key prefix that holds `_delta_log/` + Parquet files for the target table (e.g. `"s3://bucket/path/table"`). Required when `type = "content_addressed"`. |
+| `partition_columns` | list of strings | `[]` | Logical partition columns for content-addressed tables. Empty for unpartitioned tables. Optional for `"content_addressed"`. |
 
 :::note[Lakehouse formats]
 Warehouse-managed table shapes — **Delta tables**, **Iceberg tables**, **materialized views**, **streaming tables**, **plain views** — are modeled as a separate `format` axis on the `LakehouseFormat` enum. `[strategy]` controls how Rocky writes data into the table; `format` controls the physical table shape. The two are orthogonal. The engine-side DDL generator (`rocky-core::lakehouse::generate_lakehouse_ddl`) handles each format; end-to-end TOML wiring varies by adapter, so consult the per-adapter guides before committing to one.
@@ -442,6 +444,31 @@ catalog = "analytics"
 schema = "warehouse"
 table = "fct_hourly_events"
 ```
+
+---
+
+### Content-Addressed
+
+Writes the model's SELECT result to a Delta UniForm table as content-addressed Parquet (blake3-hashed file names) plus a Delta log commit. Designed for cross-engine reads from DuckDB, Trino, Spark, and any Iceberg-compatible reader — Rocky owns the writer, the consumers read directly from the object store. See [Content-Addressed Materialization](/concepts/content-addressed/) for the why and when.
+
+**Config** (`models/fct_events.toml`):
+
+```toml
+name = "fct_events"
+depends_on = []
+
+[strategy]
+type = "content_addressed"
+storage_prefix = "s3://${ROCKY_BUCKET}/marts/fct_events"
+partition_columns = ["event_date"]
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "fct_events"
+```
+
+The runtime executes the model SQL, converts the result to Arrow, hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. `partition_columns` may be omitted for unpartitioned tables. Backed by the `rocky-iceberg` writer (shipped in engine v1.30.0 across Phases 1–5: discover, write, sync, partitioned, rowTracking, schema evolution).
 
 ---
 


### PR DESCRIPTION
## Summary

Audit pass over the documentation site against the last five engine releases (v1.26.0–v1.30.0). Fixes factual drift, fills feature-doc gaps for shipped features, and corrects positioning that lagged adapter promotions.

## Changes by severity

### BLOCKER (factually wrong / user-following-the-docs would break)
- `reference/model-format.md` — add `content_addressed` to the `[strategy].type` enum + a Strategy Examples block. Document `storage_prefix` / `partition_columns` (v1.30.0).
- `reference/commands/ai.md` — describe the v1.26.0 write-to-disk behaviour (previously said stdout-only). Add `--materialization`, `--watermark`, `--target`, `--overwrite` flags + v1 merge limitation. Restamp v1.6.0 JSON samples.
- `guides/ai-features.md` — refresh the workflow + JSON samples; add the incremental-materialization invocation.
- `reference/commands/core-pipeline.md` — add `rocky init --template` (v1.28.0); extend the `rocky validate` adapter list with `trino` / `bigquery` / `airbyte` / `iceberg` (v1.27.0).

### HIGH (shipped feature had no doc presence)
- New `concepts/content-addressed.md` covering the `rocky-iceberg` writer surface (Phases 1–5), sidecar config, constraints (UniForm/DV mutex, rowTracking, replication-vs-transformation).
- Trino adapter docs presence: introduction adapter table, architecture crate tree + dedicated `rocky-trino` section, fix the stale "Trino not in-tree" line in `guides/adapter-sdk.md`.

### MEDIUM (stale framing)
- `concepts/architecture.mdx` — add `rocky-ir` / `rocky-trino` / `rocky-iceberg` to the crate tree, delete the obsolete `Plan`-enum IR description and replace with `ModelIr`. Add `ContentAddressed` / `Ephemeral` / `DeleteInsert` / `Microbatch` to the `MaterializationStrategy` variant list.
- `getting-started/introduction.md` + `CONTRIBUTING.md` — refresh crate counts (engine is now a 23-member / 21-library-crate workspace).
- `reference/configuration.md` — note `auto_create_schemas` is honoured on both replication and transformation targets (v1.29.0 parity fix).
- `reference/commands/development.md` — drop the stale "generic-test mapping deferred" bullet (shipped v1.27.0); soften "v0 limitations" → "known limitations"; restamp JSON sample.

## Test plan
- [x] `npm run build` succeeds in `docs/` (74 pages, was 73 before).
- [x] Cross-link anchors verified: `#rocky-trino`, `#rocky-ir`, `#rocky-iceberg` resolve in `concepts/architecture/`; `concepts/content-addressed/` is reachable from model-format.
- [ ] Spot-check rendered pages in the GitHub Pages preview after merge.