### PR TITLE
feat(rocky-cli): failure_kind discriminator on RunOutput.errors[*]

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -65,6 +65,19 @@ export type CheckResult1 =
  */
 export type TestSeverity = "error" | "warning";
 /**
+ * Coarse-grained failure classification for an entry on [`RunOutput::errors`]. Lets orchestrators branch on the kind of failure (retry, page someone, surface in the UI) without parsing the free-form `error` string.
+ *
+ * Variants partition the [`rocky_databricks::connector::ConnectorError`] and [`rocky_snowflake::connector::ConnectorError`] spaces; `Unknown` is the fallback for non-connector failures (drift, governance, adapter-internal errors) where the error reached the output layer already type-erased.
+ */
+export type FailureKind =
+  | "connection-failed"
+  | "auth-failed"
+  | "query-rejected"
+  | "transient"
+  | "quota-exceeded"
+  | "not-found"
+  | "unknown";
+/**
  * Status of a pipeline run.
  *
  * `Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are the short-circuit outcomes of `rocky run --idempotency-key` — see [`crate::idempotency`].
@@ -228,6 +241,10 @@ export interface DriftActionOutput {
 export interface TableErrorOutput {
   asset_key: string[];
   error: string;
+  /**
+   * Coarse classification of the failure so orchestrators can branch on kind (retry, page, surface) without parsing `error`. Defaults to [`FailureKind::Unknown`] for errors that reached the output layer type-erased.
+   */
+  failure_kind?: FailureKind & string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-adapter-sdk/src/traits.rs
+++ b/engine/crates/rocky-adapter-sdk/src/traits.rs
@@ -47,6 +47,20 @@ impl AdapterError {
     pub fn not_supported(method: &str) -> Self {
         Self::msg(format!("{method} is not supported by this adapter"))
     }
+
+    /// Borrow the boxed inner error for downcasting.
+    ///
+    /// `AdapterError` deliberately stores the concrete adapter error
+    /// type-erased so the SDK doesn't depend on any adapter crate. The
+    /// `Error::source()` impl walks past `inner` (it returns
+    /// `inner.source()`), so chain-walking consumers never see the
+    /// concrete `ConnectorError` — they jump straight to whatever the
+    /// `ConnectorError` carries underneath. This accessor lets callers
+    /// who hold the boxed wrapper attempt a `downcast_ref::<T>()`
+    /// against the wrapped error directly.
+    pub fn inner(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+        self.inner.as_ref()
+    }
 }
 
 impl std::fmt::Display for AdapterError {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -76,6 +76,11 @@ struct TableError {
     error: String,
     /// Index into the original tables_to_process vec (for retry).
     task_index: Option<usize>,
+    /// Coarse classification of the failure for the public JSON output.
+    /// Set by walking the typed connector-error chain on `e` before the
+    /// error is stringified; defaults to `Unknown` when no connector
+    /// variant is in the chain (drift / governance / panic paths).
+    failure_kind: crate::output::FailureKind,
 }
 
 /// Sentinel error signalling that `rocky run` was cancelled by a shutdown
@@ -2056,6 +2061,9 @@ pub async fn run(
                 }
             }
             Ok((idx, Err(e))) => {
+                // Classify before stringification so the typed connector
+                // variant is preserved on `TableError.failure_kind`.
+                let failure_kind = classify_anyhow_error(&e);
                 let msg = format!("{e:#}");
                 if msg.contains("TABLE_OR_VIEW_NOT_FOUND") {
                     warn!(
@@ -2118,6 +2126,7 @@ pub async fn run(
                     asset_key: vec![],
                     error: msg,
                     task_index: Some(idx),
+                    failure_kind,
                 });
                 if fail_fast {
                     join_set.abort_all();
@@ -2151,6 +2160,7 @@ pub async fn run(
                     asset_key: vec![],
                     error: msg,
                     task_index: None,
+                    failure_kind: FailureKind::Unknown,
                 });
                 if fail_fast {
                     join_set.abort_all();
@@ -2369,6 +2379,7 @@ pub async fn run(
                         info!(table = task.table_name.as_str(), "retry succeeded");
                     }
                     Err(e) => {
+                        let failure_kind = classify_anyhow_error(&e);
                         let msg = format!("{e:#}");
                         warn!(
                             table = task.table_name.as_str(),
@@ -2379,6 +2390,7 @@ pub async fn run(
                             asset_key: vec![],
                             error: msg,
                             task_index: Some(idx),
+                            failure_kind,
                         });
                     }
                 }
@@ -3033,6 +3045,7 @@ pub async fn run(
         .map(|e| TableErrorOutput {
             asset_key: e.asset_key.clone(),
             error: e.error.clone(),
+            failure_kind: e.failure_kind,
         })
         .collect();
 
@@ -4860,6 +4873,9 @@ async fn process_completed_result(
             }
         }
         Ok((idx, Err(e))) => {
+            // Classify before stringification so the typed connector
+            // variant is preserved on `TableError.failure_kind`.
+            let failure_kind = classify_anyhow_error(&e);
             let msg = format!("{e:#}");
             if msg.contains("TABLE_OR_VIEW_NOT_FOUND") {
                 warn!(
@@ -4908,6 +4924,7 @@ async fn process_completed_result(
                 asset_key: vec![],
                 error: msg,
                 task_index: Some(idx),
+                failure_kind,
             });
         }
         Err(e) => {
@@ -4937,6 +4954,7 @@ async fn process_completed_result(
                 asset_key: vec![],
                 error: msg,
                 task_index: None,
+                failure_kind: FailureKind::Unknown,
             });
         }
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -371,11 +371,154 @@ pub struct AnomalyOutput {
     pub reason: String,
 }
 
+/// Coarse-grained failure classification for an entry on
+/// [`RunOutput::errors`]. Lets orchestrators branch on the kind of
+/// failure (retry, page someone, surface in the UI) without parsing the
+/// free-form `error` string.
+///
+/// Variants partition the [`rocky_databricks::connector::ConnectorError`]
+/// and [`rocky_snowflake::connector::ConnectorError`] spaces; `Unknown`
+/// is the fallback for non-connector failures (drift, governance,
+/// adapter-internal errors) where the error reached the output layer
+/// already type-erased.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FailureKind {
+    /// TCP / TLS / DNS / connection-establishment failure.
+    ConnectionFailed,
+    /// Credentials rejected, token expired or otherwise invalid.
+    AuthFailed,
+    /// Warehouse rejected the SQL — syntax error, schema mismatch,
+    /// missing permission, semantic analysis failure.
+    QueryRejected,
+    /// Retry-worthy failure — 5xx, network glitch, statement aborted by
+    /// a transient warehouse condition.
+    Transient,
+    /// Rate limit hit or a configured budget cap (retry budget, circuit
+    /// breaker, account-level quota).
+    QuotaExceeded,
+    /// Requested catalog / schema / table not present.
+    NotFound,
+    /// Fallback when the failure could not be classified — e.g. errors
+    /// raised outside the connector layer that reach this struct
+    /// type-erased through `anyhow::Error`.
+    #[default]
+    Unknown,
+}
+
+impl From<&rocky_databricks::connector::ConnectorError> for FailureKind {
+    fn from(err: &rocky_databricks::connector::ConnectorError) -> Self {
+        use rocky_databricks::connector::ConnectorError as E;
+        match err {
+            E::Auth(_) => FailureKind::AuthFailed,
+            E::Http(e) => {
+                if e.is_connect() {
+                    FailureKind::ConnectionFailed
+                } else if e.is_timeout() {
+                    FailureKind::Transient
+                } else {
+                    FailureKind::ConnectionFailed
+                }
+            }
+            E::StatementFailed { .. } => FailureKind::QueryRejected,
+            E::Timeout { .. } => FailureKind::Transient,
+            E::Canceled { .. } => FailureKind::Unknown,
+            E::UnexpectedState { .. } => FailureKind::Unknown,
+            E::ApiError { status, .. } => match status {
+                401 | 403 => FailureKind::AuthFailed,
+                404 => FailureKind::NotFound,
+                429 => FailureKind::QuotaExceeded,
+                500..=599 => FailureKind::Transient,
+                _ => FailureKind::QueryRejected,
+            },
+            E::CircuitBreakerOpen { .. } => FailureKind::Transient,
+            E::RetryBudgetExhausted { .. } => FailureKind::QuotaExceeded,
+        }
+    }
+}
+
+impl From<&rocky_snowflake::connector::ConnectorError> for FailureKind {
+    fn from(err: &rocky_snowflake::connector::ConnectorError) -> Self {
+        use rocky_snowflake::connector::ConnectorError as E;
+        match err {
+            E::Auth(_) => FailureKind::AuthFailed,
+            E::Http(e) => {
+                if e.is_connect() {
+                    FailureKind::ConnectionFailed
+                } else if e.is_timeout() {
+                    FailureKind::Transient
+                } else {
+                    FailureKind::ConnectionFailed
+                }
+            }
+            E::StatementFailed { .. } => FailureKind::QueryRejected,
+            E::Timeout { .. } => FailureKind::Transient,
+            E::ApiError { status, .. } => match status {
+                401 | 403 => FailureKind::AuthFailed,
+                404 => FailureKind::NotFound,
+                429 => FailureKind::QuotaExceeded,
+                500..=599 => FailureKind::Transient,
+                _ => FailureKind::QueryRejected,
+            },
+            E::CircuitBreakerOpen { .. } => FailureKind::Transient,
+            E::RetryBudgetExhausted { .. } => FailureKind::QuotaExceeded,
+        }
+    }
+}
+
+/// Walk an `anyhow::Error`'s `chain()` looking for a typed
+/// `ConnectorError` and classify it via [`FailureKind`]. Returns
+/// [`FailureKind::Unknown`] when neither connector enum is reachable.
+///
+/// Production-path note: adapter calls go through
+/// [`rocky_adapter_sdk::AdapterError`], a `Box<dyn Error>` wrapper
+/// whose `Error::source()` impl returns the *inner*'s source — so a
+/// bare `chain()` walk skips past the wrapper straight to whatever the
+/// `ConnectorError` carries (e.g. `reqwest::Error`) and never sees the
+/// connector variant itself. To handle that, each cause is also
+/// downcast to `AdapterError`; when matched, its
+/// [`AdapterError::inner`] is probed for the typed `ConnectorError`.
+///
+/// Many existing call sites in `run.rs` still build their `anyhow`
+/// errors via `anyhow::anyhow!("…{e}")`, which stringifies the
+/// `AdapterError` and drops the type. Migrating those to `.context(…)`
+/// is a separate, mechanical follow-up — the classifier is correct,
+/// its reach grows as those sites are converted.
+fn classify_cause(cause: &(dyn std::error::Error + 'static)) -> Option<FailureKind> {
+    if let Some(e) = cause.downcast_ref::<rocky_databricks::connector::ConnectorError>() {
+        return Some(e.into());
+    }
+    if let Some(e) = cause.downcast_ref::<rocky_snowflake::connector::ConnectorError>() {
+        return Some(e.into());
+    }
+    None
+}
+
+pub fn classify_anyhow_error(err: &anyhow::Error) -> FailureKind {
+    for cause in err.chain() {
+        if let Some(kind) = classify_cause(cause) {
+            return kind;
+        }
+        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>() {
+            if let Some(kind) = classify_cause(adapter_err.inner()) {
+                return kind;
+            }
+        }
+    }
+    FailureKind::Unknown
+}
+
 /// Error from a table that failed during parallel processing.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TableErrorOutput {
     pub asset_key: Vec<String>,
     pub error: String,
+    /// Coarse classification of the failure so orchestrators can branch
+    /// on kind (retry, page, surface) without parsing `error`. Defaults
+    /// to [`FailureKind::Unknown`] for errors that reached the output
+    /// layer type-erased.
+    #[serde(default)]
+    pub failure_kind: FailureKind,
 }
 
 /// A table that the discovery adapter reported but that is missing from
@@ -3687,6 +3830,7 @@ mod run_record_tests {
         out.errors.push(TableErrorOutput {
             asset_key: vec!["s".to_string(), "broken".to_string()],
             error: "connection refused".to_string(),
+            failure_kind: FailureKind::Unknown,
         });
 
         let started = fixed_start();
@@ -5022,5 +5166,273 @@ impl PreviewCostOutput {
             projected_per_model_budget_breaches,
             markdown,
         }
+    }
+}
+
+#[cfg(test)]
+mod failure_kind_tests {
+    //! Mapping coverage for [`FailureKind`] against every variant of
+    //! Databricks and Snowflake [`ConnectorError`]. The `Http(reqwest::Error)`
+    //! variant is not directly constructed here (reqwest exposes no public
+    //! constructor) — its mapping is exercised end-to-end inside the
+    //! `classify_anyhow_error` path.
+    use super::*;
+    use rocky_databricks::connector::ConnectorError as DbE;
+    use rocky_snowflake::connector::ConnectorError as SnE;
+
+    fn db_api(status: u16) -> DbE {
+        DbE::ApiError {
+            status,
+            body: String::new(),
+        }
+    }
+
+    fn sn_api(status: u16) -> SnE {
+        SnE::ApiError {
+            status,
+            body: String::new(),
+        }
+    }
+
+    // ---- Databricks ConnectorError → FailureKind --------------------------
+
+    #[test]
+    fn databricks_auth_maps_to_auth_failed() {
+        let e = DbE::Auth(rocky_databricks::auth::AuthError::NoAuthConfigured);
+        assert_eq!(FailureKind::from(&e), FailureKind::AuthFailed);
+    }
+
+    #[test]
+    fn databricks_statement_failed_maps_to_query_rejected() {
+        let e = DbE::StatementFailed {
+            id: "stmt-1".into(),
+            message: "syntax error".into(),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn databricks_timeout_maps_to_transient() {
+        let e = DbE::Timeout {
+            id: "stmt-1".into(),
+            seconds: 30,
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+    }
+
+    #[test]
+    fn databricks_canceled_maps_to_unknown() {
+        let e = DbE::Canceled {
+            id: "stmt-1".into(),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Unknown);
+    }
+
+    #[test]
+    fn databricks_unexpected_state_maps_to_unknown() {
+        let e = DbE::UnexpectedState {
+            id: "stmt-1".into(),
+            state: "FOO".into(),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Unknown);
+    }
+
+    #[test]
+    fn databricks_api_error_401_403_maps_to_auth_failed() {
+        assert_eq!(FailureKind::from(&db_api(401)), FailureKind::AuthFailed);
+        assert_eq!(FailureKind::from(&db_api(403)), FailureKind::AuthFailed);
+    }
+
+    #[test]
+    fn databricks_api_error_404_maps_to_not_found() {
+        assert_eq!(FailureKind::from(&db_api(404)), FailureKind::NotFound);
+    }
+
+    #[test]
+    fn databricks_api_error_429_maps_to_quota_exceeded() {
+        assert_eq!(FailureKind::from(&db_api(429)), FailureKind::QuotaExceeded);
+    }
+
+    #[test]
+    fn databricks_api_error_5xx_maps_to_transient() {
+        for status in [500u16, 502, 503, 504, 599] {
+            assert_eq!(
+                FailureKind::from(&db_api(status)),
+                FailureKind::Transient,
+                "status {status}",
+            );
+        }
+    }
+
+    #[test]
+    fn databricks_api_error_other_maps_to_query_rejected() {
+        assert_eq!(FailureKind::from(&db_api(400)), FailureKind::QueryRejected);
+        assert_eq!(FailureKind::from(&db_api(409)), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn databricks_circuit_breaker_maps_to_transient() {
+        let e = DbE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+    }
+
+    #[test]
+    fn databricks_retry_budget_exhausted_maps_to_quota_exceeded() {
+        let e = DbE::RetryBudgetExhausted { limit: 10 };
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+    }
+
+    // ---- Snowflake ConnectorError → FailureKind ---------------------------
+
+    #[test]
+    fn snowflake_auth_maps_to_auth_failed() {
+        let e = SnE::Auth(rocky_snowflake::auth::AuthError::NoAuthConfigured);
+        assert_eq!(FailureKind::from(&e), FailureKind::AuthFailed);
+    }
+
+    #[test]
+    fn snowflake_statement_failed_maps_to_query_rejected() {
+        let e = SnE::StatementFailed {
+            handle: "h-1".into(),
+            message: "compile error".into(),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn snowflake_timeout_maps_to_transient() {
+        let e = SnE::Timeout {
+            handle: "h-1".into(),
+            seconds: 60,
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+    }
+
+    #[test]
+    fn snowflake_api_error_401_403_maps_to_auth_failed() {
+        assert_eq!(FailureKind::from(&sn_api(401)), FailureKind::AuthFailed);
+        assert_eq!(FailureKind::from(&sn_api(403)), FailureKind::AuthFailed);
+    }
+
+    #[test]
+    fn snowflake_api_error_404_maps_to_not_found() {
+        assert_eq!(FailureKind::from(&sn_api(404)), FailureKind::NotFound);
+    }
+
+    #[test]
+    fn snowflake_api_error_429_maps_to_quota_exceeded() {
+        assert_eq!(FailureKind::from(&sn_api(429)), FailureKind::QuotaExceeded);
+    }
+
+    #[test]
+    fn snowflake_api_error_5xx_maps_to_transient() {
+        for status in [500u16, 502, 503, 504, 599] {
+            assert_eq!(
+                FailureKind::from(&sn_api(status)),
+                FailureKind::Transient,
+                "status {status}",
+            );
+        }
+    }
+
+    #[test]
+    fn snowflake_api_error_other_maps_to_query_rejected() {
+        assert_eq!(FailureKind::from(&sn_api(400)), FailureKind::QueryRejected);
+        assert_eq!(FailureKind::from(&sn_api(422)), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn snowflake_circuit_breaker_maps_to_transient() {
+        let e = SnE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+    }
+
+    #[test]
+    fn snowflake_retry_budget_exhausted_maps_to_quota_exceeded() {
+        let e = SnE::RetryBudgetExhausted { limit: 10 };
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+    }
+
+    // ---- classify_anyhow_error chain walk --------------------------------
+
+    #[test]
+    fn classify_anyhow_walks_chain_for_databricks_connector_error() {
+        let err = anyhow::Error::new(DbE::StatementFailed {
+            id: "s".into(),
+            message: "boom".into(),
+        })
+        .context("running materialization");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn classify_anyhow_walks_chain_for_snowflake_connector_error() {
+        let err = anyhow::Error::new(SnE::Timeout {
+            handle: "h".into(),
+            seconds: 30,
+        })
+        .context("running materialization");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::Transient);
+    }
+
+    #[test]
+    fn classify_anyhow_returns_unknown_when_no_connector_error_in_chain() {
+        let err = anyhow::anyhow!("some non-connector failure");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::Unknown);
+    }
+
+    #[test]
+    fn classify_anyhow_unwraps_adapter_error_wrapping_databricks_connector() {
+        // Mirrors the production path: ConnectorError is wrapped in
+        // AdapterError (boxed) before crossing into anyhow.
+        let conn_err = DbE::ApiError {
+            status: 429,
+            body: String::new(),
+        };
+        let adapter_err = rocky_adapter_sdk::AdapterError::new(conn_err);
+        let err = anyhow::Error::new(adapter_err).context("execute_statement failed");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::QuotaExceeded);
+    }
+
+    #[test]
+    fn classify_anyhow_unwraps_adapter_error_wrapping_snowflake_connector() {
+        let conn_err = SnE::Timeout {
+            handle: "h".into(),
+            seconds: 30,
+        };
+        let adapter_err = rocky_adapter_sdk::AdapterError::new(conn_err);
+        let err = anyhow::Error::new(adapter_err).context("execute_statement failed");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::Transient);
+    }
+
+    // ---- Serialization contract ------------------------------------------
+
+    #[test]
+    fn failure_kind_serializes_to_kebab_case() {
+        let cases = [
+            (FailureKind::ConnectionFailed, "\"connection-failed\""),
+            (FailureKind::AuthFailed, "\"auth-failed\""),
+            (FailureKind::QueryRejected, "\"query-rejected\""),
+            (FailureKind::Transient, "\"transient\""),
+            (FailureKind::QuotaExceeded, "\"quota-exceeded\""),
+            (FailureKind::NotFound, "\"not-found\""),
+            (FailureKind::Unknown, "\"unknown\""),
+        ];
+        for (kind, expected) in cases {
+            assert_eq!(
+                serde_json::to_string(&kind).expect("serialize"),
+                expected,
+                "{kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn failure_kind_default_is_unknown() {
+        assert_eq!(FailureKind::default(), FailureKind::Unknown);
     }
 }

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -92,6 +92,62 @@ class ExecutionSummary(BaseModel):
     tables_processed: conint(ge=0)
 
 
+class FailureKind1(StrEnum):
+    """
+    TCP / TLS / DNS / connection-establishment failure.
+    """
+
+    connection_failed = "connection-failed"
+
+
+class FailureKind2(StrEnum):
+    """
+    Credentials rejected, token expired or otherwise invalid.
+    """
+
+    auth_failed = "auth-failed"
+
+
+class FailureKind3(StrEnum):
+    """
+    Warehouse rejected the SQL — syntax error, schema mismatch, missing permission, semantic analysis failure.
+    """
+
+    query_rejected = "query-rejected"
+
+
+class FailureKind4(StrEnum):
+    """
+    Retry-worthy failure — 5xx, network glitch, statement aborted by a transient warehouse condition.
+    """
+
+    transient = "transient"
+
+
+class FailureKind5(StrEnum):
+    """
+    Rate limit hit or a configured budget cap (retry budget, circuit breaker, account-level quota).
+    """
+
+    quota_exceeded = "quota-exceeded"
+
+
+class FailureKind6(StrEnum):
+    """
+    Requested catalog / schema / table not present.
+    """
+
+    not_found = "not-found"
+
+
+class FailureKind7(StrEnum):
+    """
+    Fallback when the failure could not be classified — e.g. errors raised outside the connector layer that reach this struct type-erased through `anyhow::Error`.
+    """
+
+    unknown = "unknown"
+
+
 class MaterializationMetadata(BaseModel):
     column_count: conint(ge=0) | None = None
     """
@@ -291,6 +347,19 @@ class TableErrorOutput(BaseModel):
 
     asset_key: list[str]
     error: str
+    failure_kind: (
+        FailureKind1
+        | FailureKind2
+        | FailureKind3
+        | FailureKind4
+        | FailureKind5
+        | FailureKind6
+        | FailureKind7
+        | None
+    ) = "unknown"
+    """
+    Coarse classification of the failure so orchestrators can branch on kind (retry, page, surface) without parsing `error`. Defaults to [`FailureKind::Unknown`] for errors that reached the output layer type-erased.
+    """
 
 
 class TestSeverity3(StrEnum):

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -343,6 +343,60 @@
       ],
       "type": "object"
     },
+    "FailureKind": {
+      "description": "Coarse-grained failure classification for an entry on [`RunOutput::errors`]. Lets orchestrators branch on the kind of failure (retry, page someone, surface in the UI) without parsing the free-form `error` string.\n\nVariants partition the [`rocky_databricks::connector::ConnectorError`] and [`rocky_snowflake::connector::ConnectorError`] spaces; `Unknown` is the fallback for non-connector failures (drift, governance, adapter-internal errors) where the error reached the output layer already type-erased.",
+      "oneOf": [
+        {
+          "description": "TCP / TLS / DNS / connection-establishment failure.",
+          "enum": [
+            "connection-failed"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Credentials rejected, token expired or otherwise invalid.",
+          "enum": [
+            "auth-failed"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Warehouse rejected the SQL — syntax error, schema mismatch, missing permission, semantic analysis failure.",
+          "enum": [
+            "query-rejected"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Retry-worthy failure — 5xx, network glitch, statement aborted by a transient warehouse condition.",
+          "enum": [
+            "transient"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Rate limit hit or a configured budget cap (retry budget, circuit breaker, account-level quota).",
+          "enum": [
+            "quota-exceeded"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Requested catalog / schema / table not present.",
+          "enum": [
+            "not-found"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Fallback when the failure could not be classified — e.g. errors raised outside the connector layer that reach this struct type-erased through `anyhow::Error`.",
+          "enum": [
+            "unknown"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "MaterializationMetadata": {
       "properties": {
         "column_count": {
@@ -852,6 +906,15 @@
         },
         "error": {
           "type": "string"
+        },
+        "failure_kind": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FailureKind"
+            }
+          ],
+          "default": "unknown",
+          "description": "Coarse classification of the failure so orchestrators can branch on kind (retry, page, surface) without parsing `error`. Defaults to [`FailureKind::Unknown`] for errors that reached the output layer type-erased."
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

- Adds a typed `FailureKind` enum to `RunOutput.errors[*]` so orchestrators can branch on the kind of failure (retry, page, surface) without parsing the free-form `error` string. Kebab-case wire values lock the contract.
- Variants partition the Databricks + Snowflake `ConnectorError` spaces: `connection-failed`, `auth-failed`, `query-rejected`, `transient`, `quota-exceeded`, `not-found`, `unknown`. Exhaustive `From` impls for both connector enums, with full unit-test coverage per variant.
- Adds `AdapterError::inner()` accessor in `rocky-adapter-sdk`. The SDK wrapper's `Error::source` walks past its inner box, so an `anyhow::chain()` walk never reaches the connector variant; the classifier downcasts to `AdapterError` and probes `inner()` to recover the typed `ConnectorError`.

## Notes

- Many existing call sites in `run.rs` still build their `anyhow::Error`s via `anyhow::anyhow!("…{e}")`, which stringifies the typed error and drops the variant. The classifier returns `Unknown` for those — converting them to `.context(…)` is a mechanical follow-up; the contract is the durable bit and ships in this PR.
- No fixture diffs (`just regen-fixtures` ran clean) — the playground POC's run output has no errors, so the `errors` array is empty and the new `failure_kind` field doesn't appear in any captured fixture.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --all-features` — all engine tests pass, 29 new `failure_kind` tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just codegen` — Pydantic + TypeScript bindings regenerated; `schemas/run.schema.json` carries the new `FailureKind` definition
- [x] `just regen-fixtures` — no diffs
- [x] `uv run pytest -x` in `integrations/dagster/` — 533 passed
- [x] `npm run test:unit` in `editors/vscode/` — 106 passed