### PR TITLE
feat(rocky-cli): replication strategy = "merge" with merge_keys (PR-B1)

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2092,6 +2092,26 @@
           },
           "description": "Execution settings (concurrency, retries, etc.)."
         },
+        "merge_keys": {
+          "description": "Unique-key columns for `strategy = \"merge\"`. The `MERGE` statement joins source rows onto the target on these columns; matched rows are updated, unmatched rows are inserted.\n\nRequired when `strategy = \"merge\"` and `merge_keys_fallback` is absent. Ignored for other strategies.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "merge_keys_fallback": {
+          "description": "Fallback unique-key columns used when `merge_keys` is not configured. Provides a single source of merge-key defaults for callers that derive keys from another source (e.g. the discovery adapter) but still want pipeline-level control.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "metadata_columns": {
           "default": [],
           "description": "Metadata columns added during replication.",
@@ -2110,7 +2130,7 @@
         },
         "strategy": {
           "default": "incremental",
-          "description": "Replication strategy: \"incremental\" or \"full_refresh\".",
+          "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
           "type": "string"
         },
         "target": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -750,6 +750,16 @@ export interface ReplicationPipelineConfig {
    */
   execution?: ExecutionConfig;
   /**
+   * Unique-key columns for `strategy = "merge"`. The `MERGE` statement joins source rows onto the target on these columns; matched rows are updated, unmatched rows are inserted.
+   *
+   * Required when `strategy = "merge"` and `merge_keys_fallback` is absent. Ignored for other strategies.
+   */
+  merge_keys?: string[] | null;
+  /**
+   * Fallback unique-key columns used when `merge_keys` is not configured. Provides a single source of merge-key defaults for callers that derive keys from another source (e.g. the discovery adapter) but still want pipeline-level control.
+   */
+  merge_keys_fallback?: string[] | null;
+  /**
    * Metadata columns added during replication.
    */
   metadata_columns?: MetadataColumnConfig[];
@@ -758,7 +768,9 @@ export interface ReplicationPipelineConfig {
    */
   source: PipelineSourceConfig;
   /**
-   * Replication strategy: "incremental" or "full_refresh".
+   * Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+   *
+   * `"merge"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.
    */
   strategy?: string;
   /**

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4341,6 +4341,47 @@ fn accumulate_bytes(acc: Option<u64>, next: Option<u64>) -> Option<u64> {
     }
 }
 
+/// Maps a `ReplicationPipelineConfig.strategy` string onto a
+/// `MaterializationStrategy` variant for the replication runner.
+///
+/// `"incremental"` → `Incremental { timestamp_column }`.
+/// `"merge"` → `Merge { unique_key, update_columns: ColumnSelection::All }`,
+///   reading keys from `resolved_merge_keys()` (`merge_keys` falls back to
+///   `merge_keys_fallback`). `merge` requires keys; absence is treated as
+///   a defensive `anyhow!` because `validate_replication_strategies` should
+///   have rejected it at config load time.
+/// Anything else → `FullRefresh` (backwards-compatible fallback; see follow-up
+///   note in PR body about tightening unknown strategy values).
+///
+/// Note: the watermark-filter clause (`WHERE ts > MAX(target.ts)`) lives in
+/// `sql_gen::generate_select_sql` and applies for `Incremental` only; `merge`
+/// upserts the entire source via the dialect-specific `MERGE INTO`. The
+/// runner advances the watermark timestamp after each tick regardless of
+/// strategy (via `DeferredWatermark`).
+fn build_replication_strategy(
+    pipeline: &ReplicationPipelineConfig,
+) -> Result<MaterializationStrategy> {
+    match pipeline.strategy.as_str() {
+        "incremental" => Ok(MaterializationStrategy::Incremental {
+            timestamp_column: pipeline.timestamp_column.clone(),
+        }),
+        "merge" => {
+            let keys = pipeline.resolved_merge_keys().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "strategy = \"merge\" requires merge_keys or merge_keys_fallback \
+                     (this should have been caught by load_rocky_config)"
+                )
+            })?;
+            let unique_key: Vec<Arc<str>> = keys.iter().map(|k| Arc::from(k.as_str())).collect();
+            Ok(MaterializationStrategy::Merge {
+                unique_key,
+                update_columns: ColumnSelection::All,
+            })
+        }
+        _ => Ok(MaterializationStrategy::FullRefresh),
+    }
+}
+
 /// Processes a single table: drift detection + replication.
 ///
 /// Uses `WarehouseAdapter` for all SQL execution and schema introspection,
@@ -4520,13 +4561,7 @@ async fn process_table(
     }
 
     // Build replication IR directly.
-    let strategy = if pipeline.strategy == "incremental" {
-        MaterializationStrategy::Incremental {
-            timestamp_column: pipeline.timestamp_column.clone(),
-        }
-    } else {
-        MaterializationStrategy::FullRefresh
-    };
+    let strategy = build_replication_strategy(pipeline)?;
     let model_ir = ModelIr::replication(
         TargetRef {
             catalog: task.target_catalog.clone(),
@@ -5855,5 +5890,145 @@ schema = "mart"
 
         // Should return without panicking or propagating.
         auto_sweep_retention_at_end_of_run(&blocked, &StateRetentionConfig::default()).await;
+    }
+
+    /// Pipeline TOML fragment used by `build_replication_strategy` tests.
+    /// Strategy + merge-key fields are concatenated on top per-case.
+    fn pipeline_toml_for_strategy_test() -> &'static str {
+        r#"
+[adapter.default]
+type = "duckdb"
+path = "/tmp/x.duckdb"
+
+[pipeline.bronze]
+type = "replication"
+"#
+    }
+
+    fn parse_pipeline(extra: &str) -> ReplicationPipelineConfig {
+        let mut toml_str = String::from(pipeline_toml_for_strategy_test());
+        toml_str.push_str(extra);
+        toml_str.push_str(
+            r#"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: rocky_core::config::RockyConfig = toml::from_str(&toml_str).unwrap();
+        config.pipelines["bronze"].as_replication().unwrap().clone()
+    }
+
+    #[test]
+    fn build_replication_strategy_incremental() {
+        let pipeline = parse_pipeline(
+            r#"strategy = "incremental"
+timestamp_column = "_synced_at"
+"#,
+        );
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Incremental { timestamp_column } => {
+                assert_eq!(timestamp_column, "_synced_at");
+            }
+            other => panic!("expected Incremental, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_replication_strategy_full_refresh() {
+        let pipeline = parse_pipeline(r#"strategy = "full_refresh""#);
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        assert!(matches!(strategy, MaterializationStrategy::FullRefresh));
+    }
+
+    #[test]
+    fn build_replication_strategy_merge_with_merge_keys() {
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys = ["id", "tenant_id"]
+"#,
+        );
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Merge {
+                unique_key,
+                update_columns,
+            } => {
+                let keys: Vec<&str> = unique_key.iter().map(AsRef::as_ref).collect();
+                assert_eq!(keys, vec!["id", "tenant_id"]);
+                assert!(matches!(update_columns, ColumnSelection::All));
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_replication_strategy_merge_falls_back_to_merge_keys_fallback() {
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys_fallback = ["pk"]
+"#,
+        );
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Merge { unique_key, .. } => {
+                let keys: Vec<&str> = unique_key.iter().map(AsRef::as_ref).collect();
+                assert_eq!(keys, vec!["pk"]);
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_replication_strategy_merge_prefers_merge_keys_over_fallback() {
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys = ["primary"]
+merge_keys_fallback = ["fallback_only"]
+"#,
+        );
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Merge { unique_key, .. } => {
+                let keys: Vec<&str> = unique_key.iter().map(AsRef::as_ref).collect();
+                assert_eq!(keys, vec!["primary"]);
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_replication_strategy_merge_without_keys_errors() {
+        // Defensive guard: `load_rocky_config` rejects this earlier via
+        // `validate_replication_strategies`, but callers that build the
+        // config struct in-process and bypass that path must still get
+        // a clean error.
+        let pipeline = parse_pipeline(r#"strategy = "merge""#);
+        let err = build_replication_strategy(&pipeline).expect_err("merge without keys must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("merge_keys"),
+            "error should name merge_keys: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_replication_strategy_unknown_falls_back_to_full_refresh() {
+        // Preserves prior behavior: any strategy string other than
+        // "incremental" / "merge" maps to FullRefresh. Tightening this
+        // into a typed error is a follow-up.
+        let pipeline = parse_pipeline(r#"strategy = "totally_made_up""#);
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        assert!(matches!(strategy, MaterializationStrategy::FullRefresh));
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -203,6 +203,12 @@ pub enum ConfigError {
         "pipeline '{pipeline}' source.discovery.adapter = '{adapter}' points to an adapter whose `kind` excludes discovery"
     )]
     PipelineDiscoveryAdapterNotDiscovery { pipeline: String, adapter: String },
+
+    #[error(
+        "pipeline '{pipeline}' uses strategy = \"merge\" but neither merge_keys nor merge_keys_fallback is configured. \
+         Set [pipeline.{pipeline}.merge_keys = [\"col1\", \"col2\"]] in your rocky.toml."
+    )]
+    ReplicationMergeMissingKeys { pipeline: String },
 }
 
 /// Concurrency strategy for table processing.
@@ -2611,13 +2617,34 @@ impl PipelineConfig {
 // schema; everything outside the pipeline section stays strict.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReplicationPipelineConfig {
-    /// Replication strategy: "incremental" or "full_refresh".
+    /// Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+    ///
+    /// `"merge"` upserts the watermarked delta into the target via
+    /// `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET *
+    /// WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or
+    /// `merge_keys_fallback`) to be set.
     #[serde(default = "default_strategy")]
     pub strategy: String,
 
     /// Timestamp column for incremental strategy.
     #[serde(default = "default_timestamp_column")]
     pub timestamp_column: String,
+
+    /// Unique-key columns for `strategy = "merge"`. The `MERGE` statement
+    /// joins source rows onto the target on these columns; matched rows are
+    /// updated, unmatched rows are inserted.
+    ///
+    /// Required when `strategy = "merge"` and `merge_keys_fallback` is
+    /// absent. Ignored for other strategies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_keys: Option<Vec<String>>,
+
+    /// Fallback unique-key columns used when `merge_keys` is not configured.
+    /// Provides a single source of merge-key defaults for callers that
+    /// derive keys from another source (e.g. the discovery adapter) but
+    /// still want pipeline-level control.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_keys_fallback: Option<Vec<String>>,
 
     /// Metadata columns added during replication.
     #[serde(default)]
@@ -3185,6 +3212,34 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Vec<ConfigError> {
     errors
 }
 
+/// Collects strategy-level issues on replication pipelines.
+///
+/// Today this checks one rule: `strategy = "merge"` requires
+/// `merge_keys` (or `merge_keys_fallback`). Surfacing it here means
+/// `rocky validate` can emit the issue as a structured diagnostic, and
+/// production load paths (via [`load_rocky_config`]) fail fast before
+/// any network call.
+///
+/// Returns one error per offending pipeline. Other strategy strings
+/// (`"incremental"`, `"full_refresh"`, anything else) pass through
+/// unchanged — unknown values still fall back to `FullRefresh` at
+/// dispatch time. Tightening that fallback into a typed error is a
+/// follow-up.
+pub fn validate_replication_strategies(config: &RockyConfig) -> Vec<ConfigError> {
+    let mut errors = Vec::new();
+    for (pipeline_name, pipeline) in &config.pipelines {
+        let PipelineConfig::Replication(replication) = pipeline else {
+            continue;
+        };
+        if replication.strategy == "merge" && replication.resolved_merge_keys().is_none() {
+            errors.push(ConfigError::ReplicationMergeMissingKeys {
+                pipeline: pipeline_name.clone(),
+            });
+        }
+    }
+    errors
+}
+
 /// Does this adapter actively serve `role`?
 ///
 /// An adapter block actively serves a role when:
@@ -3311,6 +3366,9 @@ pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     if let Some(first) = validate_adapter_kinds(&config).into_iter().next() {
         return Err(first);
     }
+    if let Some(first) = validate_replication_strategies(&config).into_iter().next() {
+        return Err(first);
+    }
     Ok(config)
 }
 
@@ -3382,6 +3440,14 @@ impl ReplicationPipelineConfig {
     /// Builds a SchemaPattern from the source configuration.
     pub fn schema_pattern(&self) -> Result<SchemaPattern, crate::schema::SchemaError> {
         self.source.schema_pattern.to_schema_pattern()
+    }
+
+    /// Returns the resolved merge keys, preferring `merge_keys` over
+    /// `merge_keys_fallback`. `None` when neither is set.
+    pub fn resolved_merge_keys(&self) -> Option<&Vec<String>> {
+        self.merge_keys
+            .as_ref()
+            .or(self.merge_keys_fallback.as_ref())
     }
 }
 
@@ -6583,6 +6649,311 @@ max_rows = 1000
         assert!(
             msg.contains("backend") || msg.contains("unknown field"),
             "error should mention the unknown field, got: {msg}"
+        );
+    }
+
+    /// Returns a baseline replication-pipeline TOML used by the merge-strategy
+    /// tests. Callers concatenate strategy-specific overrides on top.
+    fn merge_pipeline_toml_base() -> &'static str {
+        r#"
+[adapter.default]
+type = "duckdb"
+path = "/tmp/x.duckdb"
+
+[pipeline.bronze]
+type = "replication"
+"#
+    }
+
+    #[test]
+    fn replication_strategy_merge_parses_merge_keys() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+merge_keys = ["id", "tenant_id"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        assert_eq!(pipeline.strategy, "merge");
+        assert_eq!(
+            pipeline.merge_keys.as_deref(),
+            Some(&["id".to_string(), "tenant_id".to_string()][..])
+        );
+        assert!(pipeline.merge_keys_fallback.is_none());
+        // resolved_merge_keys prefers merge_keys.
+        assert_eq!(
+            pipeline.resolved_merge_keys(),
+            Some(&vec!["id".to_string(), "tenant_id".to_string()])
+        );
+    }
+
+    #[test]
+    fn replication_strategy_merge_falls_back_to_merge_keys_fallback() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+merge_keys_fallback = ["pk"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        assert!(pipeline.merge_keys.is_none());
+        assert_eq!(
+            pipeline.merge_keys_fallback.as_deref(),
+            Some(&["pk".to_string()][..])
+        );
+        assert_eq!(
+            pipeline.resolved_merge_keys(),
+            Some(&vec!["pk".to_string()])
+        );
+    }
+
+    #[test]
+    fn replication_strategy_merge_prefers_merge_keys_over_fallback() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+merge_keys = ["primary"]
+merge_keys_fallback = ["fallback_only"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        assert_eq!(
+            pipeline.resolved_merge_keys(),
+            Some(&vec!["primary".to_string()])
+        );
+    }
+
+    #[test]
+    fn validate_replication_strategies_rejects_merge_without_keys() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_strategies(&config);
+        assert_eq!(errors.len(), 1);
+        // Pin the exact error string — it's the contract callers (CLI / `rocky
+        // validate`) surface to operators and must stay stable.
+        assert_eq!(
+            errors[0].to_string(),
+            "pipeline 'bronze' uses strategy = \"merge\" but neither merge_keys \
+             nor merge_keys_fallback is configured. \
+             Set [pipeline.bronze.merge_keys = [\"col1\", \"col2\"]] in your rocky.toml."
+        );
+        assert!(
+            matches!(errors[0], ConfigError::ReplicationMergeMissingKeys { .. }),
+            "wrong variant: {:?}",
+            errors[0]
+        );
+    }
+
+    #[test]
+    fn validate_replication_strategies_accepts_merge_with_keys() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+merge_keys = ["id"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_strategies(&config);
+        assert!(
+            errors.is_empty(),
+            "merge with merge_keys should validate cleanly, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_replication_strategies_accepts_merge_with_fallback_only() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+merge_keys_fallback = ["id"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_strategies(&config);
+        assert!(
+            errors.is_empty(),
+            "merge with merge_keys_fallback should validate cleanly, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_replication_strategies_skips_non_merge_strategies() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+timestamp_column = "_synced"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        // No merge_keys, but strategy != "merge" — must not produce errors.
+        let errors = validate_replication_strategies(&config);
+        assert!(
+            errors.is_empty(),
+            "non-merge strategies must pass: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn load_rocky_config_fails_fast_on_merge_without_keys() {
+        use std::io::Write;
+
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "merge"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        tmp.write_all(toml_str.as_bytes()).expect("write");
+        let err = load_rocky_config(tmp.path())
+            .expect_err("load_rocky_config should reject merge without keys");
+        assert!(
+            matches!(err, ConfigError::ReplicationMergeMissingKeys { ref pipeline }
+                if pipeline == "bronze"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn merge_keys_omitted_from_serialized_output_when_none() {
+        // `skip_serializing_if = "Option::is_none"` keeps the JSON / TOML
+        // shape stable for existing replication pipelines — adding the
+        // field doesn't perturb projects that never opt into merge.
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+timestamp_column = "_synced"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        let json = serde_json::to_string(pipeline).unwrap();
+        assert!(
+            !json.contains("merge_keys"),
+            "JSON output should omit unset merge_keys/merge_keys_fallback: {json}"
         );
     }
 }

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -517,6 +517,8 @@ mod tests {
         PipelineConfig::Replication(Box::new(ReplicationPipelineConfig {
             strategy: "incremental".into(),
             timestamp_column: "_fivetran_synced".into(),
+            merge_keys: None,
+            merge_keys_fallback: None,
             metadata_columns: vec![],
             source: PipelineSourceConfig {
                 adapter: source_adapter.into(),

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -941,6 +941,8 @@ mod tests {
         PipelineConfig::Replication(Box::new(ReplicationPipelineConfig {
             strategy: "incremental".into(),
             timestamp_column: "_fivetran_synced".into(),
+            merge_keys: None,
+            merge_keys_fallback: None,
             metadata_columns: vec![],
             source: PipelineSourceConfig {
                 adapter: "default".into(),

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -2053,6 +2053,16 @@ class ReplicationPipelineConfig(BaseModel):
     """
     Execution settings (concurrency, retries, etc.).
     """
+    merge_keys: list[str] | None = None
+    """
+    Unique-key columns for `strategy = "merge"`. The `MERGE` statement joins source rows onto the target on these columns; matched rows are updated, unmatched rows are inserted.
+
+    Required when `strategy = "merge"` and `merge_keys_fallback` is absent. Ignored for other strategies.
+    """
+    merge_keys_fallback: list[str] | None = None
+    """
+    Fallback unique-key columns used when `merge_keys` is not configured. Provides a single source of merge-key defaults for callers that derive keys from another source (e.g. the discovery adapter) but still want pipeline-level control.
+    """
     metadata_columns: list[MetadataColumnConfig] | None = Field(
         [], validate_default=True
     )
@@ -2065,7 +2075,9 @@ class ReplicationPipelineConfig(BaseModel):
     """
     strategy: str | None = "incremental"
     """
-    Replication strategy: "incremental" or "full_refresh".
+    Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+
+    `"merge"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.
     """
     target: PipelineTargetConfig
     """

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2091,6 +2091,26 @@
           },
           "description": "Execution settings (concurrency, retries, etc.)."
         },
+        "merge_keys": {
+          "description": "Unique-key columns for `strategy = \"merge\"`. The `MERGE` statement joins source rows onto the target on these columns; matched rows are updated, unmatched rows are inserted.\n\nRequired when `strategy = \"merge\"` and `merge_keys_fallback` is absent. Ignored for other strategies.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "merge_keys_fallback": {
+          "description": "Fallback unique-key columns used when `merge_keys` is not configured. Provides a single source of merge-key defaults for callers that derive keys from another source (e.g. the discovery adapter) but still want pipeline-level control.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "metadata_columns": {
           "default": [],
           "description": "Metadata columns added during replication.",
@@ -2109,7 +2129,7 @@
         },
         "strategy": {
           "default": "incremental",
-          "description": "Replication strategy: \"incremental\" or \"full_refresh\".",
+          "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
           "type": "string"
         },
         "target": {


### PR DESCRIPTION
## Summary

Adds `strategy = "merge"` to replication pipelines. Wires through to the existing `MaterializationStrategy::Merge` + `sql_gen::generate_merge_sql` + per-adapter `merge_into()` path (already shipped for transformation pipelines).

- New `[pipeline.<name>].merge_keys` and `merge_keys_fallback` fields on `ReplicationPipelineConfig` (both optional `Vec<String>`).
- `load_rocky_config` fails fast when `strategy = "merge"` lacks both keys, via the new `validate_replication_strategies` hook in `rocky-core/src/config.rs`.
- New `build_replication_strategy(&ReplicationPipelineConfig) -> Result<MaterializationStrategy>` helper in `rocky-cli/src/commands/run.rs` replacing the inline `if/else` at the dispatch site.
- Codegen cascade re-run: `schemas/rocky_project.schema.json` + dagster Pydantic + vscode TS bindings all pick up the two new optional fields.

## Why

Fivetran-style ingestion ships two source shapes against the same orchestrator: clean delta connectors and whole-table-resync connectors. The latter refresh row timestamps every tick — under `strategy = "incremental"` the watermark filter passes everything, and duplicates accumulate (up to ~49x after 24h). MERGE upserts the delta by key, collapsing duplicates whichever source shape arrives.

## What this PR does NOT do

- No `[[table_overrides]]` — sequenced as a follow-up; different config shape than originally planned.
- No in-place compact-dedup primitive — separate ticket.
- No DuckDB MERGE local-smoke testing — DuckDB MERGE is a separate PR landing alongside.
- No source-side watermark migration — see below.

## Watermark behaviour (verified, not changed)

Today's filter is **target-side**: `WHERE {ts} > (SELECT MAX({ts}) FROM target_ref)` (every dialect impl in `rocky-databricks`, `rocky-snowflake`, `rocky-bigquery`, `rocky-trino`). For `incremental`, this is the misbehaviour that motivates MERGE — a resync source advances `MAX(target.ts)` correctly but the filter still passes all source rows on the next tick because the source bumped its timestamps. MERGE preserves the filter and key-collapses any duplicates that pass through, so structural correctness lands now.

Migrating to source-side watermarks (e.g. `MAX(source.ts) WHERE processed`) is a follow-up that touches all 5 dialect impls + state-store semantics + every mock dialect. Out of scope for this PR.

## Adapter coverage

- **Databricks / Snowflake / BigQuery** — `merge_into()` already implemented; `strategy = "merge"` works against all three.
- **Trino** — declares `merge: false` and fails loud at planning time (correct).
- **Snowflake `UPDATE SET *` quirk** — dispatch passes `ColumnSelection::All`, and `rocky-snowflake/src/dialect.rs::merge_into` returns `AdapterError::msg("Snowflake MERGE does not support UPDATE SET *. Use explicit update_columns.")`. Snowflake replication+merge fails loud at SQL-gen time until a follow-up threads explicit column lists through the runner (the transformation path requires users to set `update_columns` in model TOML; replication has no equivalent surface yet).
- **DuckDB** — DuckDB MERGE is its own PR. PR-B1 covers strategy-dispatch logic via SQL-string assertions; end-to-end DuckDB smoke comes with the DuckDB MERGE impl.

## Follow-up note

Any string other than `"incremental"` / `"merge"` falls back to `FullRefresh` (preserves prior behaviour). A typo of `"merge"` → `"mege"` silently maps to `FullRefresh`, defeating the safety this PR adds. Tightening to a typed error is worth doing in a follow-up.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --all-features` clean (workspace-wide; 1182 rocky-core lib tests, 516 rocky-cli, etc.)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `just codegen` produced expected diff (2 new fields on `ReplicationPipelineConfig` in schema + TS + Pydantic; description tweak on `strategy`)
- [x] `just regen-fixtures` produced no diff (playground POC doesn't exercise merge)
- [x] `uv run pytest -x` in `integrations/dagster/` — 541 passed
- [x] `npm run test:unit` in `editors/vscode/` — 106 passed
- [x] New tests: config parse + validation + dispatch (15 new unit tests across `config.rs` and `run.rs`)