### PR TITLE
feat(playground): cover v1.27.0 → v1.31.0 features (semantic ci-diff, state retention, history stats)

### DIFF
--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -36,7 +36,7 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**57 of 70 POCs run with no external credentials.** See each POC's README for prerequisites.
+**60 of 73 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
@@ -115,7 +115,7 @@ Unity Catalog grants, schema patterns, workspace isolation, tagging, classificat
 | [06-retention-policies](pocs/04-governance/06-retention-policies) | Declarative `retention = "<N>[dy]"` sidecars + `rocky retention-status --drift` | none |
 | [07-auto-create-schemas](pocs/04-governance/07-auto-create-schemas) | `[…target.governance] auto_create_schemas = true` on a transformation pipeline targeting a fresh schema (v1.29.0 parity fix) | none |
 
-### 05 — Orchestration (9 POCs · DuckDB / docker)
+### 05 — Orchestration (10 POCs · DuckDB / docker)
 
 Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode, circuit breaker, idempotency.
 
@@ -130,8 +130,9 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [07-dagster-dag-mode](pocs/05-orchestration/07-dagster-dag-mode) | `rocky run --dag` unified cross-pipeline DAG with Dagster orchestration |
 | [08-circuit-breaker](pocs/05-orchestration/08-circuit-breaker) | **Trust arc 3** — `[adapter.retry]` exponential backoff + three-state `CircuitBreaker` |
 | [09-idempotency-key](pocs/05-orchestration/09-idempotency-key) | `rocky run --idempotency-key` dedup — second run with the same key yields `status = "skipped_idempotent"` |
+| [10-state-retention-sweep](pocs/05-orchestration/10-state-retention-sweep) | `[state.retention]` + `rocky state retention sweep` — manual + end-of-run auto-sweep of run history / lineage / audit domains |
 
-### 06 — Developer Experience (14 POCs · DuckDB)
+### 06 — Developer Experience (16 POCs · DuckDB)
 
 Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff, run-watch, dbt-import failure modes.
 
@@ -151,6 +152,8 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 | [12-catalog-emit](pocs/06-developer-experience/12-catalog-emit) | `rocky catalog --format both` — column-level lineage emitted as `catalog.json` + `edges.parquet` + `assets.parquet`; readable by any Parquet client without going through the engine |
 | [13-run-watch-inner-loop](pocs/06-developer-experience/13-run-watch-inner-loop) | `rocky run --watch` re-materialises on every save; 200 ms debounce window, FSEvents-safe directory watch, NDJSON-stream output, clean SIGINT exit |
 | [14-import-dbt-failure-modes](pocs/06-developer-experience/14-import-dbt-failure-modes) | `rocky import-dbt` against malformed inputs (missing files, invalid YAML, unknown adapters) — exercises every diagnostic path the importer emits |
+| [15-semantic-breaking-change-gate](pocs/06-developer-experience/15-semantic-breaking-change-gate) | `rocky ci-diff --semantic` (informational) + `rocky branch promote --base-ref / --allow-breaking` — pre-promote gate blocks column drops; override is recorded as a `BreakingChangesAllowed` audit event |
+| [16-history-rolling-stats](pocs/06-developer-experience/16-history-rolling-stats) | `rocky history --model <name> --rolling-stats --window N` — per-model mean / std-dev / z-score / composite `health_score` over the rolling window |
 
 ### 07 — Adapters (7 POCs · mixed)
 

