### PR TITLE
feat(vscode): finish lineage Tier 2 + inline cost annotations + schema sidebar

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -112,6 +112,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Automatically run the pipeline when a model file is saved. Read-only contract — consumed by future commands; has no effect in this release."
+        },
+        "rocky.costAnnotations.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Show inline cost annotations (CodeLens) above model files. Data is fetched from `rocky optimize` on activation and refreshed via the **Rocky: Refresh Cost Annotations** command."
         }
       }
     },
@@ -338,6 +343,17 @@
       {
         "command": "rocky.playground",
         "title": "Open Playground",
+        "category": "Rocky"
+      },
+      {
+        "command": "rocky.refreshCosts",
+        "title": "Refresh Cost Annotations",
+        "category": "Rocky",
+        "icon": "$(graph)"
+      },
+      {
+        "command": "rocky.showCostDetail",
+        "title": "Show Cost Detail",
         "category": "Rocky"
       }
     ],

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -316,6 +316,17 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "rocky.refreshSchema",
+        "title": "Refresh Schema",
+        "category": "Rocky",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "rocky.copyColumnReference",
+        "title": "Copy Column Reference",
+        "category": "Rocky"
+      },
+      {
         "command": "rocky.openOutputChannel",
         "title": "Show Output Channel",
         "category": "Rocky"
@@ -458,6 +469,13 @@
           "visibility": "collapsed"
         },
         {
+          "id": "rocky.schema",
+          "name": "Schema",
+          "icon": "$(symbol-field)",
+          "contextualTitle": "Rocky Schema",
+          "visibility": "collapsed"
+        },
+        {
           "id": "rocky.help",
           "name": "Help",
           "type": "tree",
@@ -512,6 +530,16 @@
         "view": "rocky.sources",
         "contents": "Sources are discovered from your configured adapter.\n\n[Discover Sources](command:rocky.discover)",
         "when": "rocky.hasProject"
+      },
+      {
+        "view": "rocky.schema",
+        "contents": "Open a Rocky project to browse the schema catalog.",
+        "when": "!rocky.hasProject"
+      },
+      {
+        "view": "rocky.schema",
+        "contents": "No catalog data yet. Run the catalog command to populate the schema view.\n\n[Run rocky catalog](command:rocky.refreshSchema)",
+        "when": "rocky.hasProject"
       }
     ],
     "menus": {
@@ -534,6 +562,11 @@
         {
           "command": "rocky.refreshInfo",
           "when": "view == rocky.info",
+          "group": "navigation"
+        },
+        {
+          "command": "rocky.refreshSchema",
+          "when": "view == rocky.schema",
           "group": "navigation"
         }
       ],
@@ -567,6 +600,11 @@
           "command": "rocky.optimize",
           "when": "view == rocky.models && viewItem == rockyModel",
           "group": "2_inspect@4"
