### PR TITLE
feat(rocky-cli): wire failure_kind to run-path adapter errors

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1081,7 +1081,7 @@ pub async fn run(
             discovery_adapter
                 .discover(&pattern.prefix)
                 .await
-                .map_err(|e| anyhow::anyhow!("{e}"))
+                .map_err(anyhow::Error::from)
         } else {
             anyhow::bail!("no discovery adapter configured for this pipeline")
         }
@@ -1185,7 +1185,7 @@ pub async fn run(
                 // behind.
                 if let Some(ov) = governance_override {
                     ov.validate_workspace_ids(&target_catalog)
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        .map_err(anyhow::Error::from)?;
                 }
 
                 // Create catalog via generic dialect SQL
@@ -1193,7 +1193,7 @@ pub async fn run(
                     warehouse_adapter
                         .execute_statement(&sql_result?)
                         .await
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        .map_err(anyhow::Error::from)?;
                 }
                 catalogs_created += 1;
 
@@ -1377,7 +1377,7 @@ pub async fn run(
                     warehouse_adapter
                         .execute_statement(&sql_result?)
                         .await
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        .map_err(anyhow::Error::from)?;
                 }
                 schemas_created += 1;
 
@@ -2548,7 +2548,7 @@ pub async fn run(
                 }
             },
         )
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .map_err(anyhow::Error::from)?;
         (src, tgt, fresh)
     } else {
         // Per-table fallback via WarehouseAdapter for adapters with no
@@ -2562,7 +2562,7 @@ pub async fn run(
             for br in &source_batch_refs {
                 let table_ref = dialect
                     .format_table_ref(&br.catalog, &br.schema, &br.table)
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
                 let sql = format!("SELECT COUNT(*) FROM {table_ref}");
                 match shared_warehouse.execute_query(&sql).await {
                     Ok(result) => {
@@ -2588,7 +2588,7 @@ pub async fn run(
             for br in &target_batch_refs {
                 let table_ref = dialect
                     .format_table_ref(&br.catalog, &br.schema, &br.table)
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
                 let sql = format!("SELECT COUNT(*) FROM {table_ref}");
                 match shared_warehouse.execute_query(&sql).await {
                     Ok(result) => {
@@ -2617,7 +2617,7 @@ pub async fn run(
             for br in &freshness_batch_refs {
                 let table_ref = dialect
                     .format_table_ref(&br.catalog, &br.schema, &br.table)
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
                 let sql = format!("SELECT MAX({}) FROM {table_ref}", pipeline.timestamp_column);
                 match shared_warehouse.execute_query(&sql).await {
                     Ok(result) => {
@@ -3563,11 +3563,11 @@ pub(crate) async fn execute_models(
         }
         for (catalog, schema) in &targets {
             if let Some(sql_result) = dialect.create_schema_sql(catalog, schema) {
-                let sql = sql_result.map_err(|e| anyhow::anyhow!("{e}"))?;
+                let sql = sql_result.map_err(anyhow::Error::from)?;
                 warehouse
                     .execute_statement(&sql)
                     .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
             }
         }
     }
@@ -3749,7 +3749,7 @@ pub(crate) async fn execute_models(
                     &model_ir.target.schema,
                     &model_ir.target.table,
                 )
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                .map_err(anyhow::Error::from)?;
 
             // MERGE requires the target to exist before the statement runs.
             // sql_gen exposes `generate_transformation_initial_ddl` for
@@ -3788,9 +3788,9 @@ pub(crate) async fn execute_models(
                     );
                     for ddl in &initial_ddls {
                         warehouse.execute_statement(ddl).await.map_err(|e| {
-                            anyhow::anyhow!(
-                                "bootstrap of '{target_ref}' for model '{model_name}' failed: {e}"
-                            )
+                            anyhow::Error::from(e).context(format!(
+                                "bootstrap of '{target_ref}' for model '{model_name}' failed"
+                            ))
                         })?;
                     }
                 }
@@ -3827,7 +3827,9 @@ pub(crate) async fn execute_models(
                         }
                     }
                     Err(e) => {
-                        exec_error = Some(anyhow::anyhow!("model '{model_name}' failed: {e}"));
+                        exec_error = Some(
+                            anyhow::Error::from(e).context(format!("model '{model_name}' failed")),
+                        );
                         break;
                     }
                 }
@@ -4048,9 +4050,9 @@ async fn execute_time_interval_model(
             .execute_statement(&bootstrap_sql)
             .await
             .map_err(|e| {
-                anyhow::anyhow!(
-                    "bootstrap of '{target_table}' failed for model '{model_name}': {e}"
-                )
+                anyhow::Error::from(e).context(format!(
+                    "bootstrap of '{target_table}' failed for model '{model_name}'"
+                ))
             })?;
     }
 
@@ -4193,9 +4195,9 @@ async fn run_one_partition(
     if let Err(e) = state_ref.record_partition(&record) {
         return PartitionExecutionResult {
             partition_key: key.clone(),
-            outcome: Err(anyhow::anyhow!(
-                "failed to record InProgress for {model_name}|{key}: {e}"
-            )),
+            outcome: Err(anyhow::Error::from(e).context(format!(
+                "failed to record InProgress for {model_name}|{key}"
+            ))),
         };
     }
 
@@ -4214,9 +4216,8 @@ async fn run_one_partition(
         Err(e) => {
             return PartitionExecutionResult {
                 partition_key: key.clone(),
-                outcome: Err(anyhow::anyhow!(
-                    "SQL gen failed for {model_name}|{key}: {e}"
-                )),
+                outcome: Err(anyhow::Error::from(e)
+                    .context(format!("SQL gen failed for {model_name}|{key}"))),
             };
         }
     };
@@ -4255,7 +4256,7 @@ async fn run_one_partition(
                 }
             }
             Err(e) => {
-                exec_err = Some(anyhow::anyhow!("{e}"));
+                exec_err = Some(anyhow::Error::from(e));
                 break;
             }
         }
@@ -4283,9 +4284,8 @@ async fn run_one_partition(
     if let Err(e) = state_ref.record_partition(&record) {
         return PartitionExecutionResult {
             partition_key: key.clone(),
-            outcome: Err(anyhow::anyhow!(
-                "failed to record Computed for {model_name}|{key}: {e}"
-            )),
+            outcome: Err(anyhow::Error::from(e)
+                .context(format!("failed to record Computed for {model_name}|{key}"))),
         };
     }
 
@@ -4405,7 +4405,7 @@ async fn process_table(
             warehouse
                 .execute_statement(&drop_sql)
                 .await
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
+                .map_err(anyhow::Error::from)?;
             use_full_refresh = true;
 
             let reason = drift_result
@@ -4445,7 +4445,7 @@ async fn process_table(
                 warehouse
                     .execute_statement(stmt)
                     .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
             }
             // If the same drift round also surfaced added columns,
             // apply them as part of the same schema-evolution step
@@ -4460,7 +4460,7 @@ async fn process_table(
                     warehouse
                         .execute_statement(stmt)
                         .await
-                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                        .map_err(anyhow::Error::from)?;
                 }
             }
             let reason = drift_result
@@ -4503,7 +4503,7 @@ async fn process_table(
                 warehouse
                     .execute_statement(stmt)
                     .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    .map_err(anyhow::Error::from)?;
             }
             let reason = drift_result
                 .added_columns
@@ -4626,7 +4626,7 @@ async fn process_table(
     let exec_stats = warehouse
         .execute_statement_with_stats(&sql)
         .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .map_err(anyhow::Error::from)?;
 
     // Tagging and watermark updates are deferred to post-run batch phase
     // to avoid blocking the concurrency semaphore with sequential SQL

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -5435,4 +5435,97 @@ mod failure_kind_tests {
     fn failure_kind_default_is_unknown() {
         assert_eq!(FailureKind::default(), FailureKind::Unknown);
     }
+
+    // ---- run.rs-style conversion preserves typed variant ----------------
+    //
+    // These pin the conversion idiom now used in `commands/run.rs`. They
+    // ensure that the way `run.rs` materializes its `anyhow::Error`s
+    // (`.map_err(anyhow::Error::from)?` for bare wraps, and
+    // `anyhow::Error::from(e).context(...)` for prefixed wraps) keeps the
+    // typed `AdapterError` in the source chain so `classify_anyhow_error`
+    // can downcast to it and map to the correct `FailureKind`. The old
+    // `anyhow::anyhow!("{e}")` pattern stringified the typed error before
+    // the wrap and made the classifier fall through to `Unknown`.
+    //
+    // Three connector variants are pinned to prove the wiring isn't
+    // variant-specific.
+    fn db_adapter_err(conn: DbE) -> rocky_adapter_sdk::AdapterError {
+        rocky_adapter_sdk::AdapterError::new(conn)
+    }
+
+    fn sn_adapter_err(conn: SnE) -> rocky_adapter_sdk::AdapterError {
+        rocky_adapter_sdk::AdapterError::new(conn)
+    }
+
+    #[test]
+    fn run_path_bare_wrap_preserves_databricks_statement_failed() {
+        // Mirrors `.map_err(anyhow::Error::from)?` on an
+        // `AdapterResult<()>` returned from `WarehouseAdapter::execute_statement`.
+        let result: rocky_adapter_sdk::AdapterResult<()> =
+            Err(db_adapter_err(DbE::StatementFailed {
+                id: "stmt-1".into(),
+                message: "syntax error".into(),
+            }));
+        let err: anyhow::Error = result.map_err(anyhow::Error::from).unwrap_err();
+        assert_eq!(classify_anyhow_error(&err), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn run_path_bare_wrap_preserves_snowflake_timeout() {
+        let result: rocky_adapter_sdk::AdapterResult<()> = Err(sn_adapter_err(SnE::Timeout {
+            handle: "h-1".into(),
+            seconds: 60,
+        }));
+        let err: anyhow::Error = result.map_err(anyhow::Error::from).unwrap_err();
+        assert_eq!(classify_anyhow_error(&err), FailureKind::Transient);
+    }
+
+    #[test]
+    fn run_path_bare_wrap_preserves_databricks_quota_exceeded() {
+        let result: rocky_adapter_sdk::AdapterResult<()> = Err(db_adapter_err(DbE::ApiError {
+            status: 429,
+            body: String::new(),
+        }));
+        let err: anyhow::Error = result.map_err(anyhow::Error::from).unwrap_err();
+        assert_eq!(classify_anyhow_error(&err), FailureKind::QuotaExceeded);
+    }
+
+    #[test]
+    fn run_path_context_wrap_preserves_databricks_statement_failed() {
+        // Mirrors `anyhow::Error::from(e).context(format!("..."))` used at
+        // the run.rs bootstrap / model-failed / partition record sites.
+        let adapter_err = db_adapter_err(DbE::StatementFailed {
+            id: "stmt-1".into(),
+            message: "compile error".into(),
+        });
+        let err = anyhow::Error::from(adapter_err).context(format!(
+            "bootstrap of '{}' for model '{}' failed",
+            "tgt", "m"
+        ));
+        assert_eq!(classify_anyhow_error(&err), FailureKind::QueryRejected);
+    }
+
+    #[test]
+    fn run_path_context_wrap_preserves_snowflake_auth_failed() {
+        let adapter_err = sn_adapter_err(SnE::ApiError {
+            status: 401,
+            body: String::new(),
+        });
+        let err = anyhow::Error::from(adapter_err).context("model 'orders' failed");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::AuthFailed);
+    }
+
+    #[test]
+    fn run_path_unconverted_anyhow_macro_still_returns_unknown() {
+        // Negative control: the old lossy pattern still drops the typed
+        // variant. If this ever starts returning the typed kind, the
+        // classifier behaviour shifted and the rest of these pins should
+        // be reviewed.
+        let adapter_err = db_adapter_err(DbE::StatementFailed {
+            id: "stmt-1".into(),
+            message: "syntax".into(),
+        });
+        let err = anyhow::anyhow!("{adapter_err}");
+        assert_eq!(classify_anyhow_error(&err), FailureKind::Unknown);
+    }
 }


### PR DESCRIPTION
## Summary

Converts 23 lossy `anyhow::anyhow!(\"{e}\")` sites in `commands/run.rs` to type-preserving wraps so `classify_anyhow_error` (added in #548) can downcast to `AdapterError`, probe `.inner()`, and return the correct `FailureKind` on `RunOutput.errors[*]` instead of always falling through to `Unknown`.

Two idioms in use:
- `.map_err(anyhow::Error::from)?` (bare wrap)
- `anyhow::Error::from(e).context(format!(\"...\"))` (prefixed wrap)

Both keep the typed error in `Error::source()`. For non-`AdapterError` typed errors (`StateError`, `SqlGenError`, `GovernanceOverrideError`) the chain is still preserved; the classifier returns `Unknown` for those today, but the wiring is ready for future expansion.

The line 368 site (`IdempotencyError::UnsupportedBackend` rewrite into a user-facing remediation message) is intentional and left alone.

## Test coverage

Adds 6 tests in `output.rs::failure_kind_tests` (35 total in that module now):
- `run_path_bare_wrap_preserves_databricks_statement_failed` -> `QueryRejected`
- `run_path_bare_wrap_preserves_snowflake_timeout` -> `Transient`
- `run_path_bare_wrap_preserves_databricks_quota_exceeded` -> `QuotaExceeded`
- `run_path_context_wrap_preserves_databricks_statement_failed` -> `QueryRejected`
- `run_path_context_wrap_preserves_snowflake_auth_failed` -> `AuthFailed`
- `run_path_unconverted_anyhow_macro_still_returns_unknown` (negative control)

Each test mirrors the actual conversion shape used at the corresponding run.rs site.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --all-features` all engine tests pass (35 `failure_kind_tests` pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just codegen` no-op (no `JsonSchema`-deriving struct changed)