### PR TITLE
docs(dagster): add Example sections to dagster_rocky.health public API

### DIFF
--- a/integrations/dagster/src/dagster_rocky/health.py
+++ b/integrations/dagster/src/dagster_rocky/health.py
@@ -46,6 +46,29 @@ class HealthcheckResult:
             ``None`` when the binary itself failed to invoke.
         error: Human-readable error message when the binary failed.
             ``None`` on success.
+
+    Example:
+
+        Branch on the three cases described above to decide what a
+        sensor or asset check should emit:
+
+        .. code-block:: python
+
+            from dagster_rocky import HealthcheckResult, rocky_healthcheck
+
+            def classify(outcome: HealthcheckResult) -> str:
+                if outcome.healthy:
+                    return "ok"
+                if outcome.error is not None:
+                    return f"binary_failed: {outcome.error}"
+                # rocky doctor ran but at least one check is critical
+                assert outcome.doctor_result is not None
+                critical = [
+                    check.name
+                    for check in outcome.doctor_result.checks
+                    if str(check.status).lower().endswith("critical")
+                ]
+                return f"critical_checks: {','.join(critical)}"
     """
 
     healthy: bool
@@ -73,6 +96,45 @@ def rocky_healthcheck(rocky: RockyResource) -> HealthcheckResult:
 
     Returns:
         A :class:`HealthcheckResult` describing the outcome.
+
+    Example:
+
+        Use ``rocky_healthcheck`` from a Dagster sensor so the run-status
+        feed surfaces whether the rocky binary is reachable and all of
+        its checks are non-critical. The sensor emits a fresh observation
+        per tick and tags critical checks so on-call can filter them in
+        Dagster's UI.
+
+        .. code-block:: python
+
+            import dagster as dg
+            from dagster_rocky import HealthcheckResult, RockyResource, rocky_healthcheck
+
+
+            @dg.sensor(minimum_interval_seconds=60)
+            def rocky_health_sensor(
+                context: dg.SensorEvaluationContext,
+                rocky: RockyResource,
+            ) -> dg.SensorResult:
+                outcome: HealthcheckResult = rocky_healthcheck(rocky)
+                if outcome.healthy:
+                    return dg.SensorResult(
+                        skip_reason=dg.SkipReason("rocky doctor: all checks healthy"),
+                    )
+                if outcome.error is not None:
+                    return dg.SensorResult(
+                        skip_reason=dg.SkipReason(f"rocky binary failed: {outcome.error}"),
+                    )
+                # rocky ran but at least one check is critical — surface the names.
+                assert outcome.doctor_result is not None
+                critical = [
+                    c.name for c in outcome.doctor_result.checks
+                    if str(c.status).lower().endswith("critical")
+                ]
+                context.log.warning(f"rocky doctor critical: {critical}")
+                return dg.SensorResult(
+                    skip_reason=dg.SkipReason(f"rocky doctor critical: {critical}"),
+                )
     """
     try:
         result = rocky.doctor()
@@ -165,6 +227,48 @@ def state_health(rocky: RockyResource, *, probe_write: bool = False) -> StateHea
     Returns:
         A :class:`~.types.StateHealthResult` describing the current
         state-backend health.
