### PR TITLE
feat(rocky-catalog-core): introduce CatalogClient trait foundation (PR-1)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3758,6 +3758,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocky-catalog-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "rocky-cli"
 version = "1.35.0"
 dependencies = [

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/rocky-fivetran",
     "crates/rocky-airbyte",
     "crates/rocky-iceberg",
+    "crates/rocky-catalog-core",
     "crates/rocky-cache",
     "crates/rocky-duckdb",
     "crates/rocky-observe",

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rocky-catalog-core"
+version = "0.1.0"
+description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+# Exposes the `InMemoryCatalogClient` test stub so downstream crates can
+# wire it into their own tests without re-implementing one. The stub is
+# always compiled under `cfg(test)` for this crate's own tests.
+testing = []
+
+[dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/engine/crates/rocky-catalog-core/src/client.rs
+++ b/engine/crates/rocky-catalog-core/src/client.rs
@@ -1,0 +1,261 @@
+//! The [`CatalogClient`] trait — Rocky's catalog abstraction.
+
+use async_trait::async_trait;
+
+use crate::error::CatalogResult;
+use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema};
+
+/// A read/write client for a data catalog.
+///
+/// `CatalogClient` absorbs the surface that is convergent across Iceberg
+/// REST, Apache Polaris, Unity Catalog, and Project Nessie: namespace and
+/// table discovery, table lifecycle, atomic multi-table commits, branch /
+/// tag listing, and a thin governance surface. Adapter-specific extensions
+/// (catalog-specific RBAC, branch merge semantics, materialized views) are
+/// expected to live as additional trait methods or types on the adapter
+/// crate that composes a `CatalogClient`, rather than being added here.
+///
+/// Operations that are not universally available — tagging and grants on
+/// Iceberg REST, for example — must return
+/// [`crate::CatalogError::UnsupportedOperation`] from implementations that
+/// cannot serve them, rather than emulating the behaviour through a
+/// side-channel. Callers are expected to interpret the variant as a soft
+/// signal and pick an adapter-specific fallback (typically SQL DDL) when
+/// the catalog does not expose the operation over REST.
+///
+/// The trait is `Send + Sync` because adapters are routinely composed
+/// across async task boundaries; the `async_trait` macro is used so the
+/// trait remains object-safe for `dyn CatalogClient` use.
+#[async_trait]
+pub trait CatalogClient: Send + Sync {
+    // ---------------------------------------------------------------------
+    // Discovery (read-only)
+    // ---------------------------------------------------------------------
+
+    /// List the tables that live directly under `namespace`.
+    ///
+    /// `namespace` is an ordered sequence of namespace parts (e.g.
+    /// `["analytics", "marketing"]`). Implementations should paginate
+    /// internally and return the complete list; the trait does not expose
+    /// a cursor so callers do not have to handle catalog-specific paging
+    /// semantics. Implementations that cannot enumerate the namespace
+    /// (because it does not exist) must return
+    /// [`crate::CatalogError::NamespaceNotFound`].
+    async fn list_tables(&self, namespace: &[String]) -> CatalogResult<Vec<TableRef>>;
+
+    /// Describe `table` — return its current column schema as the catalog
+    /// sees it.
+    ///
+    /// Implementations that cannot resolve the table must return
+    /// [`crate::CatalogError::TableNotFound`].
+    async fn describe_table(&self, table: &TableRef) -> CatalogResult<TableSchema>;
+
+    // ---------------------------------------------------------------------
+    // Lifecycle
+    // ---------------------------------------------------------------------
+
+    /// Declare `table` in the catalog with the given `schema`.
+    ///
+    /// This is a metadata-only operation: it registers the table in the
+    /// catalog. It does not run any compute, allocate storage, or copy
+    /// data. Implementations that prefer to materialise an empty table at
+    /// declaration time may do so, but the trait contract is "the table
+    /// exists in the catalog and `describe_table` resolves" after this
+    /// returns `Ok(())`.
+    async fn create_table(&self, table: &TableRef, schema: &TableSchema) -> CatalogResult<()>;
+
+    /// Drop the catalog declaration for `table`.
+    ///
+    /// This is a metadata-only operation. It deregisters the table from
+    /// the catalog and, depending on catalog semantics, may or may not
+    /// reclaim the underlying storage. It does not run any compute on the
+    /// warehouse side. Implementations that cannot find the table must
+    /// return [`crate::CatalogError::TableNotFound`].
+    async fn drop_table(&self, table: &TableRef) -> CatalogResult<()>;
+
+    // ---------------------------------------------------------------------
+    // Transactions
+    // ---------------------------------------------------------------------
+
+    /// Apply a batch of [`TableCommit`]s atomically.
+    ///
+    /// Mirrors Iceberg REST's `POST /v1/transactions/commit` and the
+    /// equivalent endpoints on Polaris and Unity. All commits in the
+    /// slice succeed together or none of them do. Implementations must
+    /// return [`crate::CatalogError::CommitConflict`] when the catalog's
+    /// compare-and-swap rejects the commit (a concurrent writer landed
+    /// against the same base snapshot); the caller is then expected to
+    /// re-read state and retry.
+    async fn commit_transaction(&self, commits: &[TableCommit]) -> CatalogResult<()>;
+
+    // ---------------------------------------------------------------------
+    // Branches / tags
+    // ---------------------------------------------------------------------
+
+    /// List the branches and tags attached to `table`.
+    ///
+    /// The Iceberg spec models branches and tags as `SnapshotReference`
+    /// entries embedded in table metadata; Nessie exposes them as
+    /// first-class catalog resources. Implementations project both shapes
+    /// onto a uniform [`Vec<BranchRef>`] so callers do not have to branch
+    /// on the underlying model. Mutation of branches (create, fast-forward,
+    /// merge) is intentionally not part of this trait — those operations
+    /// diverge sharply between catalogs and belong on per-adapter
+    /// extension surfaces.
+    async fn list_branches(&self, table: &TableRef) -> CatalogResult<Vec<BranchRef>>;
+
+    // ---------------------------------------------------------------------
+    // Governance
+    // ---------------------------------------------------------------------
+
+    /// Attach a `key = value` tag to `table`.
+    ///
+    /// The value space is catalog-specific. Catalogs that do not expose
+    /// tagging over their REST surface — Iceberg REST today has no tag
+    /// endpoint — must return
+    /// [`crate::CatalogError::UnsupportedOperation`]; callers typically
+    /// fall back to an adapter-specific SQL DDL path on that signal.
+    async fn tag_table(&self, table: &TableRef, key: &str, value: &str) -> CatalogResult<()>;
+
+    /// List the permission grants currently in effect for `table`.
+    ///
+    /// Catalogs that do not expose RBAC over REST must return
+    /// [`crate::CatalogError::UnsupportedOperation`]. The [`Grant`] shape
+    /// here is the lowest common denominator; richer catalog-specific
+    /// grant models stay in adapter crates.
+    async fn get_grants(&self, table: &TableRef) -> CatalogResult<Vec<Grant>>;
+
+    /// Apply `grant` to `table`.
+    ///
+    /// Catalogs that do not expose grant mutation over REST must return
+    /// [`crate::CatalogError::UnsupportedOperation`]. Implementations
+    /// should be idempotent: re-applying a grant that already exists must
+    /// return `Ok(())`.
+    async fn apply_grant(&self, table: &TableRef, grant: &Grant) -> CatalogResult<()>;
+
+    /// Revoke `grant` from `table`.
+    ///
+    /// Catalogs that do not expose grant mutation over REST must return
+    /// [`crate::CatalogError::UnsupportedOperation`]. Implementations
+    /// should be idempotent: revoking a grant that does not exist must
+    /// return `Ok(())`.
+    async fn revoke_grant(&self, table: &TableRef, grant: &Grant) -> CatalogResult<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::InMemoryCatalogClient;
+    use crate::types::{ColumnSchema, TableRef, TableSchema};
+
+    fn sample_table() -> TableRef {
+        TableRef {
+            catalog: Some("cat".into()),
+            namespace: vec!["analytics".into()],
+            name: "orders".into(),
+        }
+    }
+
+    fn sample_schema() -> TableSchema {
+        TableSchema {
+            columns: vec![
+                ColumnSchema {
+                    name: "id".into(),
+                    type_str: "long".into(),
+                    nullable: false,
+                },
+                ColumnSchema {
+                    name: "amount".into(),
+                    type_str: "decimal(10,2)".into(),
+                    nullable: true,
+                },
+            ],
+        }
+    }
+
+    /// Exercise the trait through a `dyn CatalogClient` reference — this
+    /// fails to compile if the trait stops being object-safe.
+    #[tokio::test]
+    async fn trait_is_object_safe() {
+        let client: Box<dyn CatalogClient> = Box::new(InMemoryCatalogClient::new());
+        client
+            .create_table(&sample_table(), &sample_schema())
+            .await
+            .expect("create_table should succeed on empty stub");
+
+        let schema = client
+            .describe_table(&sample_table())
+            .await
+            .expect("describe_table should resolve a just-created table");
+        assert_eq!(schema, sample_schema());
+    }
+
+    #[tokio::test]
+    async fn list_tables_returns_registered_tables() {
+        let client = InMemoryCatalogClient::new();
+        let table = sample_table();
+        client
+            .create_table(&table, &sample_schema())
+            .await
+            .expect("create_table");
+
+        let listed = client
+            .list_tables(&["analytics".to_string()])
+            .await
+            .expect("list_tables");
+        // The in-memory stub is single-catalog so it strips the optional
+        // catalog field on listing; the namespace + name must match.
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].namespace, table.namespace);
+        assert_eq!(listed[0].name, table.name);
+    }
+
+    #[tokio::test]
+    async fn describe_unknown_table_is_not_found() {
+        let client = InMemoryCatalogClient::new();
+        let err = client.describe_table(&sample_table()).await.unwrap_err();
+        assert!(
+            matches!(err, crate::CatalogError::TableNotFound(_)),
+            "expected TableNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn governance_methods_are_unsupported_on_stub() {
+        let client = InMemoryCatalogClient::new();
+        let table = sample_table();
+        client
+            .create_table(&table, &sample_schema())
+            .await
+            .expect("create_table");
+
+        let tag_err = client
+            .tag_table(&table, "owner", "analytics")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            tag_err,
+            crate::CatalogError::UnsupportedOperation(_)
+        ));
+
+        let grants_err = client.get_grants(&table).await.unwrap_err();
+        assert!(matches!(
+            grants_err,
+            crate::CatalogError::UnsupportedOperation(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn drop_table_removes_registration() {
+        let client = InMemoryCatalogClient::new();
+        let table = sample_table();
+        client
+            .create_table(&table, &sample_schema())
+            .await
+            .expect("create_table");
+
+        client.drop_table(&table).await.expect("drop_table");
+        let err = client.describe_table(&table).await.unwrap_err();
+        assert!(matches!(err, crate::CatalogError::TableNotFound(_)));
+    }
+}

--- a/engine/crates/rocky-catalog-core/src/error.rs
+++ b/engine/crates/rocky-catalog-core/src/error.rs
@@ -1,0 +1,75 @@
+//! Errors returned by [`crate::CatalogClient`] implementations.
+//!
+//! [`CatalogError`] is a library-style error type using `thiserror`. Variants
+//! are intentionally coarse-grained — the goal is "library-friendly error
+//! type" rather than an exhaustive mapping of every REST status code. Catalog
+//! implementations attach the underlying transport / serde / authentication
+//! errors via [`CatalogError::Transport`] or [`CatalogError::InvalidResponse`]
+//! when richer context is needed.
+
+use std::error::Error as StdError;
+
+/// Result alias used by all [`crate::CatalogClient`] methods.
+pub type CatalogResult<T> = Result<T, CatalogError>;
+
+/// Errors that can be returned from a catalog client.
+///
+/// The variant set is shaped to let callers branch on the cases that have
+/// distinct recovery paths:
+///
+/// - [`CatalogError::TableNotFound`] / [`CatalogError::NamespaceNotFound`]
+///   are routine for callers that probe before creating.
+/// - [`CatalogError::CommitConflict`] signals a CAS failure on a multi-table
+///   transaction; the typical recovery is to re-read state and retry.
+/// - [`CatalogError::UnsupportedOperation`] tells callers that this catalog
+///   does not expose the requested operation over REST (e.g. Iceberg REST has
+///   no tag endpoint today); callers may fall back to an adapter-specific
+///   path such as SQL DDL.
+/// - The remaining variants ([`CatalogError::Transport`],
+///   [`CatalogError::AuthFailed`], [`CatalogError::InvalidResponse`],
+///   [`CatalogError::PermissionDenied`]) are general failure modes that
+///   surface from the underlying transport or authorization layer.
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    /// The catalog has no record of the requested table.
+    #[error("table not found: {0}")]
+    TableNotFound(String),
+
+    /// The catalog has no record of the requested namespace.
+    #[error("namespace not found: {0}")]
+    NamespaceNotFound(String),
+
+    /// A multi-table transaction failed to commit because the catalog's
+    /// compare-and-swap check rejected the new metadata pointer. The
+    /// underlying cause is typically a concurrent writer that committed
+    /// against the same base snapshot.
+    #[error("conflict on commit (CAS failed): {0}")]
+    CommitConflict(String),
+
+    /// The catalog does not expose this operation over its REST surface.
+    /// Callers may fall back to an adapter-specific path (e.g. SQL DDL).
+    #[error("operation not supported by this catalog: {0}")]
+    UnsupportedOperation(&'static str),
+
+    /// A transport-level failure (network, TLS, HTTP status code, body parse,
+    /// etc.) bubbled up from the catalog client.
+    #[error("transport error: {0}")]
+    Transport(#[source] Box<dyn StdError + Send + Sync>),
+
+    /// Authentication against the catalog failed. Distinct from
+    /// [`CatalogError::PermissionDenied`]: this is "we could not prove who we
+    /// are," not "we are not allowed to do this."
+    #[error("authentication failed: {0}")]
+    AuthFailed(String),
+
+    /// The catalog returned a response that did not match the expected
+    /// schema. Wraps a short diagnostic message; the original payload should
+    /// be logged at trace level inside the adapter, not surfaced here.
+    #[error("invalid response from catalog: {0}")]
+    InvalidResponse(String),
+
+    /// The catalog refused the operation on authorization grounds. The
+    /// caller is who they say they are, but lacks the required privilege.
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+}

--- a/engine/crates/rocky-catalog-core/src/lib.rs
+++ b/engine/crates/rocky-catalog-core/src/lib.rs
@@ -1,0 +1,38 @@
+//! `rocky-catalog-core` — catalog client abstraction for Rocky.
+//!
+//! The data-catalog ecosystem (Iceberg REST, Apache Polaris, Unity Catalog,
+//! Project Nessie) converges at the table-CRUD layer: namespaces, tables,
+//! schemas, and atomic transactions are spoken over a small, broadly
+//! interoperable REST surface. Above that layer the catalogs diverge — RBAC
+//! models, branch/tag semantics, materialized-view support, and tagging
+//! systems are catalog-specific.
+//!
+//! This crate defines the convergent surface as the [`CatalogClient`] trait
+//! and a handful of supporting value types. Concrete implementations live in
+//! the warehouse / catalog adapter crates that compose a `CatalogClient`
+//! field; catalog-specific extensions (per-catalog RBAC, branch merge
+//! semantics, MVs) stay in those adapter crates rather than leaking into
+//! this trait.
+//!
+//! The trait is intentionally pure-abstraction: no implementations, no
+//! callers, no behavioural opinions. It serves as the contract that
+//! adapter crates implement and that higher layers compose against.
+//!
+//! Methods that are not universally supported (e.g. `tag_table`,
+//! `get_grants`) return [`CatalogError::UnsupportedOperation`] from
+//! catalogs that lack a REST surface for the operation. Callers are
+//! expected to treat that variant as a soft signal — typically by falling
+//! back to a SQL-driven path — rather than as a hard failure.
+
+#![forbid(unsafe_code)]
+
+pub mod client;
+pub mod error;
+pub mod types;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+pub use client::CatalogClient;
+pub use error::{CatalogError, CatalogResult};
+pub use types::{BranchKind, BranchRef, ColumnSchema, Grant, TableCommit, TableRef, TableSchema};

--- a/engine/crates/rocky-catalog-core/src/testing.rs
+++ b/engine/crates/rocky-catalog-core/src/testing.rs
@@ -1,0 +1,213 @@
+//! Test utilities for [`crate::CatalogClient`] — primarily an in-memory
+//! stub that downstream crates can wire into their own tests.
+//!
+//! Enable via `features = ["testing"]` in `Cargo.toml`. The module is also
+//! compiled unconditionally under `cfg(test)` for this crate's own tests.
+//!
+//! [`InMemoryCatalogClient`] is not a faithful catalog simulation — it
+//! supports table CRUD only and returns
+//! [`crate::CatalogError::UnsupportedOperation`] from governance and
+//! transaction methods. Its purpose is to verify that the trait shape is
+//! object-safe and ergonomic, not to drive real workloads.
+//!
+//! Tests that need richer behaviour (commit-conflict simulation, branch
+//! manipulation, grant tracking) are expected to layer their own stubs on
+//! top of [`CatalogClient`] in the crate that owns the test.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::client::CatalogClient;
+use crate::error::{CatalogError, CatalogResult};
+use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema};
+
+/// In-memory [`CatalogClient`] stub backed by a [`HashMap`] of
+/// `(namespace, table-name)` to [`TableSchema`].
+///
+/// This stub is intentionally minimal:
+///
+/// - `create_table` / `describe_table` / `drop_table` / `list_tables`
+///   behave as a naive in-memory catalog. The optional `catalog` field on
+///   [`TableRef`] is ignored for keying — the stub is single-catalog.
+/// - `list_branches` returns an empty vector unconditionally.
+/// - `commit_transaction`, `tag_table`, and the grant methods return
+///   [`CatalogError::UnsupportedOperation`].
+///
+/// Downstream crates that want a sharper stub should wrap or replace this
+/// type rather than extending it; the trait surface is the contract.
+#[derive(Debug, Default)]
+pub struct InMemoryCatalogClient {
+    tables: Mutex<HashMap<Key, TableSchema>>,
+}
+
+/// Internal key used by the stub. Equivalent to `(namespace, name)`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Key {
+    namespace: Vec<String>,
+    name: String,
+}
+
+impl Key {
+    fn from_ref(table: &TableRef) -> Self {
+        Self {
+            namespace: table.namespace.clone(),
+            name: table.name.clone(),
+        }
+    }
+}
+
+impl InMemoryCatalogClient {
+    /// Construct an empty stub.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl CatalogClient for InMemoryCatalogClient {
+    async fn list_tables(&self, namespace: &[String]) -> CatalogResult<Vec<TableRef>> {
+        let guard = self.tables.lock().expect("tables mutex poisoned");
+        let mut out: Vec<TableRef> = guard
+            .keys()
+            .filter(|key| key.namespace == namespace)
+            .map(|key| TableRef {
+                catalog: None,
+                namespace: key.namespace.clone(),
+                name: key.name.clone(),
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    async fn describe_table(&self, table: &TableRef) -> CatalogResult<TableSchema> {
+        let guard = self.tables.lock().expect("tables mutex poisoned");
+        guard
+            .get(&Key::from_ref(table))
+            .cloned()
+            .ok_or_else(|| CatalogError::TableNotFound(format_table(table)))
+    }
+
+    async fn create_table(&self, table: &TableRef, schema: &TableSchema) -> CatalogResult<()> {
+        let mut guard = self.tables.lock().expect("tables mutex poisoned");
+        guard.insert(Key::from_ref(table), schema.clone());
+        Ok(())
+    }
+
+    async fn drop_table(&self, table: &TableRef) -> CatalogResult<()> {
+        let mut guard = self.tables.lock().expect("tables mutex poisoned");
+        guard
+            .remove(&Key::from_ref(table))
+            .map(|_| ())
+            .ok_or_else(|| CatalogError::TableNotFound(format_table(table)))
+    }
+
+    async fn commit_transaction(&self, _commits: &[TableCommit]) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "InMemoryCatalogClient does not support multi-table transactions",
+        ))
+    }
+
+    async fn list_branches(&self, _table: &TableRef) -> CatalogResult<Vec<BranchRef>> {
+        Ok(Vec::new())
+    }
+
+    async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "InMemoryCatalogClient does not support tagging",
+        ))
+    }
+
+    async fn get_grants(&self, _table: &TableRef) -> CatalogResult<Vec<Grant>> {
+        Err(CatalogError::UnsupportedOperation(
+            "InMemoryCatalogClient does not expose grants",
+        ))
+    }
+
+    async fn apply_grant(&self, _table: &TableRef, _grant: &Grant) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "InMemoryCatalogClient does not support apply_grant",
+        ))
+    }
+
+    async fn revoke_grant(&self, _table: &TableRef, _grant: &Grant) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "InMemoryCatalogClient does not support revoke_grant",
+        ))
+    }
+}
+
+fn format_table(table: &TableRef) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(cat) = &table.catalog {
+        parts.push(cat.clone());
+    }
+    parts.extend(table.namespace.iter().cloned());
+    parts.push(table.name.clone());
+    parts.join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BranchKind, ColumnSchema};
+
+    #[test]
+    fn table_ref_round_trips_through_serde() {
+        let table = TableRef {
+            catalog: Some("cat".into()),
+            namespace: vec!["a".into(), "b".into()],
+            name: "orders".into(),
+        };
+        let json = serde_json::to_string(&table).expect("serialize TableRef");
+        let restored: TableRef = serde_json::from_str(&json).expect("deserialize TableRef");
+        assert_eq!(table, restored);
+    }
+
+    #[test]
+    fn branch_ref_round_trips_through_serde() {
+        let branch = BranchRef {
+            name: "main".into(),
+            snapshot_id: Some(123),
+            kind: BranchKind::Branch,
+        };
+        let json = serde_json::to_string(&branch).expect("serialize BranchRef");
+        let restored: BranchRef = serde_json::from_str(&json).expect("deserialize BranchRef");
+        assert_eq!(branch, restored);
+    }
+
+    #[test]
+    fn branch_kind_serializes_as_kebab_case() {
+        let json = serde_json::to_string(&BranchKind::Branch).expect("serialize");
+        assert_eq!(json, "\"branch\"");
+        let json = serde_json::to_string(&BranchKind::Tag).expect("serialize");
+        assert_eq!(json, "\"tag\"");
+    }
+
+    #[test]
+    fn grant_round_trips_through_serde() {
+        let grant = Grant {
+            principal: "analytics@example.com".into(),
+            privilege: "SELECT".into(),
+        };
+        let json = serde_json::to_string(&grant).expect("serialize Grant");
+        let restored: Grant = serde_json::from_str(&json).expect("deserialize Grant");
+        assert_eq!(grant, restored);
+    }
+
+    #[test]
+    fn table_schema_round_trips_through_serde() {
+        let schema = TableSchema {
+            columns: vec![ColumnSchema {
+                name: "id".into(),
+                type_str: "long".into(),
+                nullable: false,
+            }],
+        };
+        let json = serde_json::to_string(&schema).expect("serialize TableSchema");
+        let restored: TableSchema = serde_json::from_str(&json).expect("deserialize TableSchema");
+        assert_eq!(schema, restored);
+    }
+}

