### PR TITLE
fix(dagster): resolver disambiguation + emit-time dedup in _emit_results

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`_emit_results` no longer crashes on cross-schema same-table-name collisions.** Two independent guards in `component.py` close the failure mode where a Rocky run with row-count anomalies could fail the multi-asset op with `DagsterInvariantViolationError: ... returned an output "..._row_count_anomaly" multiple times` after every table had already been copied successfully:
+  - **Part A — resolver disambiguation.** `_build_table_resolver`'s last-segment fallback previously returned an arbitrary dict-iteration winner when a bare identifier matched multiple translator-mapped keys (e.g. the same connector/table loaded under multiple region prefixes). It now refuses to guess on ambiguity: a unique last-segment match still resolves; an ambiguous match returns `None` and logs a single WARN line. Adopters can disambiguate by emitting schema- or catalog-qualified identifiers (`schema.table` / `catalog.schema.table`) which the trailing-tuple loop resolves deterministically.
+  - **Part B — defensive emit-time dedup.** The table-check and anomaly loops in `_emit_results` now consult `yielded_checks` before emitting, so a same-`(asset_key, check_name)` duplicate is silently dropped (with a debug log) rather than reaching Dagster's duplicate-output invariant. With Part A applied this branch is unreachable for the resolver-collision shape; the dedup guards against any other path that could legitimately yield the same check twice.
+
+  Behaviour change for adopters relying on the previous fuzzy fallback: an ambiguous bare-segment lookup that previously returned an arbitrary winner now drops the event. Adopters whose translator keys are full schema-qualified suffixes (the common case) see zero change.
+
 ## [1.32.0] — 2026-05-18
 
 Companion release to engine `v1.34.0`. The dagster bindings pick up the new `failure_kind` discriminator on `RunOutput.errors[*]` via the regenerated Pydantic models. No new dagster API surface — pure codegen cascade. The engine-side `run.rs` typed-error-preserving refactor that ships in `v1.34.0` is what makes the discriminator practically useful in production: downstream Dagster assets that key off run-output errors can now branch on a stable classification rather than `unknown`. Wheel re-cut against the v1.34.0 engine binary.

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1870,9 +1870,18 @@ def _emit_results(
         if asset_key not in selected_keys:
             continue
         for check in table_check.checks:
-            if (asset_key, check.name) not in declared_checks:
+            spec_key = (asset_key, check.name)
+            if spec_key not in declared_checks:
                 continue
-            yielded_checks.add((asset_key, check.name))
+            if spec_key in yielded_checks:
+                _log.debug(
+                    "Skipping duplicate AssetCheckResult emission: %s for %s "
+                    "(already yielded earlier in this op)",
+                    check.name,
+                    asset_key,
+                )
+                continue
+            yielded_checks.add(spec_key)
             yield dg.AssetCheckResult(
                 asset_key=asset_key,
                 check_name=check.name,
@@ -1890,9 +1899,17 @@ def _emit_results(
     # before any run; placeholders below cover the no-anomaly case.
     for run_result in results:
         for anomaly_result in anomaly_check_results(run_result, key_resolver=selected_resolver):
-            if (anomaly_result.asset_key, ANOMALY_CHECK_NAME) not in declared_checks:
+            spec_key = (anomaly_result.asset_key, ANOMALY_CHECK_NAME)
+            if spec_key not in declared_checks:
                 continue
-            yielded_checks.add((anomaly_result.asset_key, ANOMALY_CHECK_NAME))
+            if spec_key in yielded_checks:
+                _log.debug(
+                    "Skipping duplicate row_count_anomaly emission for %s "
+                    "(already yielded earlier in this op)",
+                    anomaly_result.asset_key,
+                )
+                continue
+            yielded_checks.add(spec_key)
             yield anomaly_result
 
     yield from _emit_placeholder_checks(
@@ -1929,11 +1946,30 @@ def _build_table_resolver(
             if tup in rocky_key_to_dagster_key:
                 key = rocky_key_to_dagster_key[tup]
                 return key if key in selected_keys else None
-        # Fallback: match by last path segment.
+        # Fallback: match by last path segment, but only if unique. When two
+        # translator-mapped tables share the same last segment (e.g. the same
+        # connector loaded under multiple region prefixes), an arbitrary
+        # dict-iteration winner would silently collapse distinct Rocky tables
+        # onto one Dagster asset — which causes DagsterInvariantViolationError
+        # downstream once both emit a check/anomaly/drift event in the same op.
         last = parts[-1]
-        for tup, key in rocky_key_to_dagster_key.items():
-            if tup and tup[-1] == last and key in selected_keys:
-                return key
+        candidates = [
+            key
+            for tup, key in rocky_key_to_dagster_key.items()
+            if tup and tup[-1] == last and key in selected_keys
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            _log.warning(
+                "Ambiguous Rocky table identifier %r: matched %d translator-mapped keys "
+                "via last-segment fallback. Refusing to guess; dropping event. "
+                "Adopters can disambiguate by emitting the schema-qualified "
+                "(schema.table) or catalog-qualified (catalog.schema.table) form, "
+                "which the trailing-tuple lookup resolves deterministically.",
+                table_name,
+                len(candidates),
+            )
         return None
 
     return resolve

--- a/integrations/dagster/tests/test_emit_results_dedup.py
+++ b/integrations/dagster/tests/test_emit_results_dedup.py
@@ -1,0 +1,236 @@
+"""Tests for FR-023: anomaly emit dedup + cross-schema resolver disambiguation.
+
+Two independent guards in ``component.py``:
+
+* **Part A** — ``_build_table_resolver`` refuses to guess when a bare
+  last-segment lookup matches multiple translator-mapped keys
+  (cross-schema collision). Previously returned an arbitrary
+  dict-iteration winner, silently collapsing distinct Rocky tables onto
+  one Dagster ``AssetKey`` and crashing the op downstream.
+* **Part B** — ``_emit_results`` consults ``yielded_checks`` before
+  yielding each ``AssetCheckResult``, so a same-key duplicate never
+  reaches Dagster's "duplicate output" invariant.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dagster as dg
+
+from dagster_rocky.component import _build_table_resolver, _emit_results
+from dagster_rocky.observability import ANOMALY_CHECK_NAME
+from dagster_rocky.types import (
+    AnomalyResult,
+    CheckResult,
+    DriftInfo,
+    ExecutionSummary,
+    PermissionInfo,
+    RunResult,
+    TableCheckResult,
+)
+
+
+def _run_result(
+    *,
+    check_results: list[TableCheckResult] | None = None,
+    anomalies: list[AnomalyResult] | None = None,
+) -> RunResult:
+    return RunResult(
+        version="0.3.0",
+        command="run",
+        filter="tenant=acme",
+        duration_ms=1000,
+        tables_copied=0,
+        tables_failed=0,
+        materializations=[],
+        check_results=check_results or [],
+        execution=ExecutionSummary(concurrency=4, tables_processed=0, tables_failed=0),
+        permissions=PermissionInfo(
+            grants_added=0, grants_revoked=0, catalogs_created=0, schemas_created=0
+        ),
+        drift=DriftInfo(tables_checked=0, tables_drifted=0, actions_taken=[]),
+        anomalies=anomalies or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part A — _build_table_resolver ambiguity guard
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_unique_last_segment_still_resolves():
+    """Single last-segment match keeps the existing fallback behaviour."""
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    payments = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "payments"])
+    mapping = {
+        ("fivetran", "acme", "us_west", "shopify", "orders"): orders,
+        ("fivetran", "acme", "us_west", "shopify", "payments"): payments,
+    }
+    resolver = _build_table_resolver(mapping, selected_keys={orders, payments})
+
+    assert resolver("orders") == orders
+    assert resolver("payments") == payments
+
+
+def test_resolver_exact_suffix_match_unaffected_by_collision():
+    """Trailing-tuple lookup wins before the ambiguity guard runs.
+
+    When the translator registers each Rocky table under a tuple whose
+    suffix is the Rocky-emitted identifier, the exact-suffix loop
+    resolves it deterministically even if other entries share the same
+    last segment.
+    """
+    eu_ad = dg.AssetKey(["raw", "client", "eu", "alb", "redditads", "ad"])
+    us_ad = dg.AssetKey(["raw", "client", "namer", "usa", "redditads", "ad"])
+    mapping = {
+        ("eu_alb_redditads", "ad"): eu_ad,
+        ("namer_usa_redditads", "ad"): us_ad,
+    }
+    resolver = _build_table_resolver(mapping, selected_keys={eu_ad, us_ad})
+
+    # Schema-qualified identifier hits the trailing-tuple loop and
+    # never reaches the last-segment fallback.
+    assert resolver("eu_alb_redditads.ad") == eu_ad
+    assert resolver("namer_usa_redditads.ad") == us_ad
+
+
+def test_resolver_ambiguous_last_segment_drops_with_warning(caplog):
+    """Bare last-segment lookup with multiple candidates returns None + warns.
+
+    This is the walgreens incident shape: the translator registers two
+    Rocky tables that differ only in their region prefix, then Rocky's
+    anomaly event arrives with a bare ``ad`` identifier. Previously the
+    fallback returned whichever key won the dict-iteration race, twice
+    — and Dagster crashed the op with
+    ``DagsterInvariantViolationError``. Now both events drop with a
+    single WARN logline.
+    """
+    eu_ad = dg.AssetKey(["raw", "client", "eu", "alb", "redditads", "ad"])
+    us_ad = dg.AssetKey(["raw", "client", "namer", "usa", "redditads", "ad"])
+    mapping = {
+        ("raw", "client", "eu", "alb", "redditads", "ad"): eu_ad,
+        ("raw", "client", "namer", "usa", "redditads", "ad"): us_ad,
+    }
+    resolver = _build_table_resolver(mapping, selected_keys={eu_ad, us_ad})
+
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        result = resolver("ad")
+
+    assert result is None
+    assert any("Ambiguous Rocky table identifier" in r.message for r in caplog.records)
+
+
+def test_resolver_unresolvable_table_returns_none_silently():
+    """Tables with no candidate at all stay silent (no false warning)."""
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    resolver = _build_table_resolver(
+        {("fivetran", "acme", "us_west", "shopify", "orders"): orders},
+        selected_keys={orders},
+    )
+    assert resolver("unknown_table") is None
+
+
+# ---------------------------------------------------------------------------
+# Part B — _emit_results dedup-on-yield
+# ---------------------------------------------------------------------------
+
+
+def test_emit_results_dedupes_same_key_anomaly():
+    """Two anomalies that resolve to the same AssetKey yield only once.
+
+    This guards the path where the resolver legitimately returns the
+    same key twice (e.g. the caller is OK with two source-level tables
+    rolling up to one Dagster asset). Without this dedup, Dagster
+    rejects the duplicate ``AssetCheckResult`` output and crashes the
+    op after every table has already been copied.
+    """
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    mapping = {("fivetran", "acme", "us_west", "shopify", "orders"): orders}
+    check_specs = [dg.AssetCheckSpec(name=ANOMALY_CHECK_NAME, asset=orders)]
+    anomaly = AnomalyResult(
+        table="orders",
+        current_count=900,
+        baseline_avg=1500.0,
+        deviation_pct=40.0,
+        reason="row count below baseline by 40%",
+    )
+    run_result = _run_result(anomalies=[anomaly, anomaly])
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=check_specs,
+            selected_keys={orders},
+            rocky_key_to_dagster_key=mapping,
+        )
+    )
+
+    anomaly_results = [
+        e
+        for e in events
+        if isinstance(e, dg.AssetCheckResult) and e.check_name == ANOMALY_CHECK_NAME
+    ]
+    assert len(anomaly_results) == 1
+    assert anomaly_results[0].asset_key == orders
+
+
+def test_emit_results_anomaly_yields_when_unique():
+    """Regression: the dedup guard doesn't suppress a single legitimate emit."""
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    mapping = {("fivetran", "acme", "us_west", "shopify", "orders"): orders}
+    check_specs = [dg.AssetCheckSpec(name=ANOMALY_CHECK_NAME, asset=orders)]
+    anomaly = AnomalyResult(
+        table="orders",
+        current_count=900,
+        baseline_avg=1500.0,
+        deviation_pct=40.0,
+        reason="row count below baseline by 40%",
+    )
+
+    events = list(
+        _emit_results(
+            results=[_run_result(anomalies=[anomaly])],
+            check_specs=check_specs,
+            selected_keys={orders},
+            rocky_key_to_dagster_key=mapping,
+        )
+    )
+
+    anomaly_results = [
+        e
+        for e in events
+        if isinstance(e, dg.AssetCheckResult) and e.check_name == ANOMALY_CHECK_NAME
+    ]
+    assert len(anomaly_results) == 1
+
+
+def test_emit_results_dedupes_same_key_table_check():
+    """Defensive guard: a duplicate ``(table, check_name)`` in Rocky's own
+    ``check_results`` is silently deduped on the table-check loop, not
+    only the anomaly loop. Not reachable from the current resolver
+    shape — pinned in case a future Rocky output ever double-emits."""
+    orders = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+    mapping = {("fivetran", "acme", "us_west", "shopify", "orders"): orders}
+    check_specs = [dg.AssetCheckSpec(name="row_count", asset=orders)]
+    table_check = TableCheckResult(
+        asset_key=["fivetran", "acme", "us_west", "shopify", "orders"],
+        checks=[
+            CheckResult(name="row_count", passed=True, source_count=10, target_count=10),
+            CheckResult(name="row_count", passed=True, source_count=10, target_count=10),
+        ],
+    )
+
+    events = list(
+        _emit_results(
+            results=[_run_result(check_results=[table_check])],
+            check_specs=check_specs,
+            selected_keys={orders},
+            rocky_key_to_dagster_key=mapping,
+        )
+    )
+
+    row_count_results = [
+        e for e in events if isinstance(e, dg.AssetCheckResult) and e.check_name == "row_count"
+    ]
+    assert len(row_count_results) == 1


### PR DESCRIPTION
## Summary

Two independent guards in `integrations/dagster/src/dagster_rocky/component.py` close the failure mode where a Rocky run with row-count anomalies could fail the multi-asset op with:

```
dagster._core.errors.DagsterInvariantViolationError:
Compute for op "rocky_<group>" returned an output
"<connector>_<table>_row_count_anomaly" multiple times
```

— after every underlying table had already been copied successfully. The crash fires purely in the check-emission pass at the end of the op, so all the copy work is wasted, and a retry hits the same condition deterministically as long as the data shape is unchanged.

### Part A — resolver disambiguation (root cause)

`_build_table_resolver`'s last-segment fallback previously returned an arbitrary dict-iteration winner when a bare Rocky identifier matched multiple translator-mapped keys (e.g. the same connector/table loaded under multiple region prefixes). It now refuses to guess: a unique match still resolves; an ambiguous one returns `None` and logs a single WARN line. Adopters can disambiguate by emitting schema- or catalog-qualified identifiers (`schema.table` / `catalog.schema.table`), which the trailing-tuple loop resolves deterministically.

### Part B — defensive emit-time dedup

The table-check and anomaly loops in `_emit_results` now consult `yielded_checks` before emitting, so a same-`(asset_key, check_name)` duplicate is silently dropped (debug log) rather than reaching Dagster's duplicate-output invariant. With Part A applied this branch is unreachable for the resolver-collision shape; the dedup guards against any other path that could legitimately yield the same check twice.

### Behaviour change

Adopters relying on the previous fuzzy fallback for cross-schema duplicates will now see those events drop (with a WARN logline) instead of being silently mis-attributed to whichever Dagster asset won the dict-iteration race. Adopters whose translator keys are full schema-qualified suffixes (the common case) see zero change.

## Test plan

- [x] Added `integrations/dagster/tests/test_emit_results_dedup.py` covering: unique last-segment match still resolves; exact-suffix match unaffected by collision; ambiguous last-segment drops + warns; unresolvable table stays silent; duplicate anomaly for same `AssetKey` deduped at emit; single legitimate anomaly still emits; duplicate `(table, check_name)` in `RunResult.check_results` deduped on the table-check loop (defensive).
- [x] `uv run pytest -q` — 539 → 540 passed (one new file, +7 tests merged into a single new module)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean