### PR TITLE
feat(vscode): @rocky chat participant + Previews sidebar + branded file icons

### DIFF
--- a/editors/vscode/fileicons/rocky-icon-theme.json
+++ b/editors/vscode/fileicons/rocky-icon-theme.json
@@ -1,0 +1,13 @@
+{
+  "iconDefinitions": {
+    "_rocky_file": {
+      "iconPath": "../icons/rocky-icon.svg"
+    }
+  },
+  "fileExtensions": {
+    "rocky": "_rocky_file"
+  },
+  "fileNames": {
+    "rocky.toml": "_rocky_file"
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -373,6 +373,18 @@
         "command": "rocky.showCostDetail",
         "title": "Show Cost Detail",
         "category": "Rocky"
+      },
+      {
+        "command": "rocky.refreshPreviews",
+        "title": "Refresh Previews",
+        "category": "Rocky",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "rocky.removePreview",
+        "title": "Remove Preview",
+        "category": "Rocky",
+        "icon": "$(trash)"
       }
     ],
     "semanticTokenScopes": [
@@ -483,6 +495,13 @@
           "visibility": "collapsed"
         },
         {
+          "id": "rocky.previews",
+          "name": "Previews",
+          "icon": "$(git-pull-request)",
+          "contextualTitle": "Rocky Previews",
+          "visibility": "collapsed"
+        },
+        {
           "id": "rocky.help",
           "name": "Help",
           "type": "tree",
@@ -547,6 +566,16 @@
         "view": "rocky.schema",
         "contents": "No catalog data yet. Run the catalog command to populate the schema view.\n\n[Run rocky catalog](command:rocky.refreshSchema)",
         "when": "rocky.hasProject"
+      },
+      {
+        "view": "rocky.previews",
+        "contents": "Open a Rocky project to manage preview branches.",
+        "when": "!rocky.hasProject"
+      },
+      {
+        "view": "rocky.previews",
+        "contents": "No active previews. Create a preview branch to compare your changes against base.\n\n[Create Preview](command:rocky.previewCreate)",
+        "when": "rocky.hasProject"
       }
     ],
     "menus": {
@@ -574,6 +603,11 @@
         {
           "command": "rocky.refreshSchema",
           "when": "view == rocky.schema",
+          "group": "navigation"
+        },
+        {
+          "command": "rocky.refreshPreviews",
+          "when": "view == rocky.previews",
           "group": "navigation"
         }
       ],
@@ -611,6 +645,11 @@
         {
           "command": "rocky.copyColumnReference",
           "when": "view == rocky.schema && viewItem == rockySchemaColumn",
+          "group": "inline@1"
+        },
+        {
+          "command": "rocky.removePreview",
+          "when": "view == rocky.previews && viewItem == rockyPreviewBranch",
           "group": "inline@1"
         }
       ],

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -671,6 +671,33 @@
         }
       ]
     },
