### PR TITLE
fix(vscode+engine): lineage render + SVG export + rail redesign + LSP column fix

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Collapsible right-docked rail for the lineage webview.** Replaces the previous horizontal toolbar + 320px right-side Node Details panel with a single 240px vertical rail docked on the right. Three top-level collapsible sections — **Controls** (View / Focus / Cluster / Layout / Search / Zoom subgrouped inline), **Node Details**, **Export** — each with a clickable header and chevron. A `‹/›` button at the top of the rail collapses it to a 28px strip. Per-section collapse state and rail-collapsed state both persist across reloads via `vscode.setState`. The graph auto-fits after the rail-width animation finishes so the viewport recenters.
+- **Standalone-readable lineage SVG export.** The exporter clones the live SVG, sets `xmlns` (so OS image viewers will render it), resets the d3-zoom transform on the cloned graph group (export shows the full graph regardless of current pan/zoom), paints the editor background underneath, and inlines a stylesheet with VS Code CSS variables resolved to concrete colours (foreground, badge, button, charts-blue/green, panel-border, etc). Previously the exported file referenced unresolved `var(--vscode-*)` colours and external CSS rules, so opening it outside the webview produced an unreadable SVG.
+
+### Fixed
+
+- **Lineage panel stuck on "Rendering…".** The search-box regex `/^\/(.*)\/([gimsuy]*)$/` lives inside the inline-script TS template literal. The `\/` escape was stripped by the template evaluation, producing the invalid runtime regex `/^/(.*)/(...$/` and a `SyntaxError: Unexpected token '.'` that killed the main IIFE before it could draw the graph. Doubled the backslash (`\\/(.*)\\/`) so the runtime sees the intended `\/`.
+- **Lineage panel uses the wrong `rocky.toml`.** Previously hard-coded `${workspaceFolder}/rocky.toml` and crashed with `no models found in models` if the workspace root wasn't the project root (e.g. a multi-folder workspace, or a SQL file opened from a sibling folder). Now walks up from the active file's directory to find the nearest `rocky.toml` and runs the CLI from that directory.
+- **`Run Health Check` ("No workspace folder open") in the Get Started view.** `rocky.doctor` was gated by `ensureWorkspace()`, but the Get Started welcome links there precisely so the user can verify their CLI installation **before** there's a project. Removed the gate — doctor runs fine without a workspace and reports `critical` for the missing `rocky.toml`, which is the expected output for that flow.
+- **Webview-script errors are now surfaced.** A pair of `window.addEventListener('error', …)` / `unhandledrejection` listeners live in their own `<script>` tag so a parse error in the main inline script can't prevent them from registering. Any uncaught exception now writes `Lineage error: <message> (<file>:<line>:<col>)` into the status bar instead of leaving the panel stuck on `Rendering…`.
+
 ## [1.17.0] — 2026-05-14
 
 Builds on `1.16.0`'s lineage Tier 2/3 work. Two batches: PR [#519](https://github.com/rocky-data/rocky/pull/519) finishes Lineage Tier 2 + adds the inline cost CodeLens and the Schema sidebar; PR [#520](https://github.com/rocky-data/rocky/pull/520) adds the `@rocky` chat participant, branded file icons, and the Previews sidebar. Eight new surfaces total — all vscode-only, no engine cascades.

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { getWorkspaceFolder } from "../config";
+import { resolveProjectRoot } from "../config";
 import { getExtensionUri } from "../extensionState";
 import { runRocky } from "../rockyCli";
 import type { LineageOutput } from "../types/generated/lineage";
