### PR TITLE
feat(rocky-cli): rocky ci-diff --semantic flag (Cluster 3 E PR-2)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/types/generated/ci_diff.ts
+++ b/editors/vscode/src/types/generated/ci_diff.ts
@@ -6,6 +6,135 @@
  */
 
 /**
+ * A single typed semantic change between two `ProjectIr` snapshots.
+ *
+ * Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
+ */
+export type BreakingChange =
+  | {
+      kind: "model_removed";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "model_added";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_dropped";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_added";
+      model: string;
+      nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_type_changed";
+      model: string;
+      /**
+       * `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+       */
+      narrowing: boolean;
+      new_type: string;
+      old_type: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_nullability_changed";
+      model: string;
+      new_nullable: boolean;
+      old_nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_reordered";
+      model: string;
+      new_index: number;
+      old_index: number;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "materialization_strategy_changed";
+      model: string;
+      new_strategy: string;
+      old_strategy: string;
+      [k: string]: unknown;
+    }
+  | {
+      /**
+       * Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+       */
+      key_kind: string;
+      kind: "materialization_key_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "replication_columns_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "partition_by_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "target_renamed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "source_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_mask_changed";
+      model: string;
+      new_strategy?: string | null;
+      old_strategy?: string | null;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "lakehouse_format_changed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "sql_body_changed";
+      model: string;
+      [k: string]: unknown;
+    };
+/**
+ * Severity classification for a single semantic change.
+ */
+export type BreakingSeverity = "breaking" | "warning" | "info";
+/**
  * The kind of change observed for a single column.
  */
 export type ColumnChangeType = "added" | "removed" | "type_changed";
@@ -24,6 +153,10 @@ export interface CiDiffOutput {
    * Git ref used as the comparison base (e.g. `main`).
    */
   base_ref: string;
+  /**
+   * Classified semantic findings from the typed-IR breaking-change classifier. Only populated when `ci-diff` is invoked with `--semantic` and both base + HEAD compiles succeed; omitted from JSON output when empty.
+   */
+  breaking_findings?: BreakingFinding[];
   command: string;
   /**
    * Git ref for the incoming changes (typically `HEAD`).
@@ -42,6 +175,14 @@ export interface CiDiffOutput {
    */
   summary: DiffSummary;
   version: string;
+  [k: string]: unknown;
+}
+/**
+ * A classified finding produced by [`diff_project_ir`].
+ */
+export interface BreakingFinding {
+  change: BreakingChange;
+  severity: BreakingSeverity;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -205,28 +205,30 @@ fn compile_head(
     compile::compile(&config).context("failed to compile models in the current working tree")
 }
 
-/// Try to extract schemas from the base ref by checking out model files to a temp dir.
+/// Try to compile the base ref by checking out model files to a temp dir
+/// and running the compiler against them.
 ///
-/// This is best-effort: if the base ref doesn't have a complete models directory
-/// or compilation fails, we return an empty map rather than erroring.
+/// This is best-effort: if the base ref doesn't have a complete models
+/// directory or compilation fails, we return `None` rather than erroring.
+/// Callers project schemas / typed models from the `CompileResult` (see
+/// [`typed_columns_from_compile`]).
 ///
 /// `source_schemas` seeds the compile from the *current* warehouse
 /// cache, not historical types. That's fine for diff purposes —
 /// typecheck on historical models with today's leaf types still detects
 /// the model-level schema drift that ci-diff is looking for, and there's
 /// no per-ref cache to restore from.
-fn extract_base_schemas(
+fn compile_base_ref(
     base_ref: &str,
     models_dir: &Path,
     source_schemas: HashMap<String, Vec<rocky_compiler::types::TypedColumn>>,
-) -> HashMap<String, Vec<TypedColumn>> {
+) -> Option<rocky_compiler::compile::CompileResult> {
     // Try to get the models directory path relative to the repo root
-    let models_rel = find_models_relative_path(models_dir);
-    let models_rel = match models_rel {
+    let models_rel = match find_models_relative_path(models_dir) {
         Some(p) => p,
         None => {
             debug!("could not determine models directory relative to repo root");
-            return HashMap::new();
+            return None;
         }
     };
 
@@ -235,7 +237,7 @@ fn extract_base_schemas(
         Ok(t) => t,
         Err(e) => {
             debug!("failed to create temp dir for base schema extraction: {e}");
-            return HashMap::new();
+            return None;
         }
     };
 
@@ -250,7 +252,7 @@ fn extract_base_schemas(
             debug!(
                 "git ls-tree failed for base ref '{base_ref}' — skipping base schema extraction"
             );
-            return HashMap::new();
+            return None;
         }
     };
 
@@ -294,23 +296,10 @@ fn extract_base_schemas(
     };
 
     match compile::compile(&config) {
-        Ok(result) => {
-            let mut schemas = HashMap::new();
-            for (model_name, typed_cols) in &result.type_check.typed_models {
-                let cols: Vec<TypedColumn> = typed_cols
-                    .iter()
-                    .map(|tc| TypedColumn {
-                        name: tc.name.clone(),
-                        data_type: format!("{:?}", tc.data_type),
-                    })
-                    .collect();
-                schemas.insert(model_name.clone(), cols);
-            }
-            schemas
-        }
+        Ok(result) => Some(result),
         Err(e) => {
             debug!("base ref compilation failed (expected for partial models): {e}");
-            HashMap::new()
+            None
         }
     }
 }
@@ -471,10 +460,16 @@ fn build_diff_results(
 /// `head_compile` is `None` when the models directory is missing or the
 /// HEAD compile fails — callers (e.g. `rocky lineage-diff`) that need the
 /// `semantic_graph` for downstream traces must handle that gracefully.
+///
+/// `base_compile` is similarly `None` when the base ref can't be checked
+/// out into a temp dir or fails to compile. Both are kept on the data
+/// struct so the `--semantic` path can lower them into [`ProjectIr`]
+/// without re-running the compiler.
 pub(crate) struct CiDiffData {
     pub(crate) summary: DiffSummary,
     pub(crate) results: Vec<DiffResult>,
     pub(crate) head_compile: Option<rocky_compiler::compile::CompileResult>,
+    pub(crate) base_compile: Option<rocky_compiler::compile::CompileResult>,
     /// Total count of files git reported as changed between `base_ref` and
     /// HEAD (any extension, before the model-file filter). Lets callers
     /// distinguish "PR is empty" from "PR is non-empty but only touches
@@ -520,6 +515,7 @@ pub(crate) fn compute_ci_diff(
             },
             results: vec![],
             head_compile: None,
+            base_compile: None,
             changed_file_count,
         });
     }
@@ -536,6 +532,7 @@ pub(crate) fn compute_ci_diff(
             },
             results: vec![],
             head_compile: None,
+            base_compile: None,
             changed_file_count,
         });
     }
