### PR TITLE
feat(rocky-cli): deprecate `rocky run` and bare `rocky branch promote` aliases

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`rocky run`** — Phase 4 of the plan/apply spine. Bare `rocky run` now emits a one-line `[deprecated]` notice to stderr pointing at the canonical `rocky plan` + `rocky apply <plan-id>` flow. Behaviour is unchanged; removal is targeted for a future major release. JSON-on-stdout is untouched. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
+- **`rocky branch promote <name>`** (without `--plan`) — same Phase 4 cycle. Emits a stderr notice pointing at `rocky plan promote <name>` + `rocky apply <plan-id>`. The `--plan` form is the canonical "review the plan in CI, apply on merge" UX. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
+
+The dagster integration sets `ROCKY_SUPPRESS_DEPRECATION=1` on every subprocess invocation as of `dagster-rocky 1.31.0`, so existing `RockyResource.materialize()` / `RockyResource.run()` callers see no change.
+
 ## [1.32.0] — 2026-05-15
 
 Headline: **Cluster 3 B plan/apply spine fully shipped end-to-end.** Three PRs land the unified plan/apply UX across `compact` / `archive` / `run` / `branch promote`. Plus a small LSP semantic-token column fix.

--- a/engine/crates/rocky-cli/src/deprecation.rs
+++ b/engine/crates/rocky-cli/src/deprecation.rs
@@ -1,0 +1,73 @@
+//! Deprecation-notice emission for CLI aliases retained during the Phase 4
+//! deprecation cycle.
+//!
+//! `rocky run` and the bare-verb form of `rocky branch promote <name>` are
+//! kept as aliases that internally chain `plan + apply` (per Phases 1–3 of
+//! the plan/apply spine, shipped in engine-v1.32.0). They emit a one-line
+//! `[deprecated]` notice to stderr on every invocation pointing at the
+//! canonical two-step flow. Removal target: a future major release.
+//!
+//! Suppression: set `ROCKY_SUPPRESS_DEPRECATION=1` in the environment to
+//! silence the warning. The dagster integration sets this on every
+//! subprocess invocation so existing `RockyResource.materialize()` callers
+//! don't see noise on every run while their orchestration code still
+//! routes through the alias verbs.
+
+use std::io::{self, Write};
+
+const SUPPRESS_ENV_VAR: &str = "ROCKY_SUPPRESS_DEPRECATION";
+
+/// Stderr message emitted by `rocky run`.
+pub const RUN_DEPRECATION: &str = "\
+`rocky run` is deprecated and will be removed in a future major release. \
+Use `rocky plan` to persist a content-addressed run plan, then `rocky apply <plan-id>` to execute it. \
+The two-step flow produces an auditable artifact at `.rocky/plans/<plan-id>.json`. \
+Suppress this warning with ROCKY_SUPPRESS_DEPRECATION=1.";
+
+/// Stderr message emitted by bare `rocky branch promote <name>` (without `--plan`).
+pub const BRANCH_PROMOTE_DEPRECATION: &str = "\
+`rocky branch promote <name>` (without --plan) is deprecated. \
+Use `rocky plan promote <name>` to run the approval + breaking-change gates and persist a promote plan, \
+then `rocky apply <plan-id>` to execute it — letting you inspect findings before any production data is touched. \
+Suppress this warning with ROCKY_SUPPRESS_DEPRECATION=1.";
+
+/// Emit a deprecation notice to stderr unless suppressed.
+///
+/// The notice format is `[deprecated] <message>` on one logical line.
+/// Stdout is untouched so JSON-consuming integrations (Dagster, CI) keep
+/// parsing cleanly — the warning lives on the stderr channel only.
+///
+/// Suppression honours `ROCKY_SUPPRESS_DEPRECATION=1` exactly. Other
+/// values (including `0`, empty, `true`) are treated as unset, so a sub-shell
+/// can re-enable the warning during a migration audit without unsetting the
+/// variable globally.
+pub fn warn(message: &str) {
+    if std::env::var(SUPPRESS_ENV_VAR).as_deref() == Ok("1") {
+        return;
+    }
+    let _ = writeln!(io::stderr(), "[deprecated] {message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Message shape is regression-guarded here; suppression behavior is
+    /// covered by an integration smoke (run the binary with and without the
+    /// env var, grep stderr). Process-global env state doesn't compose with
+    /// parallel cargo-test threads — we deliberately don't try to test
+    /// `warn()` in-process for that reason.
+    #[test]
+    fn warning_messages_are_one_logical_line() {
+        for msg in [RUN_DEPRECATION, BRANCH_PROMOTE_DEPRECATION] {
+            assert!(
+                !msg.contains('\n'),
+                "message must not embed newlines: {msg:?}"
+            );
+            assert!(
+                msg.contains("ROCKY_SUPPRESS_DEPRECATION=1"),
+                "suppress hint missing: {msg:?}"
+            );
+        }
+    }
+}

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod deprecation;
 pub mod error_reporter;
 pub mod otel_guard;
 pub mod output;

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1792,7 +1792,10 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             } else {
                 // `rocky run` is routed through `apply::run_apply_inline_for_run`
                 // (the Phase 2 alias path). This is a thin passthrough — behaviour
-                // is unchanged. Phase 4 will add a deprecation notice here.
+                // is unchanged. Phase 4 emits a deprecation notice; the canonical
+                // flow is `rocky plan` + `rocky apply <plan-id>`. The notice
+                // honours `ROCKY_SUPPRESS_DEPRECATION=1` (dagster sets it).
+                rocky_cli::deprecation::warn(rocky_cli::deprecation::RUN_DEPRECATION);
                 //
                 // `rocky_cli::commands::run` handles SIGINT internally so it
                 // can flush watermarks + mark in-flight tables as
@@ -2332,6 +2335,11 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     .await
                 } else {
                     // Bare-verb: plan + apply inline (backward-compatible).
+                    // Phase 4 emits a deprecation notice; canonical flow is
+                    // `rocky plan promote <name>` + `rocky apply <plan-id>`.
+                    rocky_cli::deprecation::warn(
+                        rocky_cli::deprecation::BRANCH_PROMOTE_DEPRECATION,
+                    );
                     let branch_name = name.ok_or_else(|| {
                         anyhow::anyhow!(
                             "branch name is required when not using --plan. \

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Suppress engine deprecation notices on every subprocess invocation.** Companion to engine Phase 4 (alias deprecation for `rocky run` / `rocky branch promote <name>`). `RockyResource._run_rocky_with_log_sink` now passes a per-subprocess environment to `subprocess.Popen` with `ROCKY_SUPPRESS_DEPRECATION=1` set (`setdefault`, so operators can override). Without this, every dagster-driven `rocky run` would emit a `[deprecated]` line into stderr and surface as Dagster log noise. Migration of the resource off the alias verbs is a separate work item.
+
 ## [1.30.0] — 2026-05-15
 
 Companion release to engine `v1.32.0`. Wires the Cluster 3 B plan/apply spine into the dagster integration.

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1117,11 +1117,21 @@ class RockyResource(dg.ConfigurableResource):
         # equivalent; ``proc.kill()`` fallback in ``_kill_process_group``
         # handles the single-process case, which is all rocky does on
         # Windows today.
+        # Inherit the parent environment and force-suppress engine deprecation
+        # notices. `RockyResource.materialize()` still routes through `rocky run`
+        # (and operators can call branch promote in its bare form); engine-v1.33+
+        # would otherwise emit a `[deprecated]` line on stderr for every
+        # invocation, surfacing as noise in Dagster run logs. Migration off the
+        # alias verbs is a separate dagster work item, tracked alongside the
+        # engine Phase 4 cycle.
+        rocky_env = os.environ.copy()
+        rocky_env.setdefault("ROCKY_SUPPRESS_DEPRECATION", "1")
         popen_kwargs: dict[str, object] = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.PIPE,
             "text": True,
             "bufsize": 1,  # line-buffered so the readers see lines as they're written
+            "env": rocky_env,
         }
         if os.name != "nt":
             popen_kwargs["start_new_session"] = True


### PR DESCRIPTION
## Summary

Phase 4 of the plan/apply spine: the two alias verbs retained during Phases 1–3 now emit a one-line `[deprecated]` notice to stderr on every invocation, pointing at the canonical two-step flow. Behaviour is unchanged; removal is targeted for a future major release.

- **`rocky run`** → `[deprecated]` notice pointing at `rocky plan` + `rocky apply <plan-id>`. The two-step flow produces an auditable artifact at `.rocky/plans/<plan-id>.json`.
- **`rocky branch promote <name>`** (bare form, without `--plan`) → `[deprecated]` notice pointing at `rocky plan promote <name>` + `rocky apply <plan-id>`. The `--plan` form is the canonical "review the plan in CI, apply on merge" UX; it is unaffected.
- **JSON-on-stdout is untouched** — JSON-consuming integrations keep parsing cleanly. Warnings live on the stderr channel only.
- **Suppression is opt-in via `ROCKY_SUPPRESS_DEPRECATION=1`.** The dagster integration sets this on every subprocess invocation via `subprocess.Popen(env=…)` so existing `RockyResource.materialize()` callers see no change.

### Surface

| File | Change |
|---|---|
| `engine/crates/rocky-cli/src/deprecation.rs` | New module: `warn()` emits `[deprecated] <message>` to stderr unless `ROCKY_SUPPRESS_DEPRECATION=1`. Suppression honours `=1` exactly; other values treat the variable as unset. |
| `engine/crates/rocky-cli/src/lib.rs` | `pub mod deprecation;` |
| `engine/rocky/src/main.rs` | Two `deprecation::warn` call sites: the `Command::Run` passthrough into `run_apply_inline_for_run`, and the bare-verb branch of `BranchAction::Promote`. |
| `integrations/dagster/src/dagster_rocky/resource.py` | `_run_rocky_with_log_sink` passes a per-subprocess environment to `subprocess.Popen` with `ROCKY_SUPPRESS_DEPRECATION=1` set via `setdefault` so operators can still override. |
| `engine/CHANGELOG.md` + `integrations/dagster/CHANGELOG.md` | `[Unreleased]` entries on both sides. |

## Test plan

- [x] `cargo check -p rocky-cli -p rocky` clean
- [x] `cargo clippy -p rocky-cli -p rocky --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rocky-cli --lib` — 438 tests pass (was 437; +1 const-shape regression guard)
- [x] Live smoke: `rocky run` emits the warning to stderr; `ROCKY_SUPPRESS_DEPRECATION=1 rocky run` is silent
- [x] Live smoke: bare `rocky branch promote` emits the second warning
- [x] `uv run pytest` in `integrations/dagster/` — 527 tests pass
- [x] `just codegen` — zero JSON-schema / Pydantic / TS / npm-lockfile drift

## Follow-up

Doc sweep (40 files reference `rocky run`, 5 reference `rocky branch promote`) is a separate PR — purely mechanical, splits cleanly. POCs (~59 files) do not need updating during the deprecation cycle; the warning is informational and they continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)