--- a/examples/playground/pocs/05-orchestration/10-state-retention-sweep/README.md
+++ b/examples/playground/pocs/05-orchestration/10-state-retention-sweep/README.md
@@ -1,0 +1,119 @@
+# 10-state-retention-sweep — bound `state.redb` history growth
+
+> **Category:** 05-orchestration
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s
+> **Rocky features:** `[state.retention]`, `rocky state retention sweep`,
+> end-of-run auto-sweep
+
+## What it shows
+
+Rocky tracks every run in `state.redb` — `run_history`, `dag_snapshots`,
+and `quality_history` grow monotonically until something prunes them.
+The `[state.retention]` config block governs that prune, with two
+delivery paths exercised by this POC:
+
+1. **Manual** — `rocky state retention sweep` (with `--dry-run` to plan
+   without deleting) explicitly prunes the three history domains.
+2. **Automatic** — `rocky run` end-of-run auto-sweep, throttled by
+   `sweep_interval_seconds` so a project that runs every minute doesn't
+   pay the sweep cost on every invocation.
+
+Operational tables (schema cache, watermarks, partition records,
+branches, idempotency keys, grace periods, run progress, check history)
+are **never** swept regardless of configuration.
+
+## Why it's distinctive
+
+- **No external cron.** A long-running project is a single config block
+  away from a self-bounded state store; auto-sweep amortizes the cost
+  end-of-run.
+- **Dry-run plan equals apply count.** Both paths share the same planner,
+  so the dry-run JSON's `runs_deleted` is exactly what the apply path
+  will remove (modulo concurrent writers).
+- **Operational tables are explicitly off-limits.** Retention only ever
+  touches history domains — the schema cache and watermark map stay
+  intact, so the next run isn't paying a cold-cache penalty.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        [state.retention] knobs + DuckDB pipeline
+├── run.sh            manual + auto-sweep walkthrough
+└── data/seed.sql     raw__orders.orders bootstrap
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.23.0 on PATH (`rocky state retention sweep` landed in 1.22.0,
+  end-of-run auto-sweep followed in 1.23.0)
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- `python3` for the small JSON probes in `run.sh`
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+==> Three runs with auto-sweep parked (sweep_interval_seconds = 3600)
+    history rows after 3 runs: 3
+
+==> 'rocky state retention sweep --dry-run'  (plan only — no deletes)
+    plan: runs_deleted=2  runs_kept=1  domains=['history', 'lineage', 'audit']
+    history rows after dry-run: 3  (unchanged — dry-run is a no-op)
+
+==> 'rocky state retention sweep'  (apply)
+    apply: runs_deleted=2  runs_kept=1  lineage_deleted=0  audit_deleted=0
+    history rows after apply: 1  (down to min_runs_kept = 1)
+
+==> Three more runs WITH auto-sweep (sweep_interval_seconds = 0)
+    after run 4: history rows = 1
+    after run 5: history rows = 1
+    after run 6: history rows = 1
+```
+
+## What happened
+
+1. **Three runs with auto-sweep parked** — `run.sh` copies `rocky.toml`
+   into `rocky.no-auto.toml` with `sweep_interval_seconds = 3600` so the
+   run loop's auto-sweep skips silently. After three replication runs,
+   `run_history` carries three rows.
+2. **Dry-run** — `rocky state retention sweep --dry-run` reports the
+   plan (`runs_deleted = 2`, `runs_kept = 1`) without touching the
+   state store. The probe confirms the table is still at 3.
+3. **Apply** — `rocky state retention sweep` runs the same plan for
+   real and drops the table to `min_runs_kept = 1`.
+4. **Auto-sweep on `rocky run`** — Switching back to the live
+   `rocky.toml` (`sweep_interval_seconds = 0`), three further runs each
+   trigger an end-of-run sweep. `run_history` stays flat at 1.
+
+## Config knobs
+
+```toml
+[state.retention]
+max_age_days = 365            # default
+min_runs_kept = 100           # default — the N most recent successful runs
+                              # are preserved unconditionally
+applies_to = ["history", "lineage", "audit"]  # domains to sweep
+sweep_interval_seconds = 3600 # default — minimum gap between end-of-run
+                              # auto-sweeps; 0 means "every run"
+sweep_budget_ms = 5000        # soft budget; exceeding flips the per-run
+                              # log line from debug to warn
+```
+
+Set `applies_to = []` to disable auto-sweep without removing the manual
+subcommand.
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/state.rs`,
+  `engine/crates/rocky-core/src/retention.rs`
+- Sibling POC: [`04-checkpoint-resume`](../04-checkpoint-resume/) —
+  state-store usage for resumable runs; this POC is the operational
+  housekeeping counterpart.

--- a/examples/playground/pocs/05-orchestration/10-state-retention-sweep/data/seed.sql
+++ b/examples/playground/pocs/05-orchestration/10-state-retention-sweep/data/seed.sql
@@ -1,0 +1,10 @@
+-- Bootstrap raw__orders.orders. run.sh refreshes the row count between runs.
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    100 + (i % 5) AS customer_id,
+    'completed' AS status,
+    10.0 * i AS amount
+FROM range(1, 6) AS t(i);

--- a/examples/playground/pocs/05-orchestration/10-state-retention-sweep/rocky.toml
+++ b/examples/playground/pocs/05-orchestration/10-state-retention-sweep/rocky.toml
@@ -1,0 +1,46 @@
+# 10-state-retention-sweep — `[state.retention]` + `rocky state retention sweep`
+#
+# `[state.retention]` governs the state.redb history domains (run history,
+# DAG snapshots, quality history). The aggressive thresholds below
+# (`min_runs_kept = 1`, `max_age_days = 0`) make every previous run
+# eligible the moment a new one lands. `sweep_interval_seconds = 0`
+# disables the throttle so each `rocky run` triggers an end-of-run
+# auto-sweep — handy for a 10-second demo, NOT a recommendation for a
+# real project.
+#
+# Operational tables (schema cache, watermarks, partition records,
+# branches, idempotency keys) are NEVER swept.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.discovery]
+adapter = "default"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[state.retention]
+# Sweep every history-domain row that is at least one day old.
+max_age_days = 0
+# Always keep the most recent successful run, regardless of age.
+min_runs_kept = 1
+# Domains the sweep touches. Operational tables are off-limits regardless.
+applies_to = ["history", "lineage", "audit"]
+# Auto-sweep on every `rocky run` (default is 3600s between sweeps).
+sweep_interval_seconds = 0
+# Soft wall-clock budget; sweeps that exceed it log a warning instead of debug.
+sweep_budget_ms = 5000

