### PR TITLE
feat(rocky-cli): content-address replication-only plans (Cluster 3 B Phase 5b)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -3,11 +3,15 @@
 //! Dispatches by `PlanKind`:
 //! - `Compact` → `commands::compact::run_compact_apply_in`
 //! - `Archive` → `commands::archive::run_archive_apply_in`
-//! - `Run`     → `commands::run::run` with the `RunPlan` operational metadata
+//! - `Run` → `commands::run::run` with the `RunPlan` operational metadata
+//! - `Replication` → `commands::run::run` against a replication-only project,
+//!   after re-discovering source state and asserting it matches the persisted snapshot
+//! - `Promote` → `commands::branch::run_promote_apply` with the persisted
+//!   per-target SQL statements
 //!
 //! The `--inline` flag skips plan persistence and executes immediately —
 //! this is the path that `rocky run` aliases to so existing callers see no
-//! behaviour change. Phase 4 will add a deprecation warning on `rocky run`.
+//! behaviour change.
 //!
 //! ## Plan payload for Run kind
 //!
@@ -17,12 +21,26 @@
 //! the same flags — a fast, CPU-only recompile step. Full IR persistence is
 //! deferred to a future phase if deterministic replay without recompile
 //! becomes a hard requirement.
+//!
+//! ## Plan payload for Replication kind (Phase 5b)
+//!
+//! `ReplicationPlan` persists the canonical `RockyConfig` snapshot plus a
+//! sorted source-state snapshot (connectors + tables). Apply re-runs
+//! discovery, rebuilds the snapshot with the same canonicalization, and
+//! asserts byte-equality against the persisted one — any drift surfaces
+//! a clear "source state has drifted since plan was created" error before
+//! any SQL is emitted. The successful path delegates to
+//! `commands::run::run` with `models_dir = None`, `run_all = false`, and
+//! no model filter so the engine's existing replication arm executes.
 
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
 
-use crate::output::{AuditEvent, AuditEventKind, BranchPromoteOutput, PromotePlan, RunPlan};
+use crate::output::{
+    AuditEvent, AuditEventKind, BranchPromoteOutput, PromotePlan, ReplicationConnectorSnapshot,
+    ReplicationPlan, RunPlan,
+};
 use crate::plan_store::{PlanKind, read_plan};
 
 use super::archive::run_archive_apply_in;
@@ -59,6 +77,9 @@ pub(crate) async fn run_apply_in(
             run_archive_apply_in(root, config_path, plan_id, output_json).await
         }
         PlanKind::Run => run_apply_run_plan(root, config_path, plan_id, output_json).await,
+        PlanKind::Replication => {
+            run_apply_replication_plan(root, config_path, plan_id, output_json).await
+        }
         PlanKind::Promote => run_apply_promote_plan(root, config_path, plan_id, output_json).await,
     }
 }
@@ -186,6 +207,171 @@ async fn run_apply_run_plan(
     // The `run` command has already emitted its own JSON (or text) output.
     // Nothing more to emit in the inline/non-envelope path.
     Ok(())
+}
+
+/// Apply a `PlanKind::Replication` plan by re-running discovery, asserting
+/// the source state matches the persisted snapshot, then delegating to the
+/// replication arm of `commands::run::run`.
+///
+/// Stale-source detection compares the snapshot built from a fresh discovery
+/// against the one captured at plan time. Any difference (connectors added,
+/// removed, renamed; tables added, removed, renamed; row counts changed when
+/// the adapter surfaces them) is treated as drift and aborts the apply with
+/// a clear "re-plan and re-apply" error. The check happens BEFORE any SQL
+/// is emitted to the warehouse.
+async fn run_apply_replication_plan(
+    root: &Path,
+    config_path: &Path,
+    plan_id: &str,
+    output_json: bool,
+) -> Result<()> {
+    let plan = read_plan(root, plan_id)
+        .with_context(|| format!("failed to read replication plan '{plan_id}'"))?;
+
+    if plan.kind != PlanKind::Replication {
+        bail!(
+            "plan '{plan_id}' is a {} plan, not a replication plan. \
+             Use `rocky apply {plan_id}` and let the dispatcher route it.",
+            plan.kind,
+        );
+    }
+
+    let replication_plan: ReplicationPlan = serde_json::from_value(plan.payload.clone())
+        .context("failed to deserialize replication plan payload")?;
+
+    // Re-load config + re-run discovery to detect source drift before
+    // touching the warehouse.
+    let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
+        "failed to load config from {}",
+        config_path.display()
+    ))?;
+    let (_pipeline_name, pipeline) = crate::registry::resolve_replication_pipeline(
+        &rocky_cfg,
+        replication_plan.pipeline.as_deref(),
+    )?;
+    let pattern = pipeline.schema_pattern()?;
+
+    let adapter_registry = crate::registry::AdapterRegistry::from_config(&rocky_cfg)?;
+    let live_connectors = if let Some(ref disc) = pipeline.source.discovery {
+        let discovery_adapter = adapter_registry.discovery_adapter(&disc.adapter)?;
+        discovery_adapter
+            .discover(&pattern.prefix)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .connectors
+    } else {
+        anyhow::bail!("no discovery adapter configured for this pipeline")
+    };
+
+    let live_snapshot = crate::commands::plan::build_source_state_snapshot(&live_connectors);
+
+    if live_snapshot != replication_plan.source_state_snapshot {
+        let diff_summary =
+            summarize_source_state_drift(&replication_plan.source_state_snapshot, &live_snapshot);
+        bail!(
+            "source state has drifted since plan '{plan_id}' was created.\n\
+             {diff_summary}\n\
+             Re-plan with `rocky plan` and re-apply against the resulting plan_id."
+        );
+    }
+
+    // Snapshot matched — delegate to the existing replication codepath
+    // by calling `commands::run::run` with model-related args set to
+    // defaults. The replication arm inside `run` handles everything
+    // from here.
+    let resolved = rocky_core::state::resolve_state_path(None, std::path::Path::new("models"));
+    let state_path = resolved.path;
+
+    let partition_opts = crate::commands::run::PartitionRunOptions::default();
+
+    crate::commands::run::run(
+        config_path,
+        replication_plan.filter.as_deref(),
+        replication_plan.pipeline.as_deref(),
+        &state_path,
+        replication_plan.governance_override.as_ref(),
+        output_json,
+        // No models directory — replication-only apply does not run
+        // transformation models.
+        None,
+        // `--all` runs both replication and models; replication-only
+        // apply never wants the model leg.
+        false,
+        replication_plan.resume.as_deref(),
+        replication_plan.resume_latest,
+        // No shadow config — branch promote and shadow paths are
+        // independent of replication-plan replay.
+        None,
+        &partition_opts,
+        // No model filter — replication runs every discovered table.
+        None,
+        // Cache TTL override — runtime-only, not part of the plan.
+        None,
+        replication_plan.idempotency_key.as_deref(),
+        replication_plan.env.as_deref(),
+    )
+    .await
+    .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
+
+    Ok(())
+}
+
+/// Render a human-readable summary of the diff between the persisted
+/// source-state snapshot and the live one. Surfaced inside the
+/// stale-source bail message so operators see what changed without
+/// having to inspect the plan file by hand.
+fn summarize_source_state_drift(
+    persisted: &[ReplicationConnectorSnapshot],
+    live: &[ReplicationConnectorSnapshot],
+) -> String {
+    use std::collections::BTreeMap;
+
+    let persisted_map: BTreeMap<&str, &ReplicationConnectorSnapshot> =
+        persisted.iter().map(|c| (c.id.as_str(), c)).collect();
+    let live_map: BTreeMap<&str, &ReplicationConnectorSnapshot> =
+        live.iter().map(|c| (c.id.as_str(), c)).collect();
+
+    let mut lines = vec![format!(
+        "  persisted snapshot: {} connector(s); live snapshot: {} connector(s)",
+        persisted.len(),
+        live.len(),
+    )];
+
+    let added: Vec<&str> = live_map
+        .keys()
+        .filter(|k| !persisted_map.contains_key(*k))
+        .copied()
+        .collect();
+    let removed: Vec<&str> = persisted_map
+        .keys()
+        .filter(|k| !live_map.contains_key(*k))
+        .copied()
+        .collect();
+
+    if !added.is_empty() {
+        lines.push(format!(
+            "  connectors added (in live, not in plan): {}",
+            added.join(", ")
+        ));
+    }
+    if !removed.is_empty() {
+        lines.push(format!(
+            "  connectors removed (in plan, not in live): {}",
+            removed.join(", ")
+        ));
+    }
+    for (id, p_conn) in &persisted_map {
+        if let Some(l_conn) = live_map.get(id) {
+            if p_conn != l_conn {
+                lines.push(format!(
+                    "  connector '{id}' changed (tables: {} -> {}; schema/type may also differ)",
+                    p_conn.tables.len(),
+                    l_conn.tables.len(),
+                ));
+            }
+        }
+    }
+    lines.join("\n")
 }
 
 /// Apply a `PlanKind::Promote` plan by executing the pre-built SQL statements
