### PR TITLE
feat(rocky-cli): add data_type to LineageColumnDef

### DIFF
--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -802,10 +802,15 @@ function renderLineageHtml(
   const svgEl   = document.getElementById('graph-svg');
   const focalModel = rawData.model;
 
-  // Build a column lookup from LineageOutput.columns (array of {name}).
-  // key: model name (qualified), value: array of column name strings.
+  // Build a column lookup from LineageOutput.columns (array of {name, data_type?}).
   // NOTE: LineageOutput.columns only contains focal model columns.
-  const focalColumns = (rawData.columns || []).map(c => c.name);
+  // data_type is omitted by the engine when the compiler can't infer a
+  // concrete type (e.g. SELECT * against an uncached upstream). Render the
+  // type only when it's present.
+  const focalColumns = (rawData.columns || []).map(c => ({
+    name: c.name,
+    dataType: typeof c.data_type === 'string' ? c.data_type : null,
+  }));
 
   // Restore saved state (zoom/pan/viewMode) from prior session if available.
   const saved = vscode.getState() || {};
@@ -1165,7 +1170,10 @@ function renderLineageHtml(
       html += '<div class="panel-section-title">Columns (' + focalColumns.length + ')</div>';
       html += '<ul class="column-list">';
       for (const col of focalColumns) {
-        html += '<li><span class="col-name">' + escHtml(col) + '</span></li>';
+        const typePart = col.dataType
+          ? '<span class="col-type">' + escHtml(col.dataType) + '</span>'
+          : '';
+        html += '<li><span class="col-name">' + escHtml(col.name) + '</span>' + typePart + '</li>';
       }
       html += '</ul>';
       html += '</div>';

--- a/editors/vscode/src/types/generated/lineage.ts
+++ b/editors/vscode/src/types/generated/lineage.ts
@@ -21,6 +21,10 @@ export interface LineageOutput {
   [k: string]: unknown;
 }
 export interface LineageColumnDef {
+  /**
+   * Inferred column type, rendered as a Rocky type string (e.g. `STRING`, `INT64`, `DECIMAL(10,2)`, `TIMESTAMP`). Omitted when the type could not be inferred — typically a `SELECT *` against an upstream whose schema isn't cached, or a model that did not pass typecheck.
+   */
+  data_type?: string | null;
   name: string;
   [k: string]: unknown;
 }

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -117,11 +117,24 @@ pub fn run_lineage(
                 .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
                 .map(to_edge_record)
                 .collect();
+            // Look up typed columns for this model from the typecheck
+            // pass so each `LineageColumnDef` can carry its inferred
+            // `data_type`. The typed schema may be absent (e.g. on a
+            // model that failed typecheck) or report `RockyType::Unknown`
+            // for columns it couldn't resolve — both map to `None`.
+            let typed_cols = result.type_check.typed_models.get(model_name);
             let columns: Vec<LineageColumnDef> = schema
                 .columns
                 .iter()
-                .map(|c| LineageColumnDef {
-                    name: c.name.clone(),
+                .map(|c| {
+                    let data_type = typed_cols
+                        .and_then(|cols| cols.iter().find(|t| t.name == c.name))
+                        .filter(|t| !matches!(t.data_type, rocky_ir::types::RockyType::Unknown))
+                        .map(|t| t.data_type.to_string());
+                    LineageColumnDef {
+                        name: c.name.clone(),
+                        data_type,
+                    }
                 })
                 .collect();
             let output = LineageOutput {

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1697,6 +1697,13 @@ pub struct ColumnLineageOutput {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct LineageColumnDef {
     pub name: String,
+    /// Inferred column type, rendered as a Rocky type string (e.g.
+    /// `STRING`, `INT64`, `DECIMAL(10,2)`, `TIMESTAMP`). Omitted when
+    /// the type could not be inferred — typically a `SELECT *` against
+    /// an upstream whose schema isn't cached, or a model that did not
+    /// pass typecheck.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel
 
 
 class LineageColumnDef(BaseModel):
+    data_type: str | None = None
+    """
+    Inferred column type, rendered as a Rocky type string (e.g. `STRING`, `INT64`, `DECIMAL(10,2)`, `TIMESTAMP`). Omitted when the type could not be inferred — typically a `SELECT *` against an upstream whose schema isn't cached, or a model that did not pass typecheck.
+    """
     name: str
 
 

--- a/schemas/lineage.schema.json
+++ b/schemas/lineage.schema.json
@@ -3,6 +3,13 @@
   "definitions": {
     "LineageColumnDef": {
       "properties": {
+        "data_type": {
+          "description": "Inferred column type, rendered as a Rocky type string (e.g. `STRING`, `INT64`, `DECIMAL(10,2)`, `TIMESTAMP`). Omitted when the type could not be inferred — typically a `SELECT *` against an upstream whose schema isn't cached, or a model that did not pass typecheck.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "type": "string"
         }


### PR DESCRIPTION
## Summary

- `rocky lineage <model> --output json` now emits an optional `data_type` on each `LineageColumnDef`, populated from the compiler's typed-models output and rendered via the existing `RockyType` Display impl (`STRING`, `INT64`, `DECIMAL(10,2)`, etc.).
- The field is omitted (`#[serde(skip_serializing_if = "Option::is_none")]`) when the compiler infers `RockyType::Unknown` (e.g. `SELECT *` against an uncached upstream) or no typed schema is available — consumers don't need to handle a sentinel value.
- The VS Code lineage node-details side panel renders the type next to each column name when present, using the pre-existing `.col-type` style (the column list CSS already had `display: flex; justify-content: space-between` and a `.col-type` rule waiting for a type to display).

## Engine cascade

Both the engine struct and the codegen-derived consumer bindings are in this PR:

- `engine/crates/rocky-cli/src/output.rs` — added `data_type: Option<String>` to `LineageColumnDef`.
- `engine/crates/rocky-cli/src/commands/lineage.rs` — populates the field by looking up the model in `result.type_check.typed_models`, filtering out `RockyType::Unknown`.
- `schemas/lineage.schema.json` — regenerated.
- `integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py` — regenerated (`data_type: str | None = None`).
- `editors/vscode/src/types/generated/lineage.ts` — regenerated (`data_type?: string | null`).
- `editors/vscode/src/commands/lineage.ts` — side-panel column list now renders `<span class="col-type">` alongside `<span class="col-name">` when `data_type` is present.

`just codegen` produced exactly these 5 codegen-impacted files; `just regen-fixtures` produced no diff because the lineage POC's leaf model reads from a seed source (`SELECT * FROM seeds.orders`) with no cached schema, so every column types to `Unknown` and the field is correctly omitted.

## Test plan

- [x] `cargo build -p rocky-cli` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rocky-compiler --lib` — 257 pass
- [x] `cargo test -p rocky-cli --lib` — all pass except one flaky redb lock-contention test (`auto_sweep_first_run_stamps_timestamp`) that passes in isolation; unrelated to this change
- [x] `npm run compile` (vscode) clean
- [x] `npm run lint` (vscode) clean
- [x] `npm run test:unit` (vscode) — 106/106 pass
- [x] `uv run pytest` (dagster) — 541/541 pass
- [x] `uv run ruff check && uv run ruff format --check` clean
- [x] `just codegen` clean (regenerates the 4 expected files)
- [x] `just regen-fixtures` produced no fixture diff (consistent with the POC reading from an untyped seed source)
- [ ] Manual: open the VS Code lineage panel on a model where the compiler can infer types and confirm the type renders next to each column name