--- a/engine/crates/rocky-catalog-core/src/types.rs
+++ b/engine/crates/rocky-catalog-core/src/types.rs
@@ -1,0 +1,140 @@
+//! Supporting value types for [`crate::CatalogClient`].
+//!
+//! These types are the lowest common denominator across the catalog
+//! implementations that target the converged surface (Iceberg REST, Unity
+//! Catalog REST, Apache Polaris, Project Nessie). Richer adapter-specific
+//! representations live in the warehouse / catalog adapter crates.
+//!
+//! Note that Rocky already carries a `TableRef` in `rocky-ir` that models
+//! the warehouse three-part name (`catalog.schema.table`). The
+//! [`TableRef`] defined here is intentionally distinct: it follows the
+//! catalog-side model where a namespace is a *list* of name parts (Iceberg
+//! REST allows arbitrarily nested namespaces). The two are not
+//! interchangeable; conversion between them is the responsibility of the
+//! adapter crate that bridges Rocky's IR to a concrete catalog.
+
+use serde::{Deserialize, Serialize};
+
+/// A reference to a table inside a catalog.
+///
+/// Catalogs model namespaces as ordered sequences of parts rather than a
+/// fixed two-level `schema.table` shape. Iceberg REST exposes this directly
+/// via path segments under `/v1/namespaces/{ns}`; Polaris and Unity follow
+/// the same model. The optional `catalog` field names the top-level
+/// catalog when the client is multi-catalog-aware (e.g. Polaris federated
+/// catalogs) and is left `None` otherwise.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TableRef {
+    /// Optional top-level catalog name. `None` when the client is bound to
+    /// a single catalog and the field is implicit in the connection.
+    pub catalog: Option<String>,
+    /// Ordered namespace parts (e.g. `["analytics", "marketing"]`).
+    pub namespace: Vec<String>,
+    /// The unqualified table name.
+    pub name: String,
+}
+
+impl TableRef {
+    /// Convenience constructor for the common single-namespace case.
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            catalog: None,
+            namespace: vec![namespace.into()],
+            name: name.into(),
+        }
+    }
+}
+
+/// A branch or tag attached to a table.
+///
+/// Branches and tags are unified here because both Iceberg's spec (in which
+/// they are `SnapshotReference`s embedded in table metadata) and Nessie's
+/// catalog-level branch resources can be projected onto this single shape.
+/// The [`BranchKind`] discriminates the two cases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchRef {
+    /// The branch or tag name as the catalog stores it.
+    pub name: String,
+    /// The snapshot the branch / tag currently points at. `None` when the
+    /// catalog has not yet attached a snapshot (a freshly created branch
+    /// against an empty table, for example).
+    pub snapshot_id: Option<i64>,
+    /// Whether this reference is a branch (mutable head) or a tag
+    /// (immutable label).
+    pub kind: BranchKind,
+}
+
+/// Discriminates branch references from tag references.
+///
+/// The serde representation is kebab-case to match REST-spec convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BranchKind {
+    /// A mutable named pointer that advances with each commit.
+    Branch,
+    /// An immutable label pinned to a specific snapshot.
+    Tag,
+}
+
+/// A simple permission grant on a table.
+///
+/// This is intentionally minimal — `principal` identifies the grantee in
+/// whatever form the catalog uses (user, group, role, service principal)
+/// and `privilege` is a catalog-specific privilege name (e.g. `SELECT`,
+/// `MODIFY`, `USE_CATALOG`). Catalog-specific extensions to the grant
+/// model (Polaris subcatalog RBAC, Unity ABAC predicates, etc.) live in
+/// adapter crates rather than this trait surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Grant {
+    /// Catalog-specific principal identifier.
+    pub principal: String,
+    /// Catalog-specific privilege name.
+    pub privilege: String,
+}
+
+/// A table schema as the catalog exposes it.
+///
+/// This is deliberately the lowest common denominator: every catalog that
+/// implements the converged surface can produce a `name + type-string +
+/// nullability` triple per column. Richer schema representations (Iceberg
+/// `Schema`, Spark `StructType`, Arrow `Schema`) belong inside the adapter
+/// crate that produced or consumed this value, where the field-id and
+/// nested-type information they carry is meaningful.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSchema {
+    /// Columns in declaration order.
+    pub columns: Vec<ColumnSchema>,
+}
+
+/// A single column inside a [`TableSchema`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnSchema {
+    /// Column name as the catalog stores it.
+    pub name: String,
+    /// Catalog-specific type representation, rendered as a string. The
+    /// exact spelling is catalog-defined (e.g. Iceberg `string`,
+    /// Spark `STRING`, Unity `varchar(255)`).
+    pub type_str: String,
+    /// Whether the column accepts NULL values.
+    pub nullable: bool,
+}
+
+/// One table's contribution to a multi-table transaction.
+///
+/// A [`crate::CatalogClient::commit_transaction`] call applies a slice of
+/// these atomically. The current shape is deliberately minimal: it carries
+/// the compare-and-swap pre-condition (`expected_snapshot_id`) and the
+/// target snapshot. Real writers will extend the value carried by each
+/// commit (manifest pointers, schema updates, partition spec changes) as
+/// the converged surface widens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableCommit {
+    /// The table this commit applies to.
+    pub table: TableRef,
+    /// The snapshot the caller expects the table to be at before the
+    /// commit lands. `None` means "no pre-condition" — typically used when
+    /// the commit creates the table.
+    pub expected_snapshot_id: Option<i64>,
+    /// The snapshot id the table should advance to after this commit.
+    pub new_snapshot_id: i64,
+}


