### PR TITLE
docs: sweep for plan/apply parity + dagster plan-apply migration + plan_store config (post-#535/#538/#539)

### DIFF
--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -28,6 +28,7 @@ Two mandatory sections (`[adapter]` + at least one `[pipeline.<name>]`) plus opt
 
 # Optional globals:
 [state]                  # Embedded state store backend
+[plan_store]             # Persisted plan-artifact format (`format = "v1" | "v2"`)
 [cache]                  # Valkey cache for adapter responses
 [cost]                   # Cost model for `rocky optimize`
 [governance]             # Tags, grants, workspace bindings (Databricks)
@@ -318,6 +319,20 @@ region  = "us-east-1"
 backend = "tiered"
 # … S3 fields plus local path
 ```
+
+## Plan store
+
+```toml
+# Default (legacy envelope with inline SQL — omit to keep default)
+[plan_store]
+format = "v1"
+
+# Opt in to typed-IR payloads; SQL regenerated at apply time
+[plan_store]
+format = "v2"
+```
+
+Controls how `rocky plan` persists plan artifacts to `.rocky/plans/<plan-id>.json`. Default `"v1"` keeps the legacy `CompactOutput` / `ArchiveOutput` envelope with inline SQL. Opt-in `"v2"` writes typed-IR payloads (`CompactPlanIr` / `ArchivePlanIr`); `rocky apply` regenerates SQL from the IR via `rocky_core::sql_gen::{compact_from_ir, archive_from_ir}`. Stdout JSON is unchanged in both formats; the reader accepts both regardless of writer config. `PromotePlan` (governance) and `RunPlan` (already IR-only) are intentionally untouched.
 
 ## Cache (Valkey/Redis)
 

--- a/docs/src/content/docs/advanced/failure-modes.md
+++ b/docs/src/content/docs/advanced/failure-modes.md
@@ -139,7 +139,7 @@ The dispatched adapter classifies its own failures:
 **Recovery playbook.**
 
 1. Run `rocky doctor --output json` first. The `adapters[]` block tells you which adapter Rocky thinks should work and which it currently can't reach. Treat doctor as a credentials / connectivity smoke test.
-2. For **transient** failures (`is_transient: true` on the adapter error), use `rocky run --resume-latest` (the resume flags currently live on the `rocky run` alias only) to pick up where the failed run left off rather than restarting from scratch.
+2. For **transient** failures (`is_transient: true` on the adapter error), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the legacy `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
 3. For **auth** failures, walk the adapter's auth chain (e.g. Snowflake: OAuth → JWT → password) and verify the env-vars / config in `rocky.toml`. The [authentication guide](../../features/authentication) has the per-adapter checklist.
 4. For **quota** failures, check the warehouse-side quota dashboard. Rocky's adaptive concurrency (Databricks AIMD throttle) automatically backs off, but a hard quota reset is a warehouse-side action.
 5. For **statement timeouts**, increase `timeout_secs` on the adapter, or — better — re-evaluate whether the model's materialization strategy is right (a multi-hour `FullRefresh` is often a missed `Merge` or `Incremental` opportunity; `rocky optimize` will surface the recommendation).
@@ -237,7 +237,7 @@ The dispatched adapter classifies its own failures:
 
 - [Troubleshooting](./troubleshooting) — symptom-first lookup ("I got error X")
 - [`rocky doctor`](../../reference/cli#doctor) — aggregate health check across config, state, adapters, pipelines
-- [`rocky run --resume-latest`](../../reference/cli#run) — resume a failed run from its checkpoint (resume flags currently live on the `rocky run` alias only)
+- [`rocky plan --resume-latest`](../../reference/cli#run) — resume a failed run from its checkpoint (canonical form; the legacy `rocky run --resume-latest` alias is still accepted)
 - [Schema drift](../../features/schema-drift) — graduated drift handling deep dive
 - [Data quality checks](../../features/data-quality-checks) — inline check authoring + result shape
 - [Governance guide](../../guides/governance) — permissions, classification, masking, retention

--- a/docs/src/content/docs/concepts/incremental.md
+++ b/docs/src/content/docs/concepts/incremental.md
@@ -158,15 +158,15 @@ lookback = 3
 
 ### CLI flags
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. The partition-selection flags below are currently only accepted on the legacy `rocky run` alias; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`).
+> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. Every partition-selection flag below is accepted on both `rocky plan` and the legacy `rocky run` alias; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`).
 
 ```bash
-rocky run --partition 2026-04-01           # Process one partition
-rocky run --from 2026-03-01 --to 2026-04-01  # Date range
-rocky run --latest                          # Most recent partition
-rocky run --missing                         # Discover and fill gaps
-rocky run --lookback 7                      # Reprocess last N partitions
-rocky run --parallel 4                      # Parallelize partitions
+rocky plan --partition 2026-04-01 && rocky apply <plan-id>          # Process one partition
+rocky plan --from 2026-03-01 --to 2026-04-01 && rocky apply <plan-id>  # Date range
+rocky plan --latest && rocky apply <plan-id>                        # Most recent partition
+rocky plan --missing && rocky apply <plan-id>                       # Discover and fill gaps
+rocky plan --lookback 7 && rocky apply <plan-id>                    # Reprocess last N partitions
+rocky plan --parallel 4 && rocky apply <plan-id>                    # Parallelize partitions
 ```
 
 ## Full refresh fallback

--- a/docs/src/content/docs/concepts/preview-internals.md
+++ b/docs/src/content/docs/concepts/preview-internals.md
@@ -17,7 +17,7 @@ sidebar:
 
 3. **Compute the copy set.** Every working-DAG model not in the prune set is a copy candidate: it's logically identical to its counterpart on `--base`, so re-running it would produce the same bytes. For each copy-set model, Rocky issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` against the configured adapter — the portable copy substrate, with per-adapter overrides described below.
 
-4. **Run the prune set.** Rocky calls the existing branch run path ([`rocky run --branch <name>`](/reference/commands/core-pipeline/#rocky-run)) with a model selector limited to the prune set. The branch is registered via [`rocky branch create`](/reference/commands/core-pipeline/#rocky-branch); the run writes into the branch's `schema_prefix`. (The `--branch` flag currently lives on the `rocky run` alias only; plumbing it through `rocky plan` + `rocky apply` is a future-phase follow-up.)
+4. **Run the prune set.** Rocky calls the existing branch run path ([`rocky plan --branch <name>`](/reference/commands/core-pipeline/#rocky-run) + `rocky apply <plan-id>`, with the legacy `rocky run --branch <name>` alias still accepted) with a model selector limited to the prune set. The branch is registered via [`rocky branch create`](/reference/commands/core-pipeline/#rocky-branch); the run writes into the branch's `schema_prefix`.
 
 The final output ([`PreviewCreateOutput`](#output-shapes)) records `prune_set`, `copy_set`, and `skipped_set` so the decision is auditable from the JSON alone.
 

--- a/docs/src/content/docs/dagster/branch-deployments.md
+++ b/docs/src/content/docs/dagster/branch-deployments.md
@@ -19,7 +19,8 @@ side-by-side without touching production data.
 - **`branch_deployment_info()`** — structured snapshot of the deployment
   context (deployment name, PR number, Git SHA).
 - **`branch_deploy_shadow_suffix()`** — derives a stable Rocky shadow
-  suffix suitable for `rocky run --shadow --shadow-suffix <value>`.
+  suffix suitable for `rocky plan --shadow --shadow-suffix <value>` + `rocky apply <plan-id>`
+  (the legacy `rocky run --shadow --shadow-suffix <value>` alias is still accepted).
 
 ## Quickstart
 

--- a/docs/src/content/docs/dagster/component.md
+++ b/docs/src/content/docs/dagster/component.md
@@ -75,6 +75,7 @@ By default, the component stores its state on the local filesystem. This is conf
 - **Fast reloads** -- Assets are visible in the Dagster UI instantly on code location reload, with no API calls.
 - **Resilience** -- If an external API is temporarily unavailable, the cached state ensures assets remain visible.
 - **Scalability** -- Works well with large numbers of sources and tables without adding latency to code location startup.
+- **Auditable plan artifacts** -- Materializations dispatched through `RockyResource.run_streaming()` inherit the plan-then-apply chain automatically, writing `.rocky/plans/<plan-id>.json` per materialization. See [observability](./observability/#plan-artifact-per-materialization).
 
 ## DAG mode
 

--- a/docs/src/content/docs/dagster/observability.md
+++ b/docs/src/content/docs/dagster/observability.md
@@ -11,10 +11,29 @@ warnings to first-class Dagster primitives:
 - **Schema drift** → `dg.AssetObservation` events on the asset timeline
 - **Row-count anomalies** → `dg.AssetCheckResult` with severity `WARN`
 - **Optimization recommendations** → `AssetSpec.metadata` (load-time)
+- **Plan artifact trail** → `.rocky/plans/<plan-id>.json` per materialization
 
 Drift and anomaly emission is **automatic** when using `RockyComponent` —
 nothing to wire up. Standalone helpers are also exported for users with
 hand-rolled multi_assets.
+
+## Plan artifact per materialization
+
+Every `RockyResource.run()`, `run_streaming()`, and `run_pipes()` call
+chains `rocky plan` + `rocky apply <plan-id>` under the hood (as of
+`dagster-rocky` v1.30), and each invocation writes the typed plan to
+`.rocky/plans/<plan-id>.json` before the apply phase runs. That file is
+the audit record of *exactly what Rocky tried to apply*: the materialization
+list, governance plan, drift actions, and inline SQL (or typed IR — see
+[Configuration › `[plan_store]`](/reference/configuration/#plan_store)).
+
+For `run_pipes`, the plan id is also attached as `extras={"plan_id":
+plan_id}` so Dagster surfaces it as run metadata in the run viewer — one
+click from a failed materialization back to the plan that produced it.
+
+Replication-only projects (no `models/` directory) fall back to the
+legacy single-subprocess `rocky run` path and do not write a plan
+artifact for now.
 
 ## Drift events as `AssetObservation`
 

--- a/docs/src/content/docs/dagster/partitions.md
+++ b/docs/src/content/docs/dagster/partitions.md
@@ -14,9 +14,9 @@ variants.
 
 These are **standalone helpers** today. The `RockyComponent`-side wiring
 (group splitting by partitioning shape, threading partition keys through
-`rocky run --partition`) is a follow-up that depends on derived-model
-surfacing — currently the component emits source-replication tables only,
-none of which use `time_interval`.
+`rocky plan --partition` + `rocky apply`) is a follow-up that depends on
+derived-model surfacing — currently the component emits source-replication
+tables only, none of which use `time_interval`.
 
 ## Strategy mapping
 
@@ -148,7 +148,7 @@ def fct_daily_orders_asset(
     rocky_key = dagster_to_rocky_partition_key("day", context.partition_key)
     result = rocky.run(
         filter="layer=marts",
-        partition=rocky_key,   # threads through to `rocky run --partition <key>`
+        partition=rocky_key,   # threads through to `rocky plan --partition <key>` + `rocky apply`
     )
     return result.tables_copied
 ```

--- a/docs/src/content/docs/dagster/pipes.md
+++ b/docs/src/content/docs/dagster/pipes.md
@@ -176,8 +176,15 @@ def my_asset(context: dg.AssetExecutionContext, rocky: RockyResource):
 
 Spawns rocky via [`dg.PipesSubprocessClient`](https://docs.dagster.io/api/dagster/pipes#dagster.PipesSubprocessClient)
 which sets `DAGSTER_PIPES_CONTEXT` and `DAGSTER_PIPES_MESSAGES` env vars.
-The rocky engine (v0.4+) detects these and emits structured Pipes
-messages on the messages channel:
+As of `dagster-rocky` v1.30, the client invokes `rocky plan` first to
+write `.rocky/plans/<plan-id>.json`, then runs `rocky apply <plan-id>`
+as the Pipes subprocess. The plan id is passed via `extras={"plan_id":
+plan_id}`, so the Dagster run viewer surfaces it as run metadata and
+reviewers can click straight from the materialization back to the plan
+artifact that produced it.
+
+The rocky engine (v0.4+) detects the Pipes env vars and emits structured
+Pipes messages on the messages channel:
 
 * `report_asset_materialization` per copied table — appears as a
   `MaterializationEvent` in the run viewer with structured metadata
@@ -190,6 +197,11 @@ messages on the messages channel:
 Returns a `PipesClientCompletedInvocation`. Call `.get_results()` to
 extract the materialization events Dagster constructed from the Pipes
 messages.
+
+On replication-only projects (no `models/` directory), `rocky plan`
+cannot persist a plan, so `run_pipes` falls back to a single
+`rocky run` Pipes invocation. No `plan_id` is attached to `extras` in
+that case.
 
 **This is the canonical Dagster Pipes integration pattern.**
 

--- a/docs/src/content/docs/dagster/resource.md
+++ b/docs/src/content/docs/dagster/resource.md
@@ -26,6 +26,7 @@ sidebar:
 - On CLI failure, raises `dagster.Failure` with stderr attached as metadata.
 - If the binary is not found on `PATH`, raises `Failure` with a link to the installation instructions.
 - **Partial success**: Rocky can exit non-zero but still emit valid JSON (e.g., when some tables succeed and others fail). Methods like `run()`, `compile()`, `test()`, and `ci()` handle this automatically, returning the parsed result so callers can distinguish successes from failures.
+- **Plan artifact per materialization**: as of `dagster-rocky` v1.30, `run()`, `run_streaming()`, and `run_pipes()` internally chain `rocky plan` + `rocky apply <plan-id>` instead of a single `rocky run`. Every materialization writes an auditable plan artifact to `.rocky/plans/<plan-id>.json` before execution, so a failed apply can be inspected against the exact plan it tried to apply. Public method signatures and return types are unchanged. Projects without a `models/` directory (replication-only) fall back to the legacy single-subprocess `rocky run` path because `rocky plan` cannot persist a plan there; behaviour is preserved.
 
 ---
 
@@ -55,9 +56,9 @@ Runs `rocky plan` and returns the planned SQL statements without executing them.
 
 ### `run(filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
 
-Runs `rocky run` in buffered mode (`subprocess.run`) and returns the full execution result including materializations, check results, drift detection, and permission changes.
+Runs Rocky in buffered mode (`subprocess.run`) and returns the full execution result including materializations, check results, drift detection, and permission changes.
 
-**Wraps**: `rocky run --filter <filter> --output json`
+**Wraps**: `rocky plan --filter <filter> --output json` followed by `rocky apply <plan-id> --output json`. The plan artifact is persisted to `.rocky/plans/<plan-id>.json` between the two phases. On replication-only projects (no `models/` directory), `rocky plan` emits `plan_id = null` and the method falls back to a single `rocky run --filter <filter> --output json` subprocess (`ROCKY_SUPPRESS_DEPRECATION=1` is set on the subprocess env so the alias's deprecation notice doesn't bubble up to Dagster logs).
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -74,9 +75,9 @@ Runs `rocky run` in buffered mode (`subprocess.run`) and returns the full execut
 
 ### `run_streaming(context, filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None) -> RunResult`
 
-Pipes-style `rocky run` with live stderr streaming to `context.log`. Same semantics as `run()` but spawns the binary via `subprocess.Popen` and forwards Rocky's stderr (tracing output) to `context.log.info` line-by-line as the run progresses. Use this from inside a Dagster `@multi_asset` or `@op` for runs longer than a few seconds.
+Pipes-style execution with live stderr streaming to `context.log`. Same semantics as `run()` but spawns the binary via `subprocess.Popen` and forwards Rocky's stderr (tracing output) to `context.log.info` line-by-line as the run progresses. Use this from inside a Dagster `@multi_asset` or `@op` for runs longer than a few seconds.
 
-**Wraps**: `rocky run --filter <filter> --output json`
+**Wraps**: `rocky plan --filter <filter> --output json` followed by `rocky apply <plan-id> --output json` (same plan-then-apply chain as `run()`; replication-only projects fall back to `rocky run`). Plan-phase stderr is forwarded to the `dagster_rocky` module logger only; apply-phase stderr streams to `context.log` as before. Operators watching the run viewer for discover/drift progress will see those lines start when the apply step starts.
 
 | Parameter | Type | Description |
 |---|---|---|
@@ -93,9 +94,9 @@ def replicate(context: dg.AssetExecutionContext, rocky: RockyResource):
 
 ### `run_pipes(context, filter, governance_override=None, *, run_models=False, partition=None, partition_from=None, partition_to=None, latest=False, missing=False, lookback=None, parallel=None, pipes_client=None) -> PipesClientCompletedInvocation`
 
-Full Dagster Pipes execution with structured event streaming. Spawns `rocky run` via `PipesSubprocessClient`, which sets the `DAGSTER_PIPES_CONTEXT` / `DAGSTER_PIPES_MESSAGES` env vars. The engine emits one Pipes message per materialization, asset check, and log line, so the run viewer gets `MaterializationEvent` and `AssetCheckEvaluation` events in real time.
+Full Dagster Pipes execution with structured event streaming. Spawns `rocky plan` followed by `rocky apply <plan-id>` via `PipesSubprocessClient`, which sets the `DAGSTER_PIPES_CONTEXT` / `DAGSTER_PIPES_MESSAGES` env vars on the apply subprocess. The engine emits one Pipes message per materialization, asset check, and log line, so the run viewer gets `MaterializationEvent` and `AssetCheckEvaluation` events in real time. The plan id is attached via `extras={"plan_id": plan_id}`, so Dagster surfaces it as run metadata in the run viewer.
 
-**Wraps**: `rocky run --filter <filter> --output json` (via Dagster Pipes protocol)
+**Wraps**: `rocky plan --filter <filter> --output json` followed by `rocky apply <plan-id> --output json` (via Dagster Pipes protocol). Replication-only projects fall back to a single `rocky run --filter <filter>` Pipes invocation without a `plan_id` in `extras`.
 
 | Parameter | Type | Description |
 |---|---|---|

--- a/docs/src/content/docs/features/time-interval.md
+++ b/docs/src/content/docs/features/time-interval.md
@@ -108,7 +108,7 @@ is rejected even though `chrono` would parse it.
 
 ## CLI flags
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; it emits a one-line `[deprecated]` notice to stderr that can be silenced with `ROCKY_SUPPRESS_DEPRECATION=1`. The partition-selection flags below currently live on the `rocky run` alias only; plumbing them through `rocky plan` + `rocky apply` is a future-phase follow-up.
+> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; it emits a one-line `[deprecated]` notice to stderr that can be silenced with `ROCKY_SUPPRESS_DEPRECATION=1`. Every partition-selection flag below is accepted on both `rocky plan` and `rocky run`.
 
 `rocky run` accepts seven new flags for selecting and modifying which
 partitions to compute. The selection flags are mutually exclusive (`clap`

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -26,7 +26,7 @@ A Rust-based control plane for warehouse-side data work. Storage and compute sta
 
 ## What Rocky does
 
-1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch <name>` (branch execution currently lives on the `rocky run` alias only), `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
+1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky plan --branch <name>` + `rocky apply <plan-id>` (the legacy `rocky run --branch <name>` alias is still accepted), `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
 2. **Cost attribution + budgets** — per-model cost on every run. `[budget]` block in `rocky.toml`; `budget_breach` hook event on exceed.
 3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
 4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).
@@ -51,7 +51,7 @@ A Rust-based control plane for warehouse-side data work. Storage and compute sta
 | Dependencies | `{{ ref('model') }}` | `depends_on = ["model"]` |
 | Tests | `schema.yml` + `dbt test` | Inline checks + assertions in `rocky apply` |
 | State | `manifest.json` + `target/` | Embedded `redb` database |
-| Branches | — | `rocky branch create`, `rocky run --branch <name>` |
+| Branches | — | `rocky branch create`, `rocky plan --branch <name>` |
 | Column-level lineage | Post-hoc (`dbt docs`) | Compile-time output |
 | Cost attribution | — | Per-model, every run |
 

--- a/docs/src/content/docs/guides/governance.md
+++ b/docs/src/content/docs/guides/governance.md
@@ -714,7 +714,7 @@ Each `RunRecord` carries:
 | `session_source` | Auto-detected: `Cli` / `Dagster` / `Lsp` / `HttpApi`. |
 | `git_commit` | Resolved at run start from the current repo. |
 | `git_branch` | Resolved at run start from the current repo. |
-| `idempotency_key` | Echoed from `rocky run --idempotency-key <KEY>` when passed (the idempotency-key flag currently lives on the `rocky run` alias only). |
+| `idempotency_key` | Echoed from `rocky plan --idempotency-key <KEY>` (or the legacy `rocky run --idempotency-key` alias) when passed. |
 | `target_catalog` | The catalog(s) the run wrote to. |
 | `hostname` | The host that executed the run. |
 | `rocky_version` | The CLI version that produced the record. |

--- a/docs/src/content/docs/guides/playground.mdx
+++ b/docs/src/content/docs/guides/playground.mdx
@@ -451,12 +451,12 @@ The playground includes a curated catalog of {pocCounts.total} POCs across {pocC
 | `01-shell-hooks` | Lifecycle hooks with stdin-JSON context |
 | `02-webhook-slack-preset` | Webhook presets (Slack, PagerDuty, Datadog, Teams) |
 | `03-remote-state-s3` | S3 state backend via MinIO docker-compose |
-| `04-checkpoint-resume` | `rocky run --resume-latest` after mid-pipeline failure (resume currently lives on the `rocky run` alias only) |
+| `04-checkpoint-resume` | `rocky plan --resume-latest && rocky apply <plan-id>` after mid-pipeline failure (legacy `rocky run --resume-latest` alias still accepted) |
 | `05-webhook-presets-multi` | Multiple webhook presets composed on the same run |
 | `06-valkey-distributed-cache` | Distributed cache + tiered state via Valkey/Redis |
 | `07-dagster-dag-mode` | Full asset-graph rendering from Rocky's unified DAG |
 | `08-circuit-breaker` | Trust arc 3: retry policy + three-state circuit breaker |
-| `09-idempotency-key` | `rocky run --idempotency-key` dedup + skip semantics (the flag currently lives on the `rocky run` alias only) |
+| `09-idempotency-key` | `rocky plan --idempotency-key` dedup + skip semantics (legacy `rocky run --idempotency-key` alias still accepted) |
 
 ### Developer Experience ({pocCounts.perCategory["06-developer-experience"]} POCs)
 

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -35,7 +35,7 @@ What this does:
 3. Computes the **copy set** — every working-DAG model not in the prune set.
 4. Registers a branch in the state store (mirrors `rocky branch create`).
 5. Issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` for each copy-set model.
-6. Calls `rocky run --branch <name>` with a model selector limited to the prune set. (The `--branch` flag currently lives on the `rocky run` alias only.)
+6. Calls `rocky plan --branch <name>` followed by `rocky apply <plan-id>` (or the legacy `rocky run --branch <name>` alias) with a model selector limited to the prune set.
 
 The output is a `PreviewCreateOutput` JSON document:
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -423,7 +423,7 @@ data_type = "DATE"
 
 ### `rocky compare`
 
-Compare shadow tables against production tables. Used after `rocky run --shadow` (shadow mode currently lives on the `rocky run` alias only) to validate results before promoting shadow data to production.
+Compare shadow tables against production tables. Used after `rocky plan --shadow` + `rocky apply <plan-id>` (or the legacy `rocky run --shadow` alias) to validate results before promoting shadow data to production.
 
 ```bash
 rocky compare --filter <key=value> [flags]

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -468,7 +468,7 @@ acme_warehouse.staging__eu_central__stripe.charges    | 2026-03-29T22:15:00Z    
 
 ## `rocky branch`
 
-Manage named virtual branches. A branch is the persistent, named analogue of `--shadow` mode: it records a `schema_prefix` in the state store and, when `rocky run --branch <name>` is invoked, every model target has the prefix applied. Schema-prefix branches work uniformly across every adapter today; warehouse-native clones (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`) are a follow-up. (The `--branch` flag currently lives on the `rocky run` alias only; plumbing it through `rocky plan` + `rocky apply` is a future-phase follow-up.)
+Manage named virtual branches. A branch is the persistent, named analogue of `--shadow` mode: it records a `schema_prefix` in the state store and, when `rocky plan --branch <name>` + `rocky apply <plan-id>` is invoked (or the legacy `rocky run --branch <name>` alias), every model target has the prefix applied. Schema-prefix branches work uniformly across every adapter today; warehouse-native clones (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`) are a follow-up.
 
 ```bash
 rocky branch create <name> [--description <text>]

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -624,7 +624,7 @@ Terminal outcomes surface as structured `outcome` fields on `state.upload` / `st
 
 ### `[state.idempotency]`
 
-Tuning knobs for `rocky run --idempotency-key <KEY>` dedup (the idempotency-key flag currently lives on the `rocky run` alias only). All fields are optional with the shown defaults; the block is a no-op on runs that don't pass `--idempotency-key`. Unknown fields are rejected.
+Tuning knobs for `rocky plan --idempotency-key <KEY>` dedup (also accepted on the legacy `rocky run --idempotency-key` alias). All fields are optional with the shown defaults; the block is a no-op on runs that don't pass `--idempotency-key`. Unknown fields are rejected.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -639,7 +639,7 @@ dedup_on = "success"
 in_flight_ttl_hours = 24
 ```
 
-Stamps live in the `IDEMPOTENCY_KEYS` redb table and replicate on tiered backends so sibling pods see the same entry. See [`rocky run --idempotency-key`](/reference/cli/#rocky-run) for the three possible outcomes (`fresh_run`, `skipped_idempotent`, `skipped_in_flight`).
+Stamps live in the `IDEMPOTENCY_KEYS` redb table and replicate on tiered backends so sibling pods see the same entry. See [`rocky plan --idempotency-key`](/reference/cli/#rocky-run) for the three possible outcomes (`fresh_run`, `skipped_idempotent`, `skipped_in_flight`).
 
 #### Bucket-native lifecycle for object-store backends
 
@@ -729,6 +729,31 @@ resource "google_storage_bucket" "rocky_state" {
 - **Bucket lifecycle does not replace `[state.idempotency] retention_days`.** The local redb mirror on each pod still has its own copy of the stamp; Rocky's sweep is what evicts that. Bucket lifecycle handles the durable copy.
 - **In-flight claims (`InFlight`) are TTL-bounded by `in_flight_ttl_hours`, not by the lifecycle rule.** Don't set the lifecycle window shorter than `in_flight_ttl_hours` (default 24) or you risk reaping a live claim.
 - **Tiered backends already serve hits from Valkey first.** A bucket lifecycle that's slightly behind `retention_days` is harmless — Valkey's own TTL evicts the hot copy long before the cold S3/GCS copy expires.
+
+---
+
+## `[plan_store]`
+
+Controls how `rocky plan` persists plan artifacts to `.rocky/plans/<plan-id>.json` for `rocky apply` to read back. Unknown fields are rejected.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `format` | string | `"v1"` | Persisted plan envelope. `"v1"` writes the legacy `CompactOutput` / `ArchiveOutput` envelope with inline SQL. `"v2"` writes the typed-IR payload (`CompactPlanIr` / `ArchivePlanIr`); `rocky apply` regenerates SQL from the IR at execution time via `rocky_core::sql_gen::{compact_from_ir, archive_from_ir}`. |
+
+```toml
+[plan_store]
+format = "v1"   # default; legacy envelope with inline SQL
+# format = "v2"  # opt-in; typed-IR payload, SQL regenerated at apply
+```
+
+**Behaviour:**
+
+- **The default stays `"v1"`** in engine v1.33 — existing projects see no behaviour change unless they opt in.
+- **The reader accepts both formats unconditionally**, regardless of the writer config. A binary configured for v2 writes can read v1 plans on disk, and vice versa. Mixing formats across a fleet during a rollout is safe.
+- **Stdout JSON is unchanged in both formats.** `rocky plan --output json` (and `rocky compact` / `rocky archive --output json`) always carries inline SQL for human and CI consumers. The format switch only affects the JSON written to disk under `.rocky/plans/`.
+- **Only `CompactPlan` and `ArchivePlan` are configurable.** `PromotePlan` (governance) and `RunPlan` (already IR-only) are intentionally untouched.
+
+**Soft migration cycle:** v1.33 ships v2 as opt-in; a future minor release flips the default to `"v2"`; a subsequent minor drops the v1 reader. Operators who want to validate v2 on their plans before the default flip should set `format = "v2"` now and confirm `rocky apply <plan-id>` produces the same warehouse outcomes as v1.
 
 ---
 

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -508,26 +508,26 @@ schema = "warehouse"
 table = "fct_daily_events"
 ```
 
-**CLI flags** for time-interval models. As of engine v1.33 these flags are accepted on the legacy `rocky run` alias only; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`). Plumbing them through `rocky plan` + `rocky apply` is a future-phase follow-up.
+**CLI flags** for time-interval models. As of engine v1.33 every flag below is accepted on both `rocky plan` and the legacy `rocky run` alias; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`). The canonical form is `rocky plan` followed by `rocky apply <plan-id>`.
 
 ```bash
 # Process a specific partition
-rocky run --partition 2026-04-01
+rocky plan --partition 2026-04-01 && rocky apply <plan-id>
 
 # Process a date range
-rocky run --from 2026-03-01 --to 2026-04-01
+rocky plan --from 2026-03-01 --to 2026-04-01 && rocky apply <plan-id>
 
 # Process the latest partition
-rocky run --latest
+rocky plan --latest && rocky apply <plan-id>
 
 # Discover and process missing partitions
-rocky run --missing
+rocky plan --missing && rocky apply <plan-id>
 
 # Set lookback window
-rocky run --lookback 7
+rocky plan --lookback 7 && rocky apply <plan-id>
 
 # Parallelize partition processing
-rocky run --parallel 4
+rocky plan --parallel 4 && rocky apply <plan-id>
 ```
 
 Per-partition state is tracked in the state store. The `--missing` flag consults stored partition records to discover gaps.


### PR DESCRIPTION
## Summary

Docs-only sweep covering three engine changes that landed since the previous doc sweep (#533):

- **#535** — `rocky plan` now accepts the full flag surface of `rocky run` (every flag except `--watch`); `rocky apply <plan-id>` honors them at apply time. Removes the stale "advanced flags stay on `rocky run`" caveats added in #533.
- **#538** — `RockyResource.run` / `.run_streaming` / `.run_pipes` now internally chain `rocky plan` + `rocky apply <plan-id>`; every Dagster materialization writes `.rocky/plans/<plan-id>.json`; `run_pipes` attaches `extras={"plan_id": plan_id}` so Dagster surfaces the plan id as run metadata.
- **#539** — new top-level `[plan_store] format = "v1" | "v2"` config option in `rocky.toml`; default stays `"v1"`; reader accepts both formats unconditionally.

## File counts

- **Category A** (stale `v1.33` callouts): 2 callouts simplified (the other 3 v1.33 callouts found by the preflight grep — `reference/cli.md:196`, `reference/json-output.md:107,886`, `reference/commands/core-pipeline.md:289,499` — are pure canonical-form recommendations or `rocky branch promote` deprecation notes and remain factually correct; left alone). Discovered one additional stale clause in `reference/model-format.md` (caught by the Cat B grep, not the Cat A grep) and migrated it too.
- **Category B** (`rocky run --<flag>` examples): 10 files updated. All "currently lives on the `rocky run` alias only" parentheticals stripped; canonical-flow examples migrated to `rocky plan --<flag> && rocky apply <plan-id>` (with legacy alias noted where the alias is still the more natural user-typed form).
- **Category C** (dagster pages): 5 files updated — `resource.md` (Wraps lines for `run` / `run_streaming` / `run_pipes` + new plan-artifact note in Behavior), `pipes.md` (`extras={"plan_id": plan_id}` documented for `run_pipes`), `observability.md` (new "Plan artifact per materialization" section), `component.md` (brief inheritance note), `branch-deployments.md` (Cat B updates), `partitions.md` (Cat B updates). Other 14 dagster pages skimmed without change. `resume_run` (line 117 of `resource.md`) intentionally left on `rocky run --resume` — #538 only migrated the three exec methods, not `resume_run`.
- **Category D** (plan_store config): 1 new `## `[plan_store]`` section added to `reference/configuration.md` (between `[state.idempotency]` and `[ai]`); rocky-config skill at `.claude/skills/rocky-config/SKILL.md` updated in lockstep (top-level structure table + new `## Plan store` block) so the canonical authoring reference matches the docs page.

## Representative before/after snippets

**A — `concepts/incremental.md`**

```diff
-> Note: as of engine v1.33, ... The partition-selection flags below are currently only accepted on the legacy `rocky run` alias ...
+> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. Every partition-selection flag below is accepted on both `rocky plan` and the legacy `rocky run` alias ...
```

**B — `advanced/failure-modes.md`**

```diff
-2. For **transient** failures (`is_transient: true` on the adapter error), use `rocky run --resume-latest` (the resume flags currently live on the `rocky run` alias only) to pick up where the failed run left off rather than restarting from scratch.
+2. For **transient** failures (`is_transient: true` on the adapter error), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the legacy `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
```

**C — `dagster/resource.md` (`run_pipes` Wraps line)**

```diff
-**Wraps**: `rocky run --filter <filter> --output json` (via Dagster Pipes protocol)
+**Wraps**: `rocky plan --filter <filter> --output json` followed by `rocky apply <plan-id> --output json` (via Dagster Pipes protocol). Replication-only projects fall back to a single `rocky run --filter <filter>` Pipes invocation without a `plan_id` in `extras`.
```

**C — `dagster/pipes.md` (extras={"plan_id": plan_id} mention)**

```diff
+As of `dagster-rocky` v1.30, the client invokes `rocky plan` first to write `.rocky/plans/<plan-id>.json`, then runs `rocky apply <plan-id>` as the Pipes subprocess. The plan id is passed via `extras={"plan_id": plan_id}`, so the Dagster run viewer surfaces it as run metadata ...
```

**D — `reference/configuration.md` (new section)**

```diff
+## `[plan_store]`
+
+| `format` | string | `"v1"` | Persisted plan envelope. `"v1"` writes the legacy `CompactOutput` / `ArchiveOutput` envelope with inline SQL. `"v2"` writes the typed-IR payload ... |
+
+- The default stays `"v1"` in engine v1.33 — existing projects see no behaviour change unless they opt in.
+- The reader accepts both formats unconditionally, regardless of the writer config.
+- Stdout JSON is unchanged in both formats.
+- Only `CompactPlan` and `ArchivePlan` are configurable. `PromotePlan` and `RunPlan` are intentionally untouched.
```

## Pages intentionally left on the old verb

- **`dagster/resource.md` `resume_run` (line 117)** — Wraps `rocky run --resume <run_id>` or `rocky run --resume-latest`. #538 migrated only `run` / `run_streaming` / `run_pipes`. Not touched.
- **`reference/cli.md:196`, `reference/json-output.md:107`, `reference/commands/core-pipeline.md:289`** — these v1.33 callouts are pure canonical-form recommendations with no flag-parity caveat; remain factually correct.
- **`reference/json-output.md:886`, `reference/commands/core-pipeline.md:499`** — these v1.33 callouts cover the `rocky branch promote` bare-form alias deprecation cycle (unrelated to #535's flag-surface parity); left alone.
- **`examples/playground/pocs/**`** — out of scope per the brief; #533 left them alone and the same precedent applies.

## Test plan

- [x] `npm install && npm run build` in `docs/` — 74 pages built in 4.07s, no errors. One pre-existing `[WARN] [astro-expressive-code]` about the `dot` language in `playground.mdx` (unrelated to this PR).
- [x] Verified built HTML has `id="plan_store"` anchor on `/reference/configuration/` and `id="plan-artifact-per-materialization"` on `/dagster/observability/` so the cross-link from observability resolves.
- [x] Confirmed no remaining stale "currently lives on the `rocky run` alias only" / "future-phase follow-up" clauses anywhere under `docs/src/content/docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)