@@ -345,7 +531,7 @@ pub async fn run_apply_inline_for_run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::RunPlan;
+    use crate::output::{ReplicationTableSnapshot, RunPlan};
     use crate::plan_store::write_plan;
 
     fn minimal_run_plan() -> RunPlan {
@@ -555,5 +741,260 @@ mod tests {
         assert_eq!(decoded.env.as_deref(), Some("prod"));
         assert_eq!(decoded.execution_layers.len(), 2);
         Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Replication plan (Phase 5b)
+    // ------------------------------------------------------------------
+
+    fn minimal_replication_plan() -> ReplicationPlan {
+        ReplicationPlan {
+            filter: Some("source=orders".to_string()),
+            pipeline: Some("playground".to_string()),
+            env: None,
+            idempotency_key: None,
+            resume: None,
+            resume_latest: false,
+            governance_override: None,
+            config_snapshot: serde_json::json!({"adapter": {"default": {"type": "duckdb"}}}),
+            source_state_snapshot: vec![ReplicationConnectorSnapshot {
+                id: "raw__orders".to_string(),
+                schema: "raw__orders".to_string(),
+                source_type: "duckdb".to_string(),
+                tables: vec![ReplicationTableSnapshot {
+                    name: "orders".to_string(),
+                    row_count: Some(100),
+                }],
+            }],
+        }
+    }
+
+    /// Round-trip: `ReplicationPlan` written to disk parses back into an
+    /// identical struct. Guards against accidental skip_serializing_if
+    /// drift on the new payload.
+    #[test]
+    fn replication_plan_round_trip_serde() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let rp = minimal_replication_plan();
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+        assert_eq!(plan_id.len(), 64);
+
+        let persisted = read_plan(dir.path(), &plan_id)?;
+        assert_eq!(persisted.kind, PlanKind::Replication);
+
+        let decoded: ReplicationPlan = serde_json::from_value(persisted.payload)?;
+        assert_eq!(decoded.filter.as_deref(), Some("source=orders"));
+        assert_eq!(decoded.pipeline.as_deref(), Some("playground"));
+        assert_eq!(decoded.source_state_snapshot.len(), 1);
+        assert_eq!(decoded.source_state_snapshot[0].id, "raw__orders");
+        assert_eq!(decoded.source_state_snapshot[0].tables.len(), 1);
+        assert_eq!(decoded.source_state_snapshot[0].tables[0].name, "orders");
+        assert_eq!(
+            decoded.source_state_snapshot[0].tables[0].row_count,
+            Some(100)
+        );
+        Ok(())
+    }
+
+    /// Identical replication plan payloads produce identical plan_ids —
+    /// the content-addressing property that the apply path relies on
+    /// for stale-source detection.
+    #[test]
+    fn replication_plan_same_payload_same_plan_id() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let rp = minimal_replication_plan();
+        let id1 = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+        let id2 = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+        assert_eq!(
+            id1, id2,
+            "identical replication payload must produce identical plan_id"
+        );
+        Ok(())
+    }
+
+    /// Differing config snapshots (any field) produce different plan_ids.
+    /// Critical for "I changed my rocky.toml and re-planned" workflows —
+    /// each config edit yields a fresh plan_id and the old plan stays
+    /// rejected by stale-source / stale-config logic.
+    #[test]
+    fn replication_plan_differing_config_yields_distinct_plan_ids() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut rp = minimal_replication_plan();
+        let id_a = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        // Mutate the config snapshot — even a single key change must
+        // shift the plan_id.
+        rp.config_snapshot = serde_json::json!({"adapter": {"default": {"type": "snowflake"}}});
+        let id_b = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        assert_ne!(
+            id_a, id_b,
+            "different config_snapshot must produce different plan_ids"
+        );
+        Ok(())
+    }
+
+    /// Differing source-state snapshots (e.g. table added, row_count
+    /// changed) produce different plan_ids. The plan_id is the
+    /// deterministic correlation handle apply uses to detect drift —
+    /// this is the property that keeps stale plans from re-running
+    /// against a moved source.
+    #[test]
+    fn replication_plan_differing_source_state_yields_distinct_plan_ids() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut rp = minimal_replication_plan();
+        let id_a = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        // Add a new table to the snapshot.
+        rp.source_state_snapshot[0]
+            .tables
+            .push(ReplicationTableSnapshot {
+                name: "order_items".to_string(),
+                row_count: Some(500),
+            });
+        let id_b = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        assert_ne!(
+            id_a, id_b,
+            "different source_state_snapshot must produce different plan_ids"
+        );
+
+        // Mutate row_count — also has to change the plan_id.
+        rp.source_state_snapshot[0].tables[0].row_count = Some(101);
+        let id_c = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+        assert_ne!(
+            id_b, id_c,
+            "row_count mutation must produce different plan_id"
+        );
+        Ok(())
+    }
+
+    /// Mismatched filter / idempotency_key produce different plan_ids,
+    /// mirroring `RunPlan`'s precedent. Two runs with the same source
+    /// state but different `--filter` are not the same plan.
+    #[test]
+    fn replication_plan_differing_filter_yields_distinct_plan_ids() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut rp = minimal_replication_plan();
+        rp.filter = Some("source=orders".to_string());
+        let id_a = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        rp.filter = Some("source=customers".to_string());
+        let id_b = write_plan(dir.path(), PlanKind::Replication, &rp)?;
+
+        assert_ne!(
+            id_a, id_b,
+            "different filter must produce different plan_ids"
+        );
+        Ok(())
+    }
+
+    /// Wrong-kind dispatch: an applier given a `PlanKind::Compact` id
+    /// reports the actual kind in the error message rather than
+    /// silently treating it as Replication.
+    #[test]
+    fn wrong_kind_for_replication_apply_returns_clear_error() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let plan_id = write_plan(
+            dir.path(),
+            crate::plan_store::PlanKind::Compact,
+            &serde_json::json!({"dummy": true}),
+        )?;
+
+        let plan = read_plan(dir.path(), &plan_id)?;
+        assert_eq!(plan.kind, crate::plan_store::PlanKind::Compact);
+        assert_ne!(
+            plan.kind,
+            PlanKind::Replication,
+            "compact plan kind must differ from Replication"
+        );
+        Ok(())
+    }
+
+    /// `summarize_source_state_drift` surfaces added/removed/changed
+    /// connectors so the apply-side bail message tells operators what
+    /// changed.
+    #[test]
+    fn drift_summary_calls_out_added_removed_changed() {
+        let persisted = vec![
+            ReplicationConnectorSnapshot {
+                id: "conn_a".to_string(),
+                schema: "schema_a".to_string(),
+                source_type: "fivetran".to_string(),
+                tables: vec![ReplicationTableSnapshot {
+                    name: "orders".to_string(),
+                    row_count: None,
+                }],
+            },
+            ReplicationConnectorSnapshot {
+                id: "conn_b".to_string(),
+                schema: "schema_b".to_string(),
+                source_type: "fivetran".to_string(),
+                tables: vec![],
+            },
+        ];
+        let live = vec![
+            // conn_a kept but with one extra table — changed.
+            ReplicationConnectorSnapshot {
+                id: "conn_a".to_string(),
+                schema: "schema_a".to_string(),
+                source_type: "fivetran".to_string(),
+                tables: vec![
+                    ReplicationTableSnapshot {
+                        name: "orders".to_string(),
+                        row_count: None,
+                    },
+                    ReplicationTableSnapshot {
+                        name: "shipments".to_string(),
+                        row_count: None,
+                    },
+                ],
+            },
+            // conn_b absent — removed.
+            // conn_c added.
+            ReplicationConnectorSnapshot {
+                id: "conn_c".to_string(),
+                schema: "schema_c".to_string(),
+                source_type: "fivetran".to_string(),
+                tables: vec![],
+            },
+        ];
+
+        let summary = summarize_source_state_drift(&persisted, &live);
+        assert!(
+            summary.contains("connectors added"),
+            "summary should mention adds: {summary}"
+        );
+        assert!(
+            summary.contains("conn_c"),
+            "summary should name the added connector: {summary}"
+        );
+        assert!(
+            summary.contains("connectors removed"),
+            "summary should mention removals: {summary}"
+        );
+        assert!(
+            summary.contains("conn_b"),
+            "summary should name the removed connector: {summary}"
+        );
+        assert!(
+            summary.contains("conn_a"),
+            "summary should mention the changed connector: {summary}"
+        );
+    }
+
+    /// Identical snapshots produce a summary that still surfaces counts
+    /// (operators may want to confirm "same shape but my apply still
+    /// rejected", which would be a bug elsewhere).
+    #[test]
+    fn drift_summary_handles_identical_snapshots() {
+        let snap = vec![ReplicationConnectorSnapshot {
+            id: "conn_a".to_string(),
+            schema: "schema_a".to_string(),
+            source_type: "duckdb".to_string(),
+            tables: vec![],
+        }];
+        let summary = summarize_source_state_drift(&snap, &snap);
+        assert!(summary.contains("1 connector(s)"));
     }
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -34,7 +34,7 @@ mod load;
 mod lsp;
 mod metrics;
 mod optimize;