--- a/examples/playground/pocs/05-orchestration/10-state-retention-sweep/run.sh
+++ b/examples/playground/pocs/05-orchestration/10-state-retention-sweep/run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# 10-state-retention-sweep — `[state.retention]` + `rocky state retention sweep`.
+#
+# Walks the two ways Rocky prunes its own history tables:
+#
+#   1. Manual:   `rocky state retention sweep`        — explicit, scriptable.
+#   2. Automatic: end-of-run auto-sweep on `rocky run` — gated by
+#      `sweep_interval_seconds` so high-frequency projects don't pay the
+#      sweep cost on every invocation.
+#
+# Operational tables (schema cache, watermarks, partition records,
+# branches, idempotency keys) are NEVER swept — only the three history
+# domains (`history`, `lineage`, `audit`).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+mkdir -p expected
+
+# Tell run.sh which sweep mode each section is demonstrating. The first
+# section disables auto-sweep via env-override-by-removal so the manual
+# sweep has something to delete; the second section relies on
+# `[state.retention] sweep_interval_seconds = 0` from rocky.toml to
+# trigger auto-sweeps end-of-run.
+
+count_runs() {
+    rocky -c rocky.toml -o json history 2>/dev/null \
+        | python3 -c 'import json,sys;print(len(json.load(sys.stdin)["runs"]))'
+}
+
+echo "==> Seed raw__orders.orders"
+duckdb poc.duckdb < data/seed.sql
+
+# ---- Part 1: manual sweep ---------------------------------------------------
+# Disable auto-sweep with a config override so the run loop leaves the
+# history alone; we want a fat history table to feed the manual command.
+cp rocky.toml rocky.no-auto.toml
+python3 - <<'PY'
+import re
+p = "rocky.no-auto.toml"
+src = open(p).read()
+# Park auto-sweep by raising the interval; manual sweep is unaffected.
+src = re.sub(r"sweep_interval_seconds\s*=\s*0", "sweep_interval_seconds = 3600", src)
+open(p, "w").write(src)
+PY
+
+echo "==> Three runs with auto-sweep parked (sweep_interval_seconds = 3600)"
+for i in 1 2 3; do
+    rocky -c rocky.no-auto.toml -o json run --filter source=orders \
+        > "expected/run_${i}.json"
+done
+echo "    history rows after 3 runs: $(count_runs)"
+
+echo
+echo "==> 'rocky state retention sweep --dry-run'  (plan only — no deletes)"
+rocky -c rocky.toml -o json state retention sweep --dry-run \
+    > expected/sweep_dry_run.json
+python3 - <<'PY'
+import json
+d = json.load(open("expected/sweep_dry_run.json"))
+print(f"    plan: runs_deleted={d['runs_deleted']}  runs_kept={d['runs_kept']}  "
+      f"domains={d['domains']}  duration_ms={d['duration_ms']}")
+PY
+echo "    history rows after dry-run: $(count_runs)  (unchanged — dry-run is a no-op)"
+
+echo
+echo "==> 'rocky state retention sweep'  (apply)"
+rocky -c rocky.toml -o json state retention sweep \
+    > expected/sweep_apply.json
+python3 - <<'PY'
+import json
+d = json.load(open("expected/sweep_apply.json"))
+print(f"    apply: runs_deleted={d['runs_deleted']}  runs_kept={d['runs_kept']}  "
+      f"lineage_deleted={d['lineage_deleted']}  audit_deleted={d['audit_deleted']}")
+PY
+echo "    history rows after apply: $(count_runs)  (down to min_runs_kept = 1)"
+
+# ---- Part 2: end-of-run auto-sweep -----------------------------------------
+echo
+echo "==> Three more runs WITH auto-sweep (sweep_interval_seconds = 0)"
+echo "    Each run prunes history at end-of-run, so the table never grows."
+for i in 4 5 6; do
+    rocky -c rocky.toml -o json run --filter source=orders \
+        > "expected/run_${i}.json"
+    echo "    after run ${i}: history rows = $(count_runs)"
+done
+
+rm -f rocky.no-auto.toml
+
+echo
+echo "POC complete: manual sweep pruned 3→1, then auto-sweep held the table flat."

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/README.md
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/README.md
@@ -1,0 +1,144 @@
+# 15-semantic-breaking-change-gate — block column-level regressions before promote
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 15s
+> **Rocky features:** `rocky ci-diff --semantic`, `rocky branch promote
+> --base-ref`, `--allow-breaking`, breaking-change audit events
+
+## What it shows
+
+The semantic breaking-change classifier introduced in `rocky-core`
+diffs two compiled `ProjectIr` snapshots — base ref vs HEAD — and
+classifies each structural delta into `Info` / `Warning` / `Breaking`
+severities. Two CLI surfaces consume the classifier:
+
+1. **`rocky ci-diff --semantic`** — *informational*. The classifier
+   findings surface in `breaking_findings` next to the existing column
+   diff. Even a `Breaking` finding does not change the exit code; the
+   intent is to power PR comments and CI annotations without forcing a
+   merge block.
+2. **`rocky branch promote`** — *hard gate*. After the optional
+   approval gate, the promote command compiles the project at
+   `--base-ref` (default `main`) and HEAD, runs the classifier, and
+   fails fast (exit 1, `BreakingChangesBlocked` audit event) if any
+   `Breaking`-severity finding lands. The override is `--allow-breaking`,
+   which flips the failure to a `BreakingChangesAllowed` audit event so
+   the bypass is recorded.
+
+The classifier compiles only what's under the models directory passed
+to `--models` (default `models`). Replication-only branches with no
+transformation models compile to an empty IR; the diff is empty and the
+gate is a clean no-op.
+
+## Why it's distinctive
+
+- **Typed-IR semantics, not text diff.** A column rename + retype is
+  more than two text edits — the classifier treats it as a structural
+  delta and tags it `Breaking` regardless of how the SQL was edited.
+- **Fail-open on stale base refs.** If the base ref doesn't compile
+  under today's Rocky (a parser change happened in between), the gate
+  records `BreakingChangesGateSkipped` with the reason and lets the
+  promote proceed. The approval gate already guards the trust boundary.
+- **Audit-event paper trail on both the block AND the override.**
+  `--allow-breaking` is a deliberate bypass, not a quiet silence. The
+  `breaking_changes` field on the audit event carries the full findings
+  list for the bypass too.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        replication pipeline (promote targets) + transformation models
+├── run.sh            git init + 6-step demo
+├── data/seed.sql     raw__orders.orders bootstrap
+└── models/           orders_summary + raw_orders, with column drop applied mid-run
+    ├── _defaults.toml
+    ├── raw_orders.sql / .toml
+    └── orders_summary.sql / .toml
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.31.0 on PATH (the `--semantic` flag landed in 1.31.0, the
+  pre-promote gate followed in the same triple-cut)
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- `git` (the POC initializes a throw-away repo *inside* this directory
+  so the gate has real `main` ↔ `HEAD` refs to diff)
+- `python3` for the JSON probes
+
+## Run
+
+```bash
+./run.sh
+```
+
+The script wipes any prior `.git/` and re-initializes from scratch, so
+it's safe to re-run.
+
+## Expected output
+
+```text
+==> 5. rocky ci-diff --semantic (informational — exit 0 even on Breaking)
+    breaking_findings: 2 entry/entries
+      - severity=breaking  kind=column_dropped
+      - severity=info      kind=sql_body_changed
+
+==> 6. rocky branch promote fix_orders  (gate VETOES — exit 1 expected)
+    exit 1  (nonzero = gate fired as expected)
+    success=False  audit kinds: ['breaking_changes_blocked']
+    breaking_changes carried: 2 entry/entries
+
+==> 7. rocky branch promote fix_orders --allow-breaking  (override)
+    success=True  audit kinds: ['breaking_changes_allowed', 'promote_started', 'promote_completed']
+```
+
+## What happened
+
+1. **Throw-away git repo.** `git init --initial-branch=main` inside the
+   POC dir, with a `.gitignore` so DuckDB / state files don't enter the
+   tracked tree. `commit.gpgsign = false` for portability.
+2. **Replication on main.** Seed `raw__orders.orders` and run
+   `rocky run --filter source=orders` so the prod target
+   `poc.prod__orders.orders` exists. (The breaking-change gate doesn't
+   need this — `branch promote` does.)
+3. **`branch create fix_orders` + `run --branch fix_orders`.** Creates
+   the shadow target `poc.prod__orders_rocky_shadow__fix_orders.orders`
+   that `promote` will copy from.
+4. **Feature branch + column drop.** `git checkout -b
+   feat/drop-total-amount`, edit `models/orders_summary.sql` to remove
+   `total_amount`, commit.
+5. **`rocky ci-diff --semantic`** — exit 0; the JSON output's
+   `breaking_findings` array now carries one `column_dropped`
+   (`severity = breaking`) and one `sql_body_changed`
+   (`severity = info`).
+6. **`rocky branch promote fix_orders`** — exit 1. The JSON output
+   (still emitted on stdout) reports `success = false`, an empty
+   `targets` array, and an audit log whose first entry is
+   `BreakingChangesBlocked` carrying the same finding from step 5.
+   `stderr` carries the human-readable error.
+7. **`rocky branch promote fix_orders --allow-breaking`** — exit 0.
+   The audit log carries `BreakingChangesAllowed` (with findings) ahead
+   of the routine `PromoteStarted` / `PromoteCompleted` events.
+
+## Audit event variants
+
+The promote output's `audit[]` array carries one or more of:
+
+| `kind` | Meaning |
+|---|---|
+| `breaking_changes_blocked` | Gate fired; promote refused. `breaking_changes` field on the event carries the findings. |
+| `breaking_changes_allowed` | Gate found Breaking findings, operator overrode with `--allow-breaking`. Findings still recorded. |
+| `breaking_changes_gate_skipped` | Base or HEAD failed to compile (models dir missing, stale parser, etc.). `reason` field carries the explanation; promote proceeds. |
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/branch.rs`,
+  `engine/crates/rocky-core/src/breaking_change.rs`
+- Sibling POC: [`00-foundations/08-branch-approve-promote`](../../00-foundations/08-branch-approve-promote/)
+  — the approval-gate side of `branch promote`; this POC is the
+  semantic-gate counterpart.
+- Sibling POC: [`10-pr-preview-and-data-diff`](../10-pr-preview-and-data-diff/)
+  — preview-branch data diff; complementary to the structural diff this
+  POC exercises.

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/data/seed.sql
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/data/seed.sql
@@ -1,0 +1,11 @@
+-- raw__orders feeds the replication pipeline so `branch promote` has a
+-- production target to enumerate.
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT * FROM (VALUES
+    (1, 101, 'completed', 49.50,  TIMESTAMP '2026-05-01 10:15:00'),
+    (2, 102, 'completed', 119.00, TIMESTAMP '2026-05-01 10:20:00'),
+    (3, 103, 'cancelled', 0.00,   TIMESTAMP '2026-05-01 10:30:00'),
+    (4, 101, 'completed', 19.99,  TIMESTAMP '2026-05-02 09:05:00')
+) AS t(order_id, customer_id, status, amount, ordered_at);

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/_defaults.toml
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/_defaults.toml
@@ -1,0 +1,3 @@
+[target]
+catalog = "poc"
+schema = "demo"

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/orders_summary.sql
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/orders_summary.sql
@@ -1,0 +1,8 @@
+-- Baseline shape: per-customer totals.
+-- The feature branch will drop the `total_amount` column — a Breaking-
+-- severity change the pre-promote gate must reject.
+SELECT
+    customer_id,
+    SUM(amount) AS total_amount
+FROM poc.demo.raw_orders
+GROUP BY customer_id

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/orders_summary.toml
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/orders_summary.toml
@@ -1,0 +1,4 @@
+depends_on = ["raw_orders"]
+
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/raw_orders.sql
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/raw_orders.sql
@@ -1,0 +1,8 @@
+-- Synthetic source row inline; transformation models only need the
+-- shape, not the live raw__orders feed (that's the replication pipeline's
+-- job). Keeps the breaking-change gate self-contained at compile-time.
+SELECT * FROM (VALUES
+    (1, 101, 'completed', 49.50),
+    (2, 102, 'completed', 119.00),
+    (3, 103, 'cancelled', 0.00)
+) AS t(order_id, customer_id, status, amount)

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/raw_orders.toml
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/models/raw_orders.toml
@@ -1,0 +1,2 @@
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/rocky.toml
@@ -1,0 +1,39 @@
+# 15-semantic-breaking-change-gate
+#
+# Two pipelines coexist here:
+#
+# * `[pipeline.repl]` — replication, gives `rocky branch promote` real
+#   production targets to copy onto.
+# * The transformation models under `models/` are independent — the
+#   semantic breaking-change gate compiles them at the base ref vs HEAD
+#   to detect column-level regressions.
+#
+# `[branch.approval] required = false` — this POC focuses on the
+# breaking-change gate, not the approval gate (POC `00-foundations/
+# 08-branch-approve-promote` covers that path).
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.repl]
+type = "replication"
+strategy = "full_refresh"
+
+[pipeline.repl.source.discovery]
+adapter = "default"
+
+[pipeline.repl.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.repl.target]
+catalog_template = "poc"
+schema_template = "prod__{source}"
+
+[pipeline.repl.target.governance]
+auto_create_schemas = true
+
+[branch.approval]
+required = false