+    "chatParticipants": [
+      {
+        "id": "rocky-data.rocky",
+        "name": "rocky",
+        "fullName": "Rocky",
+        "description": "Generate, explain, test, and sync Rocky pipelines",
+        "isSticky": true,
+        "commands": [
+          {
+            "name": "generate",
+            "description": "Generate a Rocky model from a description"
+          },
+          {
+            "name": "explain",
+            "description": "Explain the active Rocky model"
+          },
+          {
+            "name": "sync",
+            "description": "Discover and sync sources"
+          },
+          {
+            "name": "test",
+            "description": "Generate quality tests for a model"
+          }
+        ]
+      }
+    ],
     "keybindings": [
       {
         "command": "rocky.commandPalette",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -33,6 +33,13 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "iconThemes": [
+      {
+        "id": "rocky-icons",
+        "label": "Rocky File Icons",
+        "path": "./fileicons/rocky-icon-theme.json"
+      }
+    ],
     "languages": [
       {
         "id": "rocky",

--- a/editors/vscode/src/__tests__/chatParticipant.test.ts
+++ b/editors/vscode/src/__tests__/chatParticipant.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// vscode mock — must precede all imports that touch vscode
+// ---------------------------------------------------------------------------
+
+vi.mock("vscode", () => {
+  class Uri {
+    static joinPath(base: Uri, ...parts: string[]): Uri {
+      return new Uri(base.fsPath + "/" + parts.join("/"));
+    }
+    constructor(public fsPath: string) {}
+    toString(): string {
+      return this.fsPath;
+    }
+  }
+
+  const LanguageModelChatMessage = {
+    User: (content: string) => ({ role: "user", content }),
+  };
+
+  return {
+    Uri,
+    LanguageModelChatMessage,
+    chat: {
+      createChatParticipant: vi.fn(() => ({
+        iconPath: undefined as unknown,
+        followupProvider: undefined as unknown,
+        dispose: vi.fn(),
+      })),
+    },
+    lm: {
+      selectChatModels: vi.fn(async () => []),
+    },
+    window: {
+      activeTextEditor: undefined as
+        | { document: { fileName: string } }
+        | undefined,
+      showTextDocument: vi.fn(async () => undefined),
+    },
+    workspace: {
+      openTextDocument: vi.fn(async (opts: { content: string }) => ({
+        content: opts.content,
+      })),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// AI command mocks — intercept runRockyWithProgress calls
+// ---------------------------------------------------------------------------
+
+vi.mock("../rockyCli", () => ({
+  runRockyWithProgress: vi.fn(async () => ({ stdout: "", stderr: "" })),
+  showRockyError: vi.fn(),
+}));
+
+// Imports must follow vi.mock.
+import * as vscode from "vscode";
+import * as rockyCli from "../rockyCli";
+import { registerChatParticipant } from "../chatParticipant";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type HandlerFn = (
+  request: {
+    command: string | undefined;
+    prompt: string;
+  },
+  context: object,
+  stream: {
+    markdown: ReturnType<typeof vi.fn>;
+  },
+  token: object,
+) => Promise<{ metadata: { lastCommand: string | undefined } }>;
+
+const runWithProgress = rockyCli.runRockyWithProgress as ReturnType<
+  typeof vi.fn
+>;
+
+function makeStream(): { markdown: ReturnType<typeof vi.fn> } {
+  return { markdown: vi.fn() };
+}
+
+function makeContext(): vscode.ExtensionContext {
+  return {
+    extensionUri: new vscode.Uri("/ext"),
+    subscriptions: [],
+  } as unknown as vscode.ExtensionContext;
+}
+
+function captureHandler(): HandlerFn {
+  const createMock = vscode.chat.createChatParticipant as ReturnType<
+    typeof vi.fn
+  >;
+  const call = createMock.mock.calls[0];
+  return call[1] as HandlerFn;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("registerChatParticipant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("creates a participant with id rocky-data.rocky", () => {
+    registerChatParticipant(makeContext());
+    expect(vscode.chat.createChatParticipant).toHaveBeenCalledWith(
+      "rocky-data.rocky",
+      expect.any(Function),
+    );
+  });
+
+  it("sets iconPath and followupProvider on the participant", () => {
+    const mockParticipant = {
+      iconPath: undefined as unknown,
+      followupProvider: undefined as unknown,
+      dispose: vi.fn(),
+    };
+    (vscode.chat.createChatParticipant as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      mockParticipant,
+    );
+    registerChatParticipant(makeContext());
+    expect(mockParticipant.iconPath).toBeDefined();
+    expect(mockParticipant.followupProvider).toBeDefined();
+  });
+
+  it("pushes the participant to context.subscriptions", () => {
+    const ctx = makeContext();
+    registerChatParticipant(ctx);
+    expect(ctx.subscriptions).toHaveLength(1);
+  });
+});
+
+describe("@rocky /generate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("invokes rocky ai with the prompt as intent", async () => {
+    runWithProgress.mockResolvedValueOnce({
+      stdout: "model Foo {}",
+      stderr: "",
+    });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: "generate", prompt: "monthly revenue per customer" },
+      {},
+      stream,
+      {},
+    );
+    expect(runWithProgress).toHaveBeenCalledTimes(1);
+    const [, args] = runWithProgress.mock.calls[0] as [
+      string,
+      string[],
+      ...unknown[]
+    ];
+    expect(args[0]).toBe("ai");
+    expect(args[1]).toBe("monthly revenue per customer");
+    expect(args).toContain("--format");
+    expect(args).toContain("rocky");
+  });
+
+  it("streams the generated source as a fenced code block", async () => {
+    runWithProgress.mockResolvedValueOnce({
+      stdout: "model Foo { select * from bar }",
+      stderr: "",
+    });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: "generate", prompt: "fct_revenue" },
+      {},
+      stream,
+      {},
+    );
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    expect(calls.some((c) => c.includes("```rocky"))).toBe(true);
+    expect(calls.some((c) => c.includes("model Foo { select * from bar }"))).toBe(true);
+  });
+
+  it("returns lastCommand=generate in metadata", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "model X {}", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const result = await handler(
+      { command: "generate", prompt: "something" },
+      {},
+      makeStream(),
+      {},
+    );
+    expect(result.metadata.lastCommand).toBe("generate");
+  });
+
+  it("shows an error message when generate fails", async () => {
+    runWithProgress.mockRejectedValueOnce(new Error("CLI not found"));
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: "generate", prompt: "something" },
+      {},
+      stream,
+      {},
+    );
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    expect(calls.some((c) => c.includes("Error generating model"))).toBe(true);
+  });
+
+  it("emits help when prompt is empty", async () => {
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler({ command: "generate", prompt: "" }, {}, stream, {});
+    expect(runWithProgress).not.toHaveBeenCalled();
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    expect(calls.some((c) => c.includes("/generate"))).toBe(true);
+  });
+});
+
+describe("@rocky /explain", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("invokes rocky ai-explain without a model name when no editor is active", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    await handler({ command: "explain", prompt: "" }, {}, makeStream(), {});
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args[0]).toBe("ai-explain");
+    expect(args).toContain("--all");
+    expect(args).not.toContain("fct_revenue");
+  });
+
+  it("scopes to the active model when an editor is open", async () => {
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor = {
+      document: { fileName: "/workspace/models/fct_revenue.rocky" },
+    };
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    await handler({ command: "explain", prompt: "" }, {}, makeStream(), {});
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args).toContain("fct_revenue");
+    expect(args).not.toContain("--all");
+  });
+
+  it("returns lastCommand=explain in metadata", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const result = await handler(
+      { command: "explain", prompt: "" },
+      {},
+      makeStream(),
+      {},
+    );
+    expect(result.metadata.lastCommand).toBe("explain");
+  });
+});
+
+describe("@rocky /sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("invokes rocky ai-sync against all models", async () => {
+    runWithProgress.mockResolvedValueOnce({
+      stdout: "1 model updated",
+      stderr: "",
+    });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler({ command: "sync", prompt: "" }, {}, stream, {});
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args[0]).toBe("ai-sync");
+    expect(args).toContain("models");
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    expect(calls.some((c) => c.includes("1 model updated"))).toBe(true);
+  });
+
+  it("returns lastCommand=sync in metadata", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const result = await handler(
+      { command: "sync", prompt: "" },
+      {},
+      makeStream(),
+      {},
+    );
+    expect(result.metadata.lastCommand).toBe("sync");
+  });
+});
+
+describe("@rocky /test", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("uses explicit arg as the model name", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    await handler(
+      { command: "test", prompt: "fct_daily_revenue" },
+      {},
+      makeStream(),
+      {},
+    );
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args[0]).toBe("ai-test");
+    expect(args).toContain("fct_daily_revenue");
+  });
+
+  it("falls back to active editor when no arg is given", async () => {
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor = {
+      document: { fileName: "/workspace/models/dim_customers.sql" },
+    };
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    await handler({ command: "test", prompt: "" }, {}, makeStream(), {});
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args).toContain("dim_customers");
+  });
+
+  it("runs against all models when no arg and no active editor", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    await handler({ command: "test", prompt: "" }, {}, makeStream(), {});
+    const [, args] = runWithProgress.mock.calls[0] as [string, string[], ...unknown[]];
+    expect(args[0]).toBe("ai-test");
+    expect(args).toContain("--all");
+  });
+
+  it("returns lastCommand=test in metadata", async () => {
+    runWithProgress.mockResolvedValueOnce({ stdout: "", stderr: "" });
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const result = await handler(
+      { command: "test", prompt: "" },
+      {},
+      makeStream(),
+      {},
+    );
+    expect(result.metadata.lastCommand).toBe("test");
+  });
+});
+
+describe("@rocky natural-language fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  it("emits the help command listing when no LLM model is available", async () => {
+    (vscode.lm.selectChatModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: undefined, prompt: "what can you do?" },
+      {},
+      stream,
+      {},
+    );
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    const combined = calls.join("");
+    expect(combined).toContain("/generate");
+    expect(combined).toContain("/explain");
+    expect(combined).toContain("/sync");
+    expect(combined).toContain("/test");
+  });
+
+  it("calls the LLM when a copilot model is available", async () => {
+    const sendRequest = vi.fn(async () => ({
+      text: (async function* () {
+        yield "Here is some advice.";
+      })(),
+    }));
+    (vscode.lm.selectChatModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { sendRequest },
+    ]);
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: undefined, prompt: "how do I create a model?" },
+      {},
+      stream,
+      {},
+    );
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    expect(calls.some((c) => c.includes("Here is some advice."))).toBe(true);
+  });
+
+  it("falls back to help listing when LLM throws", async () => {
+    const sendRequest = vi.fn().mockRejectedValueOnce(new Error("no quota"));
+    (vscode.lm.selectChatModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { sendRequest },
+    ]);
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const stream = makeStream();
+    await handler(
+      { command: undefined, prompt: "help me" },
+      {},
+      stream,
+      {},
+    );
+    const calls: string[] = stream.markdown.mock.calls.map(
+      (c: [string]) => c[0],
+    );
+    const combined = calls.join("");
+    expect(combined).toContain("/generate");
+  });
+
+  it("returns lastCommand=undefined in metadata for NL requests", async () => {
+    (vscode.lm.selectChatModels as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    registerChatParticipant(makeContext());
+    const handler = captureHandler();
+    const result = await handler(
+      { command: undefined, prompt: "what is rocky?" },
+      {},
+      makeStream(),
+      {},
+    );
+    expect(result.metadata.lastCommand).toBeUndefined();
+  });
+});
+
+describe("followup provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.window as { activeTextEditor: unknown }).activeTextEditor =
+      undefined;
+  });
+
+  function getFollowupProvider(): {
+    provideFollowups: (result: { metadata: { lastCommand: string | undefined } }, ctx: object, token: object) => vscode.ChatFollowup[];
+  } {
+    const mockParticipant = {
+      iconPath: undefined as unknown,
+      followupProvider: undefined as unknown,
+      dispose: vi.fn(),
+    };
+    (vscode.chat.createChatParticipant as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      mockParticipant,
+    );
+    registerChatParticipant(makeContext());
+    return mockParticipant.followupProvider as {
+      provideFollowups: (result: { metadata: { lastCommand: string | undefined } }, ctx: object, token: object) => vscode.ChatFollowup[];
+    };
+  }
+
+  it("suggests /test and /explain after /generate", () => {
+    const provider = getFollowupProvider();
+    const followups = provider.provideFollowups(
+      { metadata: { lastCommand: "generate" } },
+      {},
+      {},
+    );
+    const prompts = followups.map((f) => f.prompt);
+    expect(prompts).toContain("/test");
+    expect(prompts).toContain("/explain");
+    // No 'command' field — VS Code would otherwise produce "@rocky /test /test"
+    for (const f of followups) {
+      expect((f as { command?: string }).command).toBeUndefined();
+    }
+  });
+
+  it("suggests /test after /explain", () => {
+    const provider = getFollowupProvider();
+    const followups = provider.provideFollowups(
+      { metadata: { lastCommand: "explain" } },
+      {},
+      {},
+    );
+    expect(followups.some((f) => f.prompt === "/test")).toBe(true);
+    for (const f of followups) {
+      expect((f as { command?: string }).command).toBeUndefined();
+    }
+  });
+
+  it("suggests /explain after /sync", () => {
+    const provider = getFollowupProvider();
+    const followups = provider.provideFollowups(
+      { metadata: { lastCommand: "sync" } },
+      {},
+      {},
+    );
+    expect(followups.some((f) => f.prompt === "/explain")).toBe(true);
+    for (const f of followups) {
+      expect((f as { command?: string }).command).toBeUndefined();
+    }
+  });
+
+  it("returns empty array for /test (no natural next step)", () => {
+    const provider = getFollowupProvider();
+    const followups = provider.provideFollowups(
+      { metadata: { lastCommand: "test" } },
+      {},
+      {},
+    );
+    expect(followups).toHaveLength(0);
+  });
+
+  it("returns empty array when lastCommand is undefined", () => {
+    const provider = getFollowupProvider();
+    const followups = provider.provideFollowups(
+      { metadata: { lastCommand: undefined } },
+      {},
+      {},
+    );
+    expect(followups).toHaveLength(0);
+  });
+});

