### PR TITLE
feat(rocky-cli): pre-promote gate on breaking changes (Cluster 3 E PR-3)

### DIFF
--- a/editors/vscode/src/types/generated/branch_promote.ts
+++ b/editors/vscode/src/types/generated/branch_promote.ts
@@ -18,9 +18,143 @@ export type ApproverSource = "local" | "ci_oidc" | "pat";
  */
 export type SignatureAlgorithm = "blake3_canonical_json";
 /**
+ * A single typed semantic change between two `ProjectIr` snapshots.
+ *
+ * Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
+ */
+export type BreakingChange =
+  | {
+      kind: "model_removed";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "model_added";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_dropped";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_added";
+      model: string;
+      nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_type_changed";
+      model: string;
+      /**
+       * `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+       */
+      narrowing: boolean;
+      new_type: string;
+      old_type: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_nullability_changed";
+      model: string;
+      new_nullable: boolean;
+      old_nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_reordered";
+      model: string;
+      new_index: number;
+      old_index: number;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "materialization_strategy_changed";
+      model: string;
+      new_strategy: string;
+      old_strategy: string;
+      [k: string]: unknown;
+    }
+  | {
+      /**
+       * Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+       */
+      key_kind: string;
+      kind: "materialization_key_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "replication_columns_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "partition_by_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "target_renamed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "source_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_mask_changed";
+      model: string;
+      new_strategy?: string | null;
+      old_strategy?: string | null;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "lakehouse_format_changed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "sql_body_changed";
+      model: string;
+      [k: string]: unknown;
+    };
+/**
+ * Severity classification for a single semantic change.
+ */
+export type BreakingSeverity = "breaking" | "warning" | "info";
+/**
  * Categorical kind of an [`AuditEvent`] emitted by `branch promote`.
  */
-export type AuditEventKind = ("promote_started" | "promote_completed" | "promote_failed") | "approval_skipped";
+export type AuditEventKind =
+  | ("promote_started" | "promote_completed" | "promote_failed")
+  | "approval_skipped"
+  | "breaking_changes_blocked"
+  | "breaking_changes_allowed"
+  | "breaking_changes_gate_skipped";
 
 /**
  * JSON output for `rocky branch promote`.
@@ -40,6 +174,10 @@ export interface BranchPromoteOutput {
   audit: AuditEvent[];
   branch: string;
   branch_state_hash: string;
+  /**
+   * Semantic breaking-change findings produced by the pre-promote gate. Empty when the gate ran and found no breaking changes; absent when the gate was skipped (compile failure on either side). When present and non-empty either the promote was blocked or `--allow-breaking` was set — see the audit trail for which.
+   */
+  breaking_changes?: BreakingFinding[] | null;
   command: string;
   /**
    * True when every target's SQL succeeded.
@@ -115,11 +253,23 @@ export interface AuditEvent {
   at: string;
   branch: string;
   branch_state_hash: string;
+  /**
+   * Breaking-change findings carried by `BreakingChangesBlocked` and `BreakingChangesAllowed` events. Always absent for other kinds.
+   */
+  breaking_changes?: BreakingFinding[] | null;
   kind: AuditEventKind;
   /**
-   * Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip ("--skip-approval CLI flag" or "ROCKY_BRANCH_APPROVAL_SKIP=1"); empty for routine state events.
+   * Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip, and for `BreakingChangesGateSkipped` to record why the gate could not run (e.g. "base ref did not compile"). Empty for routine state events.
    */
   reason?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * A classified finding produced by [`diff_project_ir`].