-mod plan;
+pub mod plan;
 mod playground;
 mod preview;
 mod profile_storage;

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 
 use rocky_core::config::GovernanceOverride;
+use rocky_core::source::DiscoveredConnector;
 use rocky_core::sql_gen;
 use rocky_ir::*;
 
@@ -252,21 +253,24 @@ pub async fn plan(
             .context("failed to compute governance action preview")?;
     }
 
-    // --- Run-plan blueprint (Cluster 3 B, Phase 2) -----------------------
+    // --- Plan-spine persistence (Cluster 3 B, Phase 2 + Phase 5b) ---------
     //
-    // When a `models/` directory exists, compile the project and persist a
-    // `RunPlan` (operational metadata only — no full IR). `rocky apply` will
-    // re-derive ProjectIr by recompiling with the same flags. Plan write is
-    // best-effort — failure is logged as a warning, not an error, so
-    // replication-only invocations in CI environments without `.rocky/`
-    // write access are not broken.
+    // Persist a `RunPlan` when the project has compiled models, or a
+    // `ReplicationPlan` for replication-only projects (no `models/`
+    // directory, or `models/` exists but compile returns zero models).
+    // In both cases `output.plan_id` ends up populated so `rocky apply`
+    // can re-execute the same intent. Plan write is best-effort —
+    // failure is logged as a warning, not an error, so CLI invocations
+    // in CI environments without `.rocky/` write access still emit the
+    // statement preview.
     //
-    // The compile honours `--models` when set; otherwise the conventional
-    // `models/` directory next to the config is used.
+    // The run-plan compile honours `--models` when set; otherwise the
+    // conventional `models/` directory next to the config is used.
     let blueprint_models_dir = run_options
         .models_dir
         .clone()
         .unwrap_or_else(|| models_dir.clone());
+    let mut run_plan_persisted = false;
     if blueprint_models_dir.exists() {
         match build_and_persist_run_plan(
             &blueprint_models_dir,
@@ -275,17 +279,54 @@ pub async fn plan(
             env,
             run_options,
         ) {
-            Ok((run_plan, plan_id, persisted_at)) => {
+            Ok(Some((run_plan, plan_id, persisted_at))) => {
                 output.plan_id = Some(plan_id);
                 output.plan_kind = Some("run".to_string());
                 output.created_at = Some(persisted_at);
                 output.models = run_plan.models.clone();
                 output.execution_layers = run_plan.execution_layers.clone();
+                run_plan_persisted = true;
+            }
+            Ok(None) => {
+                // `models/` exists but compile produced zero models —
+                // fall through to the replication-plan branch below.
+                tracing::debug!(
+                    "`models/` directory has no compiled models — building replication plan instead"
+                );
             }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     "failed to build/persist run plan; `rocky apply` will not be available for this invocation"
+                );
+            }
+        }
+    }
+
+    // Replication-plan branch — fires when there is no `models/`
+    // directory or the directory exists but contains zero compiled
+    // models. The plan_id is content-addressed by the canonical
+    // `RockyConfig` snapshot + the discovered source state (sorted
+    // connectors + tables), so identical inputs produce an identical
+    // plan_id across machines.
+    if !run_plan_persisted {
+        match build_and_persist_replication_plan(
+            &rocky_cfg,
+            &connectors,
+            filter,
+            pipeline_name,
+            env,
+            run_options,
+        ) {
+            Ok((_replication_plan, plan_id, persisted_at)) => {
+                output.plan_id = Some(plan_id);
+                output.plan_kind = Some("replication".to_string());
+                output.created_at = Some(persisted_at);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to build/persist replication plan; `rocky apply` will not be available for this invocation"
                 );
             }
         }