--- a/editors/vscode/src/__tests__/previewView.test.ts
+++ b/editors/vscode/src/__tests__/previewView.test.ts
@@ -1,0 +1,525 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// vscode mock
+// ---------------------------------------------------------------------------
+vi.mock("vscode", () => {
+  class TreeItem {
+    public label: string;
+    public collapsibleState: number;
+    public iconPath: unknown;
+    public tooltip: string | undefined;
+    public command: unknown;
+    public description: string | undefined;
+    public contextValue: string | undefined;
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  }
+
+  class ThemeIcon {
+    constructor(public id: string, public color?: unknown) {}
+  }
+
+  class ThemeColor {
+    constructor(public id: string) {}
+  }
+
+  class EventEmitter<T> {
+    private listeners: ((value: T) => void)[] = [];
+    event = (listener: (value: T) => void): { dispose(): void } => {
+      this.listeners.push(listener);
+      return { dispose: (): void => undefined };
+    };
+    fire(value: T): void {
+      for (const l of this.listeners) l(value);
+    }
+  }
+
+  class Position {
+    constructor(public line: number, public character: number) {}
+  }
+
+  return {
+    TreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon,
+    ThemeColor,
+    EventEmitter,
+    Position,
+    Uri: {
+      parse: (s: string) => ({ toString: () => s }),
+      file: (p: string) => ({ fsPath: p, toString: () => p }),
+    },
+    workspace: {
+      findFiles: vi.fn(async () => []),
+      workspaceFolders: undefined,
+      asRelativePath: (uri: { fsPath: string }) => uri.fsPath,
+      getConfiguration: () => ({
+        get: <T,>(_key: string, fallback: T): T => fallback,
+      }),
+      onDidChangeConfiguration: () => ({ dispose: () => undefined }),
+      onDidChangeWorkspaceFolders: () => ({ dispose: () => undefined }),
+      openTextDocument: vi.fn(async () => ({
+        getText: () => "",
+      })),
+    },
+    commands: {
+      registerCommand: () => ({ dispose: () => undefined }),
+    },
+    window: {
+      createTreeView: () => ({ dispose: () => undefined }),
+      createTextEditorDecorationType: () => ({ dispose: () => undefined }),
+      visibleTextEditors: [],
+      showInformationMessage: vi.fn(async () => undefined),
+      showTextDocument: vi.fn(async () => ({
+        edit: vi.fn(async (cb: (e: { insert: () => void }) => void) => {
+          cb({ insert: () => undefined });
+          return true;
+        }),
+      })),
+    },
+    env: {
+      clipboard: { writeText: vi.fn(async () => undefined) },
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let hasProject = true;
+const projectChangeListeners: ((v: boolean) => void)[] = [];
+
+vi.mock("../views/getStartedView", () => ({
+  hasRockyProject: () => hasProject,
+  onDidChangeRockyProject: (cb: (v: boolean) => void) => {
+    projectChangeListeners.push(cb);
+    return { dispose: () => undefined };
+  },
+}));
+
+const mockRunRockyJson = vi.fn<() => Promise<unknown>>();
+vi.mock("../rockyCli", () => ({
+  runRockyJson: (...args: unknown[]) => mockRunRockyJson(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import type { PreviewCostOutput, PreviewDiffOutput } from "../types/generated";
+import {
+  PreviewStateManager,
+  PreviewTreeProvider,
+  PreviewBranchNode,
+  PreviewCategoryNode,
+  PreviewCostModelNode,
+  PreviewDiffModelNode,
+  type ActivePreview,
+} from "../views/previewView";
+
+/** A minimal Memento backed by a plain object (mirrors vscode.Memento shape). */
+function makeMemento(): {
+  store: Record<string, unknown>;
+  get<T>(key: string, defaultValue: T): T;
+  update(key: string, value: unknown): Promise<void>;
+} {
+  const store: Record<string, unknown> = {};
+  return {
+    store,
+    get<T>(key: string, defaultValue: T): T {
+      return (store[key] as T) ?? defaultValue;
+    },
+    async update(key: string, value: unknown): Promise<void> {
+      store[key] = value;
+    },
+  };
+}
+
+function makeCostOutput(branchName: string): PreviewCostOutput {
+  return {
+    branch_name: branchName,
+    branch_run_id: "run-1",
+    command: "preview cost",
+    markdown: "",
+    per_model: [
+      {
+        model_name: "orders",
+        base_duration_ms: 100,
+        branch_duration_ms: 120,
+        delta_usd: 0.002,
+        skipped_via_copy: false,
+      },
+    ],
+    summary: {
+      delta_usd: 0.002,
+      models_skipped_via_copy: 0,
+      total_branch_duration_ms: 120,
+    },
+    version: "1.0.0",
+  };
+}
+
+function makeDiffOutput(branchName: string): PreviewDiffOutput {
+  return {
+    base_ref: "main",
+    branch_name: branchName,
+    command: "preview diff",
+    markdown: "# Diff\nsome changes",
+    models: [
+      {
+        model_name: "orders",
+        structural: {
+          added_columns: ["new_col"],
+          removed_columns: [],
+          type_changes: [],
+        },
+        algorithm: {
+          kind: "sampled",
+          sampled: {
+            rows_added: 5,
+            rows_changed: 2,
+            rows_removed: 0,
+            samples: [],
+          },
+          sampling_window: {
+            coverage: "first_n_by_order",
+            coverage_warning: false,
+            limit: 1000,
+            ordered_by: "id",
+          },
+        },
+      },
+    ],
+    summary: {
+      any_coverage_warning: false,
+      models_with_changes: 1,
+      models_unchanged: 0,
+      total_rows_added: 5,
+      total_rows_changed: 2,
+      total_rows_removed: 0,
+    },
+    version: "1.0.0",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PreviewStateManager tests
+// ---------------------------------------------------------------------------
+
+describe("PreviewStateManager", () => {
+  it("getAll returns [] when empty", () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    expect(mgr.getAll()).toEqual([]);
+  });
+
+  it("add stores a preview and getAll returns it", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    const preview: ActivePreview = {
+      branchName: "preview-fix-price",
+      createdAt: "2026-05-14T00:00:00Z",
+    };
+    await mgr.add(preview);
+    expect(mgr.getAll()).toHaveLength(1);
+    expect(mgr.getAll()[0].branchName).toBe("preview-fix-price");
+  });
+
+  it("add overwrites an existing entry with the same branchName", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "br", createdAt: "t1" });
+    await mgr.add({ branchName: "br", createdAt: "t2" });
+    const all = mgr.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].createdAt).toBe("t2");
+  });
+
+  it("remove deletes the matching entry", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "a", createdAt: "t" });
+    await mgr.add({ branchName: "b", createdAt: "t" });
+    await mgr.remove("a");
+    const all = mgr.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].branchName).toBe("b");
+  });
+
+  it("updateBranch merges patch fields", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "br", createdAt: "t" });
+    await mgr.updateBranch("br", {
+      lastCostSummary: { delta_usd: 0.5, models_changed: 3 },
+    });
+    const updated = mgr.getAll()[0];
+    expect(updated.lastCostSummary?.delta_usd).toBe(0.5);
+    expect(updated.createdAt).toBe("t");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreviewTreeProvider tests
+// ---------------------------------------------------------------------------
+
+describe("PreviewTreeProvider", () => {
+  beforeEach(() => {
+    hasProject = true;
+    mockRunRockyJson.mockReset();
+    projectChangeListeners.length = 0;
+  });
+
+  it("returns [] when no Rocky project is detected", async () => {
+    hasProject = false;
+    const mgr = new PreviewStateManager(makeMemento());
+    const provider = new PreviewTreeProvider(mgr);
+    expect(await provider.getChildren()).toEqual([]);
+  });
+
+  it("returns [] when no previews are tracked (triggers viewsWelcome)", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    const provider = new PreviewTreeProvider(mgr);
+    expect(await provider.getChildren()).toEqual([]);
+  });
+
+  it("returns one PreviewBranchNode per tracked preview", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "preview-a", createdAt: "t" });
+    await mgr.add({ branchName: "preview-b", createdAt: "t" });
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    expect(roots).toHaveLength(2);
+    expect(roots[0]).toBeInstanceOf(PreviewBranchNode);
+    expect(roots[0].label).toBe("preview-a");
+  });
+
+  it("PreviewBranchNode description shows cost + model count when data present", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({
+      branchName: "pr",
+      createdAt: "t",
+      lastCostSummary: { delta_usd: 0.0042, models_changed: 1 },
+      lastDiffSummary: {
+        models_with_changes: 1,
+        models_unchanged: 0,
+        total_rows_added: 5,
+        total_rows_removed: 0,
+        total_rows_changed: 2,
+        any_coverage_warning: false,
+      },
+    });
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    const node = roots[0] as PreviewBranchNode;
+    expect(node.description).toContain("Δ$");
+    expect(node.description).toContain("1 model");
+  });
+
+  it("branch node children are Cost / Diff / Models Changed categories", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "pr", createdAt: "t" });
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    const branchNode = roots[0] as PreviewBranchNode;
+    const children = await provider.getChildren(branchNode);
+    expect(children).toHaveLength(3);
+    expect(children[0]).toBeInstanceOf(PreviewCategoryNode);
+    expect(children[0].label).toBe("Cost");
+    expect(children[1].label).toBe("Diff");
+    expect(children[2].label).toBe("Models Changed");
+  });
+
+  it("Cost category children are PreviewCostModelNode instances", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({
+      branchName: "pr",
+      createdAt: "t",
+      perModelCost: [
+        {
+          model_name: "orders",
+          base_duration_ms: 100,
+          branch_duration_ms: 120,
+          delta_usd: 0.002,
+          skipped_via_copy: false,
+        },
+      ],
+    });
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    const branchNode = roots[0] as PreviewBranchNode;
+    const cats = await provider.getChildren(branchNode);
+    const costCat = cats[0] as PreviewCategoryNode;
+    const costChildren = await provider.getChildren(costCat);
+    expect(costChildren).toHaveLength(1);
+    expect(costChildren[0]).toBeInstanceOf(PreviewCostModelNode);
+    expect(costChildren[0].label).toBe("orders");
+  });
+
+  it("Diff category children are PreviewDiffModelNode instances", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({
+      branchName: "pr",
+      createdAt: "t",
+      perModelDiff: [
+        {
+          model_name: "orders",
+          structural: {
+            added_columns: ["x"],
+            removed_columns: [],
+            type_changes: [],
+          },
+          algorithm: {
+            kind: "sampled",
+            sampled: {
+              rows_added: 1,
+              rows_changed: 0,
+              rows_removed: 0,
+              samples: [],
+            },
+            sampling_window: {
+              coverage: "first_n_by_order",
+              coverage_warning: false,
+              limit: 1000,
+              ordered_by: "id",
+            },
+          },
+        },
+      ],
+    });
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    const branchNode = roots[0] as PreviewBranchNode;
+    const cats = await provider.getChildren(branchNode);
+    const diffCat = cats[1] as PreviewCategoryNode;
+    const diffChildren = await provider.getChildren(diffCat);
+    expect(diffChildren).toHaveLength(1);
+    expect(diffChildren[0]).toBeInstanceOf(PreviewDiffModelNode);
+    expect(diffChildren[0].label).toBe("orders");
+    // "added" heuristic: added_columns present, nothing removed/type-changed
+    expect((diffChildren[0] as PreviewDiffModelNode).diffStatus).toBe("added");
+  });
+
+  it("refresh fires onDidChangeTreeData", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    const provider = new PreviewTreeProvider(mgr);
+    let fired = false;
+    provider.onDidChangeTreeData(() => { fired = true; });
+    provider.refresh();
+    expect(fired).toBe(true);
+  });
+
+  it("fetchAllBranches calls runRockyJson for cost and diff per branch", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "pr", createdAt: "t" });
+    const provider = new PreviewTreeProvider(mgr);
+
+    mockRunRockyJson
+      .mockResolvedValueOnce(makeCostOutput("pr"))
+      .mockResolvedValueOnce(makeDiffOutput("pr"));
+
+    await provider.fetchAllBranches();
+
+    // 2 calls: cost + diff
+    expect(mockRunRockyJson).toHaveBeenCalledTimes(2);
+    const updated = mgr.getAll()[0];
+    expect(updated.lastCostSummary?.delta_usd).toBe(0.002);
+    expect(updated.lastDiffSummary?.models_with_changes).toBe(1);
+    expect(updated.perModelCost).toHaveLength(1);
+    expect(updated.perModelDiff).toHaveLength(1);
+  });
+
+  it("fetchAllBranches handles a failure on one branch gracefully", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "pr", createdAt: "t" });
+    const provider = new PreviewTreeProvider(mgr);
+
+    mockRunRockyJson.mockRejectedValue(new Error("CLI error"));
+
+    // Should not throw
+    await expect(provider.fetchAllBranches()).resolves.toBeUndefined();
+  });
+
+  it("remove command updates state and refreshes provider", async () => {
+    const mgr = new PreviewStateManager(makeMemento());
+    await mgr.add({ branchName: "pr", createdAt: "t" });
+    const provider = new PreviewTreeProvider(mgr);
+
+    let fired = false;
+    provider.onDidChangeTreeData(() => { fired = true; });
+
+    await mgr.remove("pr");
+    provider.refresh();
+
+    expect(fired).toBe(true);
+    const roots = await provider.getChildren();
+    expect(roots).toHaveLength(0);
+  });
+
+  it("empty state shows [] even with project (viewsWelcome takes over)", async () => {
+    hasProject = true;
+    const mgr = new PreviewStateManager(makeMemento());
+    const provider = new PreviewTreeProvider(mgr);
+    const roots = await provider.getChildren();
+    expect(roots).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreviewDiffModelNode status heuristic tests
+// ---------------------------------------------------------------------------
+
+describe("PreviewDiffModelNode diffStatus heuristic", () => {
+  function makeModel(
+    added: string[],
+    removed: string[],
+    typeChanges: { name: string; from: string; to: string }[],
+  ): import("../types/generated").PreviewModelDiff {
+    return {
+      model_name: "test",
+      structural: {
+        added_columns: added,
+        removed_columns: removed,
+        type_changes: typeChanges,
+      },
+      algorithm: {
+        kind: "sampled",
+        sampled: { rows_added: 0, rows_changed: 0, rows_removed: 0, samples: [] },
+        sampling_window: {
+          coverage: "first_n_by_order",
+          coverage_warning: false,
+          limit: 100,
+          ordered_by: "id",
+        },
+      },
+    };
+  }
+
+  it("pure added columns → diffStatus = added", () => {
+    const node = new PreviewDiffModelNode("br", makeModel(["x"], [], []), "");
+    expect(node.diffStatus).toBe("added");
+  });
+
+  it("pure removed columns → diffStatus = removed", () => {
+    const node = new PreviewDiffModelNode("br", makeModel([], ["x"], []), "");
+    expect(node.diffStatus).toBe("removed");
+  });
+
+  it("type change only → diffStatus = modified", () => {
+    const node = new PreviewDiffModelNode(
+      "br",
+      makeModel([], [], [{ name: "col", from: "INT", to: "BIGINT" }]),
+      "",
+    );
+    expect(node.diffStatus).toBe("modified");
+  });
+
+  it("mixed add + remove → diffStatus = modified", () => {
+    const node = new PreviewDiffModelNode("br", makeModel(["a"], ["b"], []), "");
+    expect(node.diffStatus).toBe("modified");
+  });
+
+  it("no structural changes → diffStatus = unchanged", () => {
+    const node = new PreviewDiffModelNode("br", makeModel([], [], []), "");
+    expect(node.diffStatus).toBe("unchanged");
+  });
+});

--- a/editors/vscode/src/chatParticipant.ts
+++ b/editors/vscode/src/chatParticipant.ts
@@ -1,0 +1,293 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { runAiExplain, runAiGenerate, runAiSync, runAiTest } from "./commands/ai";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SlashCommand = "generate" | "explain" | "sync" | "test";
+
+// ---------------------------------------------------------------------------
+// Chat handler
+// ---------------------------------------------------------------------------
+
+async function handler(
+  request: vscode.ChatRequest,
+  _context: vscode.ChatContext,
+  stream: vscode.ChatResponseStream,
+  _token: vscode.CancellationToken,
+): Promise<SlashCommand | undefined> {
+  const cmd = request.command as SlashCommand | undefined;
+
+  if (cmd === "generate") {
+    return handleGenerate(request, stream);
+  }
+  if (cmd === "explain") {
+    return handleExplain(stream);
+  }
+  if (cmd === "sync") {
+    return handleSync(stream);
+  }
+  if (cmd === "test") {
+    return handleTest(request, stream);
+  }
+
+  // Natural-language fallback
+  await handleNaturalLanguage(request, stream);
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Slash-command handlers
+// ---------------------------------------------------------------------------
+
+async function handleGenerate(
+  request: vscode.ChatRequest,
+  stream: vscode.ChatResponseStream,
+): Promise<SlashCommand> {
+  const intent = request.prompt.trim();
+  if (!intent) {
+    stream.markdown(
+      "Please provide a description after `/generate`. Example:\n\n`@rocky /generate monthly revenue per customer from the orders table`",
+    );
+    return "generate";
+  }
+
+  stream.markdown(`Generating Rocky model for: _${intent}_\n\n`);
+  try {
+    const source = await runAiGenerate(intent);
+    stream.markdown("```rocky\n" + source + "\n```\n\n");
+    stream.markdown(
+      "_Model generated. Opening in editor — review and save when ready._",
+    );
+    // Also open in the editor so the user can save it.
+    const doc = await vscode.workspace.openTextDocument({
+      content: source,
+      language: "rocky",
+    });
+    await vscode.window.showTextDocument(doc, { preserveFocus: true });
+  } catch (err) {
+    stream.markdown(
+      `**Error generating model:** ${errorMessage(err)}\n\nCheck the Rocky output channel for details.`,
+    );
+  }
+  return "generate";
+}
+
+async function handleExplain(
+  stream: vscode.ChatResponseStream,
+): Promise<SlashCommand> {
+  const modelName = activeModelName();
+  if (modelName) {
+    stream.markdown(`Explaining model: _${modelName}_\n\n`);
+  } else {
+    stream.markdown("Explaining all models with intent docs…\n\n");
+  }
+
+  try {
+    const output = await runAiExplain(modelName);
+    stream.markdown(output.trim() || "_Intent generated and saved to model files._");
+  } catch (err) {
+    stream.markdown(
+      `**Error explaining model:** ${errorMessage(err)}\n\nCheck the Rocky output channel for details.`,
+    );
+  }
+  return "explain";
+}
+
+async function handleSync(
+  stream: vscode.ChatResponseStream,
+): Promise<SlashCommand> {
+  stream.markdown("Detecting schema changes and proposing sync updates…\n\n");
+
+  try {
+    const output = await runAiSync();
+    stream.markdown(output.trim() || "_No models need syncing._");
+  } catch (err) {
+    stream.markdown(
+      `**Error syncing models:** ${errorMessage(err)}\n\nCheck the Rocky output channel for details.`,
+    );
+  }
+  return "sync";
+}
+
+async function handleTest(
+  request: vscode.ChatRequest,
+  stream: vscode.ChatResponseStream,
+): Promise<SlashCommand> {
+  // Prefer explicit arg; fall back to active editor; then all models.
+  const argModel = request.prompt.trim() || undefined;
+  const modelName = argModel ?? activeModelName();
+
+  if (modelName) {
+    stream.markdown(`Generating quality tests for: _${modelName}_\n\n`);
+  } else {
+    stream.markdown("Generating quality tests for all models…\n\n");
+  }
+
+  try {
+    const output = await runAiTest(modelName);
+    stream.markdown(output.trim() || "_Tests generated and saved to model files._");
+  } catch (err) {
+    stream.markdown(
+      `**Error generating tests:** ${errorMessage(err)}\n\nCheck the Rocky output channel for details.`,
+    );
+  }
+  return "test";
+}
+
+// ---------------------------------------------------------------------------
+// Natural-language fallback
+// ---------------------------------------------------------------------------
+
+async function handleNaturalLanguage(
+  request: vscode.ChatRequest,
+  stream: vscode.ChatResponseStream,
+): Promise<void> {
+  const models = await vscode.lm.selectChatModels({ vendor: "copilot" });
+  const model = models[0];
+
+  if (!model) {
+    stream.markdown(availableCommandsMarkdown());
+    return;
+  }
+
+  const systemContext = [
+    "You are Rocky, an AI assistant for the Rocky SQL transformation engine.",
+    "Rocky is a Rust-based control plane for warehouse SQL pipelines with branches, replay, column-level lineage, compile-time type safety, and per-model cost attribution.",
+    "Models are written in either the `.rocky` DSL or plain `.sql` files.",
+    "",
+    "You have four available actions the user can invoke as slash commands:",
+    "- `/generate <description>` — generate a Rocky model from a natural-language description.",
+    "- `/explain` — generate intent documentation for the active model.",
+    "- `/sync` — detect source schema changes and propose model sync updates.",
+    "- `/test <model>` — generate quality test cases for a named model.",
+    "",
+    "Answer the user's question directly when possible.",
+    "If the user's intent maps cleanly to one of the four actions, suggest the appropriate slash command.",
+    "Keep answers concise and actionable.",
+  ].join("\n");
+
+  const messages = [
+    vscode.LanguageModelChatMessage.User(systemContext),
+    vscode.LanguageModelChatMessage.User(request.prompt),
+  ];
+
+  try {
+    const response = await model.sendRequest(
+      messages,
+      {},
+    );
+    for await (const chunk of response.text) {
+      stream.markdown(chunk);
+    }
+  } catch {
+    // If the LLM call fails for any reason, fall back to command listing.
+    stream.markdown(availableCommandsMarkdown());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Followup provider
+// ---------------------------------------------------------------------------
+
+function followupProvider(
+  result: vscode.ChatResult,
+): vscode.ChatFollowup[] | undefined {
+  const lastCommand = result.metadata?.lastCommand as SlashCommand | undefined;
+
+  if (lastCommand === "generate") {
+    return [
+      {
+        prompt: "/explain",
+        label: "Explain the generated model",
+      },
+      {
+        prompt: "/test",
+        label: "Generate quality tests for the model",
+      },
+    ];
+  }
+  if (lastCommand === "explain") {
+    return [
+      {
+        prompt: "/test",
+        label: "Generate quality tests",
+      },
+    ];
+  }
+  if (lastCommand === "sync") {
+    return [
+      {
+        prompt: "/explain",
+        label: "Explain the newly synced sources",
+      },
+    ];
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerChatParticipant(
+  context: vscode.ExtensionContext,
+): void {
+  const participant = vscode.chat.createChatParticipant(
+    "rocky-data.rocky",
+    async (request, ctx, stream, token) => {
+      const lastCommand = await handler(request, ctx, stream, token);
+      return { metadata: { lastCommand } };
+    },
+  );
+
+  participant.iconPath = vscode.Uri.joinPath(
+    context.extensionUri,
+    "icons",
+    "rocky-icon-128.png",
+  );
+
+  participant.followupProvider = {
+    provideFollowups(
+      result: vscode.ChatResult,
+      _context: vscode.ChatContext,
+      _token: vscode.CancellationToken,
+    ): vscode.ChatFollowup[] {
+      return followupProvider(result) ?? [];
+    },
+  };
+
+  context.subscriptions.push(participant);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function activeModelName(): string | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) return undefined;
+  return path
+    .basename(editor.document.fileName)
+    .replace(/\.(rocky|sql)$/, "");
+}
+
+function errorMessage(err: unknown): string {
+  return (err as Error)?.message ?? String(err);
+}
+
+function availableCommandsMarkdown(): string {
+  return [
+    "I can help with your Rocky pipelines. Available commands:\n",
+    "| Command | What it does |",
+    "|---------|-------------|",
+    "| `/generate <description>` | Generate a Rocky model from a natural-language description |",
+    "| `/explain` | Generate intent documentation for the active model |",
+    "| `/sync` | Detect source schema changes and propose model updates |",
+    "| `/test <model>` | Generate quality test cases for a model |",
+    "",
+    "_GitHub Copilot is not available — slash commands above route directly to the Rocky CLI._",
+  ].join("\n");
+}

--- a/editors/vscode/src/commands/ai.ts
+++ b/editors/vscode/src/commands/ai.ts
@@ -2,6 +2,57 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { runRockyWithProgress, showRockyError } from "../rockyCli";
 
+// ---------------------------------------------------------------------------
+// Pure helpers — invokable from commands AND the chat participant.
+// ---------------------------------------------------------------------------
+
+/** Run `rocky ai <intent>` and return the generated model source. */
+export async function runAiGenerate(intent: string): Promise<string> {
+  const { stdout } = await runRockyWithProgress("Generating model...", [
+    "ai",
+    intent,
+    "--format",
+    "rocky",
+  ]);
+  return stdout;
+}
+
+/** Run `rocky ai-sync` optionally scoped to a single model. Returns CLI output. */
+export async function runAiSync(model?: string): Promise<string> {
+  const args = ["ai-sync", "--models", "models"];
+  if (model) args.push("--model", model);
+  const { stdout } = await runRockyWithProgress("Syncing models...", args);
+  return stdout;
+}
+
+/** Run `rocky ai-explain` for a named model or all models. Returns CLI output. */
+export async function runAiExplain(modelName?: string): Promise<string> {
+  const args = ["ai-explain", "--models", "models", "--save"];
+  if (modelName) {
+    args.push(modelName);
+  } else {
+    args.push("--all");
+  }
+  const { stdout } = await runRockyWithProgress("Generating intent...", args);
+  return stdout;
+}
+
+/** Run `rocky ai-test` for a named model or all models. Returns CLI output. */
+export async function runAiTest(modelName?: string): Promise<string> {
+  const args = ["ai-test", "--models", "models", "--save"];
+  if (modelName) {
+    args.push(modelName);
+  } else {
+    args.push("--all");
+  }
+  const { stdout } = await runRockyWithProgress("Generating tests...", args);
+  return stdout;
+}
+
+// ---------------------------------------------------------------------------
+// VS Code command handlers — prompt the user, then call the helpers above.
+// ---------------------------------------------------------------------------
+
 export async function aiGenerate(): Promise<void> {
   const intent = await vscode.window.showInputBox({
     prompt: "Describe the model you want to create",
@@ -11,14 +62,9 @@ export async function aiGenerate(): Promise<void> {
   if (!intent) return;
 
   try {
-    const { stdout } = await runRockyWithProgress("Generating model...", [
-      "ai",
-      intent,
-      "--format",
-      "rocky",
-    ]);
+    const source = await runAiGenerate(intent);
     const doc = await vscode.workspace.openTextDocument({
-      content: stdout,
+      content: source,
       language: "rocky",
     });
     await vscode.window.showTextDocument(doc);
@@ -33,13 +79,10 @@ export async function aiSync(): Promise<void> {
     placeHolder: "e.g., fct_daily_revenue",
   });
 
-  const args = ["ai-sync", "--models", "models"];
-  if (model) args.push("--model", model);
-
   try {
-    const { stdout } = await runRockyWithProgress("Syncing models...", args);
+    const output = await runAiSync(model ?? undefined);
     vscode.window.showInformationMessage(
-      stdout.trim() || "No models need syncing.",
+      output.trim() || "No models need syncing.",
     );
   } catch (err) {
     showRockyError("Rocky AI Sync failed", err);
@@ -48,17 +91,11 @@ export async function aiSync(): Promise<void> {
 
 export async function aiExplain(): Promise<void> {
   const modelName = activeModelName();
-  const args = ["ai-explain", "--models", "models", "--save"];
-  if (modelName) {
-    args.push(modelName);
-  } else {
-    args.push("--all");
-  }
 
   try {
-    const { stdout } = await runRockyWithProgress("Generating intent...", args);
+    const output = await runAiExplain(modelName);
     vscode.window.showInformationMessage(
-      stdout.trim() || "Intent generated and saved.",
+      output.trim() || "Intent generated and saved.",
     );
   } catch (err) {
     showRockyError("Rocky AI Explain failed", err);
@@ -67,17 +104,11 @@ export async function aiExplain(): Promise<void> {
 
 export async function aiTest(): Promise<void> {
   const modelName = activeModelName();
-  const args = ["ai-test", "--models", "models", "--save"];
-  if (modelName) {
-    args.push(modelName);
-  } else {
-    args.push("--all");
-  }
 
   try {
-    const { stdout } = await runRockyWithProgress("Generating tests...", args);
+    const output = await runAiTest(modelName);
     vscode.window.showInformationMessage(
-      stdout.trim() || "Tests generated and saved.",
+      output.trim() || "Tests generated and saved.",
     );
   } catch (err) {
     showRockyError("Rocky AI Test failed", err);

--- a/editors/vscode/src/commands/preview.ts
+++ b/editors/vscode/src/commands/preview.ts
@@ -5,6 +5,7 @@ import type {
   PreviewCreateOutput,
   PreviewDiffOutput,
 } from "../types/generated";
+import { firePreviewCreated } from "../views/previewView";
 import { ensureWorkspace, promptForInput, showJsonInEditor } from "./ui";
 
 const BASE_PLACEHOLDER = "e.g., main";
@@ -43,6 +44,11 @@ export async function previewCreate(): Promise<void> {
       vscode.window.showErrorMessage(summary);
     } else {
       vscode.window.showInformationMessage(summary);
+      // Notify the Previews sidebar so it can track this branch.
+      firePreviewCreated({
+        branchName: result.branch_name,
+        createdAt: new Date().toISOString(),
+      });
     }
     await showJsonInEditor(JSON.stringify(result));
   } catch (err) {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { registerChatParticipant } from "./chatParticipant";
 import { registerCodeLensProvider } from "./codeLens";
 import { registerCommands } from "./commands";
 import { registerCostCodeLensProvider } from "./costCodeLens";
@@ -18,6 +19,7 @@ export function activate(context: vscode.ExtensionContext): void {
   setExtensionUri(context.extensionUri);
   startLspClient(context);
   registerCommands(context);
+  registerChatParticipant(context);
   registerTestExplorer(context);
   registerDeclarativeTestProvider(context);
   registerCodeLensProvider(context);

--- a/editors/vscode/src/views/index.ts
+++ b/editors/vscode/src/views/index.ts
@@ -4,15 +4,18 @@ import type { ExtensionInfoTreeProvider } from "./extensionInfoView";
 import { registerGetStartedView } from "./getStartedView";
 import { registerHelpView } from "./helpView";
 import { registerModelsView } from "./modelsView";
+import { registerPreviewView } from "./previewView";
+import type { PreviewTreeProvider } from "./previewView";
 import { registerRunsView } from "./runsView";
 import { registerSchemaView } from "./schemaView";
 import { registerSourcesView } from "./sourcesView";
 
 let infoProvider: ExtensionInfoTreeProvider | undefined;
+let previewProvider: PreviewTreeProvider | undefined;
 
 /**
- * Registers all seven Rocky tree views on the activity bar:
- *   Get Started → Extension Info → Models → Runs → Sources → Schema → Help
+ * Registers all eight Rocky tree views on the activity bar:
+ *   Get Started → Extension Info → Models → Runs → Sources → Schema → Previews → Help
  *
  * The Get Started view also wires the `rocky.hasProject` context that gates
  * the welcome content of every other view.
@@ -24,7 +27,12 @@ export function registerViews(context: vscode.ExtensionContext): void {
   registerRunsView(context);
   registerSourcesView(context);
   registerSchemaView(context);
+  previewProvider = registerPreviewView(context);
   registerHelpView(context);
+}
+
+export function getPreviewProvider(): PreviewTreeProvider | undefined {
+  return previewProvider;
 }
 
 export function getInfoProvider(): ExtensionInfoTreeProvider | undefined {

--- a/editors/vscode/src/views/previewView.ts
+++ b/editors/vscode/src/views/previewView.ts
@@ -1,0 +1,694 @@
+import * as vscode from "vscode";
+import { runRockyJson } from "../rockyCli";
+import type {
+  PreviewCostOutput,
+  PreviewDiffOutput,
+  PreviewModelCostDelta,
+  PreviewModelDiff,
+} from "../types/generated";
+import { hasRockyProject, onDidChangeRockyProject } from "./getStartedView";
+
+// ---------------------------------------------------------------------------
+// Persisted state shape
+// ---------------------------------------------------------------------------
+
+/**
+ * One active preview branch tracked in workspaceState.
+ * We persist only summary-level output to keep the stored payload lean — full
+ * diff payloads can be multi-MB on large projects.
+ */
+export interface ActivePreview {
+  branchName: string;
+  createdAt: string;
+  /** Summary fields from the last `rocky preview cost` run. */
+  lastCostSummary?: {
+    delta_usd?: number | null;
+    models_changed: number;
+  };
+  /** Summary fields from the last `rocky preview diff` run. */
+  lastDiffSummary?: {
+    models_with_changes: number;
+    models_unchanged: number;
+    total_rows_added: number;
+    total_rows_removed: number;
+    total_rows_changed: number;
+    any_coverage_warning: boolean;
+  };
+  /** Per-model cost deltas from the last cost fetch (kept for the tree). */
+  perModelCost?: PreviewModelCostDelta[];
+  /** Per-model diffs from the last diff fetch (kept for the tree). */
+  perModelDiff?: PreviewModelDiff[];
+}
+
+const STATE_KEY = "rocky.activePreviews";
+
+// ---------------------------------------------------------------------------
+// Module-level preview-created event bus
+// (commands/preview.ts fires it; the view subscribes without circular deps)
+// ---------------------------------------------------------------------------
+
+type PreviewCreatedListener = (preview: ActivePreview) => void;
+const previewCreatedListeners: PreviewCreatedListener[] = [];
+
+/** Called by `commands/preview.ts` after a successful `rocky.previewCreate`. */
+export function firePreviewCreated(preview: ActivePreview): void {
+  for (const cb of previewCreatedListeners) cb(preview);
+}
+
+/** Register a listener for new previews. Returns a disposable. */
+export function onPreviewCreated(cb: PreviewCreatedListener): {
+  dispose(): void;
+} {
+  previewCreatedListeners.push(cb);
+  return {
+    dispose: (): void => {
+      const idx = previewCreatedListeners.indexOf(cb);
+      if (idx !== -1) previewCreatedListeners.splice(idx, 1);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State manager (exported so commands/preview.ts can call it)
+// ---------------------------------------------------------------------------
+
+/** Thin wrapper around workspaceState so the view and the preview commands can
+ *  share state without a circular dependency. Callers receive typed objects. */
+export class PreviewStateManager {
+  constructor(private readonly memento: vscode.Memento) {}
+
+  getAll(): ActivePreview[] {
+    return this.memento.get<ActivePreview[]>(STATE_KEY, []);
+  }
+
+  async add(preview: ActivePreview): Promise<void> {
+    const existing = this.getAll().filter(
+      (p) => p.branchName !== preview.branchName,
+    );
+    await this.memento.update(STATE_KEY, [...existing, preview]);
+  }
+
+  async remove(branchName: string): Promise<void> {
+    const filtered = this.getAll().filter((p) => p.branchName !== branchName);
+    await this.memento.update(STATE_KEY, filtered);
+  }
+
+  async updateBranch(
+    branchName: string,
+    patch: Partial<ActivePreview>,
+  ): Promise<void> {
+    const all = this.getAll().map((p) =>
+      p.branchName === branchName ? { ...p, ...patch } : p,
+    );
+    await this.memento.update(STATE_KEY, all);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Node types
+// ---------------------------------------------------------------------------
+
+type PreviewNode =
+  | PreviewBranchNode
+  | PreviewCategoryNode
+  | PreviewCostModelNode
+  | PreviewDiffModelNode
+  | PreviewMessageNode;
+
+export class PreviewBranchNode extends vscode.TreeItem {
+  override readonly contextValue = "rockyPreviewBranch";
+
+  constructor(public readonly preview: ActivePreview) {
+    super(preview.branchName, vscode.TreeItemCollapsibleState.Collapsed);
+
+    const cost = preview.lastCostSummary;
+    const diff = preview.lastDiffSummary;
+
+    const parts: string[] = [];
+    if (cost?.delta_usd != null) {
+      const sign = cost.delta_usd >= 0 ? "+" : "";
+      parts.push(`Δ$${sign}${cost.delta_usd.toFixed(4)}/mo`);
+    }
+    if (diff != null) {
+      parts.push(`${diff.models_with_changes} model${diff.models_with_changes === 1 ? "" : "s"} changed`);
+    }
+
+    this.description = parts.length > 0 ? parts.join(" · ") : "not yet fetched";
+    this.tooltip = buildBranchTooltip(preview);
+    this.iconPath = new vscode.ThemeIcon("git-branch");
+  }
+}
+
+export class PreviewCategoryNode extends vscode.TreeItem {
+  override readonly contextValue = "rockyPreviewCategory";
+
+  constructor(
+    public readonly branchName: string,
+    public readonly category: "cost" | "diff" | "models",
+    label: string,
+    description: string,
+  ) {
+    super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    this.description = description;
+    this.iconPath = categoryIcon(category);
+  }
+}
+
+export class PreviewCostModelNode extends vscode.TreeItem {
+  override readonly contextValue = "rockyPreviewCostModel";
+
+  constructor(public readonly delta: PreviewModelCostDelta) {
+    super(delta.model_name, vscode.TreeItemCollapsibleState.None);
+
+    const parts: string[] = [];
+    if (delta.delta_usd != null) {
+      const sign = delta.delta_usd >= 0 ? "+" : "";
+      parts.push(`Δ$${sign}${delta.delta_usd.toFixed(4)}`);
+    }
+    if (delta.skipped_via_copy) parts.push("copied");
+    const durMs = delta.branch_duration_ms;
+    if (durMs > 0) parts.push(formatDuration(durMs));
+
+    this.description = parts.join(" · ");
+    this.tooltip = buildCostModelTooltip(delta);
+    this.iconPath = new vscode.ThemeIcon("graph");
+  }
+}
+
+export class PreviewDiffModelNode extends vscode.TreeItem {
+  override readonly contextValue = "rockyPreviewDiffModel";
+
+  /** Status: "added" | "removed" | "modified" | "unchanged" */
+  public readonly diffStatus: string;
+
+  constructor(
+    public readonly branchName: string,
+    public readonly model: PreviewModelDiff,
+    public readonly markdownPayload: string,
+  ) {
+    super(model.model_name, vscode.TreeItemCollapsibleState.None);
+
+    const { added_columns, removed_columns, type_changes } = model.structural;
+    const hasAdded = added_columns.length > 0;
+    const hasRemoved = removed_columns.length > 0;
+    const hasTypeChanges = (type_changes?.length ?? 0) > 0;
+
+    // Heuristic: classify at column-level (rows may differ independently)
+    if (hasAdded && !hasRemoved && !hasTypeChanges) {
+      this.diffStatus = "added";
+    } else if (hasRemoved && !hasAdded && !hasTypeChanges) {
+      this.diffStatus = "removed";
+    } else if (hasAdded || hasRemoved || hasTypeChanges) {
+      this.diffStatus = "modified";
+    } else {
+      this.diffStatus = "unchanged";
+    }
+
+    const rowInfo = this.buildRowInfo();
+    this.description = `${this.diffStatus}${rowInfo ? ` · ${rowInfo}` : ""}`;
+    this.tooltip = buildDiffModelTooltip(model);
+    this.iconPath = diffStatusIcon(this.diffStatus);
+
+    // Clicking opens an in-memory markdown document with the diff payload.
+    this.command = {
+      title: "Show diff",
+      command: "rocky.showPreviewDiffMarkdown",
+      arguments: [branchName, model.model_name, markdownPayload],
+    };
+  }
+
+  private buildRowInfo(): string {
+    const algo = this.model.algorithm;
+    if (!algo) return "";
+    if (algo.kind === "sampled") {
+      const s = algo.sampled;
+      const parts: string[] = [];
+      if (s.rows_added > 0) parts.push(`+${s.rows_added}`);
+      if (s.rows_removed > 0) parts.push(`-${s.rows_removed}`);
+      if (s.rows_changed > 0) parts.push(`~${s.rows_changed}`);
+      return parts.join("/");
+    }
+    if (algo.kind === "bisection") {
+      const d = algo.diff;
+      const parts: string[] = [];
+      if (d.rows_added > 0) parts.push(`+${d.rows_added}`);
+      if (d.rows_removed > 0) parts.push(`-${d.rows_removed}`);
+      if (d.rows_changed > 0) parts.push(`~${d.rows_changed}`);
+      return parts.join("/");
+    }
+    return "";
+  }
+}
+
+class PreviewMessageNode extends vscode.TreeItem {
+  override readonly contextValue = "rockyPreviewMessage";
+
+  constructor(label: string, icon: string) {
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.iconPath = new vscode.ThemeIcon(icon);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Tree provider for the Previews sidebar view.
+ *
+ * Root level: one `PreviewBranchNode` per active preview tracked in
+ * `workspaceState`. Children: Cost / Diff / Models Changed sub-trees showing
+ * per-model data from the last `rocky preview cost` and `rocky preview diff`
+ * fetches. Data is refreshed manually (view-title button) or after
+ * `rocky.previewCreate` completes.
+ */
+export class PreviewTreeProvider
+  implements vscode.TreeDataProvider<PreviewNode>
+{
+  private readonly emitter = new vscode.EventEmitter<
+    PreviewNode | undefined | void
+  >();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(public readonly stateManager: PreviewStateManager) {}
+
+  refresh(): void {
+    this.emitter.fire();
+  }
+
+  getTreeItem(element: PreviewNode): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: PreviewNode): Promise<PreviewNode[]> {
+    // Root level
+    if (!element) {
+      if (!hasRockyProject()) return [];
+
+      const previews = this.stateManager.getAll();
+      if (previews.length === 0) return [];
+
+      return previews.map((p) => new PreviewBranchNode(p));
+    }
+
+    // Children of a branch node → 3 category nodes
+    if (element instanceof PreviewBranchNode) {
+      const { preview } = element;
+      const diff = preview.lastDiffSummary;
+      const cost = preview.lastCostSummary;
+
+      const costDesc = cost
+        ? cost.delta_usd != null
+          ? `Δ$${cost.delta_usd >= 0 ? "+" : ""}${cost.delta_usd.toFixed(4)}`
+          : "no cost data"
+        : "not fetched";
+
+      const diffDesc = diff
+        ? `${diff.models_with_changes} changed`
+        : "not fetched";
+
+      const modelsDesc = preview.perModelDiff
+        ? `${preview.perModelDiff.length} models`
+        : "not fetched";
+
+      return [
+        new PreviewCategoryNode(preview.branchName, "cost", "Cost", costDesc),
+        new PreviewCategoryNode(preview.branchName, "diff", "Diff", diffDesc),
+        new PreviewCategoryNode(preview.branchName, "models", "Models Changed", modelsDesc),
+      ];
+    }
+
+    // Children of a category node
+    if (element instanceof PreviewCategoryNode) {
+      const previews = this.stateManager.getAll();
+      const preview = previews.find(
+        (p) => p.branchName === element.branchName,
+      );
+      if (!preview) return [];
+
+      if (element.category === "cost") {
+        const items = preview.perModelCost;
+        if (!items || items.length === 0) {
+          return [new PreviewMessageNode("No cost data — click Refresh", "info")];
+        }
+        return items.map((d) => new PreviewCostModelNode(d));
+      }
+
+      if (element.category === "diff") {
+        const models = preview.perModelDiff;
+        if (!models || models.length === 0) {
+          return [new PreviewMessageNode("No diff data — click Refresh", "info")];
+        }
+        // Open the branch-level markdown payload (from PreviewDiffOutput) in
+        // the "Diff" category — per-model nodes open per-model sections.
+        return models.map(
+          (m) =>
+            new PreviewDiffModelNode(
+              element.branchName,
+              m,
+              formatModelDiffMarkdown(m),
+            ),
+        );
+      }
+
+      if (element.category === "models") {
+        const models = preview.perModelDiff;
+        if (!models || models.length === 0) {
+          return [new PreviewMessageNode("No model data — click Refresh", "info")];
+        }
+        return models.map(
+          (m) =>
+            new PreviewDiffModelNode(
+              element.branchName,
+              m,
+              formatModelDiffMarkdown(m),
+            ),
+        );
+      }
+
+      return [];
+    }
+
+    return [];
+  }
+
+  /**
+   * Fetch fresh cost + diff data for every tracked branch (in parallel).
+   * A failure on one branch does not cancel the others.
+   */
+  async fetchAllBranches(): Promise<void> {
+    if (!hasRockyProject()) return;
+
+    const previews = this.stateManager.getAll();
+    if (previews.length === 0) return;
+
+    await Promise.allSettled(
+      previews.map(async (preview) => {
+        await this.fetchBranch(preview.branchName);
+      }),
+    );
+
+    this.refresh();
+  }
+
+  async fetchBranch(branchName: string): Promise<void> {
+    const [costResult, diffResult] = await Promise.allSettled([
+      runRockyJson<PreviewCostOutput>([
+        "preview",
+        "cost",
+        "--name",
+        branchName,
+        "--output",
+        "json",
+      ]),
+      runRockyJson<PreviewDiffOutput>([
+        "preview",
+        "diff",
+        "--name",
+        branchName,
+        "--output",
+        "json",
+      ]),
+    ]);
+
+    const patch: Partial<ActivePreview> = {};
+
+    if (costResult.status === "fulfilled") {
+      const cost = costResult.value;
+      patch.lastCostSummary = {
+        delta_usd: cost.summary.delta_usd,
+        models_changed: cost.per_model.length,
+      };
+      patch.perModelCost = cost.per_model;
+    }
+
+    if (diffResult.status === "fulfilled") {
+      const diff = diffResult.value;
+      patch.lastDiffSummary = {
+        models_with_changes: diff.summary.models_with_changes,
+        models_unchanged: diff.summary.models_unchanged,
+        total_rows_added: diff.summary.total_rows_added,
+        total_rows_removed: diff.summary.total_rows_removed,
+        total_rows_changed: diff.summary.total_rows_changed,
+        any_coverage_warning: diff.summary.any_coverage_warning,
+      };
+      patch.perModelDiff = diff.models;
+    }
+
+    await this.stateManager.updateBranch(branchName, patch);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function buildBranchTooltip(preview: ActivePreview): string {
+  const lines: string[] = [];
+  lines.push(`Branch: ${preview.branchName}`);
+  lines.push(`Created: ${new Date(preview.createdAt).toLocaleString()}`);
+  const cost = preview.lastCostSummary;
+  if (cost) {
+    const delta =
+      cost.delta_usd != null
+        ? `${cost.delta_usd >= 0 ? "+" : ""}$${cost.delta_usd.toFixed(4)}`
+        : "n/a";
+    lines.push(`Cost delta: ${delta}/mo`);
+  }
+  const diff = preview.lastDiffSummary;
+  if (diff) {
+    lines.push(
+      `Diff: ${diff.models_with_changes} changed, ${diff.models_unchanged} unchanged`,
+    );
+    lines.push(
+      `Rows: +${diff.total_rows_added} / -${diff.total_rows_removed} / ~${diff.total_rows_changed}`,
+    );
+    if (diff.any_coverage_warning) lines.push("⚠ Coverage warning");
+  }
+  return lines.join("\n");
+}
+
+function buildCostModelTooltip(delta: PreviewModelCostDelta): string {
+  const lines: string[] = [];
+  lines.push(`Model: ${delta.model_name}`);
+  if (delta.skipped_via_copy) lines.push("Strategy: copied from base");
+  if (delta.delta_usd != null) {
+    lines.push(
+      `Cost delta: ${delta.delta_usd >= 0 ? "+" : ""}$${delta.delta_usd.toFixed(6)}`,
+    );
+  }
+  lines.push(
+    `Branch duration: ${formatDuration(delta.branch_duration_ms)}`,
+  );
+  if (delta.branch_bytes_scanned != null) {
+    lines.push(
+      `Branch bytes scanned: ${delta.branch_bytes_scanned.toLocaleString()}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function buildDiffModelTooltip(model: PreviewModelDiff): string {
+  const lines: string[] = [];
+  lines.push(`Model: ${model.model_name}`);
+  const { added_columns, removed_columns, type_changes } = model.structural;
+  if (added_columns.length > 0) {
+    lines.push(`Added columns: ${added_columns.join(", ")}`);
+  }
+  if (removed_columns.length > 0) {
+    lines.push(`Removed columns: ${removed_columns.join(", ")}`);
+  }
+  if ((type_changes?.length ?? 0) > 0) {
+    for (const tc of type_changes ?? []) {
+      lines.push(`Type change: ${tc.name} ${tc.from} → ${tc.to}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatModelDiffMarkdown(model: PreviewModelDiff): string {
+  const lines: string[] = [];
+  lines.push(`# Diff: ${model.model_name}`);
+  lines.push("");
+  const { added_columns, removed_columns, type_changes } = model.structural;
+  if (
+    added_columns.length === 0 &&
+    removed_columns.length === 0 &&
+    (type_changes?.length ?? 0) === 0
+  ) {
+    lines.push("No structural changes.");
+  } else {
+    if (added_columns.length > 0) {
+      lines.push("## Added Columns");
+      for (const c of added_columns) lines.push(`- \`${c}\``);
+      lines.push("");
+    }
+    if (removed_columns.length > 0) {
+      lines.push("## Removed Columns");
+      for (const c of removed_columns) lines.push(`- \`${c}\``);
+      lines.push("");
+    }
+    if ((type_changes?.length ?? 0) > 0) {
+      lines.push("## Type Changes");
+      for (const tc of type_changes ?? []) {
+        lines.push(`- \`${tc.name}\`: \`${tc.from}\` → \`${tc.to}\``);
+      }
+      lines.push("");
+    }
+  }
+
+  const algo = model.algorithm;
+  if (algo) {
+    lines.push("## Row Diff");
+    if (algo.kind === "sampled") {
+      const s = algo.sampled;
+      lines.push(
+        `Rows added: ${s.rows_added} · Removed: ${s.rows_removed} · Changed: ${s.rows_changed}`,
+      );
+      if (algo.sampling_window.coverage_warning) {
+        lines.push("");
+        lines.push(
+          "> ⚠ Coverage warning: changes outside the sampling window may not be reflected.",
+        );
+      }
+      if (s.samples.length > 0) {
+        lines.push("");
+        lines.push("### Samples");
+        for (const sample of s.samples) {
+          lines.push(`**Row (pk=${sample.primary_key})**`);
+          for (const change of sample.changes) {
+            lines.push(
+              `  - \`${change.column}\`: \`${change.base_value}\` → \`${change.branch_value}\``,
+            );
+          }
+        }
+      }
+    } else if (algo.kind === "bisection") {
+      const d = algo.diff;
+      lines.push(
+        `Rows added: ${d.rows_added} · Removed: ${d.rows_removed} · Changed: ${d.rows_changed}`,
+      );
+      if (algo.bisection_stats.depth_capped) {
+        lines.push("");
+        lines.push(
+          "> ⚠ Bisection depth capped — diff may be slower but is still correct.",
+        );
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function categoryIcon(category: "cost" | "diff" | "models"): vscode.ThemeIcon {
+  switch (category) {
+    case "cost":
+      return new vscode.ThemeIcon("graph");
+    case "diff":
+      return new vscode.ThemeIcon("diff");
+    case "models":
+      return new vscode.ThemeIcon("list-tree");
+  }
+}
+
+function diffStatusIcon(status: string): vscode.ThemeIcon {
+  switch (status) {
+    case "added":
+      return new vscode.ThemeIcon(
+        "diff-added",
+        new vscode.ThemeColor("gitDecoration.addedResourceForeground"),
+      );
+    case "removed":
+      return new vscode.ThemeIcon(
+        "diff-removed",
+        new vscode.ThemeColor("gitDecoration.deletedResourceForeground"),
+      );
+    case "modified":
+      return new vscode.ThemeIcon(
+        "diff-modified",
+        new vscode.ThemeColor("gitDecoration.modifiedResourceForeground"),
+      );
+    default:
+      return new vscode.ThemeIcon("circle-outline");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerPreviewView(
+  context: vscode.ExtensionContext,
+): PreviewTreeProvider {
+  const stateManager = new PreviewStateManager(context.workspaceState);
+  const provider = new PreviewTreeProvider(stateManager);
+
+  const view = vscode.window.createTreeView("rocky.previews", {
+    treeDataProvider: provider,
+    showCollapseAll: true,
+  });
+  context.subscriptions.push(view);
+
+  // Refresh toolbar button — re-fetches cost + diff for every tracked branch.
+  context.subscriptions.push(
+    vscode.commands.registerCommand("rocky.refreshPreviews", () => {
+      void provider.fetchAllBranches();
+    }),
+  );
+
+  // Right-click remove — UI-only; does not delete the engine branch.
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "rocky.removePreview",
+      async (node: PreviewBranchNode) => {
+        await stateManager.remove(node.preview.branchName);
+        provider.refresh();
+      },
+    ),
+  );
+
+  // Open per-model diff as an in-memory markdown document.
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "rocky.showPreviewDiffMarkdown",
+      async (
+        _branchName: string,
+        modelName: string,
+        markdown: string,
+      ) => {
+        const uri = vscode.Uri.parse(
+          `untitled:Rocky Preview Diff — ${modelName}.md`,
+        );
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(doc, {
+          preview: true,
+        });
+        await editor.edit((edit) => {
+          edit.insert(new vscode.Position(0, 0), markdown);
+        });
+      },
+    ),
+  );
+
+  // When previewCreate succeeds, add to state and fetch fresh data.
+  context.subscriptions.push(
+    onPreviewCreated(async (preview) => {
+      await stateManager.add(preview);
+      provider.refresh();
+      // Best-effort background fetch so the tree shows real data immediately.
+      void provider.fetchBranch(preview.branchName).then(() => {
+        provider.refresh();
+      });
+    }),
+  );
+
+  // Refresh when a rocky.toml appears or disappears.
+  context.subscriptions.push(onDidChangeRockyProject(() => provider.refresh()));
+
+  return provider;
+}


### PR DESCRIPTION
## Summary

Three independent broader-gap items from the backlog (#20, #21, #22). All vscode-only, no engine cascades.

### #20 — `@rocky` chat participant

Wires `aiGenerate` / `aiExplain` / `aiSync` / `aiTest` into VS Code's chat participant API (`vscode.chat.createChatParticipant`, stable since 1.90; pinned `engines.vscode` is `^1.116.0` so no bump). Users type `@rocky` in any chat conversation:

- Slash commands `/generate <desc>`, `/explain`, `/sync`, `/test [model]` route to extracted pure helpers (`runAiGenerate` / `runAiExplain` / `runAiSync` / `runAiTest` in `commands/ai.ts`) — no interactive prompts in the chat path.
- Natural-language fallback uses `vscode.lm.selectChatModels({ vendor: "copilot" })`. Falls back to a help message listing the four slash commands when no model is available.
- Followup provider suggests next-turn prompts (`/generate` → `/explain` + `/test`; `/explain` → `/test`; `/sync` → `/explain`).
- Streams responses via `stream.markdown`; `/generate` opens the result in the editor with `preserveFocus`.
- 27 new vitest cases.

**Punted:** Token-streaming from the Rocky CLI (subprocess resolves on exit only); tool-calling/structured-dispatch loops; model selection beyond `[0]` from `selectChatModels`.

### #21 — Branded file icons

Adds opt-in "Rocky File Icons" theme (`contributes.iconThemes`) that brands both `.rocky` extension files and `rocky.toml`. The existing `contributes.languages[].icon` already brands `.rocky` files for all users regardless of theme; the new iconThemes path is the only way to reach `rocky.toml` (a TOML file, not a `rocky`-language file). Asset is the existing `icons/rocky-icon.svg` — no new asset.

### #22 — Previews sidebar view

New `Previews` tree view in the Rocky activity bar. Tracks preview branches the user creates via `rocky.previewCreate` (no `preview list` command in the engine; this is the practical scope).

- Tree shape: `PreviewBranchNode` (label = branch, description = `Δ$/mo · N models changed`) → three sub-categories: **Cost** (per-model delta), **Diff** (per-model structural diff; click → markdown document), **Models Changed** (status icons).
- State persisted in `workspaceState` under `rocky.activePreviews`.
- New commands: `rocky.refreshPreviews` (view-title button), `rocky.removePreview` (right-click on a branch node; UI-only — doesn't delete the engine-side branch).
- Hooks into the existing `rocky.previewCreate` success path via a module-level event bus to avoid circular imports.
- 30 new vitest cases.

**Limitations:** No engine list command → only tracks branches the user explicitly created in this workspace. `added/modified/removed` uses a column-level heuristic; row-only changes show as `unchanged`.

## Test plan

- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` — 106/106 (was 58 — +48: 27 chat participant + 30 preview view − 9 redistributed)
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual smoke: `@rocky` participant appears in Copilot Chat, `/generate`/`/explain`/`/sync`/`/test` slash commands work
- [ ] Manual smoke: opt into "Rocky File Icons" in `Preferences: File Icon Theme` → verify `.rocky` and `rocky.toml` are branded
- [ ] Manual smoke: run `rocky.previewCreate` → verify branch appears in Previews view; click refresh; verify remove works