+ */
+export interface BreakingFinding {
+  change: BreakingChange;
+  severity: BreakingSeverity;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -27,11 +27,12 @@ use std::time::SystemTime;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
+use rocky_core::breaking_change::{self, BreakingFinding};
 use rocky_core::compare::ComparisonThresholds;
 use rocky_core::config::BranchApprovalConfig;
 use rocky_core::shadow::{self, ShadowConfig};
 use rocky_core::state::{BranchRecord, StateStore};
-use rocky_ir::TargetRef;
+use rocky_ir::{ModelIr, ProjectIr, TargetRef};
 
 use crate::output::{
     ApprovalArtifact, ApprovalSignature, ApproveOutput, ApproverIdentity, ApproverSource,
@@ -707,12 +708,25 @@ async fn discover_branch_targets(
 
 /// `rocky branch promote <name>` — promote a branch's materialized tables
 /// to their production targets, gated on `[branch.approval]` if enabled.
+///
+/// `models_dir` is the directory containing the project's transformation
+/// models; the semantic breaking-change gate compiles it against `base_ref`
+/// to detect structural regressions. Both default to `"models"` / `"main"`
+/// at the CLI layer.
+///
+/// `allow_breaking = true` bypasses the breaking-change gate (analogous to
+/// `--skip-approval` for the approval gate). The bypass is always recorded
+/// as a `BreakingChangesAllowed` audit event.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_branch_promote(
     state_path: &Path,
     config_path: &Path,
+    models_dir: &Path,
+    base_ref: &str,
     branch_name: &str,
     filter: Option<&str>,
     skip_approval_flag: bool,
+    allow_breaking: bool,
     json: bool,
 ) -> Result<()> {
     use crate::registry::AdapterRegistry;
@@ -761,6 +775,7 @@ pub async fn run_branch_promote(
             branch: record.name.clone(),
             branch_state_hash: branch_state_hash.clone(),
             reason: Some(reason.clone()),
+            breaking_changes: None,
         });
     } else if approval_cfg.required {
         let (loaded, parse_rejected) = load_approvals_for_branch(&record.name)?;
@@ -797,6 +812,88 @@ pub async fn run_branch_promote(
     // (When required = false and no skip, the gate is a no-op — proceed
     // straight to PromoteStarted with no audit entry beyond the routine ones.)
 
+    // ---- Semantic breaking-change gate ------------------------------------
+    //
+    // Compile the project at the branch's base ref and at HEAD, classify the
+    // structural delta via `rocky_core::breaking_change::diff_project_ir`,
+    // and fail fast on any `Breaking`-severity finding unless the operator
+    // passed `--allow-breaking`.
+    //
+    // Fail-open on compile failure: if either side does not compile under
+    // the current Rocky version (a stale base ref written before a parser
+    // change, a partial models tree, missing `models/` directory) the gate
+    // is *skipped*, the reason is recorded in a `BreakingChangesGateSkipped`
+    // audit event, and the promote proceeds. Failing the promote on a
+    // *compile* error in the gate would surprise users whose past commits
+    // don't compile under today's Rocky — the approval gate already guards
+    // the trust boundary.
+    let breaking_findings: Option<Vec<BreakingFinding>> = evaluate_breaking_change_gate(
+        config_path,
+        models_dir,
+        base_ref,
+        &mut audit,
+        &actor,
+        &record,
+        &branch_state_hash,
+    );
+
+    if let Some(findings) = &breaking_findings {
+        let breaking: Vec<&BreakingFinding> = findings.iter().filter(|f| f.is_breaking()).collect();
+        if !breaking.is_empty() {
+            if allow_breaking {
+                audit.push(AuditEvent {
+                    kind: AuditEventKind::BreakingChangesAllowed,
+                    at: Utc::now(),
+                    actor: actor.clone(),
+                    branch: record.name.clone(),
+                    branch_state_hash: branch_state_hash.clone(),
+                    reason: Some("--allow-breaking CLI flag".to_string()),
+                    breaking_changes: Some(findings.clone()),
+                });
+            } else {
+                audit.push(AuditEvent {
+                    kind: AuditEventKind::BreakingChangesBlocked,
+                    at: Utc::now(),
+                    actor: actor.clone(),
+                    branch: record.name.clone(),
+                    branch_state_hash: branch_state_hash.clone(),
+                    reason: None,
+                    breaking_changes: Some(findings.clone()),
+                });
+
+                let summary = breaking
+                    .iter()
+                    .map(|f| format!("{:?}", f.change))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+
+                // Emit the JSON payload before bailing so operators with
+                // `--output json` still see the findings on a blocked promote.
+                let output = BranchPromoteOutput {
+                    version: VERSION.to_string(),
+                    command: "branch promote".to_string(),
+                    branch: record.name.clone(),
+                    branch_state_hash: branch_state_hash.clone(),
+                    approvals_used,
+                    approvals_rejected,
+                    breaking_changes: Some(findings.clone()),
+                    targets: Vec::new(),
+                    audit,
+                    success: false,
+                };
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&output)?);
+                }
+
+                anyhow::bail!(
+                    "branch promote blocked by {} breaking change(s): {summary}. \
+                     Review the findings and re-run with `--allow-breaking` to override.",
+                    breaking.len()
+                );
+            }
+        }
+    }
+
     audit.push(AuditEvent {
         kind: AuditEventKind::PromoteStarted,
         at: Utc::now(),
@@ -804,6 +901,7 @@ pub async fn run_branch_promote(
         branch: record.name.clone(),
         branch_state_hash: branch_state_hash.clone(),
         reason: None,
+        breaking_changes: None,
     });
 
     let planned = discover_branch_targets(config_path, &record, filter).await?;
@@ -851,6 +949,7 @@ pub async fn run_branch_promote(
         branch: record.name.clone(),
         branch_state_hash: branch_state_hash.clone(),
         reason: None,
+        breaking_changes: None,
     });
 
     let output = BranchPromoteOutput {
@@ -860,6 +959,7 @@ pub async fn run_branch_promote(
         branch_state_hash,
         approvals_used,
         approvals_rejected,
+        breaking_changes: breaking_findings,
         targets: targets_out,
         audit,
         success: overall_success,
@@ -888,6 +988,123 @@ pub async fn run_branch_promote(
         );
     }
     Ok(())
+}
+
+/// Compute breaking-change findings between `base_ref` and HEAD for the
+/// pre-promote gate. Returns:
+///
+/// - `Some(findings)` when both refs compiled cleanly and the typed-IR diff
+///   ran. `findings` is the full classified list, including `Info`-severity
+///   entries — the caller filters on [`BreakingFinding::is_breaking`].
+/// - `None` when the gate was skipped because either side failed to compile
+///   or the models directory was unavailable. A `BreakingChangesGateSkipped`
+///   audit event is appended to `audit` carrying the human-readable reason.
+fn evaluate_breaking_change_gate(
+    config_path: &Path,
+    models_dir: &Path,
+    base_ref: &str,
+    audit: &mut Vec<AuditEvent>,
+    actor: &ApproverIdentity,
+    record: &BranchRecord,
+    branch_state_hash: &str,
+) -> Option<Vec<BreakingFinding>> {
+    use rocky_compiler::compile::{self, CompilerConfig};
+
+    let push_skip = |audit: &mut Vec<AuditEvent>, reason: String| {
+        audit.push(AuditEvent {
+            kind: AuditEventKind::BreakingChangesGateSkipped,
+            at: Utc::now(),
+            actor: actor.clone(),
+            branch: record.name.clone(),
+            branch_state_hash: branch_state_hash.to_string(),
+            reason: Some(reason),
+            breaking_changes: None,
+        });
+    };
+
+    if !models_dir.is_dir() {
+        push_skip(
+            audit,
+            format!(
+                "models directory '{}' is missing — gate skipped",
+                models_dir.display()
+            ),
+        );
+        return None;
+    }
+
+    // Seed both compiles with the cached source schemas so the resulting
+    // IR uses real types rather than `Unknown`. Mirrors `compute_ci_diff`'s
+    // policy: degrade to an empty map on config / cache failure rather than
+    // blocking the promote on a configuration issue.
+    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => {
+            let schema_cfg = cfg.cache.schemas.with_ttl_override(None);
+            // The state path is independent of the source-schemas cache for
+            // the gate's purposes; use the workspace default.
+            let state_path = std::path::PathBuf::from(".rocky/state.redb");
+            crate::source_schemas::load_cached_source_schemas(&schema_cfg, &state_path)
+        }
+        Err(_) => std::collections::HashMap::new(),
+    };
+
+    let head_compile = {
+        let config = CompilerConfig {
+            models_dir: models_dir.to_path_buf(),
+            contracts_dir: None,
+            source_schemas: source_schemas.clone(),
+            source_column_info: std::collections::HashMap::new(),
+            ..Default::default()
+        };
+        match compile::compile(&config) {
+            Ok(r) => r,
+            Err(e) => {
+                push_skip(audit, format!("HEAD compile failed — gate skipped: {e}"));
+                return None;
+            }
+        }
+    };
+
+    let base_compile =
+        match super::ci_diff::extract_base_compile(base_ref, models_dir, source_schemas) {
+            Ok(r) => r,
+            Err(reason) => {
+                push_skip(audit, format!("{reason} — gate skipped"));
+                return None;
+            }
+        };
+
+    let base_ir = compile_result_to_project_ir(&base_compile);
+    let head_ir = compile_result_to_project_ir(&head_compile);
+    Some(breaking_change::diff_project_ir(&base_ir, &head_ir))
+}
+
+/// Project a [`rocky_compiler::compile::CompileResult`] into a
+/// [`ProjectIr`] suitable for the breaking-change classifier.
+///
+/// `Model::to_model_ir()` returns a `ModelIr` with `typed_columns` empty —
+/// they live on the compiler's `TypeCheckResult::typed_models` map, keyed
+/// by `Model::config.name`. We merge them in here so the classifier sees
+/// the full typed shape it needs for column-level diffs.
+///
+/// Replication-only branches (no transformation models) compile to an
+/// empty `Project::models` and round-trip to an empty `ProjectIr`; the
+/// diff is naturally empty, which is the right answer — replication
+/// pipelines don't carry user-authored SQL whose shape could "break".
+fn compile_result_to_project_ir(result: &rocky_compiler::compile::CompileResult) -> ProjectIr {
+    let mut models: Vec<ModelIr> = Vec::with_capacity(result.project.models.len());
+    for model in &result.project.models {
+        let mut ir = model.to_model_ir();
+        if let Some(typed) = result.type_check.typed_models.get(&model.config.name) {
+            ir.typed_columns = typed.clone();
+        }
+        models.push(ir);
+    }
+    ProjectIr {
+        models,
+        dag: Vec::new(),
+        lineage_edges: Vec::new(),
+    }
 }
 
 /// `rocky branch show <name>` — inspect a single branch.