### PR DESCRIPTION
## What this PR adds

A new `rocky-catalog-core` crate that defines Rocky's catalog-client abstraction:

- `CatalogClient` async trait — 10 methods: `list_tables`, `describe_table`, `create_table`, `drop_table`, `commit_transaction`, `list_branches`, `tag_table`, `get_grants`, `apply_grant`, `revoke_grant`.
- `CatalogError` enum (via `thiserror`) + `CatalogResult<T>` alias.
- Value types: `TableRef`, `BranchRef` / `BranchKind`, `Grant`, `TableSchema` / `ColumnSchema`, `TableCommit`.
- `InMemoryCatalogClient` test stub (gated behind `cfg(test)` and the `testing` Cargo feature) so downstream crates can wire it into their own tests without re-implementing one.
- Unit tests covering trait object-safety (`dyn CatalogClient`) and serde round-trip of every value type.

## What this PR does NOT do

- No implementations against real catalogs (Iceberg REST / Unity / Polaris / Nessie).
- No callers — nothing in the workspace depends on this crate yet.
- No changes to `WarehouseAdapter`, `GovernanceAdapter`, or any other existing trait.
- Zero behaviour change for any current pipeline.

This is pure foundation: the trait shape is the deliverable.

## Why this shape

The data-catalog ecosystem converges at the table-CRUD layer — Iceberg REST is the lingua franca across Polaris, Unity OSS, Nessie, and Snowflake Horizon. The `CatalogClient` trait absorbs that convergent surface; catalog-specific extensions (per-catalog RBAC, branch merge semantics, MV support) stay in adapter crates rather than leaking into the core trait.

