### PR TITLE
feat(rocky-iceberg): impl lifecycle methods on IcebergCatalogClientAdapter (PR-3)

### DIFF
--- a/engine/crates/rocky-iceberg/src/catalog_client.rs
+++ b/engine/crates/rocky-iceberg/src/catalog_client.rs
@@ -11,12 +11,25 @@
 //!   `GET /v1/namespaces/{ns}/tables/{name}` via
 //!   [`IcebergCatalogClient::load_table`] and distills the current
 //!   schema down to a [`TableSchema`].
-//! - [`CatalogClient::create_table`], [`CatalogClient::drop_table`],
-//!   [`CatalogClient::commit_transaction`] and
-//!   [`CatalogClient::list_branches`] currently return
-//!   [`CatalogError::UnsupportedOperation`]; they will be wired up in a
-//!   follow-up that adds POST/DELETE HTTP support and full
-//!   `TableMetadata` round-trips.
+//! - [`CatalogClient::create_table`] issues
+//!   `POST /v1/namespaces/{ns}/tables`. 404 from the parent endpoint is
+//!   rewritten from the default `TableNotFound` to `NamespaceNotFound`
+//!   because a missing-parent is the only plausible 404 on table
+//!   creation.
+//! - [`CatalogClient::drop_table`] issues
+//!   `DELETE /v1/namespaces/{ns}/tables/{name}`. Default 404 mapping
+//!   (`TableNotFound`) is the right one.
+//! - [`CatalogClient::commit_transaction`] issues
+//!   `POST /v1/transactions/commit` with one entry per [`TableCommit`].
+//!   The trait's CAS contract is encoded as Iceberg
+//!   `assert-ref-snapshot-id` (when `expected_snapshot_id` is set) or
+//!   `assert-create` (when it is `None`) on the `main` branch, paired
+//!   with a `set-snapshot-ref` update advancing `main` to
+//!   `new_snapshot_id`. See [`CatalogClient::commit_transaction`] below
+//!   for the v1 contract.
+//! - [`CatalogClient::list_branches`] reuses `load_table`'s GET and
+//!   projects the `refs` map embedded in `TableMetadata` onto
+//!   [`Vec<BranchRef>`].
 //! - The four governance methods ([`CatalogClient::tag_table`],
 //!   [`CatalogClient::get_grants`], [`CatalogClient::apply_grant`],
 //!   [`CatalogClient::revoke_grant`]) return
@@ -25,13 +38,17 @@
 //!   permanent rather than "not yet".
 
 use async_trait::async_trait;
+use serde_json::json;
 
 use rocky_catalog_core::{
-    BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant, TableCommit,
-    TableRef, TableSchema,
+    BranchKind, BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant,
+    TableCommit, TableRef, TableSchema,
 };
 
-use crate::client::{IcebergCatalogClient, IcebergError};
+use crate::client::{
+    CommitTableIdentifier, CommitTableRequest, CommitTransactionRequest, CreateTableField,
+    CreateTableRequest, CreateTableSchema, IcebergCatalogClient, IcebergError,
+};
 
 /// [`CatalogClient`] implementation that delegates to an
 /// [`IcebergCatalogClient`].
@@ -136,28 +153,72 @@ impl CatalogClient for IcebergCatalogClientAdapter {
         Ok(TableSchema { columns })
     }
 