@@ -1313,6 +1530,7 @@ mod tests {
     /// disabled, nothing to read" cases.
     #[test]
     fn load_approvals_returns_empty_when_directory_missing() {
+        let _cwd_guard = cwd_lock();
         let tmp = TempDir::new().unwrap();
         let saved = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
@@ -1322,5 +1540,429 @@ mod tests {
         assert!(rejected.is_empty());
 
         std::env::set_current_dir(saved).unwrap();
+    }
+
+    // --- Breaking-change gate ----------------------------------------------
+
+    /// `compile_result_to_project_ir` must merge `typed_models` into each
+    /// `ModelIr.typed_columns` — without that, the classifier sees empty
+    /// schemas and silently produces no column-level findings. This is the
+    /// load-bearing invariant the entire gate relies on.
+    ///
+    /// Uses a two-model chain (raw → fct) so the lineage analyzer extracts
+    /// columns from the upstream source rather than producing an empty
+    /// projection for a fromless `SELECT`.
+    #[test]
+    fn compile_result_to_project_ir_populates_typed_columns() {
+        use rocky_compiler::compile::{self, CompilerConfig};
+
+        let tmp = TempDir::new().unwrap();
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        // Upstream: literal SELECT (lineage extracts column names).
+        std::fs::write(
+            models_dir.join("raw_widgets.sql"),
+            "SELECT 1 AS id, 'a' AS label",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("raw_widgets.toml"),
+            "name = \"raw_widgets\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"s\"\ntable = \"raw_widgets\"\n",
+        )
+        .unwrap();
+        // Downstream: explicit projection from the upstream.
+        std::fs::write(
+            models_dir.join("widgets.sql"),
+            "SELECT id, label FROM raw_widgets",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("widgets.toml"),
+            "name = \"widgets\"\ndepends_on = [\"raw_widgets\"]\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"s\"\ntable = \"widgets\"\n",
+        )
+        .unwrap();
+
+        let cfg = CompilerConfig {
+            models_dir,
+            ..Default::default()
+        };
+        let result = compile::compile(&cfg).expect("test fixture must compile");
+
+        let ir = compile_result_to_project_ir(&result);
+        assert_eq!(ir.models.len(), 2);
+        // Find the widgets model.
+        let widgets = ir
+            .models
+            .iter()
+            .find(|m| &*m.name == "widgets")
+            .expect("widgets must be in IR");
+        assert!(
+            !widgets.typed_columns.is_empty(),
+            "typed_columns must be merged in from type_check.typed_models"
+        );
+        let names: Vec<&str> = widgets
+            .typed_columns
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert!(names.contains(&"id"), "got {names:?}");
+        assert!(names.contains(&"label"), "got {names:?}");
+    }
+
+    /// Cwd is process-wide; the gate tests call `git rev-parse
+    /// --show-toplevel` from the test dir which means they must run
+    /// serially. The first lock acquisition is fine; the load-bearing
+    /// guarantee is that no two tests overlap their `set_current_dir`
+    /// windows. A poisoned mutex is fine to ignore — the panicked test
+    /// already restored cwd (or failed before changing it).
+    fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Helper: initialize a git repo in `dir` with a `main` branch containing
+    /// `models/` files, then return the path of the models directory.
+    fn init_git_repo_with_models(
+        dir: &Path,
+        rocky_toml: &str,
+        files: &[(&str, &str)],
+    ) -> std::path::PathBuf {
+        let models_dir = dir.join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        std::fs::write(dir.join("rocky.toml"), rocky_toml).unwrap();
+
+        let run_git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("git command must run");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run_git(&["init", "-q", "-b", "main"]);
+        run_git(&["config", "user.email", "tester@example.com"]);
+        run_git(&["config", "user.name", "Tester"]);
+        run_git(&["config", "commit.gpgsign", "false"]);
+
+        for (path, contents) in files {
+            let full = models_dir.join(path);
+            if let Some(parent) = full.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&full, contents).unwrap();
+        }
+        run_git(&["add", "."]);
+        run_git(&["commit", "-q", "-m", "base"]);
+        models_dir
+    }
+
+    fn dummy_actor() -> ApproverIdentity {
+        ApproverIdentity {
+            email: "tester@example.com".to_string(),
+            name: Some("Tester".to_string()),
+            host: "host-1".to_string(),
+            source: ApproverSource::Local,
+        }
+    }
+
+    /// Build a two-model project (`raw_widgets` + `widgets`) whose downstream
+    /// projection list is `cols`. Used by the gate tests below to vary the
+    /// downstream's column list between base and HEAD without re-stating the
+    /// upstream boilerplate.
+    fn write_two_model_chain(models_dir: &Path, downstream_cols: &str) {
+        std::fs::create_dir_all(models_dir).unwrap();
+        std::fs::write(
+            models_dir.join("raw_widgets.sql"),
+            "SELECT 1 AS id, 'a' AS name, 42 AS qty",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("raw_widgets.toml"),
+            "name = \"raw_widgets\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"s\"\ntable = \"raw_widgets\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("widgets.sql"),
+            format!("SELECT {downstream_cols} FROM raw_widgets"),
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("widgets.toml"),
+            "name = \"widgets\"\ndepends_on = [\"raw_widgets\"]\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"s\"\ntable = \"widgets\"\n",
+        )
+        .unwrap();
+    }
+
+    /// A column drop between `main` and HEAD produces a `Breaking` finding
+    /// that surfaces in the audit trail. Default behavior (no
+    /// `--allow-breaking`) must block.
+    #[test]
+    fn gate_flags_column_drop_as_breaking() {
+        let _cwd_guard = cwd_lock();
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let rocky_toml = "[adapters.duckdb]\ntype = \"duckdb\"\npath = \":memory:\"\n";
+
+        // Stage base files: downstream projects all three columns.
+        let models_relpath = "models";
+        let models_dir_abs = dir.join(models_relpath);
+        write_two_model_chain(&models_dir_abs, "id, name, qty");
+
+        // Read each base file back to seed init_git_repo_with_models.
+        let to_pair = |name: &str| -> (String, String) {
+            (
+                name.to_string(),
+                std::fs::read_to_string(models_dir_abs.join(name)).unwrap(),
+            )
+        };
+        let owned = [
+            to_pair("raw_widgets.sql"),
+            to_pair("raw_widgets.toml"),
+            to_pair("widgets.sql"),
+            to_pair("widgets.toml"),
+        ];
+        let files: Vec<(&str, &str)> = owned
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        std::fs::remove_dir_all(&models_dir_abs).unwrap();
+        let models_dir = init_git_repo_with_models(dir, rocky_toml, &files);
+
+        // Drop `qty` on HEAD.
+        write_two_model_chain(&models_dir, "id, name");
+
+        let config_path = dir.join("rocky.toml");
+        let mut audit: Vec<AuditEvent> = Vec::new();
+        let record = sample_record("fix-price");
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+
+        let findings = evaluate_breaking_change_gate(
+            &config_path,
+            &models_dir,
+            "main",
+            &mut audit,
+            &dummy_actor(),
+            &record,
+            "branch-state-hash",
+        );
+
+        std::env::set_current_dir(saved_cwd).unwrap();
+
+        let findings = findings.expect("gate must run when both refs compile");
+        let breaking: Vec<&BreakingFinding> = findings.iter().filter(|f| f.is_breaking()).collect();
+        assert!(
+            !breaking.is_empty(),
+            "dropping a column must produce a breaking finding, got: {findings:?}"
+        );
+        assert!(
+            breaking.iter().any(|f| matches!(
+                f.change,
+                rocky_core::breaking_change::BreakingChange::ColumnDropped { .. }
+            )),
+            "the breaking finding must be ColumnDropped, got: {breaking:?}"
+        );
+        // No skip event when both sides compile.
+        assert!(
+            !audit
+                .iter()
+                .any(|e| e.kind == AuditEventKind::BreakingChangesGateSkipped),
+            "gate must not record a skip event when both refs compile"
+        );
+    }
+
+    /// A pure SQL-body rewrite that preserves the typed shape produces only
+    /// `Info` findings — the gate must let the promote through with no
+    /// breaking findings.
+    #[test]
+    fn gate_clean_when_only_info_findings() {
+        let _cwd_guard = cwd_lock();
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let rocky_toml = "[adapters.duckdb]\ntype = \"duckdb\"\npath = \":memory:\"\n";
+
+        let models_dir_abs = dir.join("models");
+        write_two_model_chain(&models_dir_abs, "id, name");
+        let to_pair = |name: &str| -> (String, String) {
+            (
+                name.to_string(),
+                std::fs::read_to_string(models_dir_abs.join(name)).unwrap(),
+            )
+        };
+        let owned = [
+            to_pair("raw_widgets.sql"),
+            to_pair("raw_widgets.toml"),
+            to_pair("widgets.sql"),
+            to_pair("widgets.toml"),
+        ];
+        let files: Vec<(&str, &str)> = owned
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        std::fs::remove_dir_all(&models_dir_abs).unwrap();
+        let models_dir = init_git_repo_with_models(dir, rocky_toml, &files);
+
+        // Same shape, swap upstream SQL only to force SqlBodyChanged (Info).
+        std::fs::write(
+            models_dir.join("raw_widgets.sql"),
+            "SELECT 2 AS id, 'b' AS name, 99 AS qty",
+        )
+        .unwrap();
+
+        let config_path = dir.join("rocky.toml");
+        let mut audit: Vec<AuditEvent> = Vec::new();
+        let record = sample_record("fix-price");
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+
+        let findings = evaluate_breaking_change_gate(
+            &config_path,
+            &models_dir,
+            "main",
+            &mut audit,
+            &dummy_actor(),
+            &record,
+            "branch-state-hash",
+        );
+
+        std::env::set_current_dir(saved_cwd).unwrap();
+
+        let findings = findings.expect("gate must run when both refs compile");
+        let breaking_count = findings.iter().filter(|f| f.is_breaking()).count();
+        assert_eq!(
+            breaking_count, 0,
+            "a SQL-body-only change must produce zero breaking findings, got {findings:?}"
+        );
+    }
+
+    /// When the base ref's models directory does not exist the gate must
+    /// fail open: return `None`, append `BreakingChangesGateSkipped` to the
+    /// audit, and let the caller proceed.
+    #[test]
+    fn gate_fails_open_when_base_ref_missing_models() {
+        let _cwd_guard = cwd_lock();
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let rocky_toml = "[adapters.duckdb]\ntype = \"duckdb\"\npath = \":memory:\"\n";
+        // Commit an empty repo with only rocky.toml — no models directory at
+        // any ref. The HEAD working tree adds the models dir.
+        let _models_dir = init_git_repo_with_models(dir, rocky_toml, &[]);
+
+        // Now create a models directory on HEAD only.
+        let models_dir = dir.join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        std::fs::write(
+            models_dir.join("_defaults.toml"),
+            "[target]\ncatalog = \"poc\"\nschema = \"demo\"\n",
+        )
+        .unwrap();
+        std::fs::write(models_dir.join("widgets.sql"), "SELECT 1 AS id").unwrap();
+        std::fs::write(
+            models_dir.join("widgets.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n",
+        )
+        .unwrap();
+
+        let config_path = dir.join("rocky.toml");
+        let mut audit: Vec<AuditEvent> = Vec::new();
+        let record = sample_record("fix-price");
+
+        let saved_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir).unwrap();
+
+        let findings = evaluate_breaking_change_gate(
+            &config_path,
+            &models_dir,
+            "main",
+            &mut audit,
+            &dummy_actor(),
+            &record,
+            "branch-state-hash",
+        );
+
+        std::env::set_current_dir(saved_cwd).unwrap();
+
+        assert!(
+            findings.is_none(),
+            "gate must return None when the base ref has no models"
+        );
+        assert_eq!(audit.len(), 1, "exactly one skip event must be recorded");
+        assert_eq!(audit[0].kind, AuditEventKind::BreakingChangesGateSkipped);
+        assert!(
+            audit[0]
+                .reason
+                .as_deref()
+                .map(|r| r.contains("skipped"))
+                .unwrap_or(false),
+            "skip reason must be human-readable: {:?}",
+            audit[0].reason
+        );
+    }
+
+    /// When the models directory is absent entirely the gate must fail open
+    /// without invoking the compiler — `models_dir.is_dir()` check.
+    #[test]
+    fn gate_skips_when_models_dir_missing() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let missing = dir.join("does-not-exist");
+        let config_path = dir.join("rocky.toml");
+        std::fs::write(&config_path, "# stub\n").unwrap();
+
+        let mut audit: Vec<AuditEvent> = Vec::new();
+        let record = sample_record("fix-price");
+
+        let findings = evaluate_breaking_change_gate(
+            &config_path,
+            &missing,
+            "main",
+            &mut audit,
+            &dummy_actor(),
+            &record,
+            "branch-state-hash",
+        );
+
+        assert!(findings.is_none());
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].kind, AuditEventKind::BreakingChangesGateSkipped);
+    }
+
+    /// The `BreakingChangesAllowed` audit event carries the findings — the
+    /// `--allow-breaking` override must leave the exact same finding set on
+    /// disk so a future audit can review what was waved through.
+    #[test]
+    fn breaking_changes_allowed_audit_carries_findings() {
+        use rocky_core::breaking_change::{BreakingChange, BreakingFinding, BreakingSeverity};
+        let findings = vec![BreakingFinding {
+            change: BreakingChange::ColumnDropped {
+                model: "widgets".to_string(),
+                column: "qty".to_string(),
+                data_type: "INT64".to_string(),
+            },
+            severity: BreakingSeverity::Breaking,
+        }];
+
+        let event = AuditEvent {
+            kind: AuditEventKind::BreakingChangesAllowed,
+            at: Utc::now(),
+            actor: dummy_actor(),
+            branch: "fix-price".to_string(),
+            branch_state_hash: "deadbeef".to_string(),
+            reason: Some("--allow-breaking CLI flag".to_string()),
+            breaking_changes: Some(findings.clone()),
+        };
+
+        let json = serde_json::to_string(&event).expect("AuditEvent must serialize");
+        assert!(json.contains("breaking_changes_allowed"));
+        assert!(json.contains("column_dropped"));
+        assert!(json.contains("--allow-breaking CLI flag"));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -205,88 +205,84 @@ fn compile_head(
     compile::compile(&config).context("failed to compile models in the current working tree")
 }
 
-/// Try to compile the base ref by checking out model files to a temp dir
-/// and running the compiler against them.
+/// Try to compile the project as it stood at `base_ref` by checking out the
+/// models directory at that ref into a temp directory and running the same
+/// compile path as HEAD.
 ///
-/// This is best-effort: if the base ref doesn't have a complete models
-/// directory or compilation fails, we return `None` rather than erroring.
-/// Callers project schemas / typed models from the `CompileResult` (see
-/// [`typed_columns_from_compile`]).
+/// Returns:
+/// - `Ok(result)` when the base ref's models compiled cleanly.
+/// - `Err(reason)` with a short human-readable reason when the base could
+///   not be materialized or did not compile. The reason is intended for the
+///   semantic-diff gate's `BreakingChangesGateSkipped` audit event;
+///   `compute_ci_diff` calls `.ok()` and treats `None` the same way the
+///   pre-#510 `compile_base_ref` did.
 ///
-/// `source_schemas` seeds the compile from the *current* warehouse
-/// cache, not historical types. That's fine for diff purposes —
-/// typecheck on historical models with today's leaf types still detects
-/// the model-level schema drift that ci-diff is looking for, and there's
-/// no per-ref cache to restore from.
-fn compile_base_ref(
+/// `source_schemas` seeds the compile from the *current* warehouse cache,
+/// not historical types. That's fine for diff purposes — typecheck on
+/// historical models with today's leaf types still detects the model-level
+/// schema drift that ci-diff is looking for, and there's no per-ref cache
+/// to restore from.
+pub(crate) fn extract_base_compile(
     base_ref: &str,
     models_dir: &Path,
     source_schemas: HashMap<String, Vec<rocky_compiler::types::TypedColumn>>,
-) -> Option<rocky_compiler::compile::CompileResult> {
-    // Try to get the models directory path relative to the repo root
+) -> Result<rocky_compiler::compile::CompileResult, String> {
     let models_rel = match find_models_relative_path(models_dir) {
         Some(p) => p,
         None => {
-            debug!("could not determine models directory relative to repo root");
-            return None;
+            return Err("could not determine models directory relative to repo root".to_string());
         }
     };
 
-    // Create a temp directory and populate it with base-ref model files
     let tmp = match tempfile::tempdir() {
         Ok(t) => t,
         Err(e) => {
-            debug!("failed to create temp dir for base schema extraction: {e}");
-            return None;
+            return Err(format!(
+                "failed to create temp dir for base extraction: {e}"
+            ));
         }
     };
 
-    // Use git ls-tree to find all files under the models path at the base ref
     let ls_output = Command::new("git")
         .args(["ls-tree", "-r", "--name-only", base_ref, &models_rel])
         .output();
-
     let ls_output = match ls_output {
         Ok(o) if o.status.success() => o,
         _ => {
-            debug!(
-                "git ls-tree failed for base ref '{base_ref}' — skipping base schema extraction"
-            );
-            return None;
+            return Err(format!(
+                "git ls-tree failed for base ref '{base_ref}' — models directory missing at that ref?"
+            ));
         }
     };
 
     let file_list = String::from_utf8_lossy(&ls_output.stdout);
+    let mut wrote_any = false;
     for file_path in file_list.lines() {
         let file_path = file_path.trim();
         if file_path.is_empty() {
             continue;
         }
-
-        // Determine the relative path within the models directory
         let rel = match file_path.strip_prefix(&models_rel) {
             Some(r) => r.trim_start_matches('/'),
             None => continue,
         };
-
         let dest = tmp.path().join(rel);
         if let Some(parent) = dest.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-
-        // Extract file content from git
         let show_output = Command::new("git")
             .args(["show", &format!("{base_ref}:{file_path}")])
             .output();
-
         if let Ok(o) = show_output {
-            if o.status.success() {
-                let _ = std::fs::write(&dest, &o.stdout);
+            if o.status.success() && std::fs::write(&dest, &o.stdout).is_ok() {
+                wrote_any = true;
             }
         }
     }
+    if !wrote_any {
+        return Err(format!("no model files found at base ref '{base_ref}'"));
+    }
 
-    // Try to compile the extracted models
     let config = CompilerConfig {
         models_dir: tmp.path().to_path_buf(),
         contracts_dir: None,
@@ -295,13 +291,7 @@ fn compile_base_ref(
         ..Default::default()
     };
 
-    match compile::compile(&config) {
-        Ok(result) => Some(result),
-        Err(e) => {
-            debug!("base ref compilation failed (expected for partial models): {e}");
-            None
-        }
-    }
+    compile::compile(&config).map_err(|e| format!("base ref '{base_ref}' did not compile: {e}"))
 }
 
 /// Find the models directory path relative to the git repo root.
@@ -556,7 +546,7 @@ pub(crate) fn compute_ci_diff(
         .unwrap_or_default();
 
     let base_compile = if models_dir.is_dir() {
-        compile_base_ref(base_ref, models_dir, source_schemas)
+        extract_base_compile(base_ref, models_dir, source_schemas).ok()
     } else {
         None
     };

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3706,6 +3706,20 @@ pub enum AuditEventKind {
     /// the `ROCKY_BRANCH_APPROVAL_SKIP` env-var override. The skip reason is
     /// recorded so a future audit can tell flag-skip apart from env-skip.
     ApprovalSkipped,
+    /// Emitted when the semantic breaking-change gate blocked the promote.
+    /// The findings list is carried on the parent [`AuditEvent`] so reviewers
+    /// see exactly which structural changes triggered the block.
+    BreakingChangesBlocked,
+    /// Emitted when the semantic breaking-change gate detected one or more
+    /// `Breaking`-severity findings but the operator overrode the block via
+    /// `--allow-breaking`. Records the findings so the override leaves an
+    /// audit trail equivalent to `ApprovalSkipped`.
+    BreakingChangesAllowed,
+    /// Emitted when the semantic breaking-change gate could not run — for
+    /// example because the base ref failed to compile under the current
+    /// Rocky version. Fail-open: the gate is skipped and the promote
+    /// proceeds, but the reason is recorded so the bypass is auditable.
+    BreakingChangesGateSkipped,
 }
 
 /// Single audit-trail event emitted during `branch promote`.
@@ -3719,10 +3733,15 @@ pub struct AuditEvent {
     pub branch: String,
     pub branch_state_hash: String,
     /// Free-form context. Populated for `ApprovalSkipped` to record the
-    /// origin of the skip ("--skip-approval CLI flag" or
-    /// "ROCKY_BRANCH_APPROVAL_SKIP=1"); empty for routine state events.
+    /// origin of the skip, and for `BreakingChangesGateSkipped` to record
+    /// why the gate could not run (e.g. "base ref did not compile"). Empty
+    /// for routine state events.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Breaking-change findings carried by `BreakingChangesBlocked` and
+    /// `BreakingChangesAllowed` events. Always absent for other kinds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breaking_changes: Option<Vec<rocky_core::breaking_change::BreakingFinding>>,
 }
 
 /// One per-target promote step in [`BranchPromoteOutput::targets`].
@@ -3758,6 +3777,13 @@ pub struct BranchPromoteOutput {
     /// the reason for rejection. Surfaced even on a successful promote so
     /// operators can spot stale artifacts to clean up.
     pub approvals_rejected: Vec<RejectedApproval>,
+    /// Semantic breaking-change findings produced by the pre-promote gate.
+    /// Empty when the gate ran and found no breaking changes; absent when
+    /// the gate was skipped (compile failure on either side). When present
+    /// and non-empty either the promote was blocked or `--allow-breaking`
+    /// was set — see the audit trail for which.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breaking_changes: Option<Vec<rocky_core::breaking_change::BreakingFinding>>,
     /// One entry per managed target the promote attempted, in dispatch order.
     pub targets: Vec<PromoteTarget>,
     /// Audit-trail events emitted during this invocation, in order. At

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1296,7 +1296,8 @@ enum BranchAction {
     /// Promote a branch's tables to their production targets.
     ///
     /// Enumerates the configured replication pipeline's production
-    /// targets, runs the optional `[branch.approval]` gate, and dispatches
+    /// targets, runs the optional `[branch.approval]` gate, runs the
+    /// semantic breaking-change gate against `--base-ref`, and dispatches
     /// `CREATE OR REPLACE TABLE prod.<x> AS SELECT * FROM
     /// branch__<name>.<x>` per target.
     Promote {
@@ -1309,6 +1310,17 @@ enum BranchAction {
         /// audit event so the bypass leaves a paper trail.
         #[arg(long)]
         skip_approval: bool,
+        /// Bypass the semantic breaking-change gate. Always emits a
+        /// `BreakingChangesAllowed` audit event so the override leaves a
+        /// paper trail.
+        #[arg(long)]
+        allow_breaking: bool,
+        /// Git ref to diff against for the breaking-change gate.
+        #[arg(long, default_value = "main")]
+        base_ref: String,
+        /// Models directory used by the breaking-change gate.
+        #[arg(long, default_value = "models")]
+        models: PathBuf,
     },
 }
 
@@ -2161,13 +2173,19 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 name,
                 filter,
                 skip_approval,
+                allow_breaking,
+                base_ref,
+                models,
             } => {
                 rocky_cli::commands::run_branch_promote(
                     &state_path,
                     &cli.config,
+                    &models,
+                    &base_ref,
                     &name,
                     filter.as_deref(),
                     skip_approval,
+                    allow_breaking,
                     json,
                 )
                 .await

--- a/integrations/dagster/src/dagster_rocky/types_generated/branch_promote_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/branch_promote_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import AwareDatetime, BaseModel, RootModel
+from pydantic import AwareDatetime, BaseModel, RootModel, conint
 
 
 class ApproverSource(StrEnum):
@@ -36,6 +36,301 @@ class AuditEventKind2(StrEnum):
     """
 
     approval_skipped = "approval_skipped"
+
+
+class AuditEventKind3(StrEnum):
+    """
+    Emitted when the semantic breaking-change gate blocked the promote. The findings list is carried on the parent [`AuditEvent`] so reviewers see exactly which structural changes triggered the block.
+    """
+
+    breaking_changes_blocked = "breaking_changes_blocked"
+
+
+class AuditEventKind4(StrEnum):
+    """
+    Emitted when the semantic breaking-change gate detected one or more `Breaking`-severity findings but the operator overrode the block via `--allow-breaking`. Records the findings so the override leaves an audit trail equivalent to `ApprovalSkipped`.
+    """
+
+    breaking_changes_allowed = "breaking_changes_allowed"
+
+
+class AuditEventKind5(StrEnum):
+    """
+    Emitted when the semantic breaking-change gate could not run — for example because the base ref failed to compile under the current Rocky version. Fail-open: the gate is skipped and the promote proceeds, but the reason is recorded so the bypass is auditable.
+    """
+
+    breaking_changes_gate_skipped = "breaking_changes_gate_skipped"
+
+
+class Kind(StrEnum):
+    model_removed = "model_removed"
+
+
+class BreakingChange1(BaseModel):
+    """
+    A model present on the base side is absent on the head side.
+    """
+
+    kind: Kind
+    model: str
+
+
+class Kind1(StrEnum):
+    model_added = "model_added"
+
+
+class BreakingChange2(BaseModel):
+    """
+    A model present on the head side is absent on the base side.
+    """
+
+    kind: Kind1
+    model: str
+
+
+class Kind2(StrEnum):
+    column_dropped = "column_dropped"
+
+
+class BreakingChange3(BaseModel):
+    """
+    A column present on the base side is absent on the head side.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind2
+    model: str
+
+
+class Kind3(StrEnum):
+    column_added = "column_added"
+
+
+class BreakingChange4(BaseModel):
+    """
+    A column was added.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind3
+    model: str
+    nullable: bool
+
+
+class Kind4(StrEnum):
+    column_type_changed = "column_type_changed"
+
+
+class BreakingChange5(BaseModel):
+    """
+    A column's data type changed.
+    """
+
+    column: str
+    kind: Kind4
+    model: str
+    narrowing: bool
+    """
+    `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+    """
+    new_type: str
+    old_type: str
+
+
+class Kind5(StrEnum):
+    column_nullability_changed = "column_nullability_changed"
+
+
+class BreakingChange6(BaseModel):
+    """
+    A column's nullability flipped.
+    """
+
+    column: str
+    kind: Kind5
+    model: str
+    new_nullable: bool
+    old_nullable: bool
+
+
+class Kind6(StrEnum):
+    column_reordered = "column_reordered"
+
+
+class BreakingChange7(BaseModel):
+    """
+    A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
+    """
+
+    column: str
+    kind: Kind6
+    model: str
+    new_index: conint(ge=0)
+    old_index: conint(ge=0)
+
+
+class Kind7(StrEnum):
+    materialization_strategy_changed = "materialization_strategy_changed"
+
+
+class BreakingChange8(BaseModel):
+    """
+    The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
+    """
+
+    kind: Kind7
+    model: str
+    new_strategy: str
+    old_strategy: str
+
+
+class Kind8(StrEnum):
+    materialization_key_changed = "materialization_key_changed"
+
+
+class BreakingChange9(BaseModel):
+    """
+    Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
+    """
+
+    key_kind: str
+    """
+    Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+    """
+    kind: Kind8
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind9(StrEnum):
+    replication_columns_changed = "replication_columns_changed"
+
+
+class BreakingChange10(BaseModel):
+    """
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
+    """
+
+    kind: Kind9
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind10(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange11(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind10
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind11(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange12(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind11
+    model: str
+    new: str
+    old: str
+
+
+class Kind12(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange13(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind12
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind13(StrEnum):
+    column_mask_changed = "column_mask_changed"
+
+
+class BreakingChange14(BaseModel):
+    """
+    A column mask was added, removed, or its strategy changed.
+    """
+
+    column: str
+    kind: Kind13
+    model: str
+    new_strategy: str | None = None
+    old_strategy: str | None = None
+
+
+class Kind14(StrEnum):
+    lakehouse_format_changed = "lakehouse_format_changed"
+
+
+class BreakingChange15(BaseModel):
+    """
+    Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
+    """
+
+    kind: Kind14
+    model: str
+    new: str
+    old: str
+
+
+class Kind15(StrEnum):
+    sql_body_changed = "sql_body_changed"
+
+
+class BreakingChange16(BaseModel):
+    """
+    SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
+    """
+
+    kind: Kind15
+    model: str
+
+
+class BreakingSeverity1(StrEnum):
+    """
+    Will break a downstream consumer that reads the model's prior shape.
+    """
+
+    breaking = "breaking"
+
+
+class BreakingSeverity2(StrEnum):
+    """
+    May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
+    """
+
+    warning = "warning"
+
+
+class BreakingSeverity3(StrEnum):
+    """
+    Informational only — purely additive or backwards-compatible.
+    """
+
+    info = "info"
 
 
 class PromoteTarget(BaseModel):
@@ -120,24 +415,37 @@ class ApproverIdentity(BaseModel):
     source: ApproverSource
 
 
-class AuditEvent(BaseModel):
+class BreakingFinding(BaseModel):
     """
-    Single audit-trail event emitted during `branch promote`.
-
-    Routed to stdout JSON only in v1; persistent audit storage is a follow-up.
+    A classified finding produced by [`diff_project_ir`].
     """
 
-    actor: ApproverIdentity
-    at: AwareDatetime
-    branch: str
-    branch_state_hash: str
-    kind: AuditEventKind1 | AuditEventKind2
+    change: (
+        BreakingChange1
+        | BreakingChange2
+        | BreakingChange3
+        | BreakingChange4
+        | BreakingChange5
+        | BreakingChange6
+        | BreakingChange7
+        | BreakingChange8
+        | BreakingChange9
+        | BreakingChange10
+        | BreakingChange11
+        | BreakingChange12
+        | BreakingChange13
+        | BreakingChange14
+        | BreakingChange15
+        | BreakingChange16
+    )
     """
-    Categorical kind of an [`AuditEvent`] emitted by `branch promote`.
+    A single typed semantic change between two `ProjectIr` snapshots.
+
+    Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
     """
-    reason: str | None = None
+    severity: BreakingSeverity1 | BreakingSeverity2 | BreakingSeverity3
     """
-    Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip ("--skip-approval CLI flag" or "ROCKY_BRANCH_APPROVAL_SKIP=1"); empty for routine state events.
+    Severity classification for a single semantic change.
     """
 
 
@@ -160,6 +468,37 @@ class ApprovalArtifact(BaseModel):
     signed_at: AwareDatetime
 
 
+class AuditEvent(BaseModel):
+    """
+    Single audit-trail event emitted during `branch promote`.
+
+    Routed to stdout JSON only in v1; persistent audit storage is a follow-up.
+    """
+
+    actor: ApproverIdentity
+    at: AwareDatetime
+    branch: str
+    branch_state_hash: str
+    breaking_changes: list[BreakingFinding] | None = None
+    """
+    Breaking-change findings carried by `BreakingChangesBlocked` and `BreakingChangesAllowed` events. Always absent for other kinds.
+    """
+    kind: (
+        AuditEventKind1
+        | AuditEventKind2
+        | AuditEventKind3
+        | AuditEventKind4
+        | AuditEventKind5
+    )
+    """
+    Categorical kind of an [`AuditEvent`] emitted by `branch promote`.
+    """
+    reason: str | None = None
+    """
+    Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip, and for `BreakingChangesGateSkipped` to record why the gate could not run (e.g. "base ref did not compile"). Empty for routine state events.
+    """
+
+
 class BranchPromoteOutput(BaseModel):
     """
     JSON output for `rocky branch promote`.
@@ -179,6 +518,10 @@ class BranchPromoteOutput(BaseModel):
     """
     branch: str
     branch_state_hash: str
+    breaking_changes: list[BreakingFinding] | None = None
+    """
+    Semantic breaking-change findings produced by the pre-promote gate. Empty when the gate ran and found no breaking changes; absent when the gate was skipped (compile failure on either side). When present and non-empty either the promote was blocked or `--allow-breaking` was set — see the audit trail for which.
+    """
     command: str
     success: bool
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/ci_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/ci_diff_schema.py
@@ -12,7 +12,7 @@ class Kind(StrEnum):
     model_removed = "model_removed"
 
 
-class BreakingChange1(BaseModel):
+class BreakingChange(BaseModel):
     """
     A model present on the base side is absent on the head side.
     """
@@ -21,61 +21,61 @@ class BreakingChange1(BaseModel):
     model: str
 
 
-class Kind1(StrEnum):
+class Kind17(StrEnum):
     model_added = "model_added"
 
 
-class BreakingChange2(BaseModel):
+class BreakingChange19(BaseModel):
     """
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind1
+    kind: Kind17
     model: str
 
 
-class Kind2(StrEnum):
+class Kind18(StrEnum):
     column_dropped = "column_dropped"
 
 
-class BreakingChange3(BaseModel):
+class BreakingChange20(BaseModel):
     """
     A column present on the base side is absent on the head side.
     """
 
     column: str
     data_type: str
-    kind: Kind2
+    kind: Kind18
     model: str
 
 
-class Kind3(StrEnum):
+class Kind19(StrEnum):
     column_added = "column_added"
 
 
-class BreakingChange4(BaseModel):
+class BreakingChange21(BaseModel):
     """
     A column was added.
     """
 
     column: str
     data_type: str
-    kind: Kind3
+    kind: Kind19
     model: str
     nullable: bool
 
 
-class Kind4(StrEnum):
+class Kind20(StrEnum):
     column_type_changed = "column_type_changed"
 
 
-class BreakingChange5(BaseModel):
+class BreakingChange22(BaseModel):
     """
     A column's data type changed.
     """
 
     column: str
-    kind: Kind4
+    kind: Kind20
     model: str
     narrowing: bool
     """
@@ -85,58 +85,58 @@ class BreakingChange5(BaseModel):
     old_type: str
 
 
-class Kind5(StrEnum):
+class Kind21(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
-class BreakingChange6(BaseModel):
+class BreakingChange23(BaseModel):
     """
     A column's nullability flipped.
     """
 
     column: str
-    kind: Kind5
+    kind: Kind21
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind6(StrEnum):
+class Kind22(StrEnum):
     column_reordered = "column_reordered"
 
 
-class BreakingChange7(BaseModel):
+class BreakingChange24(BaseModel):
     """
     A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
     """
 
     column: str
-    kind: Kind6
+    kind: Kind22
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind7(StrEnum):
+class Kind23(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
-class BreakingChange8(BaseModel):
+class BreakingChange25(BaseModel):
     """
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind7
+    kind: Kind23
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind8(StrEnum):
+class Kind24(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
-class BreakingChange9(BaseModel):
+class BreakingChange26(BaseModel):
     """
     Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
     """
@@ -145,117 +145,117 @@ class BreakingChange9(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind8
+    kind: Kind24
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind9(StrEnum):
+class Kind25(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange10(BaseModel):
+class BreakingChange27(BaseModel):
     """
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind9
+    kind: Kind25
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind10(StrEnum):
+class Kind26(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
-class BreakingChange11(BaseModel):
+class BreakingChange28(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
     """
 
-    kind: Kind10
+    kind: Kind26
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind11(StrEnum):
+class Kind27(StrEnum):
     target_renamed = "target_renamed"
 
 
-class BreakingChange12(BaseModel):
+class BreakingChange29(BaseModel):
     """
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind11
+    kind: Kind27
     model: str
     new: str
     old: str
 
 
-class Kind12(StrEnum):
+class Kind28(StrEnum):
     source_changed = "source_changed"
 
 
-class BreakingChange13(BaseModel):
+class BreakingChange30(BaseModel):
     """
     Source reference rebound to a different table.
     """
 
-    kind: Kind12
+    kind: Kind28
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind13(StrEnum):
+class Kind29(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
-class BreakingChange14(BaseModel):
+class BreakingChange31(BaseModel):
     """
     A column mask was added, removed, or its strategy changed.
     """
 
     column: str
-    kind: Kind13
+    kind: Kind29
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind14(StrEnum):
+class Kind30(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
-class BreakingChange15(BaseModel):
+class BreakingChange32(BaseModel):
     """
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind14
+    kind: Kind30
     model: str
     new: str
     old: str
 
 
-class Kind15(StrEnum):
+class Kind31(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
-class BreakingChange16(BaseModel):
+class BreakingChange33(BaseModel):
     """
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind15
+    kind: Kind31
     model: str
 
 
-class BreakingSeverity1(StrEnum):
+class BreakingSeverity4(StrEnum):
     """
     Will break a downstream consumer that reads the model's prior shape.
     """
@@ -263,7 +263,7 @@ class BreakingSeverity1(StrEnum):
     breaking = "breaking"
 
 
-class BreakingSeverity2(StrEnum):
+class BreakingSeverity5(StrEnum):
     """
     May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
     """
@@ -271,7 +271,7 @@ class BreakingSeverity2(StrEnum):
     warning = "warning"
 
 
-class BreakingSeverity3(StrEnum):
+class BreakingSeverity6(StrEnum):
     """
     Informational only — purely additive or backwards-compatible.
     """
@@ -376,29 +376,29 @@ class BreakingFinding(BaseModel):
     """
 
     change: (
-        BreakingChange1
-        | BreakingChange2
-        | BreakingChange3
-        | BreakingChange4
-        | BreakingChange5
-        | BreakingChange6
-        | BreakingChange7
-        | BreakingChange8
-        | BreakingChange9
-        | BreakingChange10
-        | BreakingChange11
-        | BreakingChange12
-        | BreakingChange13
-        | BreakingChange14
-        | BreakingChange15
-        | BreakingChange16
+        BreakingChange
+        | BreakingChange19
+        | BreakingChange20
+        | BreakingChange21
+        | BreakingChange22
+        | BreakingChange23
+        | BreakingChange24
+        | BreakingChange25
+        | BreakingChange26
+        | BreakingChange27
+        | BreakingChange28
+        | BreakingChange29
+        | BreakingChange30
+        | BreakingChange31
+        | BreakingChange32
+        | BreakingChange33
     )
     """
     A single typed semantic change between two `ProjectIr` snapshots.
 
     Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
     """
-    severity: BreakingSeverity1 | BreakingSeverity2 | BreakingSeverity3
+    severity: BreakingSeverity4 | BreakingSeverity5 | BreakingSeverity6
     """
     Severity classification for a single semantic change.
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind17(StrEnum):
+class Kind33(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind17
+    kind: Kind33
 
 
 class PreviewModelDiff(BaseModel):

--- a/schemas/branch_promote.schema.json
+++ b/schemas/branch_promote.schema.json
@@ -109,11 +109,21 @@
         "branch_state_hash": {
           "type": "string"
         },
+        "breaking_changes": {
+          "description": "Breaking-change findings carried by `BreakingChangesBlocked` and `BreakingChangesAllowed` events. Always absent for other kinds.",
+          "items": {
+            "$ref": "#/definitions/BreakingFinding"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "kind": {
           "$ref": "#/definitions/AuditEventKind"
         },
         "reason": {
-          "description": "Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip (\"--skip-approval CLI flag\" or \"ROCKY_BRANCH_APPROVAL_SKIP=1\"); empty for routine state events.",
+          "description": "Free-form context. Populated for `ApprovalSkipped` to record the origin of the skip, and for `BreakingChangesGateSkipped` to record why the gate could not run (e.g. \"base ref did not compile\"). Empty for routine state events.",
           "type": [
             "string",
             "null"
@@ -144,6 +154,544 @@
           "description": "Emitted when the approval gate was bypassed via `--skip-approval` or the `ROCKY_BRANCH_APPROVAL_SKIP` env-var override. The skip reason is recorded so a future audit can tell flag-skip apart from env-skip.",
           "enum": [
             "approval_skipped"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Emitted when the semantic breaking-change gate blocked the promote. The findings list is carried on the parent [`AuditEvent`] so reviewers see exactly which structural changes triggered the block.",
+          "enum": [
+            "breaking_changes_blocked"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Emitted when the semantic breaking-change gate detected one or more `Breaking`-severity findings but the operator overrode the block via `--allow-breaking`. Records the findings so the override leaves an audit trail equivalent to `ApprovalSkipped`.",
+          "enum": [
+            "breaking_changes_allowed"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Emitted when the semantic breaking-change gate could not run — for example because the base ref failed to compile under the current Rocky version. Fail-open: the gate is skipped and the promote proceeds, but the reason is recorded so the bypass is auditable.",
+          "enum": [
+            "breaking_changes_gate_skipped"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "BreakingChange": {
+      "description": "A single typed semantic change between two `ProjectIr` snapshots.\n\nEach variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.",
+      "oneOf": [
+        {
+          "description": "A model present on the base side is absent on the head side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_removed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A model present on the head side is absent on the base side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column present on the base side is absent on the head side.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_dropped"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column was added.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model",
+            "nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's data type changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_type_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "narrowing": {
+              "description": "`true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).",
+              "type": "boolean"
+            },
+            "new_type": {
+              "type": "string"
+            },
+            "old_type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "narrowing",
+            "new_type",
+            "old_type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's nullability flipped.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_nullability_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_nullable": {
+              "type": "boolean"
+            },
+            "old_nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_nullable",
+            "old_nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_reordered"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "old_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_index",
+            "old_index"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "materialization_strategy_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": "string"
+            },
+            "old_strategy": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new_strategy",
+            "old_strategy"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).",
+          "properties": {
+            "key_kind": {
+              "description": "Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.",
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "materialization_key_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "key_kind",
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "replication_columns_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "partition_by_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Target table reference renamed (catalog, schema, or table component).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "target_renamed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Source reference rebound to a different table.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "source_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column mask was added, removed, or its strategy changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_mask_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "old_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "lakehouse_format_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "sql_body_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "BreakingFinding": {
+      "description": "A classified finding produced by [`diff_project_ir`].",
+      "properties": {
+        "change": {
+          "$ref": "#/definitions/BreakingChange"
+        },
+        "severity": {
+          "$ref": "#/definitions/BreakingSeverity"
+        }
+      },
+      "required": [
+        "change",
+        "severity"
+      ],
+      "type": "object"
+    },
+    "BreakingSeverity": {
+      "description": "Severity classification for a single semantic change.",
+      "oneOf": [
+        {
+          "description": "Will break a downstream consumer that reads the model's prior shape.",
+          "enum": [
+            "breaking"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.",
+          "enum": [
+            "warning"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Informational only — purely additive or backwards-compatible.",
+          "enum": [
+            "info"
           ],
           "type": "string"
         }
@@ -246,6 +794,16 @@
     },
     "branch_state_hash": {
       "type": "string"
+    },
+    "breaking_changes": {
+      "description": "Semantic breaking-change findings produced by the pre-promote gate. Empty when the gate ran and found no breaking changes; absent when the gate was skipped (compile failure on either side). When present and non-empty either the promote was blocked or `--allow-breaking` was set — see the audit trail for which.",
+      "items": {
+        "$ref": "#/definitions/BreakingFinding"
+      },
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "command": {
       "type": "string"


### PR DESCRIPTION
## Summary

Adds a semantic breaking-change gate to `rocky branch promote`. After the existing approval gate (and before `PromoteStarted`), the gate compiles the project at `--base-ref` (default `main`) and HEAD, runs `rocky_core::breaking_change::diff_project_ir(&base, &head)`, and **fails fast on any `Breaking`-severity finding unless `--allow-breaking` is set.**

This closes the Cluster 3 E (semantic breaking-change diff) trilogy:
- PR #508 — `rocky_core::breaking_change` classifier
- PR #509 — `rocky ci-diff --semantic` flag (informational)
- **PR #510 (this PR)** — `rocky branch promote` gate (failing)

## CLI surface

- `--allow-breaking` — override the gate; emits `BreakingChangesAllowed` audit event so the bypass leaves a paper trail (mirrors `--skip-approval` precedent).
- `--base-ref <ref>` — default `main`. Git ref to diff against.
- `--models <path>` — default `models`. Mirrors `ci-diff`'s conventions.

## Audit-event semantics (new `AuditEventKind` variants)

- `BreakingChangesBlocked` — gate blocked the promote; findings carried on the parent `AuditEvent.breaking_changes` field.
- `BreakingChangesAllowed` — gate detected `Breaking` findings but the operator overrode via `--allow-breaking`. Findings still recorded.
- `BreakingChangesGateSkipped` — gate could not run (e.g. base ref didn't compile under current Rocky). **Fail-open**: promote proceeds, `reason` recorded on the audit event.

### Why fail-open on base compile failure

Failing the promote because a past commit doesn't compile under today's Rocky would surprise users whose stale history rotted out of the type-checker. The gate degrades to a no-op with a clear audit event instead. This matches the existing `compute_ci_diff` fallback behavior.

## Shared infrastructure with `ci-diff --semantic`

Consolidated to a single helper `ci_diff::extract_base_compile(...) -> Result<CompileResult, String>`. Phase 3's gate consumes the `Result` directly so the `Err(reason)` flows into the `BreakingChangesGateSkipped` audit event. Phase 2's `compute_ci_diff` call site uses `.ok()` to preserve its existing `Option<CompileResult>` shape — no behavior change there.

The pre-#509 `compile_base_ref` helper is removed; everything routes through `extract_base_compile`.

## Tests added

6 new inline tests in `branch.rs`:

- `compile_result_to_project_ir_populates_typed_columns` — the load-bearing IR-stitching invariant (`ModelIr` from `Model::to_model_ir()` has empty `typed_columns`; the gate merges them in from `type_check.typed_models`, without which the classifier silently sees empty schemas).
- `gate_flags_column_drop_as_breaking` — default behavior blocks on `ColumnDropped`.
- `gate_clean_when_only_info_findings` — SQL-body-only change does not block.
- `gate_fails_open_when_base_ref_missing_models` — emits `BreakingChangesGateSkipped` and returns `None`.
- `gate_skips_when_models_dir_missing` — gate skipped without invoking compiler when `models_dir` absent.
- `breaking_changes_allowed_audit_carries_findings` — audit-event shape sanity check.

Tests touching `cwd` are serialized with a static `Mutex` (`cwd_lock()`); also applied to the pre-existing `load_approvals_returns_empty_when_directory_missing` to prevent neighbor flakes.

## Caveats / follow-ups

- `evaluate_breaking_change_gate` uses a hard-coded `.rocky/state.redb` for the source-schemas cache lookup. If the project's state path is non-default the gate degrades to `Unknown`-typed leaves (same fallback as `compute_ci_diff` has for stale caches). Threading `state_path` through is a follow-up if non-default state paths come up.
- The gate operates on transformation-model `ProjectIr` only. Replication-only branches diff to empty findings — correct behavior since replication pipelines don't carry user-authored SQL whose shape could break.

## Test plan

- [x] `cargo test -p rocky-cli --lib` — 407 / 407 pass (2 pre-existing `#[ignore]`)
- [x] `cargo clippy -p rocky-cli --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p rocky-cli --check` — clean
- [x] `just codegen` cascade green — `schemas/branch_promote.schema.json`, `editors/vscode/src/types/generated/branch_promote.ts`, `integrations/dagster/src/dagster_rocky/types_generated/branch_promote_schema.py` all up to date

Depends on #508 (merged) and #509 (merged).