### PR TITLE
docs: per-table error containment + failure_kind consumption

### DIFF
--- a/docs/src/content/docs/advanced/failure-modes.md
+++ b/docs/src/content/docs/advanced/failure-modes.md
@@ -124,7 +124,7 @@ The `drifted_columns` array names which columns changed and what the divergence 
 
 **Definition.** A warehouse call (compile-passing, contract-passing, drift-handled) failed at execution time. Network errors, auth errors, quota errors, statement timeouts, deadlocks — anything that originates inside the adapter rather than the engine.
 
-**Detection signal.** Non-zero `rocky apply` exit code, `error` field on the affected `MaterializationOutput`, plus a transient/rate-limit classification on the underlying error.
+**Detection signal.** Non-zero `rocky apply` exit code, an entry on `RunOutput.errors[*]` per failed table (with a typed [`failure_kind`](./per-table-error-containment#failure_kind-taxonomy) discriminator the orchestrator can branch on), plus a transient/rate-limit classification on the underlying error. Other tables in the same run continue -- see [Per-table error containment](./per-table-error-containment).
 
 The dispatched adapter classifies its own failures:
 
@@ -139,7 +139,7 @@ The dispatched adapter classifies its own failures:
 **Recovery playbook.**
 
 1. Run `rocky doctor --output json` first. The `adapters[]` block tells you which adapter Rocky thinks should work and which it currently can't reach. Treat doctor as a credentials / connectivity smoke test.
-2. For **transient** failures (`is_transient: true` on the adapter error), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the legacy `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
+2. For **transient** failures (entries with `failure_kind: "transient"` or `"connection-failed"` on `errors[*]`), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the legacy `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
 3. For **auth** failures, walk the adapter's auth chain (e.g. Snowflake: OAuth → JWT → password) and verify the env-vars / config in `rocky.toml`. The [authentication guide](../../features/authentication) has the per-adapter checklist.
 4. For **quota** failures, check the warehouse-side quota dashboard. Rocky's adaptive concurrency (Databricks AIMD throttle) automatically backs off, but a hard quota reset is a warehouse-side action.
 5. For **statement timeouts**, increase `timeout_secs` on the adapter, or — better — re-evaluate whether the model's materialization strategy is right (a multi-hour `FullRefresh` is often a missed `Merge` or `Incremental` opportunity; `rocky optimize` will surface the recommendation).
@@ -235,6 +235,7 @@ The dispatched adapter classifies its own failures:
 
 ## See also
 
+- [Per-table error containment](./per-table-error-containment) — how the run path isolates failures at the table boundary and how to consume the `failure_kind` discriminator
 - [Troubleshooting](./troubleshooting) — symptom-first lookup ("I got error X")
 - [`rocky doctor`](../../reference/cli#doctor) — aggregate health check across config, state, adapters, pipelines
 - [`rocky plan --resume-latest`](../../reference/cli#run) — resume a failed run from its checkpoint (canonical form; the legacy `rocky run --resume-latest` alias is still accepted)

--- a/docs/src/content/docs/advanced/per-table-error-containment.md
+++ b/docs/src/content/docs/advanced/per-table-error-containment.md
@@ -1,0 +1,165 @@
+---
+title: Per-table error containment
+description: How rocky run isolates failures at the table boundary and how to consume the failure_kind discriminator
+sidebar:
+  order: 4
+---
+
+`rocky run` (and the canonical `rocky plan` + `rocky apply` flow it backs) treats each table as an isolated unit of work. One table failing does not crash the run. The other tables in the same invocation keep going, the run finishes with a partial-success exit code, and the per-table failures are enumerated on `RunOutput.errors[*]` with a typed `failure_kind` discriminator so orchestrators can branch on the kind of failure without parsing the free-form `error` string.
+
+This page documents that contract and shows how downstream consumers (Dagster assets, custom scripts, alerting) should branch on it.
+
+## The containment property
+
+The per-table loop in `commands/run.rs` dispatches every table through `process_table` inside a `tokio::JoinSet`. The match arm that handles a task's `Result` has three branches:
+
+- **Success** -- the materialization is appended to `RunOutput.materializations` and progress is checkpointed.
+- **Adapter error** (`Ok((idx, Err(e)))`) -- the error is classified into a [`FailureKind`](#failure_kind-taxonomy) **before** stringification (so the typed connector variant is preserved), then a `TableError { asset_key, error, failure_kind }` is pushed onto `table_errors`. The loop continues with the remaining tables.
+- **Task panic** (`Err(JoinError)`) -- the panic message is captured into a `TableError` with `failure_kind = "unknown"`. The loop continues.
+
+The only path that aborts the run early is `--fail-fast` (which calls `JoinSet::abort_all()` on the first error). With the default behaviour, a run of N models can finish with K (< N) failures; the remaining N-K still succeed, and `RunOutput.errors[*]` enumerates the K. The exit code is non-zero so callers can distinguish partial success from clean success, but the JSON output is still well-formed.
+
+This is true for every adapter (Databricks, Snowflake, BigQuery, DuckDB) -- the loop is adapter-agnostic and catches `anyhow::Error` from any source, including connector errors, schema-drift failures, governance reconciliation errors, and worker-task panics.
+
+### What `errors[*]` looks like
+
+```json
+{
+  "version": "1.34.0",
+  "command": "run",
+  "tables_copied": 18,
+  "tables_failed": 2,
+  "materializations": [ /* 18 successful entries */ ],
+  "errors": [
+    {
+      "asset_key": ["fivetran", "acme", "us_west", "shopify", "orders"],
+      "error": "Databricks statement failed: TABLE_OR_VIEW_NOT_FOUND ...",
+      "failure_kind": "query-rejected"
+    },
+    {
+      "asset_key": ["fivetran", "acme", "us_west", "shopify", "refunds"],
+      "error": "Databricks API error 429: rate limit exceeded",
+      "failure_kind": "quota-exceeded"
+    }
+  ]
+}
+```
+
+The exit code is non-zero (partial success), but every other table in the run materialized to completion.
+
+## `failure_kind` taxonomy
+
+`failure_kind` is a coarse classifier over the failure surface. The seven kebab-case variants partition the connector error spaces for Databricks and Snowflake, with a fallback for failures that reach the output layer type-erased.
+
+| Variant | Meaning | Retry-safe? |
+|---|---|---|
+| `connection-failed` | TCP / TLS / DNS / connection-establishment failure -- the request never reached the warehouse. | Yes, with backoff. |
+| `auth-failed` | Credentials rejected or token expired -- 401, 403, or an auth-chain rejection. | No. Fix credentials before retrying. |
+| `query-rejected` | Warehouse parsed and rejected the SQL -- syntax error, missing column, missing permission, semantic analysis failure. | No. The SQL needs fixing. |
+| `transient` | Retry-worthy failure -- 5xx, network glitch, statement aborted by a transient warehouse condition, statement timeout, circuit-breaker open. | Yes. |
+| `quota-exceeded` | Rate limit hit or a configured cap reached -- 429, retry-budget exhaustion, account-level quota. | Yes, with extended backoff and an alert. |
+| `not-found` | Requested catalog / schema / table not present -- 404 from the warehouse, often an upstream rename. | No. Re-discovery or human triage needed. |
+| `unknown` | The failure could not be classified -- e.g. errors raised outside the connector layer that reach the output struct type-erased. | Depends. Surface the raw `error` string. |
+
+The classifier walks the `anyhow::Error` chain on each per-table failure, downcasts to `AdapterError`, and probes `.inner()` for the typed connector enum. Errors built via `anyhow::anyhow!("...{e}")` (which stringify and drop the type) fall through to `unknown`; errors propagated via `?` / `.context(...)` preserve the typed source and classify correctly. As of engine `v1.34`, the 23 sites in `run.rs` that previously stringified adapter errors have been converted to type-preserving wraps, so `failure_kind` returns a non-`unknown` value for every real production adapter error.
+
+### Recommended consumer policy
+
+Map each variant to one of four actions:
+
+| Action | Variants |
+|---|---|
+| **Retry with backoff** | `transient`, `connection-failed` |
+| **Retry with extended backoff and alert** | `quota-exceeded` |
+| **Don't retry; alert the model owner** | `auth-failed`, `query-rejected`, `not-found` |
+| **Surface raw `error` for triage** | `unknown` |
+
+Treat `connection-failed` as retry-safe even though the warehouse never saw the request: `reqwest::is_connect()` is the discriminator, which fires on actual TCP / TLS / DNS failures, not on credentials issues (which land on `auth-failed` instead).
+
+## Consuming from Dagster
+
+Branch on `failure_kind` inside the asset / op body after the rocky call returns. The kebab-case string values (`"transient"`, `"auth-failed"`, ...) are the stable wire contract, so a set-membership check is the safest pattern:
+
+```python
+import dagster as dg
+from dagster_rocky import RockyResource
+
+RETRY_KINDS = {"transient", "connection-failed", "quota-exceeded"}
+ALERT_KINDS = {"auth-failed", "query-rejected", "not-found"}
+
+
+@dg.asset
+def replicated_tables(
+    context: dg.AssetExecutionContext,
+    rocky: RockyResource,
+) -> dg.MaterializeResult:
+    result = rocky.run(filter="tenant=acme")
+
+    retryable: list[tuple[str, str, str]] = []
+    alertable: list[tuple[str, str, str]] = []
+    for err in result.errors:
+        target = "/".join(err.asset_key)
+        if err.failure_kind in RETRY_KINDS:
+            retryable.append((target, err.failure_kind, err.error))
+        elif err.failure_kind in ALERT_KINDS:
+            alertable.append((target, err.failure_kind, err.error))
+        else:
+            context.log.warning(f"unclassified failure on {target}: {err.error}")
+
+    if alertable:
+        # Hand off to your alerting layer (PagerDuty, Slack, Sentry, ...).
+        for target, kind, msg in alertable:
+            context.log.error(f"alert: {target} -- {kind} -- {msg}")
+
+    if retryable:
+        # Surface as a non-fatal failure so Dagster's retry policy picks it up.
+        raise dg.Failure(
+            description=f"{len(retryable)} table(s) failed transiently; retrying.",
+            metadata={
+                "retryable": dg.MetadataValue.json(
+                    [{"target": t, "kind": k} for t, k, _ in retryable]
+                ),
+            },
+        )
+
+    return dg.MaterializeResult(
+        metadata={"tables_copied": result.tables_copied}
+    )
+```
+
+Pair the asset with a Dagster `RetryPolicy` to back off on `dg.Failure`:
+
+```python
+defs = dg.Definitions(
+    assets=[replicated_tables.with_retry_policy(
+        dg.RetryPolicy(max_retries=3, delay=30, backoff=dg.Backoff.EXPONENTIAL),
+    )],
+    resources={"rocky": RockyResource(config_path="rocky.toml")},
+)
+```
+
+Requires engine `v1.34+` (which emits the discriminator on the wire) and `dagster-rocky` `v1.35+` (which surfaces `failure_kind` directly on `RunResult.errors[*]`). Older bindings default the field to `"unknown"` when parsing a newer engine's output.
+
+For non-Dagster consumers, `rocky run --output json | jq` gives the same shape:
+
+```bash
+rocky run --output json --config rocky.toml \
+  | jq -r '.errors[] | "\(.failure_kind)\t\(.asset_key | join("/"))\t\(.error)"'
+```
+
+Branch on the first column in your shell pipeline -- `transient` and `quota-exceeded` go into a retry loop, everything else pages the on-call.
+
+## When `failure_kind` is `unknown`
+
+`unknown` is the fallback when the classifier can't reach a typed connector variant on the error chain. Two cases produce it today:
+
+1. **Non-adapter errors** -- drift reconciliation failures, governance errors, state-store failures that surface at the per-table level. The error is real and well-formed, but the type-erased `anyhow::Error` doesn't expose a connector variant. The free-form `error` string is the only signal; triage manually.
+2. **Worker-task panics** -- a `JoinError` from a panicked task produces a `TableError` with `failure_kind = "unknown"`. The panic message is in `error`. This is rare and almost always a bug to file rather than retry.
+
+Treat `unknown` as a surface-and-triage signal, never as silently retry-safe.
+
+## See also
+
+- [Failure modes](./failure-modes) -- the nine-category taxonomy and recovery playbook for every kind of Rocky failure.
+- [JSON output](../../reference/json-output) -- the full versioned schema for `rocky run` and every other command.
+- [`rocky plan --resume-latest`](../../reference/cli) -- resume a failed run from its last checkpoint; per-table progress is recorded for every success and every classified failure.

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`TableError.failure_kind` now surfaces on `RunResult.errors[*]`.** The legacy hand-written `TableError` Pydantic model previously stripped the engine's `failure_kind` field during parsing — only the generated `TableErrorOutput` model exposed it. Added `failure_kind: str = "unknown"` to the legacy model so downstream Dagster assets that read `RunResult.errors[*].failure_kind` see the engine-emitted classifier directly. Strictly additive; the default makes the field forward-compatible with older engine binaries that don't emit it.
+
 ## [1.34.0] — 2026-05-18
 
 Companion release to engine `v1.36.0`. The regenerated Pydantic models in `dagster_rocky/types_generated/` pick up the new `merge_keys` and `merge_keys_fallback` fields on `ReplicationPipelineConfig` from engine v1.36.0's replication `strategy = "merge"` (engine [#561](https://github.com/rocky-data/rocky/pull/561)). No new dagster API surface — pure codegen cascade. Wheel re-cut against the v1.36.0 engine binary. Dagster code that constructs `RockyResource` configs against engine v1.36.0+ can now declare `strategy = "merge"` on replication pipelines and supply the keys via the typed config; consumers parsing Rocky JSON output via Pydantic see the new optional fields without overriding `extra = "forbid"`. Also bundles a small fix to `RockyComponent`'s state-cache plumbing so the JSON written to the discover/compile/optimize caches now uses the same field-alias convention as the rocky CLI (matches the existing `dag()` call at `component.py:655`).

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -234,6 +234,13 @@ class AnomalyResult(BaseModel):
 class TableError(BaseModel):
     asset_key: list[str]
     error: str
+    #: Coarse classification of the failure so orchestrators can branch on
+    #: kind (retry, page, surface) without parsing ``error``. One of
+    #: ``connection-failed``, ``auth-failed``, ``query-rejected``,
+    #: ``transient``, ``quota-exceeded``, ``not-found``, ``unknown``.
+    #: Defaults to ``"unknown"`` for older engine binaries that omit the
+    #: field.
+    failure_kind: str = "unknown"
 
 
 class ExcludedTable(BaseModel):


### PR DESCRIPTION
## Summary

- Adds a new docs page at `docs/src/content/docs/advanced/per-table-error-containment.md` documenting (a) Rocky's per-table containment contract on `rocky run` — one table failing does not crash the run; the other tables in the same invocation keep going and `RunOutput.errors[*]` enumerates the failures with a typed `failure_kind` — and (b) how downstream consumers (Dagster assets, custom scripts, `jq` pipelines) should branch on the discriminator. Includes the 7-variant taxonomy, a recommended retry-vs-alert consumer policy, a Dagster asset example pairing `RunResult.errors` branching with a `RetryPolicy`, and a `jq` snippet for non-Dagster consumers.
- Updates `docs/src/content/docs/advanced/failure-modes.md` Section 5 (Adapter / runtime failures) to reference `failure_kind` instead of the deprecated `is_transient` accessor, and adds the new page to its "See also".
- Companion two-line fix in `integrations/dagster/src/dagster_rocky/types.py`: the hand-written `TableError` Pydantic model previously stripped the engine's `failure_kind` field during parsing — only the generated `TableErrorOutput` carried it. Adds `failure_kind: str = "unknown"` to the legacy model so `RunResult.errors[*].failure_kind` matches the wire contract on engine `v1.34+` and defaults gracefully on older engine binaries.

## Test plan

- [x] `npm run build` in `docs/` — 76 pages built, no errors; pre-existing i18n + `dot` highlighter warnings unchanged
- [x] `uv run pytest -q` in `integrations/dagster/` — 541 passed
- [x] `uv run ruff check src/dagster_rocky/types.py` — clean
- [x] `uv run ruff format --check src/dagster_rocky/types.py` — clean
- [x] Empirical: parsed a `RunResult` with `failure_kind: "transient"` and confirmed `r.errors[0].failure_kind == "transient"` (was previously stripped to absent)
- [x] Empirical: parsed an older-engine `RunResult` without `failure_kind` and confirmed the default `"unknown"` value