### PR TITLE
feat(rocky-cli): replication [[table_overrides]] with per-field most-specific-match-wins (PR-B3)

### DIFF
--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -155,8 +155,10 @@ All four share `execution`, `checks`, `depends_on`, and `target.adapter`. They d
 ```toml
 [pipeline.raw]
 # type = "replication"               # optional, this is the default
-strategy         = "incremental"     # or "full_refresh"
+strategy         = "incremental"     # or "full_refresh" or "merge"
 timestamp_column = "_fivetran_synced"
+# merge_keys     = ["id"]            # required when strategy = "merge"
+# merge_keys_fallback = ["id"]       # used when merge_keys is unset
 metadata_columns = [
     { name = "_loaded_by", type = "STRING", value = "'rocky'" },
 ]
@@ -169,11 +171,42 @@ separator  = "__"
 components = ["client", "regions...", "connector"]
 # "name"    = single segment
 # "name..." = variable-length (1+)
+# Reserved: `table` and `id` are not allowed as component names
+# (they're consumed by `--filter` and `[[table_overrides]]`).
 
 [pipeline.raw.target]
 catalog_template = "{client}_warehouse"
 schema_template  = "staging__{regions}__{connector}"
+
+# Per-`(connector, table)` overrides on top of the pipeline defaults.
+# Per-field most-specific-match-wins: each field is supplied by the
+# most-specific matching rule that sets it; unrelated rules don't
+# clobber it. See `engine/crates/rocky-core/src/config.rs` ::
+# `TableOverride` for the full surface.
+
+# Skip diagnostic tables on every connector.
+[[pipeline.raw.table_overrides]]
+match.table = "_diagnostics_*"        # `*`/`?` glob in TOML only — CLI literals
+enabled     = false
+
+# `pii_users` on one specific connector needs a composite merge key.
+[[pipeline.raw.table_overrides]]
+match.connector = "stripe_main"        # matches conn.id OR conn.schema
+match.table     = "pii_users"
+merge_keys      = ["user_id", "tenant_id"]
+
+# `audit_log` is append-only — keep it on incremental even when
+# the pipeline default is `merge`.
+[[pipeline.raw.table_overrides]]
+match.connector  = "stripe_main"
+match.table      = "audit_log"
+strategy         = "incremental"
+timestamp_column = "occurred_at"
 ```
+
+**CLI symmetry:** `--filter table=<literal>` filters to one table at a
+time (no globs at the CLI; shell quoting is too fragile). The
+connector-level `--filter id=<conn_id>` keys remain unchanged.
 
 ### Transformation pipeline
 

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2133,6 +2133,13 @@
           "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
           "type": "string"
         },
