### PR TITLE
feat(vscode): interactive lineage + code-lens fixes + Models tree polish

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -523,6 +523,23 @@
           "when": "view == rocky.models && viewItem == rockyModel",
           "group": "2_inspect@4"
         }
+      ],
+      "editor/context": [
+        {
+          "command": "rocky.history",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@1"
+        },
+        {
+          "command": "rocky.metrics",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@2"
+        },
+        {
+          "command": "rocky.optimize",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@3"
+        }
       ]
     },
     "keybindings": [

--- a/editors/vscode/src/codeLens.ts
+++ b/editors/vscode/src/codeLens.ts
@@ -63,10 +63,7 @@ export class RockyCodeLensProvider implements vscode.CodeLensProvider {
         modelName,
       ]),
       makeLens(range, "$(beaker) Test", "rocky.test", [modelName]),
-      makeLens(range, "$(graph) Lineage", "rocky.showLineage"),
-      makeLens(range, "$(history) History", "rocky.history", [modelName]),
-      makeLens(range, "$(pulse) Metrics", "rocky.metrics", [modelName]),
-      makeLens(range, "$(rocket) Optimize", "rocky.optimize", [modelName]),
+      makeLens(range, "$(graph) Lineage", "rocky.showLineage", [modelName]),
     ];
   }
 }
