### PR TITLE
fix(rocky-cli): clarify Phase 4 deprecation copy for advanced `rocky run` flags

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- **`rocky run`** — Phase 4 of the plan/apply spine. Bare `rocky run` now emits a one-line `[deprecated]` notice to stderr pointing at the canonical `rocky plan` + `rocky apply <plan-id>` flow. Behaviour is unchanged; removal is targeted for a future major release. JSON-on-stdout is untouched. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
+- **`rocky run`** — Phase 4 of the plan/apply spine. Bare `rocky run` now emits a one-line `[deprecated]` notice to stderr pointing at the canonical `rocky plan` + `rocky apply <plan-id>` flow. Behaviour is unchanged. JSON-on-stdout is untouched. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
+
+  **Scope note (added 2026-05-16):** the canonical `rocky plan` / `rocky apply` pair currently accepts only the basic invocation surface (`--filter`, `--pipeline`, `--env`). Advanced flags — `--resume` / `--resume-latest`, `--shadow*`, `--partition` / `--from` / `--to` / `--latest` / `--missing` / `--lookback`, `--idempotency-key`, `--parallel`, `--all`, `--branch`, `--governance-override`, `--dag` — continue to live on `rocky run` until plan/apply parity lands. The deprecation message acknowledges this. `rocky run` is retained for those advanced flows.
 - **`rocky branch promote <name>`** (without `--plan`) — same Phase 4 cycle. Emits a stderr notice pointing at `rocky plan promote <name>` + `rocky apply <plan-id>`. The `--plan` form is the canonical "review the plan in CI, apply on merge" UX. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
 
 The dagster integration sets `ROCKY_SUPPRESS_DEPRECATION=1` on every subprocess invocation as of `dagster-rocky 1.31.0`, so existing `RockyResource.materialize()` / `RockyResource.run()` callers see no change.

--- a/engine/crates/rocky-cli/src/deprecation.rs
+++ b/engine/crates/rocky-cli/src/deprecation.rs
@@ -18,10 +18,17 @@ use std::io::{self, Write};
 const SUPPRESS_ENV_VAR: &str = "ROCKY_SUPPRESS_DEPRECATION";
 
 /// Stderr message emitted by `rocky run`.
+///
+/// Wording acknowledges that `rocky plan` / `rocky apply` do not yet accept
+/// the full flag surface of `rocky run` (e.g. `--resume`, `--shadow`,
+/// `--partition`, `--idempotency-key`, `--parallel`, `--all`, `--branch`,
+/// `--governance-override`, `--dag`). Until plan/apply parity lands those
+/// flags continue to live on `rocky run` and the alias is retained for them.
 pub const RUN_DEPRECATION: &str = "\
-`rocky run` is deprecated and will be removed in a future major release. \
-Use `rocky plan` to persist a content-addressed run plan, then `rocky apply <plan-id>` to execute it. \
-The two-step flow produces an auditable artifact at `.rocky/plans/<plan-id>.json`. \
+`rocky run` is deprecated for basic invocations — the canonical form is `rocky plan` followed by `rocky apply <plan-id>`, \
+which persists an auditable artifact at `.rocky/plans/<plan-id>.json`. \
+Advanced flags (--resume, --shadow, --partition, --idempotency-key, --parallel, --all, --branch, --governance-override, --dag) \
+are not yet available on `rocky plan` / `rocky apply` and remain on `rocky run` until plan/apply parity lands. \
 Suppress this warning with ROCKY_SUPPRESS_DEPRECATION=1.";
 
 /// Stderr message emitted by bare `rocky branch promote <name>` (without `--plan`).


### PR DESCRIPTION
## Summary

Follow-up to #532 (Phase 4 alias deprecation) and #533 (Phase 4 doc sweep).

The doc-sweep PR surfaced that `rocky plan` and `rocky apply` accept only the basic invocation surface (`--filter`, `--pipeline`, `--env`). The flag-rich surface of `rocky run` has no canonical replacement on the plan/apply pair yet — users invoking those flows cannot honestly migrate. The deprecation message shipped in #532 implied otherwise.

This PR amends the user-facing copy to match the actual scope:

- `RUN_DEPRECATION` message in `engine/crates/rocky-cli/src/deprecation.rs` now acknowledges that advanced flags remain on `rocky run` until plan/apply parity lands. Basic invocations still route users to the auditable two-step flow.
- Engine `CHANGELOG.md` `[Unreleased]` entry gets a scope note enumerating which flags stay on `rocky run`: `--resume` / `--resume-latest`, `--shadow*`, `--partition` / `--from` / `--to` / `--latest` / `--missing` / `--lookback`, `--idempotency-key`, `--parallel`, `--all`, `--branch`, `--governance-override`, `--dag`.

No behaviour change. Plan/apply parity is a separate engineering effort (~3-5 days of CLI work) that will land as its own PR; until then the deprecation copy is honest about what users can and can't move off.

## Test plan

- [x] `cargo test -p rocky-cli --lib deprecation` — 1 const-shape regression guard passes
- [x] `cargo clippy -p rocky-cli -p rocky --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live smoke: `rocky run --output json` emits the new clarified deprecation line on stderr
- [x] `ROCKY_SUPPRESS_DEPRECATION=1` still suppresses (unchanged from #532)