### PR TITLE
feat(rocky-cli): add target_schema + source_id to LineageOutput nodes

### DIFF
--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -812,6 +812,22 @@ function renderLineageHtml(
     dataType: typeof c.data_type === 'string' ? c.data_type : null,
   }));
 
+  // Build a per-node lookup from LineageOutput.nodes (array of
+  // {model, target_schema?, source_id?}). The engine emits one entry
+  // per distinct model referenced by the focal lineage so the cluster
+  // helpers below can avoid parsing qualified names. Older lineage
+  // JSON cached locally omits this field entirely — the helpers fall
+  // back to the legacy heuristics in that case.
+  const nodeMeta = new Map();
+  for (const node of (rawData.nodes || [])) {
+    if (node && typeof node.model === 'string') {
+      nodeMeta.set(node.model, {
+        targetSchema: typeof node.target_schema === 'string' ? node.target_schema : null,
+        sourceId: typeof node.source_id === 'string' ? node.source_id : null,
+      });
+    }
+  }
+
   // Restore saved state (zoom/pan/viewMode) from prior session if available.
   const saved = vscode.getState() || {};
 
@@ -871,22 +887,31 @@ function renderLineageHtml(
   // ── Cluster key helpers ───────────────────────────────────────────────────────
 
   /**
-   * Derive a schema cluster key from a qualified model name.
+   * Derive a schema cluster key for a node.
+   * Prefers the engine-emitted target_schema (LineageOutput.nodes), and
+   * falls back to splitting the qualified name when the field is absent —
+   * matters for older cached lineage JSON that pre-dates the nodes field.
    * "schema.model"          → cluster key "schema"
    * "catalog.schema.model"  → cluster key "catalog.schema"
    * "model"                 → null (no dots → no cluster)
    */
   function schemaClusterKey(modelId) {
+    const meta = nodeMeta.get(modelId);
+    if (meta && meta.targetSchema) return meta.targetSchema;
     const parts = modelId.split('.');
     if (parts.length < 2) return null;
     return parts.slice(0, -1).join('.');
   }
 
   /**
-   * For Source clustering: only nodes without incoming edges are grouped.
-   * They share a single synthetic cluster "sources".
+   * For Source clustering: prefer the engine-emitted source_id
+   * (LineageOutput.nodes) — present iff the node is an external source.
+   * Falls back to "node has no incoming edges" for older cached JSON.
+   * Either way, matching nodes share a single synthetic cluster "sources".
    */
   function sourceClusterKey(nodeId, hasIncoming) {
+    const meta = nodeMeta.get(nodeId);
+    if (meta) return meta.sourceId ? 'sources' : null;
     return hasIncoming.has(nodeId) ? null : 'sources';
   }
 

--- a/editors/vscode/src/types/generated/lineage.ts
+++ b/editors/vscode/src/types/generated/lineage.ts
@@ -16,6 +16,10 @@ export interface LineageOutput {
   downstream: string[];
   edges: LineageEdgeRecord[];
   model: string;
+  /**
+   * Per-node metadata for every model referenced by this lineage view (the focal model plus each endpoint of `edges`). Lets consumers (e.g. the VS Code subgraph drill-in) cluster nodes by their resolved target schema or source identity instead of parsing the qualified node name. Empty when no nodes were resolved; older JSON payloads cached locally may omit the field entirely.
+   */
+  nodes?: LineageNodeDef[];
   upstream: string[];
   version: string;
   [k: string]: unknown;
@@ -40,5 +44,25 @@ export interface LineageEdgeRecord {
 export interface LineageQualifiedColumn {
   column: string;
   model: string;
+  [k: string]: unknown;
+}
+/**
+ * Per-node metadata for the lineage graph.
+ *
+ * One entry per distinct model referenced by `LineageOutput.edges` (plus the focal model). Carries cluster keys consumers can use to group nodes without having to parse the qualified node name. Either optional field may be absent — `target_schema` is `None` for nodes that aren't project models, and `source_id` is `None` for nodes that are project models (i.e. the two fields are mutually exclusive in practice).
+ */
+export interface LineageNodeDef {
+  /**
+   * Qualified node identifier as it appears in `edges[].source.model` and `edges[].target.model`. Stable across the rest of the payload.
+   */
+  model: string;
+  /**
+   * Source identifier for nodes that represent an external source (i.e. a referenced table outside the project model set). The value mirrors how the SQL referenced the source so consumers can key on it directly. Omitted for project models.
+   */
+  source_id?: string | null;
+  /**
+   * Resolved target schema for project models, from the model's declared target config. Omitted for external sources and any node Rocky couldn't resolve to a project model.
+   */
+  target_schema?: string | null;
   [k: string]: unknown;
 }

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use rocky_compiler::compile::{self, CompilerConfig};
 
 use crate::output::{
-    ColumnLineageOutput, LineageColumnDef, LineageEdgeRecord, LineageOutput,
+    ColumnLineageOutput, LineageColumnDef, LineageEdgeRecord, LineageNodeDef, LineageOutput,
     LineageQualifiedColumn, print_json,
 };
 
@@ -137,6 +137,50 @@ pub fn run_lineage(
                     }
                 })
                 .collect();
+            // Per-node metadata for the focal model + every distinct
+            // endpoint of `edges`. Project models contribute a
+            // `target_schema` from their declared target config; nodes
+            // not present in `project.models` are treated as external
+            // sources and carry their qualified reference string as
+            // `source_id` so the VS Code lineage subgraph drill-in can
+            // cluster them without parsing the qualified name.
+            let mut node_ids: Vec<String> = Vec::new();
+            let mut seen_nodes: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            if seen_nodes.insert(model_name.to_string()) {
+                node_ids.push(model_name.to_string());
+            }
+            for edge in result
+                .semantic_graph
+                .edges
+                .iter()
+                .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
+            {
+                for endpoint in [&edge.source.model, &edge.target.model] {
+                    let name = endpoint.to_string();
+                    if seen_nodes.insert(name.clone()) {
+                        node_ids.push(name);
+                    }
+                }
+            }
+            let nodes: Vec<LineageNodeDef> = node_ids
+                .into_iter()
+                .map(|id| {
+                    if let Some(model) = result.project.model(&id) {
+                        LineageNodeDef {
+                            model: id,
+                            target_schema: Some(model.config.target.schema.clone()),
+                            source_id: None,
+                        }
+                    } else {
+                        LineageNodeDef {
+                            model: id.clone(),
+                            target_schema: None,
+                            source_id: Some(id),
+                        }
+                    }
+                })
+                .collect();
             let output = LineageOutput {
                 version: VERSION.to_string(),
                 command: "lineage".to_string(),
@@ -145,6 +189,7 @@ pub fn run_lineage(
                 upstream: schema.upstream.clone(),
                 downstream: schema.downstream.clone(),
                 edges,
+                nodes,
             };
             print_json(&output)?;
         }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1678,6 +1678,14 @@ pub struct LineageOutput {
     pub upstream: Vec<String>,
     pub downstream: Vec<String>,
     pub edges: Vec<LineageEdgeRecord>,
+    /// Per-node metadata for every model referenced by this lineage view
+    /// (the focal model plus each endpoint of `edges`). Lets consumers
+    /// (e.g. the VS Code subgraph drill-in) cluster nodes by their
+    /// resolved target schema or source identity instead of parsing the
+    /// qualified node name. Empty when no nodes were resolved; older
+    /// JSON payloads cached locally may omit the field entirely.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nodes: Vec<LineageNodeDef>,
 }
 
 /// JSON output for `rocky lineage <model> --column <col>`.
@@ -1704,6 +1712,33 @@ pub struct LineageColumnDef {
     /// pass typecheck.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_type: Option<String>,
+}
+
+/// Per-node metadata for the lineage graph.
+///
+/// One entry per distinct model referenced by `LineageOutput.edges`
+/// (plus the focal model). Carries cluster keys consumers can use to
+/// group nodes without having to parse the qualified node name. Either
+/// optional field may be absent — `target_schema` is `None` for nodes
+/// that aren't project models, and `source_id` is `None` for nodes that
+/// are project models (i.e. the two fields are mutually exclusive in
+/// practice).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LineageNodeDef {
+    /// Qualified node identifier as it appears in `edges[].source.model`
+    /// and `edges[].target.model`. Stable across the rest of the payload.
+    pub model: String,
+    /// Resolved target schema for project models, from the model's
+    /// declared target config. Omitted for external sources and any
+    /// node Rocky couldn't resolve to a project model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_schema: Option<String>,
+    /// Source identifier for nodes that represent an external source
+    /// (i.e. a referenced table outside the project model set). The
+    /// value mirrors how the SQL referenced the source so consumers can
+    /// key on it directly. Omitted for project models.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py
@@ -14,6 +14,27 @@ class LineageColumnDef(BaseModel):
     name: str
 
 
+class LineageNodeDef(BaseModel):
+    """
+    Per-node metadata for the lineage graph.
+
+    One entry per distinct model referenced by `LineageOutput.edges` (plus the focal model). Carries cluster keys consumers can use to group nodes without having to parse the qualified node name. Either optional field may be absent — `target_schema` is `None` for nodes that aren't project models, and `source_id` is `None` for nodes that are project models (i.e. the two fields are mutually exclusive in practice).
+    """
+
+    model: str
+    """
+    Qualified node identifier as it appears in `edges[].source.model` and `edges[].target.model`. Stable across the rest of the payload.
+    """
+    source_id: str | None = None
+    """
+    Source identifier for nodes that represent an external source (i.e. a referenced table outside the project model set). The value mirrors how the SQL referenced the source so consumers can key on it directly. Omitted for project models.
+    """
+    target_schema: str | None = None
+    """
+    Resolved target schema for project models, from the model's declared target config. Omitted for external sources and any node Rocky couldn't resolve to a project model.
+    """
+
+
 class LineageQualifiedColumn(BaseModel):
     column: str
     model: str
@@ -40,5 +61,9 @@ class LineageOutput(BaseModel):
     downstream: list[str]
     edges: list[LineageEdgeRecord]
     model: str
+    nodes: list[LineageNodeDef] | None = None
+    """
+    Per-node metadata for every model referenced by this lineage view (the focal model plus each endpoint of `edges`). Lets consumers (e.g. the VS Code subgraph drill-in) cluster nodes by their resolved target schema or source identity instead of parsing the qualified node name. Empty when no nodes were resolved; older JSON payloads cached locally may omit the field entirely.
+    """
     upstream: list[str]
     version: str

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -65,5 +65,15 @@
       },
       "transform": "direct"
     }
