### PR TITLE
feat(rocky-cli): backfill `rocky run` flag surface onto `rocky plan` / `rocky apply`

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky plan` flag-surface parity with `rocky run`.** `rocky plan` now accepts the full flag surface of `rocky run` (`--resume`, `--resume-latest`, `--shadow`, `--shadow-suffix`, `--shadow-schema`, `--branch`, `--partition`, `--from`, `--to`, `--latest`, `--missing`, `--lookback`, `--parallel`, `--all`, `--dag`, `--idempotency-key`, `--governance-override`, `--model`, `--models`) — the plan/apply pair is now a complete replacement for `rocky run`. Flags are captured into the persisted `RunPlan` payload so `rocky apply <plan-id>` honours them at apply time, including branch → shadow resolution. `--watch` is the one exception: its re-run-loop semantics have no plan/apply analogue and it remains exclusive to `rocky run`.
+
 ### Deprecated
 
-- **`rocky run`** — Phase 4 of the plan/apply spine. Bare `rocky run` now emits a one-line `[deprecated]` notice to stderr pointing at the canonical `rocky plan` + `rocky apply <plan-id>` flow. Behaviour is unchanged. JSON-on-stdout is untouched. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
-
-  **Scope note (added 2026-05-16):** the canonical `rocky plan` / `rocky apply` pair currently accepts only the basic invocation surface (`--filter`, `--pipeline`, `--env`). Advanced flags — `--resume` / `--resume-latest`, `--shadow*`, `--partition` / `--from` / `--to` / `--latest` / `--missing` / `--lookback`, `--idempotency-key`, `--parallel`, `--all`, `--branch`, `--governance-override`, `--dag` — continue to live on `rocky run` until plan/apply parity lands. The deprecation message acknowledges this. `rocky run` is retained for those advanced flows.
+- **`rocky run`** — Phase 4 of the plan/apply spine. Bare `rocky run` now emits a one-line `[deprecated]` notice to stderr pointing at the canonical `rocky plan` + `rocky apply <plan-id>` flow. Behaviour is unchanged. JSON-on-stdout is untouched. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`. With the flag-surface parity above, `rocky run` is now fully migratable; only `--watch` callers (re-run loop) need to keep using it.
 - **`rocky branch promote <name>`** (without `--plan`) — same Phase 4 cycle. Emits a stderr notice pointing at `rocky plan promote <name>` + `rocky apply <plan-id>`. The `--plan` form is the canonical "review the plan in CI, apply on merge" UX. Suppress with `ROCKY_SUPPRESS_DEPRECATION=1`.
 
 The dagster integration sets `ROCKY_SUPPRESS_DEPRECATION=1` on every subprocess invocation as of `dagster-rocky 1.31.0`, so existing `RockyResource.materialize()` / `RockyResource.run()` callers see no change.

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -65,6 +65,13 @@ pub(crate) async fn run_apply_in(
 
 /// Apply a `PlanKind::Run` plan by re-executing `commands::run::run` with
 /// the persisted operational metadata.
+///
+/// The full flag surface of `rocky run` is replayed from the persisted
+/// `RunPlan` payload — partitioning, shadow / branch routing, governance
+/// override, resume, idempotency key, and the `--dag` mode. Flags whose
+/// semantics depend on state at apply time (`--missing`,
+/// `--resume-latest`) are passed through as booleans; the actual state-store
+/// lookup happens inside `commands::run::run`.
 async fn run_apply_run_plan(
     root: &Path,
     config_path: &Path,
@@ -97,25 +104,55 @@ async fn run_apply_run_plan(
         parallel: run_plan.parallel,
     };
 
-    // Shadow config — not persisted in RunPlan (branch is tracked but
-    // shadow_suffix / shadow_schema are derived at apply time from branch).
-    // For Phase 2, branch → shadow routing is not wired; apply executes
-    // against the default (production) target. Phase 3 will add branch-based
-    // shadow resolution.
-    let shadow_config = if let Some(ref _branch) = run_plan.branch {
-        tracing::warn!(
-            "run plan includes a --branch flag but apply does not yet resolve \
-             branch → shadow config; executing against default target. \
-             Phase 3 will add branch-based shadow resolution."
-        );
-        None
+    // Resolve the state path via the standard resolver (mirrors main.rs).
+    // Used both by branch→shadow resolution below and by `run` itself.
+    let resolved = rocky_core::state::resolve_state_path(None, std::path::Path::new("models"));
+    let state_path = resolved.path;
+
+    // Shadow config. Mirrors the `Command::Run` dispatch in main.rs:
+    // `--branch` is internally equivalent to `--shadow --shadow-schema
+    // <branch.schema_prefix>`; otherwise `--shadow` activates the shadow
+    // path with the persisted suffix / schema override. clap rejects
+    // `--branch` combined with the shadow flags at plan time, so we only
+    // see one of the two shapes here.
+    let shadow_suffix = run_plan
+        .shadow_suffix
+        .clone()
+        .unwrap_or_else(|| "_rocky_shadow".to_string());
+    let shadow_config = if let Some(ref name) = run_plan.branch {
+        let store = rocky_core::state::StateStore::open_read_only(&state_path)
+            .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+        let record = store.get_branch(name)?.with_context(|| {
+            format!("branch '{name}' not found — create it with `rocky branch create {name}`")
+        })?;
+        Some(rocky_core::shadow::ShadowConfig {
+            suffix: shadow_suffix,
+            schema_override: Some(record.schema_prefix),
+            cleanup_after: false,
+        })
+    } else if run_plan.shadow {
+        Some(rocky_core::shadow::ShadowConfig {
+            suffix: shadow_suffix,
+            schema_override: run_plan.shadow_schema.clone(),
+            cleanup_after: false,
+        })
     } else {
         None
     };
 
-    // Resolve the state path via the standard resolver (mirrors main.rs).
-    let resolved = rocky_core::state::resolve_state_path(None, std::path::Path::new("models"));
-    let state_path = resolved.path;
+    let models_dir_path = run_plan.models_dir.as_ref().map(std::path::PathBuf::from);
+
+    // `--dag` runs every pipeline as a unified DAG. The DAG runner is
+    // currently flag-light (it reads config + tooling defaults rather than
+    // walking the same flag matrix as `commands::run::run`), so we dispatch
+    // to it for plans that captured `dag = true` and let the future
+    // unification land separately. This preserves the parity-with-`rocky run`
+    // shape for the alias-deprecation path.
+    if run_plan.dag {
+        return crate::commands::run_with_dag(config_path, output_json)
+            .await
+            .with_context(|| format!("rocky apply run plan '{plan_id}' failed (dag path)"));
+    }
 
     // Capture stdout from the run command — `run` writes JSON directly.
     // We execute it normally (it emits output) to preserve streaming
@@ -130,17 +167,17 @@ async fn run_apply_run_plan(
         run_plan.filter.as_deref(),
         run_plan.pipeline.as_deref(),
         &state_path,
-        None, // governance_override — not persisted in RunPlan
+        run_plan.governance_override.as_ref(),
         output_json,
-        None, // models_dir — resolved inside run from config
+        models_dir_path.as_deref(),
         run_plan.run_all,
-        None,  // resume_run_id
-        false, // resume_latest
+        run_plan.resume.as_deref(),
+        run_plan.resume_latest,
         shadow_config.as_ref(),
         &partition_opts,
-        None, // model_name_filter
-        None, // cache_ttl_override
-        None, // idempotency_key — not re-used across apply calls
+        run_plan.model.as_deref(),
+        None, // cache_ttl_override — runtime-only, not part of the plan
+        run_plan.idempotency_key.as_deref(),
         run_plan.env.as_deref(),
     )
     .await
@@ -315,6 +352,7 @@ mod tests {
         RunPlan {
             filter: None,
             pipeline: None,
+            model: None,
             branch: None,
             partition: None,
             partition_from: None,
@@ -325,6 +363,15 @@ mod tests {
             parallel: 1,
             run_all: false,
             env: None,
+            models_dir: None,
+            resume: None,
+            resume_latest: false,
+            shadow: false,
+            shadow_suffix: None,
+            shadow_schema: None,
+            dag: false,
+            idempotency_key: None,
+            governance_override: None,
             models: vec!["schema.orders".to_string()],
             execution_layers: vec![vec!["schema.orders".to_string()]],
         }
@@ -373,12 +420,103 @@ mod tests {
         Ok(())
     }
 
+    /// Every flag in the backfilled surface round-trips through write/read +
+    /// serde. This is the apply-side guarantee that no field is silently
+    /// dropped by the persistence layer.
+    #[test]
+    fn run_plan_full_flag_surface_round_trips() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let rp = RunPlan {
+            filter: Some("client=acme".to_string()),
+            pipeline: Some("main".to_string()),
+            model: Some("orders".to_string()),
+            branch: None,
+            partition: Some("2026-04-07".to_string()),
+            partition_from: None,
+            partition_to: None,
+            latest: false,
+            missing: false,
+            lookback: Some(7),
+            parallel: 2,
+            run_all: true,
+            env: Some("prod".to_string()),
+            models_dir: Some("custom_models".to_string()),
+            resume: Some("rid_123".to_string()),
+            resume_latest: false,
+            shadow: true,
+            shadow_suffix: Some("_my_shadow".to_string()),
+            shadow_schema: Some("custom_schema".to_string()),
+            dag: false,
+            idempotency_key: Some("my_idem_key".to_string()),
+            governance_override: Some(rocky_core::config::GovernanceOverride {
+                workspace_ids: None,
+                allow_empty_workspace_ids: false,
+                grants: vec![],
+                schema_grants: vec![],
+            }),
+            models: vec!["db.s.orders".to_string()],
+            execution_layers: vec![vec!["db.s.orders".to_string()]],
+        };
+        let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+        let persisted = read_plan(dir.path(), &plan_id)?;
+        let decoded: RunPlan = serde_json::from_value(persisted.payload)?;
+
+        assert_eq!(decoded.model.as_deref(), Some("orders"));
+        assert_eq!(decoded.partition.as_deref(), Some("2026-04-07"));
+        assert_eq!(decoded.resume.as_deref(), Some("rid_123"));
+        assert!(decoded.shadow);
+        assert_eq!(decoded.shadow_suffix.as_deref(), Some("_my_shadow"));
+        assert_eq!(decoded.shadow_schema.as_deref(), Some("custom_schema"));
+        assert_eq!(decoded.idempotency_key.as_deref(), Some("my_idem_key"));
+        assert_eq!(decoded.models_dir.as_deref(), Some("custom_models"));
+        assert!(decoded.governance_override.is_some());
+        Ok(())
+    }
+
+    /// `--idempotency-key` is part of the content-hashed plan payload, so
+    /// two plans differing only by key get distinct plan_ids. This is the
+    /// canonical answer per the parity PR — the hash discriminates.
+    #[test]
+    fn different_idempotency_keys_produce_distinct_plan_ids() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut base = minimal_run_plan();
+        base.idempotency_key = Some("key_a".to_string());
+        let id_a = write_plan(dir.path(), PlanKind::Run, &base)?;
+
+        base.idempotency_key = Some("key_b".to_string());
+        let id_b = write_plan(dir.path(), PlanKind::Run, &base)?;
+
+        assert_ne!(
+            id_a, id_b,
+            "different idempotency keys must produce different plan_ids"
+        );
+        Ok(())
+    }
+
+    /// `--missing` and `--resume-latest` persist as booleans; both round-trip
+    /// even though the actual lookup happens at apply time against the state
+    /// store. This guards against accidental skip_serializing_if drift.
+    #[test]
+    fn deferred_state_flags_round_trip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut rp = minimal_run_plan();
+        rp.missing = true;
+        rp.resume_latest = true;
+        let plan_id = write_plan(dir.path(), PlanKind::Run, &rp)?;
+        let persisted = read_plan(dir.path(), &plan_id)?;
+        let decoded: RunPlan = serde_json::from_value(persisted.payload)?;
+        assert!(decoded.missing);
+        assert!(decoded.resume_latest);
+        Ok(())
+    }
+
     #[test]
     fn run_plan_with_all_flags_round_trips() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let rp = RunPlan {
             filter: Some("client=acme".to_string()),
             pipeline: Some("main".to_string()),
+            model: None,
             branch: None,
             partition: None,
             partition_from: Some("2026-01-01".to_string()),
@@ -389,6 +527,15 @@ mod tests {
             parallel: 4,
             run_all: true,
             env: Some("prod".to_string()),
+            models_dir: None,
+            resume: None,
+            resume_latest: false,
+            shadow: false,
+            shadow_suffix: None,
+            shadow_schema: None,
+            dag: false,
+            idempotency_key: None,
+            governance_override: None,
             models: vec!["db.s.orders".to_string(), "db.s.users".to_string()],
             execution_layers: vec![
                 vec!["db.s.users".to_string()],

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -99,7 +99,7 @@ pub use load::run_load;
 pub use lsp::run_lsp;
 pub use metrics::run_metrics;
 pub use optimize::run_optimize;
-pub use plan::{plan, plan_promote};
+pub use plan::{PlanRunOptions, plan, plan_promote};
 pub use playground::{run_playground, run_playground_with_template};
 pub use preview::{
     PreviewDiffAlgorithmSelector, run_preview_cost, run_preview_create, run_preview_diff,

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
 
+use rocky_core::config::GovernanceOverride;
 use rocky_core::sql_gen;
 use rocky_ir::*;
 
@@ -10,7 +11,28 @@ use crate::output::*;
 use crate::plan_store::{PlanKind, write_plan};
 use crate::registry;
 
+use super::run::PartitionRunOptions;
 use super::{matches_filter, parse_filter};
+
+/// Bundle of `rocky plan` flags that are not consumed by the SQL-generation
+/// preview but are persisted into `RunPlan` so `rocky apply <plan-id>` can
+/// honour them. Mirrors the flag surface of `rocky run`.
+#[derive(Debug, Default, Clone)]
+pub struct PlanRunOptions {
+    pub model: Option<String>,
+    pub all: bool,
+    pub resume: Option<String>,
+    pub resume_latest: bool,
+    pub shadow: bool,
+    pub shadow_suffix: Option<String>,
+    pub shadow_schema: Option<String>,
+    pub branch: Option<String>,
+    pub dag: bool,
+    pub idempotency_key: Option<String>,
+    pub governance_override: Option<GovernanceOverride>,
+    pub models_dir: Option<PathBuf>,
+    pub partition_opts: PartitionRunOptions,
+}
 
 /// Execute `rocky plan` — dry-run SQL generation plus optional run-plan blueprint.
 ///
@@ -35,6 +57,7 @@ pub async fn plan(
     filter: Option<&str>,
     pipeline_name: Option<&str>,
     env: Option<&str>,
+    run_options: &PlanRunOptions,
     output_json: bool,
 ) -> Result<()> {
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
@@ -237,8 +260,21 @@ pub async fn plan(
     // best-effort — failure is logged as a warning, not an error, so
     // replication-only invocations in CI environments without `.rocky/`
     // write access are not broken.
-    if models_dir.exists() {
-        match build_and_persist_run_plan(&models_dir, filter, pipeline_name, env) {
+    //
+    // The compile honours `--models` when set; otherwise the conventional
+    // `models/` directory next to the config is used.
+    let blueprint_models_dir = run_options
+        .models_dir
+        .clone()
+        .unwrap_or_else(|| models_dir.clone());
+    if blueprint_models_dir.exists() {
+        match build_and_persist_run_plan(
+            &blueprint_models_dir,
+            filter,
+            pipeline_name,
+            env,
+            run_options,
+        ) {
             Ok((run_plan, plan_id, persisted_at)) => {
                 output.plan_id = Some(plan_id);
                 output.plan_kind = Some("run".to_string());
@@ -280,11 +316,16 @@ pub async fn plan(
 
 /// Compile the models directory, build a `RunPlan` payload, persist it to
 /// `.rocky/plans/<plan_id>.json`, and return `(payload, plan_id, persisted_at)`.
+///
+/// Captures the full `rocky run` flag surface from `run_options` so apply-time
+/// replay is intent-preserving. `--missing` / `--resume-latest` are persisted
+/// as booleans; the actual state-store lookup happens at apply time.
 fn build_and_persist_run_plan(
     models_dir: &Path,
     filter: Option<&str>,
     pipeline: Option<&str>,
     env: Option<&str>,
+    run_options: &PlanRunOptions,
 ) -> Result<(RunPlan, String, chrono::DateTime<Utc>)> {
     use rocky_compiler::compile::{self, CompilerConfig};
 
@@ -310,19 +351,33 @@ fn build_and_persist_run_plan(
     // Execution layers from the DAG (names only — informational).
     let execution_layers: Vec<Vec<String>> = result.project.layers.clone();
 
+    let partition = &run_options.partition_opts;
     let run_plan = RunPlan {
         filter: filter.map(str::to_string),
         pipeline: pipeline.map(str::to_string),
-        branch: None,
-        partition: None,
-        partition_from: None,
-        partition_to: None,
-        latest: false,
-        missing: false,
-        lookback: None,
-        parallel: 1,
-        run_all: false,
+        model: run_options.model.clone(),
+        branch: run_options.branch.clone(),
+        partition: partition.partition.clone(),
+        partition_from: partition.from.clone(),
+        partition_to: partition.to.clone(),
+        latest: partition.latest,
+        missing: partition.missing,
+        lookback: partition.lookback,
+        parallel: partition.parallel,
+        run_all: run_options.all,
         env: env.map(str::to_string),
+        models_dir: run_options
+            .models_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
+        resume: run_options.resume.clone(),
+        resume_latest: run_options.resume_latest,
+        shadow: run_options.shadow,
+        shadow_suffix: run_options.shadow_suffix.clone(),
+        shadow_schema: run_options.shadow_schema.clone(),
+        dag: run_options.dag,
+        idempotency_key: run_options.idempotency_key.clone(),
+        governance_override: run_options.governance_override.clone(),
         models,
         execution_layers,
     };

--- a/engine/crates/rocky-cli/src/deprecation.rs
+++ b/engine/crates/rocky-cli/src/deprecation.rs
@@ -19,16 +19,18 @@ const SUPPRESS_ENV_VAR: &str = "ROCKY_SUPPRESS_DEPRECATION";
 
 /// Stderr message emitted by `rocky run`.
 ///
-/// Wording acknowledges that `rocky plan` / `rocky apply` do not yet accept
-/// the full flag surface of `rocky run` (e.g. `--resume`, `--shadow`,
-/// `--partition`, `--idempotency-key`, `--parallel`, `--all`, `--branch`,
-/// `--governance-override`, `--dag`). Until plan/apply parity lands those
-/// flags continue to live on `rocky run` and the alias is retained for them.
+/// As of the flag-surface parity work, `rocky plan` accepts the full flag
+/// surface of `rocky run` (`--resume`, `--shadow`, `--partition`,
+/// `--idempotency-key`, `--parallel`, `--all`, `--branch`,
+/// `--governance-override`, `--dag`, `--model`, `--models`, `--from`,
+/// `--to`, `--latest`, `--missing`, `--lookback`, `--resume-latest`,
+/// `--shadow-suffix`, `--shadow-schema`). `--watch` remains on `rocky run`
+/// because its re-run-loop semantics have no plan/apply analogue.
 pub const RUN_DEPRECATION: &str = "\
-`rocky run` is deprecated for basic invocations — the canonical form is `rocky plan` followed by `rocky apply <plan-id>`, \
+`rocky run` is deprecated — the canonical form is `rocky plan [flags]` followed by `rocky apply <plan-id>`, \
 which persists an auditable artifact at `.rocky/plans/<plan-id>.json`. \
-Advanced flags (--resume, --shadow, --partition, --idempotency-key, --parallel, --all, --branch, --governance-override, --dag) \
-are not yet available on `rocky plan` / `rocky apply` and remain on `rocky run` until plan/apply parity lands. \
+`rocky plan` accepts the same flag surface as `rocky run` (filter, pipeline, partition, shadow, branch, resume, idempotency-key, parallel, all, dag, governance-override, model, models, env). \
+The only exception is `--watch`, whose re-run-loop semantics are inherently runtime-only; it remains on `rocky run`. \
 Suppress this warning with ROCKY_SUPPRESS_DEPRECATION=1.";
 
 /// Stderr message emitted by bare `rocky branch promote <name>` (without `--plan`).

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2092,6 +2092,9 @@ pub struct RunPlan {
     /// Pipeline name if `--pipeline` was specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pipeline: Option<String>,
+    /// Single compiled model to execute (`--model`). Skips replication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     /// Branch name if `--branch` was specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
@@ -2107,7 +2110,9 @@ pub struct RunPlan {
     /// Whether `--latest` was specified.
     #[serde(default)]
     pub latest: bool,
-    /// Whether `--missing` was specified.
+    /// Whether `--missing` was specified. Resolved against the state store
+    /// at apply time (the partition set is computed when the plan is
+    /// applied, not when it is planned).
     #[serde(default)]
     pub missing: bool,
     /// Lookback window (`--lookback`).
@@ -2122,6 +2127,45 @@ pub struct RunPlan {
     /// Optional governance environment (`--env`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
+    /// Models directory used for transformation execution (`--models`).
+    /// Defaults to `models/` when unset, resolved relative to the config.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models_dir: Option<String>,
+    /// Resume a failed run by `run_id` (`--resume`). At apply time this is
+    /// passed through to the run path unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume: Option<String>,
+    /// Resume the most recent failed run (`--resume-latest`). The actual
+    /// `run_id` is resolved against the state store at apply time.
+    #[serde(default)]
+    pub resume_latest: bool,
+    /// Run in shadow mode (`--shadow`). When set, `shadow_suffix` /
+    /// `shadow_schema` describe the shadow target. Mutually exclusive with
+    /// `branch`; clap rejects the combination at plan time.
+    #[serde(default)]
+    pub shadow: bool,
+    /// Suffix appended to table names in shadow mode (`--shadow-suffix`).
+    /// Only meaningful when `shadow == true` or `branch.is_some()`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadow_suffix: Option<String>,
+    /// Override schema for shadow tables (`--shadow-schema`).
+    /// Only meaningful when `shadow == true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shadow_schema: Option<String>,
+    /// Run all pipelines as a unified DAG (`--dag`). When `true`, apply
+    /// dispatches to the DAG runner instead of the standard run path.
+    #[serde(default)]
+    pub dag: bool,
+    /// Caller-supplied idempotency key (`--idempotency-key` or
+    /// `ROCKY_IDEMPOTENCY_KEY`). Different keys produce different plan_ids
+    /// (the hash discriminates) — there is no key-rewriting at apply time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Governance override resolved at plan time from `--governance-override`
+    /// (`@file.json` is read at plan time; the parsed struct is persisted so
+    /// apply does not need filesystem access to the original file).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_override: Option<rocky_core::config::GovernanceOverride>,
     /// Qualified model names discovered at plan time. Used to populate
     /// `PlanOutput.models` and surfaced in `rocky apply` dry-run info.
     /// Re-derived at apply time via recompile; this list is informational.

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -1160,7 +1160,7 @@ pub struct ClassificationsConfig {
 /// The empty-list guard protects callers from a footgun where a
 /// misconfigured permission store or off-by-one serializer silently
 /// strips every workspace binding from the target catalog.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct GovernanceOverride {
     /// Desired workspace-binding set for this run.
     ///

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -243,6 +243,13 @@ enum Command {
     /// Subcommands extend the plan spine:
     ///   `rocky plan promote <branch>` — run approval + breaking-change gates
     ///   and persist a `PromotePlan` that `rocky apply <plan-id>` can execute.
+    ///
+    /// The flag surface mirrors `rocky run` (except `--watch`, which is
+    /// inherently a runtime re-run loop with no plan/apply semantics). Each
+    /// flag is captured into the persisted `RunPlan` so `rocky apply
+    /// <plan-id>` replays the same intent. Flags whose semantics depend on
+    /// state observed at apply time — `--resume-latest`, `--missing` — are
+    /// evaluated at apply time, not plan time.
     Plan {
         /// Optional subcommand (e.g. `promote`). When absent, runs the default
         /// replication dry-run plan.
@@ -256,6 +263,123 @@ enum Command {
         /// Applies to the default plan subcommand only.
         #[arg(long, global = false)]
         pipeline: Option<String>,
+        /// Execute a single compiled model by name (skips replication).
+        /// Alternative to --filter for model-only execution.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        model: Option<String>,
+        /// Additional governance config (JSON or @file.json), merged with defaults.
+        /// Resolved at plan time and persisted into the `RunPlan` payload.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        governance_override: Option<String>,
+        /// Models directory for transformation execution.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        models: Option<PathBuf>,
+        /// Execute both replication and compiled models.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        all: bool,
+        /// Resume a failed run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        resume: Option<String>,
+        /// Resume the most recent failed run; mints a new `run_id` and records the prior one as `resumed_from`.
+        /// Resolved against the state store at apply time.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        resume_latest: bool,
+        /// Run in shadow mode: write to shadow targets instead of production.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        shadow: bool,
+        /// Suffix appended to table names in shadow mode (default: _rocky_shadow).
+        /// Applies to the default plan subcommand only.
+        #[arg(long, default_value = "_rocky_shadow", global = false)]
+        shadow_suffix: String,
+        /// Override schema for shadow tables (mutually exclusive with --shadow-suffix).
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        shadow_schema: Option<String>,
+        /// Execute the run against a named branch created with `rocky branch
+        /// create`. Internally equivalent to `--shadow --shadow-schema
+        /// <branch.schema_prefix>`; mutually exclusive with the shadow flags.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, conflicts_with_all = ["shadow", "shadow_schema"], global = false)]
+        branch: Option<String>,
+
+        // ----- time_interval partition selection -----
+        /// Run a single partition by canonical key (e.g. 2026-04-07 for daily,
+        /// 2026-04 for monthly). Errors if the format doesn't match the
+        /// model's granularity. Mutually exclusive with --from/--to/--latest/--missing.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, conflicts_with_all = ["from", "to", "latest", "missing"], global = false)]
+        partition: Option<String>,
+        /// Lower bound of a closed partition range (inclusive). Both bounds
+        /// must align to the model's grain. Requires --to.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, requires = "to", conflicts_with_all = ["partition", "latest", "missing"], global = false)]
+        from: Option<String>,
+        /// Upper bound of a closed partition range (inclusive). Requires --from.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, requires = "from", conflicts_with_all = ["partition", "latest", "missing"], global = false)]
+        to: Option<String>,
+        /// Run the partition containing now() (UTC). Default for time_interval
+        /// models when no other selection flag is given.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, conflicts_with_all = ["partition", "from", "to", "missing"], global = false)]
+        latest: bool,
+        /// Run the partitions missing from the state store (computed from
+        /// model's first_partition → now). Errors if first_partition is unset.
+        /// Resolved against the state store at apply time.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, conflicts_with_all = ["partition", "from", "to", "latest"], global = false)]
+        missing: bool,
+        /// Recompute the previous N partitions in addition to the selected
+        /// ones (CLI override beats model's TOML lookback). Standard handling
+        /// for late-arriving data.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        lookback: Option<u32>,
+        /// Run N partitions concurrently (default 1). Warehouse-query
+        /// parallelism only — state writes serialize through redb.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, default_value = "1", global = false)]
+        parallel: u32,
+
+        /// Run all pipelines as a unified DAG, in dependency order.
+        /// Each pipeline is a node; cross-pipeline `depends_on` edges define
+        /// execution order. Layers run in parallel.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        dag: bool,
+
+        /// Caller-supplied opaque key used to dedup this run against prior
+        /// runs with the same key. Persisted into the `RunPlan`; the plan_id
+        /// is a content-hash of the payload, so plans differing only by
+        /// idempotency-key get distinct plan_ids — the hash discriminates.
+        ///
+        /// Supported on `local`, `valkey`, and `tiered` state backends.
+        /// `s3`-only and `gcs`-only backends error at flag-parse time — use
+        /// `tiered` for multi-pod deployments.
+        ///
+        /// ⚠️ Keys are stored verbatim in the state store; do NOT put
+        /// secrets in idempotency keys.
+        ///
+        /// Falls back to the `ROCKY_IDEMPOTENCY_KEY` environment variable
+        /// when the flag is not given. Useful for orchestrators that
+        /// already plumb an idempotency key through env (cron wrappers,
+        /// Airflow pod templates, ad-hoc CI bash scripts).
+        /// Applies to the default plan subcommand only.
+        #[arg(
+            long,
+            value_name = "KEY",
+            env = "ROCKY_IDEMPOTENCY_KEY",
+            global = false
+        )]
+        idempotency_key: Option<String>,
+
         /// Scope the governance preview (`mask_actions`) to a specific
         /// environment. When set, `[mask.<env>]` overrides from
         /// `rocky.toml` overlay the workspace `[mask]` defaults in the
@@ -1567,6 +1691,28 @@ fn main() -> Result<()> {
     runtime.block_on(run_async(cli, json))
 }
 
+/// Parse `--governance-override` from its CLI string form.
+///
+/// Accepts an inline JSON object (`'{...}'`) or an `@file.json` reference. The
+/// parsed `GovernanceOverride` is used both by `rocky run` directly and by
+/// `rocky plan` to capture intent into the persisted `RunPlan` payload.
+fn parse_governance_override(
+    raw: Option<&str>,
+) -> Result<Option<rocky_core::config::GovernanceOverride>> {
+    let Some(s) = raw else {
+        return Ok(None);
+    };
+    let parsed: rocky_core::config::GovernanceOverride = if let Some(path) = s.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read governance override file: {path}"))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse governance override from {path}"))?
+    } else {
+        serde_json::from_str(s).context("failed to parse governance override JSON")?
+    };
+    Ok(Some(parsed))
+}
+
 async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // Install miette's fancy handler for rich error rendering in text mode.
     // In JSON mode we skip it — errors are serialized as structured data.
@@ -1638,14 +1784,78 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             subcommand,
             filter,
             pipeline,
+            model,
+            governance_override,
+            models: models_dir,
+            all,
+            resume,
+            resume_latest,
+            shadow,
+            shadow_suffix,
+            shadow_schema,
+            branch,
+            partition,
+            from,
+            to,
+            latest,
+            missing,
+            lookback,
+            parallel,
+            dag,
+            idempotency_key,
             env,
         } => match subcommand {
             None => {
+                // Mirror the `rocky run` guard: --idempotency-key is mutually
+                // exclusive with --resume / --resume-latest. Enforced at plan
+                // time so a malformed plan never lands on disk.
+                if idempotency_key.is_some() && (resume.is_some() || resume_latest) {
+                    anyhow::bail!(
+                        "--idempotency-key cannot be combined with --resume / --resume-latest \
+                         (resume is an explicit override of idempotent skip)"
+                    );
+                }
+                let gov_override = parse_governance_override(governance_override.as_deref())?;
+                let partition_opts = rocky_cli::commands::PartitionRunOptions {
+                    partition,
+                    from,
+                    to,
+                    latest,
+                    missing,
+                    lookback,
+                    parallel,
+                };
+                // Only persist `shadow_suffix` when shadow mode is actually
+                // requested (either --shadow or --branch). Otherwise it's the
+                // clap default `_rocky_shadow` and would pollute every plan's
+                // payload — and change the plan_id hash — for plans where the
+                // flag is meaningless.
+                let shadow_suffix = if shadow || branch.is_some() {
+                    Some(shadow_suffix)
+                } else {
+                    None
+                };
+                let run_options = rocky_cli::commands::PlanRunOptions {
+                    model,
+                    all,
+                    resume,
+                    resume_latest,
+                    shadow,
+                    shadow_suffix,
+                    shadow_schema,
+                    branch,
+                    dag,
+                    idempotency_key,
+                    governance_override: gov_override,
+                    models_dir,
+                    partition_opts,
+                };
                 rocky_cli::commands::plan(
                     &cli.config,
                     filter.as_deref(),
                     pipeline.as_deref(),
                     env.as_deref(),
+                    &run_options,
                     json,
                 )
                 .await
@@ -1706,21 +1916,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 );
             }
             // Parse governance override (JSON string or @file.json)
-            let gov_override = match governance_override {
-                Some(ref s) if s.starts_with('@') => {
-                    let path = &s[1..];
-                    let content = std::fs::read_to_string(path).with_context(|| {
-                        format!("failed to read governance override file: {path}")
-                    })?;
-                    Some(serde_json::from_str(&content).with_context(|| {
-                        format!("failed to parse governance override from {path}")
-                    })?)
-                }
-                Some(ref s) => Some(
-                    serde_json::from_str(s).context("failed to parse governance override JSON")?,
-                ),
-                None => None,
-            };
+            let gov_override = parse_governance_override(governance_override.as_deref())?;
 
             // Resolve --branch to the same machinery as --shadow. clap
             // guarantees branch can't coexist with `shadow` / `shadow_schema`.
@@ -2651,5 +2847,186 @@ mod tests {
         remove_env("ROCKY_IDEMPOTENCY_KEY");
         let key = parse_run_idempotency_key(&["rocky", "run"]);
         assert!(key.is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // `rocky plan` flag-surface parity tests.
+    //
+    // The new flags backfilled onto `rocky plan` mirror `rocky run`. These
+    // tests pin the clap surface: same flag names, same semantics. The
+    // round-trip end-to-end (plan → persist → apply → run) is tested in
+    // `crates/rocky-cli/src/commands/apply.rs`.
+    // ------------------------------------------------------------------------
+
+    /// Helper: parse `rocky plan` flags and assert we got the bare-plan
+    /// (no subcommand) shape.
+    #[allow(clippy::type_complexity)]
+    fn parse_plan_flags<F, T>(args: &[&str], extract: F) -> T
+    where
+        F: FnOnce(
+            Option<String>,             // filter
+            Option<String>,             // pipeline
+            Option<String>,             // model
+            Option<String>,             // governance_override
+            Option<std::path::PathBuf>, // models_dir
+            bool,                       // all
+            Option<String>,             // resume
+            bool,                       // resume_latest
+            bool,                       // shadow
+            String,                     // shadow_suffix
+            Option<String>,             // shadow_schema
+            Option<String>,             // branch
+            Option<String>,             // partition
+            Option<String>,             // from
+            Option<String>,             // to
+            bool,                       // latest
+            bool,                       // missing
+            Option<u32>,                // lookback
+            u32,                        // parallel
+            bool,                       // dag
+            Option<String>,             // idempotency_key
+            Option<String>,             // env
+        ) -> T,
+    {
+        let cli = Cli::try_parse_from(args).expect("parse should succeed");
+        match cli.command {
+            Command::Plan {
+                subcommand: None,
+                filter,
+                pipeline,
+                model,
+                governance_override,
+                models,
+                all,
+                resume,
+                resume_latest,
+                shadow,
+                shadow_suffix,
+                shadow_schema,
+                branch,
+                partition,
+                from,
+                to,
+                latest,
+                missing,
+                lookback,
+                parallel,
+                dag,
+                idempotency_key,
+                env,
+            } => extract(
+                filter,
+                pipeline,
+                model,
+                governance_override,
+                models,
+                all,
+                resume,
+                resume_latest,
+                shadow,
+                shadow_suffix,
+                shadow_schema,
+                branch,
+                partition,
+                from,
+                to,
+                latest,
+                missing,
+                lookback,
+                parallel,
+                dag,
+                idempotency_key,
+                env,
+            ),
+            _ => panic!("expected bare Plan subcommand"),
+        }
+    }
+
+    #[test]
+    fn plan_accepts_resume_latest() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let resume_latest = parse_plan_flags(
+            &["rocky", "plan", "--resume-latest"],
+            |_, _, _, _, _, _, _, resume_latest, _, _, _, _, _, _, _, _, _, _, _, _, _, _| {
+                resume_latest
+            },
+        );
+        assert!(resume_latest, "--resume-latest should parse to true");
+    }
+
+    #[test]
+    fn plan_accepts_shadow_with_suffix() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let (shadow, shadow_suffix) = parse_plan_flags(
+            &["rocky", "plan", "--shadow", "--shadow-suffix", "_my_shadow"],
+            |_, _, _, _, _, _, _, _, shadow, shadow_suffix, _, _, _, _, _, _, _, _, _, _, _, _| {
+                (shadow, shadow_suffix)
+            },
+        );
+        assert!(shadow);
+        assert_eq!(shadow_suffix, "_my_shadow");
+    }
+
+    #[test]
+    fn plan_accepts_partition_range() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let (from, to) = parse_plan_flags(
+            &[
+                "rocky",
+                "plan",
+                "--from",
+                "2026-01-01",
+                "--to",
+                "2026-01-31",
+            ],
+            |_, _, _, _, _, _, _, _, _, _, _, _, _, from, to, _, _, _, _, _, _, _| (from, to),
+        );
+        assert_eq!(from.as_deref(), Some("2026-01-01"));
+        assert_eq!(to.as_deref(), Some("2026-01-31"));
+    }
+
+    #[test]
+    fn plan_rejects_branch_with_shadow() {
+        // clap should reject this combination at parse time via the
+        // `conflicts_with_all = ["shadow", "shadow_schema"]` modifier.
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let result = Cli::try_parse_from(["rocky", "plan", "--branch", "feature_x", "--shadow"]);
+        assert!(
+            result.is_err(),
+            "--branch and --shadow must be mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn plan_idempotency_key_falls_back_to_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        set_env("ROCKY_IDEMPOTENCY_KEY", "plan_env_key");
+        let key = parse_plan_flags(
+            &["rocky", "plan"],
+            |_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, idempotency_key, _| {
+                idempotency_key
+            },
+        );
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        assert_eq!(key.as_deref(), Some("plan_env_key"));
+    }
+
+    #[test]
+    fn plan_accepts_all_dag_and_parallel() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        remove_env("ROCKY_IDEMPOTENCY_KEY");
+        let (all, dag, parallel) = parse_plan_flags(
+            &["rocky", "plan", "--all", "--dag", "--parallel", "4"],
+            |_, _, _, _, _, all, _, _, _, _, _, _, _, _, _, _, _, _, parallel, dag, _, _| {
+                (all, dag, parallel)
+            },
+        );
+        assert!(all);
+        assert!(dag);
+        assert_eq!(parallel, 4);
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2813,8 +2813,32 @@ mod tests {
         }
     }
 
+    /// Spawn the clap parser on a scoped thread with an 8 MB stack.
+    ///
+    /// `Cli`/`Command` is intentionally large — `Command` carries every
+    /// subcommand's argument set inline (see
+    /// `#[allow(clippy::large_enum_variant)]` on `enum Command`). The
+    /// flag-surface parity work (#535) widened `Command::Plan` materially,
+    /// and clap's generated `FromArgMatches` code now allocates a parsed
+    /// `Cli` that exceeds Rust's default 2 MB test-thread stack on Linux
+    /// (macOS gets larger defaults; CI is where the overflow shows up).
+    /// A scoped thread keeps the workaround local to test code; production
+    /// `main()` uses the OS-default 8 MB thread stack and is unaffected.
+    fn try_parse_with_big_stack(args: &[&str]) -> Cli {
+        std::thread::scope(|s| {
+            std::thread::Builder::new()
+                .stack_size(8 * 1024 * 1024)
+                .spawn_scoped(s, || {
+                    Cli::try_parse_from(args).expect("parse should succeed")
+                })
+                .expect("spawn parser thread")
+                .join()
+                .expect("parser thread panicked")
+        })
+    }
+
     fn parse_run_idempotency_key(args: &[&str]) -> Option<String> {
-        let cli = Cli::try_parse_from(args).expect("parse should succeed");
+        let cli = try_parse_with_big_stack(args);
         match cli.command {
             Command::Run {
                 idempotency_key, ..
@@ -2888,7 +2912,7 @@ mod tests {
             Option<String>,             // env
         ) -> T,
     {
-        let cli = Cli::try_parse_from(args).expect("parse should succeed");
+        let cli = try_parse_with_big_stack(args);
         match cli.command {
             Command::Plan {
                 subcommand: None,
@@ -2994,7 +3018,18 @@ mod tests {
         // `conflicts_with_all = ["shadow", "shadow_schema"]` modifier.
         let _guard = ENV_LOCK.lock().unwrap();
         remove_env("ROCKY_IDEMPOTENCY_KEY");
-        let result = Cli::try_parse_from(["rocky", "plan", "--branch", "feature_x", "--shadow"]);
+        let result = std::thread::scope(|s| {
+            std::thread::Builder::new()
+                .stack_size(8 * 1024 * 1024)
+                .spawn_scoped(s, || {
+                    Cli::try_parse_from(["rocky", "plan", "--branch", "feature_x", "--shadow"])
+                        .map(|_| ())
+                        .map_err(|e| e.kind())
+                })
+                .expect("spawn parser thread")
+                .join()
+                .expect("parser thread panicked")
+        });
         assert!(
             result.is_err(),
             "--branch and --shadow must be mutually exclusive"

--- a/integrations/dagster/tests/fixtures_generated/plan.json
+++ b/integrations/dagster/tests/fixtures_generated/plan.json
@@ -14,7 +14,7 @@
       "sql": "CREATE OR REPLACE TABLE staging__orders.orders AS\nSELECT *\nFROM raw__orders.orders"
     }
   ],
-  "plan_id": "0cbce5ff506d07db4d952e7ce38cda4654c842e481d56f9180ac0963e6114ab6",
+  "plan_id": "5d76a60260b1ff0dcd16d2fddf82b955605d980f26a4be18a5d075315760614d",
   "plan_kind": "run",
   "created_at": "2000-01-01T00:00:00Z",
   "models": [


### PR DESCRIPTION
## Summary

Phase 4 of the plan/apply spine (PR #532, merged 2026-05-15) deprecated `rocky run` in favor of `rocky plan` + `rocky apply <plan-id>`. The follow-up doc + copy-clarification PRs (#533, #534) acknowledged that `rocky plan` only accepted the basic invocation surface (`--filter`, `--pipeline`, `--env`) — every advanced `rocky run` caller (resume, shadow, partition, idempotency-key, ...) had no canonical replacement. This PR backfills the full flag surface so the plan/apply pair is a complete drop-in for `rocky run`. With parity landed, the deprecation warning can recommend `rocky plan && rocky apply` without caveat.

## Flags added to `rocky plan`

- `--resume <RUN_ID>` — resume a failed run by id
- `--resume-latest` — resume the most recent failed run (state-store lookup happens at apply time)
- `--shadow` / `--shadow-suffix <SUFFIX>` / `--shadow-schema <SCHEMA>` — shadow-mode targets
- `--branch <NAME>` — apply-time branch -> shadow resolution lifted out of `main.rs::Command::Run` into `apply::run_apply_run_plan`
- `--partition <KEY>` / `--from <KEY>` / `--to <KEY>` / `--latest` / `--missing` / `--lookback <N>` — partition selection (`--missing` is also state-store-at-apply-time)
- `--parallel <N>` — partition concurrency
- `--all` — run replication + models together
- `--dag` — apply routes to `run_with_dag` instead of the standard run path
- `--idempotency-key <KEY>` — incl. the `ROCKY_IDEMPOTENCY_KEY` env fallback (now also active under `rocky plan`)
- `--governance-override <JSON|@file.json>` — parsed at plan time, persisted as `GovernanceOverride` so apply has no filesystem dependency on the original file
- `--model <NAME>` — single-model execution
- `--models <PATH>` — alternate models directory

### Excluded: `--watch`

`--watch` is inherently a runtime re-run loop with no plan/apply analogue — "persist plan, apply later" has no meaningful semantics for a filesystem-watching loop. It stays exclusive to `rocky run` and the deprecation message names it explicitly.

## Design notes

- `--idempotency-key` is part of the content-hashed plan payload, so two plans differing only by key get distinct `plan_id`s. No special-casing needed — the hash discriminates. Tested.
- `--resume-latest` / `--missing` persist as booleans; the actual state-store lookup happens at apply time. Intentional: the user wants "resume what's latest when I apply", not "resume what was latest when I planned".
- `--governance-override` is parsed at plan time (so `@file.json` is resolved early) and persisted as the parsed `GovernanceOverride` struct — apply does not need access to the original file. `GovernanceOverride` gains a `JsonSchema` derive for plan-store round-trip; its sub-types (`WorkspaceBindingConfig`, `GrantConfig`) already derived it.
- `shadow_suffix` only persists when `--shadow` or `--branch` is set, so the clap default (`_rocky_shadow`) doesn't pollute every plan's payload (and the plan_id hash).
- `RunPlan` is internal-only (not registered in `export_schemas`), so the new fields don't cascade into Pydantic / TypeScript bindings.

## Codegen + fixtures drift

- `just codegen` — no schema / Pydantic / TypeScript drift (RunPlan is internal-only).
- `just regen-fixtures` — `integrations/dagster/tests/fixtures_generated/plan.json` plan_id flips because the persisted-payload shape changed (RunPlan grew). This is mechanical drift from the content hash, not a behaviour change.

## Test plan

- [x] `cargo test -p rocky-cli -p rocky` — 438 + 9 + 1 = 448 tests pass
- [x] `cargo test --workspace` — all crates green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just codegen` — no drift outside `RunPlan`'s internal scope
- [x] `just regen-fixtures` — only `fixtures_generated/plan.json` plan_id changes
- [x] `uv run pytest -q` (dagster) — 527 tests pass
- [x] Live smoke: `rocky plan --resume-latest --shadow --shadow-suffix _smoke_shadow` against the playground POC — persisted RunPlan contains `resume_latest: true`, `shadow: true`, `shadow_suffix: "_smoke_shadow"`; `rocky apply <plan-id>` reports `"shadow": true` in the RunOutput.
- [x] Live smoke: `rocky plan --idempotency-key smoke_test_001 --parallel 2`; first apply -> `status: Success`; re-apply -> `status: SkippedIdempotent` with matching idempotency_key. Idempotency contract preserved across plan/apply.

### New unit tests

- `engine/rocky/src/main.rs` — 6 clap-parse tests pinning the new flag surface: `--resume-latest`, `--shadow --shadow-suffix`, `--from --to`, branch+shadow mutex, idempotency env-fallback, `--all --dag --parallel`.
- `engine/crates/rocky-cli/src/commands/apply.rs` — 3 round-trip tests: full-flag-surface RunPlan, distinct-plan-id-per-idempotency-key, deferred-state-flag round-trip.