### PR TITLE
fix(vscode): include .sql models in sidebar and test explorer

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -445,7 +445,7 @@
       },
       {
         "view": "rocky.models",
-        "contents": "No models found in this workspace.\n\nCreate a `.rocky` file under `models/`, or browse the [documentation](command:rocky.openDocumentation) for examples.",
+        "contents": "No models found in this workspace.\n\nAdd a `.rocky` or `.sql` file under `models/`, or browse the [documentation](command:rocky.openDocumentation) for examples.",
         "when": "rocky.hasProject"
       },
       {

--- a/editors/vscode/src/testExplorer.ts
+++ b/editors/vscode/src/testExplorer.ts
@@ -3,12 +3,12 @@ import * as vscode from "vscode";
 import { runRockyJson, RockyCliError } from "./rockyCli";
 import type { TestResult } from "./types/rockyJson";
 
-const MODELS_GLOB = "**/models/**/*.rocky";
+const MODELS_GLOB = "**/models/**/*.{rocky,sql}";
 
 /**
- * Wires Rocky models into VS Code's Test Explorer. Each `.rocky` file under
- * `**\/models\/**` becomes a test item; running an item shells out to
- * `rocky test --model NAME --output json` and reports pass/fail back.
+ * Wires Rocky models into VS Code's Test Explorer. Each `.rocky` or `.sql`
+ * file under `**\/models\/**` becomes a test item; running an item shells out
+ * to `rocky test --model NAME --output json` and reports pass/fail back.
  *
  * Phase 3 keeps the tree flat (one item per model). Per-contract granularity
  * will come once the CLI exposes it via either a `rocky test --list` flag or a
@@ -117,7 +117,7 @@ async function runHandler(
     // and `TestFailure.name` use the model basename, so derive that from
     // `item.uri` for the rocky invocation and the failure-name filter.
     const modelName = item.uri
-      ? path.basename(item.uri.fsPath, ".rocky")
+      ? path.basename(item.uri.fsPath, path.extname(item.uri.fsPath))
       : item.id;
 
     try {

--- a/editors/vscode/src/views/modelsView.ts
+++ b/editors/vscode/src/views/modelsView.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-const MODELS_GLOB = "**/models/**/*.rocky";
+const MODELS_GLOB = "**/models/**/*.{rocky,sql}";
 
 /**
  * Tree view for the Rocky models in the workspace. Items are discovered by
@@ -41,7 +41,10 @@ export class ModelTreeItem extends vscode.TreeItem {
   override readonly contextValue = "rockyModel";
 
   constructor(public readonly resourceUri: vscode.Uri) {
-    const label = path.basename(resourceUri.fsPath, ".rocky");
+    const label = path.basename(
+      resourceUri.fsPath,
+      path.extname(resourceUri.fsPath),
+    );
     super(label, vscode.TreeItemCollapsibleState.None);
     this.label = label;
     this.id = vscode.workspace.asRelativePath(resourceUri);


### PR DESCRIPTION
## Summary
- Models sidebar and Test Explorer globbed only `**/models/**/*.rocky`, so workspaces with raw SQL models (first-class in Rocky) showed the "No models found" empty state.
- Broaden the glob to `**/models/**/*.{rocky,sql}` in `modelsView.ts` and `testExplorer.ts`; strip whichever extension is on the file when deriving the label / `--model NAME` arg.
- Reword the empty-state copy in `package.json` to mention both file types.

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit` (35/35)
- [ ] Reload the extension against a workspace with `models/foo.sql` — model appears in the sidebar and Test Explorer