@@ -558,11 +555,15 @@ pub(crate) fn compute_ci_diff(
         .map(typed_columns_from_compile)
         .unwrap_or_default();
 
-    let base_schemas = if models_dir.is_dir() {
-        extract_base_schemas(base_ref, models_dir, source_schemas)
+    let base_compile = if models_dir.is_dir() {
+        compile_base_ref(base_ref, models_dir, source_schemas)
     } else {
-        HashMap::new()
+        None
     };
+    let base_schemas = base_compile
+        .as_ref()
+        .map(typed_columns_from_compile)
+        .unwrap_or_default();
 
     let results = build_diff_results(&model_changes, &head_schemas, &base_schemas);
     let summary = DiffSummary::from_results(&results);
@@ -571,8 +572,67 @@ pub(crate) fn compute_ci_diff(
         summary,
         results,
         head_compile,
+        base_compile,
         changed_file_count,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Semantic breaking-change lowering
+// ---------------------------------------------------------------------------
+
+/// Lower a [`rocky_compiler::compile::CompileResult`] into a
+/// [`rocky_ir::ProjectIr`] suitable for the
+/// [`rocky_core::breaking_change`] classifier.
+///
+/// Each model in `result.project.models` is converted via
+/// [`rocky_core::models::Model::to_model_ir`] (which leaves
+/// `typed_columns` empty) and then enriched with the typed columns from
+/// `result.type_check.typed_models`, keyed by `config.name`. Models the
+/// type-checker did not produce columns for keep their empty
+/// `typed_columns` vec — the classifier handles this gracefully (it
+/// just won't emit per-column findings for that model).
+///
+/// `dag` and `lineage_edges` are left empty: the classifier ignores both
+/// (they are implementation-detail fields per the
+/// `rocky_core::breaking_change` module docs).
+pub(crate) fn project_ir_from_compile(
+    result: &rocky_compiler::compile::CompileResult,
+) -> rocky_ir::ProjectIr {
+    let typed = &result.type_check.typed_models;
+    let models = result
+        .project
+        .models
+        .iter()
+        .map(|m| {
+            let mut ir = m.to_model_ir();
+            if let Some(cols) = typed.get(&m.config.name) {
+                ir.typed_columns = cols.clone();
+            }
+            ir
+        })
+        .collect();
+    rocky_ir::ProjectIr {
+        models,
+        dag: Vec::new(),
+        lineage_edges: Vec::new(),
+    }
+}
+
+/// Run the semantic breaking-change classifier across `base` and `head`
+/// compiles. Returns an empty vec when either side is `None`.
+fn semantic_findings(
+    base: Option<&rocky_compiler::compile::CompileResult>,
+    head: Option<&rocky_compiler::compile::CompileResult>,
+) -> Vec<rocky_core::breaking_change::BreakingFinding> {
+    match (base, head) {
+        (Some(b), Some(h)) => {
+            let old = project_ir_from_compile(b);
+            let new = project_ir_from_compile(h);
+            rocky_core::breaking_change::diff_project_ir(&old, &new)
+        }
+        _ => Vec::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -580,12 +640,19 @@ pub(crate) fn compute_ci_diff(
 // ---------------------------------------------------------------------------
 
 /// Execute `rocky ci-diff`.
+///
+/// `semantic` enables the typed-IR breaking-change classifier
+/// ([`rocky_core::breaking_change::diff_project_ir`]); findings are
+/// attached to the JSON output under `breaking_findings`. The flag is
+/// informational only: even a `Breaking` finding does not change the
+/// exit code. The hard gate lives on `rocky branch promote`.
 pub fn run_ci_diff(
     config_path: &Path,
     state_path: &Path,
     base_ref: &str,
     models_dir: &Path,
     output_json: bool,
+    semantic: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
     let data = compute_ci_diff(
@@ -621,13 +688,20 @@ pub fn run_ci_diff(
         return Ok(());
     }
 
+    let findings = if semantic {
+        semantic_findings(data.base_compile.as_ref(), data.head_compile.as_ref())
+    } else {
+        Vec::new()
+    };
+
     if output_json {
         let output = CiDiffOutput::new(
             base_ref.to_string(),
             "HEAD".to_string(),
             data.summary,
             data.results,
-        );
+        )
+        .with_breaking_findings(findings);
         print_json(&output)?;
     } else {
         println!("Rocky CI Diff ({base_ref}...HEAD)\n");
@@ -635,6 +709,18 @@ pub fn run_ci_diff(
         println!();
         println!("--- Markdown (for PR comment) ---\n");
         print!("{}", format_diff_markdown(&data.results));
+        if semantic && !findings.is_empty() {
+            println!();
+            println!("--- Semantic Findings ({} total) ---\n", findings.len());
+            for f in &findings {
+                let sev = match f.severity {
+                    rocky_core::breaking_change::BreakingSeverity::Breaking => "BREAKING",
+                    rocky_core::breaking_change::BreakingSeverity::Warning => "WARNING",
+                    rocky_core::breaking_change::BreakingSeverity::Info => "INFO",
+                };
+                println!("[{sev}] {:?}", f.change);
+            }
+        }
     }
 
     Ok(())
@@ -1030,5 +1116,136 @@ mod tests {
             results[0].column_changes[0].change_type,
             ColumnChangeType::Removed
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // project_ir_from_compile + semantic_findings (semantic mode stitching)
+    // -----------------------------------------------------------------------
+
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Write a minimal transformation model: `<name>.sql` + sidecar
+    /// `<name>.toml`. Mirrors the test helper in `compile.rs`.
+    fn write_model(dir: &Path, name: &str, sql: &str) {
+        let sql_path = dir.join(format!("{name}.sql"));
+        let toml_path = dir.join(format!("{name}.toml"));
+        fs::write(&sql_path, sql).unwrap();
+        fs::write(
+            &toml_path,
+            format!(
+                "name = \"{name}\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// Build a `HashMap<source_name, Vec<TypedColumn>>` to seed the
+    /// compiler so SELECT FROM <source> yields concrete typed columns.
+    fn source_schema(
+        name: &str,
+        cols: &[(&str, rocky_ir::RockyType)],
+    ) -> HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
+        let mut map = HashMap::new();
+        map.insert(
+            name.to_string(),
+            cols.iter()
+                .map(|(n, t)| rocky_compiler::types::TypedColumn {
+                    name: (*n).to_string(),
+                    data_type: t.clone(),
+                    nullable: true,
+                })
+                .collect(),
+        );
+        map
+    }
+
+    #[test]
+    fn project_ir_from_compile_stitches_typed_columns_from_type_check() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path();
+        // SELECT FROM a seeded source so the typechecker produces real
+        // typed columns; SELECT-without-FROM yields an empty schema.
+        write_model(models_dir, "orders", "SELECT id, name FROM src_orders");
+
+        let sources = source_schema(
+            "src_orders",
+            &[
+                ("id", rocky_ir::RockyType::Int64),
+                ("name", rocky_ir::RockyType::String),
+            ],
+        );
+        let result = compile_head(models_dir, sources).expect("compile succeeds");
+        let ir = project_ir_from_compile(&result);
+
+        assert_eq!(ir.models.len(), 1);
+        let model = &ir.models[0];
+        assert_eq!(&*model.name, "orders");
+        assert!(
+            !model.typed_columns.is_empty(),
+            "typed_columns must be stitched from type_check.typed_models",
+        );
+        let names: Vec<&str> = model
+            .typed_columns
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert!(names.contains(&"id"));
+        assert!(names.contains(&"name"));
+    }
+
+    #[test]
+    fn semantic_findings_flag_column_drop_as_breaking() {
+        // Compile two minimal projects that differ only by a dropped
+        // column on a shared model; assert the classifier surfaces a
+        // `column_dropped` finding with `breaking` severity via the
+        // stitched IR.
+        let sources = source_schema(
+            "src_orders",
+            &[
+                ("id", rocky_ir::RockyType::Int64),
+                ("legacy_flag", rocky_ir::RockyType::String),
+            ],
+        );
+
+        let base_dir = TempDir::new().unwrap();
+        write_model(
+            base_dir.path(),
+            "orders",
+            "SELECT id, legacy_flag FROM src_orders",
+        );
+        let head_dir = TempDir::new().unwrap();
+        write_model(head_dir.path(), "orders", "SELECT id FROM src_orders");
+
+        let base_compile = compile_head(base_dir.path(), sources.clone()).expect("base compile");
+        let head_compile = compile_head(head_dir.path(), sources).expect("head compile");
+
+        let findings = semantic_findings(Some(&base_compile), Some(&head_compile));
+        let dropped: Vec<_> = findings
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.change,
+                    rocky_core::breaking_change::BreakingChange::ColumnDropped { .. }
+                )
+            })
+            .collect();
+        assert_eq!(
+            dropped.len(),
+            1,
+            "expected exactly one column_dropped finding, got findings: {findings:?}",
+        );
+        assert!(
+            dropped[0].is_breaking(),
+            "column_dropped must surface as breaking severity",
+        );
+    }
+
+    #[test]
+    fn semantic_findings_empty_when_either_side_missing() {
+        // No compile on either side → classifier is skipped, empty vec.
+        // The CLI relies on `skip_serializing_if = "Vec::is_empty"` to
+        // omit the field from JSON output in this case.
+        assert!(semantic_findings(None, None).is_empty());
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -991,6 +991,12 @@ pub struct CiDiffOutput {
     pub models: Vec<rocky_core::ci_diff::DiffResult>,
     /// Pre-rendered Markdown suitable for posting as a GitHub PR comment.
     pub markdown: String,
+    /// Classified semantic findings from the typed-IR breaking-change
+    /// classifier. Only populated when `ci-diff` is invoked with
+    /// `--semantic` and both base + HEAD compiles succeed; omitted from
+    /// JSON output when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breaking_findings: Vec<rocky_core::breaking_change::BreakingFinding>,
 }
 
 impl CiDiffOutput {
@@ -1009,7 +1015,17 @@ impl CiDiffOutput {
             summary,
             models,
             markdown,
+            breaking_findings: Vec::new(),
         }
+    }
+
+    /// Attach semantic breaking-change findings to this output.
+    pub fn with_breaking_findings(
+        mut self,
+        findings: Vec<rocky_core::breaking_change::BreakingFinding>,
+    ) -> Self {
+        self.breaking_findings = findings;
+        self
     }
 }
 

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -786,6 +786,13 @@ enum Command {
         /// Models directory
         #[arg(long, default_value = "models")]
         models: PathBuf,
+        /// Also run the typed-IR semantic breaking-change classifier and
+        /// surface findings under `breaking_findings` in the JSON output.
+        ///
+        /// Informational only — even a `Breaking` finding does not change
+        /// the exit code. The hard gate lives on `rocky branch promote`.
+        #[arg(long)]
+        semantic: bool,
     },
 
     /// Per-changed-column downstream impact, formatted for PR review
@@ -1979,12 +1986,17 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         Command::Ci { models, contracts } => {
             rocky_cli::commands::run_ci(&models, contracts.as_deref(), json)
         }
-        Command::CiDiff { base_ref, models } => rocky_cli::commands::run_ci_diff(
+        Command::CiDiff {
+            base_ref,
+            models,
+            semantic,
+        } => rocky_cli::commands::run_ci_diff(
             &cli.config,
             &state_path,
             &base_ref,
             &models,
             json,
+            semantic,
             cli.cache_ttl,
         ),
         Command::LineageDiff { base_ref, models } => rocky_cli::commands::run_lineage_diff(

--- a/integrations/dagster/src/dagster_rocky/types_generated/ci_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/ci_diff_schema.py
@@ -8,6 +8,277 @@ from enum import StrEnum
 from pydantic import BaseModel, conint
 
 
+class Kind(StrEnum):
+    model_removed = "model_removed"
+
+
+class BreakingChange1(BaseModel):
+    """
+    A model present on the base side is absent on the head side.
+    """
+
+    kind: Kind
+    model: str
+
+
+class Kind1(StrEnum):
+    model_added = "model_added"
+
+
+class BreakingChange2(BaseModel):
+    """
+    A model present on the head side is absent on the base side.
+    """
+
+    kind: Kind1
+    model: str
+
+
+class Kind2(StrEnum):
+    column_dropped = "column_dropped"
+
+
+class BreakingChange3(BaseModel):
+    """
+    A column present on the base side is absent on the head side.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind2
+    model: str
+
+
+class Kind3(StrEnum):
+    column_added = "column_added"
+
+
+class BreakingChange4(BaseModel):
+    """
+    A column was added.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind3
+    model: str
+    nullable: bool
+
+
+class Kind4(StrEnum):
+    column_type_changed = "column_type_changed"
+
+
+class BreakingChange5(BaseModel):
+    """
+    A column's data type changed.
+    """
+
+    column: str
+    kind: Kind4
+    model: str
+    narrowing: bool
+    """
+    `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+    """
+    new_type: str
+    old_type: str
+
+
+class Kind5(StrEnum):
+    column_nullability_changed = "column_nullability_changed"
+
+
+class BreakingChange6(BaseModel):
+    """
+    A column's nullability flipped.
+    """
+
+    column: str
+    kind: Kind5
+    model: str
+    new_nullable: bool
+    old_nullable: bool
+
+
+class Kind6(StrEnum):
+    column_reordered = "column_reordered"
+
+
+class BreakingChange7(BaseModel):
+    """
+    A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
+    """
+
+    column: str
+    kind: Kind6
+    model: str
+    new_index: conint(ge=0)
+    old_index: conint(ge=0)
+
+
+class Kind7(StrEnum):
+    materialization_strategy_changed = "materialization_strategy_changed"
+
+
+class BreakingChange8(BaseModel):
+    """
+    The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
+    """
+
+    kind: Kind7
+    model: str
+    new_strategy: str
+    old_strategy: str
+
+
+class Kind8(StrEnum):
+    materialization_key_changed = "materialization_key_changed"
+
+
+class BreakingChange9(BaseModel):
+    """
+    Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
+    """
+
+    key_kind: str
+    """
+    Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+    """
+    kind: Kind8
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind9(StrEnum):
+    replication_columns_changed = "replication_columns_changed"
+
+
+class BreakingChange10(BaseModel):
+    """
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
+    """
+
+    kind: Kind9
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind10(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange11(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind10
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind11(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange12(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind11
+    model: str
+    new: str
+    old: str
+
+
+class Kind12(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange13(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind12
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind13(StrEnum):
+    column_mask_changed = "column_mask_changed"
+
+
+class BreakingChange14(BaseModel):
+    """
+    A column mask was added, removed, or its strategy changed.
+    """
+
+    column: str
+    kind: Kind13
+    model: str
+    new_strategy: str | None = None
+    old_strategy: str | None = None
+
+
+class Kind14(StrEnum):
+    lakehouse_format_changed = "lakehouse_format_changed"
+
+
+class BreakingChange15(BaseModel):
+    """
+    Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
+    """
+
+    kind: Kind14
+    model: str
+    new: str
+    old: str
+
+
+class Kind15(StrEnum):
+    sql_body_changed = "sql_body_changed"
+
+
+class BreakingChange16(BaseModel):
+    """
+    SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
+    """
+
+    kind: Kind15
+    model: str
+
+
+class BreakingSeverity1(StrEnum):
+    """
+    Will break a downstream consumer that reads the model's prior shape.
+    """
+
+    breaking = "breaking"
+
+
+class BreakingSeverity2(StrEnum):
+    """
+    May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
+    """
+
+    warning = "warning"
+
+
+class BreakingSeverity3(StrEnum):
+    """
+    Informational only — purely additive or backwards-compatible.
+    """
+
+    info = "info"
+
+
 class ColumnChangeType1(StrEnum):
     """
     Column was added in the incoming side.
@@ -99,6 +370,40 @@ class ModelDiffStatus4(StrEnum):
     removed = "removed"
 
 
+class BreakingFinding(BaseModel):
+    """
+    A classified finding produced by [`diff_project_ir`].
+    """
+
+    change: (
+        BreakingChange1
+        | BreakingChange2
+        | BreakingChange3
+        | BreakingChange4
+        | BreakingChange5
+        | BreakingChange6
+        | BreakingChange7
+        | BreakingChange8
+        | BreakingChange9
+        | BreakingChange10
+        | BreakingChange11
+        | BreakingChange12
+        | BreakingChange13
+        | BreakingChange14
+        | BreakingChange15
+        | BreakingChange16
+    )
+    """
+    A single typed semantic change between two `ProjectIr` snapshots.
+
+    Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
+    """
+    severity: BreakingSeverity1 | BreakingSeverity2 | BreakingSeverity3
+    """
+    Severity classification for a single semantic change.
+    """
+
+
 class DiffResult(BaseModel):
     """
     Diff result for a single model between two pipeline states.
@@ -140,6 +445,10 @@ class CiDiffOutput(BaseModel):
     base_ref: str
     """
     Git ref used as the comparison base (e.g. `main`).
+    """
+    breaking_findings: list[BreakingFinding] | None = None
+    """
+    Classified semantic findings from the typed-IR breaking-change classifier. Only populated when `ci-diff` is invoked with `--semantic` and both base + HEAD compiles succeed; omitted from JSON output when empty.
     """
     command: str
     head_ref: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind1(StrEnum):
+class Kind17(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind1
+    kind: Kind17
 
 
 class PreviewModelDiff(BaseModel):

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.27.0"
+version = "1.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },

--- a/schemas/ci_diff.schema.json
+++ b/schemas/ci_diff.schema.json
@@ -1,6 +1,523 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BreakingChange": {
+      "description": "A single typed semantic change between two `ProjectIr` snapshots.\n\nEach variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.",
+      "oneOf": [
+        {
+          "description": "A model present on the base side is absent on the head side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_removed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A model present on the head side is absent on the base side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column present on the base side is absent on the head side.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_dropped"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column was added.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model",
+            "nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's data type changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_type_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "narrowing": {
+              "description": "`true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).",
+              "type": "boolean"
+            },
+            "new_type": {
+              "type": "string"
+            },
+            "old_type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "narrowing",
+            "new_type",
+            "old_type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's nullability flipped.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_nullability_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_nullable": {
+              "type": "boolean"
+            },
+            "old_nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_nullable",
+            "old_nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_reordered"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "old_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_index",
+            "old_index"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "materialization_strategy_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": "string"
+            },
+            "old_strategy": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new_strategy",
+            "old_strategy"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).",
+          "properties": {
+            "key_kind": {
+              "description": "Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.",
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "materialization_key_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "key_kind",
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "replication_columns_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "partition_by_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Target table reference renamed (catalog, schema, or table component).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "target_renamed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Source reference rebound to a different table.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "source_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column mask was added, removed, or its strategy changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_mask_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "old_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "lakehouse_format_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "sql_body_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "BreakingFinding": {
+      "description": "A classified finding produced by [`diff_project_ir`].",
+      "properties": {
+        "change": {
+          "$ref": "#/definitions/BreakingChange"
+        },
+        "severity": {
+          "$ref": "#/definitions/BreakingSeverity"
+        }
+      },
+      "required": [
+        "change",
+        "severity"
+      ],
+      "type": "object"
+    },
+    "BreakingSeverity": {
+      "description": "Severity classification for a single semantic change.",
+      "oneOf": [
+        {
+          "description": "Will break a downstream consumer that reads the model's prior shape.",
+          "enum": [
+            "breaking"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.",
+          "enum": [
+            "warning"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Informational only — purely additive or backwards-compatible.",
+          "enum": [
+            "info"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ColumnChangeType": {
       "description": "The kind of change observed for a single column.",
       "oneOf": [
@@ -200,6 +717,13 @@
     "base_ref": {
       "description": "Git ref used as the comparison base (e.g. `main`).",
       "type": "string"
+    },
+    "breaking_findings": {
+      "description": "Classified semantic findings from the typed-IR breaking-change classifier. Only populated when `ci-diff` is invoked with `--semantic` and both base + HEAD compiles succeed; omitted from JSON output when empty.",
+      "items": {
+        "$ref": "#/definitions/BreakingFinding"
+      },
+      "type": "array"
     },
     "command": {
       "type": "string"


### PR DESCRIPTION
## Summary

Wires the new `BreakingChange` classifier (shipped in #508) through the existing `rocky ci-diff` command. When `--semantic` is set, after the existing column-diff runs, both refs' models are compiled into `ProjectIr` values, fed through `rocky_core::breaking_change::diff_project_ir(&base, &head)`, and the findings surface in `CiDiffOutput.breaking_findings` (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`).

**Informational only — no exit-code change.** The failing gate lands in PR-3 on `rocky branch promote`.

### Implementation notes

- `CompileResult` does not carry `ProjectIr`, so a new `project_ir_from_compile()` helper stitches `result.type_check.typed_models` onto each `Model::to_model_ir()` — without the stitch the classifier sees empty schemas on both sides.
- `extract_base_schemas` refactored to `compile_base_ref` returning `Option<CompileResult>`; `CiDiffData` now carries both `head_compile` and `base_compile` (lineage-diff caller is untouched — it only reads `head_compile`).

### Codegen cascade

`schemas/ci_diff.schema.json` (+524), `editors/vscode/src/types/generated/ci_diff.ts` (+141), `integrations/dagster/src/dagster_rocky/types_generated/ci_diff_schema.py` (+309) all pick up the BreakingChange/BreakingFinding `oneOf`. `preview_diff_schema.py` has a 4-line rename churn — `Kind1` → `Kind17` because `datamodel-codegen` renumbers `Kind` classes by encounter order and the 16 new BreakingChange variants now precede the existing `Kind1`. Pure rename; no behaviour change.

### Lockfile drift

`editors/vscode/package-lock.json` 1.15.1 → 1.15.2 and `integrations/dagster/uv.lock` dagster-rocky 1.27.0 → 1.28.0 were stale on main from the v1.30.0 cut (release commit didn't refresh them). Included here as a side-effect of `just codegen` per `feedback_codegen_npm_lockfile_drift`; trivially separable into a prep commit if preferred.

## Test plan

- [x] `cargo test -p rocky-cli ci_diff` — 21/21 (18 pre-existing + 3 new: stitching, end-to-end column-drop classifier, both-sides-missing)
- [x] `cargo clippy -p rocky-cli --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p rocky-cli --check` — clean
- [x] `rocky ci-diff --help` shows `--semantic` registered

Depends on #508 (already merged).