--- a/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/run.sh
+++ b/examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/run.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# 15-semantic-breaking-change-gate — `rocky ci-diff --semantic` (informational)
+# + `rocky branch promote` pre-promote gate (hard veto).
+#
+# The POC stands up a throw-away git repo INSIDE the POC dir so the
+# breaking-change gate has real `main` ↔ `HEAD` refs to diff. The repo is
+# self-contained — nothing leaks out via `..` or the parent repo.
+#
+# Flow:
+#   1. Initialize the throw-away git repo with the baseline models.
+#   2. Seed raw__orders, run the replication pipeline on `main`, create
+#      the `fix_orders` rocky branch and run on it (so promote has a
+#      shadow target to copy from).
+#   3. Edit `orders_summary.sql` to drop `total_amount`, commit on a
+#      feature branch — a clear Breaking-severity column drop.
+#   4. `rocky ci-diff --semantic` surfaces the BREAKING classification
+#      (informational — exit 0 even on Breaking findings).
+#   5. `rocky branch promote fix_orders` — the pre-promote gate VETOES
+#      with exit 1 and an explanatory error.
+#   6. `rocky branch promote fix_orders --allow-breaking` — gate
+#      overridden; promote completes and emits a
+#      `BreakingChangesAllowed` audit event for the paper trail.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# Restore the committed baseline of orders_summary.sql on ANY exit
+# (success, failure, SIGINT) so the source tree stays clean — the smoke
+# runner re-runs every POC and we don't want the feature-branch variant
+# leaking back into the repo. Idempotent on re-run.
+restore_baseline() {
+    cat > models/orders_summary.sql <<'SQL'
+-- Baseline shape: per-customer totals.
+-- The feature branch will drop the `total_amount` column — a Breaking-
+-- severity change the pre-promote gate must reject.
+SELECT
+    customer_id,
+    SUM(amount) AS total_amount
+FROM poc.demo.raw_orders
+GROUP BY customer_id
+SQL
+}
+trap restore_baseline EXIT
+
+# Wipe anything the previous run left behind. Rocky stores state at
+# `<models>/.rocky-state.redb` since the LSP↔CLI state-path unification;
+# the bare-CWD `.rocky-state.redb` is the legacy fallback. Wipe both.
+rm -rf .rocky-state.redb .rocky-state.redb.lock poc.duckdb .rocky
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+rm -rf .git
+# Restore baseline up-front so the throwaway git repo has the right
+# initial state to commit.
+restore_baseline
+mkdir -p expected
+
+echo "==> 1. Initialize throw-away git repo (scoped to this POC dir)"
+# `--initial-branch=main` so the base-ref default works on machines whose
+# git defaults to `master`. Repo lives in this dir only.
+git -c init.defaultBranch=main init -q
+git config user.email "poc@rocky.local"
+git config user.name "POC"
+git config commit.gpgsign false
+# Excludes go to .git/info/exclude so we don't leave a .gitignore on
+# disk after the trap restores baseline — the parent playground
+# .gitignore already filters these patterns from the outer Rocky repo.
+cat > .git/info/exclude <<'EOF'
+.rocky-state.redb
+.rocky-state.redb.lock
+.rocky/
+poc.duckdb
+expected/
+EOF
+git add -A
+git commit -q -m "baseline: orders_summary with total_amount column"
+
+echo "==> 2. Seed raw__orders + run replication on 'main'"
+duckdb poc.duckdb < data/seed.sql
+rocky -c rocky.toml -o json run --filter source=orders \
+    > expected/run_main.json
+
+echo "==> 3. Create rocky branch 'fix_orders' and run on it"
+rocky branch create fix_orders \
+    --description "drop total_amount from orders_summary" \
+    > expected/branch_create.json
+rocky -c rocky.toml -o json run --filter source=orders --branch fix_orders \
+    > expected/run_branch.json
+
+echo "==> 4. Switch to feature branch and drop the 'total_amount' column"
+git checkout -q -b feat/drop-total-amount
+cat > models/orders_summary.sql <<'SQL'
+-- Feature branch: total_amount column dropped (a Breaking change).
+SELECT
+    customer_id
+FROM poc.demo.raw_orders
+GROUP BY customer_id
+SQL
+git add models/orders_summary.sql
+git commit -q -m "drop total_amount column"
+
+echo
+echo "==> 5. rocky ci-diff --semantic (informational — exit 0 even on Breaking)"
+rocky ci-diff --semantic --models models main \
+    > expected/ci_diff_semantic.json
+python3 - <<'PY'
+import json
+d = json.load(open("expected/ci_diff_semantic.json"))
+findings = d.get("breaking_findings", [])
+print(f"    breaking_findings: {len(findings)} entry/entries")
+for f in findings:
+    print(f"      - severity={f['severity']:9s} kind={f['change']['kind']}")
+breaking = [f for f in findings if f["severity"] == "breaking"]
+assert len(breaking) >= 1, f"expected at least one Breaking finding, got: {findings}"
+PY
+
+echo
+echo "==> 6. rocky branch promote fix_orders  (gate VETOES — exit 1 expected)"
+set +e
+rocky -c rocky.toml -o json branch promote fix_orders \
+    --base-ref main \
+    --models models \
+    > expected/promote_blocked.json 2>expected/promote_blocked.stderr
+PROMOTE_RC=$?
+set -e
+echo "    exit $PROMOTE_RC  (nonzero = gate fired as expected)"
+if [[ "$PROMOTE_RC" -eq 0 ]]; then
+    echo "    FAIL: gate did not block the promote" >&2
+    exit 1
+fi
+python3 - <<'PY'
+import json
+d = json.load(open("expected/promote_blocked.json"))
+print(f"    success={d['success']}  audit kinds: "
+      f"{[a['kind'] for a in d['audit']]}")
+breaking = d.get("breaking_changes") or []
+print(f"    breaking_changes carried: {len(breaking)} entry/entries")
+assert any(a["kind"] == "breaking_changes_blocked" for a in d["audit"]), \
+    "expected BreakingChangesBlocked in audit log"
+PY
+
+echo
+echo "==> 7. rocky branch promote fix_orders --allow-breaking  (override)"
+rocky -c rocky.toml -o json branch promote fix_orders \
+    --base-ref main \
+    --models models \
+    --allow-breaking \
+    > expected/promote_allowed.json
+python3 - <<'PY'
+import json
+d = json.load(open("expected/promote_allowed.json"))
+print(f"    success={d['success']}  audit kinds: "
+      f"{[a['kind'] for a in d['audit']]}")
+assert d["success"] is True, "expected promote to succeed under --allow-breaking"
+assert any(a["kind"] == "breaking_changes_allowed" for a in d["audit"]), \
+    "expected BreakingChangesAllowed in audit log"
+PY
+
+echo
+echo "POC complete: gate VETOED the column drop; --allow-breaking overrode with a paper trail."