-    async fn create_table(&self, _table: &TableRef, _schema: &TableSchema) -> CatalogResult<()> {
-        Err(CatalogError::UnsupportedOperation(
-            "create_table not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds POST support",
-        ))
+    async fn create_table(&self, table: &TableRef, schema: &TableSchema) -> CatalogResult<()> {
+        let request = build_create_table_request(&table.name, schema);
+        self.inner
+            .create_table(&table.namespace, &request)
+            .await
+            // The endpoint is namespace-scoped: a 404 here means the
+            // parent namespace doesn't exist, not the table (which
+            // could not exist anyway — that's the point of the call).
+            // Rewrite the default `TableNotFound` mapping accordingly.
+            .map_err(|e| match icebergerror_into_catalog(e) {
+                CatalogError::TableNotFound(msg) => CatalogError::NamespaceNotFound(msg),
+                other => other,
+            })?;
+        Ok(())
     }
 
-    async fn drop_table(&self, _table: &TableRef) -> CatalogResult<()> {
-        Err(CatalogError::UnsupportedOperation(
-            "drop_table not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds DELETE support",
-        ))
+    async fn drop_table(&self, table: &TableRef) -> CatalogResult<()> {
+        self.inner
+            .drop_table(&table.namespace, &table.name)
+            .await
+            .map_err(icebergerror_into_catalog)?;
+        Ok(())
     }
 
-    async fn commit_transaction(&self, _commits: &[TableCommit]) -> CatalogResult<()> {
-        Err(CatalogError::UnsupportedOperation(
-            "commit_transaction not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that adds POST + TableMetadata round-trips",
-        ))
+    async fn commit_transaction(&self, commits: &[TableCommit]) -> CatalogResult<()> {
+        // Empty slice short-circuits: the spec accepts an empty
+        // `table-changes` list, but calling the network for a no-op is
+        // wasteful and obscures the failure mode if the server rejects
+        // it.
+        if commits.is_empty() {
+            return Ok(());
+        }
+
+        let table_changes = commits.iter().map(build_commit_table_request).collect();
+        let request = CommitTransactionRequest { table_changes };
+
+        self.inner
+            .commit_transaction(&request)
+            .await
+            .map_err(icebergerror_into_catalog)?;
+        Ok(())
     }
 
-    async fn list_branches(&self, _table: &TableRef) -> CatalogResult<Vec<BranchRef>> {
-        Err(CatalogError::UnsupportedOperation(
-            "list_branches not yet implemented in IcebergCatalogClientAdapter; tracked for a follow-up that surfaces SnapshotReference entries from TableMetadata",
-        ))
+    async fn list_branches(&self, table: &TableRef) -> CatalogResult<Vec<BranchRef>> {
+        let resp = self
+            .inner
+            .load_table(&table.namespace, &table.name)
+            .await
+            .map_err(icebergerror_into_catalog)?;
+
+        // `refs` is an unordered map on the wire; collect first then
+        // sort by name to keep the projection deterministic across
+        // calls. Stable output matters for callers that diff
+        // branch-set snapshots.
+        let mut out: Vec<BranchRef> = resp
+            .metadata
+            .refs
+            .into_iter()
+            .map(|(name, snap_ref)| BranchRef {
+                name,
+                snapshot_id: Some(snap_ref.snapshot_id),
+                kind: parse_branch_kind(&snap_ref.kind),
+            })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
     }
 
     async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
@@ -250,6 +311,109 @@ fn format_table(table: &TableRef) -> String {
     parts.extend(table.namespace.iter().cloned());
     parts.push(table.name.clone());
     parts.join(".")
+}
+
+/// Build the Iceberg [`CreateTableRequest`] body from the
+/// catalog-agnostic [`TableSchema`].
+///
+/// Field ids are assigned sequentially from 1 — Iceberg requires every
+/// field to have a stable id and the trait-level [`TableSchema`] does
+/// not carry one. `required` is the inverse of `nullable`. The
+/// `type_str` is forwarded as-is into a JSON string value; Iceberg's
+/// wire format accepts primitive type names (`"long"`, `"string"`,
+/// `"double"`, ...) as bare strings, so the common case is a clean
+/// round-trip. Type strings that were originally a nested JSON object
+/// (lists, maps, structs) come through `describe_table` as a serialised
+/// JSON string and would arrive here as that string — this is the
+/// known one-way trip noted in [`render_type`]. Callers with richer
+/// schema information (full Iceberg `Schema`) should call
+/// [`IcebergCatalogClient::create_table`] directly.
+fn build_create_table_request(name: &str, schema: &TableSchema) -> CreateTableRequest {
+    let fields = schema
+        .columns
+        .iter()
+        .enumerate()
+        .map(|(idx, col)| CreateTableField {
+            id: (idx as i64) + 1,
+            name: col.name.clone(),
+            required: !col.nullable,
+            type_repr: serde_json::Value::String(col.type_str.clone()),
+        })
+        .collect();
+
+    CreateTableRequest {
+        name: name.to_owned(),
+        schema: CreateTableSchema {
+            schema_type: "struct",
+            schema_id: 0,
+            fields,
+        },
+    }
+}
+
+/// Build one `CommitTableRequest` from a catalog-agnostic [`TableCommit`].
+///
+/// The v1 translation pins the convention `main` as the branch this
+/// commit advances. The trait's CAS contract maps to two Iceberg
+/// primitives:
+///
+/// - [`TableCommit::expected_snapshot_id`] = `Some(id)` → an
+///   `assert-ref-snapshot-id` requirement on `main` pinning the base
+///   snapshot to `id`. A concurrent writer that landed against the same
+///   base fails this CAS and surfaces as
+///   [`CatalogError::CommitConflict`].
+/// - [`TableCommit::expected_snapshot_id`] = `None` → an `assert-create`
+///   requirement, used when the commit creates the table.
+///
+/// The update is a `set-snapshot-ref` advancing `main` to
+/// [`TableCommit::new_snapshot_id`]. This assumes the new snapshot
+/// already exists in the table's metadata (real callers write the
+/// snapshot row + manifest list first, then call commit). Richer
+/// commit shapes (schema updates, partition spec changes, multiple ref
+/// advances) belong on per-adapter extension surfaces rather than the
+/// converged trait.
+fn build_commit_table_request(commit: &TableCommit) -> CommitTableRequest {
+    let requirement = match commit.expected_snapshot_id {
+        Some(snapshot_id) => json!({
+            "type": "assert-ref-snapshot-id",
+            "ref": "main",
+            "snapshot-id": snapshot_id,
+        }),
+        None => json!({
+            "type": "assert-create",
+        }),
+    };
+
+    let update = json!({
+        "action": "set-snapshot-ref",
+        "ref-name": "main",
+        "type": "branch",
+        "snapshot-id": commit.new_snapshot_id,
+    });
+
+    CommitTableRequest {
+        identifier: CommitTableIdentifier {
+            namespace: commit.table.namespace.clone(),
+            name: commit.table.name.clone(),
+        },
+        requirements: vec![requirement],
+        updates: vec![update],
+    }
+}
+
+/// Project an Iceberg `SnapshotReference.type` string onto the
+/// catalog-agnostic [`BranchKind`].
+///
+/// The spec defines `"branch"` and `"tag"`; future spec revisions could
+/// in principle add more variants. We default unknown kinds to
+/// `Branch` because that is the safer assumption for mutation-policy
+/// callers — treating an unfamiliar ref as a *tag* (immutable) could
+/// hide real divergence, whereas treating it as a branch surfaces it.
+fn parse_branch_kind(s: &str) -> BranchKind {
+    match s {
+        "tag" => BranchKind::Tag,
+        _ => BranchKind::Branch,
+    }
 }
 
 #[cfg(test)]
@@ -375,5 +539,116 @@ mod tests {
         };
         let mapped: CatalogError = err.into();
         assert!(matches!(mapped, CatalogError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn build_create_table_request_assigns_sequential_ids() {
+        let schema = TableSchema {
+            columns: vec![
+                ColumnSchema {
+                    name: "id".into(),
+                    type_str: "long".into(),
+                    nullable: false,
+                },
+                ColumnSchema {
+                    name: "name".into(),
+                    type_str: "string".into(),
+                    nullable: true,
+                },
+            ],
+        };
+        let req = build_create_table_request("orders", &schema);
+        assert_eq!(req.name, "orders");
+        assert_eq!(req.schema.schema_type, "struct");
+        assert_eq!(req.schema.schema_id, 0);
+        assert_eq!(req.schema.fields.len(), 2);
+
+        assert_eq!(req.schema.fields[0].id, 1);
+        assert_eq!(req.schema.fields[0].name, "id");
+        assert!(req.schema.fields[0].required, "non-nullable → required");
+        assert_eq!(
+            req.schema.fields[0].type_repr,
+            serde_json::Value::String("long".into())
+        );
+
+        assert_eq!(req.schema.fields[1].id, 2);
+        assert_eq!(req.schema.fields[1].name, "name");
+        assert!(
+            !req.schema.fields[1].required,
+            "nullable → required = false"
+        );
+    }
+
+    #[test]
+    fn build_create_table_request_serialises_to_spec_wire_format() {
+        let schema = TableSchema {
+            columns: vec![ColumnSchema {
+                name: "id".into(),
+                type_str: "long".into(),
+                nullable: false,
+            }],
+        };
+        let req = build_create_table_request("orders", &schema);
+        let v: serde_json::Value = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["name"], "orders");
+        assert_eq!(v["schema"]["type"], "struct");
+        assert_eq!(v["schema"]["schema-id"], 0);
+        assert_eq!(v["schema"]["fields"][0]["id"], 1);
+        assert_eq!(v["schema"]["fields"][0]["name"], "id");
+        assert_eq!(v["schema"]["fields"][0]["required"], true);
+        assert_eq!(v["schema"]["fields"][0]["type"], "long");
+    }
+
+    #[test]
+    fn build_commit_table_request_uses_assert_ref_when_base_pinned() {
+        let commit = TableCommit {
+            table: TableRef {
+                catalog: None,
+                namespace: vec!["analytics".into()],
+                name: "orders".into(),
+            },
+            expected_snapshot_id: Some(42),
+            new_snapshot_id: 43,
+        };
+        let req = build_commit_table_request(&commit);
+        assert_eq!(req.identifier.namespace, vec!["analytics".to_string()]);
+        assert_eq!(req.identifier.name, "orders");
+        assert_eq!(req.requirements.len(), 1);
+        assert_eq!(req.requirements[0]["type"], "assert-ref-snapshot-id");
+        assert_eq!(req.requirements[0]["ref"], "main");
+        assert_eq!(req.requirements[0]["snapshot-id"], 42);
+
+        assert_eq!(req.updates.len(), 1);
+        assert_eq!(req.updates[0]["action"], "set-snapshot-ref");
+        assert_eq!(req.updates[0]["ref-name"], "main");
+        assert_eq!(req.updates[0]["type"], "branch");
+        assert_eq!(req.updates[0]["snapshot-id"], 43);
+    }
+
+    #[test]
+    fn build_commit_table_request_uses_assert_create_when_no_base() {
+        let commit = TableCommit {
+            table: TableRef {
+                catalog: None,
+                namespace: vec!["analytics".into()],
+                name: "orders".into(),
+            },
+            expected_snapshot_id: None,
+            new_snapshot_id: 1,
+        };
+        let req = build_commit_table_request(&commit);
+        assert_eq!(req.requirements[0]["type"], "assert-create");
+    }
+
+    #[test]
+    fn parse_branch_kind_recognises_tag() {
+        assert!(matches!(parse_branch_kind("tag"), BranchKind::Tag));
+    }
+
+    #[test]
+    fn parse_branch_kind_defaults_unknown_to_branch() {
+        assert!(matches!(parse_branch_kind("branch"), BranchKind::Branch));
+        assert!(matches!(parse_branch_kind("rollback"), BranchKind::Branch));
+        assert!(matches!(parse_branch_kind(""), BranchKind::Branch));
     }
 }

--- a/engine/crates/rocky-iceberg/src/client.rs
+++ b/engine/crates/rocky-iceberg/src/client.rs
@@ -1,13 +1,15 @@
 //! Async Iceberg REST Catalog API client.
 //!
 //! Wraps the [Iceberg REST Catalog API](https://iceberg.apache.org/spec/#rest-catalog)
-//! to list namespaces and tables. This is a metadata-only client -- it does not
+//! to list namespaces and tables, load and create / drop tables, and commit
+//! multi-table transactions. This is a metadata-only client -- it does not
 //! read Iceberg data files.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
-use reqwest::Client;
+use reqwest::{Client, RequestBuilder};
 
 /// Build the shared `reqwest::Client` used for every Iceberg REST
 /// catalog call. `Client::new()` left both connect and request
@@ -104,8 +106,8 @@ pub struct LoadTableResponse {
 /// The on-the-wire document is large (snapshots, manifests, partition
 /// specs, sort orders, refs, properties); this struct only models the
 /// fields needed to project the current column schema onto a
-/// `TableSchema`. Unknown fields are ignored by serde's default
-/// behaviour.
+/// `TableSchema` and to enumerate branch / tag references. Unknown
+/// fields are ignored by serde's default behaviour.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TableMetadata {
     /// Schema id of the current schema, used to pick the right entry
@@ -116,6 +118,15 @@ pub struct TableMetadata {
     /// The set of schemas the table has ever had; the entry with
     /// `schema-id == current_schema_id` is the active one.
     pub schemas: Vec<IcebergSchema>,
+    /// Named branch / tag references (keyed by ref name).
+    ///
+    /// Per the Iceberg v2 spec, `refs` is a top-level map embedded in
+    /// table metadata that names every branch (mutable head) and tag
+    /// (immutable label) attached to the table. Older catalogs may omit
+    /// the field entirely; serde defaults the missing case to an empty
+    /// map.
+    #[serde(default)]
+    pub refs: HashMap<String, SnapshotReference>,
 }
 
 /// One entry in [`TableMetadata::schemas`].
@@ -144,6 +155,111 @@ pub struct IcebergField {
     /// Type representation; either a primitive string or a JSON object.
     #[serde(rename = "type")]
     pub type_repr: serde_json::Value,
+}
+
+/// An entry in [`TableMetadata::refs`] — a named branch or tag.
+///
+/// Iceberg's spec models branches and tags as `SnapshotReference`
+/// entries embedded in table metadata. Each carries the snapshot id it
+/// points at and a `type` discriminator (`"branch"` or `"tag"`). Other
+/// fields (`max-ref-age-ms`, `min-snapshots-to-keep`, etc.) are
+/// retention hints the caller does not need to project, so they are
+/// intentionally not modelled.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SnapshotReference {
+    /// The snapshot id this reference points at.
+    #[serde(rename = "snapshot-id")]
+    pub snapshot_id: i64,
+    /// Reference kind: `"branch"` for a mutable head, `"tag"` for an
+    /// immutable label. Left as a string here so unknown future
+    /// variants survive deserialisation; the catalog-agnostic
+    /// projection in `IcebergCatalogClientAdapter::list_branches`
+    /// classifies it.
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+/// Request body for `POST /v1/namespaces/{ns}/tables`.
+///
+/// The Iceberg REST `CreateTableRequest` carries a name and a schema at
+/// minimum; partition specs, sort orders, table properties, location
+/// hints, and stage-create flags are spec-optional and intentionally
+/// not modelled until a caller needs them. The fields are flat-cased to
+/// match the spec's wire shape (`name`, `schema`).
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateTableRequest {
+    /// Unqualified table name. The catalog scopes it to the
+    /// `{ns}`-path namespace under which the request is issued.
+    pub name: String,
+    /// Iceberg schema (fields + types + schema-id).
+    pub schema: CreateTableSchema,
+}
+
+/// Schema payload inside [`CreateTableRequest`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateTableSchema {
+    /// Always `"struct"` for a top-level table schema. The spec models a
+    /// schema as a struct of nested fields; the type tag is required.
+    #[serde(rename = "type")]
+    pub schema_type: &'static str,
+    /// Schema-id; first revision is `0` by convention.
+    #[serde(rename = "schema-id")]
+    pub schema_id: i64,
+    /// Columns in declaration order.
+    pub fields: Vec<CreateTableField>,
+}
+
+/// One column inside [`CreateTableSchema`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateTableField {
+    /// Stable field id. Assigned sequentially from 1 by the caller.
+    pub id: i64,
+    /// Column name.
+    pub name: String,
+    /// Whether the column is required (`NOT NULL`).
+    pub required: bool,
+    /// Iceberg type. Primitive types are flat strings (`"long"`,
+    /// `"string"`, `"double"`); nested types are a JSON object. The
+    /// catalog-agnostic `TableSchema` only carries a string, so this
+    /// field always serialises as a JSON string when produced from a
+    /// reverse conversion — adapters that have richer schema
+    /// information should call this method directly.
+    #[serde(rename = "type")]
+    pub type_repr: serde_json::Value,
+}
+
+/// Request body for `POST /v1/transactions/commit`.
+///
+/// The spec wraps a list of [`CommitTableRequest`] entries. Each entry
+/// targets one table and carries the CAS pre-condition (`requirements`)
+/// and the metadata mutation (`updates`).
+#[derive(Debug, Clone, Serialize)]
+pub struct CommitTransactionRequest {
+    /// One entry per table in the transaction.
+    #[serde(rename = "table-changes")]
+    pub table_changes: Vec<CommitTableRequest>,
+}
+
+/// One table's contribution to a `POST /v1/transactions/commit`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CommitTableRequest {
+    /// Fully qualified table identifier (namespace parts + name).
+    pub identifier: CommitTableIdentifier,
+    /// Pre-conditions the commit asserts. Spec example: an
+    /// `assert-ref-snapshot-id` on `main` to pin the base snapshot.
+    pub requirements: Vec<serde_json::Value>,
+    /// Mutations the commit applies. Spec example: `set-snapshot-ref`
+    /// advancing the `main` branch to a new snapshot.
+    pub updates: Vec<serde_json::Value>,
+}
+
+/// Wire-format identifier inside [`CommitTableRequest`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CommitTableIdentifier {
+    /// Namespace as a slice of parts.
+    pub namespace: Vec<String>,
+    /// Table name.
+    pub name: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -263,23 +379,186 @@ impl IcebergCatalogClient {
         Ok(resp)
     }
 
+    /// Create a new table under `namespace`.
+    ///
+    /// Targets `POST /v1/namespaces/{ns}/tables` with the
+    /// [`CreateTableRequest`] body. The catalog returns the freshly
+    /// created [`LoadTableResponse`] on success — callers that only
+    /// care about the side-effect can discard it. 404 from this
+    /// endpoint typically means the parent namespace is missing rather
+    /// than a table-not-found; the adapter rewrites the default 404
+    /// mapping accordingly.
+    pub async fn create_table(
+        &self,
+        namespace: &[String],
+        request: &CreateTableRequest,
+    ) -> Result<LoadTableResponse, IcebergError> {
+        let encoded_ns = encode_namespace_parts(namespace);
+        let url = format!("{}/v1/namespaces/{}/tables", self.base_url, encoded_ns);
+        let resp: LoadTableResponse = self.post(&url, request).await?;
+        debug!(
+            namespace = ?namespace,
+            name = %request.name,
+            "created Iceberg table"
+        );
+        Ok(resp)
+    }
+
+    /// Drop a table from the catalog.
+    ///
+    /// Targets `DELETE /v1/namespaces/{ns}/tables/{name}`. The Iceberg
+    /// REST spec returns 204 No Content on success; callers should not
+    /// assume the underlying object storage is reclaimed (that depends
+    /// on the catalog's `purge` policy).
+    pub async fn drop_table(&self, namespace: &[String], name: &str) -> Result<(), IcebergError> {
+        let encoded_ns = encode_namespace_parts(namespace);
+        let encoded_name = utf8_percent_encode(name, PATH_SAFE).to_string();
+        let url = format!(
+            "{}/v1/namespaces/{}/tables/{}",
+            self.base_url, encoded_ns, encoded_name
+        );
+        self.delete(&url).await?;
+        debug!(
+            namespace = ?namespace,
+            name,
+            "dropped Iceberg table"
+        );
+        Ok(())
+    }
+
+    /// Commit a multi-table transaction.
+    ///
+    /// Targets `POST /v1/transactions/commit`. The catalog applies all
+    /// `table-changes` atomically: every requirement passes its CAS
+    /// check and every update lands, or nothing does. A 409 response
+    /// indicates a concurrent writer landed against the same base
+    /// snapshot; the call site is expected to surface this as
+    /// [`crate::CatalogError::CommitConflict`] and let the caller retry
+    /// after re-reading state.
+    pub async fn commit_transaction(
+        &self,
+        request: &CommitTransactionRequest,
+    ) -> Result<(), IcebergError> {
+        let url = format!("{}/v1/transactions/commit", self.base_url);
+        self.post_no_response(&url, request).await?;
+        debug!(
+            table_count = request.table_changes.len(),
+            "committed Iceberg transaction"
+        );
+        Ok(())
+    }
+
     /// Internal GET with retry on transient errors.
+    ///
+    /// Thin wrapper over [`Self::send_with_retry`] specialised for
+    /// idempotent GETs: timeouts and connect failures are both safe to
+    /// retry because the request cannot have side-effected the server.
     async fn get<T: serde::de::DeserializeOwned>(&self, url: &str) -> Result<T, IcebergError> {
+        let resp = self
+            .send_with_retry("GET", url, RetryClass::Idempotent, || {
+                self.bearer(self.client.get(url))
+            })
+            .await?;
+        Self::parse_json(resp).await
+    }
+
+    /// Internal POST with retry, returning the deserialised body.
+    ///
+    /// POST is treated as non-idempotent: timeouts after the request
+    /// landed cannot be safely retried (the server may have applied the
+    /// effect), so only `is_connect()` failures are retried at the
+    /// transport layer. 429 and 5xx are still retried — 429 is the
+    /// server explicitly inviting retry, and 5xx retry on POST is
+    /// industry-common; the trade-off is documented at-least-once
+    /// semantics on the call site (`commit_transaction` specifically
+    /// notes this).
+    async fn post<TReq: serde::Serialize, TResp: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        body: &TReq,
+    ) -> Result<TResp, IcebergError> {
+        let resp = self
+            .send_with_retry("POST", url, RetryClass::NonIdempotent, || {
+                self.bearer(self.client.post(url).json(body))
+            })
+            .await?;
+        Self::parse_json(resp).await
+    }
+
+    /// Internal POST that discards the response body.
+    ///
+    /// Same retry semantics as [`Self::post`]; used when the spec returns
+    /// 204 No Content or when the caller does not need to consume the
+    /// response (`POST /v1/transactions/commit`).
+    async fn post_no_response<TReq: serde::Serialize>(
+        &self,
+        url: &str,
+        body: &TReq,
+    ) -> Result<(), IcebergError> {
+        self.send_with_retry("POST", url, RetryClass::NonIdempotent, || {
+            self.bearer(self.client.post(url).json(body))
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Internal DELETE with retry on transient errors.
+    ///
+    /// DELETE is idempotent by spec: re-issuing it against an
+    /// already-deleted resource yields a 404, which the caller is
+    /// expected to handle as `TableNotFound`. Same retry envelope as
+    /// [`Self::get`].
+    async fn delete(&self, url: &str) -> Result<(), IcebergError> {
+        self.send_with_retry("DELETE", url, RetryClass::Idempotent, || {
+            self.bearer(self.client.delete(url))
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Attach Bearer auth to a request builder when a token is set.
+    fn bearer(&self, mut req: RequestBuilder) -> RequestBuilder {
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose());
+        }
+        req
+    }
+
+    /// Send a request with retry, returning the raw success response.
+    ///
+    /// The `build` closure is invoked once per attempt so that POST /
+    /// PUT bodies (which `RequestBuilder` consumes by value on `send`)
+    /// can be rebuilt cleanly across retries. `class` controls which
+    /// transport-level failures are eligible for retry; see
+    /// [`RetryClass`].
+    ///
+    /// The success contract: returns `Ok(resp)` for `2xx`. Returns the
+    /// usual [`IcebergError`] for everything else, including
+    /// [`IcebergError::RateLimited`] once 429 retries are exhausted.
+    /// Non-success bodies are buffered as UTF-8 lossily — the caller
+    /// gets the response text as part of [`IcebergError::Api`].
+    async fn send_with_retry<F>(
+        &self,
+        method: &'static str,
+        url: &str,
+        class: RetryClass,
+        mut build: F,
+    ) -> Result<reqwest::Response, IcebergError>
+    where
+        F: FnMut() -> RequestBuilder,
+    {
         for attempt in 0..=self.retry.max_retries {
-            debug!(url, attempt, "GET");
+            debug!(method, url, attempt, "sending request");
 
-            let mut req = self.client.get(url);
-            if let Some(token) = &self.auth_token {
-                req = req.bearer_auth(token.expose());
-            }
-
+            let req = build();
             let resp = match req.send().await {
                 Ok(r) => r,
                 Err(e)
-                    if attempt < self.retry.max_retries && (e.is_connect() || e.is_timeout()) =>
+                    if attempt < self.retry.max_retries && is_retriable_send_error(&e, class) =>
                 {
                     let backoff = retry_backoff(&self.retry, attempt);
                     warn!(
+                        method,
                         attempt = attempt + 1,
                         backoff_ms = backoff.as_millis() as u64,
                         error = %e,
@@ -295,6 +574,7 @@ impl IcebergCatalogClient {
                 if attempt < self.retry.max_retries {
                     let backoff = retry_backoff(&self.retry, attempt);
                     warn!(
+                        method,
                         attempt = attempt + 1,
                         backoff_ms = backoff.as_millis() as u64,
                         "rate limited, retrying"
@@ -309,6 +589,7 @@ impl IcebergCatalogClient {
                 let status = resp.status().as_u16();
                 let backoff = retry_backoff(&self.retry, attempt);
                 warn!(
+                    method,
                     attempt = attempt + 1,
                     status,
                     backoff_ms = backoff.as_millis() as u64,
@@ -327,12 +608,41 @@ impl IcebergCatalogClient {
                 });
             }
 
-            return resp.json().await.map_err(|e| {
-                IcebergError::UnexpectedResponse(format!("failed to parse response: {e}"))
-            });
+            return Ok(resp);
         }
 
         unreachable!("retry loop should always return")
+    }
+
+    /// Parse a successful response as JSON; surface deser failures as
+    /// [`IcebergError::UnexpectedResponse`] rather than transport errors.
+    async fn parse_json<T: serde::de::DeserializeOwned>(
+        resp: reqwest::Response,
+    ) -> Result<T, IcebergError> {
+        resp.json()
+            .await
+            .map_err(|e| IcebergError::UnexpectedResponse(format!("failed to parse response: {e}")))
+    }
+}
+
+/// Whether the request is safe to retry after a partial-send failure.
+///
+/// `Idempotent` (GET, DELETE) tolerates connect and timeout errors —
+/// the server either never saw the request or, in the DELETE case,
+/// applied it once and a retry is a 404. `NonIdempotent` (POST without
+/// idempotency keys) only retries `is_connect()` failures, where the
+/// request demonstrably did not reach the server.
+#[derive(Debug, Clone, Copy)]
+enum RetryClass {
+    Idempotent,
+    NonIdempotent,
+}
+
+/// Classify a `reqwest::Error` as retriable for the given class.
+fn is_retriable_send_error(e: &reqwest::Error, class: RetryClass) -> bool {
+    match class {
+        RetryClass::Idempotent => e.is_connect() || e.is_timeout(),
+        RetryClass::NonIdempotent => e.is_connect(),
     }
 }
 

--- a/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
@@ -7,14 +7,17 @@
 //! payload, and that the `CatalogClient` implementation maps REST
 //! status codes onto the appropriate `CatalogError` variants.
 
-use rocky_catalog_core::{CatalogClient, CatalogError, Grant, TableRef};
+use rocky_catalog_core::{
+    BranchKind, CatalogClient, CatalogError, ColumnSchema, Grant, TableCommit, TableRef,
+    TableSchema,
+};
 use rocky_core::source::FailedSourceErrorClass;
 use rocky_core::traits::DiscoveryAdapter;
 use rocky_iceberg::IcebergCatalogClientAdapter;
 use rocky_iceberg::adapter::IcebergDiscoveryAdapter;
 use rocky_iceberg::client::IcebergCatalogClient;
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -369,38 +372,436 @@ async fn governance_methods_all_return_unsupported_operation() {
     ));
 }
 
-#[tokio::test]
-async fn deferred_lifecycle_methods_return_unsupported_operation() {
-    let server = MockServer::start().await;
-    let client = IcebergCatalogClient::new(&server.uri(), None);
-    let adapter = IcebergCatalogClientAdapter::new(client);
-    let table = TableRef {
+// ---------------------------------------------------------------------------
+// Lifecycle method tests — PR-3
+// ---------------------------------------------------------------------------
+
+fn sample_table() -> TableRef {
+    TableRef {
         catalog: None,
         namespace: vec!["analytics".into()],
         name: "orders".into(),
-    };
-    let schema = rocky_catalog_core::TableSchema {
-        columns: vec![rocky_catalog_core::ColumnSchema {
-            name: "id".into(),
-            type_str: "long".into(),
-            nullable: false,
-        }],
-    };
+    }
+}
 
-    assert!(matches!(
-        adapter.create_table(&table, &schema).await.unwrap_err(),
-        CatalogError::UnsupportedOperation(_)
-    ));
-    assert!(matches!(
-        adapter.drop_table(&table).await.unwrap_err(),
-        CatalogError::UnsupportedOperation(_)
-    ));
-    assert!(matches!(
-        adapter.commit_transaction(&[]).await.unwrap_err(),
-        CatalogError::UnsupportedOperation(_)
-    ));
-    assert!(matches!(
-        adapter.list_branches(&table).await.unwrap_err(),
-        CatalogError::UnsupportedOperation(_)
-    ));
+fn sample_schema() -> TableSchema {
+    TableSchema {
+        columns: vec![
+            ColumnSchema {
+                name: "id".into(),
+                type_str: "long".into(),
+                nullable: false,
+            },
+            ColumnSchema {
+                name: "amount".into(),
+                type_str: "double".into(),
+                nullable: true,
+            },
+        ],
+    }
+}
+
+/// Minimal `LoadTableResponse` body — Iceberg REST returns the freshly
+/// created table on `POST /v1/namespaces/{ns}/tables`, so the happy
+/// path needs a body that satisfies our partial deser surface.
+fn minimal_load_table_body() -> serde_json::Value {
+    json!({
+        "metadata-location": "s3://bucket/path/metadata.json",
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [{
+                "schema-id": 0,
+                "fields": [
+                    { "id": 1, "name": "id", "required": true, "type": "long" }
+                ]
+            }]
+        }
+    })
+}
+
+#[tokio::test]
+async fn create_table_happy_path_posts_to_namespace_endpoint() {
+    let server = MockServer::start().await;
+
+    // Expected wire body: name + schema with fields + sequential ids.
+    let expected_body = json!({
+        "name": "orders",
+        "schema": {
+            "type": "struct",
+            "schema-id": 0,
+            "fields": [
+                { "id": 1, "name": "id", "required": true, "type": "long" },
+                { "id": 2, "name": "amount", "required": false, "type": "double" }
+            ]
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/namespaces/analytics/tables"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(200).set_body_json(minimal_load_table_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    adapter
+        .create_table(&sample_table(), &sample_schema())
+        .await
+        .expect("create_table should succeed");
+}
+
+#[tokio::test]
+async fn create_table_404_maps_to_namespace_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/namespaces/missing/tables"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("namespace not found"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["missing".into()],
+        name: "orders".into(),
+    };
+    let err = adapter
+        .create_table(&table, &sample_schema())
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::NamespaceNotFound(_)),
+        "expected NamespaceNotFound (rewritten from default TableNotFound), got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_table_409_maps_to_commit_conflict() {
+    // A 409 on create_table indicates a name collision (the catalog's
+    // serial table-name CAS rejected the new row). The trait surfaces
+    // this as `CommitConflict` because the recovery shape is the same
+    // as a transaction CAS failure: re-read state, decide whether to
+    // retry under a different name or abort.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/namespaces/analytics/tables"))
+        .respond_with(ResponseTemplate::new(409).set_body_string("already exists"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let err = adapter
+        .create_table(&sample_table(), &sample_schema())
+        .await
+        .expect_err("409 should not succeed");
+    assert!(
+        matches!(err, CatalogError::CommitConflict(_)),
+        "expected CommitConflict, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn drop_table_happy_path_calls_delete() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/namespaces/analytics/tables/orders"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    adapter
+        .drop_table(&sample_table())
+        .await
+        .expect("drop_table should succeed");
+}
+
+#[tokio::test]
+async fn drop_table_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/namespaces/analytics/tables/missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("table does not exist"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "missing".into(),
+    };
+    let err = adapter
+        .drop_table(&table)
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::TableNotFound(_)),
+        "expected TableNotFound (default), got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn commit_transaction_happy_path_assert_ref_snapshot_id() {
+    let server = MockServer::start().await;
+
+    let expected_body = json!({
+        "table-changes": [{
+            "identifier": {
+                "namespace": ["analytics"],
+                "name": "orders"
+            },
+            "requirements": [{
+                "type": "assert-ref-snapshot-id",
+                "ref": "main",
+                "snapshot-id": 42
+            }],
+            "updates": [{
+                "action": "set-snapshot-ref",
+                "ref-name": "main",
+                "type": "branch",
+                "snapshot-id": 43
+            }]
+        }]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/transactions/commit"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let commit = TableCommit {
+        table: sample_table(),
+        expected_snapshot_id: Some(42),
+        new_snapshot_id: 43,
+    };
+    adapter
+        .commit_transaction(&[commit])
+        .await
+        .expect("commit_transaction should succeed");
+}
+
+#[tokio::test]
+async fn commit_transaction_assert_create_when_no_base_snapshot() {
+    let server = MockServer::start().await;
+
+    let expected_body = json!({
+        "table-changes": [{
+            "identifier": {
+                "namespace": ["analytics"],
+                "name": "orders"
+            },
+            "requirements": [{ "type": "assert-create" }],
+            "updates": [{
+                "action": "set-snapshot-ref",
+                "ref-name": "main",
+                "type": "branch",
+                "snapshot-id": 1
+            }]
+        }]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/transactions/commit"))
+        .and(body_json(&expected_body))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let commit = TableCommit {
+        table: sample_table(),
+        expected_snapshot_id: None,
+        new_snapshot_id: 1,
+    };
+    adapter
+        .commit_transaction(&[commit])
+        .await
+        .expect("commit_transaction should succeed");
+}
+
+#[tokio::test]
+async fn commit_transaction_409_maps_to_commit_conflict() {
+    // The discriminating case: 409 on `/v1/transactions/commit` is the
+    // CAS failure the trait contract surfaces as `CommitConflict`.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/transactions/commit"))
+        .respond_with(
+            ResponseTemplate::new(409)
+                .set_body_string("expected ref main at snapshot 42, found 99 — concurrent writer"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let commit = TableCommit {
+        table: sample_table(),
+        expected_snapshot_id: Some(42),
+        new_snapshot_id: 43,
+    };
+    let err = adapter
+        .commit_transaction(&[commit])
+        .await
+        .expect_err("409 should not succeed");
+    assert!(
+        matches!(err, CatalogError::CommitConflict(_)),
+        "expected CommitConflict, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn commit_transaction_empty_slice_is_a_noop() {
+    // No mock — if the adapter fires a request for an empty slice the
+    // test fails because the request is unmatched. Empty short-circuit
+    // lets callers compose commits without special-casing empty
+    // batches.
+    let server = MockServer::start().await;
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    adapter
+        .commit_transaction(&[])
+        .await
+        .expect("empty commit slice should be a no-op");
+}
+
+#[tokio::test]
+async fn list_branches_projects_refs_to_branch_refs() {
+    let server = MockServer::start().await;
+
+    // `load_table` body with two refs: main (branch, snapshot 1) and
+    // v1.0.0 (tag, snapshot 2).
+    let body = json!({
+        "metadata-location": "s3://bucket/path/metadata.json",
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [{
+                "schema-id": 0,
+                "fields": [
+                    { "id": 1, "name": "id", "required": true, "type": "long" }
+                ]
+            }],
+            "refs": {
+                "main": { "snapshot-id": 1, "type": "branch" },
+                "v1.0.0": { "snapshot-id": 2, "type": "tag" }
+            }
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/orders"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let branches = adapter
+        .list_branches(&sample_table())
+        .await
+        .expect("list_branches should succeed");
+
+    // Sorted by name for determinism.
+    assert_eq!(branches.len(), 2);
+    assert_eq!(branches[0].name, "main");
+    assert_eq!(branches[0].snapshot_id, Some(1));
+    assert!(matches!(branches[0].kind, BranchKind::Branch));
+
+    assert_eq!(branches[1].name, "v1.0.0");
+    assert_eq!(branches[1].snapshot_id, Some(2));
+    assert!(matches!(branches[1].kind, BranchKind::Tag));
+}
+
+#[tokio::test]
+async fn list_branches_returns_empty_when_refs_missing() {
+    // Older catalogs may omit `refs` from the metadata entirely.
+    // serde's `#[serde(default)]` means we get an empty HashMap rather
+    // than a deser failure.
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "metadata-location": "s3://bucket/path/metadata.json",
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [{
+                "schema-id": 0,
+                "fields": [
+                    { "id": 1, "name": "id", "required": true, "type": "long" }
+                ]
+            }]
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/orders"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let branches = adapter
+        .list_branches(&sample_table())
+        .await
+        .expect("list_branches should succeed when refs absent");
+    assert!(branches.is_empty());
+}
+
+#[tokio::test]
+async fn list_branches_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("table does not exist"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "missing".into(),
+    };
+    let err = adapter
+        .list_branches(&table)
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::TableNotFound(_)),
+        "expected TableNotFound, got {err:?}"
+    );
 }


### PR DESCRIPTION
## Summary

- Implements the four `CatalogClient` lifecycle methods that PR-2 deferred on `IcebergCatalogClientAdapter`: `create_table`, `drop_table`, `commit_transaction`, `list_branches`.
- Adds POST + DELETE support to `IcebergCatalogClient` by generalising the GET-only retry loop into a method-parametric `send_with_retry` helper. A `RetryClass` enum gates transport-error retries: idempotent verbs (GET, DELETE) tolerate connect + timeout errors; non-idempotent POST only retries `is_connect()` failures so a post-send timeout cannot double-apply.
- Extends `TableMetadata` with a `refs` map (serde-defaulted) so `list_branches` projects Iceberg's embedded `SnapshotReference` entries onto `Vec<BranchRef>` without an extra round-trip. `commit_transaction` translates the trait's CAS contract to Iceberg `assert-ref-snapshot-id` / `assert-create` requirements + `set-snapshot-ref` updates on the `main` branch.

### Error mapping

| Method | 404 maps to | 409 maps to |
|---|---|---|
| `create_table` | `NamespaceNotFound` (parent ns missing) | `CommitConflict` (name collision) |
| `drop_table` | `TableNotFound` (default) | n/a |
| `commit_transaction` | `TableNotFound` (default) | `CommitConflict` (CAS failure) |
| `list_branches` | `TableNotFound` (via `load_table`) | n/a |

### v1 contract notes

- `commit_transaction` pins `main` as the branch each commit advances. Multi-ref commits, schema updates, and partition spec changes are out of scope and belong on per-adapter extension surfaces.
- `create_table` serialises `TableSchema.type_str` as a JSON string. Primitive Iceberg types round-trip cleanly; columns that came through `describe_table` as a nested JSON string (lists, maps, structs) are a known one-way trip. Callers with richer schema information should call `IcebergCatalogClient::create_table` directly.

## Test plan

- [x] `cargo build -p rocky-iceberg --tests`
- [x] `cargo clippy -p rocky-iceberg --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (full workspace)
- [x] `cargo fmt --check`
- [x] `cargo test -p rocky-iceberg` — 71 unit tests + 22 wiremock tests pass
- [x] 11 new wiremock tests cover all 4 methods' happy paths, the 404 rewrites, `commit_transaction`'s 409 → `CommitConflict`, the empty-slice no-op, and the missing-refs deserialization fallback
- [x] 7 new unit tests cover the request-builder helpers (`build_create_table_request`, `build_commit_table_request`, `parse_branch_kind`)