@@ -302,11 +343,22 @@ pub async fn plan(
         render_governance_preview_text(&output);
         if let Some(ref plan_id) = output.plan_id {
             println!();
-            println!(
-                "Run plan persisted — {} model(s) across {} layer(s)",
-                output.models.len(),
-                output.execution_layers.len()
-            );
+            match output.plan_kind.as_deref() {
+                Some("replication") => {
+                    println!(
+                        "Replication plan persisted — {} statement(s) across {} connector(s)",
+                        output.statements.len(),
+                        connectors.len(),
+                    );
+                }
+                _ => {
+                    println!(
+                        "Run plan persisted — {} model(s) across {} layer(s)",
+                        output.models.len(),
+                        output.execution_layers.len()
+                    );
+                }
+            }
             println!("Plan ID:   {plan_id}");
             println!("Apply with: rocky apply {plan_id}");
         }
@@ -315,7 +367,11 @@ pub async fn plan(
 }
 
 /// Compile the models directory, build a `RunPlan` payload, persist it to
-/// `.rocky/plans/<plan_id>.json`, and return `(payload, plan_id, persisted_at)`.
+/// `.rocky/plans/<plan_id>.json`, and return
+/// `Some((payload, plan_id, persisted_at))`.
+///
+/// Returns `Ok(None)` when the compile succeeds but produces zero models —
+/// the caller falls through to the replication-plan branch in that case.
 ///
 /// Captures the full `rocky run` flag surface from `run_options` so apply-time
 /// replay is intent-preserving. `--missing` / `--resume-latest` are persisted
@@ -326,7 +382,7 @@ fn build_and_persist_run_plan(
     pipeline: Option<&str>,
     env: Option<&str>,
     run_options: &PlanRunOptions,
-) -> Result<(RunPlan, String, chrono::DateTime<Utc>)> {
+) -> Result<Option<(RunPlan, String, chrono::DateTime<Utc>)>> {
     use rocky_compiler::compile::{self, CompilerConfig};
 
     let config = CompilerConfig {
@@ -339,6 +395,14 @@ fn build_and_persist_run_plan(
     };
 
     let result = compile::compile(&config).context("failed to compile models for run plan")?;
+
+    if result.project.models.is_empty() {
+        // No models compiled — this is a replication-only project even
+        // though `models/` exists on disk (e.g. it only holds
+        // `_defaults.toml` or stub files). Let the caller take the
+        // replication-plan path.
+        return Ok(None);
+    }
 
     // Collect qualified model names from the project.
     let models: Vec<String> = result
@@ -386,7 +450,83 @@ fn build_and_persist_run_plan(
     let plan_id = write_plan(&cwd, PlanKind::Run, &run_plan).context("failed to write run plan")?;
 
     let persisted_at = Utc::now();
-    Ok((run_plan, plan_id, persisted_at))
+    Ok(Some((run_plan, plan_id, persisted_at)))
+}
+
+/// Build a canonical, sorted source-state snapshot from the discovered
+/// connectors. Used both at plan time (to build the `ReplicationPlan`
+/// payload) and at apply time (to assert the source hasn't drifted
+/// since the plan was created).
+///
+/// Sort order is stable: connectors by `id`, tables by `name`. Volatile
+/// fields (`last_sync_at`, adapter `metadata`) are intentionally
+/// omitted — see [`ReplicationConnectorSnapshot`] for the rationale.
+pub(crate) fn build_source_state_snapshot(
+    connectors: &[DiscoveredConnector],
+) -> Vec<ReplicationConnectorSnapshot> {
+    let mut snapshot: Vec<ReplicationConnectorSnapshot> = connectors
+        .iter()
+        .map(|c| {
+            let mut tables: Vec<ReplicationTableSnapshot> = c
+                .tables
+                .iter()
+                .map(|t| ReplicationTableSnapshot {
+                    name: t.name.clone(),
+                    row_count: t.row_count,
+                })
+                .collect();
+            tables.sort_by(|a, b| a.name.cmp(&b.name));
+            ReplicationConnectorSnapshot {
+                id: c.id.clone(),
+                schema: c.schema.clone(),
+                source_type: c.source_type.clone(),
+                tables,
+            }
+        })
+        .collect();
+    snapshot.sort_by(|a, b| a.id.cmp(&b.id));
+    snapshot
+}
+
+/// Build a `ReplicationPlan` payload from the loaded config + the
+/// already-discovered connectors, persist it to
+/// `.rocky/plans/<plan_id>.json`, and return
+/// `(payload, plan_id, persisted_at)`.
+///
+/// Called by the replication-plan branch of `rocky plan` — fires when
+/// the project has no `models/` directory or when compile produced
+/// zero models. Discovery has already happened earlier in `plan()`;
+/// this function only canonicalizes the result and persists.
+fn build_and_persist_replication_plan(
+    rocky_cfg: &rocky_core::config::RockyConfig,
+    connectors: &[DiscoveredConnector],
+    filter: Option<&str>,
+    pipeline: Option<&str>,
+    env: Option<&str>,
+    run_options: &PlanRunOptions,
+) -> Result<(ReplicationPlan, String, chrono::DateTime<Utc>)> {
+    let config_snapshot = serde_json::to_value(rocky_cfg)
+        .context("failed to serialize RockyConfig for replication plan")?;
+    let source_state_snapshot = build_source_state_snapshot(connectors);
+
+    let replication_plan = ReplicationPlan {
+        filter: filter.map(str::to_string),
+        pipeline: pipeline.map(str::to_string),
+        env: env.map(str::to_string),
+        idempotency_key: run_options.idempotency_key.clone(),
+        resume: run_options.resume.clone(),
+        resume_latest: run_options.resume_latest,
+        governance_override: run_options.governance_override.clone(),
+        config_snapshot,
+        source_state_snapshot,
+    };
+
+    let cwd = std::env::current_dir().context("failed to get current working directory")?;
+    let plan_id = write_plan(&cwd, PlanKind::Replication, &replication_plan)
+        .context("failed to write replication plan")?;
+
+    let persisted_at = Utc::now();
+    Ok((replication_plan, plan_id, persisted_at))
 }
 
 /// Compile the project and populate `classification_actions`,
@@ -1131,5 +1271,102 @@ ssn = "confidential"
         let kind = AuditEventKind::PromotePlanCreated;
         let json = serde_json::to_string(&kind).unwrap();
         assert_eq!(json, r#""promote_plan_created""#);
+    }
+
+    // ------------------------------------------------------------------
+    // Replication plan source-state snapshot canonicalization (Phase 5b)
+    //
+    // The plan_id digest is computed over the JSON bytes of the
+    // payload, so `build_source_state_snapshot` MUST be deterministic
+    // across discover runs — same connectors, same tables, same
+    // plan_id. These tests pin the sort + field-omission contract that
+    // makes that property hold.
+    // ------------------------------------------------------------------
+
+    use rocky_core::source::{DiscoveredConnector, DiscoveredTable};
+
+    fn make_connector(id: &str, schema: &str, table_names: &[&str]) -> DiscoveredConnector {
+        DiscoveredConnector {
+            id: id.to_string(),
+            schema: schema.to_string(),
+            source_type: "duckdb".to_string(),
+            // last_sync_at is intentionally volatile — verify it
+            // doesn't leak into the snapshot.
+            last_sync_at: Some(chrono::Utc::now()),
+            tables: table_names
+                .iter()
+                .map(|n| DiscoveredTable {
+                    name: n.to_string(),
+                    row_count: Some(10),
+                })
+                .collect(),
+            // metadata is intentionally volatile (rate-limit counters
+            // etc.) — verify it doesn't leak either.
+            metadata: indexmap::IndexMap::from([(
+                "fivetran.rate_limit_used".to_string(),
+                serde_json::json!(42),
+            )]),
+        }
+    }
+
+    /// Connectors sort by `id`, tables within each connector sort by
+    /// `name`. Discover adapters may return either ordering depending
+    /// on the upstream API; without this canonicalization the
+    /// content-addressed plan_id would wiggle.
+    #[test]
+    fn snapshot_sorts_connectors_and_tables() {
+        let connectors = vec![
+            make_connector("conn_zebra", "schema_z", &["zulu", "alpha"]),
+            make_connector("conn_alpha", "schema_a", &["delta", "bravo"]),
+        ];
+        let snap = build_source_state_snapshot(&connectors);
+
+        assert_eq!(snap.len(), 2);
+        // Connectors sorted by id.
+        assert_eq!(snap[0].id, "conn_alpha");
+        assert_eq!(snap[1].id, "conn_zebra");
+        // Tables sorted by name within each connector.
+        assert_eq!(snap[0].tables[0].name, "bravo");
+        assert_eq!(snap[0].tables[1].name, "delta");
+        assert_eq!(snap[1].tables[0].name, "alpha");
+        assert_eq!(snap[1].tables[1].name, "zulu");
+    }
+
+    /// Re-running the snapshot on the same connector list must
+    /// produce byte-identical JSON. This is the property the plan_id
+    /// content-addressing relies on.
+    #[test]
+    fn snapshot_is_deterministic_across_runs() {
+        let connectors = vec![
+            make_connector("c2", "s2", &["t2", "t1"]),
+            make_connector("c1", "s1", &["t1"]),
+        ];
+        let s1 = build_source_state_snapshot(&connectors);
+        let s2 = build_source_state_snapshot(&connectors);
+
+        let j1 = serde_json::to_string(&s1).unwrap();
+        let j2 = serde_json::to_string(&s2).unwrap();
+        assert_eq!(j1, j2, "snapshot must be byte-stable for the same input");
+    }
+
+    /// Volatile fields (`last_sync_at`, adapter `metadata`) MUST be
+    /// excluded from the snapshot. Including them would invalidate
+    /// the plan on every sync tick — the very bug Phase 5b avoids by
+    /// content-addressing on stable identity only.
+    #[test]
+    fn snapshot_excludes_volatile_fields() {
+        let conn = make_connector("c1", "s1", &["t1"]);
+        let snap = build_source_state_snapshot(std::slice::from_ref(&conn));
+        let json = serde_json::to_value(&snap).unwrap();
+
+        // Spot-check the wire format: no last_sync_at, no metadata.
+        assert!(json[0].get("last_sync_at").is_none());
+        assert!(json[0].get("metadata").is_none());
+        // Identity fields are present.
+        assert_eq!(json[0]["id"], "c1");
+        assert_eq!(json[0]["schema"], "s1");
+        assert_eq!(json[0]["source_type"], "duckdb");
+        assert_eq!(json[0]["tables"][0]["name"], "t1");
+        assert_eq!(json[0]["tables"][0]["row_count"], 10);
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2338,6 +2338,107 @@ fn default_parallel() -> u32 {
 // so existing consumers and fixtures remain byte-stable when the compile path
 // is absent.
 
+/// A connector snapshot recorded in a `ReplicationPlan` for stale-source
+/// detection at apply time.
+///
+/// Volatile fields are intentionally omitted: `last_sync_at` is a
+/// wall-clock value that wiggles every sync, and the adapter-namespaced
+/// `metadata` map can include fields like rate-limit counters that
+/// change without altering the replication contract. Only the identity
+/// of the source (`id`, `schema`, `source_type`) and the table list
+/// (sorted, name + row_count) influence the plan_id digest.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ReplicationConnectorSnapshot {
+    pub id: String,
+    pub schema: String,
+    pub source_type: String,
+    /// Tables discovered for this connector. Sorted by `name` so the
+    /// serialized payload is deterministic across discover runs.
+    pub tables: Vec<ReplicationTableSnapshot>,
+}
+
+/// A table snapshot inside a `ReplicationConnectorSnapshot`.
+///
+/// `row_count` is captured when the discovery adapter surfaces it
+/// (DuckDB does; Fivetran does not). Including the count in the
+/// snapshot means a row-count change between plan and apply marks the
+/// plan stale — that's intentional for the row-count-aware adapters,
+/// since downstream materializations may depend on size class.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct ReplicationTableSnapshot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row_count: Option<u64>,
+}
+
+/// Plan payload persisted by `rocky plan` for a replication-only project.
+///
+/// A "replication-only" project is one with no `models/` directory (or
+/// where `models/` exists but compile returns zero models). For those
+/// the `RunPlan` spine has nothing to persist — there are no models
+/// to re-derive at apply time. This payload captures the full
+/// `RockyConfig` plus the discovered source state so the plan_id is
+/// genuinely content-addressed: same config + same source state ⇒
+/// same plan_id.
+///
+/// ## Design call: plan-time discovery (not apply-time)
+///
+/// Discovery already runs inside `rocky plan` today (the existing
+/// statement preview iterates discovered connectors). Capturing the
+/// snapshot in the plan payload is essentially free I/O-wise and
+/// gives us a deterministic plan_id keyed on observable inputs.
+/// Apply re-runs discovery and asserts the snapshot still matches —
+/// any drift fails with a clear "re-plan and re-apply" error before
+/// SQL is emitted.
+///
+/// ## What is NOT in the snapshot
+///
+/// - `last_sync_at` (volatile, not part of the replication contract)
+/// - Adapter-namespaced `metadata` map (rate-limit counters etc.
+///   change without altering what gets replicated)
+///
+/// Including those would invite "I planned, waited 5 minutes, and now
+/// the plan is stale" surprises with no actionable difference.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ReplicationPlan {
+    /// `--filter` passed to `rocky plan` (e.g. `"client=acme"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    /// `--pipeline` if specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline: Option<String>,
+    /// `--env` for governance preview.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    /// `--idempotency-key` (or `ROCKY_IDEMPOTENCY_KEY`). Different keys
+    /// produce different plan_ids — the hash discriminates, mirroring
+    /// `RunPlan`'s behaviour.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// `--resume <run_id>` if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume: Option<String>,
+    /// `--resume-latest` toggle. Resolved against the state store at
+    /// apply time, like `RunPlan.resume_latest`.
+    #[serde(default)]
+    pub resume_latest: bool,
+    /// Governance override resolved at plan time from
+    /// `--governance-override`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_override: Option<rocky_core::config::GovernanceOverride>,
+    /// Full `RockyConfig` snapshot, serialised after env-var
+    /// substitution. Captured verbatim — apply does not try to extract
+    /// "the replication-relevant subset" because that's a footgun: any
+    /// hidden runtime dependency on a config field that isn't in the
+    /// subset would silently break replay. Cheaper to keep the whole
+    /// config and let the hash do its job.
+    pub config_snapshot: serde_json::Value,
+    /// Discovered connectors sorted by `id`. Tables within each
+    /// connector are sorted by `name`. Apply re-discovers and asserts
+    /// byte-equality against this snapshot before running SQL.
+    pub source_state_snapshot: Vec<ReplicationConnectorSnapshot>,
+}
+
 /// JSON output for `rocky apply <plan-id>`.
 ///
 /// Wraps the inner apply output (compact / archive / run) with a top-level

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -58,6 +58,15 @@ pub enum PlanKind {
     /// list, execution layers). Full `ProjectIr` is not persisted — `apply`
     /// re-derives it by re-compiling with the same flags.
     Run,
+    /// A `rocky plan` / `rocky apply` plan for a replication-only project
+    /// (no `models/` directory, or `models/` exists but contains zero
+    /// compiled models). The payload is a `ReplicationPlan` struct
+    /// capturing the canonical `RockyConfig` snapshot and the discovered
+    /// source state (sorted connectors + tables) at plan time. At apply
+    /// time discovery is re-run and the snapshot is asserted byte-equal
+    /// against the persisted one — stale plans are rejected with a clear
+    /// "re-plan and re-apply" error before any SQL is executed.
+    Replication,
     /// A `rocky plan promote` / `rocky apply` promote plan. The payload is a
     /// `PromotePlan` struct (branch name, base ref, per-target SQL statements,
     /// plan-time audit events). At apply time the branch-state hash is
@@ -72,6 +81,7 @@ impl std::fmt::Display for PlanKind {
             PlanKind::Compact => write!(f, "compact"),
             PlanKind::Archive => write!(f, "archive"),
             PlanKind::Run => write!(f, "run"),
+            PlanKind::Replication => write!(f, "replication"),
             PlanKind::Promote => write!(f, "promote"),
         }
     }
@@ -302,6 +312,7 @@ mod tests {
         let id_compact = write_plan(dir.path(), PlanKind::Compact, &payload)?;
         let id_archive = write_plan(dir.path(), PlanKind::Archive, &payload)?;
         let id_run = write_plan(dir.path(), PlanKind::Run, &payload)?;
+        let id_replication = write_plan(dir.path(), PlanKind::Replication, &payload)?;
         let id_promote = write_plan(dir.path(), PlanKind::Promote, &payload)?;
         assert_ne!(
             id_compact, id_archive,
@@ -314,6 +325,14 @@ mod tests {
         assert_ne!(
             id_archive, id_run,
             "archive and run must produce different plan_ids"
+        );
+        assert_ne!(
+            id_run, id_replication,
+            "run and replication must produce different plan_ids"
+        );
+        assert_ne!(
+            id_compact, id_replication,
+            "compact and replication must produce different plan_ids"
         );
         assert_ne!(
             id_compact, id_promote,
@@ -348,6 +367,39 @@ mod tests {
     }
 
     #[test]
+    fn replication_kind_round_trip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let payload = DummyPayload {
+            model: "cat.sc.replication_table",
+            statement_count: 4,
+        };
+
+        let plan_id = write_plan(dir.path(), PlanKind::Replication, &payload)?;
+        assert_eq!(plan_id.len(), 64);
+
+        let plan = read_plan(dir.path(), &plan_id)?;
+        assert_eq!(plan.kind, PlanKind::Replication);
+        assert_eq!(
+            plan.payload["model"],
+            serde_json::json!("cat.sc.replication_table")
+        );
+        assert_eq!(plan.payload["statement_count"], serde_json::json!(4));
+        Ok(())
+    }
+
+    /// `PlanKind::Replication` serializes to the snake_case wire name
+    /// `"replication"`, mirroring the other variants. The dispatcher in
+    /// `commands::apply` relies on this for round-trip dispatch.
+    #[test]
+    fn replication_kind_wire_name() {
+        let kind = PlanKind::Replication;
+        let json = serde_json::to_string(&kind).unwrap();
+        assert_eq!(json, r#""replication""#);
+        let parsed: PlanKind = serde_json::from_str(r#""replication""#).unwrap();
+        assert_eq!(parsed, PlanKind::Replication);
+    }
+
+    #[test]
     fn run_kind_round_trip() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
         let payload = DummyPayload {
@@ -370,6 +422,7 @@ mod tests {
         assert_eq!(PlanKind::Compact.to_string(), "compact");
         assert_eq!(PlanKind::Archive.to_string(), "archive");
         assert_eq!(PlanKind::Run.to_string(), "run");
+        assert_eq!(PlanKind::Replication.to_string(), "replication");
         assert_eq!(PlanKind::Promote.to_string(), "promote");
     }
 

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1187,13 +1187,12 @@ class RockyResource(dg.ConfigurableResource):
         # handles the single-process case, which is all rocky does on
         # Windows today.
         # Inherit the parent environment and force-suppress engine deprecation
-        # notices. After Cluster 3 B Phase 5, the three exec methods route
-        # through `rocky plan` + `rocky apply <plan-id>` so the alias warning
-        # is mostly silent — but the replication-only fallback in
-        # :meth:`_apply_plan` still invokes `rocky run` (engine cannot persist
-        # a plan when no `models/` directory exists), and operators can call
-        # `branch promote <name>` in its bare form too. Keep the suppression
-        # so neither path leaks a `[deprecated]` line into Dagster run logs.
+        # notices. After Cluster 3 B Phase 5b, the three exec methods route
+        # exclusively through `rocky plan` + `rocky apply <plan-id>` (the
+        # replication-only fallback was dropped — every project shape now
+        # emits a plan_id). The suppression stays for direct callers
+        # (operators invoking `rocky run` from CI scripts) and for the bare
+        # `branch promote <name>` invocation that some tests still exercise.
         # `setdefault` keeps the env var operator-overridable.
         rocky_env = os.environ.copy()
         rocky_env.setdefault("ROCKY_SUPPRESS_DEPRECATION", "1")
@@ -1390,15 +1389,15 @@ class RockyResource(dg.ConfigurableResource):
     ) -> PlanResult:
         """Run ``rocky plan`` and return the parsed result.
 
-        When a ``models/`` directory exists in the project, ``rocky plan``
-        also compiles the project and persists a ``RunPlan`` blueprint to
-        ``.rocky/plans/<plan_id>.json``. The returned :class:`PlanResult`
-        will have ``plan_id``, ``plan_kind``, ``created_at``, ``models``,
-        and ``execution_layers`` populated in that case. Call
-        :meth:`apply` with the returned ``plan_id`` to execute the plan.
-
-        For replication-only projects (no ``models/`` directory), the plan
-        acts as a SQL dry-run preview and ``plan_id`` will be ``None``.
+        Every project shape — including replication-only (no
+        ``models/`` directory) — content-addresses a plan and persists
+        it to ``.rocky/plans/<plan_id>.json``. The returned
+        :class:`PlanResult` always has ``plan_id``, ``plan_kind``, and
+        ``created_at`` populated. ``plan_kind`` is ``"run"`` when
+        compiled models drive the plan and ``"replication"`` when the
+        plan is content-addressed by the canonical ``rocky.toml``
+        snapshot + the discovered source state. Call :meth:`apply`
+        with the returned ``plan_id`` to execute the plan.
 
         Args:
             filter: Component filter (e.g. ``"client=acme"``). Optional.
@@ -1427,6 +1426,10 @@ class RockyResource(dg.ConfigurableResource):
         - ``archive`` plan → DELETE/VACUUM statements via the warehouse adapter.
         - ``run`` plan → full pipeline re-execution with the flags that were
           active when ``rocky plan`` was called.
+        - ``replication`` plan → re-discover source state, assert it matches
+          the persisted snapshot, then execute the replication-only pipeline.
+          Stale source state aborts the apply with a clear "re-plan and
+          re-apply" error.
         - ``promote`` plan → executes the pre-built promotion SQL statements
           without re-running the approval or breaking-change gate.
 
@@ -1600,14 +1603,14 @@ class RockyResource(dg.ConfigurableResource):
           ``.rocky/plans/<plan_id>.json`` before applying — the same
           plan id you'd see if you invoked ``rocky plan`` from the CLI.
 
-        Log narrative note (Cluster 3 B Phase 5): the integration now
+        Log narrative note (Cluster 3 B Phase 5b): the integration
         runs ``rocky plan`` first (buffered, single-digit seconds) and
-        then ``rocky apply <plan_id>`` (streamed). Plan-phase stderr is
-        forwarded to the module logger only — it does **not** reach
+        then ``rocky apply <plan_id>`` (streamed). Plan-phase stderr
+        is forwarded to the module logger only — it does **not** reach
         ``context.log``. Apply-phase stderr streams to ``context.log``
-        as before. Replication-only projects (no ``models/`` directory)
-        fall back to ``rocky run`` and keep the legacy single-stream
-        narrative.
+        as before. Every project shape — including replication-only —
+        content-addresses a plan after Phase 5b, so the two-stream
+        narrative is uniform across the matrix.
 
         Args:
             context: Dagster execution context. Either an
@@ -1682,14 +1685,15 @@ class RockyResource(dg.ConfigurableResource):
     ) -> list[str]:
         """Shared argv builder for the legacy ``rocky run`` alias path.
 
-        After Cluster 3 B Phase 5, the three public exec methods
+        After Cluster 3 B Phase 5b, the three public exec methods
         (:meth:`run`, :meth:`run_streaming`, :meth:`run_pipes`) route
-        through :meth:`_build_plan_args` + :meth:`_apply_plan` by
-        default. This builder remains in place for the replication-only
-        fallback (projects with no ``models/`` directory, where
-        ``rocky plan`` cannot persist a plan and there is no
-        ``plan_id`` to apply). It is also kept for any direct caller
-        that still wants the single-subprocess shape.
+        exclusively through :meth:`_build_plan_args` + :meth:`_apply_plan`
+        (the replication-only fallback was dropped — engine-v1.34+
+        emits a content-addressed plan_id for every project shape,
+        replication-only included). This builder is still passed to
+        :meth:`_apply_plan` for argv-symmetry across exec methods, and
+        remains exposed for direct callers that want the
+        single-subprocess shape (CI scripts, ad-hoc tooling).
 
         Single source of truth for the flag plumbing so adding a new
         flag is a one-place change. The flags are defensive:
@@ -1827,41 +1831,55 @@ class RockyResource(dg.ConfigurableResource):
         is the callable that exec the apply argv with whatever process
         model the caller wants (buffered, streaming, Pipes, …).
 
-        Replication-only fallback: when ``rocky plan`` cannot persist a
-        plan because the project has no ``models/`` directory (the
-        ``plan_id`` field is ``None`` on the wire), this method
-        transparently falls back to ``rocky run`` with the original
-        flag surface — behavior-preserving for the pre-Phase-5
-        replication-only path. The deprecation notice is still
-        suppressed via ``ROCKY_SUPPRESS_DEPRECATION`` in
-        :meth:`_run_rocky_with_log_sink` so users see no stderr noise
-        on the fallback.
+        After Phase 5b every supported project shape — including
+        replication-only (no ``models/`` directory) — emits a
+        content-addressed ``plan_id``. A ``None`` ``plan_id`` is now
+        treated as a malformed payload and surfaces as a clear
+        :class:`dg.Failure` instead of silently falling back to
+        ``rocky run``. The version skew is intentional: the dagster
+        wheel that ships this method requires an engine that emits
+        ``plan_id`` for every project shape (engine-v1.34+).
 
         Args:
             plan_args: Argv for ``rocky plan`` (built by
                 :meth:`_build_plan_args`).
-            run_fallback_args: Argv for the ``rocky run`` legacy path
-                (built by :meth:`_build_run_args`). Used only when
-                ``rocky plan`` returns ``plan_id = null``.
+            run_fallback_args: Unused since Phase 5b — kept on the
+                signature so the three call sites (`run`,
+                `run_streaming`, `run_pipes`) stay symmetrical while
+                the engine alias-deprecation cycle runs. Build it the
+                normal way; this method just doesn't read it anymore.
             apply_runner: Per-method exec callable. Receives the
-                ``["apply", <plan_id>]`` argv (or
-                ``run_fallback_args`` on the fallback path) and
-                returns the resulting stdout. Examples:
+                ``["apply", <plan_id>]`` argv and returns the resulting
+                stdout. Examples:
                 ``lambda args: self._run_rocky(args, allow_partial=True)``
                 for the buffered path; the streaming sink-emitting
                 helper for the streaming path.
 
         Returns:
-            The captured stdout from the apply (or fallback ``run``)
-            invocation, ready to be parsed.
+            The captured stdout from the apply invocation, ready to be
+            parsed.
+
+        Raises:
+            :class:`dg.Failure`: When ``rocky plan`` fails to emit a
+                ``plan_id`` (engine version skew or malformed payload).
         """
+        del run_fallback_args  # see docstring — kept on signature for symmetry only
         plan_stdout = self._run_rocky(plan_args)
         plan_id = self._extract_plan_id(plan_stdout)
         if plan_id is None:
-            # Replication-only project (no models/ directory) — engine
-            # cannot persist a plan and there is no plan_id to apply.
-            # Fall back to the single-subprocess `rocky run` path.
-            return apply_runner(run_fallback_args)
+            raise dg.Failure(
+                description=(
+                    "rocky plan did not emit a plan_id — this dagster integration "
+                    "requires engine-v1.34+ which content-addresses every plan, "
+                    "including replication-only projects. Upgrade the rocky binary "
+                    "or pin dagster-rocky<1.33 if a downgrade is needed."
+                ),
+                metadata={
+                    "plan_stdout_tail": dg.MetadataValue.text(
+                        _truncate_stderr_for_metadata(plan_stdout)
+                    ),
+                },
+            )
         return apply_runner(["apply", plan_id])
 
     def run_pipes(
@@ -2004,16 +2022,26 @@ class RockyResource(dg.ConfigurableResource):
         # Plan step is buffered and a separate subprocess. Pipes attaches
         # to the apply step (the engine's Pipes emitter is a no-op on
         # ``rocky plan`` — only ``rocky apply`` reports materializations).
-        # Replication-only projects fall back to ``rocky run`` (no plan
-        # persisted), which still emits Pipes messages under the
-        # ``DAGSTER_PIPES_*`` env vars set by ``PipesSubprocessClient``.
+        # After Phase 5b every project shape — including replication-only
+        # — content-addresses a plan, so the null-plan_id fallback to
+        # ``rocky run`` is gone. ``run_fallback_args`` is computed above
+        # for symmetry with the other two exec methods but unused here.
+        del run_fallback_args  # see comment above
         plan_stdout = self._run_rocky(plan_args)
         plan_id = self._extract_plan_id(plan_stdout)
         if plan_id is None:
-            # Replication-only fallback — single subprocess via Pipes.
-            return client.run(
-                context=context,
-                command=self._build_cmd(run_fallback_args),
+            raise dg.Failure(
+                description=(
+                    "rocky plan did not emit a plan_id — this dagster integration "
+                    "requires engine-v1.34+ which content-addresses every plan, "
+                    "including replication-only projects. Upgrade the rocky binary "
+                    "or pin dagster-rocky<1.33 if a downgrade is needed."
+                ),
+                metadata={
+                    "plan_stdout_tail": dg.MetadataValue.text(
+                        _truncate_stderr_for_metadata(plan_stdout)
+                    ),
+                },
             )
         return client.run(
             context=context,

--- a/integrations/dagster/tests/test_resolvers.py
+++ b/integrations/dagster/tests/test_resolvers.py
@@ -72,11 +72,35 @@ def _apply_envelope_json() -> str:
     )
 
 
+def _plan_json(plan_id: str = "a" * 64) -> str:
+    """Phase 5b: ``rocky plan`` always emits a plan_id, replication or not."""
+    return json.dumps(
+        {
+            "version": "0.1.0",
+            "command": "plan",
+            "filter": "tenant=acme",
+            "statements": [],
+            "plan_id": plan_id,
+            "plan_kind": "replication",
+            "created_at": "2026-05-18T00:00:00Z",
+        }
+    )
+
+
 def _capture_run_args() -> tuple[list[list[str]], Any]:
+    """Phase 5b: ``rocky.run()`` invokes ``plan`` then ``apply``. Return the
+    plan JSON on the first call and the empty run JSON on the second.
+
+    Resolver tests assert against ``captured[0]`` (the plan argv) since
+    every flag emitted by ``_build_run_args`` also lands on the plan
+    argv via ``_build_plan_args`` (engine flag-surface parity, Phase 4).
+    """
     captured: list[list[str]] = []
 
     def fake_run(self, args, allow_partial=False):
         captured.append(args)
+        if args[0] == "plan":
+            return _plan_json()
         return _empty_run_json()
 
     return captured, fake_run
@@ -565,6 +589,8 @@ def test_resolvers_survive_dagster_materialize_lifecycle():
 
     def fake_run(self, args, allow_partial=False):
         captured.append(args)
+        if args[0] == "plan":
+            return _plan_json()
         return _empty_run_json()
 
     @dg.asset

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -318,9 +318,26 @@ def test_run_rocky_timeout_kills_proc_and_raises():
 def test_run_passes_governance_override_as_json():
     rocky = RockyResource()
     captured: list[list[str]] = []
+    plan_id = "a" * 64
 
     def fake_run(*, args, **_):
         captured.append(args)
+        if args[0] == "plan":
+            # Phase 5b: plan emits a real plan_id even for
+            # replication-only projects. ``--governance-override``
+            # appears on both ``plan`` and ``apply``, but the test
+            # only needs to see it land on the plan argv.
+            return json.dumps(
+                {
+                    "version": "0.1.0",
+                    "command": "plan",
+                    "filter": "tenant=acme",
+                    "statements": [],
+                    "plan_id": plan_id,
+                    "plan_kind": "replication",
+                    "created_at": "2026-05-18T00:00:00Z",
+                }
+            )
         return (
             '{"version":"0.3.0","command":"run","filter":"tenant=acme",'
             '"duration_ms":0,"tables_copied":0,"materializations":[],'
@@ -333,6 +350,8 @@ def test_run_passes_governance_override_as_json():
         run_mock.side_effect = lambda self, args, allow_partial=False: fake_run(args=args)
         rocky.run(filter="tenant=acme", governance_override={"workspace_ids": [1, 2]})
 
+    # `rocky plan` is invoked first; the governance override flag must
+    # land on its argv (the persisted plan stamps the override).
     assert "--governance-override" in captured[0]
     idx = captured[0].index("--governance-override")
     assert '"workspace_ids"' in captured[0][idx + 1]
@@ -420,9 +439,22 @@ def test_run_rejects_empty_workspace_ids_before_subprocess():
 def test_run_with_run_models_appends_models_and_all():
     rocky = RockyResource(models_dir="m")
     captured: list[list[str]] = []
+    plan_id = "a" * 64
 
     def fake_run(self, args, allow_partial=False):
         captured.append(args)
+        if args[0] == "plan":
+            return json.dumps(
+                {
+                    "version": "0.1.0",
+                    "command": "plan",
+                    "filter": "tenant=acme",
+                    "statements": [],
+                    "plan_id": plan_id,
+                    "plan_kind": "replication",
+                    "created_at": "2026-05-18T00:00:00Z",
+                }
+            )
         return (
             '{"version":"0.3.0","command":"run","filter":"tenant=acme",'
             '"duration_ms":0,"tables_copied":0,"materializations":[],'
@@ -434,6 +466,8 @@ def test_run_with_run_models_appends_models_and_all():
     with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
         rocky.run(filter="tenant=acme", run_models=True)
 
+    # `--models <dir> --all` lands on the plan argv (the persisted plan
+    # stamps the model-execution intent).
     assert captured[0][-3:] == ["--models", "m", "--all"]
 
 
@@ -452,12 +486,36 @@ def _empty_run_json() -> str:
     )
 
 
+def _plan_then_run_json(plan_id: str = "a" * 64) -> str:
+    """Return the Phase-5b plan JSON used by plan-args captors."""
+    return json.dumps(
+        {
+            "version": "0.1.0",
+            "command": "plan",
+            "filter": "tenant=acme",
+            "statements": [],
+            "plan_id": plan_id,
+            "plan_kind": "replication",
+            "created_at": "2026-05-18T00:00:00Z",
+        }
+    )
+
+
 def _capture_run_args() -> tuple[list[list[str]], Any]:
-    """Set up a captor + side_effect that records args and returns empty JSON."""
+    """Set up a captor + side_effect for the plan/apply two-step flow.
+
+    Phase 5b: ``rocky.run()`` invokes ``rocky plan`` then
+    ``rocky apply <plan_id>``. Returns the plan JSON on the first call
+    and the empty run JSON on the second. Most flag-plumbing tests
+    assert against ``captured[0]`` — the plan argv — since the engine
+    flag-surface parity guarantees plan and run share the same flags.
+    """
     captured: list[list[str]] = []
 
     def fake_run(self, args, allow_partial=False):
         captured.append(args)
+        if args[0] == "plan":
+            return _plan_then_run_json()
         return _empty_run_json()
 
     return captured, fake_run
@@ -1467,33 +1525,35 @@ def test_run_dispatches_plan_then_apply_when_plan_id_persisted():
     assert result.tables_copied == 1
 
 
-def test_run_falls_back_to_rocky_run_when_plan_id_absent():
-    """Phase 5 fallback — ``rocky plan`` without a ``models/`` directory
-    emits ``plan_id = null``. The integration falls back to the legacy
-    ``rocky run`` argv (single subprocess) so replication-only projects
-    keep working with no functional change."""
+def test_run_routes_replication_only_project_through_apply():
+    """Phase 5b — replication-only projects now content-address a plan
+    just like model-driven projects do, so ``run`` always routes
+    through ``rocky apply`` and never falls back to ``rocky run``. The
+    plan output carries ``plan_kind == "replication"`` and a real
+    64-char plan_id.
+    """
     rocky = RockyResource()
     captured: list[list[str]] = []
+    plan_id = "f" * 64
 
     def fake_run(self, args, allow_partial=False):
         captured.append(list(args))
         if args[0] == "plan":
-            # Engine emits PlanOutput with plan_id = None when no
-            # models/ directory exists next to the config.
+            # Phase 5b: engine emits a real plan_id for replication-only.
             return json.dumps(
                 {
                     "version": "0.1.0",
                     "command": "plan",
                     "filter": "tenant=acme",
                     "statements": [],
-                    "plan_id": None,
-                    "plan_kind": None,
-                    "created_at": None,
+                    "plan_id": plan_id,
+                    "plan_kind": "replication",
+                    "created_at": "2026-05-18T00:00:00Z",
                     "models": [],
                     "execution_layers": [],
                 }
             )
-        # Fallback path runs `rocky run` and returns RunResult directly.
+        # Apply path returns the standard RunResult shape.
         return _run_json()
 
     with patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run):
@@ -1501,11 +1561,42 @@ def test_run_falls_back_to_rocky_run_when_plan_id_absent():
 
     # First call: rocky plan.
     assert captured[0][0] == "plan"
-    # Second call (fallback): rocky run with the original flags.
-    assert captured[1][:3] == ["run", "--filter", "tenant=acme"]
-    # Direct RunResult — no apply envelope unwrap needed.
+    # Second call: rocky apply <plan_id> — NOT the legacy run fallback.
+    assert captured[1] == ["apply", plan_id]
     assert result.command == "run"
     assert result.tables_copied == 1
+
+
+def test_run_raises_when_engine_returns_null_plan_id():
+    """Phase 5b — the engine should always emit a plan_id. When it
+    doesn't (engine version skew, malformed payload), ``_apply_plan``
+    raises :class:`dg.Failure` with an upgrade hint instead of
+    silently falling back to ``rocky run``."""
+    rocky = RockyResource()
+
+    def fake_run(self, args, allow_partial=False):
+        if args[0] == "plan":
+            # Simulated stale-engine payload — plan_id absent.
+            return json.dumps(
+                {
+                    "version": "0.1.0",
+                    "command": "plan",
+                    "filter": "tenant=acme",
+                    "statements": [],
+                    "plan_id": None,
+                }
+            )
+        # If apply were called we'd reach here — but we shouldn't.
+        return _run_json()
+
+    with (
+        patch.object(RockyResource, "_run_rocky", autospec=True, side_effect=fake_run),
+        pytest.raises(dg.Failure) as exc,
+    ):
+        rocky.run(filter="tenant=acme")
+
+    assert "plan_id" in str(exc.value)
+    assert "engine-v1.34" in str(exc.value) or "plan_id" in str(exc.value)
 
 
 def test_run_pipes_attaches_extras_with_plan_id():
@@ -1527,13 +1618,11 @@ def test_run_pipes_attaches_extras_with_plan_id():
     assert extras == {"plan_id": plan_id}
 
 
-def test_run_pipes_replication_only_fallback_omits_extras():
-    """Replication-only fallback for run_pipes — no plan_id to surface.
-
-    The single-subprocess ``rocky run`` argv is handed to
-    ``PipesSubprocessClient.run`` (Pipes still emits structured events
-    from the run binary). ``extras`` is NOT passed because there is no
-    plan id to correlate against.
+def test_run_pipes_raises_when_engine_returns_null_plan_id():
+    """Phase 5b — ``run_pipes`` no longer falls back to ``rocky run``
+    when the engine returns a null ``plan_id``. It raises
+    :class:`dg.Failure` so version skew surfaces loudly instead of a
+    silent behaviour change.
     """
     rocky = RockyResource()
     context = MagicMock(spec=dg.AssetExecutionContext)
@@ -1547,29 +1636,27 @@ def test_run_pipes_replication_only_fallback_omits_extras():
             "filter": "tenant=acme",
             "statements": [],
             "plan_id": None,
-            "plan_kind": None,
-            "created_at": None,
-            "models": [],
-            "execution_layers": [],
         }
     )
-    with patch.object(RockyResource, "_run_rocky", return_value=plan_without_id):
+    with (
+        patch.object(RockyResource, "_run_rocky", return_value=plan_without_id),
+        pytest.raises(dg.Failure) as exc,
+    ):
         rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
 
-    fake_client.run.assert_called_once()
-    call_kwargs = fake_client.run.call_args.kwargs
-    assert "extras" not in call_kwargs
-    # Subprocess argv is the legacy `rocky run` shape, not `apply`.
-    cmd = call_kwargs["command"]
-    assert "run" in cmd
-    assert "apply" not in cmd
+    # Pipes client should NOT have been invoked — the failure is raised
+    # before reaching the subprocess.
+    fake_client.run.assert_not_called()
+    assert "plan_id" in str(exc.value)
 
 
 def test_extract_plan_id_returns_none_for_malformed_payload():
     """``_extract_plan_id`` is the gate keeping malformed plan output
     from sending the apply step into a broken state. Treat any
     non-string ``plan_id`` (missing, null, wrong type, malformed JSON)
-    as 'no plan persisted' so the fallback path kicks in."""
+    as 'no plan persisted' so :meth:`_apply_plan` raises a clear
+    upgrade-hint Failure instead of silently routing into a broken
+    state."""
     assert RockyResource._extract_plan_id("not json") is None
     assert RockyResource._extract_plan_id("{}") is None
     assert RockyResource._extract_plan_id(json.dumps({"plan_id": None})) is None


### PR DESCRIPTION
## Summary

- `rocky plan` now emits a non-null content-addressed `plan_id` for every project shape, including replication-only projects (no `models/` directory, or `models/` with zero compiled models). A new `PlanKind::Replication` variant carries a payload with the full `RockyConfig` snapshot + a sorted source-state snapshot (connectors + tables); `plan_id = blake3(kind + payload)`.
- `rocky apply <id>` for replication-kind plans re-runs discovery, asserts the source state matches the persisted snapshot, then delegates to the existing replication arm of `commands::run::run`. Source drift aborts the apply with an explicit diff and a "re-plan and re-apply" pointer before any SQL is emitted.
- Dagster's `RockyResource` drops the `rocky run` fallback in `_apply_plan` and `run_pipes`. All three exec methods (`run`, `run_streaming`, `run_pipes`) now route uniformly through `rocky plan` + `rocky apply <plan-id>`. A null `plan_id` now raises `dg.Failure` with an engine-v1.34+ upgrade hint.

## Design call: plan-time discovery (not apply-time)

`rocky plan` already runs discovery to build its statement preview, so capturing the source-state snapshot at plan time is essentially free I/O-wise. The trade is:

| Time | Plan cost | Plan_id keyed on | Drift detection |
|---|---|---|---|
| **Plan-time (this PR)** | discover already ran | config + source state | apply re-discovers, asserts byte-match |
| Apply-time | cheap plan | config only | none — silently runs against drifted source |

Apply-time was a strictly weaker tradeoff: cheaper plan, but no way to detect that the source moved between plan and apply. Picked plan-time.

Volatile fields are intentionally excluded from the snapshot: `last_sync_at` (wall-clock, changes every sync) and the adapter-namespaced `metadata` map (can carry rate-limit counters etc.). Including them would invalidate plans on every sync tick with no actionable difference.

## Stale-source behaviour

If the source state changes between plan and apply, the apply path fails:

```
Error: source state has drifted since plan '<plan_id>' was created.
  persisted snapshot: 2 connector(s); live snapshot: 2 connector(s)
  connector 'raw__orders' changed (tables: 1 -> 0; schema/type may also differ)
Re-plan with `rocky plan` and re-apply against the resulting plan_id.
```

The diff names added / removed / changed connectors so operators can act without reading the plan file by hand.

## Version-skew contract

Dagster-rocky shipped from this PR requires engine-v1.34+ (every project shape content-addresses a plan). A null `plan_id` from an older engine now surfaces as `dg.Failure` with an upgrade hint instead of silently routing into the dropped fallback. Pin `dagster-rocky<1.33` if a downgrade is needed.

## What stays the same

- `RunPlan`, `PromotePlan`, `CompactPlan`, `ArchivePlan` are unchanged.
- The playground POC plan_id fixture (`5d76a60260b1ff...`) is byte-stable — that POC has `models/`, so it still produces a `run` plan, not a replication plan.
- `_build_run_args` and the `ROCKY_SUPPRESS_DEPRECATION` env-var stay for direct `rocky run` callers (CI scripts, bare `branch promote`).

## Test plan

- [x] Engine: `cargo test --all-features` — 507 unit tests pass (+13 new).
- [x] Engine: `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] Engine: `cargo fmt --check` clean.
- [x] Dagster: `uv run pytest` — 534 tests pass.
- [x] Dagster: `ruff check` + `ruff format --check` clean.
- [x] VS Code: `npm run test:unit` — 106 tests pass.
- [x] `just codegen` — no schema or binding drift (no top-level shape change).
- [x] `just regen-fixtures` — no fixture drift (playground POC stays on the `run` plan branch).
- [x] Live: replication-only DuckDB project confirms (a) `plan_id` is non-null and byte-stable across runs, (b) stale-source check fires with a diff after mutating the source, (c) playground POC `plan_id` unchanged.

## Follow-up

- `_build_run_args` is now built-then-discarded at three call sites (kept on `_apply_plan`'s signature for argv-symmetry while the engine alias-deprecation cycle runs). A small future cleanup can drop the parameter and call sites once the deprecation completes.