--- a/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/README.md
+++ b/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/README.md
@@ -1,0 +1,105 @@
+# 16-history-rolling-stats — rolling stats on `rocky history --model`
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 10s
+> **Rocky features:** `rocky history --model`, `--rolling-stats`, `--window`
+
+## What it shows
+
+`rocky history --model <name>` returns the per-execution timeline for one
+model. Passing `--rolling-stats` adds a `rolling_stats` block containing
+mean / population std-dev / latest-execution z-score over the most recent
+`--window` (default 20) successful executions, plus a composite
+`health_score`. The health score is `1.0` when both `duration_ms` and
+`rows_affected` are within 2σ of the rolling mean; it decays linearly to
+`0.0` at 6σ or beyond.
+
+The POC reseeds `raw__orders.orders` with five different row counts and
+runs the replication pipeline five times in a row to populate a window
+with real variance, then queries the rolling-stats block.
+
+## Why it's distinctive
+
+- **Per-model regression signal in a single JSON call.** No external
+  metrics pipeline; the history table is enough to flag runs whose
+  duration or row count drifts outside the rolling band.
+- **Window math is explicit.** The block reports the `window` requested,
+  the `samples` actually available (so a fresh project doesn't lie about
+  precision), and `latest_z_score` so the caller can decide its own
+  threshold rather than relying on the bundled `health_score`.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        DuckDB replication pipeline
+├── run.sh            five varied seeds + rolling-stats query
+└── data/seed.sql     parametric raw__orders.orders bootstrap
+```
+
+## Prerequisites
+
+- `rocky` ≥ 1.22.0 on PATH (the `--rolling-stats` flag landed in 1.22.0)
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- `python3` for the JSON assertion
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+==> rocky history --model orders --rolling-stats --window 5
+    samples=5  window=5  health_score=1.0
+    duration_ms.mean=0.80  std_dev=0.40  latest_z=0.50
+
+==> Compare bare history vs rolling-stats (block only appears with --rolling-stats)
+    bare output: rolling_stats absent (correct)
+    --rolling-stats: rolling_stats present (correct)
+```
+
+The full `rolling_stats` JSON block looks like:
+
+```json
+{
+  "window": 5,
+  "samples": 5,
+  "rows_affected": { "mean": 0.0, "std_dev": 0.0 },
+  "duration_ms": {
+    "mean": 0.8,
+    "std_dev": 0.4,
+    "latest_z_score": 0.5
+  },
+  "health_score": 1.0
+}
+```
+
+`rows_affected` reads as zero on the playground's full-refresh
+replication path; the same block populates real values when the run
+records carry row counts (transformation pipelines, incremental
+strategies, etc.).
+
+## What happened
+
+1. **Reseed + run** — for each of `{5, 50, 200, 25, 12}` rows, the script
+   refreshes `raw__orders.orders` and invokes `rocky run --filter
+   source=orders`. Each run lands a row in the state store's
+   `run_history` table tagged with the model's execution duration.
+2. **Rolling-stats query** — `rocky history --model orders
+   --rolling-stats --window 5` pulls the most recent successful
+   executions (the fetch pool is widened to `max(window * 5, 100)` so
+   failures don't starve the window) and computes the rolling block.
+3. **Negative control** — re-running `rocky history --model orders`
+   *without* the flag confirms the `rolling_stats` field is omitted
+   entirely (the field uses `skip_serializing_if`).
+
+## Related
+
+- Engine source: `engine/crates/rocky-cli/src/commands/history.rs`
+- Sibling POC: [`13-run-watch-inner-loop`](../13-run-watch-inner-loop/) —
+  inner-loop ergonomics; this POC is the post-hoc analytics counterpart.

--- a/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/data/seed.sql
+++ b/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/data/seed.sql
@@ -1,0 +1,11 @@
+-- Bootstrap raw__orders.orders so rocky discover/run can pick it up.
+-- run.sh refreshes the row count between runs to drive duration variance.
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    100 + (i % 5) AS customer_id,
+    'completed' AS status,
+    10.0 * i AS amount
+FROM range(1, 6) AS t(i);

--- a/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/rocky.toml
@@ -1,0 +1,27 @@
+# 16-history-rolling-stats — `rocky history --model <name> --rolling-stats`
+#
+# Five back-to-back replication runs vary the source row count; the
+# rolling-stats summary then surfaces mean / std-dev / z-score / health-score
+# computed over the window of successful executions.
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.discovery]
+adapter = "default"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true