+        },
+        {
+          "command": "rocky.copyColumnReference",
+          "when": "view == rocky.schema && viewItem == rockySchemaColumn",
+          "group": "inline@1"
         }
       ],
       "editor/context": [

--- a/editors/vscode/src/__tests__/costCodeLens.test.ts
+++ b/editors/vscode/src/__tests__/costCodeLens.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// VS Code mock — must precede all imports that touch vscode
+// ---------------------------------------------------------------------------
+
+let costAnnotationsEnabled = true;
+
+vi.mock("vscode", () => {
+  class Range {
+    constructor(
+      public startLine: number,
+      public startChar: number,
+      public endLine: number,
+      public endChar: number,
+    ) {}
+  }
+
+  class CodeLens {
+    constructor(
+      public range: Range,
+      public command?: { title: string; command: string; arguments?: unknown[] },
+    ) {}
+  }
+
+  class EventEmitter {
+    private listeners: (() => void)[] = [];
+    event = (listener: () => void): { dispose(): void } => {
+      this.listeners.push(listener);
+      return { dispose: (): void => undefined };
+    };
+    fire(): void {
+      for (const l of this.listeners) l();
+    }
+    dispose(): void {}
+  }
+
+  return {
+    Range,
+    CodeLens,
+    EventEmitter,
+    workspace: {
+      getConfiguration: (_section: string) => ({
+        get: <T,>(key: string, fallback: T): T => {
+          if (key === "costAnnotations.enabled")
+            return costAnnotationsEnabled as unknown as T;
+          return fallback;
+        },
+      }),
+      onDidChangeConfiguration: () => ({ dispose: () => undefined }),
+    },
+    languages: {
+      registerCodeLensProvider: () => ({ dispose: () => undefined }),
+    },
+    commands: {
+      registerCommand: () => ({ dispose: () => undefined }),
+    },
+    window: {
+      showInformationMessage: vi.fn(() => Promise.resolve(undefined)),
+    },
+  };
+});
+
+// rockyCli mock — use vi.fn() with no factory so hoisting works safely.
+// We'll set the implementation in beforeEach via mockImplementation.
+vi.mock("../rockyCli", () => ({
+  runRockyJson: vi.fn(),
+}));
+
+// output channel mock
+vi.mock("../output", () => ({
+  getOutputChannel: () => ({ appendLine: vi.fn() }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — must follow vi.mock calls (hoisting works, but named bindings need
+// to come AFTER the mock declarations so the mock factory runs first)
+// ---------------------------------------------------------------------------
+
+import * as rockyCliModule from "../rockyCli";
+import type { OptimizeOutput, OptimizeRecommendation } from "../types/generated/optimize";
+import {
+  CostCodeLensProvider,
+  invalidateCostCache,
+} from "../costCodeLens";
+
+// Typed handle on the mock so we can configure per-test responses.
+const runRockyJsonMock = rockyCliModule.runRockyJson as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+function makeRecommendation(
+  modelName: string,
+  overrides: Partial<OptimizeRecommendation> = {},
+): OptimizeRecommendation {
+  return {
+    model_name: modelName,
+    compute_cost_per_run: 0.12,
+    storage_cost_per_month: 3.5,
+    estimated_monthly_savings: 1.25,
+    current_strategy: "view",
+    recommended_strategy: "table",
+    reasoning: "High downstream fan-out",
+    downstream_references: 5,
+    ...overrides,
+  };
+}
+
+function makeOptimizeOutput(recs: OptimizeRecommendation[]): OptimizeOutput {
+  return {
+    command: "optimize",
+    version: "1.31.0",
+    total_models_analyzed: recs.length,
+    recommendations: recs,
+  };
+}
+
+/** Fake VS Code TextDocument for a model file. */
+function makeDocument(filePath: string): import("vscode").TextDocument {
+  return {
+    fileName: filePath,
+    lineCount: 1,
+    lineAt: () => ({ text: "" }),
+  } as unknown as import("vscode").TextDocument;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CostCodeLensProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    costAnnotationsEnabled = true;
+    invalidateCostCache();
+  });
+
+  afterEach(() => {
+    invalidateCostCache();
+  });
+
+  describe("cache hit → CodeLens is emitted", () => {
+    it("returns a CodeLens with cost label for a known model after refresh", async () => {
+      const rec = makeRecommendation("orders");
+      runRockyJsonMock.mockResolvedValueOnce(makeOptimizeOutput([rec]));
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      const doc = makeDocument("/workspace/models/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+
+      expect(lenses).toHaveLength(1);
+      expect(lenses[0].command?.title).toContain("$0.1200/run");
+      expect(lenses[0].command?.title).toContain("$3.50/mo storage");
+      expect(lenses[0].command?.title).toContain("save $1.25/mo");
+      expect(lenses[0].command?.command).toBe("rocky.showCostDetail");
+    });
+
+    it("works for .rocky files under models/", async () => {
+      const rec = makeRecommendation("customers");
+      runRockyJsonMock.mockResolvedValueOnce(makeOptimizeOutput([rec]));
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      const doc = makeDocument("/workspace/models/customers.rocky");
+      const lenses = provider.provideCodeLenses(doc);
+
+      expect(lenses).toHaveLength(1);
+      expect(lenses[0].command?.arguments?.[0]).toMatchObject({
+        model_name: "customers",
+      });
+    });
+  });
+
+  describe("cache miss → no CodeLens", () => {
+    it("returns empty array before any refresh", () => {
+      const provider = new CostCodeLensProvider();
+      const doc = makeDocument("/workspace/models/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+
+    it("returns empty array when model is not in the optimize output", async () => {
+      runRockyJsonMock.mockResolvedValueOnce(
+        makeOptimizeOutput([makeRecommendation("other_model")]),
+      );
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      const doc = makeDocument("/workspace/models/unknown.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+
+    it("returns empty array for files outside models/", async () => {
+      runRockyJsonMock.mockResolvedValueOnce(
+        makeOptimizeOutput([makeRecommendation("orders")]),
+      );
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      const doc = makeDocument("/workspace/seeds/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+  });
+
+  describe("disabled setting → CodeLens is cleared", () => {
+    it("returns empty array when costAnnotations.enabled is false", async () => {
+      runRockyJsonMock.mockResolvedValueOnce(
+        makeOptimizeOutput([makeRecommendation("orders")]),
+      );
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      costAnnotationsEnabled = false;
+
+      const doc = makeDocument("/workspace/models/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+  });
+
+  describe("malformed / failed JSON → graceful no-op", () => {
+    it("silently no-ops when rocky optimize fails, leaving cache empty", async () => {
+      runRockyJsonMock.mockRejectedValueOnce(new Error("spawn rocky ENOENT"));
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh(); // must not throw
+
+      const doc = makeDocument("/workspace/models/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+
+    it("does not throw when recommendations is empty", async () => {
+      runRockyJsonMock.mockResolvedValueOnce(makeOptimizeOutput([]));
+
+      const provider = new CostCodeLensProvider();
+      await provider.refresh();
+
+      const doc = makeDocument("/workspace/models/orders.sql");
+      const lenses = provider.provideCodeLenses(doc);
+      expect(lenses).toHaveLength(0);
+    });
+  });
+
+  describe("fireChange", () => {
+    it("fires the onDidChangeCodeLenses event", () => {
+      const provider = new CostCodeLensProvider();
+      const listener = vi.fn();
+      provider.onDidChangeCodeLenses(listener);
+      provider.fireChange();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/editors/vscode/src/__tests__/schemaView.test.ts
+++ b/editors/vscode/src/__tests__/schemaView.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// vscode mock
+// ---------------------------------------------------------------------------
+vi.mock("vscode", () => {
+  class TreeItem {
+    public label: string;
+    public collapsibleState: number;
+    public iconPath: unknown;
+    public tooltip: string | undefined;
+    public command: unknown;
+    public description: string | undefined;
+    public contextValue: string | undefined;
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  }
+
+  class ThemeIcon {
+    constructor(public id: string, public color?: unknown) {}
+  }
+
+  class ThemeColor {
+    constructor(public id: string) {}
+  }
+
+  class Range {
+    constructor(
+      public start: unknown,
+      public end: unknown,
+    ) {}
+  }
+
+  return {
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon,
+    ThemeColor,
+    Range,
+    EventEmitter: class {
+      private listeners: ((value: unknown) => void)[] = [];
+      event = (listener: (value: unknown) => void): { dispose(): void } => {
+        this.listeners.push(listener);
+        return { dispose: (): void => undefined };
+      };
+      fire(value: unknown): void {
+        for (const l of this.listeners) l(value);
+      }
+    },
+    Uri: { file: (p: string) => ({ fsPath: p, toString: () => p }) },
+    workspace: {
+      findFiles: vi.fn(async () => []),
+      workspaceFolders: undefined,
+      asRelativePath: (uri: { fsPath: string }) => uri.fsPath,
+      getConfiguration: () => ({
+        get: <T,>(_key: string, fallback: T): T => fallback,
+      }),
+      onDidChangeConfiguration: () => ({ dispose: () => undefined }),
+      onDidChangeWorkspaceFolders: () => ({ dispose: () => undefined }),
+    },
+    commands: {
+      registerCommand: () => ({ dispose: () => undefined }),
+    },
+    window: {
+      createTreeView: () => ({ dispose: () => undefined }),
+      createTextEditorDecorationType: () => ({
+        dispose: () => undefined,
+      }),
+      visibleTextEditors: [],
+      showInformationMessage: vi.fn(async () => undefined),
+    },
+    env: {
+      clipboard: {
+        writeText: vi.fn(async () => undefined),
+      },
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let hasProject = true;
+const projectChangeListeners: ((v: boolean) => void)[] = [];
+
+vi.mock("../views/getStartedView", () => ({
+  hasRockyProject: () => hasProject,
+  onDidChangeRockyProject: (cb: (v: boolean) => void) => {
+    projectChangeListeners.push(cb);
+    return { dispose: () => undefined };
+  },
+}));
+
+const mockRunRockyJson = vi.fn<() => Promise<unknown>>();
+vi.mock("../rockyCli", () => ({
+  runRockyJson: (...args: unknown[]) => mockRunRockyJson(...args),
+}));
+
+vi.mock("../output", () => ({
+  getOutputChannel: () => ({ appendLine: () => undefined }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import type { CatalogOutput, CatalogAsset } from "../types/generated";
+import { SchemaTreeProvider, SchemaModelNode, SchemaColumnNode } from "../views/schemaView";
+
+function makeCatalog(assets: CatalogAsset[]): CatalogOutput {
+  return {
+    assets,
+    command: "catalog",
+    config_hash: "abc123",
+    edges: [],
+    generated_at: "2026-05-14T00:00:00Z",
+    project_name: "test_project",
+    stats: {
+      asset_count: assets.length,
+      assets_with_star: 0,
+      column_count: assets.reduce((n, a) => n + a.columns.length, 0),
+      duration_ms: 1,
+      edge_count: 0,
+      orphan_columns: 0,
+    },
+    version: "1.0.0",
+  };
+}
+
+function makeAsset(modelName: string, cols: { name: string; data_type?: string; nullable?: boolean }[]): CatalogAsset {
+  return {
+    model_name: modelName,
+    fqn: `catalog.schema.${modelName}`,
+    kind: "Model",
+    columns: cols.map((c) => ({
+      name: c.name,
+      data_type: c.data_type,
+      nullable: c.nullable,
+    })),
+    downstream_models: [],
+    upstream_models: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SchemaTreeProvider", () => {
+  beforeEach(() => {
+    hasProject = true;
+    mockRunRockyJson.mockReset();
+    projectChangeListeners.length = 0;
+  });
+
+  it("returns [] when no Rocky project is detected", async () => {
+    hasProject = false;
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+    expect(roots).toEqual([]);
+    // CLI should never be called with no project
+    expect(mockRunRockyJson).not.toHaveBeenCalled();
+  });
+
+  it("loads catalog and returns one SchemaModelNode per asset", async () => {
+    const asset = makeAsset("orders", [
+      { name: "id", data_type: "INT64", nullable: false },
+      { name: "amount", data_type: "FLOAT64", nullable: true },
+    ]);
+    mockRunRockyJson.mockResolvedValueOnce(makeCatalog([asset]));
+
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+
+    expect(roots).toHaveLength(1);
+    const modelNode = roots[0];
+    expect(modelNode).toBeInstanceOf(SchemaModelNode);
+    expect(modelNode.label).toBe("orders");
+    expect((modelNode as SchemaModelNode).description).toBe("2 cols");
+  });
+
+  it("returns [] (empty viewsWelcome state) when catalog has no assets", async () => {
+    mockRunRockyJson.mockResolvedValueOnce(makeCatalog([]));
+
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+    expect(roots).toHaveLength(0);
+  });
+
+  it("returns an error MessageNode when runRockyJson throws", async () => {
+    mockRunRockyJson.mockRejectedValueOnce(new Error("binary not found"));
+
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].label).toContain("Error:");
+  });
+
+  it("getChildren of a SchemaModelNode returns SchemaColumnNode per column", async () => {
+    const asset = makeAsset("orders", [
+      { name: "id", data_type: "INT64", nullable: false },
+      { name: "amount", data_type: "FLOAT64", nullable: true },
+    ]);
+    mockRunRockyJson.mockResolvedValueOnce(makeCatalog([asset]));
+
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+    const modelNode = roots[0] as SchemaModelNode;
+    const cols = await provider.getChildren(modelNode);
+
+    expect(cols).toHaveLength(2);
+    expect(cols[0]).toBeInstanceOf(SchemaColumnNode);
+    expect(cols[0].label).toBe("id");
+    expect((cols[0] as SchemaColumnNode).description).toBe("INT64");   // not nullable → no ?
+    expect(cols[1].label).toBe("amount");
+    expect((cols[1] as SchemaColumnNode).description).toBe("FLOAT64?"); // nullable → ?
+  });
+
+  it("SchemaColumnNode description falls back to 'unknown' when data_type is absent", async () => {
+    const asset = makeAsset("dim_user", [{ name: "uid" }]);
+    mockRunRockyJson.mockResolvedValueOnce(makeCatalog([asset]));
+
+    const provider = new SchemaTreeProvider();
+    const roots = await provider.getChildren();
+    const modelNode = roots[0] as SchemaModelNode;
+    const cols = await provider.getChildren(modelNode);
+
+    expect((cols[0] as SchemaColumnNode).description).toBe("unknown");
+  });
+
+  it("refresh clears cache and fires onDidChangeTreeData", async () => {
+    mockRunRockyJson.mockResolvedValue(makeCatalog([]));
+
+    const provider = new SchemaTreeProvider();
+    await provider.getChildren(); // prime cache
+
+    let fired = false;
+    provider.onDidChangeTreeData(() => {
+      fired = true;
+    });
+
+    provider.refresh();
+    expect(fired).toBe(true);
+  });
+
+  it("fires onDidChangeTreeData twice during load (loading state + result)", async () => {
+    let resolveLoad!: (v: unknown) => void;
+    mockRunRockyJson.mockReturnValueOnce(
+      new Promise((res) => {
+        resolveLoad = res;
+      }),
+    );
+
+    const provider = new SchemaTreeProvider();
+    const fireCount = { n: 0 };
+    provider.onDidChangeTreeData(() => {
+      fireCount.n++;
+    });
+
+    const loadingPromise = provider.getChildren();
+
+    // Still loading — kick off but don't await yet
+    resolveLoad(makeCatalog([]));
+    await loadingPromise;
+    // Two fires: one for loading=true, one for loading=false
+    expect(fireCount.n).toBeGreaterThanOrEqual(2);
+  });
+
+  it("copy command arg produces '<modelName>.<columnName>' string", () => {
+    const col: SchemaColumnNode = new SchemaColumnNode("orders", {
+      name: "amount",
+      data_type: "FLOAT64",
+      nullable: true,
+    });
+    const ref = `${col.modelName}.${col.column.name}`;
+    expect(ref).toBe("orders.amount");
+  });
+});

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -18,6 +18,8 @@ interface SerializedState {
   clusterMode?: "none" | "schema" | "source";
   layout?: "LR" | "TB";
   searchQuery?: string;
+  focusMode?: "all" | "upstream" | "downstream" | "selected";
+  focusNode?: string | null;
 }
 
 /** Message types sent from the extension host to the webview. */
@@ -527,6 +529,23 @@ function renderLineageHtml(
     select.layout-select:hover {
       background: var(--vscode-button-secondaryHoverBackground);
     }
+    /* Focus mode select */
+    select.focus-mode-select {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+      border: 1px solid var(--vscode-button-border, transparent);
+      padding: 3px 6px;
+      font-size: 12px;
+      cursor: pointer;
+      border-radius: 2px;
+    }
+    select.focus-mode-select:hover {
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
+    select.focus-mode-select.focus-active {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
     /* Search input */
     .search-input {
       background: var(--vscode-input-background);
@@ -557,6 +576,14 @@ function renderLineageHtml(
       stroke-width: 2.5px;
       stroke: var(--vscode-focusBorder, #007fd4);
     }
+    /* Node-focus dimming (focus mode) — orthogonal to search and cluster dim */
+    .node.node-focus-dimmed rect,
+    .node.node-focus-dimmed text {
+      opacity: 0.15;
+    }
+    .edgePath.node-focus-dimmed path {
+      opacity: 0.08;
+    }
   </style>
 </head>
 <body>
@@ -567,6 +594,14 @@ function renderLineageHtml(
       <button id="mode-model" class="active" title="Model-level view (aggregated)">Model</button>
       <button id="mode-column" title="Column-level view (detailed)">Column</button>
     </div>
+    <div class="separator"></div>
+    <span class="cluster-select-label">Focus:</span>
+    <select id="focus-mode" class="focus-mode-select" title="Click a node to set focus. Upstream/Downstream dims unrelated nodes.">
+      <option value="all">All</option>
+      <option value="upstream">Upstream</option>
+      <option value="downstream">Downstream</option>
+      <option value="selected">Selected only</option>
+    </select>
     <div class="separator"></div>
     <span class="cluster-select-label">Cluster:</span>
     <select id="cluster-mode" class="cluster-select" title="Group nodes into clusters">
@@ -636,8 +671,19 @@ function renderLineageHtml(
     ? saved.clusterMode : 'none';
   let currentLayout = (saved.layout === 'TB') ? 'TB' : 'LR';
   let currentSearchQuery = (typeof saved.searchQuery === 'string') ? saved.searchQuery : '';
+  const validFocusModes = ['all', 'upstream', 'downstream', 'selected'];
+  let currentFocusMode = validFocusModes.includes(saved.focusMode) ? saved.focusMode : 'all';
+  let currentFocusNode = (typeof saved.focusNode === 'string') ? saved.focusNode : null;
   let selectedNodeModel = null; // currently selected model name (for side panel)
   let focusedClusterId = null;  // currently focused cluster (null = none)
+
+  // Adjacency maps built once per render() for BFS in focus mode
+  // nodeId → Set of upstream nodeIds (predecessors)
+  // nodeId → Set of downstream nodeIds (successors)
+  let adjUpstream = new Map();
+  let adjDownstream = new Map();
+  // All rendered node ids (non-cluster) for the current graph
+  let renderedNodeIds = new Set();
 
   let currentState = {
     modelName: focalModel,
@@ -648,6 +694,8 @@ function renderLineageHtml(
     clusterMode: currentClusterMode,
     layout: currentLayout,
     searchQuery: currentSearchQuery,
+    focusMode: currentFocusMode,
+    focusNode: currentFocusNode,
   };
 
   function persistState(patch) {
@@ -1149,6 +1197,84 @@ function renderLineageHtml(
     });
   }
 
+  // ── Focus mode (upstream / downstream / selected only) ────────────────────────
+
+  /**
+   * BFS from startId following adj (a Map of nodeId to Set of neighbors).
+   * Returns a Set of all reachable node ids (including startId).
+   */
+  function bfsReachable(startId, adj) {
+    const visited = new Set();
+    const queue = [startId];
+    while (queue.length > 0) {
+      const id = queue.shift();
+      if (visited.has(id)) continue;
+      visited.add(id);
+      const neighbors = adj.get(id);
+      if (neighbors) {
+        for (const n of neighbors) {
+          if (!visited.has(n)) queue.push(n);
+        }
+      }
+    }
+    return visited;
+  }
+
+  /**
+   * Apply node-focus dimming without re-running dagre.
+   * Uses the node-focus-dimmed class so it's orthogonal to search's dimmed
+   * and cluster's dim-mode.
+   */
+  function applyFocusMode() {
+    if (currentFocusMode === 'all' || !currentFocusNode) {
+      d3.selectAll('.node').classed('node-focus-dimmed', false);
+      d3.selectAll('.edgePath').classed('node-focus-dimmed', false);
+      return;
+    }
+
+    // Verify the focus node still exists in the rendered graph
+    if (!renderedNodeIds.has(currentFocusNode)) {
+      d3.selectAll('.node').classed('node-focus-dimmed', false);
+      d3.selectAll('.edgePath').classed('node-focus-dimmed', false);
+      return;
+    }
+
+    let keepIds;
+    if (currentFocusMode === 'selected') {
+      keepIds = new Set([currentFocusNode]);
+    } else if (currentFocusMode === 'upstream') {
+      // Upstream = nodes that can reach the focus node (follow adjUpstream from focus)
+      keepIds = bfsReachable(currentFocusNode, adjUpstream);
+      keepIds.add(currentFocusNode);
+    } else if (currentFocusMode === 'downstream') {
+      // Downstream = nodes reachable from the focus node
+      keepIds = bfsReachable(currentFocusNode, adjDownstream);
+      keepIds.add(currentFocusNode);
+    } else {
+      keepIds = new Set([currentFocusNode]);
+    }
+
+    d3.selectAll('.node').each(function() {
+      const el = d3.select(this);
+      const nodeId = el.attr('data-node-id');
+      el.classed('node-focus-dimmed', nodeId ? !keepIds.has(nodeId) : false);
+    });
+
+    d3.selectAll('.edgePath').each(function() {
+      const el = d3.select(this);
+      const src = el.attr('data-src');
+      const tgt = el.attr('data-tgt');
+      // Keep edge if at least one endpoint is in the focus set
+      el.classed('node-focus-dimmed', !keepIds.has(src) && !keepIds.has(tgt));
+    });
+  }
+
+  /** Update the focus select visual state (active highlight when not "all"). */
+  function updateFocusSelectStyle() {
+    const sel = document.getElementById('focus-mode');
+    if (sel) sel.classList.toggle('focus-active', currentFocusMode !== 'all');
+  }
+
   function render(viewMode) {
     graphGroup.selectAll('*').remove();
     focusedClusterId = null;
@@ -1253,6 +1379,27 @@ function renderLineageHtml(
       }
     }
 
+    // ── Build adjacency maps for focus-mode BFS ───────────────────────────────
+    adjUpstream = new Map();
+    adjDownstream = new Map();
+    renderedNodeIds = new Set();
+    for (const e of g.edges()) {
+      // e.v → e.w means e.v is upstream of e.w
+      if (!adjDownstream.has(e.v)) adjDownstream.set(e.v, new Set());
+      adjDownstream.get(e.v).add(e.w);
+      if (!adjUpstream.has(e.w)) adjUpstream.set(e.w, new Set());
+      adjUpstream.get(e.w).add(e.v);
+    }
+    for (const nodeId of g.nodes()) {
+      if (!g.node(nodeId).isCluster) renderedNodeIds.add(nodeId);
+    }
+
+    // If the saved focusNode is no longer in the graph, clear it
+    if (currentFocusNode && !renderedNodeIds.has(currentFocusNode)) {
+      currentFocusNode = null;
+      persistState({ focusNode: null });
+    }
+
     // Nodes
     const nodeGroup = graphGroup.append('g').attr('class', 'nodes');
     for (const nodeId of g.nodes()) {
@@ -1299,7 +1446,7 @@ function renderLineageHtml(
           .text(line);
       });
 
-      // Click: open side panel (not the file directly)
+      // Click: open side panel + update focus node if focus mode is active
       ng.on('click', (e) => {
         e.stopPropagation();
         // Update selected state
@@ -1307,6 +1454,12 @@ function renderLineageHtml(
         // Update visual selection — toggle class on all nodes
         d3.selectAll('.node').classed('selected', false);
         ng.classed('selected', true);
+        // Update focus node when focus mode is active
+        if (currentFocusMode !== 'all') {
+          currentFocusNode = nodeId;
+          persistState({ focusNode: nodeId });
+          applyFocusMode();
+        }
         // Show loading state in panel
         showPanelLoading(n.model);
         // Request details from extension host
@@ -1339,8 +1492,9 @@ function renderLineageHtml(
       }
     }
 
-    // Re-apply search filter after each render so classes are up to date
+    // Re-apply search filter and focus mode after each render
     applySearchFilter(currentSearchQuery);
+    applyFocusMode();
   }
 
   // ── Initial render ────────────────────────────────────────────────────────────
@@ -1376,11 +1530,44 @@ function renderLineageHtml(
     }, 250);
   });
 
-  // ── Background click → clear cluster focus ────────────────────────────────────
+  // Restore focus mode select to saved value
+  document.getElementById('focus-mode').value = currentFocusMode;
+  updateFocusSelectStyle();
+
+  // ── Focus mode select ─────────────────────────────────────────────────────────
+  document.getElementById('focus-mode').addEventListener('change', (e) => {
+    const newMode = e.target.value;
+    if (newMode === currentFocusMode) return;
+    currentFocusMode = newMode;
+    // Clear focus node when switching to "all"
+    if (newMode === 'all') {
+      currentFocusNode = null;
+      persistState({ focusMode: newMode, focusNode: null });
+      d3.selectAll('.node').classed('node-focus-dimmed', false);
+      d3.selectAll('.edgePath').classed('node-focus-dimmed', false);
+    } else {
+      persistState({ focusMode: newMode });
+      // Re-apply with current focus node (may be null — no dimming until click)
+      applyFocusMode();
+    }
+    updateFocusSelectStyle();
+  });
+
+  // ── Background click → clear cluster focus + node focus ──────────────────────
   svgEl.addEventListener('click', (e) => {
     // Only clear if the click target is the SVG itself, not a child element
-    if (e.target === svgEl && focusedClusterId !== null) {
+    if (e.target !== svgEl) return;
+    let changed = false;
+    if (focusedClusterId !== null) {
       clearClusterFocus();
+      changed = true;
+    }
+    if (currentFocusMode !== 'all' && currentFocusNode !== null) {
+      currentFocusNode = null;
+      persistState({ focusNode: null });
+      d3.selectAll('.node').classed('node-focus-dimmed', false);
+      d3.selectAll('.edgePath').classed('node-focus-dimmed', false);
+      changed = true;
     }
   });
 

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -17,6 +17,7 @@ interface SerializedState {
   viewMode?: "model" | "column";
   clusterMode?: "none" | "schema" | "source";
   layout?: "LR" | "TB";
+  searchQuery?: string;
 }
 
 /** Message types sent from the extension host to the webview. */
@@ -526,6 +527,36 @@ function renderLineageHtml(
     select.layout-select:hover {
       background: var(--vscode-button-secondaryHoverBackground);
     }
+    /* Search input */
+    .search-input {
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+      padding: 3px 7px;
+      font-size: 12px;
+      border-radius: 2px;
+      width: 160px;
+      outline: none;
+    }
+    .search-input:focus {
+      border-color: var(--vscode-focusBorder, #007fd4);
+    }
+    .search-input.search-error {
+      border-color: var(--vscode-errorForeground);
+    }
+    /* Dimming for search + focus mode — applied to individual nodes/edges */
+    .node.dimmed rect,
+    .node.dimmed text {
+      opacity: 0.2;
+    }
+    .edgePath.dimmed path {
+      opacity: 0.1;
+    }
+    /* Matched nodes get a bolder stroke */
+    .node.matched rect {
+      stroke-width: 2.5px;
+      stroke: var(--vscode-focusBorder, #007fd4);
+    }
   </style>
 </head>
 <body>
@@ -549,6 +580,8 @@ function renderLineageHtml(
       <option value="LR">Horizontal</option>
       <option value="TB">Vertical</option>
     </select>
+    <div class="separator"></div>
+    <input id="search-input" class="search-input" type="text" placeholder="Search nodes…" title="Filter nodes by name (case-insensitive). Use /regex/ for pattern matching." />
     <div class="separator"></div>
     <button id="zoom-out" title="Zoom out (-)">−</button>
     <button id="zoom-reset" title="Reset zoom (0)">100%</button>
@@ -602,6 +635,7 @@ function renderLineageHtml(
   let currentClusterMode = (saved.clusterMode === 'schema' || saved.clusterMode === 'source')
     ? saved.clusterMode : 'none';
   let currentLayout = (saved.layout === 'TB') ? 'TB' : 'LR';
+  let currentSearchQuery = (typeof saved.searchQuery === 'string') ? saved.searchQuery : '';
   let selectedNodeModel = null; // currently selected model name (for side panel)
   let focusedClusterId = null;  // currently focused cluster (null = none)
 
@@ -613,6 +647,7 @@ function renderLineageHtml(
     viewMode: currentViewMode,
     clusterMode: currentClusterMode,
     layout: currentLayout,
+    searchQuery: currentSearchQuery,
   };
 
   function persistState(patch) {
@@ -1045,6 +1080,75 @@ function renderLineageHtml(
     fitToView();
   }
 
+  // ── Search / filter ───────────────────────────────────────────────────────────
+
+  /**
+   * Build a matcher from the current search query string.
+   * If query is empty → match everything.
+   * If query starts and ends with '/' → attempt regex (/pattern/flags).
+   * Otherwise → case-insensitive substring.
+   * Returns { test(s): boolean, isError: boolean }.
+   */
+  function buildMatcher(query) {
+    if (!query) return { test: () => true, isError: false };
+    const regexMatch = query.match(/^\/(.*)\/([gimsuy]*)$/);
+    if (regexMatch) {
+      try {
+        const re = new RegExp(regexMatch[1], regexMatch[2] || 'i');
+        return { test: (s) => re.test(s), isError: false };
+      } catch (_) {
+        // Fallback to plain substring on regex parse error
+        return { test: (s) => s.toLowerCase().includes(query.toLowerCase()), isError: true };
+      }
+    }
+    const lower = query.toLowerCase();
+    return { test: (s) => s.toLowerCase().includes(lower), isError: false };
+  }
+
+  /**
+   * Apply search dimming without re-running dagre.
+   * Matched nodes get class 'matched'; non-matched get 'dimmed'.
+   * Edges are dimmed if both endpoints are dimmed.
+   * An empty query clears all search classes.
+   */
+  function applySearchFilter(query) {
+    const matcher = buildMatcher(query);
+    const searchInput = document.getElementById('search-input');
+    if (matcher.isError) {
+      searchInput.classList.add('search-error');
+    } else {
+      searchInput.classList.remove('search-error');
+    }
+
+    if (!query) {
+      // Clear all search classes
+      d3.selectAll('.node').classed('matched', false).classed('dimmed', false);
+      d3.selectAll('.edgePath').classed('dimmed', false);
+      return;
+    }
+
+    // Determine which node-ids match
+    const matchedIds = new Set();
+    d3.selectAll('.node').each(function() {
+      const el = d3.select(this);
+      const nodeId = el.attr('data-node-id');
+      if (!nodeId) return;
+      // In column mode, nodeId is "model·column"; in model mode it's the model name
+      const testStr = nodeId.replace('·', '.');
+      const matches = matcher.test(testStr);
+      el.classed('matched', matches).classed('dimmed', !matches);
+      if (matches) matchedIds.add(nodeId);
+    });
+
+    // Dim edges where neither endpoint matches
+    d3.selectAll('.edgePath').each(function() {
+      const el = d3.select(this);
+      const src = el.attr('data-src');
+      const tgt = el.attr('data-tgt');
+      el.classed('dimmed', !matchedIds.has(src) && !matchedIds.has(tgt));
+    });
+  }
+
   function render(viewMode) {
     graphGroup.selectAll('*').remove();
     focusedClusterId = null;
@@ -1234,6 +1338,9 @@ function renderLineageHtml(
           clusterSuffix + ' · click a node for details · drag to pan · scroll to zoom · F to fit · 0 to reset';
       }
     }
+
+    // Re-apply search filter after each render so classes are up to date
+    applySearchFilter(currentSearchQuery);
   }
 
   // ── Initial render ────────────────────────────────────────────────────────────
@@ -1250,6 +1357,24 @@ function renderLineageHtml(
 
   // Restore layout select to saved value
   document.getElementById('layout-mode').value = currentLayout;
+
+  // Restore search query to saved value
+  if (currentSearchQuery) {
+    document.getElementById('search-input').value = currentSearchQuery;
+    applySearchFilter(currentSearchQuery);
+  }
+
+  // ── Search input (debounced 250ms) ────────────────────────────────────────────
+  let searchDebounceTimer = null;
+  document.getElementById('search-input').addEventListener('input', (e) => {
+    const query = e.target.value;
+    clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      currentSearchQuery = query;
+      persistState({ searchQuery: query });
+      applySearchFilter(query);
+    }, 250);
+  });
 
   // ── Background click → clear cluster focus ────────────────────────────────────
   svgEl.addEventListener('click', (e) => {

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -16,6 +16,7 @@ interface SerializedState {
   panY?: number;
   viewMode?: "model" | "column";
   clusterMode?: "none" | "schema" | "source";
+  layout?: "LR" | "TB";
 }
 
 /** Message types sent from the extension host to the webview. */
@@ -512,6 +513,19 @@ function renderLineageHtml(
     select.cluster-select:hover {
       background: var(--vscode-button-secondaryHoverBackground);
     }
+    /* Layout select */
+    select.layout-select {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+      border: 1px solid var(--vscode-button-border, transparent);
+      padding: 3px 6px;
+      font-size: 12px;
+      cursor: pointer;
+      border-radius: 2px;
+    }
+    select.layout-select:hover {
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
   </style>
 </head>
 <body>
@@ -528,6 +542,12 @@ function renderLineageHtml(
       <option value="none">None</option>
       <option value="schema">Schema</option>
       <option value="source">Source</option>
+    </select>
+    <div class="separator"></div>
+    <span class="cluster-select-label">Layout:</span>
+    <select id="layout-mode" class="layout-select" title="Graph layout direction">
+      <option value="LR">Horizontal</option>
+      <option value="TB">Vertical</option>
     </select>
     <div class="separator"></div>
     <button id="zoom-out" title="Zoom out (-)">−</button>
@@ -581,6 +601,7 @@ function renderLineageHtml(
   let currentViewMode = (saved.viewMode === 'column') ? 'column' : 'model';
   let currentClusterMode = (saved.clusterMode === 'schema' || saved.clusterMode === 'source')
     ? saved.clusterMode : 'none';
+  let currentLayout = (saved.layout === 'TB') ? 'TB' : 'LR';
   let selectedNodeModel = null; // currently selected model name (for side panel)
   let focusedClusterId = null;  // currently focused cluster (null = none)
 
@@ -591,6 +612,7 @@ function renderLineageHtml(
     panY: saved.panY,
     viewMode: currentViewMode,
     clusterMode: currentClusterMode,
+    layout: currentLayout,
   };
 
   function persistState(patch) {
@@ -626,7 +648,7 @@ function renderLineageHtml(
     const useCompound = currentClusterMode !== 'none';
     const g = new dagre.graphlib.Graph({ multigraph: false, compound: useCompound });
     g.setGraph({
-      rankdir: 'LR',
+      rankdir: currentLayout,
       nodesep: useCompound ? 40 : 30,
       ranksep: useCompound ? 100 : 80,
       marginx: 20,
@@ -716,7 +738,7 @@ function renderLineageHtml(
     const useCompound = currentClusterMode !== 'none';
     const g = new dagre.graphlib.Graph({ multigraph: false, compound: useCompound });
     g.setGraph({
-      rankdir: 'LR',
+      rankdir: currentLayout,
       nodesep: useCompound ? 28 : 20,
       ranksep: useCompound ? 80 : 60,
       marginx: 20,
@@ -1226,6 +1248,9 @@ function renderLineageHtml(
   // Restore cluster mode select to saved value
   document.getElementById('cluster-mode').value = currentClusterMode;
 
+  // Restore layout select to saved value
+  document.getElementById('layout-mode').value = currentLayout;
+
   // ── Background click → clear cluster focus ────────────────────────────────────
   svgEl.addEventListener('click', (e) => {
     // Only clear if the click target is the SVG itself, not a child element
@@ -1258,6 +1283,16 @@ function renderLineageHtml(
     if (newMode === currentClusterMode) return;
     currentClusterMode = newMode;
     persistState({ clusterMode: newMode });
+    render(currentViewMode);
+    fitToView();
+  });
+
+  // ── Layout direction select ───────────────────────────────────────────────────
+  document.getElementById('layout-mode').addEventListener('change', (e) => {
+    const newLayout = e.target.value;
+    if (newLayout === currentLayout) return;
+    currentLayout = newLayout;
+    persistState({ layout: newLayout });
     render(currentViewMode);
     fitToView();
   });

--- a/editors/vscode/src/costCodeLens.ts
+++ b/editors/vscode/src/costCodeLens.ts
@@ -1,0 +1,200 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import type { OptimizeOutput, OptimizeRecommendation } from "./types/generated/optimize";
+import { getOutputChannel } from "./output";
+import { runRockyJson } from "./rockyCli";
+
+const COST_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CostCache {
+  data: Map<string, OptimizeRecommendation>;
+  fetchedAt: number;
+}
+
+let costCache: CostCache | undefined;
+
+/**
+ * Fetch fresh cost data from `rocky optimize --output json`, populate the
+ * cache, and return the Map. On any failure, logs to the output channel and
+ * returns the empty map — callers treat missing entries as "no lens to show".
+ */
+async function fetchCostData(): Promise<Map<string, OptimizeRecommendation>> {
+  try {
+    const output = await runRockyJson<OptimizeOutput>([
+      "optimize",
+      "--output",
+      "json",
+    ]);
+    const data = new Map<string, OptimizeRecommendation>();
+    for (const rec of output.recommendations ?? []) {
+      data.set(rec.model_name, rec);
+    }
+    costCache = { data, fetchedAt: Date.now() };
+    return data;
+  } catch (err) {
+    getOutputChannel().appendLine(
+      `[cost annotations] rocky optimize failed — no cost lenses will appear: ${(err as Error).message}`,
+    );
+    costCache = { data: new Map(), fetchedAt: Date.now() };
+    return costCache.data;
+  }
+}
+
+/**
+ * Return the cached cost data if still within TTL, otherwise return undefined
+ * (caller should trigger a refresh).
+ */
+function getCachedData(): Map<string, OptimizeRecommendation> | undefined {
+  if (!costCache) return undefined;
+  if (Date.now() - costCache.fetchedAt >= COST_CACHE_TTL_MS) return undefined;
+  return costCache.data;
+}
+
+/** Invalidate the cost cache so the next `provideCodeLenses` triggers a fetch. */
+export function invalidateCostCache(): void {
+  costCache = undefined;
+}
+
+function isCostAnnotationsEnabled(): boolean {
+  return vscode.workspace
+    .getConfiguration("rocky")
+    .get<boolean>("costAnnotations.enabled", true);
+}
+
+function formatCostLabel(rec: OptimizeRecommendation): string {
+  const compute = rec.compute_cost_per_run.toFixed(4);
+  const storage = rec.storage_cost_per_month.toFixed(2);
+  const savings = rec.estimated_monthly_savings.toFixed(2);
+  return `$(graph) ~$${compute}/run · $${storage}/mo storage · save $${savings}/mo`;
+}
+
+function formatCostDetail(rec: OptimizeRecommendation): string {
+  const lines = [
+    `Model: ${rec.model_name}`,
+    `Compute cost per run: $${rec.compute_cost_per_run.toFixed(4)}`,
+    `Storage cost per month: $${rec.storage_cost_per_month.toFixed(2)}`,
+    `Estimated monthly savings: $${rec.estimated_monthly_savings.toFixed(2)}`,
+    `Current strategy: ${rec.current_strategy}`,
+    `Recommended strategy: ${rec.recommended_strategy}`,
+    `Downstream references: ${rec.downstream_references}`,
+    `Reasoning: ${rec.reasoning}`,
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Returns true when the file sits under a `models/` directory segment.
+ * Mirrors the logic in codeLens.ts.
+ */
+function isModelFile(filePath: string): boolean {
+  const segments = filePath.split(path.sep);
+  return segments.includes("models");
+}
+
+/**
+ * Provides inline cost CodeLenses above every `.rocky` and `.sql` model file.
+ *
+ * The cache is populated on extension activation and on the `rocky.refreshCosts`
+ * command. It expires after 5 minutes; once stale, lenses disappear until the
+ * next refresh. Fetches are never triggered inside `provideCodeLenses` (which
+ * fires on every edit/scroll) — all async work is separate.
+ */
+export class CostCodeLensProvider implements vscode.CodeLensProvider {
+  private readonly emitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeCodeLenses = this.emitter.event;
+
+  /**
+   * Trigger a data fetch, then fire `onDidChangeCodeLenses` so VS Code
+   * re-evaluates every open model file. Safe to call repeatedly — the second
+   * call while a fetch is in-flight will just see the freshly-populated cache.
+   */
+  async refresh(): Promise<void> {
+    await fetchCostData();
+    this.emitter.fire();
+  }
+
+  /** Fire the change event without fetching (e.g. when the setting is toggled). */
+  fireChange(): void {
+    this.emitter.fire();
+  }
+
+  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+    if (!isCostAnnotationsEnabled()) return [];
+
+    const ext = path.extname(document.fileName);
+    if (ext !== ".rocky" && ext !== ".sql") return [];
+    if (!isModelFile(document.fileName)) return [];
+
+    const modelName = path.basename(document.fileName, ext);
+    if (!modelName) return [];
+
+    const data = getCachedData();
+    if (!data) return []; // cache miss or expired — no lenses until next refresh
+
+    const rec = data.get(modelName);
+    if (!rec) return [];
+
+    const range = new vscode.Range(0, 0, 0, 0);
+    return [
+      new vscode.CodeLens(range, {
+        title: formatCostLabel(rec),
+        command: "rocky.showCostDetail",
+        arguments: [rec],
+      }),
+    ];
+  }
+}
+
+/**
+ * Wire the provider, the `rocky.refreshCosts` command, and the configuration
+ * change listener into the extension context.
+ *
+ * On activation we fire an initial refresh in the background (no-op on
+ * failure). When `rocky.costAnnotations.enabled` changes we fire the change
+ * event to clear or restore lenses immediately.
+ */
+export function registerCostCodeLensProvider(
+  context: vscode.ExtensionContext,
+): CostCodeLensProvider {
+  const provider = new CostCodeLensProvider();
+
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      [
+        { scheme: "file", language: "rocky" },
+        { scheme: "file", language: "sql", pattern: "**/models/**/*.sql" },
+      ],
+      provider,
+    ),
+
+    vscode.commands.registerCommand("rocky.refreshCosts", () => {
+      invalidateCostCache();
+      void provider.refresh();
+    }),
+
+    vscode.commands.registerCommand(
+      "rocky.showCostDetail",
+      (rec: OptimizeRecommendation) => {
+        void vscode.window
+          .showInformationMessage(formatCostDetail(rec), "Refresh Costs")
+          .then((choice) => {
+            if (choice === "Refresh Costs") {
+              invalidateCostCache();
+              void provider.refresh();
+            }
+          });
+      },
+    ),
+
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("rocky.costAnnotations.enabled")) {
+        provider.fireChange();
+      }
+    }),
+  );
+
+  // Initial background fetch — silently no-ops if rocky optimize fails.
+  void provider.refresh();
+
+  return provider;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { registerCodeLensProvider } from "./codeLens";
 import { registerCommands } from "./commands";
+import { registerCostCodeLensProvider } from "./costCodeLens";
 import { registerDriftDiagnostics } from "./driftDiagnostics";
 import { setExtensionUri } from "./extensionState";
 import { registerFoldingProvider } from "./foldingProvider";
@@ -20,6 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
   registerTestExplorer(context);
   registerDeclarativeTestProvider(context);
   registerCodeLensProvider(context);
+  registerCostCodeLensProvider(context);
   registerFoldingProvider(context);
   registerFormattingProvider(context);
   registerRunDecorations(context);

--- a/editors/vscode/src/views/index.ts
+++ b/editors/vscode/src/views/index.ts
@@ -5,13 +5,14 @@ import { registerGetStartedView } from "./getStartedView";
 import { registerHelpView } from "./helpView";
 import { registerModelsView } from "./modelsView";
 import { registerRunsView } from "./runsView";
+import { registerSchemaView } from "./schemaView";
 import { registerSourcesView } from "./sourcesView";
 
 let infoProvider: ExtensionInfoTreeProvider | undefined;
 
 /**
- * Registers all six Rocky tree views on the activity bar:
- *   Get Started → Extension Info → Models → Runs → Sources → Help
+ * Registers all seven Rocky tree views on the activity bar:
+ *   Get Started → Extension Info → Models → Runs → Sources → Schema → Help
  *
  * The Get Started view also wires the `rocky.hasProject` context that gates
  * the welcome content of every other view.
@@ -22,6 +23,7 @@ export function registerViews(context: vscode.ExtensionContext): void {
   registerModelsView(context);
   registerRunsView(context);
   registerSourcesView(context);
+  registerSchemaView(context);
   registerHelpView(context);
 }
 

--- a/editors/vscode/src/views/schemaView.ts
+++ b/editors/vscode/src/views/schemaView.ts
@@ -1,0 +1,257 @@
+import * as vscode from "vscode";
+import { runRockyJson } from "../rockyCli";
+import { getOutputChannel } from "../output";
+import type { CatalogResult } from "../types/rockyJson";
+import type { CatalogAsset, CatalogColumn } from "../types/generated";
+import { hasRockyProject, onDidChangeRockyProject } from "./getStartedView";
+
+// Single module-scoped decoration type so that re-highlighting replaces the
+// previous highlight rather than stacking decorations.
+const columnHighlightDecoration = vscode.window.createTextEditorDecorationType(
+  {
+    backgroundColor: new vscode.ThemeColor(
+      "editor.findMatchHighlightBackground",
+    ),
+    borderRadius: "2px",
+  },
+);
+
+type Node = SchemaModelNode | SchemaColumnNode | MessageNode;
+
+/**
+ * Tree provider for the Schema sidebar view.
+ *
+ * Backs the `rocky.schema` tree view with a two-level tree:
+ *   Model (with column count) → Column (with data_type + nullability).
+ *
+ * Data is fetched from `rocky catalog --output json` on first open or manual
+ * refresh and held in memory until the next refresh. Errors are surfaced in
+ * the output channel; the empty state (no data) falls through to the
+ * `viewsWelcome` content defined in `package.json`.
+ */
+export class SchemaTreeProvider implements vscode.TreeDataProvider<Node> {
+  private readonly emitter = new vscode.EventEmitter<Node | undefined | void>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  private assets: CatalogAsset[] | undefined;
+  private loadError: string | undefined;
+  private loading = false;
+
+  refresh(): void {
+    this.assets = undefined;
+    this.loadError = undefined;
+    this.loading = false;
+    this.emitter.fire();
+  }
+
+  getTreeItem(node: Node): vscode.TreeItem {
+    return node;
+  }
+
+  async getChildren(node?: Node): Promise<Node[]> {
+    if (!node) {
+      // No project → viewsWelcome takes over.
+      if (!hasRockyProject()) return [];
+
+      if (this.loading) {
+        return [new MessageNode("Loading catalog…", "loading~spin")];
+      }
+
+      if (this.assets === undefined) {
+        await this.loadCatalog();
+      }
+
+      if (this.loadError) {
+        return [new MessageNode(`Error: ${this.loadError}`, "error")];
+      }
+
+      const assets = this.assets ?? [];
+      // Empty: fall through to viewsWelcome (with "Run rocky catalog" CTA).
+      if (assets.length === 0) return [];
+
+      return assets.map((a) => new SchemaModelNode(a));
+    }
+
+    if (node instanceof SchemaModelNode) {
+      return node.asset.columns.map(
+        (col) => new SchemaColumnNode(node.asset.model_name, col),
+      );
+    }
+
+    return [];
+  }
+
+  private async loadCatalog(): Promise<void> {
+    this.loading = true;
+    this.emitter.fire();
+    try {
+      const result = await runRockyJson<CatalogResult>([
+        "catalog",
+        "--output",
+        "json",
+      ]);
+      this.assets = result.assets ?? [];
+    } catch (err) {
+      this.assets = [];
+      this.loadError = (err as Error).message;
+      getOutputChannel().appendLine(
+        `[Schema] rocky catalog failed: ${this.loadError}`,
+      );
+    } finally {
+      this.loading = false;
+      this.emitter.fire();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree item classes
+// ---------------------------------------------------------------------------
+
+export class SchemaModelNode extends vscode.TreeItem {
+  override readonly contextValue = "rockySchemaModel";
+
+  constructor(public readonly asset: CatalogAsset) {
+    super(asset.model_name, vscode.TreeItemCollapsibleState.Collapsed);
+    const count = asset.columns.length;
+    this.description = `${count} col${count === 1 ? "" : "s"}`;
+    this.tooltip = asset.fqn;
+    this.iconPath = new vscode.ThemeIcon("database");
+  }
+}
+
+export class SchemaColumnNode extends vscode.TreeItem {
+  override readonly contextValue = "rockySchemaColumn";
+
+  constructor(
+    public readonly modelName: string,
+    public readonly column: CatalogColumn,
+  ) {
+    super(column.name, vscode.TreeItemCollapsibleState.None);
+
+    const typePart = column.data_type ?? "unknown";
+    const nullPart = column.nullable === true ? "?" : "";
+    this.description = `${typePart}${nullPart}`;
+    this.tooltip = column.data_type ?? "type unknown";
+
+    this.iconPath = new vscode.ThemeIcon("symbol-field");
+
+    // Clicking a column node reveals it in the editor.
+    this.command = {
+      title: "Reveal column in editor",
+      command: "rocky.revealColumnInEditor",
+      arguments: [modelName, column.name],
+    };
+  }
+}
+
+class MessageNode extends vscode.TreeItem {
+  override readonly contextValue = "rockySchemaMessage";
+
+  constructor(label: string, icon: string) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(icon);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Column-highlight helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Opens the model file matching the glob pattern for a given model name in the
+ * active editor and highlights every occurrence of columnName using a
+ * word-boundary regex. Clears the previous decoration before applying the new
+ * one.
+ *
+ * Silently no-ops if the file cannot be found (e.g. for source assets).
+ */
+async function revealColumnInEditor(
+  modelName: string,
+  columnName: string,
+): Promise<void> {
+  const files = await vscode.workspace.findFiles(
+    `**/models/**/${modelName}.{rocky,sql}`,
+    "**/node_modules/**",
+    1,
+  );
+
+  // Clear any previous highlight regardless of whether we find a new file.
+  for (const editor of vscode.window.visibleTextEditors) {
+    editor.setDecorations(columnHighlightDecoration, []);
+  }
+
+  if (files.length === 0) return;
+
+  const doc = await vscode.workspace.openTextDocument(files[0]);
+  const editor = await vscode.window.showTextDocument(doc);
+
+  const text = doc.getText();
+  const ranges: vscode.Range[] = [];
+  // Word-boundary match so `id` doesn't highlight inside `order_id`.
+  const pattern = new RegExp(`\\b${escapeRegExp(columnName)}\\b`, "g");
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const start = doc.positionAt(match.index);
+    const end = doc.positionAt(match.index + match[0].length);
+    ranges.push(new vscode.Range(start, end));
+  }
+
+  editor.setDecorations(columnHighlightDecoration, ranges);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSchemaView(
+  context: vscode.ExtensionContext,
+): SchemaTreeProvider {
+  const provider = new SchemaTreeProvider();
+
+  const view = vscode.window.createTreeView("rocky.schema", {
+    treeDataProvider: provider,
+  });
+  context.subscriptions.push(view);
+
+  // Refresh toolbar button.
+  context.subscriptions.push(
+    vscode.commands.registerCommand("rocky.refreshSchema", () =>
+      provider.refresh(),
+    ),
+  );
+
+  // Copy <modelName>.<columnName> to clipboard (right-click context menu).
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "rocky.copyColumnReference",
+      (node: SchemaColumnNode) => {
+        const ref = `${node.modelName}.${node.column.name}`;
+        void vscode.env.clipboard.writeText(ref).then(() => {
+          void vscode.window.showInformationMessage(
+            `Copied: ${ref}`,
+          );
+        });
+      },
+    ),
+  );
+
+  // Internal command: click column → reveal in editor.
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "rocky.revealColumnInEditor",
+      (modelName: string, columnName: string) => {
+        void revealColumnInEditor(modelName, columnName);
+      },
+    ),
+  );
+
+  // Refresh when a rocky.toml appears or disappears.
+  context.subscriptions.push(onDidChangeRockyProject(() => provider.refresh()));
+
+  return provider;
+}


### PR DESCRIPTION
## Summary

5 commits across three logical bundles. All vscode-only — no engine cascades. None of the previously-documented Tier 3 punts are unblocked here; that engine work is still its own decision.

### Bundle A — Lineage Tier 2 finish (3 commits, `~236 LOC` in `commands/lineage.ts`)

- **#15 Layout toggle (LR ↔ TB)** — `Layout: [Horizontal | Vertical]` toolbar `<select>`. Re-runs dagre + re-renders + fits on change. Persisted in `SerializedState.layout`. Cluster labels still anchor at the bbox top-left in TB mode (verified).
- **#16 Search / filter box** — debounced text input (250ms). Plain substring by default; `/regex/flags` syntax for power users (validates; on regex parse error, falls back to substring + flags the input red). Matches highlighted; non-matches `dimmed`. Edges dim only when both endpoints non-match. Persisted in `SerializedState.searchQuery`. Keyboard shortcuts (`+` / `-` / `0` / `F`) suppressed while typing in the input.
- **#14 Focus mode** — `Focus: [All | Upstream | Downstream | Selected only]`. Click-a-node sets focus; BFS reachability against pre-built adjacency maps. Orthogonal to cluster focus + search dim (separate CSS classes; can stack). Background click clears both focus types. Persisted (`focusMode` + `focusNode`) with graph-membership validation on restore.

### Bundle B — Inline cost annotations (#23, vscode-only)

CodeLens at line 1 of every `**/models/**/*.{rocky,sql}` file showing `~$X/run · $Y/mo storage · save $Z/mo`, sourced from `rocky optimize --output json` (which already exposes `compute_cost_per_run` / `storage_cost_per_month` / `estimated_monthly_savings` per recommendation).

- Module-level cost cache with 5-minute TTL.
- Manual `rocky.refreshCosts` command + `rocky.showCostDetail` (info message with the full breakdown + a "Refresh Costs" action button).
- Setting `rocky.costAnnotations.enabled` (default `true`) — toggle clears immediately.
- Silent no-op if `rocky optimize` fails (no warehouse, no auth) — error logged to the output channel; lenses just don't appear.
- 9 new vitest cases.

### Bundle C — Schema sidebar view (#24, vscode-only)

New `Schema` tree view in the Rocky activity bar, sourced from `rocky catalog --output json` (`CatalogAsset.columns[].data_type` already exists).

- Two-level tree: `SchemaModelNode` → `SchemaColumnNode` (label = name; description = `<data_type><?` for nullable).
- Click a column → opens the model file and applies a subtle word-boundary highlight to matching column references.
- Right-click → "Copy column reference" writes `<model>.<col>` to the clipboard.
- View title refresh button. Empty state via `viewsWelcome` gated on `rocky.hasProject`.
- `rocky.refreshSchema` + `rocky.copyColumnReference` commands.
- 8 new vitest cases.

## Test plan

- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 58/58 (was 40 — 9 cost + 8 schema + 1 ancillary)
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual extension-host smoke: lineage Layout toggle / search box / focus mode all behave; cost CodeLenses appear on a workspace where `rocky optimize` succeeds; Schema view populates from `rocky catalog`; click-to-highlight + copy-reference work
- [ ] Verify silent-no-op behavior when `rocky optimize` fails (e.g. no warehouse configured)

## Notes

- **Base commit:** branched off `origin/main` (`e563c9fb`) — does NOT depend on the in-flight #518 release PR (`1.16.0` version bump). When #518 lands, this PR's base will advance; merge order doesn't matter.
- **Eligible for the next vscode minor cut** (`1.17.0`) along with anything else that lands in this window.