+  ],
+  "nodes": [
+    {
+      "model": "revenue_summary",
+      "target_schema": "gold"
+    },
+    {
+      "model": "customer_orders",
+      "target_schema": "silver"
+    }
   ]
 }

--- a/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/lineage_model.json
@@ -37,5 +37,15 @@
       },
       "transform": "aggregation: sum"
     }
+  ],
+  "nodes": [
+    {
+      "model": "fct_revenue",
+      "target_schema": "demo"
+    },
+    {
+      "model": "stg_orders",
+      "target_schema": "demo"
+    }
   ]
 }

--- a/schemas/lineage.schema.json
+++ b/schemas/lineage.schema.json
@@ -39,6 +39,33 @@
       ],
       "type": "object"
     },
+    "LineageNodeDef": {
+      "description": "Per-node metadata for the lineage graph.\n\nOne entry per distinct model referenced by `LineageOutput.edges` (plus the focal model). Carries cluster keys consumers can use to group nodes without having to parse the qualified node name. Either optional field may be absent — `target_schema` is `None` for nodes that aren't project models, and `source_id` is `None` for nodes that are project models (i.e. the two fields are mutually exclusive in practice).",
+      "properties": {
+        "model": {
+          "description": "Qualified node identifier as it appears in `edges[].source.model` and `edges[].target.model`. Stable across the rest of the payload.",
+          "type": "string"
+        },
+        "source_id": {
+          "description": "Source identifier for nodes that represent an external source (i.e. a referenced table outside the project model set). The value mirrors how the SQL referenced the source so consumers can key on it directly. Omitted for project models.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_schema": {
+          "description": "Resolved target schema for project models, from the model's declared target config. Omitted for external sources and any node Rocky couldn't resolve to a project model.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "model"
+      ],
+      "type": "object"
+    },
     "LineageQualifiedColumn": {
       "properties": {
         "column": {
@@ -80,6 +107,13 @@
     },
     "model": {
       "type": "string"
+    },
+    "nodes": {
+      "description": "Per-node metadata for every model referenced by this lineage view (the focal model plus each endpoint of `edges`). Lets consumers (e.g. the VS Code subgraph drill-in) cluster nodes by their resolved target schema or source identity instead of parsing the qualified node name. Empty when no nodes were resolved; older JSON payloads cached locally may omit the field entirely.",
+      "items": {
+        "$ref": "#/definitions/LineageNodeDef"
+      },
+      "type": "array"
     },
     "upstream": {
       "items": {


### PR DESCRIPTION
## Summary

- `rocky lineage <model> --output json` now emits a `nodes: LineageNodeDef[]` array on `LineageOutput`, with one entry per distinct model referenced by the focal lineage (the focal model plus every endpoint of `edges`).
- Each entry carries cluster keys: `target_schema` for project models (from `model.config.target.schema`) and `source_id` for external references (the qualified table reference as it appears in the model SQL). The two are mutually exclusive in practice, and the field itself is omitted (`#[serde(skip_serializing_if = "Vec::is_empty")]`) when no nodes were resolved, so existing consumers don't need to handle a sentinel value.
- The VS Code lineage subgraph drill-in now consults the engine-emitted fields first and falls back to the legacy heuristics (`schemaClusterKey` dot-parse and `sourceClusterKey` no-incoming-edge) when `rawData.nodes` is absent or empty — preserving back-compat for users with older lineage JSON cached locally.

## Engine cascade

Both the engine struct and the codegen-derived consumer bindings are in this PR:

- `engine/crates/rocky-cli/src/output.rs` — added `LineageNodeDef` and `nodes: Vec<LineageNodeDef>` on `LineageOutput`.
- `engine/crates/rocky-cli/src/commands/lineage.rs` — emission site populates `nodes` from `project.model()` (project models → `target_schema`, external nodes → `source_id`).
- `schemas/lineage.schema.json` — regenerated.
- `integrations/dagster/src/dagster_rocky/types_generated/lineage_schema.py` — regenerated (`nodes: list[LineageNodeDef] | None = None`).
- `editors/vscode/src/types/generated/lineage.ts` — regenerated (`nodes?: LineageNodeDef[]`).
- `editors/vscode/src/commands/lineage.ts` — `schemaClusterKey` / `sourceClusterKey` prefer the engine-emitted fields and fall back to the legacy heuristics.
- `integrations/dagster/tests/fixtures_generated/lineage.json` and `lineage/lineage_model.json` — refreshed via `just regen-fixtures`; both POCs reference project-only models, so the captured entries carry `target_schema` only.

## Back-compat fallback

When `rawData.nodes` is `undefined` or empty (older cached JSON), the renderer's `nodeMeta` lookup stays empty, both cluster-key helpers short-circuit, and the legacy heuristics (`schemaClusterKey` dot-parse, `sourceClusterKey` no-incoming-edge) take over unchanged.

## Test plan

- [x] `cargo build -p rocky-cli` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (full workspace)
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rocky-cli` — 514 pass
- [x] `cargo test -p rocky-compiler --lib` — 257 pass
- [x] `npm run compile` (vscode) clean
- [x] `npm run lint` (vscode) clean
- [x] `npm run test:unit` (vscode) — 106/106 pass
- [x] `uv run pytest` (dagster) — 541/541 pass
- [x] `just codegen` clean — regenerates exactly the 4 expected files (schema + dagster + vscode + project schema copy)
- [x] `just regen-fixtures` captures the two affected lineage fixtures (both POCs are project-only, so only `target_schema` populated)
- [x] Smoke run of `rocky lineage revenue_summary` against the playground POC confirms the new `nodes` array is emitted with the expected `target_schema` values
- [ ] Manual: open the VS Code lineage panel against a project with external sources, switch cluster mode to "schema" / "source", and confirm clusters are derived from the engine-emitted fields