### PR TITLE
feat(rocky-iceberg): impl CatalogClient via IcebergCatalogClientAdapter (PR-2)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3974,6 +3974,7 @@ dependencies = [
  "parquet",
  "percent-encoding",
  "reqwest",
+ "rocky-catalog-core",
  "rocky-core",
  "rocky-databricks",
  "serde",

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 rocky-core = { path = "../rocky-core" }
+rocky-catalog-core = { path = "../rocky-catalog-core" }
 async-trait = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }

--- a/engine/crates/rocky-iceberg/src/catalog_client.rs
+++ b/engine/crates/rocky-iceberg/src/catalog_client.rs
@@ -1,0 +1,379 @@
+//! [`CatalogClient`] implementation backed by the Iceberg REST catalog.
+//!
+//! [`IcebergCatalogClientAdapter`] composes an [`IcebergCatalogClient`]
+//! and projects its surface onto the catalog-agnostic
+//! [`rocky_catalog_core::CatalogClient`] trait. The trait surface splits
+//! cleanly along Iceberg REST availability:
+//!
+//! - [`CatalogClient::list_tables`] routes to the existing
+//!   [`IcebergCatalogClient::list_tables`].
+//! - [`CatalogClient::describe_table`] performs a fresh
+//!   `GET /v1/namespaces/{ns}/tables/{name}` via
+//!   [`IcebergCatalogClient::load_table`] and distills the current
+//!   schema down to a [`TableSchema`].
+//! - [`CatalogClient::create_table`], [`CatalogClient::drop_table`],
+//!   [`CatalogClient::commit_transaction`] and
+//!   [`CatalogClient::list_branches`] currently return
+//!   [`CatalogError::UnsupportedOperation`]; they will be wired up in a
+//!   follow-up that adds POST/DELETE HTTP support and full
+//!   `TableMetadata` round-trips.
+//! - The four governance methods ([`CatalogClient::tag_table`],
+//!   [`CatalogClient::get_grants`], [`CatalogClient::apply_grant`],
+//!   [`CatalogClient::revoke_grant`]) return
+//!   [`CatalogError::UnsupportedOperation`] unconditionally — the
+//!   Iceberg REST spec exposes no governance endpoints, so the gap is
+//!   permanent rather than "not yet".
+
+use async_trait::async_trait;
+
+use rocky_catalog_core::{
+    BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant, TableCommit,
+    TableRef, TableSchema,
+};
+
+use crate::client::{IcebergCatalogClient, IcebergError};
+
+/// [`CatalogClient`] implementation that delegates to an
+/// [`IcebergCatalogClient`].
+///
+/// The adapter is single-catalog: the [`TableRef::catalog`] field is
+/// ignored because the underlying Iceberg REST client is bound to a
+/// fixed base URL and has no multi-catalog routing. Multi-catalog
+/// support would belong on a higher-level facade rather than this
+/// adapter.
+pub struct IcebergCatalogClientAdapter {
+    inner: IcebergCatalogClient,
+}
+
+impl IcebergCatalogClientAdapter {
+    /// Wrap an existing [`IcebergCatalogClient`].
+    pub fn new(inner: IcebergCatalogClient) -> Self {
+        Self { inner }
+    }
+
+    /// Borrow the underlying [`IcebergCatalogClient`].
+    pub fn inner(&self) -> &IcebergCatalogClient {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for IcebergCatalogClientAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IcebergCatalogClientAdapter")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl CatalogClient for IcebergCatalogClientAdapter {
+    async fn list_tables(&self, namespace: &[String]) -> CatalogResult<Vec<TableRef>> {
+        // The trait carries the spec-native multi-part namespace; the
+        // existing client takes a dot-joined string. Join here so the
+        // existing percent-encoding path (which `.split('.')` first)
+        // continues to work.
+        let ns_joined = namespace.join(".");
+        let table_ids = self
+            .inner
+            .list_tables(&ns_joined)
+            .await
+            // 404 on a namespace-scoped endpoint means the namespace is
+            // gone, not a table; rewrite the default (table-targeted)
+            // mapping accordingly.
+            .map_err(|e| match icebergerror_into_catalog(e) {
+                CatalogError::TableNotFound(msg) => CatalogError::NamespaceNotFound(msg),
+                other => other,
+            })?;
+
+        let mut out = Vec::with_capacity(table_ids.len());
+        for id in table_ids {
+            out.push(TableRef {
+                catalog: None,
+                namespace: id.namespace.split('.').map(str::to_owned).collect(),
+                name: id.name,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn describe_table(&self, table: &TableRef) -> CatalogResult<TableSchema> {
+        let resp = self
+            .inner
+            .load_table(&table.namespace, &table.name)
+            .await
+            .map_err(icebergerror_into_catalog)?;
+
+        let metadata = resp.metadata;
+        let current_id = metadata.current_schema_id;
+
+        // Spec: pick the schemas entry whose `schema-id` matches
+        // `current-schema-id`. Defensive fallback to the last schema in
+        // the vec keeps us robust if a catalog returns slightly off
+        // metadata; an empty `schemas` array is a hard error because
+        // there is nothing to describe.
+        let schema = metadata
+            .schemas
+            .iter()
+            .find(|s| s.schema_id == current_id)
+            .or_else(|| metadata.schemas.last())
+            .ok_or_else(|| {
+                CatalogError::InvalidResponse(format!(
+                    "load_table response for {} carries no schemas",
+                    format_table(table)
+                ))
+            })?;
+
+        let columns = schema
+            .fields
+            .iter()
+            .map(|f| ColumnSchema {
+                name: f.name.clone(),
+                type_str: render_type(&f.type_repr),
+                nullable: !f.required,
+            })
+            .collect();
+
+        Ok(TableSchema { columns })
+    }
+
+    async fn create_table(&self, _table: &TableRef, _schema: &TableSchema) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "create_table not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds POST support",
+        ))
+    }
+
+    async fn drop_table(&self, _table: &TableRef) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "drop_table not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds DELETE support",
+        ))
+    }
+
+    async fn commit_transaction(&self, _commits: &[TableCommit]) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "commit_transaction not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds POST + TableMetadata round-trips",
+        ))
+    }
+
+    async fn list_branches(&self, _table: &TableRef) -> CatalogResult<Vec<BranchRef>> {
+        Err(CatalogError::UnsupportedOperation(
+            "list_branches not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that surfaces SnapshotReference entries from TableMetadata",
+        ))
+    }
+
+    async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "Iceberg REST spec exposes no tagging endpoint",
+        ))
+    }
+
+    async fn get_grants(&self, _table: &TableRef) -> CatalogResult<Vec<Grant>> {
+        Err(CatalogError::UnsupportedOperation(
+            "Iceberg REST spec exposes no governance endpoints",
+        ))
+    }
+
+    async fn apply_grant(&self, _table: &TableRef, _grant: &Grant) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "Iceberg REST spec exposes no governance endpoints",
+        ))
+    }
+
+    async fn revoke_grant(&self, _table: &TableRef, _grant: &Grant) -> CatalogResult<()> {
+        Err(CatalogError::UnsupportedOperation(
+            "Iceberg REST spec exposes no governance endpoints",
+        ))
+    }
+}
+
+/// Render an Iceberg field-type payload as a flat string.
+///
+/// Iceberg's spec lets a column's `type` be either a primitive type name
+/// (`"long"`, `"timestamp"`, `"string"`) or a nested JSON object that
+/// describes a list / map / struct. The catalog-agnostic
+/// [`ColumnSchema::type_str`] is a string, so we take whichever shape
+/// arrived: bare strings pass through as-is, anything else is
+/// serialised back to JSON.
+fn render_type(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Map an [`IcebergError`] onto the catalog-agnostic [`CatalogError`].
+///
+/// Rules:
+///
+/// - HTTP 404 → [`CatalogError::TableNotFound`] (the table-targeted
+///   default; namespace-scoped call sites are expected to rewrite this
+///   to [`CatalogError::NamespaceNotFound`] in a `.map_err()` after
+///   conversion).
+/// - HTTP 401 → [`CatalogError::AuthFailed`].
+/// - HTTP 403 → [`CatalogError::PermissionDenied`].
+/// - HTTP 409 → [`CatalogError::CommitConflict`].
+/// - HTTP 429 and 5xx → [`CatalogError::Transport`] (the underlying
+///   error retains the original detail; callers see it via the
+///   `#[source]` chain).
+/// - [`IcebergError::RateLimited`] (429 after retries exhausted) and
+///   transport-level [`IcebergError::Http`] also become
+///   [`CatalogError::Transport`].
+/// - [`IcebergError::UnexpectedResponse`] → [`CatalogError::InvalidResponse`].
+fn icebergerror_into_catalog(err: IcebergError) -> CatalogError {
+    match err {
+        IcebergError::Api { status, message } => match status {
+            401 => CatalogError::AuthFailed(format!("HTTP 401: {message}")),
+            403 => CatalogError::PermissionDenied(format!("HTTP 403: {message}")),
+            404 => CatalogError::TableNotFound(format!("HTTP 404: {message}")),
+            409 => CatalogError::CommitConflict(format!("HTTP 409: {message}")),
+            429 | 500..=599 => {
+                CatalogError::Transport(Box::new(IcebergError::Api { status, message }))
+            }
+            _ => CatalogError::InvalidResponse(format!("HTTP {status}: {message}")),
+        },
+        IcebergError::RateLimited => CatalogError::Transport(Box::new(IcebergError::RateLimited)),
+        IcebergError::Http(e) => CatalogError::Transport(Box::new(e)),
+        IcebergError::UnexpectedResponse(msg) => CatalogError::InvalidResponse(msg),
+    }
+}
+
+impl From<IcebergError> for CatalogError {
+    fn from(err: IcebergError) -> Self {
+        icebergerror_into_catalog(err)
+    }
+}
+
+fn format_table(table: &TableRef) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(cat) = &table.catalog {
+        parts.push(cat.clone());
+    }
+    parts.extend(table.namespace.iter().cloned());
+    parts.push(table.name.clone());
+    parts.join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_type_unwraps_primitive_string() {
+        let v = serde_json::Value::String("long".to_string());
+        assert_eq!(render_type(&v), "long");
+    }
+
+    #[test]
+    fn render_type_serialises_nested_object() {
+        let v = serde_json::json!({
+            "type": "list",
+            "element-id": 7,
+            "element": "string",
+            "element-required": true
+        });
+        let rendered = render_type(&v);
+        assert!(rendered.starts_with('{') && rendered.ends_with('}'));
+        assert!(rendered.contains("\"type\":\"list\""));
+    }
+
+    #[test]
+    fn api_401_classifies_as_auth_failed() {
+        let err = IcebergError::Api {
+            status: 401,
+            message: "unauthorized".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(
+            matches!(mapped, CatalogError::AuthFailed(_)),
+            "expected AuthFailed, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn api_403_classifies_as_permission_denied() {
+        let err = IcebergError::Api {
+            status: 403,
+            message: "forbidden".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(
+            matches!(mapped, CatalogError::PermissionDenied(_)),
+            "expected PermissionDenied, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn api_404_classifies_as_table_not_found_by_default() {
+        let err = IcebergError::Api {
+            status: 404,
+            message: "no such".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(
+            matches!(mapped, CatalogError::TableNotFound(_)),
+            "expected TableNotFound (default), got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn api_409_classifies_as_commit_conflict() {
+        let err = IcebergError::Api {
+            status: 409,
+            message: "conflict".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(
+            matches!(mapped, CatalogError::CommitConflict(_)),
+            "expected CommitConflict, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn api_5xx_classifies_as_transport() {
+        for status in [500u16, 502, 503, 504] {
+            let err = IcebergError::Api {
+                status,
+                message: format!("status {status}"),
+            };
+            let mapped: CatalogError = err.into();
+            assert!(
+                matches!(mapped, CatalogError::Transport(_)),
+                "status {status} expected Transport, got {mapped:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn api_429_classifies_as_transport() {
+        let err = IcebergError::Api {
+            status: 429,
+            message: "rate limited".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(matches!(mapped, CatalogError::Transport(_)));
+    }
+
+    #[test]
+    fn rate_limited_variant_classifies_as_transport() {
+        let mapped: CatalogError = IcebergError::RateLimited.into();
+        assert!(matches!(mapped, CatalogError::Transport(_)));
+    }
+
+    #[test]
+    fn unexpected_response_classifies_as_invalid_response() {
+        let mapped: CatalogError = IcebergError::UnexpectedResponse("bad json".into()).into();
+        assert!(matches!(mapped, CatalogError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn unknown_api_status_classifies_as_invalid_response() {
+        // 418 / 451 / etc. — not one of the explicitly classified
+        // codes; surfaces as InvalidResponse rather than silently
+        // becoming Transport.
+        let err = IcebergError::Api {
+            status: 418,
+            message: "teapot".into(),
+        };
+        let mapped: CatalogError = err.into();
+        assert!(matches!(mapped, CatalogError::InvalidResponse(_)));
+    }
+}

--- a/engine/crates/rocky-iceberg/src/client.rs
+++ b/engine/crates/rocky-iceberg/src/client.rs
@@ -86,6 +86,66 @@ pub struct TableIdentifierResponse {
     pub name: String,
 }
 
+/// Response body for `GET /v1/namespaces/{ns}/tables/{name}` — the Iceberg
+/// REST "load table" endpoint.
+///
+/// Wraps the [`TableMetadata`] payload that the spec returns. Other
+/// top-level fields (`metadata-location`, `config`, signed storage
+/// credentials) are intentionally not modelled here because PR-2 only
+/// consumes the schema.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoadTableResponse {
+    /// The table metadata document, as defined by the Iceberg spec.
+    pub metadata: TableMetadata,
+}
+
+/// Partial view of the Iceberg `TableMetadata` document.
+///
+/// The on-the-wire document is large (snapshots, manifests, partition
+/// specs, sort orders, refs, properties); this struct only models the
+/// fields needed to project the current column schema onto a
+/// `TableSchema`. Unknown fields are ignored by serde's default
+/// behaviour.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TableMetadata {
+    /// Schema id of the current schema, used to pick the right entry
+    /// out of `schemas`. The field is camel-cased on the wire as
+    /// `current-schema-id`.
+    #[serde(rename = "current-schema-id")]
+    pub current_schema_id: i64,
+    /// The set of schemas the table has ever had; the entry with
+    /// `schema-id == current_schema_id` is the active one.
+    pub schemas: Vec<IcebergSchema>,
+}
+
+/// One entry in [`TableMetadata::schemas`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct IcebergSchema {
+    /// Unique identifier for this schema revision.
+    #[serde(rename = "schema-id")]
+    pub schema_id: i64,
+    /// Columns in declaration order.
+    pub fields: Vec<IcebergField>,
+}
+
+/// One column in an [`IcebergSchema`].
+///
+/// `type` is left as a [`serde_json::Value`] because the Iceberg spec
+/// allows it to be either a primitive type name (`"long"`,
+/// `"timestamp"`) or a nested JSON object describing a list/map/struct.
+/// Distillation into a string happens at consume time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IcebergField {
+    /// Column name as the catalog stores it.
+    pub name: String,
+    /// Whether the column is required (i.e. `NOT NULL`). The catalog-side
+    /// `nullable` projection is the inverse of this flag.
+    pub required: bool,
+    /// Type representation; either a primitive string or a JSON object.
+    #[serde(rename = "type")]
+    pub type_repr: serde_json::Value,
+}
+
 // ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
@@ -170,6 +230,39 @@ impl IcebergCatalogClient {
         Ok(tables)
     }
 
+    /// Load a single table's metadata.
+    ///
+    /// Targets `GET /v1/namespaces/{ns}/tables/{name}`, the Iceberg REST
+    /// "load table" endpoint. The full [`LoadTableResponse`] is returned;
+    /// callers that only want the column-level schema should reach into
+    /// [`LoadTableResponse::metadata`] and select the schema entry whose
+    /// `schema-id` matches `current-schema-id`.
+    ///
+    /// `namespace` is the multi-level namespace as a slice of parts;
+    /// the parts are percent-encoded and joined with the spec-required
+    /// `%1F` separator. `name` is the unqualified table name and is
+    /// percent-encoded individually so caller-supplied names cannot
+    /// inject path-altering bytes into the URL.
+    pub async fn load_table(
+        &self,
+        namespace: &[String],
+        name: &str,
+    ) -> Result<LoadTableResponse, IcebergError> {
+        let encoded_ns = encode_namespace_parts(namespace);
+        let encoded_name = utf8_percent_encode(name, PATH_SAFE).to_string();
+        let url = format!(
+            "{}/v1/namespaces/{}/tables/{}",
+            self.base_url, encoded_ns, encoded_name
+        );
+        let resp: LoadTableResponse = self.get(&url).await?;
+        debug!(
+            namespace = ?namespace,
+            name,
+            "loaded Iceberg table metadata"
+        );
+        Ok(resp)
+    }
+
     /// Internal GET with retry on transient errors.
     async fn get<T: serde::de::DeserializeOwned>(&self, url: &str) -> Result<T, IcebergError> {
         for attempt in 0..=self.retry.max_retries {
@@ -243,22 +336,36 @@ impl IcebergCatalogClient {
     }
 }
 
+/// Byte set used when percent-encoding individual namespace / table-name
+/// parts. Allows the RFC 3986 unreserved chars (`-`, `_`, `~`,
+/// alphanumerics) and encodes everything else — including `.`, so `..`
+/// traversal cannot escape the catalog prefix.
+const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
+
 /// Encode a dot-separated namespace for the URL path.
 ///
 /// The Iceberg REST spec uses `%1F` (unit separator) to encode multi-level
 /// namespaces in URL paths. Each level is also percent-encoded so
 /// caller-supplied namespace parts cannot inject `/`, `?`, `#`, `..`, or
-/// other path-altering bytes into the URL. The encoding allows RFC 3986
-/// unreserved chars (`-`, `_`, `~`, alphanumerics) but explicitly encodes
-/// `.` so `..` traversal cannot escape the catalog prefix.
+/// other path-altering bytes into the URL.
 ///
 /// Order matters: split on `.`, percent-encode each part, then join with
 /// the literal `%1F` separator. Encoding after the join would re-encode
 /// the `%` of `%1F` to `%25` and break the spec-required separator.
 fn encode_namespace(namespace: &str) -> String {
-    const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
     namespace
         .split('.')
+        .map(|part| utf8_percent_encode(part, PATH_SAFE).to_string())
+        .collect::<Vec<_>>()
+        .join("%1F")
+}
+
+/// Encode a multi-part namespace (already split into parts) for the URL
+/// path. Mirrors [`encode_namespace`] but accepts the spec-native
+/// representation (a slice of parts) instead of a dot-joined string.
+pub(crate) fn encode_namespace_parts(parts: &[String]) -> String {
+    parts
+        .iter()
         .map(|part| utf8_percent_encode(part, PATH_SAFE).to_string())
         .collect::<Vec<_>>()
         .join("%1F")

--- a/engine/crates/rocky-iceberg/src/lib.rs
+++ b/engine/crates/rocky-iceberg/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod adapter;
+pub mod catalog_client;
 pub mod client;
 pub mod uniform_writer;
+
+pub use catalog_client::IcebergCatalogClientAdapter;

--- a/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
@@ -1,12 +1,16 @@
-//! Wire-level mock tests for the Iceberg discovery adapter.
+//! Wire-level mock tests for the Iceberg discovery adapter and the
+//! catalog-client adapter.
 //!
 //! Uses wiremock to simulate the Iceberg REST Catalog at the HTTP level
 //! and verifies that `IcebergError` variants flow through to the
 //! correct `FailedSourceErrorClass` on the discovered `failed_sources`
-//! payload.
+//! payload, and that the `CatalogClient` implementation maps REST
+//! status codes onto the appropriate `CatalogError` variants.
 
+use rocky_catalog_core::{CatalogClient, CatalogError, Grant, TableRef};
 use rocky_core::source::FailedSourceErrorClass;
 use rocky_core::traits::DiscoveryAdapter;
+use rocky_iceberg::IcebergCatalogClientAdapter;
 use rocky_iceberg::adapter::IcebergDiscoveryAdapter;
 use rocky_iceberg::client::IcebergCatalogClient;
 use serde_json::json;
@@ -115,4 +119,288 @@ async fn list_tables_unknown_status_classifies_as_unknown() {
         result.failed[0].error_class,
         FailedSourceErrorClass::Unknown
     );
+}
+
+// ---------------------------------------------------------------------------
+// CatalogClient adapter tests
+// ---------------------------------------------------------------------------
+
+/// `load_table` response with two schemas; only the second is current.
+/// Used by happy-path tests below.
+fn load_table_body_two_schemas() -> serde_json::Value {
+    json!({
+        "metadata-location": "s3://bucket/path/metadata.json",
+        "metadata": {
+            "current-schema-id": 2,
+            "schemas": [
+                {
+                    "schema-id": 1,
+                    "fields": [
+                        { "id": 1, "name": "old_col", "required": true, "type": "long" }
+                    ]
+                },
+                {
+                    "schema-id": 2,
+                    "fields": [
+                        { "id": 1, "name": "id", "required": true, "type": "long" },
+                        { "id": 2, "name": "amount", "required": false, "type": "double" },
+                        {
+                            "id": 3,
+                            "name": "tags",
+                            "required": false,
+                            "type": {
+                                "type": "list",
+                                "element-id": 4,
+                                "element": "string",
+                                "element-required": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    })
+}
+
+#[tokio::test]
+async fn describe_table_happy_path_distills_current_schema() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/orders"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(load_table_body_two_schemas()))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "orders".into(),
+    };
+
+    let schema = adapter
+        .describe_table(&table)
+        .await
+        .expect("describe_table should succeed");
+
+    // Picked schema-id == 2 (current); the schema-id == 1 entry is
+    // ignored. Required → nullable inversion holds.
+    assert_eq!(schema.columns.len(), 3);
+    assert_eq!(schema.columns[0].name, "id");
+    assert_eq!(schema.columns[0].type_str, "long");
+    assert!(!schema.columns[0].nullable);
+
+    assert_eq!(schema.columns[1].name, "amount");
+    assert_eq!(schema.columns[1].type_str, "double");
+    assert!(schema.columns[1].nullable);
+
+    // Nested type — serialised back to JSON rather than dropped.
+    assert_eq!(schema.columns[2].name, "tags");
+    assert!(
+        schema.columns[2].type_str.contains("\"type\":\"list\""),
+        "nested-type column should round-trip JSON, got {}",
+        schema.columns[2].type_str
+    );
+    assert!(schema.columns[2].nullable);
+}
+
+#[tokio::test]
+async fn describe_table_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("table does not exist"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "missing".into(),
+    };
+
+    let err = adapter
+        .describe_table(&table)
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::TableNotFound(_)),
+        "expected TableNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn describe_table_401_maps_to_auth_failed() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/private"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "private".into(),
+    };
+
+    let err = adapter
+        .describe_table(&table)
+        .await
+        .expect_err("401 should not succeed");
+    assert!(
+        matches!(err, CatalogError::AuthFailed(_)),
+        "expected AuthFailed, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn list_tables_via_adapter_routes_to_inner_client() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "identifiers": [
+                { "namespace": ["analytics"], "name": "orders" },
+                { "namespace": ["analytics"], "name": "customers" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let tables = adapter
+        .list_tables(&["analytics".to_string()])
+        .await
+        .expect("list_tables should succeed");
+
+    assert_eq!(tables.len(), 2);
+    assert_eq!(tables[0].name, "orders");
+    assert_eq!(tables[0].namespace, vec!["analytics".to_string()]);
+    assert!(tables[0].catalog.is_none());
+    assert_eq!(tables[1].name, "customers");
+}
+
+#[tokio::test]
+async fn list_tables_404_maps_to_namespace_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/nope/tables"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("namespace not found"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let err = adapter
+        .list_tables(&["nope".to_string()])
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::NamespaceNotFound(_)),
+        "expected NamespaceNotFound (rewritten from default TableNotFound), got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn tag_table_returns_unsupported_operation() {
+    // No HTTP mock needed — tag_table short-circuits before any wire
+    // traffic. The constructor still requires a base URL, so we point
+    // it at a never-contacted MockServer to be explicit that no
+    // request must be issued.
+    let server = MockServer::start().await;
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "orders".into(),
+    };
+
+    let err = adapter
+        .tag_table(&table, "owner", "analytics")
+        .await
+        .expect_err("tag_table must be UnsupportedOperation");
+    assert!(
+        matches!(err, CatalogError::UnsupportedOperation(_)),
+        "expected UnsupportedOperation, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn governance_methods_all_return_unsupported_operation() {
+    let server = MockServer::start().await;
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "orders".into(),
+    };
+    let grant = Grant {
+        principal: "analytics@example.com".into(),
+        privilege: "SELECT".into(),
+    };
+
+    assert!(matches!(
+        adapter.get_grants(&table).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+    assert!(matches!(
+        adapter.apply_grant(&table, &grant).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+    assert!(matches!(
+        adapter.revoke_grant(&table, &grant).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+}
+
+#[tokio::test]
+async fn deferred_lifecycle_methods_return_unsupported_operation() {
+    let server = MockServer::start().await;
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "orders".into(),
+    };
+    let schema = rocky_catalog_core::TableSchema {
+        columns: vec![rocky_catalog_core::ColumnSchema {
+            name: "id".into(),
+            type_str: "long".into(),
+            nullable: false,
+        }],
+    };
+
+    assert!(matches!(
+        adapter.create_table(&table, &schema).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+    assert!(matches!(
+        adapter.drop_table(&table).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+    assert!(matches!(
+        adapter.commit_transaction(&[]).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
+    assert!(matches!(
+        adapter.list_branches(&table).await.unwrap_err(),
+        CatalogError::UnsupportedOperation(_)
+    ));
 }


### PR DESCRIPTION
## Summary

Adds `IcebergCatalogClientAdapter` in `rocky-iceberg`, implementing the `CatalogClient` trait introduced in #558. The trait surface splits cleanly along Iceberg REST availability.

**Implemented:**
- `list_tables`: routes to the existing `IcebergCatalogClient::list_tables`.
- `describe_table`: new `GET /v1/namespaces/{ns}/tables/{name}` call (`IcebergCatalogClient::load_table`) plus schema distillation onto the catalog-agnostic `TableSchema`.

**Returns `UnsupportedOperation` (deferred):**
- `create_table`, `drop_table`, `commit_transaction`, `list_branches`. These need POST/DELETE HTTP infrastructure and full `TableMetadata` round-trips; tracked for a follow-up to keep this PR reviewable.

**Returns `UnsupportedOperation` (permanent):**
- `tag_table`, `get_grants`, `apply_grant`, `revoke_grant`. The Iceberg REST spec exposes no governance endpoints, so the gap is permanent rather than not-yet.

**Error mapping:**
- 401 -> `AuthFailed`, 403 -> `PermissionDenied`, 404 -> `TableNotFound` (namespace-scoped call sites rewrite to `NamespaceNotFound`), 409 -> `CommitConflict`, 429 / 5xx -> `Transport`. Unknown statuses -> `InvalidResponse`. `IcebergError::UnexpectedResponse` -> `InvalidResponse`.

## What this PR does NOT do

- No changes to the UniForm writer (it operates at the object-store + SQL DDL layer, independent of the catalog REST layer).
- No changes to existing `IcebergDiscoveryAdapter` callers; they keep using the discovery trait.
- No user-facing behaviour change.

## Files

- `engine/crates/rocky-iceberg/Cargo.toml` — add `rocky-catalog-core` path dep
- `engine/crates/rocky-iceberg/src/client.rs` — new `load_table` method, supporting types (`LoadTableResponse`, `TableMetadata`, `IcebergSchema`, `IcebergField`), `pub(crate)` `encode_namespace_parts` helper
- `engine/crates/rocky-iceberg/src/catalog_client.rs` (new) — `IcebergCatalogClientAdapter` plus `From<IcebergError> for CatalogError` mapping
- `engine/crates/rocky-iceberg/src/lib.rs` — module declaration and re-export
- `engine/crates/rocky-iceberg/tests/wiremock_tests.rs` — eight new wiremock tests for the adapter

## Test plan

- [x] `cargo test -p rocky-iceberg --all-features` — 65 lib tests + 11 wiremock tests pass (was 3; 8 new for the adapter)
- [x] `cargo clippy -p rocky-iceberg --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -p rocky-iceberg --check` clean
- [x] `cargo build --release` clean
- [x] `just codegen` no-op (neither the new catalog-core types nor the touched files derive `JsonSchema`)