### PR TITLE
docs: arc 4 demo polish — trace+cost+replay landing-page copy + cross-links

### DIFF
--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -166,6 +166,7 @@ Plus: window functions with PARTITION BY / ORDER BY / frame specs, `match` expre
 - **Exhaustive checksum-bisection diff** — `rocky preview diff --algorithm bisection` walks the chunk lattice over a single-column integer / numeric primary key for exhaustive row-level coverage at bounded scan cost (`O(K · log_K(N))` chunks examined for a single-row change). Per-adapter native row-hashes — DuckDB `hash`, BigQuery `FARM_FINGERPRINT`, Databricks Spark `xxhash64`. Snowflake stays on the sampled fallback until a consumer drives the override.
 - **Per-run cost attribution** — `RunOutput.cost_summary` carries per-run total cost; per-materialization `cost_usd` flows through `MaterializationMetadata`.
 - **`rocky cost <run_id|latest>`** — historical rollup over stored runs. Reads the same `RunRecord` as `replay` / `trace`; recomputes per-model cost via the adapter-appropriate formula (duration × DBU for Databricks/Snowflake; bytes × $/TB for BigQuery; zero for DuckDB).
+- See the combo in action — POC #17 (trace + cost + replay against the same run_id): [examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo)
 
 ## IDE / Language Server (11 capabilities)
 

--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -122,3 +122,4 @@ Shows stored watermarks for every table.
 - [Silver layer](/concepts/silver-layer/) — add transformation models
 - [Data quality checks](/features/data-quality-checks/)
 - [Dagster integration](/dagster/introduction/)
+- See the combo in action — POC #17 (trace + cost + replay against the same run_id): [examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -51,6 +51,13 @@ rocky apply <plan-id>    # execute the plan
 
 No credentials needed — the playground is DuckDB-backed.
 
+## One trace, one cost graph, one replay handle
+
+`rocky run` writes a single `RunRecord` to the state store. Three read commands — `rocky trace`, `rocky cost`, `rocky replay` — each project that same record from a different angle: causality and concurrency, per-model warehouse spend, and the byte-for-byte reproducibility artefact. Three views of one tree, not three telemetry domains stitched together after the fact. Walk through it end-to-end in [POC #17 (trace + cost + replay against the same run_id)](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo).
+
+{/* TODO(hugo): record + drop in docs/public/trace-cost-replay-combo.mp4 */}
+<video src="/trace-cost-replay-combo.mp4" controls width="720"></video>
+
 <CardGrid>
   <LinkCard title="Coming from dbt?" href="/guides/migrate-from-dbt/" description="Import your dbt project, convert tests to contracts, and adopt Rocky incrementally." />
   <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="Auto-discovery, rich metadata, and check-result integration via dagster-rocky." />


### PR DESCRIPTION
## Summary

- Adds a landing-page section ("One trace, one cost graph, one replay handle") that frames the trace + cost + replay combo: one `rocky run` writes one `RunRecord`, and three read commands project it from a different angle each (causality, per-model spend, reproducibility).
- Drops a screencast placeholder (`<video src="/trace-cost-replay-combo.mp4">`) so the asset slot lands now; the recording follows in a separate commit.
- Cross-links to POC #17 (`examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo`) from `getting-started/quickstart.md` and from the Observability section of `features/all-features.md` (closest existing observability home — no `advanced/observability.md` exists; the only sibling is `dagster/observability.md` which is integration-scoped).

## Test plan

- [x] `npm install && npm run build` in `docs/` — clean build, 74 pages, zero errors.
- [x] Missing `/trace-cost-replay-combo.mp4` asset does not break the build (Astro tolerates it).
- [x] POC #17 paths verified — README + run.sh exist at the linked location.