### PR TITLE
feat(rocky-cli): ROCKY_SCRUB_HOST env var + docs drift fixes

### DIFF
--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -135,7 +135,7 @@ Pipeline-oriented syntax that compiles to standard SQL:
 
 Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expressions (→ CASE WHEN), date literals (`@2025-01-01`), IS NULL / IS NOT NULL, IN lists.
 
-## CLI Commands (38+)
+## CLI Commands (50+)
 
 ### Core Pipeline
 `init` · `validate` · `discover` · `plan` · `run` · `compare` · `state` · `branch` (incl. `branch approve`, `branch promote --allow-breaking --base-ref --models --skip-approval`) · `preview create` · `preview diff` · `preview cost`
@@ -190,7 +190,7 @@ Published VS Code extension with TextMate grammar + semantic tokens.
 - **dagster-rocky** package with `RockyResource` and `RockyComponent`
 - **Auto-discovery**: Rocky discover → Dagster asset definitions
 - **Dagster Pipes protocol**: Hand-rolled emitter (no external dependency) — reports materializations, check results, drift observations, anomaly alerts
-- **38 typed JSON output schemas** with auto-generated Pydantic v2 models and TypeScript interfaces via `rocky export-schemas`
+- **55 typed JSON output schemas** with auto-generated Pydantic v2 models and TypeScript interfaces via `rocky export-schemas`
 - **Freshness policies** auto-attached from `[checks.freshness]` config
 - **Column lineage** attached to derived model asset metadata
 

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -569,6 +569,8 @@ rocky ci-diff --semantic
 
 The `breaking_findings` array is omitted from JSON output when empty or when `--semantic` is not set. Each finding carries a tagged `change` object (`kind` discriminator) and a `severity` (`breaking` / `warning` / `info`). Use `--semantic` in `ci-diff` to surface findings on every PR; rely on [`rocky branch promote`](/reference/commands/core-pipeline/#rocky-branch) to block promotion when `severity == "breaking"`.
 
+The `breaking_findings` field is JSON-only — `--output table` still renders the structural diff but does not print the semantic findings list. Use `--output json` (and pipe through `jq`) to inspect them.
+
 ### Related Commands
 
 - [`rocky ci`](#rocky-ci) -- full compile + test for CI

--- a/editors/vscode/src/types/generated/branch_approve.ts
+++ b/editors/vscode/src/types/generated/branch_approve.ts
@@ -52,7 +52,7 @@ export interface ApprovalArtifact {
 /**
  * Identity of an approver, captured at sign time.
  *
- * Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.
+ * Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `"redacted"` when recording public demos.
  */
 export interface ApproverIdentity {
   email: string;

--- a/editors/vscode/src/types/generated/branch_promote.ts
+++ b/editors/vscode/src/types/generated/branch_promote.ts
@@ -223,7 +223,7 @@ export interface ApprovalArtifact {
 /**
  * Identity of an approver, captured at sign time.
  *
- * Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.
+ * Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `"redacted"` when recording public demos.
  */
 export interface ApproverIdentity {
   email: string;

--- a/engine/.claude/skills/rust-analyzer-ssr/SKILL.md
+++ b/engine/.claude/skills/rust-analyzer-ssr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-analyzer-ssr
-description: Use rust-analyzer's Structural Search and Replace (SSR) for semantic Rust code transformations across the engine workspace. Apply when refactoring API shapes, migrating patterns, or searching for code structure across all 20 crates.
+description: Use rust-analyzer's Structural Search and Replace (SSR) for semantic Rust code transformations across the engine workspace. Apply when refactoring API shapes, migrating patterns, or searching for code structure across all 21 crates.
 ---
 
 # rust-analyzer Structural Search and Replace (SSR)
@@ -8,7 +8,7 @@ description: Use rust-analyzer's Structural Search and Replace (SSR) for semanti
 Source: vendored from [davidbarsky/8fae6dc45c294297db582378284bd1f2](https://gist.github.com/davidbarsky/8fae6dc45c294297db582378284bd1f2) @ `191b2ee46088920de97d682561e2abd1edd64a42` (SKILL-3.md).
 Author: David Barsky (rust-analyzer contributor at Meta). This is a pure tooling reference with no style opinions.
 
-Use rust-analyzer's SSR for semantic code transformations in Rust projects. SSR matches code by AST structure and semantic meaning, not text. In Rocky this is especially useful for cross-crate refactors against the 20-crate workspace — string `grep` regularly over-matches.
+Use rust-analyzer's SSR for semantic code transformations in Rust projects. SSR matches code by AST structure and semantic meaning, not text. In Rocky this is especially useful for cross-crate refactors against the 21-crate workspace — string `grep` regularly over-matches.
 
 ## When to Use
 
@@ -193,4 +193,4 @@ Adapter::old_method($self, $arg) ==>> $self.new_method($arg)
 RunOutput { tables_copied: $t, materializations: $m, ..$rest } ==>> RunOutput { materializations: $m, tables_copied: $t, ..$rest }
 ```
 
-Always dry-run with `parseOnly: true` or preview in the editor before applying workspace-wide — the 20-crate workspace makes a botched refactor expensive to back out.
+Always dry-run with `parseOnly: true` or preview in the editor before applying workspace-wide — the 21-crate workspace makes a botched refactor expensive to back out.

--- a/engine/.claude/skills/rust-style/SKILL.md
+++ b/engine/.claude/skills/rust-style/SKILL.md
@@ -17,7 +17,7 @@ This is a **cherry-pick** of Barsky's `rust-style` gist, not a verbatim vendor. 
 |---|---|
 | "Use `for` loops, not iterator chains" | Rocky uses `iter().filter().map().collect()` freely throughout the codebase — it's idiomatic Rust and the codebase is already consistent with it. Swapping to mutable-accumulator loops would be a large and contentious rewrite. |
 | "Avoid the `matches!` macro" | `matches!` is the standard Rust idiom for boolean variant checks. Rocky uses it; removing it would produce more verbose code, not clearer code. |
-| "Always use explicit destructuring for struct field access" | Too strict for a 20-crate workspace. Dot-access is fine for ad-hoc reads; reserve destructuring for match arms and when all fields are consumed. |
+| "Always use explicit destructuring for struct field access" | Too strict for a 21-crate workspace. Dot-access is fine for ad-hoc reads; reserve destructuring for match arms and when all fields are consumed. |
 
 The rules below are the ones that **are** enforced.
 
@@ -198,7 +198,7 @@ If a wildcard seems unavoidable for a Rocky-owned enum, **stop and reconsider** 
 
 ## Code navigation: prefer rust-analyzer LSP
 
-When searching or navigating Rust code in the 20-crate workspace, prefer LSP operations over raw text search — they respect type resolution and paths:
+When searching or navigating Rust code in the 21-crate workspace, prefer LSP operations over raw text search — they respect type resolution and paths:
 
 - `goToDefinition` — find where a symbol is defined
 - `findReferences` — find all references (respects re-exports)

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -271,15 +271,28 @@ fn run_git_config(key: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Resolve the hostname surfaced in [`ApproverIdentity::host`].
+///
+/// When `scrub` is true the hostname lookup is skipped and the string
+/// `"redacted"` is returned instead. Pure helper so the env-var policy can
+/// be unit-tested without racy `std::env::set_var` calls.
+fn pick_host(scrub: bool) -> String {
+    if scrub {
+        return "redacted".to_string();
+    }
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 /// Build an [`ApproverIdentity`] from the local environment. Used by both
 /// `branch approve` (signing identity) and `branch promote` (actor on every
 /// audit event).
 fn approver_identity() -> Result<ApproverIdentity> {
     let (email, name) = git_identity()?;
-    let host = hostname::get()
-        .ok()
-        .and_then(|h| h.into_string().ok())
-        .unwrap_or_else(|| "unknown".to_string());
+    let scrub = std::env::var_os("ROCKY_SCRUB_HOST").is_some();
+    let host = pick_host(scrub);
     Ok(ApproverIdentity {
         email,
         name,
@@ -1146,6 +1159,24 @@ mod tests {
         assert!(validate_branch_name("feat_new_join").is_ok());
         assert!(validate_branch_name("hotfix.2026-04-20").is_ok());
         assert!(validate_branch_name("a").is_ok());
+    }
+
+    /// `pick_host(true)` always returns the literal `"redacted"` placeholder
+    /// — preserving the `host: String` schema while keeping the machine
+    /// hostname out of audit JSON when `ROCKY_SCRUB_HOST` is set.
+    #[test]
+    fn pick_host_scrub_returns_redacted_placeholder() {
+        assert_eq!(pick_host(true), "redacted");
+    }
+
+    /// `pick_host(false)` returns a non-empty, non-redacted string — either
+    /// the real hostname or the `"unknown"` fallback. We avoid asserting the
+    /// exact value because it varies by machine.
+    #[test]
+    fn pick_host_unscrubbed_is_not_redacted() {
+        let h = pick_host(false);
+        assert!(!h.is_empty());
+        assert_ne!(h, "redacted");
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3621,6 +3621,8 @@ pub struct BranchDeleteOutput {
 /// Email is sourced from `git config user.email`; name from
 /// `git config user.name`. Hostname is best-effort from the `hostname` crate
 /// and surfaced as an audit aid only — it is not part of the trust boundary.
+/// Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with
+/// `"redacted"` when recording public demos.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ApproverIdentity {
     pub email: String,

--- a/integrations/dagster/src/dagster_rocky/types_generated/branch_approve_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/branch_approve_schema.py
@@ -53,7 +53,7 @@ class ApproverIdentity(BaseModel):
     """
     Identity of an approver, captured at sign time.
 
-    Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.
+    Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `"redacted"` when recording public demos.
     """
 
     email: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/branch_promote_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/branch_promote_schema.py
@@ -406,7 +406,7 @@ class ApproverIdentity(BaseModel):
     """
     Identity of an approver, captured at sign time.
 
-    Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.
+    Email is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `"redacted"` when recording public demos.
     """
 
     email: str

--- a/schemas/branch_approve.schema.json
+++ b/schemas/branch_approve.schema.json
@@ -59,7 +59,7 @@
       "type": "object"
     },
     "ApproverIdentity": {
-      "description": "Identity of an approver, captured at sign time.\n\nEmail is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.",
+      "description": "Identity of an approver, captured at sign time.\n\nEmail is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `\"redacted\"` when recording public demos.",
       "properties": {
         "email": {
           "type": "string"

--- a/schemas/branch_promote.schema.json
+++ b/schemas/branch_promote.schema.json
@@ -59,7 +59,7 @@
       "type": "object"
     },
     "ApproverIdentity": {
-      "description": "Identity of an approver, captured at sign time.\n\nEmail is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary.",
+      "description": "Identity of an approver, captured at sign time.\n\nEmail is sourced from `git config user.email`; name from `git config user.name`. Hostname is best-effort from the `hostname` crate and surfaced as an audit aid only — it is not part of the trust boundary. Set `ROCKY_SCRUB_HOST` in the environment to replace the hostname with `\"redacted\"` when recording public demos.",
       "properties": {
         "email": {
           "type": "string"


### PR DESCRIPTION
## Summary

### Engine fix
- `rocky branch approve` / `branch promote --output json` embeds `actor.host` in every audit event. Setting `ROCKY_SCRUB_HOST` in the environment now replaces the hostname with the literal string `"redacted"` so recording public demos doesn't leak the machine name.
- The JSON schema is unchanged: `host` stays a non-optional `String`. The env-var check is `var_os(...).is_some()`, so any value (including empty) triggers the scrub.
- Factored a pure `pick_host(scrub: bool)` helper so the policy is unit-testable without racy `std::env::set_var` calls in Rust 2024.
- Doc-comment on `ApproverIdentity` documents the env var (propagates to generated TS + JSON Schema via codegen).

### Docs note
- `reference/commands/modeling.md`: noted that `ci-diff --output table` shows the structural diff but suppresses `breaking_findings`. Use `--output json` to inspect the semantic findings list.

### Count drift
- `features/all-features.md`: `CLI Commands (38+)` -> `(50+)` (verified via `rocky --help`: 53 verbs).
- `features/all-features.md`: `38 typed JSON output schemas` -> `55` (matches `schemas/*.schema.json`).
- `engine/.claude/skills/rust-style/SKILL.md` + `rust-analyzer-ssr/SKILL.md`: `20-crate workspace` -> `21-crate workspace` (rocky-ir was extracted into its own crate).

## Test plan
- [x] `cargo build -p rocky-cli` clean
- [x] `cargo test -p rocky-cli` (2 new tests for `pick_host`; full suite passes)
- [x] `cargo clippy -p rocky-cli -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live smoke against the `15-semantic-breaking-change-gate` POC:
  - `ROCKY_SCRUB_HOST=1 bash run.sh` -> `jq '[.audit[].actor.host] | unique'` returns `["redacted"]` on both `promote_blocked.json` and `promote_allowed.json`.
  - Same POC unset -> returns the real hostname; default behavior unchanged.