--- a/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/run.sh
+++ b/examples/playground/pocs/06-developer-experience/16-history-rolling-stats/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# 16-history-rolling-stats — `rocky history --model <name> --rolling-stats`
+#
+# Five back-to-back replication runs vary the source row count to drive
+# real duration variance, then `rocky history --model orders` surfaces the
+# rolling statistics block (mean / std-dev / z-score / health-score).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+mkdir -p expected
+
+reseed() {
+    local rows="$1"
+    duckdb poc.duckdb <<SQL >/dev/null
+CREATE SCHEMA IF NOT EXISTS raw__orders;
+CREATE OR REPLACE TABLE raw__orders.orders AS
+SELECT
+    i AS order_id,
+    100 + (i % 5) AS customer_id,
+    'completed' AS status,
+    10.0 * i AS amount
+FROM range(1, ${rows}) AS t(i);
+SQL
+}
+
+echo "==> Seed raw__orders.orders (5 rows)"
+reseed 6
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_1.json
+
+echo "==> Reseed with 50 rows; second run"
+reseed 51
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_2.json
+
+echo "==> Reseed with 200 rows; third run"
+reseed 201
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_3.json
+
+echo "==> Reseed with 25 rows; fourth run"
+reseed 26
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_4.json
+
+echo "==> Reseed with 12 rows; fifth run"
+reseed 13
+rocky -c rocky.toml -o json run --filter source=orders > expected/run_5.json
+
+echo
+echo "==> rocky history --model orders --rolling-stats --window 5"
+rocky -c rocky.toml -o json history --model orders --rolling-stats --window 5 \
+    > expected/history_rolling.json
+
+# Quick sanity check — the rolling_stats block must surface and carry the
+# window we asked for. Anything else means the flag silently dropped.
+python3 - <<'PY'
+import json, sys
+with open("expected/history_rolling.json") as f:
+    h = json.load(f)
+rs = h.get("rolling_stats")
+if rs is None:
+    print("FAIL: rolling_stats block missing from history JSON", file=sys.stderr)
+    sys.exit(1)
+assert rs["window"] == 5, f"unexpected window: {rs['window']}"
+assert rs["samples"] >= 1, f"unexpected samples: {rs['samples']}"
+assert 0.0 <= rs["health_score"] <= 1.0, f"health_score out of range: {rs['health_score']}"
+print(f"    samples={rs['samples']}  window={rs['window']}  health_score={rs['health_score']}")
+print(f"    duration_ms.mean={rs['duration_ms']['mean']:.2f}  "
+      f"std_dev={rs['duration_ms']['std_dev']:.2f}  "
+      f"latest_z={rs['duration_ms'].get('latest_z_score', 'n/a')}")
+PY
+
+echo
+echo "==> Compare bare history vs rolling-stats (block only appears with --rolling-stats)"
+rocky -c rocky.toml -o json history --model orders > expected/history_bare.json
+python3 - <<'PY'
+import json
+bare = json.load(open("expected/history_bare.json"))
+roll = json.load(open("expected/history_rolling.json"))
+assert "rolling_stats" not in bare, "rolling_stats leaked into bare --model output"
+assert "rolling_stats" in roll, "rolling_stats missing from --rolling-stats output"
+print("    bare output: rolling_stats absent (correct)")
+print("    --rolling-stats: rolling_stats present (correct)")
+PY
+
+echo
+echo "POC complete: five runs feed the window; rolling_stats surfaces health_score + per-dimension z-scores."

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,6 +1,6 @@
 # POC Catalog
 