@@ -132,9 +129,7 @@ export function registerCodeLensProvider(
     vscode.languages.registerCodeLensProvider(
       [
         { scheme: "file", language: "rocky" },
-        { scheme: "file", pattern: "**/*.rocky" },
         { scheme: "file", language: "sql", pattern: "**/models/**/*.sql" },
-        { scheme: "file", pattern: "**/models/**/*.sql" },
       ],
       provider,
     ),

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -14,7 +14,7 @@ import {
   viewMarketplace,
 } from "./info";
 import { catalog, history, metrics } from "./inspect";
-import { showLineage } from "./lineage";
+import { registerLineageSerializer, showLineage } from "./lineage";
 import { importDbt, validateMigration } from "./migration";
 import { doctor, optimize } from "./ops";
 import { previewCost, previewCreate, previewDiff } from "./preview";
@@ -27,6 +27,8 @@ import { test } from "./test";
  * is one line here plus a `commands` entry in package.json.
  */
 export function registerCommands(context: vscode.ExtensionContext): void {
+  registerLineageSerializer(context);
+
   context.subscriptions.push(
     // Command palette (Cmd+Shift+R / Ctrl+Shift+R)
     vscode.commands.registerCommand("rocky.commandPalette", commandPalette),

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -5,6 +5,15 @@ import { getExtensionUri } from "../extensionState";
 import { runRocky } from "../rockyCli";
 import { resolveModelName } from "./ui";
 
+const VIEW_TYPE = "rockyLineage";
+
+interface SerializedState {
+  modelName?: string;
+  scale?: number;
+  panX?: number;
+  panY?: number;
+}
+
 export async function showLineage(arg?: unknown): Promise<void> {
   // When invoked from the tree-view context menu, `arg` is a ModelTreeItem.
   // When invoked from the command palette, fall back to the active editor.
@@ -22,12 +31,11 @@ export async function showLineage(arg?: unknown): Promise<void> {
   }
   if (!modelName) return;
 
-  const workspaceFolder = getWorkspaceFolder();
   const extensionUri = getExtensionUri();
   const mediaUri = vscode.Uri.joinPath(extensionUri, "media");
 
   const panel = vscode.window.createWebviewPanel(
-    "rockyLineage",
+    VIEW_TYPE,
     `Lineage: ${modelName}`,
     vscode.ViewColumn.Beside,
     {
@@ -37,7 +45,67 @@ export async function showLineage(arg?: unknown): Promise<void> {
     },
   );
 
+  await populatePanel(panel, modelName);
+}
+
+/**
+ * Registers a webview-panel serializer so lineage panels survive workspace
+ * reloads. The webview persists `{ modelName, scale, panX, panY }` via
+ * `vscode.setState`; on reload we re-run the CLI and restore zoom/pan.
+ */
+export function registerLineageSerializer(
+  context: vscode.ExtensionContext,
+): void {
+  context.subscriptions.push(
+    vscode.window.registerWebviewPanelSerializer(VIEW_TYPE, {
+      async deserializeWebviewPanel(
+        panel: vscode.WebviewPanel,
+        state: SerializedState | undefined,
+      ) {
+        const modelName = state?.modelName;
+        if (!modelName) {
+          panel.dispose();
+          return;
+        }
+        const extensionUri = getExtensionUri();
+        const mediaUri = vscode.Uri.joinPath(extensionUri, "media");
+        panel.webview.options = {
+          enableScripts: true,
+          localResourceRoots: [mediaUri],
+        };
+        await populatePanel(panel, modelName);
+      },
+    }),
+  );
+}
+
+async function populatePanel(
+  panel: vscode.WebviewPanel,
+  modelName: string,
+): Promise<void> {
+  const workspaceFolder = getWorkspaceFolder();
+  const extensionUri = getExtensionUri();
+  const mediaUri = vscode.Uri.joinPath(extensionUri, "media");
+
   panel.webview.html = renderLoadingHtml(panel.webview, modelName);
+
+  // Resolve clicks from the webview by globbing the workspace for the model file
+  // and opening the first match. Disposed when the panel closes.
+  panel.webview.onDidReceiveMessage(
+    async (msg: { type?: string; name?: string }) => {
+      if (msg?.type !== "openModel" || typeof msg.name !== "string") return;
+      const matches = await vscode.workspace.findFiles(
+        `**/models/**/${msg.name}.{rocky,sql}`,
+        undefined,
+        1,
+      );
+      if (matches[0]) {
+        void vscode.commands.executeCommand("vscode.open", matches[0]);
+      }
+    },
+    undefined,
+    [],
+  );
 
   // `-o table` opts out of the CLI's default `--output json`, so the lineage
   // handler honours `--format dot`. Without this, stdout is a JSON blob and
@@ -137,6 +205,7 @@ function renderLineageHtml(
   // from a hidden <script type="application/json"> tag rather than via string
   // interpolation, which keeps the CSP simple.
   const dotJson = JSON.stringify(dot);
+  const modelNameJson = JSON.stringify(modelName);
 
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -185,10 +254,34 @@ function renderLineageHtml(
       will-change: transform;
     }
     #graph svg { display: block; }
-    #graph svg text { fill: var(--vscode-foreground); }
-    #graph svg polygon { fill: var(--vscode-editor-background); stroke: var(--vscode-foreground); }
-    #graph svg ellipse { fill: var(--vscode-badge-background); stroke: var(--vscode-foreground); }
-    #graph svg path { stroke: var(--vscode-foreground); }
+    #graph svg text { fill: var(--vscode-foreground); pointer-events: none; }
+    #graph svg g.node { cursor: pointer; }
+    #graph svg g.node ellipse,
+    #graph svg g.node polygon {
+      stroke: var(--vscode-foreground);
+      fill: var(--vscode-badge-background);
+      transition: fill 80ms ease, stroke-width 80ms ease;
+    }
+    #graph svg g.node.source ellipse,
+    #graph svg g.node.source polygon {
+      fill: var(--vscode-charts-blue, var(--vscode-badge-background));
+    }
+    #graph svg g.node.leaf ellipse,
+    #graph svg g.node.leaf polygon {
+      fill: var(--vscode-charts-green, var(--vscode-badge-background));
+    }
+    #graph svg g.node:hover ellipse,
+    #graph svg g.node:hover polygon {
+      stroke-width: 2px;
+    }
+    #graph svg g.edge path {
+      stroke: var(--vscode-descriptionForeground);
+      fill: none;
+    }
+    #graph svg g.edge polygon {
+      fill: var(--vscode-descriptionForeground);
+      stroke: var(--vscode-descriptionForeground);
+    }
     .status {
       padding: 8px 12px;
       color: var(--vscode-descriptionForeground);
@@ -201,9 +294,10 @@ function renderLineageHtml(
   <header>
     <h2>Lineage: ${escapeHtml(modelName)}</h2>
     <span class="spacer"></span>
-    <button id="zoom-out" title="Zoom out">−</button>
-    <button id="zoom-reset" title="Reset zoom">100%</button>
-    <button id="zoom-in" title="Zoom in">+</button>
+    <button id="zoom-out" title="Zoom out (-)">−</button>
+    <button id="zoom-reset" title="Reset zoom (0)">100%</button>
+    <button id="zoom-in" title="Zoom in (+)">+</button>
+    <button id="zoom-fit" title="Fit to view (F)">Fit</button>
     <button id="export-svg" title="Export as SVG">Export SVG</button>
   </header>
   <div id="viewport">
@@ -212,37 +306,73 @@ function renderLineageHtml(
   <div id="status" class="status">Rendering…</div>
 
   <script id="dot-source" type="application/json" nonce="${nonce}">${escapeJsonForScript(dotJson)}</script>
+  <script id="model-name" type="application/json" nonce="${nonce}">${escapeJsonForScript(modelNameJson)}</script>
   <script src="${vizUri}" nonce="${nonce}"></script>
   <script nonce="${nonce}">
     (function () {
+      const vscode = acquireVsCodeApi();
       const dot = JSON.parse(document.getElementById('dot-source').textContent);
+      const modelName = JSON.parse(document.getElementById('model-name').textContent);
       const graph = document.getElementById('graph');
       const viewport = document.getElementById('viewport');
       const status = document.getElementById('status');
+      const saved = vscode.getState() || {};
 
-      let scale = 1;
-      let panX = 0;
-      let panY = 0;
+      let scale = typeof saved.scale === 'number' ? saved.scale : 1;
+      let panX = typeof saved.panX === 'number' ? saved.panX : 0;
+      let panY = typeof saved.panY === 'number' ? saved.panY : 0;
       let panning = false;
       let panOriginX = 0;
       let panOriginY = 0;
 
+      function saveState() {
+        vscode.setState({ modelName: modelName, scale: scale, panX: panX, panY: panY });
+      }
+
       function applyTransform() {
         graph.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + scale + ')';
+        document.getElementById('zoom-reset').textContent = Math.round(scale * 100) + '%';
       }
 
       function setZoom(next) {
         scale = Math.min(8, Math.max(0.1, next));
-        document.getElementById('zoom-reset').textContent = Math.round(scale * 100) + '%';
         applyTransform();
+        saveState();
+      }
+
+      function fitToView() {
+        const svg = graph.querySelector('svg');
+        if (!svg) return;
+        const bbox = svg.getBBox();
+        if (!bbox.width || !bbox.height) return;
+        const margin = 0.9;
+        const sx = (viewport.clientWidth / bbox.width) * margin;
+        const sy = (viewport.clientHeight / bbox.height) * margin;
+        scale = Math.min(8, Math.max(0.1, Math.min(sx, sy)));
+        panX = (viewport.clientWidth - bbox.width * scale) / 2 - bbox.x * scale;
+        panY = (viewport.clientHeight - bbox.height * scale) / 2 - bbox.y * scale;
+        applyTransform();
+        saveState();
+      }
+
+      function resetView() {
+        scale = 1; panX = 0; panY = 0;
+        applyTransform();
+        saveState();
       }
 
       document.getElementById('zoom-in').onclick = () => setZoom(scale * 1.2);
       document.getElementById('zoom-out').onclick = () => setZoom(scale / 1.2);
-      document.getElementById('zoom-reset').onclick = () => {
-        scale = 1; panX = 0; panY = 0;
-        setZoom(1);
-      };
+      document.getElementById('zoom-reset').onclick = resetView;
+      document.getElementById('zoom-fit').onclick = fitToView;
+
+      window.addEventListener('keydown', (e) => {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        if (e.key === '+' || e.key === '=') { setZoom(scale * 1.2); e.preventDefault(); }
+        else if (e.key === '-') { setZoom(scale / 1.2); e.preventDefault(); }
+        else if (e.key === '0') { resetView(); e.preventDefault(); }
+        else if (e.key === 'f' || e.key === 'F') { fitToView(); e.preventDefault(); }
+      });
 
       viewport.addEventListener('wheel', (e) => {
         e.preventDefault();
@@ -263,8 +393,10 @@ function renderLineageHtml(
         applyTransform();
       });
       window.addEventListener('mouseup', () => {
+        if (!panning) return;
         panning = false;
         viewport.classList.remove('panning');
+        saveState();
       });
 
       document.getElementById('export-svg').onclick = () => {
@@ -274,17 +406,74 @@ function renderLineageHtml(
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = '${escapeJsForString(modelName)}-lineage.svg';
+        a.download = modelName + '-lineage.svg';
         a.click();
         URL.revokeObjectURL(url);
       };
+
+      // Classify nodes by in/out degree, parsed from DOT before viz.js renders.
+      // Rocky's lineage DOT emits edges as \`"model.column" -> "model.column";\`,
+      // so we match any quoted string on each side of -> and key the in/out
+      // sets by the exact node label.
+      function classifyNodes(dotText) {
+        const incoming = new Set();
+        const outgoing = new Set();
+        const edgeRe = /"([^"]+)"\\s*->\\s*"([^"]+)"/g;
+        let m;
+        while ((m = edgeRe.exec(dotText)) !== null) {
+          outgoing.add(m[1]);
+          incoming.add(m[2]);
+        }
+        const all = new Set([...incoming, ...outgoing]);
+        const sources = new Set([...all].filter(n => !incoming.has(n)));
+        const leaves = new Set([...all].filter(n => !outgoing.has(n)));
+        return { sources: sources, leaves: leaves };
+      }
+
+      // Node labels are \`model.column\`. The column is always the last
+      // dot-separated segment; the rest is the model name we want to open.
+      function modelFromLabel(label) {
+        const idx = label.lastIndexOf('.');
+        return idx > 0 ? label.slice(0, idx) : label;
+      }
+
+      function decorateNodes(svgRoot, classes) {
+        svgRoot.querySelectorAll('g.node').forEach(nodeEl => {
+          const textEl = nodeEl.querySelector('text');
+          if (!textEl) return;
+          const label = (textEl.textContent || '').trim();
+          if (!label) return;
+          if (classes.sources.has(label)) nodeEl.classList.add('source');
+          else if (classes.leaves.has(label)) nodeEl.classList.add('leaf');
+
+          const model = modelFromLabel(label);
+
+          // Native browser tooltip on hover — no extra DOM, no positioning.
+          const titleEl = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+          titleEl.textContent = 'Open ' + model;
+          nodeEl.appendChild(titleEl);
+
+          nodeEl.addEventListener('click', (e) => {
+            e.stopPropagation();
+            vscode.postMessage({ type: 'openModel', name: model });
+          });
+        });
+      }
 
       Viz.instance().then((viz) => {
         try {
           const svg = viz.renderSVGElement(dot);
           graph.innerHTML = '';
           graph.appendChild(svg);
-          status.textContent = 'Drag to pan · scroll to zoom';
+          const classes = classifyNodes(dot);
+          decorateNodes(svg, classes);
+          status.textContent = 'Drag to pan · scroll to zoom · click a node to open · F to fit · 0 to reset';
+          if (saved.scale || saved.panX || saved.panY) {
+            applyTransform();
+          } else {
+            // Auto-fit on first render so wide DAGs are immediately legible.
+            fitToView();
+          }
         } catch (err) {
           status.textContent = 'Render error: ' + err.message;
           status.classList.add('error');
@@ -311,13 +500,6 @@ function escapeHtml(text: string): string {
 function escapeJsonForScript(json: string): string {
   // Prevent </script> from terminating the parent script tag.
   return json.replace(/<\/script/gi, "<\\/script");
-}
-
-function escapeJsForString(value: string): string {
-  return value
-    .replace(/\\/g, "\\\\")
-    .replace(/'/g, "\\'")
-    .replace(/\n/g, "\\n");
 }
 
 function makeNonce(): string {

--- a/editors/vscode/src/views/modelsView.ts
+++ b/editors/vscode/src/views/modelsView.ts
@@ -41,15 +41,14 @@ export class ModelTreeItem extends vscode.TreeItem {
   override readonly contextValue = "rockyModel";
 
   constructor(public readonly resourceUri: vscode.Uri) {
-    const label = path.basename(
-      resourceUri.fsPath,
-      path.extname(resourceUri.fsPath),
-    );
+    const ext = path.extname(resourceUri.fsPath);
+    const label = path.basename(resourceUri.fsPath, ext);
     super(label, vscode.TreeItemCollapsibleState.None);
     this.label = label;
     this.id = vscode.workspace.asRelativePath(resourceUri);
     this.tooltip = resourceUri.fsPath;
-    this.description = vscode.workspace.asRelativePath(resourceUri);
+    const kind = ext === ".sql" ? "SQL" : "DSL";
+    this.description = `${kind} · ${vscode.workspace.asRelativePath(resourceUri)}`;
     this.command = {
       command: "vscode.open",
       title: "Open Model",


### PR DESCRIPTION
## Summary

Wide-sweep audit of the VS Code extension, organised into three buckets. Stacked on top of #512 (rebase onto main once that lands).

### Bugs (verified)
- **Duplicate code-lens registration** — `codeLens.ts` had 4 overlapping document selectors causing the provider to fire twice per file (14 lenses rendered instead of 7). Reduced to 2.
- **Lineage code lens dropped its arg** — every other lens passed `[modelName]`; Lineage did not. Worked by accident via the active-editor fallback. Now consistent.

### UX polish
- **Code-lens overcrowding** — trimmed the inline row from 7 to 4 (Run / Compile / Test / Lineage). History / Metrics / Optimize were already on the Models tree's right-click menu; mirrored to `editor/context` so they're discoverable when right-clicking a model file in the editor.
- **Models tree kind badge** — items now show `DSL · path` or `SQL · path` so raw-SQL models are visually distinguishable from `.rocky` ones (directly addresses the original "no models found" confusion).

### Lineage webview ("can it look nicer?" — yes)
- **Click a node** → opens its source file (webview posts `openModel`; extension resolves via `workspace.findFiles` and `vscode.open`).
- **Hover tooltip** on every node via `<title>` injection.
- **Fit button + keyboard shortcuts** — `+`/`-` zoom, `0` reset, `F` fit. Auto-fit on first render so wide DAGs are legible from the start.
- **Source/leaf coloring** — nodes with zero in-degree get `--vscode-charts-blue`, zero out-degree gets `--vscode-charts-green`. Edge stroke softened to `--vscode-descriptionForeground` for visual hierarchy.
- **Persistence** — webview state (modelName + zoom/pan) saved via `setState`; a `WebviewPanelSerializer` re-runs the CLI on workspace reload and restores the prior view.

## Behavior changes worth noting
- The lineage webview now auto-fits on first render (previously: 1:1 scale). For small DAGs this is unchanged; for wide ones it's strictly better. The user can press `0` to reset to 100%.

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:unit` (35/35)
- [x] `rocky lineage customer_orders --format dot` against playground POC — confirmed DOT format (`"model.column" -> "model.column"`) matches the webview's edge-parsing regex
- [ ] F5 in extension host against playground:
  - [ ] Lineage panel: hover shows tooltip, click opens source, `F`/`0` keys work
  - [ ] Source nodes blue, leaf nodes green
  - [ ] 4 code lenses (not 7) above a model header
  - [ ] Right-click in editor on a model file → History/Metrics/Optimize visible
  - [ ] Models tree shows `DSL` / `SQL` next to each item
  - [ ] Close lineage panel, reload window, reopen → state restored