@@ -96,7 +96,10 @@ async function populatePanel(
   panel: vscode.WebviewPanel,
   modelName: string,
 ): Promise<void> {
-  const workspaceFolder = getWorkspaceFolder();
+  // Resolve the project root by walking up from the active editor's file,
+  // so users can open a SQL file outside the workspace root (or in a sibling
+  // folder) and lineage still finds the right rocky.toml.
+  const projectRoot = resolveProjectRoot();
   const extensionUri = getExtensionUri();
   const mediaUri = vscode.Uri.joinPath(extensionUri, "media");
 
@@ -127,12 +130,8 @@ async function populatePanel(
         let errorMsg: string | undefined;
 
         try {
-          const args: string[] = [];
-          if (workspaceFolder) {
-            args.push("--config", `${workspaceFolder}/rocky.toml`);
-          }
-          args.push("history", "--model", clickedModel, "--output", "json");
-          const { stdout } = await runRocky(args, { cwd: workspaceFolder });
+          const args = ["history", "--model", clickedModel, "--output", "json"];
+          const { stdout } = await runRocky(args, { cwd: projectRoot });
           history = JSON.parse(stdout) as ModelHistoryOutput;
         } catch (err) {
           errorMsg = (err as Error).message;
@@ -153,13 +152,11 @@ async function populatePanel(
 
   // Use the default JSON output (no -o table / --format dot).
   // The engine emits LineageOutput JSON with upstream/downstream/edges.
+  // Rocky discovers rocky.toml from cwd, so we don't pass --config.
   const args = ["lineage", modelName];
-  if (workspaceFolder) {
-    args.unshift("--config", `${workspaceFolder}/rocky.toml`);
-  }
 
   try {
-    const { stdout } = await runRocky(args, { cwd: workspaceFolder });
+    const { stdout } = await runRocky(args, { cwd: projectRoot });
     const lineageData = JSON.parse(stdout) as LineageOutput;
     panel.webview.html = renderLineageHtml(
       panel.webview,
@@ -270,25 +267,116 @@ function renderLineageHtml(
       display: flex; flex-direction: column;
       height: 100vh; overflow: hidden;
     }
-    header {
-      display: flex; align-items: center; gap: 8px;
-      padding: 8px 12px;
-      border-bottom: 1px solid var(--vscode-panel-border);
-      background: var(--vscode-editor-background);
+    /* Vertical controls rail (right-docked) */
+    #left-rail {
+      width: 240px;
+      min-width: 240px;
+      border-left: 1px solid var(--vscode-panel-border);
+      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+      display: flex; flex-direction: column;
+      gap: 6px;
+      padding: 12px 10px;
+      overflow-y: auto;
+      overflow-x: hidden;
+      flex-shrink: 0;
+      transition: width 0.15s ease, min-width 0.15s ease, padding 0.15s ease;
+    }
+    #left-rail.collapsed {
+      width: 28px;
+      min-width: 28px;
+      padding: 8px 4px;
+      gap: 0;
+    }
+    #left-rail.collapsed > :not(.rail-header) { display: none; }
+    .rail-header {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+    #left-rail.collapsed .rail-header { justify-content: center; margin-bottom: 0; }
+    #left-rail.collapsed .rail-title { display: none; }
+    #rail-toggle {
+      background: transparent;
+      color: var(--vscode-descriptionForeground);
+      border: 1px solid transparent;
+      padding: 2px 4px;
+      font-size: 14px;
+      line-height: 1;
+      cursor: pointer;
+      border-radius: 2px;
       flex-shrink: 0;
     }
-    header h2 { margin: 0; font-size: 13px; font-weight: 600; }
-    header .spacer { flex: 1; }
-    .btn-group {
-      display: flex; gap: 0;
+    #rail-toggle:hover {
+      background: var(--vscode-toolbar-hoverBackground, var(--vscode-button-secondaryHoverBackground));
+      color: var(--vscode-foreground);
     }
-    .btn-group button {
-      border-radius: 0;
-      border-right-width: 0;
+    /* Collapsible section accordion */
+    .rail-section {
+      display: flex; flex-direction: column;
+      border-top: 1px solid var(--vscode-panel-border);
+      padding-top: 6px;
     }
-    .btn-group button:first-child { border-radius: 2px 0 0 2px; }
-    .btn-group button:last-child  { border-radius: 0 2px 2px 0; border-right-width: 1px; }
-    button {
+    .rail-section:first-of-type { border-top: none; padding-top: 0; }
+    .rail-section-toggle {
+      display: flex; align-items: center; justify-content: space-between;
+      width: 100%;
+      background: transparent;
+      border: none;
+      padding: 4px 0;
+      cursor: pointer;
+      color: var(--vscode-descriptionForeground);
+      font: inherit;
+      text-align: left;
+    }
+    .rail-section-toggle:hover { color: var(--vscode-foreground); }
+    .rail-section-toggle:focus { outline: none; }
+    .rail-section-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .rail-section-chevron {
+      font-size: 10px;
+      line-height: 1;
+      transition: transform 0.15s ease;
+    }
+    .rail-section.collapsed .rail-section-chevron { transform: rotate(-90deg); }
+    .rail-section-body {
+      display: flex; flex-direction: column;
+      gap: 4px;
+      padding: 4px 0 6px;
+    }
+    .rail-section.collapsed .rail-section-body { display: none; }
+    /* Sub-grouping inside a section (e.g. View / Focus / etc. live under Controls) */
+    .rail-subgroup { display: flex; flex-direction: column; gap: 3px; }
+    .rail-subgroup + .rail-subgroup { margin-top: 6px; }
+    .rail-subgroup-label {
+      font-size: 10px;
+      color: var(--vscode-descriptionForeground);
+    }
+    #left-rail .rail-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--vscode-descriptionForeground);
+      margin: 0;
+    }
+    #left-rail .rail-model {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--vscode-foreground);
+      word-break: break-word;
+      margin: -8px 0 4px;
+    }
+    #left-rail .btn-group { display: flex; gap: 0; }
+    #left-rail .btn-group button { flex: 1; }
+    #left-rail .btn-group button:not(:first-child) { border-left-width: 0; }
+    #left-rail .btn-group button:first-child { border-radius: 2px 0 0 2px; }
+    #left-rail .btn-group button:last-child  { border-radius: 0 2px 2px 0; }
+    #left-rail .btn-group button:not(:first-child):not(:last-child) { border-radius: 0; }
+    #left-rail button {
       background: var(--vscode-button-secondaryBackground);
       color: var(--vscode-button-secondaryForeground);
       border: 1px solid var(--vscode-button-border, transparent);
@@ -297,16 +385,31 @@ function renderLineageHtml(
       cursor: pointer;
       border-radius: 2px;
     }
-    button:hover { background: var(--vscode-button-secondaryHoverBackground); }
-    button.active {
+    #left-rail button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+    #left-rail button.active {
       background: var(--vscode-button-background);
       color: var(--vscode-button-foreground);
     }
-    .separator {
-      width: 1px;
-      background: var(--vscode-panel-border);
-      margin: 0 4px;
+    #left-rail select,
+    #left-rail input[type="text"] {
+      width: 100%;
+      background: var(--vscode-input-background, var(--vscode-button-secondaryBackground));
+      color: var(--vscode-input-foreground, var(--vscode-button-secondaryForeground));
+      border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+      padding: 4px 7px;
+      font-size: 12px;
+      border-radius: 2px;
+      outline: none;
     }
+    #left-rail input[type="text"]:focus,
+    #left-rail select:focus { border-color: var(--vscode-focusBorder, #007fd4); }
+    #left-rail .zoom-row { display: flex; gap: 4px; }
+    #left-rail .zoom-row button { flex: 1; padding: 4px 0; }
+    #left-rail .export-btn {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    #left-rail .export-btn:hover { background: var(--vscode-button-hoverBackground); }
     /* Main content area: graph + side panel */
     #main-content {
       flex: 1; display: flex; overflow: hidden;
@@ -322,42 +425,23 @@ function renderLineageHtml(
     #graph-container svg {
       display: block; width: 100%; height: 100%;
     }
-    /* Side panel */
-    #side-panel {
-      width: 320px;
-      min-width: 320px;
-      border-left: 1px solid var(--vscode-panel-border);
-      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
-      display: flex; flex-direction: column;
-      overflow: hidden;
-    }
-    #side-panel-header {
-      padding: 10px 12px 6px;
-      border-bottom: 1px solid var(--vscode-panel-border);
-      font-size: 11px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      color: var(--vscode-descriptionForeground);
-      flex-shrink: 0;
-    }
+    /* Node details (now inside the left rail) */
     #side-panel-content {
-      flex: 1; overflow-y: auto; padding: 12px;
+      display: flex; flex-direction: column;
+      gap: 8px;
     }
     .panel-empty {
       color: var(--vscode-descriptionForeground);
       font-size: 12px;
-      text-align: center;
-      margin-top: 40px;
+      margin: 0;
     }
     .panel-loading {
       color: var(--vscode-descriptionForeground);
       font-size: 12px;
-      text-align: center;
-      margin-top: 40px;
+      margin: 0;
     }
     .panel-section {
-      margin-bottom: 14px;
+      margin: 0;
     }
     .panel-section-title {
       font-size: 11px;
@@ -587,58 +671,127 @@ function renderLineageHtml(
   </style>
 </head>
 <body>
-  <header>
-    <h2>Lineage: ${escapeHtml(modelName)}</h2>
-    <span class="spacer"></span>
-    <div class="btn-group" title="View granularity">
-      <button id="mode-model" class="active" title="Model-level view (aggregated)">Model</button>
-      <button id="mode-column" title="Column-level view (detailed)">Column</button>
-    </div>
-    <div class="separator"></div>
-    <span class="cluster-select-label">Focus:</span>
-    <select id="focus-mode" class="focus-mode-select" title="Click a node to set focus. Upstream/Downstream dims unrelated nodes.">
-      <option value="all">All</option>
-      <option value="upstream">Upstream</option>
-      <option value="downstream">Downstream</option>
-      <option value="selected">Selected only</option>
-    </select>
-    <div class="separator"></div>
-    <span class="cluster-select-label">Cluster:</span>
-    <select id="cluster-mode" class="cluster-select" title="Group nodes into clusters">
-      <option value="none">None</option>
-      <option value="schema">Schema</option>
-      <option value="source">Source</option>
-    </select>
-    <div class="separator"></div>
-    <span class="cluster-select-label">Layout:</span>
-    <select id="layout-mode" class="layout-select" title="Graph layout direction">
-      <option value="LR">Horizontal</option>
-      <option value="TB">Vertical</option>
-    </select>
-    <div class="separator"></div>
-    <input id="search-input" class="search-input" type="text" placeholder="Search nodes…" title="Filter nodes by name (case-insensitive). Use /regex/ for pattern matching." />
-    <div class="separator"></div>
-    <button id="zoom-out" title="Zoom out (-)">−</button>
-    <button id="zoom-reset" title="Reset zoom (0)">100%</button>
-    <button id="zoom-in" title="Zoom in (+)">+</button>
-    <button id="zoom-fit" title="Fit to view (F)">Fit</button>
-    <button id="export-svg" title="Export as SVG">Export SVG</button>
-  </header>
   <div id="main-content">
     <div id="viewport">
       <div id="graph-container"><svg id="graph-svg"></svg></div>
     </div>
-    <div id="side-panel">
-      <div id="side-panel-header">Node Details</div>
-      <div id="side-panel-content">
-        <p class="panel-empty">Click a node for details.</p>
+    <aside id="left-rail">
+      <div class="rail-header">
+        <h2 class="rail-title">Lineage</h2>
+        <button id="rail-toggle" type="button" title="Collapse panel" aria-label="Collapse panel">›</button>
       </div>
-    </div>
+      <div class="rail-model" title="${escapeHtml(modelName)}">${escapeHtml(modelName)}</div>
+
+      <div class="rail-section" data-section="controls">
+        <button type="button" class="rail-section-toggle" aria-expanded="true">
+          <span class="rail-section-label">Controls</span>
+          <span class="rail-section-chevron">▾</span>
+        </button>
+        <div class="rail-section-body">
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">View</div>
+            <div class="btn-group" title="View granularity">
+              <button id="mode-model" class="active" title="Model-level view (aggregated)">Model</button>
+              <button id="mode-column" title="Column-level view (detailed)">Column</button>
+            </div>
+          </div>
+
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">Focus</div>
+            <select id="focus-mode" class="focus-mode-select" title="Click a node to set focus. Upstream/Downstream dims unrelated nodes.">
+              <option value="all">All</option>
+              <option value="upstream">Upstream</option>
+              <option value="downstream">Downstream</option>
+              <option value="selected">Selected only</option>
+            </select>
+          </div>
+
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">Cluster</div>
+            <select id="cluster-mode" class="cluster-select" title="Group nodes into clusters">
+              <option value="none">None</option>
+              <option value="schema">Schema</option>
+              <option value="source">Source</option>
+            </select>
+          </div>
+
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">Layout</div>
+            <select id="layout-mode" class="layout-select" title="Graph layout direction">
+              <option value="LR">Horizontal</option>
+              <option value="TB">Vertical</option>
+            </select>
+          </div>
+
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">Search</div>
+            <input id="search-input" class="search-input" type="text" placeholder="filter…" title="Filter nodes by name (case-insensitive). Use /regex/ for pattern matching." />
+          </div>
+
+          <div class="rail-subgroup">
+            <div class="rail-subgroup-label">Zoom</div>
+            <div class="zoom-row">
+              <button id="zoom-out" title="Zoom out (-)">−</button>
+              <button id="zoom-reset" title="Reset zoom (0)">100%</button>
+              <button id="zoom-in" title="Zoom in (+)">+</button>
+            </div>
+            <button id="zoom-fit" title="Fit to view (F)">Fit</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="rail-section" data-section="details">
+        <button type="button" class="rail-section-toggle" aria-expanded="true">
+          <span class="rail-section-label">Node Details</span>
+          <span class="rail-section-chevron">▾</span>
+        </button>
+        <div class="rail-section-body">
+          <div id="side-panel-content">
+            <p class="panel-empty">Click a node for details.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="rail-section" data-section="export">
+        <button type="button" class="rail-section-toggle" aria-expanded="true">
+          <span class="rail-section-label">Export</span>
+          <span class="rail-section-chevron">▾</span>
+        </button>
+        <div class="rail-section-body">
+          <button id="export-svg" class="export-btn" title="Export as SVG">Export SVG</button>
+        </div>
+      </div>
+    </aside>
   </div>
   <div id="status" class="status">Rendering…</div>
 
   <script id="lineage-data" type="application/json" nonce="${nonce}">${escapeJsonForScript(dataJson)}</script>
   <script src="${graphUri}" nonce="${nonce}"></script>
+  <script nonce="${nonce}">
+// Error handler lives in its OWN script tag so a parse error in the main
+// script tag below doesn't prevent it from registering. Surfaces any
+// uncaught error to the status bar instead of leaving "Rendering…" stuck.
+(function () {
+  function showError(msg) {
+    const el = document.getElementById('status');
+    if (el) {
+      el.textContent = 'Lineage error: ' + msg;
+      el.classList.add('error');
+    }
+  }
+  window.addEventListener('error', (e) => {
+    if (e.filename && e.lineno) {
+      showError((e.message || 'error') + ' (' + e.filename + ':' + e.lineno + ':' + (e.colno || 0) + ')');
+    } else {
+      showError((e.error && e.error.message) || e.message || 'unknown error');
+    }
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    const r = e.reason;
+    showError((r && r.message) || String(r) || 'unhandled rejection');
+  });
+})();
+  </script>
   <script nonce="${nonce}">
 (function () {
   'use strict';
@@ -674,6 +827,11 @@ function renderLineageHtml(
   const validFocusModes = ['all', 'upstream', 'downstream', 'selected'];
   let currentFocusMode = validFocusModes.includes(saved.focusMode) ? saved.focusMode : 'all';
   let currentFocusNode = (typeof saved.focusNode === 'string') ? saved.focusNode : null;
+  let railCollapsed = saved.railCollapsed === true;
+  // IDs of rail-sections that should be rendered collapsed.
+  let collapsedSections = new Set(
+    Array.isArray(saved.collapsedSections) ? saved.collapsedSections : []
+  );
   let selectedNodeModel = null; // currently selected model name (for side panel)
   let focusedClusterId = null;  // currently focused cluster (null = none)
 
@@ -696,6 +854,8 @@ function renderLineageHtml(
     searchQuery: currentSearchQuery,
     focusMode: currentFocusMode,
     focusNode: currentFocusNode,
+    railCollapsed: railCollapsed,
+    collapsedSections: Array.from(collapsedSections),
   };
 
   function persistState(patch) {
@@ -1139,7 +1299,9 @@ function renderLineageHtml(
    */
   function buildMatcher(query) {
     if (!query) return { test: () => true, isError: false };
-    const regexMatch = query.match(/^\/(.*)\/([gimsuy]*)$/);
+    // Double-escaped because this entire script body lives inside a TS
+    // template literal; the runtime needs to see \/ in the regex literal.
+    const regexMatch = query.match(/^\\/(.*)\\/([gimsuy]*)$/);
     if (regexMatch) {
       try {
         const re = new RegExp(regexMatch[1], regexMatch[2] || 'i');
@@ -1655,15 +1817,123 @@ function renderLineageHtml(
   });
 
   // ── Export SVG ───────────────────────────────────────────────────────────────
+  // The live SVG references VS Code CSS variables (e.g. --vscode-foreground)
+  // that don't resolve outside the webview, has no xmlns, and lacks a
+  // background. Build a standalone-readable clone that inlines a resolved
+  // stylesheet, adds the SVG namespace, resets the user's pan/zoom, and paints
+  // the editor-background color underneath.
   document.getElementById('export-svg').onclick = () => {
-    const blob = new Blob([svgEl.outerHTML], { type: 'image/svg+xml' });
-    const url  = URL.createObjectURL(blob);
-    const a    = document.createElement('a');
-    a.href     = url;
+    const clone = svgEl.cloneNode(true);
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+
+    // Reset the d3-zoom transform on the cloned graph group so the export
+    // shows the full graph (not the user's current zoom/pan).
+    const gg = clone.querySelector('g[transform]');
+    if (gg) gg.removeAttribute('transform');
+
+    // Set width/height attrs (some viewers ignore SVGs without them).
+    const vb = (clone.getAttribute('viewBox') || '').split(/\\s+/);
+    if (vb.length === 4) {
+      clone.setAttribute('width', vb[2]);
+      clone.setAttribute('height', vb[3]);
+    }
+
+    // Resolve VS Code CSS variables to concrete colors.
+    const root = getComputedStyle(document.documentElement);
+    const v = (name, fallback) => (root.getPropertyValue(name).trim() || fallback);
+    const fg = v('--vscode-foreground', '#cccccc');
+    const bg = v('--vscode-editor-background', '#1e1e1e');
+    const muted = v('--vscode-descriptionForeground', '#888888');
+    const focalBg = v('--vscode-button-background', '#0e639c');
+    const focalFg = v('--vscode-button-foreground', '#ffffff');
+    const badgeBg = v('--vscode-badge-background', '#4d4d4d');
+    const sourceFill = v('--vscode-charts-blue', badgeBg);
+    const leafFill = v('--vscode-charts-green', badgeBg);
+    const panelBorder = v('--vscode-panel-border', '#444444');
+
+    // Inline stylesheet — order matters; .focal overrides .source/.leaf.
+    const svgNs = 'http://www.w3.org/2000/svg';
+    const styleEl = document.createElementNS(svgNs, 'style');
+    styleEl.textContent =
+      'text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 11px; }' +
+      '.node rect { fill: ' + badgeBg + '; stroke: ' + fg + '; stroke-width: 1.5px; }' +
+      '.node text { fill: ' + fg + '; }' +
+      '.node.source rect { fill: ' + sourceFill + '; }' +
+      '.node.leaf rect { fill: ' + leafFill + '; }' +
+      '.node.focal rect { fill: ' + focalBg + '; stroke: ' + focalFg + '; stroke-width: 2px; }' +
+      '.node.focal text { fill: ' + focalFg + '; font-weight: 600; }' +
+      '.cluster-bbox { fill: transparent; stroke: ' + panelBorder + '; stroke-width: 1px; stroke-dasharray: 4 3; }' +
+      '.cluster-label { fill: ' + muted + '; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }' +
+      '.cluster-header-hit { display: none; }' +
+      '.edgePath path { stroke: ' + muted + '; stroke-width: 1.5px; fill: none; }' +
+      '.edgeLabel text { fill: ' + muted + '; font-size: 10px; }' +
+      'marker path { fill: ' + muted + '; stroke: none; }';
+
+    // Background rect so the SVG isn't transparent when opened standalone.
+    const bgRect = document.createElementNS(svgNs, 'rect');
+    bgRect.setAttribute('x', '0');
+    bgRect.setAttribute('y', '0');
+    bgRect.setAttribute('width', '100%');
+    bgRect.setAttribute('height', '100%');
+    bgRect.setAttribute('fill', bg);
+
+    clone.insertBefore(styleEl, clone.firstChild);
+    clone.insertBefore(bgRect, styleEl.nextSibling);
+
+    const xml = '<?xml version="1.0" encoding="UTF-8"?>\\n' + clone.outerHTML;
+    const blob = new Blob([xml], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
     a.download = focalModel + '-lineage.svg';
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  // ── Rail collapse toggle ─────────────────────────────────────────────────────
+  const railEl = document.getElementById('left-rail');
+  const railToggleBtn = document.getElementById('rail-toggle');
+  function applyRailState() {
+    railEl.classList.toggle('collapsed', railCollapsed);
+    // Rail is right-docked: ‹ expands (push left), › collapses (push right).
+    railToggleBtn.textContent = railCollapsed ? '‹' : '›';
+    railToggleBtn.title = railCollapsed ? 'Expand panel' : 'Collapse panel';
+    railToggleBtn.setAttribute('aria-label', railToggleBtn.title);
+  }
+  applyRailState();
+  railToggleBtn.onclick = () => {
+    railCollapsed = !railCollapsed;
+    persistState({ railCollapsed: railCollapsed });
+    applyRailState();
+    // Re-fit after the rail width animation finishes so the graph re-centers
+    // into the new viewport.
+    setTimeout(() => fitToView(), 180);
+  };
+
+  // ── Per-section accordion toggles ────────────────────────────────────────────
+  // Each rail-section has a header button that collapses/expands its body.
+  // The collapsed set is persisted so reloads remember which sections the user
+  // had closed.
+  function applySectionState(section) {
+    const id = section.getAttribute('data-section');
+    const collapsed = collapsedSections.has(id);
+    section.classList.toggle('collapsed', collapsed);
+    const toggle = section.querySelector('.rail-section-toggle');
+    if (toggle) toggle.setAttribute('aria-expanded', String(!collapsed));
+  }
+  document.querySelectorAll('#left-rail .rail-section').forEach((section) => {
+    applySectionState(section);
+    const toggle = section.querySelector('.rail-section-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      const id = section.getAttribute('data-section');
+      if (collapsedSections.has(id)) collapsedSections.delete(id);
+      else collapsedSections.add(id);
+      applySectionState(section);
+      persistState({ collapsedSections: Array.from(collapsedSections) });
+    });
+  });
 
   // ── Initial zoom/pan restore or auto-fit ──────────────────────────────────────
   if (typeof saved.scale === 'number' && (saved.panX !== undefined || saved.panY !== undefined)) {

--- a/editors/vscode/src/commands/ops.ts
+++ b/editors/vscode/src/commands/ops.ts
@@ -10,8 +10,9 @@ import { showDoctorResult } from "../webviews/doctor";
 import { ensureWorkspace, resolveModelName, showJsonInEditor } from "./ui";
 
 export async function doctor(): Promise<void> {
-  if (!ensureWorkspace()) return;
-
+  // Doctor checks binary install + config — it runs without a workspace
+  // and reports `critical` for the missing rocky.toml. The Get Started
+  // welcome links here precisely to verify installation, so don't gate it.
   try {
     const result = await runRockyJsonWithProgress<DoctorResult>(
       "Running Rocky doctor...",

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 
 export interface RockyConfig {
@@ -19,4 +21,47 @@ export function getConfig(): RockyConfig {
 /** Returns the first workspace folder's path, or undefined when none is open. */
 export function getWorkspaceFolder(): string | undefined {
   return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+}
+
+/**
+ * Walk up from `startDir` looking for the nearest directory containing a
+ * `rocky.toml`. Returns that directory, or undefined if none found before
+ * hitting the filesystem root.
+ */
+function findRockyTomlUp(startDir: string): string | undefined {
+  let dir = startDir;
+  for (let i = 0; i < 32; i++) {
+    if (fs.existsSync(path.join(dir, "rocky.toml"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the Rocky project root for a command. Strategy:
+ *  1. If an active file is given, walk up from its directory to find `rocky.toml`.
+ *  2. Otherwise, walk up from the active text editor's file (if any).
+ *  3. Otherwise, walk up from each workspace folder.
+ *  4. Fall back to the first workspace folder (let the CLI report the error).
+ */
+export function resolveProjectRoot(activeFile?: vscode.Uri | string): string | undefined {
+  const candidates: string[] = [];
+  if (activeFile) {
+    const p = typeof activeFile === "string" ? activeFile : activeFile.fsPath;
+    candidates.push(path.dirname(p));
+  }
+  const editor = vscode.window.activeTextEditor;
+  if (editor && editor.document.uri.scheme === "file") {
+    candidates.push(path.dirname(editor.document.uri.fsPath));
+  }
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    candidates.push(folder.uri.fsPath);
+  }
+  for (const dir of candidates) {
+    const found = findRockyTomlUp(dir);
+    if (found) return found;
+  }
+  return getWorkspaceFolder();
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LSP semantic tokens off-by-one column** (`rocky-server`). `sqlparser` reports identifier spans with **1-indexed** lines *and* columns, but the LSP token collector only converted the line (`line - 1`) and emitted the column as-is. Identifiers at the end of a line ended up with `endChar = startChar + len` overflowing the line length, causing VS Code to log `Invalid Semantic Tokens Data From Extension: end character > model.getLineLength(lineNumber)` and silently drop the tokens. Fix subtracts 1 from `column` on every emitted token in `collect_tokens_from_table_factor` and the `Identifier` / `CompoundIdentifier` / `Function` arms of `collect_tokens_from_expr`. The qualified-name token in `collect_tokens_from_table_factor` also now uses the first identifier's `value.len()` instead of the full `name.to_string().len()`, so the range can't extend past the line when a `catalog.schema.model` name wraps.
+
 ## [1.31.0] — 2026-05-13
 
 **Cluster 3 E — semantic breaking-change diff — shipped end-to-end** across three PRs. Rocky now produces typed structural classifications of changes between two `ProjectIr` snapshots, exposes them informationally via `rocky ci-diff --semantic`, and uses them as a failing pre-promote gate on `rocky branch promote`. Strictly more powerful than text-shaped diff (SQLMesh's approach): operates on the typed IR rather than parsing emitted SQL strings.

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -2887,8 +2887,11 @@ fn collect_tokens_from_table_factor(
                 if let Some(first_ident) = first_part.as_ident() {
                     let line = first_ident.span.start.line as u32;
                     let col = first_ident.span.start.column as u32;
-                    // line is 1-indexed from sqlparser, convert to 0-indexed
-                    tokens.push((line.saturating_sub(1), col, table_name.len() as u32, 0)); // NAMESPACE
+                    // sqlparser uses 1-indexed line/column; LSP expects 0-indexed.
+                    // Only emit a token for the leading identifier so the range
+                    // can't extend past the line if the qualified name wraps.
+                    let len = first_ident.value.len() as u32;
+                    tokens.push((line.saturating_sub(1), col.saturating_sub(1), len, 0)); // NAMESPACE
                 }
             }
         }
@@ -2904,16 +2907,17 @@ fn collect_tokens_from_expr(
         ast::Expr::Identifier(ident) => {
             let line = ident.span.start.line as u32;
             let col = ident.span.start.column as u32;
-            if line > 0 {
-                tokens.push((line - 1, col, ident.value.len() as u32, 1)); // VARIABLE
+            // sqlparser uses 1-indexed line/column; LSP expects 0-indexed.
+            if line > 0 && col > 0 {
+                tokens.push((line - 1, col - 1, ident.value.len() as u32, 1)); // VARIABLE
             }
         }
         ast::Expr::CompoundIdentifier(parts) => {
             for part in parts {
                 let line = part.span.start.line as u32;
                 let col = part.span.start.column as u32;
-                if line > 0 {
-                    tokens.push((line - 1, col, part.value.len() as u32, 1)); // VARIABLE
+                if line > 0 && col > 0 {
+                    tokens.push((line - 1, col - 1, part.value.len() as u32, 1)); // VARIABLE
                 }
             }
         }
@@ -2924,8 +2928,11 @@ fn collect_tokens_from_expr(
                     if let Some(first_ident) = first_part.as_ident() {
                         let line = first_ident.span.start.line as u32;
                         let col = first_ident.span.start.column as u32;
-                        if line > 0 {
-                            tokens.push((line - 1, col, func_name.len() as u32, 2)); // FUNCTION
+                        // Emit only the first ident's length to keep the range
+                        // single-line and within the line bounds.
+                        let len = first_ident.value.len() as u32;
+                        if line > 0 && col > 0 {
+                            tokens.push((line - 1, col - 1, len, 2)); // FUNCTION
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Two-subproject session split into two commits. No version bumps in this PR — release later.

**Engine** (`rocky-server`, LSP)
- Fix semantic-tokens off-by-one column. `sqlparser` is 1-indexed for both line and column, but the LSP collector only converted the line. Tokens at end-of-line ended up with `endChar > lineLength` and got dropped by VS Code (`Invalid Semantic Tokens Data From Extension: end character > model.getLineLength(lineNumber)`).

**VS Code extension** (lineage)
- **Fix:** Lineage panel was stuck on `Rendering…`. The search regex `/^\/(.*)\/([gimsuy]*)$/` lives in a TS template literal; `\/` was stripped at evaluation, producing an invalid runtime regex (`SyntaxError: Unexpected token '.'`) that killed the main IIFE. Doubled the escapes.
- **Fix:** `rocky.doctor` no longer requires a workspace folder — the "Run Health Check" welcome flow explicitly exists to verify the CLI install before there's a project.
- **Fix:** Lineage now walks up from the active file's directory to find the nearest `rocky.toml` (new `resolveProjectRoot()` in `config.ts`), instead of hard-coding `${workspaceFolder}/rocky.toml` and failing when the workspace root isn't the project root.
- **Fix:** SVG export now produces a standalone-readable file — sets `xmlns`, resets the d3-zoom transform on the clone, paints the editor background, and inlines a stylesheet with VS Code CSS variables resolved to concrete colours.
- **Feat:** Webview script errors are surfaced. A small handler in its own `<script>` tag writes `Lineage error: <msg> (<file>:<line>:<col>)` into the status bar instead of leaving the panel stuck on `Rendering…`.
- **Feat:** Lineage rail redesign. Old horizontal toolbar + 320px right-side details panel → single right-docked 240px vertical rail with three top-level collapsible sections: **Controls** (View / Focus / Cluster / Layout / Search / Zoom subgrouped inline), **Node Details**, **Export**. Each section header has a chevron toggle; a `‹/›` button at the top of the rail collapses it to a 28px strip. Per-section and rail-collapsed state persist via `vscode.setState`. Graph re-fits after the rail-width animation.

## Test plan

- [x] `cargo build -p rocky-server` (engine)
- [x] `cargo test -p rocky-server --lib` → 61 passed
- [x] `npm run compile` + `npm run lint` (vscode)
- [x] `npm run test:unit` → 106 passed
- [ ] Reload VS Code with the new VSIX, open a project, exercise the lineage panel: open / search (try `/regex/`) / collapse sections / collapse rail / Export SVG / open exported SVG in a browser.
- [ ] Open a file from outside the workspace root and run "Show Lineage" — should still find the right `rocky.toml`.
- [ ] Run "Run Health Check" from the Get Started welcome with no workspace open — should render the doctor webview, not show `No workspace folder open`.
- [ ] Restart the Rocky LSP server (`Rocky: Restart Server`) and confirm the `Invalid Semantic Tokens Data From Extension` warning no longer fires in `Help → Toggle Developer Tools → Console`.