Methods that are not universally supported return `CatalogError::UnsupportedOperation`, letting callers fall back to adapter-specific paths (typically SQL DDL) on that signal rather than treating it as a hard failure.

## Forward looking

This is the first in a short sequence of PRs introducing a catalog abstraction layer. Subsequent PRs will:

- Implement `CatalogClient` for Iceberg REST inside `rocky-iceberg`.
- Implement `CatalogClient` for Unity Catalog inside `rocky-databricks`.
- Implement `CatalogClient` for Polaris inside `rocky-snowflake`.
- Move the catalog-shaped methods on `WarehouseAdapter` to default impls that delegate to `self.catalog()`, with SQL fallback preserved for adapters that don't compose a `CatalogClient`.

User-facing CLI surface is unchanged across the whole sequence.

## Test plan

- [x] `cargo test -p rocky-catalog-core --all-features` — 10 tests pass (trait object-safety + serde round-trips + stub CRUD behaviour).
- [x] `cargo test --all-features --workspace` — no regression; new crate adds 10 unit tests, every existing test still passes.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo build --release` — clean workspace release build.
- [x] `just codegen` — no-op for committed bindings (no `JsonSchema` derives in this crate; nothing under `schemas/`, `integrations/dagster/.../types_generated/`, or `editors/vscode/.../types/generated/` drifts).