+        "table_overrides": {
+          "description": "Per-`(connector, table)` overrides applied on top of the pipeline defaults. Each rule matches against a discovered connector + table pair and, when matched, replaces selected pipeline-level fields with override-supplied values.\n\nResolution is **per-field most-specific-match-wins**: for each overrideable field, the most specific matching rule that explicitly sets that field wins; less-specific rules contribute values only for fields they actually set. Specificity ranking (highest to lowest):\n\n1. Both `match.connector` AND `match.table` set, with `match.table` a literal (no glob). 2. Both set, with `match.table` containing a `*` or `?` glob. 3. Only `match.connector` set. 4. Only `match.table` set.\n\nTies at the same specificity tier for a `(connector, table)` pair are rejected at parse time as ambiguous.\n\nEmpty by default — projects that don't need per-table tweaking pay nothing in JSON output, schema surface area, or runtime cost.",
+          "items": {
+            "$ref": "#/definitions/TableOverride"
+          },
+          "type": "array"
+        },
         "target": {
           "allOf": [
             {
@@ -2730,6 +2737,84 @@
           "type": "string"
         }
       ]
+    },
+    "TableMatch": {
+      "additionalProperties": false,
+      "description": "Match criteria for a [`TableOverride`].\n\nAt least one of `connector` or `table` must be set (`None` for both is rejected at parse time as redundant — use pipeline-level fields to change defaults globally).\n\n`connector` matches against either [`crate::source::DiscoveredConnector::id`] (the stable adapter-side identifier — e.g. a Fivetran connector_id) **or** [`crate::source::DiscoveredConnector::schema`] (the human-meaningful source schema name — e.g. `src__acme__shopify`). String equality on either match wins.\n\n`table` matches against [`crate::source::DiscoveredTable::name`]. Supports `*` (zero or more characters) and `?` (exactly one character) glob wildcards; presence of either character switches the value from literal to glob.\n\n# Reserved\n\n`table` and `id` are reserved as schema-pattern component names — configs that use either as a component in [`SchemaPatternConfig::components`] are rejected at parse time to avoid colliding with `--filter table=` and `--filter id=`.",
+      "properties": {
+        "connector": {
+          "description": "Connector match — equals either `DiscoveredConnector.id` or `DiscoveredConnector.schema`. `None` matches every connector.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
+          "description": "Table-name match. Literal when no `*`/`?`; glob otherwise. `None` matches every table.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "TableOverride": {
+      "additionalProperties": false,
+      "description": "A per-`(connector, table)` override rule on a replication pipeline.\n\nAuthored as one TOML array entry under `[[pipeline.<name>.table_overrides]]`. Each field except `match_` is optional — `None` means \"inherit from the pipeline-level default.\" The resolver applies overrides with per-field most-specific-wins semantics; see [`ReplicationPipelineConfig::table_overrides`] for the ranking.\n\n# Example\n\n```toml [[pipeline.raw.table_overrides]] match.connector = \"stripe_main\" match.table     = \"pii_users\" merge_keys      = [\"user_id\", \"tenant_id\"] ```",
+      "properties": {
+        "enabled": {
+          "description": "When `Some(false)`, the matched `(connector, table)` pairs are dropped from the run and surfaced under `RunOutput.excluded_tables` with `reason = \"table_override_disabled\"`. Net-new field with no pipeline-level counterpart — disabling a whole pipeline is already covered by removing the pipeline block.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "match": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TableMatch"
+            }
+          ],
+          "default": {},
+          "description": "Match criteria — at least one of `connector` or `table` must be set. A rule with neither (or a `match` block omitted entirely) is rejected at parse time (use pipeline-level fields to change defaults for all tables). `default` lets serde deserialize an override missing the whole `match` block; the validator catches the resulting empty match."
+        },
+        "merge_keys": {
+          "description": "Override for [`ReplicationPipelineConfig::merge_keys`]. `None` inherits the pipeline default.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "merge_keys_fallback": {
+          "description": "Override for [`ReplicationPipelineConfig::merge_keys_fallback`]. `None` inherits the pipeline default.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "strategy": {
+          "description": "Override for [`ReplicationPipelineConfig::strategy`]. `None` inherits the pipeline default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestamp_column": {
+          "description": "Override for [`ReplicationPipelineConfig::timestamp_column`]. `None` inherits the pipeline default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "TableRef": {
       "additionalProperties": false,

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -774,6 +774,18 @@ export interface ReplicationPipelineConfig {
    */
   strategy?: string;
   /**
+   * Per-`(connector, table)` overrides applied on top of the pipeline defaults. Each rule matches against a discovered connector + table pair and, when matched, replaces selected pipeline-level fields with override-supplied values.
+   *
+   * Resolution is **per-field most-specific-match-wins**: for each overrideable field, the most specific matching rule that explicitly sets that field wins; less-specific rules contribute values only for fields they actually set. Specificity ranking (highest to lowest):
+   *
+   * 1. Both `match.connector` AND `match.table` set, with `match.table` a literal (no glob). 2. Both set, with `match.table` containing a `*` or `?` glob. 3. Only `match.connector` set. 4. Only `match.table` set.
+   *
+   * Ties at the same specificity tier for a `(connector, table)` pair are rejected at parse time as ambiguous.
+   *
+   * Empty by default — projects that don't need per-table tweaking pay nothing in JSON output, schema surface area, or runtime cost.
+   */
+  table_overrides?: TableOverride[];
+  /**
    * Target configuration.
    */
   target: PipelineTargetConfig;
@@ -945,6 +957,64 @@ export interface SchemaPatternConfig {
   components: string[];
   prefix: string;
   separator: string;
+}
+/**
+ * A per-`(connector, table)` override rule on a replication pipeline.
+ *
+ * Authored as one TOML array entry under `[[pipeline.<name>.table_overrides]]`. Each field except `match_` is optional — `None` means "inherit from the pipeline-level default." The resolver applies overrides with per-field most-specific-wins semantics; see [`ReplicationPipelineConfig::table_overrides`] for the ranking.
+ *
+ * # Example
+ *
+ * ```toml [[pipeline.raw.table_overrides]] match.connector = "stripe_main" match.table     = "pii_users" merge_keys      = ["user_id", "tenant_id"] ```
+ */
+export interface TableOverride {
+  /**
+   * When `Some(false)`, the matched `(connector, table)` pairs are dropped from the run and surfaced under `RunOutput.excluded_tables` with `reason = "table_override_disabled"`. Net-new field with no pipeline-level counterpart — disabling a whole pipeline is already covered by removing the pipeline block.
+   */
+  enabled?: boolean | null;
+  /**
+   * Match criteria — at least one of `connector` or `table` must be set. A rule with neither (or a `match` block omitted entirely) is rejected at parse time (use pipeline-level fields to change defaults for all tables). `default` lets serde deserialize an override missing the whole `match` block; the validator catches the resulting empty match.
+   */
+  match?: TableMatch;
+  /**
+   * Override for [`ReplicationPipelineConfig::merge_keys`]. `None` inherits the pipeline default.
+   */
+  merge_keys?: string[] | null;
+  /**
+   * Override for [`ReplicationPipelineConfig::merge_keys_fallback`]. `None` inherits the pipeline default.
+   */
+  merge_keys_fallback?: string[] | null;
+  /**
+   * Override for [`ReplicationPipelineConfig::strategy`]. `None` inherits the pipeline default.
+   */
+  strategy?: string | null;
+  /**
+   * Override for [`ReplicationPipelineConfig::timestamp_column`]. `None` inherits the pipeline default.
+   */
+  timestamp_column?: string | null;
+}
+/**
+ * Match criteria for a [`TableOverride`].
+ *
+ * At least one of `connector` or `table` must be set (`None` for both is rejected at parse time as redundant — use pipeline-level fields to change defaults globally).
+ *
+ * `connector` matches against either [`crate::source::DiscoveredConnector::id`] (the stable adapter-side identifier — e.g. a Fivetran connector_id) **or** [`crate::source::DiscoveredConnector::schema`] (the human-meaningful source schema name — e.g. `src__acme__shopify`). String equality on either match wins.
+ *
+ * `table` matches against [`crate::source::DiscoveredTable::name`]. Supports `*` (zero or more characters) and `?` (exactly one character) glob wildcards; presence of either character switches the value from literal to glob.
+ *
+ * # Reserved
+ *
+ * `table` and `id` are reserved as schema-pattern component names — configs that use either as a component in [`SchemaPatternConfig::components`] are rejected at parse time to avoid colliding with `--filter table=` and `--filter id=`.
+ */
+export interface TableMatch {
+  /**
+   * Connector match — equals either `DiscoveredConnector.id` or `DiscoveredConnector.schema`. `None` matches every connector.
+   */
+  connector?: string | null;
+  /**
+   * Table-name match. Literal when no `*`/`?`; glob otherwise. `None` matches every table.
+   */
+  table?: string | null;
 }
 /**
  * Pipeline target configuration.

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -119,6 +119,10 @@ export interface RunOutput {
   materializations: MaterializationOutput[];
   metrics?: MetricsSnapshot | null;
   /**
+   * Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.
+   */
+  override_warnings?: OverrideWarningOutput[];
+  /**
    * Per-model partition execution summaries, present only when the run touched one or more `time_interval` models. Empty for runs that didn't execute any partitioned models.
    */
   partition_summaries: PartitionSummary[];
@@ -375,6 +379,34 @@ export interface MetricsSnapshot {
   table_duration_p95_ms: number;
   tables_failed: number;
   tables_processed: number;
+  [k: string]: unknown;
+}
+/**
+ * Soft warning surfaced on [`RunOutput::override_warnings`] when an override rule matched no tables this run.
+ *
+ * Distinct kinds let orchestrators (Dagster) branch on cause without parsing free-form messages.
+ */
+export interface OverrideWarningOutput {
+  /**
+   * Echo of `match.connector` from the rule, for cross-reference.
+   */
+  connector?: string | null;
+  /**
+   * Coarse kind: `"zero_match"` (rule matched no pair at all) or `"connector_match_empty"` (the connector half of the match resolved nothing).
+   */
+  kind: string;
+  /**
+   * Human-readable explanation, for logs and Dagster UI rendering.
+   */
+  message: string;
+  /**
+   * Position of the rule in `[[table_overrides]]`, 0-based — same index the validator's error messages use.
+   */
+  rule_index: number;
+  /**
+   * Echo of `match.table` from the rule, for cross-reference.
+   */
+  table?: string | null;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -853,7 +853,7 @@ async fn discover_branch_targets(
     record: &BranchRecord,
     filter: Option<&str>,
 ) -> Result<Vec<PlannedPromote>> {
-    use super::{matches_filter, parse_filter};
+    use super::{filter_table_matches, matches_filter, parse_filter};
     use crate::registry::{self, AdapterRegistry};
 
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
@@ -908,6 +908,10 @@ async fn discover_branch_targets(
         let target_schema = parsed.resolve_template(target_schema_template, target_sep);
 
         for table in &conn.tables {
+            // PR-B3: CLI `--filter table=<literal>` consumed here.
+            if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
+                continue;
+            }
             let prod = TargetRef {
                 catalog: target_catalog.clone(),
                 schema: target_schema.clone(),

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -16,7 +16,7 @@ use rocky_ir::TargetRef;
 use crate::output::{CompareOutput, TableCompareResult, print_json};
 use crate::registry::{self, AdapterRegistry};
 
-use super::{matches_filter, parse_filter};
+use super::{filter_table_matches, matches_filter, parse_filter};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -88,6 +88,10 @@ pub async fn compare(
         let target_schema = parsed.resolve_template(target_schema_template, target_sep);
 
         for table in &conn.tables {
+            // PR-B3: CLI `--filter table=<literal>` consumed here.
+            if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
+                continue;
+            }
             // Build production and shadow target refs
             let prod_target = TargetRef {
                 catalog: target_catalog.clone(),

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -144,7 +144,14 @@ pub(crate) fn parse_filter(filter: &str) -> Result<(String, String)> {
 
 /// Checks if a connector matches a filter.
 ///
-/// The special key `id` matches against the connector's unique identifier.
+/// Reserved keys:
+/// - `id` matches against `DiscoveredConnector.id`.
+/// - `table` is also reserved (used for per-table filtering); the
+///   connector-level filter never accepts it as a schema-component
+///   axis. Callers that need to filter by table name must apply the
+///   `table=` filter on the discovered table list separately. See
+///   [`filter_table_matches`].
+///
 /// All other keys match against parsed schema components.
 pub(crate) fn matches_filter(
     conn: &rocky_core::source::DiscoveredConnector,
@@ -155,6 +162,13 @@ pub(crate) fn matches_filter(
     if filter_key == "id" {
         return conn.id == filter_value;
     }
+    if filter_key == "table" {
+        // `table=` is consumed at the table level — every connector
+        // passes the connector-level filter; the table loop filters
+        // the discovered tables individually via
+        // `filter_table_matches`.
+        return true;
+    }
     match parsed.get(filter_key) {
         Some(val) => val == filter_value,
         None => {
@@ -164,6 +178,27 @@ pub(crate) fn matches_filter(
                 .is_some_and(|vals| vals.iter().any(|v| v == filter_value))
         }
     }
+}
+
+/// Returns true when a `--filter table=<literal>` filter (or no
+/// table filter at all) matches the given table name.
+///
+/// CLI `--filter table=` accepts literals only — no globs. Globs live
+/// in the TOML `[[table_overrides]]` `match.table` grammar instead, to
+/// avoid CLI shell-quoting footguns (`--filter table=*_temp` would be
+/// shell-globbed before reaching Rocky on most shells).
+///
+/// When `filter` is `None` or the key isn't `"table"`, every table
+/// matches (the connector-level filter has already decided whether
+/// this connector is in scope).
+pub(crate) fn filter_table_matches(filter: Option<&(String, String)>, table_name: &str) -> bool {
+    let Some((key, value)) = filter else {
+        return true;
+    };
+    if key != "table" {
+        return true;
+    }
+    table_name == value
 }
 
 /// Converts a ParsedSchema into a JSON-compatible components map.
@@ -286,6 +321,55 @@ mod tests {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
         };
         assert!(!matches_filter(&conn, &parsed, "nonexistent", "value"));
+    }
+
+    #[test]
+    fn test_matches_filter_table_passes_at_connector_level() {
+        // `table=` is the new reserved key — at the connector level,
+        // every connector passes, and the table-level filter
+        // (`filter_table_matches`) handles the actual subsetting.
+        let conn = DiscoveredConnector {
+            id: "conn_123".into(),
+            schema: "test".into(),
+            source_type: "fivetran".into(),
+            last_sync_at: None,
+            tables: vec![],
+            metadata: Default::default(),
+        };
+        let parsed = ParsedSchema {
+            values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
+        };
+        assert!(matches_filter(&conn, &parsed, "table", "anything"));
+    }
+
+    #[test]
+    fn test_filter_table_matches_no_filter_matches_all() {
+        assert!(filter_table_matches(None, "users"));
+        assert!(filter_table_matches(None, "_diagnostics_x"));
+    }
+
+    #[test]
+    fn test_filter_table_matches_non_table_key_passes() {
+        // Connector-level filters don't subset at the table level.
+        let f = ("client".to_string(), "acme".to_string());
+        assert!(filter_table_matches(Some(&f), "users"));
+    }
+
+    #[test]
+    fn test_filter_table_matches_table_literal_subsets() {
+        let f = ("table".to_string(), "pii_users".to_string());
+        assert!(filter_table_matches(Some(&f), "pii_users"));
+        assert!(!filter_table_matches(Some(&f), "orders"));
+    }
+
+    #[test]
+    fn test_filter_table_matches_no_glob_in_cli() {
+        // CLI accepts literals only — globs live in TOML
+        // [[table_overrides]]. A `*` in the filter value is treated
+        // literally (won't match anything in practice).
+        let f = ("table".to_string(), "_diagnostics_*".to_string());
+        assert!(filter_table_matches(Some(&f), "_diagnostics_*"));
+        assert!(!filter_table_matches(Some(&f), "_diagnostics_x"));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -13,7 +13,7 @@ use crate::plan_store::{PlanKind, write_plan};
 use crate::registry;
 
 use super::run::PartitionRunOptions;
-use super::{matches_filter, parse_filter};
+use super::{filter_table_matches, matches_filter, parse_filter};
 
 /// Bundle of `rocky plan` flags that are not consumed by the SQL-generation
 /// preview but are persisted into `RunPlan` so `rocky apply <plan-id>` can
@@ -160,6 +160,10 @@ pub async fn plan(
             String::new()
         };
         for table in &conn.tables {
+            // PR-B3: CLI `--filter table=<literal>` consumed here.
+            if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
+                continue;
+            }
             let metadata_columns: Vec<MetadataColumn> = pipeline
                 .metadata_columns
                 .iter()

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -12,7 +12,9 @@ use tracing::{Instrument, debug, info, info_span, warn};
 use rocky_adapter_sdk::throttle::AdaptiveThrottle;
 
 use rocky_core::checks;
-use rocky_core::config::{GovernanceOverride, ReplicationPipelineConfig};
+use rocky_core::config::{
+    GovernanceOverride, ReplicationPipelineConfig, ResolvedTableOverride, resolve_table_override,
+};
 use rocky_core::drift;
 use rocky_core::hooks::{HookContext, HookRegistry};
 use rocky_core::sql_gen;
@@ -28,7 +30,7 @@ use crate::registry::{self, AdapterRegistry};
 use crate::schema_cache_writer::{SchemaCacheWriteTap, persist_batch_describe};
 
 use super::run_audit::AuditContext;
-use super::{matches_filter, parse_filter, parsed_to_json_map};
+use super::{filter_table_matches, matches_filter, parse_filter, parsed_to_json_map};
 
 /// Accumulated check results for a table, assembled after batched execution.
 struct PendingCheck {
@@ -151,6 +153,13 @@ struct TableTask {
     /// When present, `process_table` skips individual DESCRIBE TABLE calls.
     prefetched_source_cols: Option<Vec<ColumnInfo>>,
     prefetched_target_cols: Option<Vec<ColumnInfo>>,
+    /// Per-table override resolved against
+    /// `ReplicationPipelineConfig::table_overrides` at connector-loop
+    /// time. Empty when no rule matched this `(connector, table)` pair.
+    /// `process_table` reads this when building the materialization
+    /// strategy so per-table overrides apply ahead of pipeline-level
+    /// defaults.
+    effective_override: ResolvedTableOverride,
 }
 
 /// CLI selection state for `time_interval` partition execution.
@@ -1124,6 +1133,12 @@ pub async fn run(
     let mut batch_asset_keys: Vec<(String, Vec<String>)> = Vec::new();
     let mut pending_checks: HashMap<String, PendingCheck> = HashMap::new();
     let mut tables_to_process: Vec<TableTask> = Vec::new();
+    // PR-B3: count how many `(connector, table)` pairs matched each
+    // `[[table_overrides]]` rule. Rules with zero matches surface as
+    // soft warnings on `RunOutput.override_warnings` (T2) so
+    // orchestrators can flag stale rules without breaking the pipeline
+    // for connectors that come and go.
+    let mut override_rule_match_counts: HashMap<usize, usize> = HashMap::new();
 
     let governance = &pipeline.target.governance;
     let target_catalog_template = &pipeline.target.catalog_template;
@@ -1468,6 +1483,12 @@ pub async fn run(
 
             let mut skipped_source_missing = 0usize;
             for table in &conn.tables {
+                // PR-B3: CLI `--filter table=<literal>` consumed here
+                // — every other connector-level filter dimension has
+                // already short-circuited above via `matches_filter`.
+                if !filter_table_matches(parsed_filter.as_ref(), &table.name) {
+                    continue;
+                }
                 if !source_tables.contains(&table.name.to_lowercase()) {
                     // Build the same asset key the materialization path
                     // would have used (`[source_type, ...components, table]`)
@@ -1503,6 +1524,60 @@ pub async fn run(
                     skipped_source_missing += 1;
                     continue;
                 }
+
+                // PR-B3: resolve per-table override against the
+                // pipeline's `table_overrides` rules. Record per-rule
+                // match counts for the discovery-time zero-match
+                // warning (T2).
+                let effective_override = resolve_table_override(
+                    &pipeline.table_overrides,
+                    &conn.id,
+                    &conn.schema,
+                    &table.name,
+                );
+                for (idx, rule) in pipeline.table_overrides.iter().enumerate() {
+                    if rule.match_.matches(&conn.id, &conn.schema, &table.name) {
+                        override_rule_match_counts
+                            .entry(idx)
+                            .and_modify(|c| *c += 1usize)
+                            .or_insert(1);
+                    }
+                }
+
+                // `enabled = false` → skip the table with an
+                // explanatory excluded_tables entry. Mirrors the
+                // missing-from-source path above so orchestrators see
+                // a uniform exclusion surface.
+                if effective_override.enabled == Some(false) {
+                    let mut asset_key = vec![conn.source_type.clone()];
+                    for v in components.values() {
+                        match v {
+                            serde_json::Value::String(s) => asset_key.push(s.clone()),
+                            serde_json::Value::Array(arr) => {
+                                for item in arr {
+                                    if let Some(s) = item.as_str() {
+                                        asset_key.push(s.to_string());
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    asset_key.push(table.name.clone());
+                    info!(
+                        table = table.name.as_str(),
+                        schema = conn.schema.as_str(),
+                        "table excluded by [[table_overrides]] (enabled = false)"
+                    );
+                    output.excluded_tables.push(ExcludedTableOutput {
+                        asset_key,
+                        source_schema: conn.schema.clone(),
+                        table_name: table.name.clone(),
+                        reason: "table_override_disabled".to_string(),
+                    });
+                    continue;
+                }
+
                 // In shadow suffix mode, append suffix to table name
                 let target_table_name = if let Some(shadow_cfg) = shadow_config {
                     if shadow_cfg.schema_override.is_none() {
@@ -1558,6 +1633,7 @@ pub async fn run(
                     // Populated later by batch pre-fetch phase
                     prefetched_source_cols: None,
                     prefetched_target_cols: None,
+                    effective_override,
                 });
             }
             if skipped_source_missing > 0 {
@@ -1569,6 +1645,44 @@ pub async fn run(
             }
         }
     }
+
+    // PR-B3 (T2): emit a structured warning for every
+    // `[[table_overrides]]` rule that matched no `(connector, table)`
+    // pair this run. Soft warning only — connectors come and go in
+    // real production environments, and a stale rule is recoverable.
+    // The output struct lets Dagster branch on `kind` without text
+    // parsing.
+    for (idx, rule) in pipeline.table_overrides.iter().enumerate() {
+        if override_rule_match_counts.get(&idx).copied().unwrap_or(0) > 0 {
+            continue;
+        }
+        let kind = if rule.match_.connector.is_some() && rule.match_.table.is_some() {
+            "zero_match".to_string()
+        } else if rule.match_.connector.is_some() {
+            "connector_match_empty".to_string()
+        } else {
+            "zero_match".to_string()
+        };
+        let message = format!(
+            "[[table_overrides]] rule index {idx} (connector = {:?}, table = {:?}) \
+             matched no (connector, table) pair in this run",
+            rule.match_.connector, rule.match_.table
+        );
+        warn!(
+            rule_index = idx,
+            kind = kind.as_str(),
+            message = message.as_str(),
+            "table_override rule matched zero tables"
+        );
+        output.override_warnings.push(OverrideWarningOutput {
+            rule_index: idx,
+            kind,
+            message,
+            connector: rule.match_.connector.clone(),
+            table: rule.match_.table.clone(),
+        });
+    }
+
     // --- Checkpoint / resume: filter already-completed tables ---
     // `run_id` minted at the top of `run()`.
 
@@ -4358,18 +4472,58 @@ fn accumulate_bytes(acc: Option<u64>, next: Option<u64>) -> Option<u64> {
 /// upserts the entire source via the dialect-specific `MERGE INTO`. The
 /// runner advances the watermark timestamp after each tick regardless of
 /// strategy (via `DeferredWatermark`).
+/// Convenience wrapper used by unit tests — applies no per-table
+/// override. Production code paths go through
+/// [`build_replication_strategy_with_override`] so per-table overrides
+/// land.
+#[cfg(test)]
 fn build_replication_strategy(
     pipeline: &ReplicationPipelineConfig,
 ) -> Result<MaterializationStrategy> {
-    match pipeline.strategy.as_str() {
+    build_replication_strategy_with_override(pipeline, &ResolvedTableOverride::default())
+}
+
+/// Build a materialization strategy applying any per-table override on
+/// top of pipeline defaults. Per-field most-specific-match-wins
+/// resolution has already produced `override_` at the connector-loop
+/// level; this function consumes the merged result with pipeline
+/// fallback.
+///
+/// T3 fail-fast lives here — an effective `strategy = "merge"` with
+/// no reachable merge_keys returns an error so the table fails (the
+/// pipeline keeps running and other tables continue).
+fn build_replication_strategy_with_override(
+    pipeline: &ReplicationPipelineConfig,
+    override_: &ResolvedTableOverride,
+) -> Result<MaterializationStrategy> {
+    let effective_strategy = override_
+        .strategy
+        .as_deref()
+        .unwrap_or(pipeline.strategy.as_str());
+    let effective_timestamp = override_
+        .timestamp_column
+        .as_deref()
+        .unwrap_or(pipeline.timestamp_column.as_str());
+
+    match effective_strategy {
         "incremental" => Ok(MaterializationStrategy::Incremental {
-            timestamp_column: pipeline.timestamp_column.clone(),
+            timestamp_column: effective_timestamp.to_string(),
         }),
         "merge" => {
-            let keys = pipeline.resolved_merge_keys().ok_or_else(|| {
+            // Resolve merge keys with per-field inheritance.
+            // Effective merge_keys: override > pipeline.merge_keys >
+            // override.merge_keys_fallback > pipeline.merge_keys_fallback.
+            let effective_keys: Option<Vec<String>> = override_
+                .merge_keys
+                .clone()
+                .or_else(|| pipeline.merge_keys.clone())
+                .or_else(|| override_.merge_keys_fallback.clone())
+                .or_else(|| pipeline.merge_keys_fallback.clone());
+            let keys = effective_keys.filter(|k| !k.is_empty()).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "strategy = \"merge\" requires merge_keys or merge_keys_fallback \
-                     (this should have been caught by load_rocky_config)"
+                    "table override produces strategy = \"merge\" with empty effective \
+                     merge_keys — set merge_keys on the override or the pipeline default \
+                     (this guard catches a residual not caught at parse time)"
                 )
             })?;
             let unique_key: Vec<Arc<str>> = keys.iter().map(|k| Arc::from(k.as_str())).collect();
@@ -4560,8 +4714,10 @@ async fn process_table(
         }
     }
 
-    // Build replication IR directly.
-    let strategy = build_replication_strategy(pipeline)?;
+    // Build replication IR directly. Applies any per-table override
+    // already resolved at the connector-loop level — see
+    // `TableTask::effective_override`.
+    let strategy = build_replication_strategy_with_override(pipeline, &task.effective_override)?;
     let model_ir = ModelIr::replication(
         TargetRef {
             catalog: task.target_catalog.clone(),
@@ -5341,6 +5497,7 @@ mod tests {
             interrupted: false,
             cost_summary: None,
             budget_breaches: vec![],
+            override_warnings: vec![],
         };
 
         emit_pipes_events(&emitter, &output);
@@ -6030,5 +6187,139 @@ merge_keys_fallback = ["fallback_only"]
         let pipeline = parse_pipeline(r#"strategy = "totally_made_up""#);
         let strategy = build_replication_strategy(&pipeline).expect("strategy build");
         assert!(matches!(strategy, MaterializationStrategy::FullRefresh));
+    }
+
+    // ----- PR-B3: per-table override application -----
+
+    #[test]
+    fn override_changes_strategy_from_merge_to_incremental() {
+        // Pipeline default is strategy = "merge", but the override
+        // resolved for this table flips to "incremental". The
+        // resulting MaterializationStrategy must be Incremental and
+        // pick up the override's timestamp column.
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys = ["id"]
+"#,
+        );
+        let resolved = ResolvedTableOverride {
+            strategy: Some("incremental".to_string()),
+            merge_keys: None,
+            merge_keys_fallback: None,
+            timestamp_column: Some("occurred_at".to_string()),
+            enabled: None,
+        };
+        let strategy = build_replication_strategy_with_override(&pipeline, &resolved)
+            .expect("strategy build with override");
+        match strategy {
+            MaterializationStrategy::Incremental { timestamp_column } => {
+                assert_eq!(timestamp_column, "occurred_at");
+            }
+            other => panic!("expected Incremental, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn override_replaces_pipeline_merge_keys() {
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys = ["id"]
+"#,
+        );
+        let resolved = ResolvedTableOverride {
+            strategy: None,
+            merge_keys: Some(vec!["user_id".into(), "tenant_id".into()]),
+            merge_keys_fallback: None,
+            timestamp_column: None,
+            enabled: None,
+        };
+        let strategy =
+            build_replication_strategy_with_override(&pipeline, &resolved).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Merge { unique_key, .. } => {
+                let keys: Vec<&str> = unique_key.iter().map(AsRef::as_ref).collect();
+                assert_eq!(keys, vec!["user_id", "tenant_id"]);
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn override_inherits_pipeline_merge_keys_when_unset() {
+        // Override sets only the strategy; merge_keys inherit from
+        // the pipeline default.
+        let pipeline = parse_pipeline(
+            r#"strategy = "incremental"
+merge_keys = ["id"]
+"#,
+        );
+        let resolved = ResolvedTableOverride {
+            strategy: Some("merge".to_string()),
+            merge_keys: None,
+            merge_keys_fallback: None,
+            timestamp_column: None,
+            enabled: None,
+        };
+        let strategy =
+            build_replication_strategy_with_override(&pipeline, &resolved).expect("strategy build");
+        match strategy {
+            MaterializationStrategy::Merge { unique_key, .. } => {
+                let keys: Vec<&str> = unique_key.iter().map(AsRef::as_ref).collect();
+                assert_eq!(keys, vec!["id"]);
+            }
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn override_merge_with_empty_effective_keys_errors_t3() {
+        // T3 fail-fast guard: even though the parse-time validator
+        // catches the obvious case, an override that explicitly sets
+        // `merge_keys = []` (empty vec) is also caught here at
+        // strategy-build time.
+        let pipeline = parse_pipeline(r#"strategy = "full_refresh""#);
+        let resolved = ResolvedTableOverride {
+            strategy: Some("merge".to_string()),
+            merge_keys: Some(vec![]),
+            merge_keys_fallback: None,
+            timestamp_column: None,
+            enabled: None,
+        };
+        let err = build_replication_strategy_with_override(&pipeline, &resolved)
+            .expect_err("empty effective keys must fail");
+        let msg = format!("{err}");
+        assert!(msg.contains("empty effective"), "wrong error: {msg}");
+    }
+
+    #[test]
+    fn override_empty_is_pipeline_identity() {
+        // Sanity: ResolvedTableOverride::default() yields the
+        // pre-PR-B3 behavior — equal to plain build_replication_strategy.
+        let pipeline = parse_pipeline(
+            r#"strategy = "merge"
+merge_keys = ["id"]
+"#,
+        );
+        let baseline = build_replication_strategy(&pipeline).expect("baseline");
+        let overridden =
+            build_replication_strategy_with_override(&pipeline, &ResolvedTableOverride::default())
+                .expect("override empty");
+        match (baseline, overridden) {
+            (
+                MaterializationStrategy::Merge {
+                    unique_key: a,
+                    update_columns: _,
+                },
+                MaterializationStrategy::Merge {
+                    unique_key: b,
+                    update_columns: _,
+                },
+            ) => {
+                let ak: Vec<&str> = a.iter().map(AsRef::as_ref).collect();
+                let bk: Vec<&str> = b.iter().map(AsRef::as_ref).collect();
+                assert_eq!(ak, bk);
+            }
+            (a, b) => panic!("mismatch: {a:?} vs {b:?}"),
+        }
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -243,6 +243,39 @@ pub struct RunOutput {
     /// `on_budget_breach` hook so subscribers see them live.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub budget_breaches: Vec<BudgetBreachOutput>,
+    /// Soft warnings raised by the per-table override resolver — one
+    /// entry per `[[table_overrides]]` rule that matched zero
+    /// `(connector, table)` pairs this run, or whose connector half
+    /// resolved nothing. Discovery-time-only — the pipeline runs to
+    /// completion regardless. Empty for runs whose pipeline declares
+    /// no overrides.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub override_warnings: Vec<OverrideWarningOutput>,
+}
+
+/// Soft warning surfaced on
+/// [`RunOutput::override_warnings`] when an override rule matched no
+/// tables this run.
+///
+/// Distinct kinds let orchestrators (Dagster) branch on cause without
+/// parsing free-form messages.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct OverrideWarningOutput {
+    /// Position of the rule in `[[table_overrides]]`, 0-based — same
+    /// index the validator's error messages use.
+    pub rule_index: usize,
+    /// Coarse kind: `"zero_match"` (rule matched no pair at all) or
+    /// `"connector_match_empty"` (the connector half of the match
+    /// resolved nothing).
+    pub kind: String,
+    /// Human-readable explanation, for logs and Dagster UI rendering.
+    pub message: String,
+    /// Echo of `match.connector` from the rule, for cross-reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connector: Option<String>,
+    /// Echo of `match.table` from the rule, for cross-reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
 }
 
 /// Per-model cost attribution entry inside [`RunCostSummary`].
@@ -3116,6 +3149,7 @@ impl RunOutput {
             interrupted: false,
             cost_summary: None,
             budget_breaches: vec![],
+            override_warnings: vec![],
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -209,6 +209,50 @@ pub enum ConfigError {
          Set [pipeline.{pipeline}.merge_keys = [\"col1\", \"col2\"]] in your rocky.toml."
     )]
     ReplicationMergeMissingKeys { pipeline: String },
+
+    #[error(
+        "pipeline '{pipeline}' table_overrides[{rule_index}] has an empty `match` block. \
+         Set at least one of `match.connector` or `match.table`, or remove the rule and \
+         change pipeline-level defaults instead."
+    )]
+    TableOverrideEmptyMatch { pipeline: String, rule_index: usize },
+
+    #[error(
+        "pipeline '{pipeline}' table_overrides have two duplicate fully-specific rules \
+         (connector = {connector:?}, table = {table:?}) at indices {first_index} and \
+         {second_index}. Combine them or narrow one further."
+    )]
+    TableOverrideDuplicate {
+        pipeline: String,
+        first_index: usize,
+        second_index: usize,
+        connector: String,
+        table: String,
+    },
+
+    #[error(
+        "pipeline '{pipeline}' table_overrides[{rule_index}] has an invalid glob pattern \
+         in `match.table`: {reason}"
+    )]
+    TableOverrideInvalidGlob {
+        pipeline: String,
+        rule_index: usize,
+        reason: String,
+    },
+
+    #[error(
+        "pipeline '{pipeline}' table_overrides[{rule_index}] sets strategy = \"merge\" \
+         but no merge_keys (or merge_keys_fallback) are reachable for the matched tables — \
+         neither the override nor the pipeline default supplies any."
+    )]
+    TableOverrideMergeMissingKeys { pipeline: String, rule_index: usize },
+
+    #[error(
+        "pipeline '{pipeline}' source.schema_pattern.components contains the reserved \
+         name {component:?} — rename it (e.g. `source_{component}`). \
+         `table` and `id` are reserved for `--filter` and `[[table_overrides]]`."
+    )]
+    SchemaPatternReservedComponent { pipeline: String, component: String },
 }
 
 /// Concurrency strategy for table processing.
@@ -2667,10 +2711,363 @@ pub struct ReplicationPipelineConfig {
     /// Pipeline dependencies for chaining.
     #[serde(default)]
     pub depends_on: Vec<String>,
+
+    /// Per-`(connector, table)` overrides applied on top of the pipeline
+    /// defaults. Each rule matches against a discovered connector +
+    /// table pair and, when matched, replaces selected pipeline-level
+    /// fields with override-supplied values.
+    ///
+    /// Resolution is **per-field most-specific-match-wins**: for each
+    /// overrideable field, the most specific matching rule that
+    /// explicitly sets that field wins; less-specific rules contribute
+    /// values only for fields they actually set. Specificity ranking
+    /// (highest to lowest):
+    ///
+    /// 1. Both `match.connector` AND `match.table` set, with
+    ///    `match.table` a literal (no glob).
+    /// 2. Both set, with `match.table` containing a `*` or `?` glob.
+    /// 3. Only `match.connector` set.
+    /// 4. Only `match.table` set.
+    ///
+    /// Ties at the same specificity tier for a `(connector, table)`
+    /// pair are rejected at parse time as ambiguous.
+    ///
+    /// Empty by default — projects that don't need per-table tweaking
+    /// pay nothing in JSON output, schema surface area, or runtime
+    /// cost.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub table_overrides: Vec<TableOverride>,
 }
 
 /// Backward-compatible alias for [`ReplicationPipelineConfig`].
 pub type PipelineConfigV2 = ReplicationPipelineConfig;
+
+/// A per-`(connector, table)` override rule on a replication pipeline.
+///
+/// Authored as one TOML array entry under
+/// `[[pipeline.<name>.table_overrides]]`. Each field except `match_` is
+/// optional — `None` means "inherit from the pipeline-level default."
+/// The resolver applies overrides with per-field most-specific-wins
+/// semantics; see [`ReplicationPipelineConfig::table_overrides`] for the
+/// ranking.
+///
+/// # Example
+///
+/// ```toml
+/// [[pipeline.raw.table_overrides]]
+/// match.connector = "stripe_main"
+/// match.table     = "pii_users"
+/// merge_keys      = ["user_id", "tenant_id"]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TableOverride {
+    /// Match criteria — at least one of `connector` or `table` must be
+    /// set. A rule with neither (or a `match` block omitted entirely)
+    /// is rejected at parse time (use pipeline-level fields to change
+    /// defaults for all tables). `default` lets serde deserialize an
+    /// override missing the whole `match` block; the validator catches
+    /// the resulting empty match.
+    #[serde(rename = "match", default)]
+    pub match_: TableMatch,
+
+    /// Override for [`ReplicationPipelineConfig::strategy`]. `None`
+    /// inherits the pipeline default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+
+    /// Override for [`ReplicationPipelineConfig::merge_keys`]. `None`
+    /// inherits the pipeline default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_keys: Option<Vec<String>>,
+
+    /// Override for
+    /// [`ReplicationPipelineConfig::merge_keys_fallback`]. `None`
+    /// inherits the pipeline default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge_keys_fallback: Option<Vec<String>>,
+
+    /// Override for [`ReplicationPipelineConfig::timestamp_column`].
+    /// `None` inherits the pipeline default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp_column: Option<String>,
+
+    /// When `Some(false)`, the matched `(connector, table)` pairs are
+    /// dropped from the run and surfaced under
+    /// `RunOutput.excluded_tables` with
+    /// `reason = "table_override_disabled"`. Net-new field with no
+    /// pipeline-level counterpart — disabling a whole pipeline is
+    /// already covered by removing the pipeline block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+}
+
+/// Match criteria for a [`TableOverride`].
+///
+/// At least one of `connector` or `table` must be set (`None` for both
+/// is rejected at parse time as redundant — use pipeline-level fields
+/// to change defaults globally).
+///
+/// `connector` matches against either
+/// [`crate::source::DiscoveredConnector::id`] (the stable
+/// adapter-side identifier — e.g. a Fivetran connector_id) **or**
+/// [`crate::source::DiscoveredConnector::schema`] (the human-meaningful
+/// source schema name — e.g. `src__acme__shopify`). String equality on
+/// either match wins.
+///
+/// `table` matches against
+/// [`crate::source::DiscoveredTable::name`]. Supports `*` (zero or more
+/// characters) and `?` (exactly one character) glob wildcards; presence
+/// of either character switches the value from literal to glob.
+///
+/// # Reserved
+///
+/// `table` and `id` are reserved as schema-pattern component names —
+/// configs that use either as a component in
+/// [`SchemaPatternConfig::components`] are rejected at parse time to
+/// avoid colliding with `--filter table=` and `--filter id=`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TableMatch {
+    /// Connector match — equals either `DiscoveredConnector.id` or
+    /// `DiscoveredConnector.schema`. `None` matches every connector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connector: Option<String>,
+
+    /// Table-name match. Literal when no `*`/`?`; glob otherwise.
+    /// `None` matches every table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+}
+
+/// The set of fields a [`TableOverride`] can change, after the
+/// per-field most-specific-match-wins resolver has merged the matching
+/// rules for a given `(connector, table)` pair.
+///
+/// Fields that no matching rule set remain `None` so callers can
+/// distinguish "use pipeline default" from "explicitly cleared."
+/// Construct via [`resolve_table_override`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedTableOverride {
+    pub strategy: Option<String>,
+    pub merge_keys: Option<Vec<String>>,
+    pub merge_keys_fallback: Option<Vec<String>>,
+    pub timestamp_column: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+impl ResolvedTableOverride {
+    /// Returns `true` when this override carries no field overrides at
+    /// all — equivalent to "no rule matched."
+    pub fn is_empty(&self) -> bool {
+        self.strategy.is_none()
+            && self.merge_keys.is_none()
+            && self.merge_keys_fallback.is_none()
+            && self.timestamp_column.is_none()
+            && self.enabled.is_none()
+    }
+}
+
+/// Specificity tier of a [`TableMatch`] for a given `(connector,
+/// table)` pair, used by [`resolve_table_override`] to break per-field
+/// ties.
+///
+/// Variants are ordered from most-specific to least-specific so the
+/// resolver can sort by `(rule_tier, declaration_order)` and pick the
+/// first rule that sets each field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum MatchSpecificity {
+    /// Both `connector` and `table` set, with a literal table.
+    BothLiteralTable = 0,
+    /// Both `connector` and `table` set, with a glob table.
+    BothGlobTable = 1,
+    /// Only `connector` set.
+    ConnectorOnly = 2,
+    /// Only `table` set.
+    TableOnly = 3,
+}
+
+impl TableMatch {
+    /// Returns `true` when the rule's connector half (if any) matches
+    /// the given discovered connector. A rule with no `connector`
+    /// constraint matches everything.
+    ///
+    /// `connector_schema` is `DiscoveredConnector.schema`. Both the id
+    /// and schema axes are checked — OR semantics — so users can write
+    /// `match.connector = "stripe_main"` against either identity.
+    pub fn matches_connector(&self, connector_id: &str, connector_schema: &str) -> bool {
+        let Some(pattern) = self.connector.as_deref() else {
+            return true;
+        };
+        pattern == connector_id || pattern == connector_schema
+    }
+
+    /// Returns `true` when the rule's table half (if any) matches the
+    /// given discovered table name. A rule with no `table` constraint
+    /// matches every table; a value containing `*` or `?` is treated
+    /// as a glob, otherwise literal equality.
+    pub fn matches_table(&self, table_name: &str) -> bool {
+        let Some(pattern) = self.table.as_deref() else {
+            return true;
+        };
+        if pattern_is_glob(pattern) {
+            glob_match(pattern, table_name)
+        } else {
+            pattern == table_name
+        }
+    }
+
+    /// Returns `true` when both halves match. The full match predicate
+    /// used by [`resolve_table_override`].
+    pub fn matches(&self, connector_id: &str, connector_schema: &str, table_name: &str) -> bool {
+        self.matches_connector(connector_id, connector_schema) && self.matches_table(table_name)
+    }
+
+    /// Specificity tier — see [`MatchSpecificity`]. Panics if both
+    /// halves are `None` (parse-time validation must reject that case
+    /// via [`validate_replication_overrides`]).
+    fn specificity(&self) -> MatchSpecificity {
+        match (self.connector.as_deref(), self.table.as_deref()) {
+            (Some(_), Some(t)) if pattern_is_glob(t) => MatchSpecificity::BothGlobTable,
+            (Some(_), Some(_)) => MatchSpecificity::BothLiteralTable,
+            (Some(_), None) => MatchSpecificity::ConnectorOnly,
+            (None, Some(_)) => MatchSpecificity::TableOnly,
+            (None, None) => unreachable!(
+                "empty TableMatch should be rejected by validate_replication_overrides"
+            ),
+        }
+    }
+}
+
+/// Returns `true` when `pattern` contains a glob metacharacter
+/// (`*` or `?`).
+fn pattern_is_glob(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?')
+}
+
+/// Hand-rolled `*`/`?` glob matcher. `*` matches zero or more
+/// characters; `?` matches exactly one. No character classes, no
+/// alternation. Returns `true` when `pattern` matches `text` against
+/// the entire input.
+///
+/// Implementation is a straightforward backtracking matcher over byte
+/// slices. Table names are ASCII (warehouse identifier conventions),
+/// so byte-level comparison is correct.
+pub(crate) fn glob_match(pattern: &str, text: &str) -> bool {
+    let pat = pattern.as_bytes();
+    let txt = text.as_bytes();
+    let mut pi = 0usize;
+    let mut ti = 0usize;
+    // Snapshots used to back up after a failed `*` consumption.
+    let mut star_pi: Option<usize> = None;
+    let mut star_ti: usize = 0;
+
+    while ti < txt.len() {
+        if pi < pat.len() && pat[pi] == b'*' {
+            star_pi = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if pi < pat.len() && (pat[pi] == b'?' || pat[pi] == txt[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if let Some(sp) = star_pi {
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+
+    // Consume any trailing `*`s.
+    while pi < pat.len() && pat[pi] == b'*' {
+        pi += 1;
+    }
+
+    pi == pat.len()
+}
+
+/// Validates a glob pattern. Today the only invalid forms are an empty
+/// pattern (`""`) — every other byte sequence is a valid `*`/`?` glob.
+/// Returns the offending pattern string when invalid.
+fn validate_glob_pattern(pattern: &str) -> Result<(), String> {
+    if pattern.is_empty() {
+        return Err("empty glob pattern".to_string());
+    }
+    Ok(())
+}
+
+/// Resolves the effective per-field override for a `(connector_id,
+/// connector_schema, table_name)` triple against an ordered list of
+/// [`TableOverride`] rules.
+///
+/// Walks every matching rule in increasing specificity order
+/// (most-specific first; ties broken by declaration order). For each
+/// overrideable field, the first rule that explicitly sets it wins;
+/// less-specific rules contribute values only for fields they actually
+/// set. Returns an empty [`ResolvedTableOverride`] when no rule
+/// matches.
+///
+/// # Example
+///
+/// Given:
+///
+/// ```toml
+/// [[pipeline.raw.table_overrides]]
+/// match.connector  = "stripe_main"
+/// timestamp_column = "_stripe_synced"
+///
+/// [[pipeline.raw.table_overrides]]
+/// match.connector = "stripe_main"
+/// match.table     = "pii_users"
+/// merge_keys      = ["user_id", "tenant_id"]
+/// ```
+///
+/// For `("conn_xyz", "stripe_main", "pii_users")` the resolver
+/// returns `merge_keys = ["user_id", "tenant_id"]` (from the
+/// more-specific rule) **and** `timestamp_column = "_stripe_synced"`
+/// (from the less-specific rule). Both are applied — per-field, not
+/// whole-rule.
+pub fn resolve_table_override(
+    rules: &[TableOverride],
+    connector_id: &str,
+    connector_schema: &str,
+    table_name: &str,
+) -> ResolvedTableOverride {
+    // Collect matching rules paired with their specificity tier.
+    let mut matched: Vec<(MatchSpecificity, usize, &TableOverride)> = rules
+        .iter()
+        .enumerate()
+        .filter(|(_, rule)| {
+            rule.match_
+                .matches(connector_id, connector_schema, table_name)
+        })
+        .map(|(idx, rule)| (rule.match_.specificity(), idx, rule))
+        .collect();
+
+    // Sort by (specificity, declaration index) — most specific first.
+    matched.sort_by_key(|(spec, idx, _)| (*spec, *idx));
+
+    let mut resolved = ResolvedTableOverride::default();
+    for (_, _, rule) in &matched {
+        if resolved.strategy.is_none() && rule.strategy.is_some() {
+            resolved.strategy = rule.strategy.clone();
+        }
+        if resolved.merge_keys.is_none() && rule.merge_keys.is_some() {
+            resolved.merge_keys = rule.merge_keys.clone();
+        }
+        if resolved.merge_keys_fallback.is_none() && rule.merge_keys_fallback.is_some() {
+            resolved.merge_keys_fallback = rule.merge_keys_fallback.clone();
+        }
+        if resolved.timestamp_column.is_none() && rule.timestamp_column.is_some() {
+            resolved.timestamp_column = rule.timestamp_column.clone();
+        }
+        if resolved.enabled.is_none() && rule.enabled.is_some() {
+            resolved.enabled = rule.enabled;
+        }
+    }
+    resolved
+}
 
 /// Transformation pipeline configuration.
 ///
@@ -3240,6 +3637,146 @@ pub fn validate_replication_strategies(config: &RockyConfig) -> Vec<ConfigError>
     errors
 }
 
+/// Parse-time validation for `[[table_overrides]]` blocks.
+///
+/// Catches the structural classes the resolver and runner can't
+/// recover from gracefully:
+///
+/// - **T1.1** Duplicate fully-specific rules — two entries with the
+///   same `(match.connector, match.table)` literal pair. The resolver
+///   would otherwise have to break the tie by declaration order,
+///   which is the trust-failure mode the rest of `rocky.toml` avoids.
+/// - **T1.2** Empty `match` block — both `connector` and `table` are
+///   `None`. Use pipeline-level fields to change defaults globally.
+/// - **T1.4** Unreachable merge keys — an override sets
+///   `strategy = "merge"` and supplies no `merge_keys` /
+///   `merge_keys_fallback`, **and** the pipeline default supplies
+///   neither either. The effective config would crash at run time.
+/// - **T1.6** Malformed glob in `match.table` — an empty pattern
+///   today; the surface is intentionally narrow to keep future
+///   `globset`-style extensions backwards-compatible.
+///
+/// Zero-match rules are intentionally **not** caught here — connectors
+/// come and go in real production environments, and a rule that
+/// doesn't match today may match tomorrow. The runner emits a soft
+/// warning via `RunOutput.override_warnings` instead.
+pub fn validate_replication_overrides(config: &RockyConfig) -> Vec<ConfigError> {
+    let mut errors = Vec::new();
+    for (pipeline_name, pipeline) in &config.pipelines {
+        let PipelineConfig::Replication(replication) = pipeline else {
+            continue;
+        };
+        let overrides = &replication.table_overrides;
+
+        // T1.2 + T1.6 — per-rule structural checks.
+        for (idx, rule) in overrides.iter().enumerate() {
+            if rule.match_.connector.is_none() && rule.match_.table.is_none() {
+                errors.push(ConfigError::TableOverrideEmptyMatch {
+                    pipeline: pipeline_name.clone(),
+                    rule_index: idx,
+                });
+            }
+            if let Some(table_pat) = rule.match_.table.as_deref() {
+                if pattern_is_glob(table_pat) {
+                    if let Err(reason) = validate_glob_pattern(table_pat) {
+                        errors.push(ConfigError::TableOverrideInvalidGlob {
+                            pipeline: pipeline_name.clone(),
+                            rule_index: idx,
+                            reason,
+                        });
+                    }
+                } else if table_pat.is_empty() {
+                    errors.push(ConfigError::TableOverrideInvalidGlob {
+                        pipeline: pipeline_name.clone(),
+                        rule_index: idx,
+                        reason: "empty table pattern".to_string(),
+                    });
+                }
+            }
+
+            // T1.4 — strategy="merge" with no reachable merge keys.
+            if rule.strategy.as_deref() == Some("merge") {
+                let override_has_keys =
+                    rule.merge_keys.is_some() || rule.merge_keys_fallback.is_some();
+                let pipeline_has_keys = replication.resolved_merge_keys().is_some();
+                if !override_has_keys && !pipeline_has_keys {
+                    errors.push(ConfigError::TableOverrideMergeMissingKeys {
+                        pipeline: pipeline_name.clone(),
+                        rule_index: idx,
+                    });
+                }
+            }
+        }
+
+        // T1.1 — duplicate fully-specific (connector, table) literal
+        // pairs. We compare by the raw strings; two glob patterns that
+        // happen to overlap (e.g. `_x_*` vs `*_y`) are not a duplicate
+        // — same-tier ambiguity for an actual `(connector, table)` is
+        // a per-resolution concern surfaced at run time below if any
+        // such pair is ever discovered (see T1.3 note).
+        for (i, a) in overrides.iter().enumerate() {
+            if a.match_.connector.is_none() || a.match_.table.is_none() {
+                continue;
+            }
+            let a_table = a.match_.table.as_deref().unwrap_or_default();
+            if pattern_is_glob(a_table) {
+                continue;
+            }
+            for (j, b) in overrides.iter().enumerate().skip(i + 1) {
+                if b.match_.connector.is_none() || b.match_.table.is_none() {
+                    continue;
+                }
+                let b_table = b.match_.table.as_deref().unwrap_or_default();
+                if pattern_is_glob(b_table) {
+                    continue;
+                }
+                if a.match_.connector == b.match_.connector && a.match_.table == b.match_.table {
+                    errors.push(ConfigError::TableOverrideDuplicate {
+                        pipeline: pipeline_name.clone(),
+                        first_index: i,
+                        second_index: j,
+                        connector: a.match_.connector.clone().unwrap_or_default(),
+                        table: a_table.to_string(),
+                    });
+                }
+            }
+        }
+    }
+    errors
+}
+
+/// Parse-time validation that schema-pattern components don't use the
+/// reserved names `table` or `id`. Both are reserved for
+/// [`--filter`-style keys](crate::source::DiscoveredConnector::id) and
+/// the new `[[table_overrides]]` match grammar — a schema pattern
+/// component that shadows either would create ambiguity that no
+/// runtime resolver can untangle.
+///
+/// Returns one error per reserved component. Rename the component in
+/// `[pipeline.x.source.schema_pattern]` (e.g. `source_table` instead
+/// of `table`) to resolve.
+pub fn validate_schema_pattern_reserved_components(config: &RockyConfig) -> Vec<ConfigError> {
+    const RESERVED: &[&str] = &["table", "id"];
+    let mut errors = Vec::new();
+    for (pipeline_name, pipeline) in &config.pipelines {
+        let PipelineConfig::Replication(replication) = pipeline else {
+            continue;
+        };
+        for component in &replication.source.schema_pattern.components {
+            // `regions...` style variadic components — strip the
+            // suffix before comparing.
+            let name = component.trim_end_matches("...");
+            if RESERVED.contains(&name) {
+                errors.push(ConfigError::SchemaPatternReservedComponent {
+                    pipeline: pipeline_name.clone(),
+                    component: name.to_string(),
+                });
+            }
+        }
+    }
+    errors
+}
+
 /// Does this adapter actively serve `role`?
 ///
 /// An adapter block actively serves a role when:
@@ -3367,6 +3904,15 @@ pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
         return Err(first);
     }
     if let Some(first) = validate_replication_strategies(&config).into_iter().next() {
+        return Err(first);
+    }
+    if let Some(first) = validate_schema_pattern_reserved_components(&config)
+        .into_iter()
+        .next()
+    {
+        return Err(first);
+    }
+    if let Some(first) = validate_replication_overrides(&config).into_iter().next() {
         return Err(first);
     }
     Ok(config)
@@ -6920,6 +7466,539 @@ schema_template = "raw__{source}"
         assert!(
             matches!(err, ConfigError::ReplicationMergeMissingKeys { ref pipeline }
                 if pipeline == "bronze"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    // ---------------- Table-override tests (PR-B3) ----------------
+
+    /// TOML base for table-override tests. Pipeline name is `bronze`,
+    /// strategy is `merge` with pipeline-level `merge_keys = ["id"]`,
+    /// schema pattern uses `source` component only.
+    fn override_pipeline_toml_base() -> String {
+        let mut s = String::from(merge_pipeline_toml_base());
+        s.push_str(
+            r#"
+strategy = "merge"
+merge_keys = ["id"]
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#,
+        );
+        s
+    }
+
+    #[test]
+    fn glob_match_literal_no_wildcards() {
+        assert!(glob_match("pii_users", "pii_users"));
+        assert!(!glob_match("pii_users", "pii_orders"));
+    }
+
+    #[test]
+    fn glob_match_star_prefix_suffix_middle() {
+        assert!(glob_match("_diagnostics_*", "_diagnostics_x"));
+        assert!(glob_match("_diagnostics_*", "_diagnostics_"));
+        assert!(!glob_match("_diagnostics_*", "diagnostics_x"));
+        assert!(glob_match("*_temp", "users_temp"));
+        assert!(!glob_match("*_temp", "users_temp_extra"));
+        assert!(glob_match("a*b*c", "aXbYc"));
+        assert!(glob_match("a*b*c", "abc"));
+        assert!(!glob_match("a*b*c", "ac"));
+    }
+
+    #[test]
+    fn glob_match_question_mark_single_char() {
+        assert!(glob_match("u?ers", "users"));
+        assert!(!glob_match("u?ers", "uers"));
+        assert!(!glob_match("u?ers", "useers"));
+    }
+
+    #[test]
+    fn glob_match_full_anchor() {
+        // Patterns are anchored — partial matches do not pass.
+        assert!(!glob_match("pii", "pii_users"));
+        assert!(!glob_match("users", "pii_users"));
+    }
+
+    #[test]
+    fn pattern_is_glob_detects_wildcards() {
+        assert!(pattern_is_glob("_diagnostics_*"));
+        assert!(pattern_is_glob("u?ers"));
+        assert!(!pattern_is_glob("pii_users"));
+        assert!(!pattern_is_glob(""));
+    }
+
+    #[test]
+    fn table_overrides_parse_minimal() {
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "pii_users"
+merge_keys      = ["user_id", "tenant_id"]
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        assert_eq!(pipeline.table_overrides.len(), 1);
+        let rule = &pipeline.table_overrides[0];
+        assert_eq!(rule.match_.connector.as_deref(), Some("stripe_main"));
+        assert_eq!(rule.match_.table.as_deref(), Some("pii_users"));
+        assert_eq!(
+            rule.merge_keys.as_deref(),
+            Some(&["user_id".to_string(), "tenant_id".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn table_overrides_serialize_skips_when_empty() {
+        // `skip_serializing_if = "Vec::is_empty"` keeps the JSON shape
+        // stable for replication pipelines that don't opt into
+        // overrides.
+        let toml_str = override_pipeline_toml_base();
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let pipeline = config.pipelines["bronze"].as_replication().unwrap();
+        let json = serde_json::to_string(pipeline).unwrap();
+        assert!(
+            !json.contains("table_overrides"),
+            "JSON output should omit empty table_overrides: {json}"
+        );
+    }
+
+    #[test]
+    fn resolve_table_override_no_rules_returns_empty() {
+        let resolved = resolve_table_override(&[], "conn_x", "stripe_main", "users");
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn resolve_table_override_per_field_most_specific_wins() {
+        // Less-specific rule sets `timestamp_column`, more-specific
+        // rule sets `merge_keys`. Both must apply for the matched
+        // table — per-field, not whole-rule.
+        let rules = vec![
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: None,
+                },
+                strategy: None,
+                merge_keys: None,
+                merge_keys_fallback: None,
+                timestamp_column: Some("_stripe_synced".to_string()),
+                enabled: None,
+            },
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: Some("pii_users".to_string()),
+                },
+                strategy: None,
+                merge_keys: Some(vec!["user_id".to_string(), "tenant_id".to_string()]),
+                merge_keys_fallback: None,
+                timestamp_column: None,
+                enabled: None,
+            },
+        ];
+        let resolved = resolve_table_override(&rules, "conn_xyz", "stripe_main", "pii_users");
+        assert_eq!(
+            resolved.merge_keys,
+            Some(vec!["user_id".to_string(), "tenant_id".to_string()])
+        );
+        assert_eq!(resolved.timestamp_column.as_deref(), Some("_stripe_synced"));
+    }
+
+    #[test]
+    fn resolve_table_override_more_specific_wins_for_same_field() {
+        // Both rules set `merge_keys`. The more-specific rule wins.
+        let rules = vec![
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: None,
+                },
+                strategy: None,
+                merge_keys: Some(vec!["pipeline_id".to_string()]),
+                merge_keys_fallback: None,
+                timestamp_column: None,
+                enabled: None,
+            },
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: Some("pii_users".to_string()),
+                },
+                strategy: None,
+                merge_keys: Some(vec!["user_id".to_string()]),
+                merge_keys_fallback: None,
+                timestamp_column: None,
+                enabled: None,
+            },
+        ];
+        let resolved = resolve_table_override(&rules, "conn_xyz", "stripe_main", "pii_users");
+        assert_eq!(resolved.merge_keys, Some(vec!["user_id".to_string()]));
+    }
+
+    #[test]
+    fn resolve_table_override_connector_matches_id_or_schema() {
+        // `match.connector` matches against either the discovered id
+        // or the discovered schema name (OR semantics).
+        let rule = TableOverride {
+            match_: TableMatch {
+                connector: Some("stripe_main".to_string()),
+                table: Some("users".to_string()),
+            },
+            strategy: Some("incremental".to_string()),
+            merge_keys: None,
+            merge_keys_fallback: None,
+            timestamp_column: None,
+            enabled: None,
+        };
+        // Match against schema.
+        let by_schema = resolve_table_override(
+            std::slice::from_ref(&rule),
+            "conn_abc",
+            "stripe_main",
+            "users",
+        );
+        assert_eq!(by_schema.strategy.as_deref(), Some("incremental"));
+        // Match against id.
+        let by_id = resolve_table_override(
+            std::slice::from_ref(&rule),
+            "stripe_main",
+            "some_schema",
+            "users",
+        );
+        assert_eq!(by_id.strategy.as_deref(), Some("incremental"));
+        // No match against either.
+        let no_match = resolve_table_override(&[rule], "conn_z", "other_schema", "users");
+        assert!(no_match.is_empty());
+    }
+
+    #[test]
+    fn resolve_table_override_glob_matches() {
+        let rule = TableOverride {
+            match_: TableMatch {
+                connector: None,
+                table: Some("_diagnostics_*".to_string()),
+            },
+            strategy: None,
+            merge_keys: None,
+            merge_keys_fallback: None,
+            timestamp_column: None,
+            enabled: Some(false),
+        };
+        let resolved = resolve_table_override(
+            std::slice::from_ref(&rule),
+            "c",
+            "stripe_main",
+            "_diagnostics_x",
+        );
+        assert_eq!(resolved.enabled, Some(false));
+        let unmatched = resolve_table_override(&[rule], "c", "stripe_main", "users_diagnostics_no");
+        assert!(unmatched.is_empty());
+    }
+
+    #[test]
+    fn resolve_table_override_literal_beats_glob_at_same_pair_tier() {
+        // Both rules match `(stripe_main, pii_users)`. The literal one
+        // is more specific than the glob one.
+        let rules = vec![
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: Some("pii_*".to_string()),
+                },
+                strategy: None,
+                merge_keys: Some(vec!["from_glob".to_string()]),
+                merge_keys_fallback: None,
+                timestamp_column: None,
+                enabled: None,
+            },
+            TableOverride {
+                match_: TableMatch {
+                    connector: Some("stripe_main".to_string()),
+                    table: Some("pii_users".to_string()),
+                },
+                strategy: None,
+                merge_keys: Some(vec!["from_literal".to_string()]),
+                merge_keys_fallback: None,
+                timestamp_column: None,
+                enabled: None,
+            },
+        ];
+        let resolved = resolve_table_override(&rules, "c", "stripe_main", "pii_users");
+        assert_eq!(resolved.merge_keys, Some(vec!["from_literal".to_string()]));
+    }
+
+    #[test]
+    fn validate_replication_overrides_rejects_empty_match() {
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+merge_keys = ["x"]
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors[0],
+            ConfigError::TableOverrideEmptyMatch { rule_index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn validate_replication_overrides_rejects_duplicate_fully_specific_literal() {
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "pii_users"
+merge_keys      = ["user_id"]
+
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "pii_users"
+timestamp_column = "synced_at"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(matches!(
+            errors[0],
+            ConfigError::TableOverrideDuplicate {
+                first_index: 0,
+                second_index: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_replication_overrides_allows_duplicate_glob_table_patterns() {
+        // Two glob rules with overlapping match sets are NOT treated
+        // as duplicates at parse time — the resolver disambiguates by
+        // declaration order if they tie on specificity. Only literal
+        // fully-specific dupes fail-fast.
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "pii_*"
+merge_keys      = ["x"]
+
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "*_users"
+merge_keys      = ["y"]
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert!(errors.is_empty(), "got: {errors:?}");
+    }
+
+    #[test]
+    fn validate_replication_overrides_rejects_unreachable_merge_keys() {
+        // Pipeline default is `strategy="incremental"` (no
+        // merge_keys), and the override sets `strategy="merge"`
+        // without keys → unreachable.
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+timestamp_column = "_synced"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "audit_log"
+strategy        = "merge"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(matches!(
+            errors[0],
+            ConfigError::TableOverrideMergeMissingKeys { rule_index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn validate_replication_overrides_unreachable_keys_accepts_pipeline_default() {
+        // Pipeline default supplies merge_keys, so an override that
+        // sets strategy="merge" without its own keys is fine —
+        // inheritance covers it.
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = "audit_log"
+strategy        = "merge"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert!(errors.is_empty(), "got: {errors:?}");
+    }
+
+    #[test]
+    fn validate_replication_overrides_rejects_empty_glob_pattern() {
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+match.connector = "stripe_main"
+match.table     = ""
+merge_keys      = ["x"]
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_replication_overrides(&config);
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ConfigError::TableOverrideInvalidGlob { .. })),
+            "expected TableOverrideInvalidGlob: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_schema_pattern_reserved_components_rejects_table() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["client", "table"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{client}__{table}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_schema_pattern_reserved_components(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            &errors[0],
+            ConfigError::SchemaPatternReservedComponent { component, .. } if component == "table"
+        ));
+    }
+
+    #[test]
+    fn validate_schema_pattern_reserved_components_rejects_id() {
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["client", "id"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{client}__{id}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_schema_pattern_reserved_components(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            &errors[0],
+            ConfigError::SchemaPatternReservedComponent { component, .. } if component == "id"
+        ));
+    }
+
+    #[test]
+    fn validate_schema_pattern_reserved_components_strips_variadic_suffix() {
+        // `regions...` is fine; reserving `regions` would block a
+        // common user pattern. The variadic stripping must look at
+        // the bare name.
+        let mut toml_str = String::from(merge_pipeline_toml_base());
+        toml_str.push_str(
+            r#"
+strategy = "incremental"
+
+[pipeline.bronze.source]
+catalog = "raw_catalog"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["client", "id..."]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{client}"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_schema_pattern_reserved_components(&config);
+        // `id...` (variadic) is rejected the same as `id` (literal)
+        // because the bare name is still reserved.
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn load_rocky_config_fails_fast_on_empty_match() {
+        use std::io::Write;
+        let mut toml_str = override_pipeline_toml_base();
+        toml_str.push_str(
+            r#"
+[[pipeline.bronze.table_overrides]]
+strategy = "incremental"
+"#,
+        );
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        tmp.write_all(toml_str.as_bytes()).expect("write");
+        let err = load_rocky_config(tmp.path())
+            .expect_err("load_rocky_config should reject empty match block");
+        assert!(
+            matches!(
+                err,
+                ConfigError::TableOverrideEmptyMatch { rule_index: 0, .. }
+            ),
             "unexpected error: {err:?}"
         );
     }

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -540,6 +540,7 @@ mod tests {
             checks: ChecksConfig::default(),
             execution: ExecutionConfig::default(),
             depends_on,
+            table_overrides: vec![],
         }))
     }
 

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -964,6 +964,7 @@ mod tests {
             checks: ChecksConfig::default(),
             execution: ExecutionConfig::default(),
             depends_on: depends_on.into_iter().map(String::from).collect(),
+            table_overrides: vec![],
         }))
     }
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -902,6 +902,74 @@ class StateUploadFailureMode2(StrEnum):
     fail = "fail"
 
 
+class TableMatch(BaseModel):
+    """
+    Match criteria for a [`TableOverride`].
+
+    At least one of `connector` or `table` must be set (`None` for both is rejected at parse time as redundant — use pipeline-level fields to change defaults globally).
+
+    `connector` matches against either [`crate::source::DiscoveredConnector::id`] (the stable adapter-side identifier — e.g. a Fivetran connector_id) **or** [`crate::source::DiscoveredConnector::schema`] (the human-meaningful source schema name — e.g. `src__acme__shopify`). String equality on either match wins.
+
+    `table` matches against [`crate::source::DiscoveredTable::name`]. Supports `*` (zero or more characters) and `?` (exactly one character) glob wildcards; presence of either character switches the value from literal to glob.
+
+    # Reserved
+
+    `table` and `id` are reserved as schema-pattern component names — configs that use either as a component in [`SchemaPatternConfig::components`] are rejected at parse time to avoid colliding with `--filter table=` and `--filter id=`.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    connector: str | None = None
+    """
+    Connector match — equals either `DiscoveredConnector.id` or `DiscoveredConnector.schema`. `None` matches every connector.
+    """
+    table: str | None = None
+    """
+    Table-name match. Literal when no `*`/`?`; glob otherwise. `None` matches every table.
+    """
+
+
+class TableOverride(BaseModel):
+    """
+    A per-`(connector, table)` override rule on a replication pipeline.
+
+    Authored as one TOML array entry under `[[pipeline.<name>.table_overrides]]`. Each field except `match_` is optional — `None` means "inherit from the pipeline-level default." The resolver applies overrides with per-field most-specific-wins semantics; see [`ReplicationPipelineConfig::table_overrides`] for the ranking.
+
+    # Example
+
+    ```toml [[pipeline.raw.table_overrides]] match.connector = "stripe_main" match.table     = "pii_users" merge_keys      = ["user_id", "tenant_id"] ```
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    enabled: bool | None = None
+    """
+    When `Some(false)`, the matched `(connector, table)` pairs are dropped from the run and surfaced under `RunOutput.excluded_tables` with `reason = "table_override_disabled"`. Net-new field with no pipeline-level counterpart — disabling a whole pipeline is already covered by removing the pipeline block.
+    """
+    match: TableMatch | None = Field({}, validate_default=True)
+    """
+    Match criteria — at least one of `connector` or `table` must be set. A rule with neither (or a `match` block omitted entirely) is rejected at parse time (use pipeline-level fields to change defaults for all tables). `default` lets serde deserialize an override missing the whole `match` block; the validator catches the resulting empty match.
+    """
+    merge_keys: list[str] | None = None
+    """
+    Override for [`ReplicationPipelineConfig::merge_keys`]. `None` inherits the pipeline default.
+    """
+    merge_keys_fallback: list[str] | None = None
+    """
+    Override for [`ReplicationPipelineConfig::merge_keys_fallback`]. `None` inherits the pipeline default.
+    """
+    strategy: str | None = None
+    """
+    Override for [`ReplicationPipelineConfig::strategy`]. `None` inherits the pipeline default.
+    """
+    timestamp_column: str | None = None
+    """
+    Override for [`ReplicationPipelineConfig::timestamp_column`]. `None` inherits the pipeline default.
+    """
+
+
 class TableRef(BaseModel):
     """
     A reference to a specific catalog/schema/table for quality checks and snapshot pipelines.
@@ -2078,6 +2146,18 @@ class ReplicationPipelineConfig(BaseModel):
     Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
 
     `"merge"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.
+    """
+    table_overrides: list[TableOverride] | None = None
+    """
+    Per-`(connector, table)` overrides applied on top of the pipeline defaults. Each rule matches against a discovered connector + table pair and, when matched, replaces selected pipeline-level fields with override-supplied values.
+
+    Resolution is **per-field most-specific-match-wins**: for each overrideable field, the most specific matching rule that explicitly sets that field wins; less-specific rules contribute values only for fields they actually set. Specificity ranking (highest to lowest):
+
+    1. Both `match.connector` AND `match.table` set, with `match.table` a literal (no glob). 2. Both set, with `match.table` containing a `*` or `?` glob. 3. Only `match.connector` set. 4. Only `match.table` set.
+
+    Ties at the same specificity tier for a `(connector, table)` pair are rejected at parse time as ambiguous.
+
+    Empty by default — projects that don't need per-table tweaking pay nothing in JSON output, schema surface area, or runtime cost.
     """
     target: PipelineTargetConfig
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -205,6 +205,35 @@ class ModelCostEntry(BaseModel):
     duration_ms: conint(ge=0)
 
 
+class OverrideWarningOutput(BaseModel):
+    """
+    Soft warning surfaced on [`RunOutput::override_warnings`] when an override rule matched no tables this run.
+
+    Distinct kinds let orchestrators (Dagster) branch on cause without parsing free-form messages.
+    """
+
+    connector: str | None = None
+    """
+    Echo of `match.connector` from the rule, for cross-reference.
+    """
+    kind: str
+    """
+    Coarse kind: `"zero_match"` (rule matched no pair at all) or `"connector_match_empty"` (the connector half of the match resolved nothing).
+    """
+    message: str
+    """
+    Human-readable explanation, for logs and Dagster UI rendering.
+    """
+    rule_index: conint(ge=0)
+    """
+    Position of the rule in `[[table_overrides]]`, 0-based — same index the validator's error messages use.
+    """
+    table: str | None = None
+    """
+    Echo of `match.table` from the rule, for cross-reference.
+    """
+
+
 class PartitionInfo(BaseModel):
     """
     Partition window information for a single `time_interval` materialization.
@@ -564,6 +593,10 @@ class RunOutput(BaseModel):
     """
     materializations: list[MaterializationOutput]
     metrics: MetricsSnapshot | None = None
+    override_warnings: list[OverrideWarningOutput] | None = None
+    """
+    Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.
+    """
     partition_summaries: list[PartitionSummary]
     """
     Per-model partition execution summaries, present only when the run touched one or more `time_interval` models. Empty for runs that didn't execute any partitioned models.

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2132,6 +2132,13 @@
           "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
           "type": "string"
         },
+        "table_overrides": {
+          "description": "Per-`(connector, table)` overrides applied on top of the pipeline defaults. Each rule matches against a discovered connector + table pair and, when matched, replaces selected pipeline-level fields with override-supplied values.\n\nResolution is **per-field most-specific-match-wins**: for each overrideable field, the most specific matching rule that explicitly sets that field wins; less-specific rules contribute values only for fields they actually set. Specificity ranking (highest to lowest):\n\n1. Both `match.connector` AND `match.table` set, with `match.table` a literal (no glob). 2. Both set, with `match.table` containing a `*` or `?` glob. 3. Only `match.connector` set. 4. Only `match.table` set.\n\nTies at the same specificity tier for a `(connector, table)` pair are rejected at parse time as ambiguous.\n\nEmpty by default — projects that don't need per-table tweaking pay nothing in JSON output, schema surface area, or runtime cost.",
+          "items": {
+            "$ref": "#/definitions/TableOverride"
+          },
+          "type": "array"
+        },
         "target": {
           "allOf": [
             {
@@ -2729,6 +2736,84 @@
           "type": "string"
         }
       ]
+    },
+    "TableMatch": {
+      "additionalProperties": false,
+      "description": "Match criteria for a [`TableOverride`].\n\nAt least one of `connector` or `table` must be set (`None` for both is rejected at parse time as redundant — use pipeline-level fields to change defaults globally).\n\n`connector` matches against either [`crate::source::DiscoveredConnector::id`] (the stable adapter-side identifier — e.g. a Fivetran connector_id) **or** [`crate::source::DiscoveredConnector::schema`] (the human-meaningful source schema name — e.g. `src__acme__shopify`). String equality on either match wins.\n\n`table` matches against [`crate::source::DiscoveredTable::name`]. Supports `*` (zero or more characters) and `?` (exactly one character) glob wildcards; presence of either character switches the value from literal to glob.\n\n# Reserved\n\n`table` and `id` are reserved as schema-pattern component names — configs that use either as a component in [`SchemaPatternConfig::components`] are rejected at parse time to avoid colliding with `--filter table=` and `--filter id=`.",
+      "properties": {
+        "connector": {
+          "description": "Connector match — equals either `DiscoveredConnector.id` or `DiscoveredConnector.schema`. `None` matches every connector.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
+          "description": "Table-name match. Literal when no `*`/`?`; glob otherwise. `None` matches every table.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "TableOverride": {
+      "additionalProperties": false,
+      "description": "A per-`(connector, table)` override rule on a replication pipeline.\n\nAuthored as one TOML array entry under `[[pipeline.<name>.table_overrides]]`. Each field except `match_` is optional — `None` means \"inherit from the pipeline-level default.\" The resolver applies overrides with per-field most-specific-wins semantics; see [`ReplicationPipelineConfig::table_overrides`] for the ranking.\n\n# Example\n\n```toml [[pipeline.raw.table_overrides]] match.connector = \"stripe_main\" match.table     = \"pii_users\" merge_keys      = [\"user_id\", \"tenant_id\"] ```",
+      "properties": {
+        "enabled": {
+          "description": "When `Some(false)`, the matched `(connector, table)` pairs are dropped from the run and surfaced under `RunOutput.excluded_tables` with `reason = \"table_override_disabled\"`. Net-new field with no pipeline-level counterpart — disabling a whole pipeline is already covered by removing the pipeline block.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "match": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TableMatch"
+            }
+          ],
+          "default": {},
+          "description": "Match criteria — at least one of `connector` or `table` must be set. A rule with neither (or a `match` block omitted entirely) is rejected at parse time (use pipeline-level fields to change defaults for all tables). `default` lets serde deserialize an override missing the whole `match` block; the validator catches the resulting empty match."
+        },
+        "merge_keys": {
+          "description": "Override for [`ReplicationPipelineConfig::merge_keys`]. `None` inherits the pipeline default.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "merge_keys_fallback": {
+          "description": "Override for [`ReplicationPipelineConfig::merge_keys_fallback`]. `None` inherits the pipeline default.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "strategy": {
+          "description": "Override for [`ReplicationPipelineConfig::strategy`]. `None` inherits the pipeline default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestamp_column": {
+          "description": "Override for [`ReplicationPipelineConfig::timestamp_column`]. `None` inherits the pipeline default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "TableRef": {
       "additionalProperties": false,

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -644,6 +644,45 @@
       ],
       "type": "object"
     },
+    "OverrideWarningOutput": {
+      "description": "Soft warning surfaced on [`RunOutput::override_warnings`] when an override rule matched no tables this run.\n\nDistinct kinds let orchestrators (Dagster) branch on cause without parsing free-form messages.",
+      "properties": {
+        "connector": {
+          "description": "Echo of `match.connector` from the rule, for cross-reference.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "description": "Coarse kind: `\"zero_match\"` (rule matched no pair at all) or `\"connector_match_empty\"` (the connector half of the match resolved nothing).",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable explanation, for logs and Dagster UI rendering.",
+          "type": "string"
+        },
+        "rule_index": {
+          "description": "Position of the rule in `[[table_overrides]]`, 0-based — same index the validator's error messages use.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "table": {
+          "description": "Echo of `match.table` from the rule, for cross-reference.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "message",
+        "rule_index"
+      ],
+      "type": "object"
+    },
     "PartitionInfo": {
       "description": "Partition window information for a single `time_interval` materialization.\n\n`key` is the canonical Rocky partition key (e.g. `\"2026-04-07\"` for daily; `\"2026-04-07T13\"` for hourly). `start` / `end` are the half-open `[start, end)` window the SQL substituted for `@start_date` / `@end_date`. `batched_with` lists any additional partition keys that were merged into this batch when `batch_size > 1` — empty for the default one-partition-per-statement case.",
       "properties": {
@@ -1031,6 +1070,13 @@
           "type": "null"
         }
       ]
+    },
+    "override_warnings": {
+      "description": "Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.",
+      "items": {
+        "$ref": "#/definitions/OverrideWarningOutput"
+      },
+      "type": "array"
     },
     "partition_summaries": {
       "description": "Per-model partition execution summaries, present only when the run touched one or more `time_interval` models. Empty for runs that didn't execute any partitioned models.",


### PR DESCRIPTION
## Summary

Adds `[[pipeline.<name>.table_overrides]]` to replication pipelines — the natural follow-up to PR #561's pipeline-wide `strategy = "merge"`. Each rule matches against a discovered `(connector, table)` pair and supplies per-field overrides on top of pipeline-level defaults. Realistic shape: *pipeline default + a handful of per-table exceptions* (e.g. `pii_users` needs different keys, `audit_log` stays `incremental`, `_diagnostics_*` is skipped).

## What ships

**Config surface** (`engine/crates/rocky-core/src/config.rs`):

```toml
[pipeline.raw]
strategy   = \"merge\"
merge_keys = [\"id\"]
# ...

# Skip diagnostics on every connector.
[[pipeline.raw.table_overrides]]
match.table = \"_diagnostics_*\"
enabled     = false

# `pii_users` on stripe needs a composite merge key.
[[pipeline.raw.table_overrides]]
match.connector = \"stripe_main\"
match.table     = \"pii_users\"
merge_keys      = [\"user_id\", \"tenant_id\"]

# `audit_log` is append-only — stay incremental.
[[pipeline.raw.table_overrides]]
match.connector  = \"stripe_main\"
match.table      = \"audit_log\"
strategy         = \"incremental\"
timestamp_column = \"occurred_at\"
```

**Overrideable fields:** `strategy`, `merge_keys`, `merge_keys_fallback`, `timestamp_column`, `enabled` (net-new — drops the table from the run with `reason = \"table_override_disabled\"` on `RunOutput.excluded_tables`, parallel to today's `\"missing_from_source\"`).

**Match grammar:**
- `match.connector` matches `DiscoveredConnector.id` OR `DiscoveredConnector.schema` (OR semantics).
- `match.table` supports `*` and `?` globs in TOML; CLI `--filter table=<literal>` accepts literals only.
- `table` and `id` are reserved as schema-pattern component names — configs that use either are rejected at parse time.

**Resolver:** per-field most-specific-match-wins. Specificity tiers (highest→lowest): `BothLiteralTable > BothGlobTable > ConnectorOnly > TableOnly`. For each overrideable field, the most-specific rule that sets it wins; unrelated rules don't clobber it.

**CLI parity:** `--filter table=<literal>` wired into `run`, `plan`, `compare`, and `branch` table loops.

## Validation tier map

| Tier | Where | Rules caught |
|---|---|---|
| **T1** (parse-time fail-fast in `validate_replication_overrides` + `validate_schema_pattern_reserved_components`) | `load_rocky_config` | T1.1 duplicate fully-specific literal rules · T1.2 empty match block · T1.4 unreachable merge keys · T1.5 reserved-component collision (`table` / `id`) · T1.6 malformed glob |
| **T2** (discovery-time soft warn) | `RunOutput.override_warnings` (new structured field) | Zero-match rule (rule matched no `(connector, table)` pair this run) — pipeline runs to completion regardless |
| **T3** (run-time fail per-table) | `build_replication_strategy_with_override` | Empty effective merge_keys after inheritance — fails the table, not the pipeline |

## What's descoped

Memo step 7 — new POC at `examples/playground/pocs/12-replication-table-overrides/` — is intentionally not in this PR. The memo explicitly allows it to land separately; punting to a follow-up keeps this PR focused on engine + cascade. Filed as a TODO for a small follow-up PR.

## Reviewer notes

### Reversible decisions from the design memo

Stayed with the memo on both reversible decisions:
- **Per-field most-specific-wins** (vs whole-rule). The memo's worked example for the split-field case (`stripe_main` rule sets `timestamp_column`; `stripe_main+pii_users` rule sets `merge_keys`) is the strongest argument — under whole-rule the user would have to redeclare `timestamp_column` on the table-specific rule. Implementation: see `resolve_table_override` in `engine/crates/rocky-core/src/config.rs`.
- **Glob in `match.table`** (vs literal-only). The `_diagnostics_*` skip case is real enough to motivate it; hand-rolled `*`/`?` matcher (~30 LOC, no new workspace dep — `glob_match` in `config.rs`). CLI keeps literals only to avoid shell-quoting footguns.

### Memo correction

The memo's §Q3 / §validation summary claimed T2 needed *no schema change* (\"existing field, no new schema\"). In fact `RunOutput` had no pre-existing `warnings` field — the two `pub warnings:` hits in `output.rs` are on different structs (`HookContextWarning` and `ChecksConfigOutput`). T2 therefore lands as a new `override_warnings: Vec<OverrideWarningOutput>` field, structured (rule_index + kind + message + connector/table echo) so Dagster can branch on `kind` without text parsing. `skip_serializing_if = \"Vec::is_empty\"` keeps the JSON shape stable for runs without overrides — playground dagster fixtures show zero drift.

### Same-tier ambiguity at non-literal tiers — known limitation

T1.1 only rejects two rules at `BothLiteralTable` specificity for the same `(connector, table)`. Two rules at `ConnectorOnly` / `TableOnly` / `BothGlobTable` with the same match values that *both set the same field* will tiebreak by declaration order (the resolver's `(spec, idx)` sort). This is intentionally permissive for the common-case where two same-tier rules set *different* fields (composition is legitimate, e.g. one sets `timestamp_column`, the other sets `merge_keys`), but it means a user who writes two rules with identical glob patterns both setting `merge_keys` will get the first-declared one without a parse-time warning. Same-tier-same-field conflict detection is a small follow-up if it turns out to bite real users — the design space is decided (per-field), so the change would be additive.

### Other notes

- **No new workspace dependency.** Hand-rolled `*` / `?` glob matcher (`glob_match` in `engine/crates/rocky-core/src/config.rs`) — ~30 LOC + 4 tests. Trade-off vs `globset`: no character classes, no alternation; we'll add the crate if the use case grows.
- **`OverrideWarningOutput` derives.** Mirrored neighbouring `ExcludedTableOutput` — just `Debug + Serialize + JsonSchema`. No `Deserialize` or `Clone` (nothing downstream needs them).
- **No package-lock drift.** `just codegen` ran `npm install` but `package-lock.json` is unchanged.

## Test plan

- [x] `cargo test -p rocky-core --lib config` — 184 passing (14 new for overrides + glob + validators).
- [x] `cargo test -p rocky-cli --lib commands::run` — 75 passing (5 new for `build_replication_strategy_with_override`).
- [x] `cargo test -p rocky-cli --lib commands::tests` — 5 new tests on `filter_table_matches` + reserved `table=` key.
- [x] `cargo test` workspace-wide — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `just codegen` — schemas + Pydantic + TS regenerated; no drift.
- [x] `just regen-fixtures` — no dagster fixture diff (playground POCs don't declare overrides; `override_warnings` is `skip_serializing_if = \"Vec::is_empty\"`).
- [x] Dagster pytest — 541 passing.