-70 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+73 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
@@ -9,15 +9,15 @@
 - [02-performance](02-performance/) — Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, trust-arc 2 cost+budgets, strategy showcase (11 POCs · DuckDB)
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention, auto-create schemas (7 POCs · Databricks / DuckDB)
-- [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys (9 POCs · DuckDB / docker)
-- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop, dbt-import failure modes (14 POCs · DuckDB)
+- [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys, state retention sweep (10 POCs · DuckDB / docker)
+- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop, dbt-import failure modes, semantic breaking-change gate, history rolling stats (16 POCs · DuckDB)
 - [07-adapters](07-adapters/) — Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native adapter skeleton, Trino-Docker (7 POCs · mixed)
 
 ## Credentials at a glance
 
 | POCs | Credentials |
 |---|---|
-| 57 of 70 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
+| 60 of 73 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
 | 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |


### PR DESCRIPTION
## Summary

- **NEW POC** `06-developer-experience/15-semantic-breaking-change-gate` — exercises both the informational `rocky ci-diff --semantic` flag and the hard `rocky branch promote` pre-promote gate. The flow stands up a throwaway git repo inside the POC dir, drops the `total_amount` column on a feature branch, watches the gate veto the promote (exit 1, `BreakingChangesBlocked` audit event), then retries under `--allow-breaking` to confirm the override leaves a `BreakingChangesAllowed` paper trail.
- **NEW POC** `05-orchestration/10-state-retention-sweep` — covers both `[state.retention]` delivery paths: manual `rocky state retention sweep` (with `--dry-run` plan-parity) and the end-of-run auto-sweep gated by `sweep_interval_seconds`. Demonstrates that operational tables (schema cache, watermarks, partition records, etc.) stay intact while history / lineage / audit domains prune.
- **NEW POC** `06-developer-experience/16-history-rolling-stats` — five varied-rowcount runs feed the window; `rocky history --model orders --rolling-stats --window 5` surfaces mean / std-dev / latest-z-score plus the composite `health_score`. Includes a negative-control assertion that the `rolling_stats` field is absent when the flag is omitted.

## Catalog deltas

- `05-orchestration`: 9 → 10 POCs
- `06-developer-experience`: 14 → 16 POCs
- Total: 70 → 73 POCs; credential-free: 57/70 → 60/73

## Test plan

- [x] `./run.sh` succeeds standalone in each of the three new POC directories.
- [x] `scripts/run-all-duckdb.sh` reports **56 passed / 0 failed / 17 skipped** (baseline before this PR: 53 / 0 / 17 — the +3 is the three new POCs).
- [x] The breaking-change POC's run.sh restores the baseline model on `EXIT` so the smoke runner leaves the source tree clean across repeated runs.
- [x] Each POC pins a minimum `rocky` version in its README matching the earliest engine release that carries the feature.