### PR TITLE
fix(playground): ignore expected/*.stderr fixtures

### DIFF
--- a/examples/playground/.gitignore
+++ b/examples/playground/.gitignore
@@ -14,6 +14,7 @@ pocs/**/expected/*.txt
 pocs/**/expected/*.jsonl
 pocs/**/expected/*.log
 pocs/**/expected/*.err
+pocs/**/expected/*.stderr
 !pocs/**/expected/.gitkeep
 # Aspirational target shapes for not-yet-implemented commands stay tracked.
 !pocs/**/expected/*.example.json


### PR DESCRIPTION
## Summary
- `examples/playground/.gitignore` already ignored captured streams under `pocs/**/expected/` (`.json`, `.err`, `.log`, `.jsonl`, `.txt`, `.dot`) but not `.stderr`.
- The 15-semantic-breaking-change-gate POC's `run.sh` captures `rocky branch promote` stderr to `expected/promote_blocked.stderr`, so the directory kept showing as untracked after every run even though every file in it is regenerated.
- Adds `pocs/**/expected/*.stderr` so the rule matches the others.

## Test plan
- [ ] `./run.sh` in `examples/playground/pocs/06-developer-experience/15-semantic-breaking-change-gate/` leaves `git status` clean.