+
+    Example:
+
+        Use ``state_health`` from a schedule body to make per-tick
+        decisions based on the state backend's freshness, and run the
+        full ``state_rw`` round-trip (``probe_write=True``) so failures
+        get a structured ``probe_outcome`` instead of a thrown error.
+
+        .. code-block:: python
+
+            import dagster as dg
+            from dagster_rocky import RockyResource, StateHealthResult, state_health
+
+
+            @dg.schedule(cron_schedule="*/15 * * * *", target=dg.AssetSelection.all())
+            def rocky_state_aware_schedule(
+                context: dg.ScheduleEvaluationContext,
+                rocky: RockyResource,
+            ) -> dg.RunRequest | dg.SkipReason:
+                # Cheap path: just inspect the latest run + configured backend.
+                snapshot: StateHealthResult = state_health(rocky)
+                if snapshot.last_run_status == "failure":
+                    return dg.SkipReason(
+                        f"last rocky run failed at {snapshot.last_run_at}"
+                    )
+
+                # Stronger gate: actually exercise the state backend's put/get/delete.
+                probed: StateHealthResult = state_health(rocky, probe_write=True)
+                if probed.probe_outcome != "ok":
+                    context.log.warning(
+                        f"state_rw probe={probed.probe_outcome} duration_ms="
+                        f"{probed.probe_duration_ms} error={probed.probe_error}"
+                    )
+                    return dg.SkipReason(f"state_rw probe={probed.probe_outcome}")
+
+                return dg.RunRequest(
+                    run_key=context.scheduled_execution_time.isoformat(),
+                    tags={
+                        "rocky/state_backend": probed.backend,
+                        "rocky/state_rw_ms": str(probed.probe_duration_ms or "?"),
+                    },
+                )
     """
     backend = _read_state_backend(rocky.config_path)
     last_run_status, last_run_at = _last_run_from_history(rocky)

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -917,6 +917,27 @@ class StateHealthResult(BaseModel):
     * :attr:`probe_error` — human-readable failure message from the same
       check when :attr:`probe_outcome` is ``"timeout"`` or ``"error"``.
       ``None`` on success and when the probe wasn't requested.
+
+    Example:
+
+        Inspect a snapshot to log or tag the per-tick state-backend
+        health. ``probe_outcome`` is ``None`` on the cheap path; on the
+        ``probe_write=True`` path it's one of ``"ok"`` / ``"timeout"`` /
+        ``"error"``.
+
+        .. code-block:: python
+
+            from dagster_rocky import StateHealthResult, state_health
+
+            snapshot: StateHealthResult = state_health(rocky, probe_write=True)
+            tags = {
+                "rocky/state_backend": snapshot.backend,
+                "rocky/last_run_status": snapshot.last_run_status or "unknown",
+            }
+            if snapshot.probe_outcome == "ok":
+                tags["rocky/state_rw_ms"] = str(snapshot.probe_duration_ms)
+            elif snapshot.probe_outcome in ("timeout", "error"):
+                tags["rocky/state_rw_error"] = snapshot.probe_error or "unknown"
     """
 
     backend: StateBackendKind


### PR DESCRIPTION
## Summary

Adds Sphinx-style `Example:` blocks to the three public symbols exposed by `dagster_rocky.health` (`HealthcheckResult`, `rocky_healthcheck`, `state_health`) plus the public `StateHealthResult` dataclass that `state_health` returns, so the API documents how to actually wire each helper into a Dagster sensor, schedule, or per-tick observability tag.

Closes #482

## Why

Today the docstrings on these symbols document their parameters and return types but never show what calling them from a real Dagster sensor or schedule body looks like — which is the only context where any of them are useful. The issue calls this out as a discoverability problem: the API is technically documented but you'd never know how to wire it up.

The four examples cover the patterns named in the issue's scope: how to call `rocky_healthcheck` from a sensor body and surface the result, how to use `state_health` (with and without `probe_write=True`) from a schedule, and how the returned dataclasses are shaped for tagging or logging failures.

## Subproject(s) touched

- [x] `integrations/dagster/` (Python package)

## Changes

- `health.py:HealthcheckResult` — `Example:` block that branches by case (healthy / critical-checks / binary-failed) and shows how a classifier function maps each to a short string outcome.
- `health.py:rocky_healthcheck` — Dagster sensor wiring (`@dg.sensor(minimum_interval_seconds=60)`) that emits a structured `SkipReason` for each outcome shape and tags critical check names into the warning log line.
- `health.py:state_health` — Dagster schedule (`@dg.schedule(...)`) showing the two-tier pattern: cheap-path `last_run_status` gate, then `probe_write=True` `state_rw` round-trip with the probe outcome surfaced as run tags and skip reasons.
- `types.py:StateHealthResult` — Short tag-building snippet covering the three `probe_outcome` states (`ok` / `timeout` / `error`) so callers see the canonical fields-to-tags mapping.

All examples import from the `dagster_rocky` package root (the canonical re-export path) per the issue's acceptance criteria. Pure docstring work — no logic changes, no return-type changes.

## Test Plan

- `uv run ruff check src/dagster_rocky/health.py src/dagster_rocky/types.py` — clean.
- `uv run pytest tests/test_health.py -v` — 5/5 passing, no regressions.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/), scoped by subproject when relevant
- [x] No `Co-Authored-By` trailers
- [x] If this is a CLI JSON schema or DSL syntax change, all consumers are updated in this same PR — N/A, docs-only.

### Engine (`engine/`)

- [x] Not touched — docstring-only change inside `integrations/dagster/`.

### Dagster (`integrations/dagster/`)

- [x] `uv run pytest` passes (tests/test_health.py: 5/5)
- [x] `uv run ruff check` is clean
- [x] `uv run ruff format --check` passes

### VS Code (`editors/vscode/`)

- [x] Not touched — docstring-only change inside `integrations/dagster/`.
