### PR TITLE
docs: cover v1.31.0 surfaces (semantic ci-diff, breaking-change gate) + drift fixes

### DIFF
--- a/.claude/skills/rocky-dev/SKILL.md
+++ b/.claude/skills/rocky-dev/SKILL.md
@@ -11,7 +11,7 @@ Rocky is a monorepo with three shipping subprojects + a playground catalog. Most
 
 | Path | Language | Ships as | Build | Test |
 |---|---|---|---|---|
-| `engine/` | Rust (20 crates) | `rocky` CLI binary | `cargo build --release` | `cargo test` |
+| `engine/` | Rust (21 crates) | `rocky` CLI binary | `cargo build --release` | `cargo test` |
 | `integrations/dagster/` | Python | `dagster-rocky` wheel | `uv build --wheel` | `uv run pytest` |
 | `editors/vscode/` | TypeScript | Rocky VSIX | `npm run compile` | `npm run test:unit` |
 | `examples/playground/` | Config | (not published) | `./run.sh` per POC | `./scripts/run-all-duckdb.sh` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Single repository for the Rocky data platform — a Rust-based control plane for
 
 | Path | Language | What it is |
 |---|---|---|
-| `engine/` | Rust | Core CLI + engine — SQL transformation, schema drift, incremental loads, adapters. 20-crate Cargo workspace. |
+| `engine/` | Rust | Core CLI + engine — SQL transformation, schema drift, incremental loads, adapters. 21-crate Cargo workspace. |
 | `integrations/dagster/` | Python | Dagster integration — wraps the `rocky` binary as a `ConfigurableResource`, parses JSON output into Pydantic models. |
 | `editors/vscode/` | TypeScript | VS Code extension — LSP client (stdio to `rocky lsp`), syntax highlighting, commands for AI features. |
 | `examples/playground/` | Config only | Self-contained DuckDB sample pipeline. Used as a smoke test and a benchmark fixture. No credentials needed. |
@@ -60,7 +60,7 @@ Every Rocky CLI command that emits `--output json` is backed by a typed Rust out
 
 The `codegen-drift` CI workflow (`.github/workflows/codegen-drift.yml`) fails any PR where the committed bindings drift from what `just codegen` produces locally.
 
-**Status:** The codegen migration is complete — all 37 CLI JSON schemas are backed by typed Rust structs deriving `JsonSchema`. The pipeline runs end-to-end via `just codegen`, enforced by `codegen-drift.yml` CI. The vscode `rockyJson.ts` is a type-alias shim over generated TypeScript. The dagster `types.py` re-exports generated Pydantic models (soft swap) — see [`integrations/dagster/CLAUDE.md`](integrations/dagster/CLAUDE.md). `just regen-fixtures` captures fresh dagster test fixtures from the live binary.
+**Status:** The codegen migration is complete — all 55 CLI JSON schemas are backed by typed Rust structs deriving `JsonSchema`. The pipeline runs end-to-end via `just codegen`, enforced by `codegen-drift.yml` CI. The vscode `rockyJson.ts` is a type-alias shim over generated TypeScript. The dagster `types.py` re-exports generated Pydantic models (soft swap) — see [`integrations/dagster/CLAUDE.md`](integrations/dagster/CLAUDE.md). `just regen-fixtures` captures fresh dagster test fixtures from the live binary.
 
 **When modifying Rocky DSL syntax (`.rocky` files):**
 1. `engine/crates/rocky-lang/` (parser + lexer)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Tag PII columns in the model sidecar; bind tags to mask strategies in `[mask]` /
 
 | Path | Artifact | Language | Description |
 |---|---|---|---|
-| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine — 20-crate Cargo workspace |
+| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine — 21-crate Cargo workspace |
 | [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component wrapping the Rocky CLI |
 | [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension — LSP client + commands for AI features |
 | [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | Self-contained DuckDB sample pipeline used for smoke tests and benchmarks |

--- a/docs/scripts/llms.txt.tmpl
+++ b/docs/scripts/llms.txt.tmpl
@@ -26,7 +26,7 @@ Scope on the ELT spectrum:
 
 | Path | Artifact | Purpose |
 |---|---|---|
-| `engine/` | `rocky` CLI | 20-crate Rust workspace |
+| `engine/` | `rocky` CLI | 21-crate Rust workspace |
 | `integrations/dagster/` | `dagster-rocky` PyPI wheel | Dagster resource + component |
 | `editors/vscode/` | Rocky VSIX | LSP client + AI commands |
 | `examples/playground/` | Config only | {{TOTAL_POCS}} POCs across {{CATEGORY_COUNT}} categories; DuckDB-backed, no credentials |

--- a/docs/src/content/docs/advanced/contributing.md
+++ b/docs/src/content/docs/advanced/contributing.md
@@ -11,7 +11,7 @@ Rocky is a monorepo with four subprojects:
 
 ```
 rocky-data/
-├── engine/                     # Rust CLI + engine (20-crate Cargo workspace)
+├── engine/                     # Rust CLI + engine (21-crate Cargo workspace)
 ├── integrations/dagster/       # dagster-rocky Python package
 ├── editors/vscode/             # VS Code extension (LSP client)
 ├── examples/playground/        # POC catalog + benchmarks

--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -138,10 +138,10 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 ## CLI Commands (38+)
 
 ### Core Pipeline
-`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch` · `preview create` · `preview diff` · `preview cost`
+`init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch` (incl. `branch approve`, `branch promote --allow-breaking --base-ref --models --skip-approval`) · `preview create` · `preview diff` · `preview cost`
 
 ### Modeling & Compilation
-`compile` · `lineage` · `lineage-diff` · `test` · `ci` · `ci-diff` · `export-schemas`
+`compile` · `lineage` · `lineage-diff` · `test` · `ci` · `ci-diff` (with `--semantic` for typed-IR breaking-change findings) · `export-schemas`
 
 ### AI
 `ai` (generate) · `ai-sync` · `ai-explain` · `ai-test`

--- a/docs/src/content/docs/guides/ci-cd.md
+++ b/docs/src/content/docs/guides/ci-cd.md
@@ -54,6 +54,31 @@ In GitHub Actions, post the pre-rendered Markdown block to the PR directly:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Semantic breaking-change findings and the promote gate
+
+`rocky ci-diff --semantic` runs the typed-IR breaking-change classifier on top of the structural diff and surfaces classified findings under `breaking_findings` in the JSON output:
+
+```bash
+rocky ci-diff --semantic --output json | jq '.breaking_findings'
+```
+
+Each finding has a tagged `change.kind` (e.g. `column_dropped`, `column_type_changed`, `target_renamed`) and a `severity` (`breaking` / `warning` / `info`). `ci-diff --semantic` is **informational** — even a `breaking` finding does not change `ci-diff`'s exit code. Use it on every PR to make breaking changes visible to reviewers before promotion.
+
+The hard gate lives on `rocky branch promote`. When promoting a branch to production, Rocky runs the same classifier against `--base-ref` (default `main`); any finding with `severity == "breaking"` blocks the promote and the command exits nonzero. To override (e.g. a planned breaking release with downstream consumers already migrated), pass `--allow-breaking`. The override emits a `breaking_changes_allowed` audit event so the bypass leaves a paper trail.
+
+```bash
+# PR-time: detect (informational)
+rocky ci-diff --semantic
+
+# Promote-time: gate (blocks on `breaking` findings)
+rocky branch promote fix-price --base-ref main
+
+# Promote-time override (audited)
+rocky branch promote fix-price --base-ref main --allow-breaking
+```
+
+See [`rocky branch promote`](/reference/commands/core-pipeline/#rocky-branch) for the full flag list and the audit-event reference under [`rocky branch promote` in the JSON output reference](/reference/json-output/#rocky-branch-promote).
+
 ## 2. GitHub Actions
 
 ### Basic setup

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -9,6 +9,8 @@ sidebar:
 
 For the design — how Rocky picks the prune set, why CTAS today and clones tomorrow, how the sampling window works — see the [How Preview Works](/concepts/preview-internals/) concept page. For the full output schemas, see the [`rocky preview` CLI reference](/reference/commands/modeling/#rocky-preview).
 
+Preview surfaces the data and cost shape of a PR. For typed schema-level breaking-change detection on the same PR, pair preview with [`rocky ci-diff --semantic`](/reference/commands/modeling/#rocky-ci-diff) — and rely on the hard semantic gate that fires when the branch is promoted via `rocky branch promote`. The full flow (PR-time detection → promote-time gate → audited override) is documented in the [CI/CD integration guide](/guides/ci-cd/#semantic-breaking-change-findings-and-the-promote-gate).
+
 ## Prerequisites
 
 You'll need:

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -474,9 +474,36 @@ rocky branch delete <name>
 rocky branch list
 rocky branch show <name>
 rocky branch compare <name> [--filter <key=value>]
+rocky branch approve <name> [--message <text>] [--out <path>]
+rocky branch promote <name> [--allow-breaking] [--base-ref <ref>]
+                            [--models <path>] [--skip-approval]
+                            [--filter <key=value>]
 ```
 
 Branch names accept `[A-Za-z0-9_.\-]` up to 64 characters. The default schema prefix is `branch__<name>`. Deleting a branch removes the state-store entry but does **not** drop warehouse tables that were materialized under it.
+
+### `branch approve` flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--message <text>` | `string` | (none) | Optional free-form note persisted in the approval artifact. |
+| `--out <path>` | `PathBuf` | `./.rocky/approvals/<branch>/<approval_id>.json` | Override the artifact destination path. |
+
+Writes a content-addressed approval artifact that binds the approver's git identity to the branch's current state hash. `rocky branch promote` later refuses to run unless the on-disk approvals satisfy the [`[branch.approval]`](/reference/configuration/#branchapproval) policy.
+
+### `branch promote` flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--allow-breaking` | flag | off | Bypass the semantic breaking-change gate. Always emits a `breaking_changes_allowed` audit event so the override leaves a paper trail. |
+| `--base-ref <ref>` | `string` | `main` | Git ref to diff against for the breaking-change gate. |
+| `--models <path>` | `PathBuf` | `models` | Models directory used by the breaking-change gate. |
+| `--skip-approval` | flag | off | Bypass the approval gate. Always emits an `approval_skipped` audit event so the bypass leaves a paper trail. |
+| `--filter <key=value>` | `string` | (none) | Filter sources by component value (e.g. `--filter client=acme`). |
+
+Enumerates the configured replication pipeline's production targets, runs the optional `[branch.approval]` gate, runs the semantic breaking-change gate against `--base-ref`, then dispatches `CREATE OR REPLACE TABLE prod.<x> AS SELECT * FROM branch__<name>.<x>` per target.
+
+The breaking-change gate vetoes the promote (exit nonzero) when any finding has `severity == "breaking"` unless `--allow-breaking` is passed. Every gate decision — block, allow-via-override, or fail-open when the gate couldn't run — is recorded in the audit trail. See [`rocky ci-diff --semantic`](/reference/commands/modeling/#rocky-ci-diff) to surface the same findings informationally on every PR.
 
 ### Examples
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -493,6 +493,7 @@ rocky ci-diff [base_ref] [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--models <PATH>` | `PathBuf` | `models` | Directory containing model files. |
+| `--semantic` | flag | off | Also run the typed-IR semantic breaking-change classifier and surface findings under `breaking_findings` in the JSON output. Informational only — even a `Breaking` finding does not change `ci-diff`'s exit code. The hard gate lives on [`rocky branch promote`](/reference/commands/core-pipeline/#rocky-branch). |
 
 ### Examples
 
@@ -504,7 +505,7 @@ rocky ci-diff
 
 ```json
 {
-  "version": "1.7.0",
+  "version": "1.31.0",
   "command": "ci-diff",
   "base_ref": "main",
   "head_ref": "HEAD",
@@ -535,11 +536,45 @@ rocky ci-diff release/2026-04 --models src/models
 
 The `markdown` field holds a ready-to-post report; in a GitHub Actions workflow you can `jq -r .markdown` the JSON output and feed it into `gh pr comment`.
 
+Run with `--semantic` to surface classified breaking-change findings alongside the structural diff:
+
+```bash
+rocky ci-diff --semantic
+```
+
+```json
+{
+  "version": "1.31.0",
+  "command": "ci-diff",
+  "base_ref": "main",
+  "head_ref": "HEAD",
+  "summary": { "added": 0, "modified": 1, "removed": 0 },
+  "models": [ /* ... */ ],
+  "markdown": "...",
+  "breaking_findings": [
+    {
+      "change": {
+        "kind": "column_type_changed",
+        "model": "analytics.marts.fct_orders",
+        "column": "amount_cents",
+        "old_type": "BIGINT",
+        "new_type": "INT",
+        "narrowing": true
+      },
+      "severity": "breaking"
+    }
+  ]
+}
+```
+
+The `breaking_findings` array is omitted from JSON output when empty or when `--semantic` is not set. Each finding carries a tagged `change` object (`kind` discriminator) and a `severity` (`breaking` / `warning` / `info`). Use `--semantic` in `ci-diff` to surface findings on every PR; rely on [`rocky branch promote`](/reference/commands/core-pipeline/#rocky-branch) to block promotion when `severity == "breaking"`.
+
 ### Related Commands
 
 - [`rocky ci`](#rocky-ci) -- full compile + test for CI
 - [`rocky compile`](#rocky-compile) -- compile a single branch without diffing
 - [`rocky preview`](#rocky-preview) -- pruned re-run + sampled data diff + cost delta on top of `ci-diff`'s structural diff
+- [`rocky branch promote`](/reference/commands/core-pipeline/#rocky-branch) -- promote a branch's tables to production with a hard semantic breaking-change gate
 
 ---
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -848,6 +848,143 @@ Branches use three distinct output shapes — see [`rocky branch`](/reference/co
 
 ---
 
+### `rocky branch approve`
+
+Writes a content-addressed approval artifact that binds the approver's git identity to a branch's current state hash. The artifact path is returned so callers can stage it for review.
+
+```json
+{
+  "version": "1.31.0",
+  "command": "branch approve",
+  "artifact": {
+    "version": "1",
+    "branch": "fix-price",
+    "branch_state_hash": "sha256:9a4f…",
+    "approver": {
+      "name": "Hugo Correia",
+      "email": "hugo@example.com"
+    },
+    "signed_at": "2026-05-13T10:14:22Z",
+    "message": "ready to promote",
+    "signature": {
+      "algorithm": "git_identity",
+      "value": "…"
+    }
+  },
+  "artifact_path": "./.rocky/approvals/fix-price/01HXZ…json"
+}
+```
+
+`signature.algorithm` reflects whichever signing identity Rocky could resolve at sign time. `message` is omitted when `--message` is not passed.
+
+---
+
+### `rocky branch promote`
+
+Promotes a branch's tables to their production targets. Emits the approval and semantic-breaking-change gate decisions in `audit`, the per-target SQL outcomes in `targets`, and a top-level `success` flag.
+
+```json
+{
+  "version": "1.31.0",
+  "command": "branch promote",
+  "branch": "fix-price",
+  "branch_state_hash": "sha256:9a4f…",
+  "approvals_used": [ /* ApprovalArtifact, see `branch approve` above */ ],
+  "approvals_rejected": [],
+  "breaking_changes": [
+    {
+      "change": {
+        "kind": "column_dropped",
+        "model": "analytics.marts.fct_orders",
+        "column": "legacy_status",
+        "data_type": "STRING"
+      },
+      "severity": "breaking"
+    }
+  ],
+  "targets": [
+    {
+      "target": "analytics.marts.fct_orders",
+      "source": "analytics.branch__fix-price.fct_orders",
+      "statement": "CREATE OR REPLACE TABLE analytics.marts.fct_orders AS SELECT * FROM analytics.branch__fix-price.fct_orders",
+      "succeeded": true
+    }
+  ],
+  "audit": [
+    {
+      "kind": "promote_started",
+      "at": "2026-05-13T10:20:00Z",
+      "actor": { "name": "Hugo Correia", "email": "hugo@example.com" },
+      "branch": "fix-price",
+      "branch_state_hash": "sha256:9a4f…"
+    },
+    {
+      "kind": "breaking_changes_allowed",
+      "at": "2026-05-13T10:20:00Z",
+      "actor": { "name": "Hugo Correia", "email": "hugo@example.com" },
+      "branch": "fix-price",
+      "branch_state_hash": "sha256:9a4f…",
+      "breaking_changes": [ /* same shape as top-level `breaking_changes` */ ]
+    },
+    {
+      "kind": "promote_completed",
+      "at": "2026-05-13T10:20:02Z",
+      "actor": { "name": "Hugo Correia", "email": "hugo@example.com" },
+      "branch": "fix-price",
+      "branch_state_hash": "sha256:9a4f…"
+    }
+  ],
+  "success": true
+}
+```
+
+**Top-level fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch` | string | Branch name being promoted. |
+| `branch_state_hash` | string | Content-addressed hash of the branch's current state — the same value approval artifacts are bound to. |
+| `approvals_used` | array | Approval artifacts that satisfied the `[branch.approval]` gate at promote time. Empty when the gate was disabled or skipped. |
+| `approvals_rejected` | array | Approval artifacts loaded from disk that failed verification, with the reason for rejection. Surfaced even on success so operators can clean up stale artifacts. |
+| `breaking_changes` | array \| absent | Semantic findings produced by the pre-promote gate. Absent when the gate was skipped (compile failure on either side). Empty array when the gate ran and found no breaking changes. When present and non-empty, either the promote was blocked or `--allow-breaking` was set — check `audit`. |
+| `targets` | array | One entry per managed target the promote attempted, in dispatch order. Each carries `target`, `source`, `statement`, `succeeded`, and an optional `error`. |
+| `audit` | array | Audit-trail events emitted during this invocation, in order. |
+| `success` | boolean | True when every target's SQL succeeded. |
+
+**`AuditEvent.kind` values:**
+
+| Kind | Meaning |
+|------|---------|
+| `promote_started` | Promote began. |
+| `promote_completed` | Promote finished successfully (every target's SQL succeeded). |
+| `promote_failed` | A target's SQL failed; subsequent targets did not run. |
+| `approval_skipped` | The approval gate was bypassed via `--skip-approval` or the `ROCKY_BRANCH_APPROVAL_SKIP` env-var override. The `reason` field records which. |
+| `breaking_changes_blocked` | The semantic breaking-change gate blocked the promote. `breaking_changes` carries the findings that triggered the block. Exit code is nonzero. |
+| `breaking_changes_allowed` | The gate detected one or more `breaking`-severity findings but the operator overrode via `--allow-breaking`. `breaking_changes` carries the findings. |
+| `breaking_changes_gate_skipped` | The gate could not run (e.g. base ref failed to compile under the current Rocky version). Fail-open: the gate is skipped and the promote proceeds, but `reason` records why so the bypass is auditable. |
+
+`breaking_changes` is attached to `breaking_changes_blocked` and `breaking_changes_allowed` events; it is absent on every other kind. The top-level `breaking_changes` and the per-event `breaking_changes` carry the same `BreakingFinding` shape.
+
+**`BreakingFinding` shape** (also emitted by [`rocky ci-diff --semantic`](/reference/commands/modeling/#rocky-ci-diff)):
+
+```json
+{
+  "change": {
+    "kind": "column_type_changed",
+    "model": "analytics.marts.fct_orders",
+    "column": "amount_cents",
+    "old_type": "BIGINT",
+    "new_type": "INT",
+    "narrowing": true
+  },
+  "severity": "breaking"
+}
+```
+
+`change.kind` is a tagged discriminator. Common variants: `model_removed`, `model_added`, `column_dropped`, `column_added`, `column_type_changed`, `column_nullability_changed`, `column_reordered`, `materialization_strategy_changed`, `materialization_key_changed`, `replication_columns_changed`, `partition_by_changed`, `target_renamed`, `source_changed`, `column_mask_changed`, `lakehouse_format_changed`, `sql_body_changed`. Each variant carries the minimum identifying context (model + before/after values) needed to render a useful message without re-loading the IR. `severity` is one of `breaking`, `warning`, `info`.
+
+---
+
 ### `rocky metrics <model>`
 
 Quality metrics for a model, including snapshots, alerts, and column trends.

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -112,10 +112,11 @@ table = "fct_orders"
 
 ## Crate Architecture
 
-20-crate Cargo workspace (Rust edition 2024, MSRV 1.85):
+21-crate Cargo workspace (Rust edition 2024, MSRV 1.85):
 
 ```
-rocky-core         — Warehouse-agnostic engine: IR, adapter traits, DAG, models, checks, contracts, config, state
+rocky-core         — Warehouse-agnostic engine: adapter traits, DAG executor, models, checks, contracts, config, state
+rocky-ir           — Typed IR (ModelIr / ModelIrVariant / ProjectIr), lakehouse format/options, column lineage, masks, time grains, RockyType
 rocky-sql          — SQL parsing, validation, dialect support, transpilation, lineage
 rocky-lang         — Rocky DSL parser (.rocky files) — lexer (logos) + parser → IR lowering
 rocky-compiler     — Type checking, semantic analysis, contract validation, diagnostics
@@ -126,6 +127,7 @@ rocky-adapter-sdk  — Adapter SDK for building custom warehouse adapters
 rocky-databricks   — Databricks warehouse adapter (SQL execution, Unity Catalog governance, permissions, workspace isolation)
 rocky-snowflake    — Snowflake warehouse adapter (SQL execution, OAuth/key-pair/password auth)
 rocky-bigquery     — BigQuery warehouse adapter (connector, auth, dialect)
+rocky-trino        — Trino warehouse adapter
 rocky-fivetran     — Fivetran source adapter (REST API discovery of connectors/tables — metadata only, no extraction)
 rocky-duckdb       — DuckDB warehouse adapter (local dev/testing, schema discovery, seed loading)
 rocky-cache        — Three-tier caching (memory LRU → Valkey → API)

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -6,18 +6,31 @@ Rust SQL transformation engine. Replaces dbt's core responsibilities (DAG resolu
 
 ## Project Structure
 
-Cargo workspace with 20 crates (Rust edition 2024, MSRV 1.85):
+Cargo workspace with 21 crates (Rust edition 2024, MSRV 1.85):
+
+The `Plan` enum was deleted in the Phase 3 typed-IR migration; `ModelIr` is now the sole transformation intermediate, dispatched via `ModelIrVariant`. The IR data types (`ModelIr`, `ModelIrVariant`, `ProjectIr`, lakehouse format/options, column lineage, masks, time grains, `RockyType`) live in their own `rocky-ir` crate; `rocky-core` keeps the runtime surface (adapter traits, DAG executor, state store, drift, SQL generation, breaking-change classifier, ci-diff).
 
 ```
 engine/                         # this directory, inside the rocky monorepo
 ├── Cargo.toml                  # Workspace manifest
 ├── crates/
+│   ├── rocky-ir/               # Typed IR (data only — no runtime traits)
+│   │   └── src/
+│   │       ├── ir.rs           # ModelIr, ModelIrVariant, ProjectIr, MaterializationStrategy (FullRefresh, Incremental, Merge, MaterializedView, DynamicTable, TimeInterval), TargetRef, SourceRef, ColumnSelection, governance, grants, masks
+│   │       ├── lakehouse.rs    # LakehouseFormat, LakehouseOptions, LakehouseError (data types — DDL gen lives in rocky-core)
+│   │       ├── lineage.rs      # LineageEdge, QualifiedColumn
+│   │       ├── mask.rs         # MaskStrategy
+│   │       ├── time_grain.rs   # TimeGrain
+│   │       ├── types.rs        # RockyType, StructField, TypedColumn, common_supertype, is_assignable
+│   │       └── dag.rs          # DagNode, topological_sort, execution_layers
 │   ├── rocky-core/             # Generic SQL transformation engine
 │   │   ├── src/
-│   │   │   ├── ir.rs           # Plan, MaterializationStrategy (FullRefresh, Incremental, Merge, MaterializedView, DynamicTable, TimeInterval)
+│   │   │   ├── breaking_change.rs # Typed-IR semantic breaking-change classifier (BreakingFinding / BreakingChange / BreakingSeverity)
+│   │   │   ├── ci_diff.rs      # Structural diff used by `rocky ci-diff`
 │   │   │   ├── schema.rs       # Configurable schema pattern parsing
 │   │   │   ├── drift.rs        # Schema drift detection + graduated evolution (ALTER TABLE for safe widenings)
 │   │   │   ├── sql_gen.rs      # IR → dialect-specific SQL generation (incl. MV, dynamic table)
+│   │   │   ├── lakehouse.rs    # Dialect-aware lakehouse DDL generator (depends on the SqlDialect trait)
 │   │   │   ├── state.rs        # Embedded state store (redb): watermarks, run history, checkpoint/resume progress
 │   │   │   ├── state_sync.rs   # Remote state persistence (S3, Valkey, tiered)
 │   │   │   ├── catalog.rs      # Catalog/schema lifecycle management


### PR DESCRIPTION
## Summary

Documents the user-visible surfaces shipped in engine v1.31.0:

- `rocky ci-diff --semantic` — surface classified breaking-change findings under `breaking_findings` (informational; never changes the `ci-diff` exit code).
- `rocky branch approve` — content-addressed approval artifact bound to a branch's state hash.
- `rocky branch promote` — promotes a branch's tables to production. Runs the approval gate and a hard semantic breaking-change gate against `--base-ref`. New flags: `--allow-breaking`, `--base-ref`, `--models`, `--skip-approval`. Three new audit-event kinds (`breaking_changes_blocked`, `breaking_changes_allowed`, `breaking_changes_gate_skipped`).

Also fixes accumulated internal-doc drift: the engine workspace grew from 20 to 21 crates (rocky-ir was extracted), and a stale schema count + `Plan`-enum reference in `engine/CLAUDE.md` lingered after the typed-IR migration.

## Files touched

**Public docs (`docs/`):**
- `reference/commands/modeling.md` — `--semantic` flag row + JSON example
- `reference/commands/core-pipeline.md` — `branch approve` / `branch promote` synopsis + flag tables
- `reference/json-output.md` — new `branch approve` / `branch promote` JSON sections, `BreakingFinding` shape, `AuditEvent.kind` variants
- `features/all-features.md` — CLI rollup
- `guides/ci-cd.md` — new `--semantic` + promote-gate section
- `guides/preview-a-pr.md` — one-paragraph cross-reference to the gate
- `scripts/llms.txt.tmpl`, `advanced/contributing.md` — crate count

**Internal docs:**
- `README.md`, top-level `CLAUDE.md`, `.claude/skills/rocky-dev/SKILL.md` — crate count + schema count
- `engine/CLAUDE.md` — crate count, rocky-ir crate added to the tree, rocky-core's IR module listing brought in line with the post-typed-IR layout (no `Plan` enum, `ModelIr` dispatched via `ModelIrVariant`)
- `engine/AGENTS.md` — crate count, added previously-missing `rocky-ir` and `rocky-trino` entries

## Test plan

- [x] `npm run build` in `docs/` completes cleanly (74 pages built, no new warnings)
- [x] All new cross-link anchors (`#rocky-branch-promote`, `#semantic-breaking-change-findings-and-the-promote-gate`, `#rocky-branch`) verified in built HTML
- [x] `cargo run --release --bin rocky -- ci-diff --help` / `branch promote --help` / `branch approve --help` match the documented flags
- [x] JSON examples cross-checked against `engine/crates/rocky-cli/src/output.rs` (`CiDiffOutput`, `BranchPromoteOutput`, `ApproveOutput`, `AuditEventKind`) and `engine/crates/rocky-core/src/breaking_change.rs` (`BreakingFinding`)