### PR TITLE
feat(rocky-databricks): implement CatalogClient via Unity REST (catalog-first PR-4)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3891,8 +3891,10 @@ version = "1.36.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "percent-encoding",
  "reqwest",
  "rocky-adapter-sdk",
+ "rocky-catalog-core",
  "rocky-core",
  "rocky-ir",
  "rocky-observe",

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 rocky-core = { path = "../rocky-core" }
+rocky-catalog-core = { path = "../rocky-catalog-core" }
 rocky-ir = { path = "../rocky-ir" }
 rocky-observe = { path = "../rocky-observe" }
 rocky-sql = { path = "../rocky-sql" }
@@ -20,12 +21,17 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+percent-encoding = { workspace = true }
 
 [features]
 test-support = []
 
 [[test]]
 name = "wiremock_tests"
+required-features = ["test-support"]
+
+[[test]]
+name = "unity_catalog_client_wiremock"
 required-features = ["test-support"]
 
 [dev-dependencies]

--- a/engine/crates/rocky-databricks/src/lib.rs
+++ b/engine/crates/rocky-databricks/src/lib.rs
@@ -10,4 +10,7 @@ pub mod permissions;
 pub mod scim;
 pub mod throttle;
 pub mod types;
+pub mod unity_catalog_client;
 pub mod workspace;
+
+pub use unity_catalog_client::{UnityCatalogClient, UnityRestError};

--- a/engine/crates/rocky-databricks/src/unity_catalog_client.rs
+++ b/engine/crates/rocky-databricks/src/unity_catalog_client.rs
@@ -1,0 +1,1385 @@
+//! [`CatalogClient`] implementation backed by Databricks Unity Catalog REST.
+//!
+//! [`UnityCatalogClient`] talks directly to Unity's REST surface
+//! (`/api/2.1/unity-catalog/...`) for the catalog operations Unity
+//! exposes natively. The shape mirrors
+//! [`crate::workspace::WorkspaceManager`] and
+//! [`crate::scim::ScimClient`] — a thin `host + Auth + reqwest::Client`
+//! triple, no retry/circuit-breaker layer (those live on
+//! [`crate::connector::DatabricksConnector`] for the SQL path), and a
+//! single error type that maps cleanly onto
+//! [`rocky_catalog_core::CatalogError`].
+//!
+//! ## Method coverage
+//!
+//! Operations split into three buckets:
+//!
+//! 1. **Unity REST native** — implemented as direct HTTP calls.
+//!    - [`CatalogClient::describe_table`] → `GET /api/2.1/unity-catalog/tables/{full_name}`
+//!    - [`CatalogClient::list_tables`] → `GET /api/2.1/unity-catalog/tables?catalog_name=X&schema_name=Y`
+//!    - [`CatalogClient::create_table`] → `POST /api/2.1/unity-catalog/tables` (managed Delta)
+//!    - [`CatalogClient::drop_table`] → `DELETE /api/2.1/unity-catalog/tables/{full_name}`
+//!    - [`CatalogClient::get_grants`] → `GET /api/2.1/unity-catalog/permissions/table/{full_name}`
+//!    - [`CatalogClient::apply_grant`] / [`CatalogClient::revoke_grant`] →
+//!      `PATCH /api/2.1/unity-catalog/permissions/table/{full_name}` with
+//!      one entry in `changes[]` carrying the add or remove list.
+//! 2. **No Unity REST equivalent** — return
+//!    [`CatalogError::UnsupportedOperation`] today.
+//!    - [`CatalogClient::tag_table`] — Unity exposes tags via
+//!      `ALTER TABLE SET TAGS` SQL only; there is no REST tagging
+//!      endpoint on tables in Databricks runtime (confirmed against the
+//!      catalog-first plan's risk-2). Callers that want the SQL fallback
+//!      compose [`crate::catalog::CatalogManager::set_table_tags`].
+//!    - [`CatalogClient::commit_transaction`] — Catalog-Managed Commits
+//!      exist in Unity 0.4+ but are not surfaced as a generic multi-table
+//!      commit REST endpoint.
+//!    - [`CatalogClient::list_branches`] — Unity OSS does not model
+//!      Iceberg branches/tags.
+//!
+//! ## Three-level naming
+//!
+//! Unity is rigidly `catalog.schema.table`. The catalog-agnostic
+//! [`TableRef`] allows multi-part namespaces (Iceberg REST shape); this
+//! adapter projects that onto Unity's three-level model:
+//!
+//! - [`TableRef::catalog`] must be `Some(_)` — the Unity catalog name.
+//! - [`TableRef::namespace`] must contain exactly one part — the Unity
+//!   schema name.
+//! - [`TableRef::name`] is the Unity table name.
+//!
+//! Calls that violate this shape return
+//! [`CatalogError::InvalidResponse`] with a precise diagnostic, before
+//! any network hop. Future Polaris/Nessie implementations that accept
+//! multi-level namespaces will not share this constraint.
+//!
+//! Namespace-listing operations
+//! ([`CatalogClient::list_tables`](rocky_catalog_core::CatalogClient::list_tables))
+//! take `namespace = [catalog, schema]` since the trait signature has
+//! no separate catalog parameter. Per-table operations read catalog
+//! from [`TableRef::catalog`]. The asymmetry is inherent to mapping
+//! Unity's three-level model (multi-catalog per workspace) onto a
+//! trait whose namespace surface is shared with single-catalog
+//! Iceberg-style implementations.
+//!
+//! ## Error mapping
+//!
+//! HTTP status → [`CatalogError`] follows the rocky-iceberg precedent:
+//!
+//! - `401` → [`CatalogError::AuthFailed`]
+//! - `403` → [`CatalogError::PermissionDenied`]
+//! - `404` → [`CatalogError::TableNotFound`] by default; namespace-scoped
+//!   call sites (e.g. [`list_tables`]) rewrite to
+//!   [`CatalogError::NamespaceNotFound`].
+//! - `409` → [`CatalogError::CommitConflict`]
+//! - `429` and `5xx` → [`CatalogError::Transport`]
+//! - all other 4xx → [`CatalogError::InvalidResponse`]
+//! - transport-level failures → [`CatalogError::Transport`]
+//!
+//! [`CatalogClient`]: rocky_catalog_core::CatalogClient
+//! [`CatalogClient::describe_table`]: rocky_catalog_core::CatalogClient::describe_table
+//! [`CatalogClient::list_tables`]: rocky_catalog_core::CatalogClient::list_tables
+//! [`CatalogClient::create_table`]: rocky_catalog_core::CatalogClient::create_table
+//! [`CatalogClient::drop_table`]: rocky_catalog_core::CatalogClient::drop_table
+//! [`CatalogClient::get_grants`]: rocky_catalog_core::CatalogClient::get_grants
+//! [`CatalogClient::apply_grant`]: rocky_catalog_core::CatalogClient::apply_grant
+//! [`CatalogClient::revoke_grant`]: rocky_catalog_core::CatalogClient::revoke_grant
+//! [`CatalogClient::tag_table`]: rocky_catalog_core::CatalogClient::tag_table
+//! [`CatalogClient::commit_transaction`]: rocky_catalog_core::CatalogClient::commit_transaction
+//! [`CatalogClient::list_branches`]: rocky_catalog_core::CatalogClient::list_branches
+//! [`list_tables`]: rocky_catalog_core::CatalogClient::list_tables
+//! [`CatalogError`]: rocky_catalog_core::CatalogError
+//! [`CatalogError::UnsupportedOperation`]: rocky_catalog_core::CatalogError::UnsupportedOperation
+//! [`CatalogError::TableNotFound`]: rocky_catalog_core::CatalogError::TableNotFound
+//! [`CatalogError::NamespaceNotFound`]: rocky_catalog_core::CatalogError::NamespaceNotFound
+//! [`CatalogError::InvalidResponse`]: rocky_catalog_core::CatalogError::InvalidResponse
+//! [`CatalogError::Transport`]: rocky_catalog_core::CatalogError::Transport
+//! [`CatalogError::AuthFailed`]: rocky_catalog_core::CatalogError::AuthFailed
+//! [`CatalogError::PermissionDenied`]: rocky_catalog_core::CatalogError::PermissionDenied
+//! [`CatalogError::CommitConflict`]: rocky_catalog_core::CatalogError::CommitConflict
+//! [`TableRef`]: rocky_catalog_core::TableRef
+//! [`TableRef::catalog`]: rocky_catalog_core::TableRef::catalog
+//! [`TableRef::namespace`]: rocky_catalog_core::TableRef::namespace
+//! [`TableRef::name`]: rocky_catalog_core::TableRef::name
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use rocky_catalog_core::{
+    BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant, TableCommit,
+    TableRef, TableSchema,
+};
+
+use crate::auth::{Auth, AuthError};
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`UnityCatalogClient`] internally.
+///
+/// This is an intermediate error type — every variant maps cleanly onto
+/// [`CatalogError`] via the [`From<UnityRestError> for CatalogError`]
+/// impl below. Kept distinct so the HTTP / serde / auth layer can keep
+/// its own vocabulary (status + body) without leaking into the trait
+/// surface, mirroring the way
+/// [`crate::client::IcebergError`](../../rocky-iceberg/src/client.rs)
+/// is structured.
+#[derive(Debug, thiserror::Error)]
+pub enum UnityRestError {
+    /// Auth-layer failure (token mint, OAuth exchange).
+    #[error("auth error: {0}")]
+    Auth(#[from] AuthError),
+
+    /// Transport-level HTTP error (connect, TLS, body parse, etc.).
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Non-2xx status from the Unity API.
+    #[error("Unity API error {status}: {body}")]
+    Api { status: u16, body: String },
+
+    /// Response body parsed successfully but did not carry the expected shape.
+    #[error("unexpected Unity response: {0}")]
+    UnexpectedResponse(String),
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — request bodies
+// ---------------------------------------------------------------------------
+
+/// Body for `POST /api/2.1/unity-catalog/tables`.
+///
+/// We model only the fields Rocky writes today: name, parent catalog +
+/// schema, the column list, and the managed-Delta combination
+/// (`table_type = "MANAGED"`, `data_source_format = "DELTA"`). Storage
+/// location, comment, properties, and partitions are spec-optional and
+/// can be added by future callers without a trait change.
+#[derive(Debug, Clone, Serialize)]
+struct CreateTableBody<'a> {
+    name: &'a str,
+    catalog_name: &'a str,
+    schema_name: &'a str,
+    table_type: &'static str,
+    data_source_format: &'static str,
+    columns: Vec<CreateColumn<'a>>,
+}
+
+/// One column inside [`CreateTableBody::columns`].
+///
+/// `type_name`, `type_text` and `type_json` are all required by Unity's
+/// table-create endpoint. `type_name` is the enum name
+/// (`STRING`, `LONG`, etc.), `type_text` is the SQL spelling
+/// (`"string"`, `"bigint"`), and `type_json` is a JSON-encoded
+/// description that Unity validates against the other two.
+#[derive(Debug, Clone, Serialize)]
+struct CreateColumn<'a> {
+    name: &'a str,
+    type_name: String,
+    type_text: String,
+    type_json: String,
+    position: i32,
+    nullable: bool,
+}
+
+/// Body for `PATCH /api/2.1/unity-catalog/permissions/{securable_type}/{full_name}`.
+///
+/// Unity's permission PATCH applies a list of `changes[]` per request.
+/// Each change names one `principal` and an `add` and / or `remove`
+/// list of privilege strings. The
+/// [`CatalogClient::apply_grant`](rocky_catalog_core::CatalogClient::apply_grant)
+/// and
+/// [`CatalogClient::revoke_grant`](rocky_catalog_core::CatalogClient::revoke_grant)
+/// methods both produce a single-change PATCH — the same endpoint, with
+/// the privilege landing in the `add` or `remove` slot respectively.
+#[derive(Debug, Clone, Serialize)]
+struct UpdatePermissionsBody {
+    changes: Vec<PermissionChange>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PermissionChange {
+    principal: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    add: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    remove: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — response bodies
+// ---------------------------------------------------------------------------
+
+/// Response body for `GET /api/2.1/unity-catalog/tables/{full_name}` and
+/// `POST /api/2.1/unity-catalog/tables`.
+///
+/// Unity's table-info response is large (storage location, properties,
+/// metadata, owner, etc.); only the unqualified `name` and the column
+/// list are projected here. List responses use the same shape per
+/// entry; `name` is the unqualified table name and is `None` on
+/// describe responses that omit it (`full_name` carries the qualified
+/// form in that case but is not modelled today).
+#[derive(Debug, Clone, Deserialize)]
+struct TableInfo {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    columns: Vec<TableColumn>,
+}
+
+/// One column inside [`TableInfo::columns`].
+#[derive(Debug, Clone, Deserialize)]
+struct TableColumn {
+    name: String,
+    #[serde(default)]
+    type_text: Option<String>,
+    #[serde(default)]
+    type_name: Option<String>,
+    #[serde(default)]
+    nullable: Option<bool>,
+}
+
+/// Response body for `GET /api/2.1/unity-catalog/tables?...`.
+///
+/// Unity paginates via `next_page_token`; the in-memory unification of
+/// pages happens in [`UnityCatalogClient::list_tables_inner`].
+#[derive(Debug, Clone, Deserialize)]
+struct ListTablesResponse {
+    #[serde(default)]
+    tables: Vec<TableInfo>,
+    #[serde(default)]
+    next_page_token: Option<String>,
+}
+
+/// Response body for `GET /api/2.1/unity-catalog/permissions/{type}/{fqn}`.
+///
+/// Unity returns one `privilege_assignment` per principal; each carries
+/// the principal name and the list of privileges granted to it.
+#[derive(Debug, Clone, Deserialize)]
+struct PermissionsResponse {
+    #[serde(default)]
+    privilege_assignments: Vec<PrivilegeAssignment>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PrivilegeAssignment {
+    principal: String,
+    #[serde(default)]
+    privileges: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/// Unity Catalog REST-backed [`CatalogClient`] implementation.
+///
+/// Composes a `host + Auth + reqwest::Client` triple and translates the
+/// catalog-agnostic trait surface onto Unity's `/api/2.1/unity-catalog/`
+/// endpoints. The struct is cheaply cloneable: `Auth` is `Clone` (Arc
+/// inside), `reqwest::Client` is Arc-backed, and the host is a small
+/// owned string. Multiple Rocky tasks may share the same instance
+/// across async boundaries.
+#[derive(Clone)]
+pub struct UnityCatalogClient {
+    host: String,
+    auth: Auth,
+    client: Client,
+    /// Override for the base URL scheme + host (used by tests to point
+    /// at wiremock). Matches the pattern used by
+    /// [`crate::workspace::WorkspaceManager`].
+    #[cfg(any(test, feature = "test-support"))]
+    base_url_override: Option<String>,
+}
+
+impl UnityCatalogClient {
+    /// Build a new client.
+    ///
+    /// `host` is the Databricks workspace host (no scheme), e.g.
+    /// `"dbc-12345678-abcd.cloud.databricks.com"`. `auth` is the same
+    /// [`Auth`] instance the SQL connector uses — both PAT and OAuth
+    /// M2M flow through transparently.
+    pub fn new(host: String, auth: Auth) -> Self {
+        UnityCatalogClient {
+            host,
+            auth,
+            client: build_http_client(),
+            #[cfg(any(test, feature = "test-support"))]
+            base_url_override: None,
+        }
+    }
+
+    /// Overrides the base URL for API calls (for testing with wiremock).
+    #[cfg(any(test, feature = "test-support"))]
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url_override = Some(base_url);
+        self
+    }
+
+    /// Returns the base URL for API calls.
+    fn api_base_url(&self) -> String {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(url) = &self.base_url_override {
+            return url.clone();
+        }
+        format!("https://{}", self.host)
+    }
+
+    /// Sends `req` with bearer auth attached, awaits a response, and
+    /// surfaces non-2xx status codes as [`UnityRestError::Api`] (with
+    /// the body buffered as UTF-8 lossily so 4xx diagnostic strings are
+    /// not lost). Successful 2xx responses are returned unchanged for
+    /// the caller to body-parse.
+    async fn send(
+        &self,
+        req: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, UnityRestError> {
+        let token = self.auth.get_token().await?;
+        let resp = req.bearer_auth(token).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(UnityRestError::Api { status, body });
+        }
+        Ok(resp)
+    }
+}
+
+impl std::fmt::Debug for UnityCatalogClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnityCatalogClient")
+            .field("host", &self.host)
+            .field("auth", &self.auth)
+            .finish_non_exhaustive()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the shared `reqwest::Client` used for every Unity REST call.
+fn build_http_client() -> Client {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("reqwest client builder is infallible with these options")
+}
+
+/// Byte set used when percent-encoding individual identifier parts in
+/// the URL path. Allows RFC 3986 unreserved chars (`-`, `_`, `~`,
+/// alphanumerics) and encodes everything else, including `.` so a name
+/// with embedded dots cannot fake an extra level on the path. The
+/// literal `.` separator between catalog/schema/table is *not* encoded
+/// — it's inserted by [`build_full_name`] after each part has been
+/// individually encoded.
+const PATH_SAFE: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'_').remove(b'~');
+
+/// Encode one identifier for use in a Unity REST URL path.
+fn encode_part(part: &str) -> String {
+    utf8_percent_encode(part, PATH_SAFE).to_string()
+}
+
+/// Project a catalog-agnostic [`TableRef`] onto Unity's three-level name.
+///
+/// Unity is rigidly `catalog.schema.table`. The mapping is:
+///
+/// - [`TableRef::catalog`] must be `Some(_)`.
+/// - [`TableRef::namespace`] must contain exactly one entry (the schema).
+/// - [`TableRef::name`] is the table.
+///
+/// Returns [`CatalogError::InvalidResponse`] with a precise diagnostic
+/// when the shape doesn't match — caught before any network hop.
+fn unity_parts(table: &TableRef) -> CatalogResult<(&str, &str, &str)> {
+    let catalog = table.catalog.as_deref().ok_or_else(|| {
+        CatalogError::InvalidResponse(
+            "Unity Catalog requires TableRef.catalog to be Some(_)".to_string(),
+        )
+    })?;
+    if table.namespace.len() != 1 {
+        return Err(CatalogError::InvalidResponse(format!(
+            "Unity Catalog requires exactly one namespace part (schema); got {} parts",
+            table.namespace.len()
+        )));
+    }
+    Ok((catalog, &table.namespace[0], &table.name))
+}
+
+/// Build the URL-path-safe Unity `full_name` (`{catalog}.{schema}.{table}`).
+///
+/// Each part is percent-encoded with [`PATH_SAFE`] before being joined
+/// with a literal `.`. This prevents identifiers carrying `/`, `?`,
+/// `#`, or extra `.` characters from forging paths on the Unity API
+/// server.
+fn build_full_name(catalog: &str, schema: &str, table: &str) -> String {
+    format!(
+        "{}.{}.{}",
+        encode_part(catalog),
+        encode_part(schema),
+        encode_part(table),
+    )
+}
+
+/// Map [`UnityRestError`] onto the catalog-agnostic [`CatalogError`].
+///
+/// Rules (mirror the rocky-iceberg precedent so cross-adapter behaviour
+/// is uniform):
+///
+/// - 401 → [`CatalogError::AuthFailed`]
+/// - 403 → [`CatalogError::PermissionDenied`]
+/// - 404 → [`CatalogError::TableNotFound`] (table-targeted default;
+///   namespace-scoped call sites rewrite to
+///   [`CatalogError::NamespaceNotFound`] in a `map_err`).
+/// - 409 → [`CatalogError::CommitConflict`]
+/// - 429 or 5xx → [`CatalogError::Transport`]
+/// - other 4xx → [`CatalogError::InvalidResponse`]
+/// - transport-level [`UnityRestError::Http`],
+///   [`UnityRestError::Auth`] → [`CatalogError::Transport`] (auth
+///   failures bubble via the `From<AuthError>` chain to
+///   `Transport` since `AuthError` is the runtime-layer wrapper around
+///   refresh failures — the dedicated [`CatalogError::AuthFailed`]
+///   variant is reserved for surfaced 401s).
+/// - [`UnityRestError::UnexpectedResponse`] → [`CatalogError::InvalidResponse`].
+fn unity_into_catalog(err: UnityRestError) -> CatalogError {
+    match err {
+        UnityRestError::Api { status, body } => match status {
+            401 => CatalogError::AuthFailed(format!("HTTP 401: {body}")),
+            403 => CatalogError::PermissionDenied(format!("HTTP 403: {body}")),
+            404 => CatalogError::TableNotFound(format!("HTTP 404: {body}")),
+            409 => CatalogError::CommitConflict(format!("HTTP 409: {body}")),
+            429 | 500..=599 => {
+                CatalogError::Transport(Box::new(UnityRestError::Api { status, body }))
+            }
+            _ => CatalogError::InvalidResponse(format!("HTTP {status}: {body}")),
+        },
+        UnityRestError::Http(e) => CatalogError::Transport(Box::new(e)),
+        UnityRestError::Auth(e) => CatalogError::Transport(Box::new(e)),
+        UnityRestError::UnexpectedResponse(msg) => CatalogError::InvalidResponse(msg),
+    }
+}
+
+impl From<UnityRestError> for CatalogError {
+    fn from(err: UnityRestError) -> Self {
+        unity_into_catalog(err)
+    }
+}
+
+/// Build the catalog-agnostic [`TableSchema`] from a Unity [`TableInfo`].
+///
+/// `type_text` is preferred (SQL spelling, `"string"`/`"bigint"`); falls
+/// back to `type_name` (`"STRING"`/`"LONG"`) when `type_text` is absent.
+/// Defaults to `nullable = true` when Unity omits the flag — Delta's
+/// declarative nullability comes through this field but historical
+/// table-info responses occasionally omit it.
+fn schema_from_table_info(info: &TableInfo) -> TableSchema {
+    let columns = info
+        .columns
+        .iter()
+        .map(|c| ColumnSchema {
+            name: c.name.clone(),
+            type_str: c
+                .type_text
+                .clone()
+                .or_else(|| c.type_name.clone())
+                .unwrap_or_default(),
+            nullable: c.nullable.unwrap_or(true),
+        })
+        .collect();
+    TableSchema { columns }
+}
+
+/// Render Rocky's [`ColumnSchema::type_str`] into the trio of
+/// `type_name` / `type_text` / `type_json` Unity's create-table
+/// endpoint demands.
+///
+/// `type_str` is the SQL spelling Rocky carries on the trait surface
+/// (`"string"`, `"bigint"`, `"decimal(10,2)"`, ...). For primitive types
+/// we project onto the Unity enum name via [`unity_type_name`]; for
+/// complex types (lists/maps/structs) we leave the enum as `STRING`
+/// and let `type_text` carry the spec — Rocky's trait does not carry
+/// rich enough information to round-trip complex types here, and
+/// callers that need them should use a richer adapter surface.
+fn create_columns_from_schema<'a>(schema: &'a TableSchema) -> Vec<CreateColumn<'a>> {
+    schema
+        .columns
+        .iter()
+        .enumerate()
+        .map(|(idx, col)| {
+            let type_text = col.type_str.clone();
+            let type_name = unity_type_name(&col.type_str);
+            // Unity validates `type_json` against the other two; the
+            // minimal form is a JSON object with `name` / `type` /
+            // `nullable` / `metadata`. Rocky carries no field metadata
+            // on the trait, so emit an empty `metadata` object.
+            let type_json = serde_json::json!({
+                "name": col.name,
+                "type": type_text.to_lowercase(),
+                "nullable": col.nullable,
+                "metadata": {},
+            })
+            .to_string();
+            CreateColumn {
+                name: &col.name,
+                type_name,
+                type_text,
+                type_json,
+                position: idx as i32,
+                nullable: col.nullable,
+            }
+        })
+        .collect()
+}
+
+/// Map a SQL-spelling type string (`"bigint"`, `"string"`, ...) to the
+/// Unity enum name (`LONG`, `STRING`, ...).
+///
+/// Coverage is intentionally limited to the common cases Rocky's IR
+/// emits today. Unknown spellings default to `STRING` — the trait does
+/// not promise round-trip fidelity for warehouse-specific types, and
+/// callers that need richer mapping should route through a non-trait
+/// surface.
+fn unity_type_name(type_str: &str) -> String {
+    let lower = type_str.trim().to_ascii_lowercase();
+    let head = lower.split('(').next().unwrap_or(&lower).trim();
+    let name = match head {
+        "boolean" | "bool" => "BOOLEAN",
+        "byte" | "tinyint" => "BYTE",
+        "short" | "smallint" => "SHORT",
+        "int" | "integer" => "INT",
+        "long" | "bigint" => "LONG",
+        "float" => "FLOAT",
+        "double" => "DOUBLE",
+        "string" | "varchar" | "char" | "text" => "STRING",
+        "binary" => "BINARY",
+        "date" => "DATE",
+        "timestamp" | "timestamp_ntz" => "TIMESTAMP",
+        "decimal" | "numeric" => "DECIMAL",
+        "array" => "ARRAY",
+        "map" => "MAP",
+        "struct" => "STRUCT",
+        _ => "STRING",
+    };
+    name.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// CatalogClient impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl CatalogClient for UnityCatalogClient {
+    async fn list_tables(&self, namespace: &[String]) -> CatalogResult<Vec<TableRef>> {
+        // Unity needs both the catalog and schema names to list tables.
+        // The trait gives us a multi-part namespace; project onto the
+        // Unity two-of-three (catalog + schema) and fail before the
+        // network hop if the shape is wrong.
+        if namespace.len() != 2 {
+            return Err(CatalogError::InvalidResponse(format!(
+                "Unity Catalog list_tables requires namespace = [catalog, schema]; got {} parts",
+                namespace.len()
+            )));
+        }
+        let catalog = &namespace[0];
+        let schema = &namespace[1];
+        // 404 on this endpoint typically means the parent schema is
+        // missing; rewrite the default `TableNotFound` accordingly.
+        self.list_tables_inner(catalog, schema)
+            .await
+            .map_err(|e| match unity_into_catalog(e) {
+                CatalogError::TableNotFound(msg) => CatalogError::NamespaceNotFound(msg),
+                other => other,
+            })
+    }
+
+    async fn describe_table(&self, table: &TableRef) -> CatalogResult<TableSchema> {
+        let (catalog, schema, name) = unity_parts(table)?;
+        let full = build_full_name(catalog, schema, name);
+        let url = format!(
+            "{}/api/2.1/unity-catalog/tables/{}",
+            self.api_base_url(),
+            full
+        );
+        let resp = self
+            .send(self.client.get(&url))
+            .await
+            .map_err(unity_into_catalog)?;
+        let info: TableInfo = resp
+            .json()
+            .await
+            .map_err(|e| CatalogError::InvalidResponse(format!("describe_table body: {e}")))?;
+        debug!(catalog, schema, name, "described Unity table");
+        Ok(schema_from_table_info(&info))
+    }
+
+    async fn create_table(&self, table: &TableRef, schema: &TableSchema) -> CatalogResult<()> {
+        let (cat, sch, name) = unity_parts(table)?;
+        let body = CreateTableBody {
+            name,
+            catalog_name: cat,
+            schema_name: sch,
+            table_type: "MANAGED",
+            data_source_format: "DELTA",
+            columns: create_columns_from_schema(schema),
+        };
+        let url = format!("{}/api/2.1/unity-catalog/tables", self.api_base_url());
+        // 404 on a parent-scoped endpoint means the catalog or schema
+        // is missing, not the table; rewrite the default mapping.
+        self.send(self.client.post(&url).json(&body))
+            .await
+            .map_err(|e| match unity_into_catalog(e) {
+                CatalogError::TableNotFound(msg) => CatalogError::NamespaceNotFound(msg),
+                other => other,
+            })?;
+        debug!(catalog = cat, schema = sch, name, "created Unity table");
+        Ok(())
+    }
+
+    async fn drop_table(&self, table: &TableRef) -> CatalogResult<()> {
+        let (catalog, schema, name) = unity_parts(table)?;
+        let full = build_full_name(catalog, schema, name);
+        let url = format!(
+            "{}/api/2.1/unity-catalog/tables/{}",
+            self.api_base_url(),
+            full
+        );
+        self.send(self.client.delete(&url))
+            .await
+            .map_err(unity_into_catalog)?;
+        debug!(catalog, schema, name, "dropped Unity table");
+        Ok(())
+    }
+
+    async fn commit_transaction(&self, _commits: &[TableCommit]) -> CatalogResult<()> {
+        // Unity exposes Catalog-Managed Commits internally (UC 0.4+,
+        // 2026-02 Delta integration), but not as a generic multi-table
+        // commit REST endpoint Rocky can target uniformly. Surface as
+        // unsupported so callers route through warehouse-side execution.
+        Err(CatalogError::UnsupportedOperation(
+            "Unity Catalog REST exposes no generic multi-table commit endpoint",
+        ))
+    }
+
+    async fn list_branches(&self, _table: &TableRef) -> CatalogResult<Vec<BranchRef>> {
+        // Unity OSS does not model Iceberg branches/tags. Even reading
+        // foreign Iceberg from Databricks pins to `main`. Surface as
+        // unsupported so branch-aware callers fall back to per-adapter
+        // primitives or skip the call.
+        Err(CatalogError::UnsupportedOperation(
+            "Unity Catalog does not expose Iceberg-style branches/tags",
+        ))
+    }
+
+    async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
+        // Unity has no general-purpose table-tag REST endpoint in
+        // Databricks runtime — `ALTER TABLE SET TAGS` SQL is the only
+        // supported path. Callers that need the SQL fallback compose
+        // [`crate::catalog::CatalogManager::set_table_tags`] directly;
+        // this client stays SQL-free by design.
+        Err(CatalogError::UnsupportedOperation(
+            "Unity Catalog exposes no table-tag REST endpoint; use ALTER TABLE SET TAGS SQL",
+        ))
+    }
+
+    async fn get_grants(&self, table: &TableRef) -> CatalogResult<Vec<Grant>> {
+        let (catalog, schema, name) = unity_parts(table)?;
+        let full = build_full_name(catalog, schema, name);
+        let url = format!(
+            "{}/api/2.1/unity-catalog/permissions/table/{}",
+            self.api_base_url(),
+            full
+        );
+        let resp = self
+            .send(self.client.get(&url))
+            .await
+            .map_err(unity_into_catalog)?;
+        let body: PermissionsResponse = resp
+            .json()
+            .await
+            .map_err(|e| CatalogError::InvalidResponse(format!("get_grants body: {e}")))?;
+        let mut out = Vec::new();
+        for assignment in body.privilege_assignments {
+            for privilege in assignment.privileges {
+                out.push(Grant {
+                    principal: assignment.principal.clone(),
+                    privilege,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    async fn apply_grant(&self, table: &TableRef, grant: &Grant) -> CatalogResult<()> {
+        self.patch_permissions(table, grant, /*adding=*/ true).await
+    }
+
+    async fn revoke_grant(&self, table: &TableRef, grant: &Grant) -> CatalogResult<()> {
+        self.patch_permissions(table, grant, /*adding=*/ false)
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inner helpers (keep CatalogClient impl readable)
+// ---------------------------------------------------------------------------
+
+impl UnityCatalogClient {
+    /// Paginated `GET /api/2.1/unity-catalog/tables?catalog_name=&schema_name=`.
+    ///
+    /// Drains `next_page_token` so the caller sees the full list without
+    /// having to thread cursors through the trait surface.
+    async fn list_tables_inner(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> Result<Vec<TableRef>, UnityRestError> {
+        let mut out = Vec::new();
+        let mut page_token: Option<String> = None;
+        loop {
+            let mut req = self
+                .client
+                .get(format!(
+                    "{}/api/2.1/unity-catalog/tables",
+                    self.api_base_url()
+                ))
+                .query(&[("catalog_name", catalog), ("schema_name", schema)]);
+            if let Some(token) = &page_token {
+                req = req.query(&[("page_token", token.as_str())]);
+            }
+            let resp = self.send(req).await?;
+            let parsed: ListTablesResponse = resp.json().await.map_err(|e| {
+                UnityRestError::UnexpectedResponse(format!("list_tables body: {e}"))
+            })?;
+            for info in parsed.tables {
+                let Some(name) = info.name else {
+                    continue;
+                };
+                if name.is_empty() {
+                    continue;
+                }
+                out.push(TableRef {
+                    catalog: Some(catalog.to_string()),
+                    namespace: vec![schema.to_string()],
+                    name,
+                });
+            }
+            match parsed.next_page_token {
+                Some(t) if !t.is_empty() => page_token = Some(t),
+                _ => break,
+            }
+        }
+        debug!(catalog, schema, count = out.len(), "listed Unity tables");
+        Ok(out)
+    }
+
+    /// PATCH `/api/2.1/unity-catalog/permissions/table/{fqn}` with a
+    /// single-change body. Used by both
+    /// [`CatalogClient::apply_grant`](rocky_catalog_core::CatalogClient::apply_grant)
+    /// (privilege lands in `add`) and
+    /// [`CatalogClient::revoke_grant`](rocky_catalog_core::CatalogClient::revoke_grant)
+    /// (privilege lands in `remove`) — Unity's permissions endpoint is
+    /// a single PATCH that does both via the `add` / `remove` slots.
+    async fn patch_permissions(
+        &self,
+        table: &TableRef,
+        grant: &Grant,
+        adding: bool,
+    ) -> CatalogResult<()> {
+        let (catalog, schema, name) = unity_parts(table)?;
+        let full = build_full_name(catalog, schema, name);
+        let url = format!(
+            "{}/api/2.1/unity-catalog/permissions/table/{}",
+            self.api_base_url(),
+            full
+        );
+        let change = PermissionChange {
+            principal: grant.principal.clone(),
+            add: if adding {
+                vec![grant.privilege.clone()]
+            } else {
+                Vec::new()
+            },
+            remove: if adding {
+                Vec::new()
+            } else {
+                vec![grant.privilege.clone()]
+            },
+        };
+        let body = UpdatePermissionsBody {
+            changes: vec![change],
+        };
+        self.send(self.client.patch(&url).json(&body))
+            .await
+            .map_err(unity_into_catalog)?;
+        debug!(
+            catalog,
+            schema,
+            name,
+            principal = %grant.principal,
+            privilege = %grant.privilege,
+            action = if adding { "grant" } else { "revoke" },
+            "Unity permission change applied"
+        );
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_table_ref() -> TableRef {
+        TableRef {
+            catalog: Some("hcv2_cat".to_string()),
+            namespace: vec!["hcv2_sch".to_string()],
+            name: "hcv2_tbl".to_string(),
+        }
+    }
+
+    fn sample_schema() -> TableSchema {
+        TableSchema {
+            columns: vec![
+                ColumnSchema {
+                    name: "id".into(),
+                    type_str: "bigint".into(),
+                    nullable: false,
+                },
+                ColumnSchema {
+                    name: "amount".into(),
+                    type_str: "decimal(10,2)".into(),
+                    nullable: true,
+                },
+            ],
+        }
+    }
+
+    // ---- shape projection ----
+
+    #[test]
+    fn unity_parts_accepts_three_level_shape() {
+        let table = sample_table_ref();
+        let r = unity_parts(&table).expect("ok");
+        assert_eq!(r, ("hcv2_cat", "hcv2_sch", "hcv2_tbl"));
+    }
+
+    #[test]
+    fn unity_parts_rejects_missing_catalog() {
+        let t = TableRef {
+            catalog: None,
+            namespace: vec!["s".into()],
+            name: "t".into(),
+        };
+        let err = unity_parts(&t).unwrap_err();
+        assert!(
+            matches!(err, CatalogError::InvalidResponse(_)),
+            "expected InvalidResponse, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unity_parts_rejects_multi_part_namespace() {
+        let t = TableRef {
+            catalog: Some("c".into()),
+            namespace: vec!["a".into(), "b".into()],
+            name: "t".into(),
+        };
+        let err = unity_parts(&t).unwrap_err();
+        assert!(matches!(err, CatalogError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn unity_parts_rejects_empty_namespace() {
+        let t = TableRef {
+            catalog: Some("c".into()),
+            namespace: vec![],
+            name: "t".into(),
+        };
+        let err = unity_parts(&t).unwrap_err();
+        assert!(matches!(err, CatalogError::InvalidResponse(_)));
+    }
+
+    // ---- URL building ----
+
+    #[test]
+    fn build_full_name_joins_with_dot() {
+        assert_eq!(build_full_name("cat", "sch", "tbl"), "cat.sch.tbl");
+    }
+
+    #[test]
+    fn build_full_name_encodes_special_chars() {
+        // `/` and `?` would forge new endpoints if left raw; `.`
+        // would forge an extra level. Each is encoded individually
+        // before the literal `.` joiner.
+        assert_eq!(build_full_name("a/b", "s?x", "t.t"), "a%2Fb.s%3Fx.t%2Et");
+    }
+
+    #[test]
+    fn build_full_name_preserves_alphanumerics_and_underscores() {
+        assert_eq!(
+            build_full_name("hcv2_cat", "hcv2_sch", "hcv2_orders_2026"),
+            "hcv2_cat.hcv2_sch.hcv2_orders_2026"
+        );
+    }
+
+    // ---- status mapping ----
+
+    #[test]
+    fn api_401_maps_to_auth_failed() {
+        let mapped: CatalogError = UnityRestError::Api {
+            status: 401,
+            body: "unauthorized".into(),
+        }
+        .into();
+        assert!(matches!(mapped, CatalogError::AuthFailed(_)));
+    }
+
+    #[test]
+    fn api_403_maps_to_permission_denied() {
+        let mapped: CatalogError = UnityRestError::Api {
+            status: 403,
+            body: "forbidden".into(),
+        }
+        .into();
+        assert!(matches!(mapped, CatalogError::PermissionDenied(_)));
+    }
+
+    #[test]
+    fn api_404_maps_to_table_not_found_by_default() {
+        let mapped: CatalogError = UnityRestError::Api {
+            status: 404,
+            body: "no such".into(),
+        }
+        .into();
+        assert!(matches!(mapped, CatalogError::TableNotFound(_)));
+    }
+
+    #[test]
+    fn api_409_maps_to_commit_conflict() {
+        let mapped: CatalogError = UnityRestError::Api {
+            status: 409,
+            body: "conflict".into(),
+        }
+        .into();
+        assert!(matches!(mapped, CatalogError::CommitConflict(_)));
+    }
+
+    #[test]
+    fn api_429_and_5xx_map_to_transport() {
+        for status in [429u16, 500, 502, 503, 504] {
+            let mapped: CatalogError = UnityRestError::Api {
+                status,
+                body: format!("status {status}"),
+            }
+            .into();
+            assert!(
+                matches!(mapped, CatalogError::Transport(_)),
+                "status {status} should map to Transport, got {mapped:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_4xx_maps_to_invalid_response() {
+        let mapped: CatalogError = UnityRestError::Api {
+            status: 418,
+            body: "teapot".into(),
+        }
+        .into();
+        assert!(matches!(mapped, CatalogError::InvalidResponse(_)));
+    }
+
+    #[test]
+    fn unexpected_response_maps_to_invalid_response() {
+        let mapped: CatalogError =
+            UnityRestError::UnexpectedResponse("bad json".to_string()).into();
+        assert!(matches!(mapped, CatalogError::InvalidResponse(_)));
+    }
+
+    // ---- type projection ----
+
+    #[test]
+    fn unity_type_name_primitive_coverage() {
+        assert_eq!(unity_type_name("bigint"), "LONG");
+        assert_eq!(unity_type_name("BIGINT"), "LONG");
+        assert_eq!(unity_type_name("string"), "STRING");
+        assert_eq!(unity_type_name("varchar(255)"), "STRING");
+        assert_eq!(unity_type_name("decimal(10,2)"), "DECIMAL");
+        assert_eq!(unity_type_name("boolean"), "BOOLEAN");
+        assert_eq!(unity_type_name("timestamp"), "TIMESTAMP");
+        assert_eq!(unity_type_name("date"), "DATE");
+    }
+
+    #[test]
+    fn unity_type_name_unknown_defaults_to_string() {
+        // Trait does not promise round-trip fidelity for warehouse-
+        // specific types; unknown spellings fall back to STRING.
+        assert_eq!(unity_type_name("rocky_special_type"), "STRING");
+    }
+
+    #[test]
+    fn create_columns_from_schema_assigns_position_zero_first() {
+        let schema = sample_schema();
+        let cols = create_columns_from_schema(&schema);
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].position, 0);
+        assert_eq!(cols[1].position, 1);
+    }
+
+    #[test]
+    fn create_columns_from_schema_preserves_nullability() {
+        let schema = sample_schema();
+        let cols = create_columns_from_schema(&schema);
+        assert!(!cols[0].nullable, "id is non-null");
+        assert!(cols[1].nullable, "amount is nullable");
+    }
+
+    #[test]
+    fn create_columns_from_schema_picks_unity_enum_name() {
+        let schema = sample_schema();
+        let cols = create_columns_from_schema(&schema);
+        assert_eq!(cols[0].type_name, "LONG");
+        assert_eq!(cols[1].type_name, "DECIMAL");
+    }
+
+    #[test]
+    fn schema_from_table_info_prefers_type_text() {
+        let info = TableInfo {
+            name: Some("orders".into()),
+            columns: vec![TableColumn {
+                name: "id".into(),
+                type_text: Some("bigint".into()),
+                type_name: Some("LONG".into()),
+                nullable: Some(false),
+            }],
+        };
+        let schema = schema_from_table_info(&info);
+        assert_eq!(schema.columns[0].type_str, "bigint");
+        assert!(!schema.columns[0].nullable);
+    }
+
+    #[test]
+    fn schema_from_table_info_falls_back_to_type_name_when_text_absent() {
+        let info = TableInfo {
+            name: None,
+            columns: vec![TableColumn {
+                name: "id".into(),
+                type_text: None,
+                type_name: Some("LONG".into()),
+                nullable: None,
+            }],
+        };
+        let schema = schema_from_table_info(&info);
+        assert_eq!(schema.columns[0].type_str, "LONG");
+        assert!(
+            schema.columns[0].nullable,
+            "missing nullable defaults to true"
+        );
+    }
+
+    // ---- request body serialisation ----
+
+    #[test]
+    fn create_table_body_serialises_managed_delta() {
+        let schema = sample_schema();
+        let body = CreateTableBody {
+            name: "hcv2_orders",
+            catalog_name: "hcv2_cat",
+            schema_name: "hcv2_sch",
+            table_type: "MANAGED",
+            data_source_format: "DELTA",
+            columns: create_columns_from_schema(&schema),
+        };
+        let v: serde_json::Value = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["name"], "hcv2_orders");
+        assert_eq!(v["catalog_name"], "hcv2_cat");
+        assert_eq!(v["schema_name"], "hcv2_sch");
+        assert_eq!(v["table_type"], "MANAGED");
+        assert_eq!(v["data_source_format"], "DELTA");
+        assert_eq!(v["columns"][0]["name"], "id");
+        assert_eq!(v["columns"][0]["type_name"], "LONG");
+        assert_eq!(v["columns"][0]["nullable"], false);
+        assert_eq!(v["columns"][1]["type_name"], "DECIMAL");
+    }
+
+    #[test]
+    fn update_permissions_body_skips_empty_lists() {
+        // `add` empty / `remove` set — the revoke shape. Empty `add`
+        // is skipped on the wire so Unity doesn't see an empty array
+        // it might reject.
+        let body = UpdatePermissionsBody {
+            changes: vec![PermissionChange {
+                principal: "engineers".into(),
+                add: vec![],
+                remove: vec!["SELECT".into()],
+            }],
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("\"add\""), "empty add should be skipped");
+        assert!(json.contains("\"remove\""), "remove must be present");
+        assert!(json.contains("\"principal\":\"engineers\""));
+    }
+
+    #[test]
+    fn update_permissions_body_apply_shape() {
+        // `add` set / `remove` empty — the apply shape.
+        let body = UpdatePermissionsBody {
+            changes: vec![PermissionChange {
+                principal: "engineers".into(),
+                add: vec!["SELECT".into()],
+                remove: vec![],
+            }],
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"add\""));
+        assert!(
+            !json.contains("\"remove\""),
+            "empty remove should be skipped"
+        );
+    }
+
+    // ---- response body deserialisation ----
+
+    #[test]
+    fn table_info_deserialises_columns() {
+        let json = r#"{
+            "name": "orders",
+            "columns": [
+                {"name": "id", "type_text": "bigint", "type_name": "LONG", "nullable": false},
+                {"name": "amount", "type_text": "decimal(10,2)", "type_name": "DECIMAL", "nullable": true}
+            ]
+        }"#;
+        let info: TableInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.columns.len(), 2);
+        assert_eq!(info.columns[0].name, "id");
+        assert_eq!(info.columns[0].type_text.as_deref(), Some("bigint"));
+        assert_eq!(info.columns[0].nullable, Some(false));
+    }
+
+    #[test]
+    fn list_tables_response_handles_pagination_token() {
+        let json = r#"{
+            "tables": [
+                {"name": "orders", "columns": []},
+                {"name": "customers", "columns": []}
+            ],
+            "next_page_token": "token-abc"
+        }"#;
+        let resp: ListTablesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.tables.len(), 2);
+        assert_eq!(resp.next_page_token.as_deref(), Some("token-abc"));
+    }
+
+    #[test]
+    fn list_tables_response_no_token_terminates_pagination() {
+        let json = r#"{"tables": []}"#;
+        let resp: ListTablesResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.next_page_token.is_none());
+    }
+
+    #[test]
+    fn permissions_response_flattens_assignments_to_grants() {
+        // Unity returns one assignment per principal with the
+        // principal's list of privileges; the trait surface flattens
+        // it to one Grant per (principal, privilege) pair.
+        let json = r#"{
+            "privilege_assignments": [
+                {"principal": "engineers", "privileges": ["SELECT", "MODIFY"]},
+                {"principal": "analysts", "privileges": ["SELECT"]}
+            ]
+        }"#;
+        let resp: PermissionsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.privilege_assignments.len(), 2);
+        assert_eq!(resp.privilege_assignments[0].privileges.len(), 2);
+    }
+
+    // ---- unsupported operations ----
+
+    #[tokio::test]
+    async fn tag_table_returns_unsupported() {
+        let client = make_offline_client();
+        let err = client
+            .tag_table(&sample_table_ref(), "k", "v")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn list_branches_returns_unsupported() {
+        let client = make_offline_client();
+        let err = client.list_branches(&sample_table_ref()).await.unwrap_err();
+        assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+    }
+
+    #[tokio::test]
+    async fn commit_transaction_returns_unsupported() {
+        let client = make_offline_client();
+        let err = client.commit_transaction(&[]).await.unwrap_err();
+        assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+    }
+
+    // ---- shape gating fires before network ----
+
+    #[tokio::test]
+    async fn describe_table_with_invalid_shape_fails_offline() {
+        let client = make_offline_client();
+        let bad = TableRef {
+            catalog: None,
+            namespace: vec!["s".into()],
+            name: "t".into(),
+        };
+        let err = client.describe_table(&bad).await.unwrap_err();
+        // Hits the unity_parts gate before any HTTP request — no
+        // network call required for this test to be deterministic.
+        assert!(matches!(err, CatalogError::InvalidResponse(_)));
+    }
+
+    #[tokio::test]
+    async fn list_tables_rejects_wrong_namespace_shape() {
+        let client = make_offline_client();
+        // One part instead of two — fails the shape gate.
+        let err = client
+            .list_tables(&["only_one".to_string()])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CatalogError::InvalidResponse(_)));
+    }
+
+    // ---- debug redaction ----
+
+    #[test]
+    fn debug_does_not_leak_secrets() {
+        let auth = Auth::from_config(crate::auth::AuthConfig {
+            host: "test.databricks.com".into(),
+            token: Some("dapi_secret_value".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .unwrap();
+        let client = UnityCatalogClient::new("test.databricks.com".into(), auth);
+        let dbg = format!("{client:?}");
+        assert!(!dbg.contains("dapi_secret_value"));
+    }
+
+    fn make_offline_client() -> UnityCatalogClient {
+        let auth = Auth::from_config(crate::auth::AuthConfig {
+            host: "offline.databricks.test".into(),
+            token: Some("offline_test_token".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .expect("auth from PAT is infallible");
+        UnityCatalogClient::new("offline.databricks.test".into(), auth)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Live integration test (gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod live_tests {
+    //! Live integration tests against a real Databricks workspace.
+    //!
+    //! Gated on `ROCKY_TEST_DATABRICKS_HOST` + auth env vars per the
+    //! sandbox-identifier-scrubbing convention; `#[ignore]` keeps them
+    //! out of the default `cargo test` run. To exercise:
+    //!
+    //! ```sh
+    //! ROCKY_TEST_DATABRICKS_HOST=... \
+    //! ROCKY_TEST_DATABRICKS_TOKEN=... \
+    //! ROCKY_TEST_DATABRICKS_CATALOG=hcv2_... \
+    //! ROCKY_TEST_DATABRICKS_SCHEMA=hcv2_... \
+    //! cargo test -p rocky-databricks --test unity_catalog_live -- --ignored
+    //! ```
+    //!
+    //! Any resource the live tests create must use the `hcv2_` prefix
+    //! convention to keep sandbox bookkeeping separable from production.
+
+    use super::*;
+
+    fn read_env() -> Option<(String, String, String, String)> {
+        let host = std::env::var("ROCKY_TEST_DATABRICKS_HOST").ok()?;
+        let token = std::env::var("ROCKY_TEST_DATABRICKS_TOKEN").ok()?;
+        let catalog = std::env::var("ROCKY_TEST_DATABRICKS_CATALOG").ok()?;
+        let schema = std::env::var("ROCKY_TEST_DATABRICKS_SCHEMA").ok()?;
+        Some((host, token, catalog, schema))
+    }
+
+    /// Optional table name for the describe-table live test. If unset,
+    /// the test no-ops with a `eprintln!` skip instead of failing —
+    /// keeps the test surface usable against any sandbox where the
+    /// caller has read-only catalog access but no known table.
+    fn read_describe_target() -> Option<(String, String, String, String, String)> {
+        let (host, token, catalog, schema) = read_env()?;
+        let table = std::env::var("ROCKY_TEST_DATABRICKS_TABLE").ok()?;
+        Some((host, token, catalog, schema, table))
+    }
+
+    fn live_client(host: String, token: String) -> UnityCatalogClient {
+        let auth = Auth::from_config(crate::auth::AuthConfig {
+            host: host.clone(),
+            token: Some(token),
+            client_id: None,
+            client_secret: None,
+        })
+        .expect("PAT auth is infallible");
+        UnityCatalogClient::new(host, auth)
+    }
+
+    #[tokio::test]
+    #[ignore = "requires ROCKY_TEST_DATABRICKS_* env vars; run with --ignored"]
+    async fn live_list_tables_in_existing_schema() {
+        let Some((host, token, catalog, schema)) = read_env() else {
+            eprintln!("skipping: ROCKY_TEST_DATABRICKS_* not set");
+            return;
+        };
+        let client = live_client(host, token);
+        let tables = client
+            .list_tables(&[catalog, schema])
+            .await
+            .expect("list_tables against live Unity Catalog");
+        // We don't assert a count — the live schema may be empty.
+        // The smoke check is that the call returns Ok and the
+        // TableRef shape is well-formed.
+        for t in tables.iter().take(5) {
+            assert!(t.catalog.is_some());
+            assert_eq!(t.namespace.len(), 1);
+            assert!(!t.name.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires ROCKY_TEST_DATABRICKS_* + _TABLE env vars; run with --ignored"]
+    async fn live_describe_table_returns_columns() {
+        let Some((host, token, catalog, schema, table)) = read_describe_target() else {
+            eprintln!("skipping: ROCKY_TEST_DATABRICKS_TABLE not set");
+            return;
+        };
+        let client = live_client(host, token);
+        let schema_resp = client
+            .describe_table(&TableRef {
+                catalog: Some(catalog),
+                namespace: vec![schema],
+                name: table,
+            })
+            .await
+            .expect("describe_table against live Unity Catalog");
+        // The smoke check is that the call returns Ok with a non-empty
+        // column list — we don't assert exact contents (the sandbox
+        // table may evolve).
+        assert!(
+            !schema_resp.columns.is_empty(),
+            "expected at least one column on the live table"
+        );
+    }
+}

--- a/engine/crates/rocky-databricks/tests/unity_catalog_client_wiremock.rs
+++ b/engine/crates/rocky-databricks/tests/unity_catalog_client_wiremock.rs
@@ -1,0 +1,516 @@
+//! Wire-level mock tests for [`UnityCatalogClient`] against Unity REST
+//! endpoints.
+//!
+//! Uses wiremock to simulate `/api/2.1/unity-catalog/*` paths at the
+//! HTTP level, verifying URL paths, body shapes, and the
+//! [`UnityRestError`] → [`CatalogError`] mapping for the production
+//! call sites.
+//!
+//! Requires the `test-support` cargo feature so [`UnityCatalogClient::with_base_url`]
+//! is callable. Run via:
+//!
+//! ```sh
+//! cargo test -p rocky-databricks --features test-support --test unity_catalog_client_wiremock
+//! ```
+//!
+//! [`UnityCatalogClient`]: rocky_databricks::UnityCatalogClient
+//! [`UnityCatalogClient::with_base_url`]: rocky_databricks::UnityCatalogClient::with_base_url
+//! [`UnityRestError`]: rocky_databricks::UnityRestError
+//! [`CatalogError`]: rocky_catalog_core::CatalogError
+
+use rocky_catalog_core::{CatalogClient, CatalogError, ColumnSchema, Grant, TableRef, TableSchema};
+use rocky_databricks::UnityCatalogClient;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn test_client(server: &MockServer) -> UnityCatalogClient {
+    let auth = Auth::from_config(AuthConfig {
+        host: "test.databricks.com".into(),
+        token: Some("test-token".into()),
+        client_id: None,
+        client_secret: None,
+    })
+    .expect("PAT auth");
+    UnityCatalogClient::new("test.databricks.com".into(), auth).with_base_url(server.uri())
+}
+
+fn sample_table_ref() -> TableRef {
+    TableRef {
+        catalog: Some("hcv2_cat".into()),
+        namespace: vec!["hcv2_sch".into()],
+        name: "hcv2_orders".into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// describe_table
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn describe_table_happy_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .and(header("Authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "hcv2_orders",
+            "columns": [
+                {"name": "id", "type_text": "bigint", "type_name": "LONG", "nullable": false},
+                {"name": "amount", "type_text": "decimal(10,2)", "type_name": "DECIMAL", "nullable": true}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let schema = test_client(&server)
+        .describe_table(&sample_table_ref())
+        .await
+        .expect("describe_table happy path");
+
+    assert_eq!(schema.columns.len(), 2);
+    assert_eq!(schema.columns[0].name, "id");
+    assert_eq!(schema.columns[0].type_str, "bigint");
+    assert!(!schema.columns[0].nullable);
+    assert_eq!(schema.columns[1].type_str, "decimal(10,2)");
+    assert!(schema.columns[1].nullable);
+}
+
+#[tokio::test]
+async fn describe_table_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_string("table not found"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .describe_table(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, CatalogError::TableNotFound(_)),
+        "expected TableNotFound, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn describe_table_403_maps_to_permission_denied() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .describe_table(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::PermissionDenied(_)));
+}
+
+// ---------------------------------------------------------------------------
+// list_tables
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_tables_happy_path_single_page() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "hcv2_cat"))
+        .and(query_param("schema_name", "hcv2_sch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tables": [
+                {"name": "orders", "columns": []},
+                {"name": "customers", "columns": []}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tables = test_client(&server)
+        .list_tables(&["hcv2_cat".into(), "hcv2_sch".into()])
+        .await
+        .expect("list_tables happy path");
+    assert_eq!(tables.len(), 2);
+    assert_eq!(tables[0].name, "orders");
+    assert_eq!(tables[1].name, "customers");
+    assert_eq!(tables[0].catalog.as_deref(), Some("hcv2_cat"));
+    assert_eq!(tables[0].namespace, vec!["hcv2_sch".to_string()]);
+}
+
+#[tokio::test]
+async fn list_tables_paginates_until_no_next_token() {
+    let server = MockServer::start().await;
+
+    // First page carries a token, second page is the terminator.
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "hcv2_cat"))
+        .and(query_param("schema_name", "hcv2_sch"))
+        .and(query_param("page_token", "tok-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tables": [
+                {"name": "events", "columns": []}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "hcv2_cat"))
+        .and(query_param("schema_name", "hcv2_sch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tables": [
+                {"name": "orders", "columns": []}
+            ],
+            "next_page_token": "tok-2"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tables = test_client(&server)
+        .list_tables(&["hcv2_cat".into(), "hcv2_sch".into()])
+        .await
+        .expect("list_tables paginates");
+    let names: Vec<String> = tables.into_iter().map(|t| t.name).collect();
+    assert_eq!(names, vec!["orders", "events"]);
+}
+
+#[tokio::test]
+async fn list_tables_404_maps_to_namespace_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "missing"))
+        .and(query_param("schema_name", "missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("no such schema"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .list_tables(&["missing".into(), "missing".into()])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, CatalogError::NamespaceNotFound(_)),
+        "expected NamespaceNotFound (404 rewritten), got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// create_table
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_table_posts_managed_delta_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(body_partial_json(json!({
+            "name": "hcv2_orders",
+            "catalog_name": "hcv2_cat",
+            "schema_name": "hcv2_sch",
+            "table_type": "MANAGED",
+            "data_source_format": "DELTA"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "hcv2_orders",
+            "columns": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let schema = TableSchema {
+        columns: vec![ColumnSchema {
+            name: "id".into(),
+            type_str: "bigint".into(),
+            nullable: false,
+        }],
+    };
+    test_client(&server)
+        .create_table(&sample_table_ref(), &schema)
+        .await
+        .expect("create_table happy path");
+}
+
+#[tokio::test]
+async fn create_table_404_maps_to_namespace_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("schema does not exist"))
+        .mount(&server)
+        .await;
+
+    let schema = TableSchema {
+        columns: vec![ColumnSchema {
+            name: "id".into(),
+            type_str: "bigint".into(),
+            nullable: false,
+        }],
+    };
+    let err = test_client(&server)
+        .create_table(&sample_table_ref(), &schema)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, CatalogError::NamespaceNotFound(_)),
+        "expected NamespaceNotFound (404 rewritten on create), got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// drop_table
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn drop_table_issues_delete() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    test_client(&server)
+        .drop_table(&sample_table_ref())
+        .await
+        .expect("drop_table happy path");
+}
+
+#[tokio::test]
+async fn drop_table_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_string("no such table"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .drop_table(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::TableNotFound(_)));
+}
+
+// ---------------------------------------------------------------------------
+// get_grants
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_grants_flattens_assignments_to_pairs() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/permissions/table/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "privilege_assignments": [
+                {"principal": "engineers", "privileges": ["SELECT", "MODIFY"]},
+                {"principal": "analysts", "privileges": ["SELECT"]}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let grants = test_client(&server)
+        .get_grants(&sample_table_ref())
+        .await
+        .expect("get_grants happy path");
+
+    // 2 + 1 privileges = 3 (principal, privilege) pairs.
+    assert_eq!(grants.len(), 3);
+    assert!(
+        grants
+            .iter()
+            .any(|g| g.principal == "engineers" && g.privilege == "SELECT")
+    );
+    assert!(
+        grants
+            .iter()
+            .any(|g| g.principal == "engineers" && g.privilege == "MODIFY")
+    );
+    assert!(
+        grants
+            .iter()
+            .any(|g| g.principal == "analysts" && g.privilege == "SELECT")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// apply_grant / revoke_grant
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn apply_grant_patches_with_add_list() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/2.1/unity-catalog/permissions/table/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .and(body_partial_json(json!({
+            "changes": [
+                {"principal": "engineers", "add": ["SELECT"]}
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let grant = Grant {
+        principal: "engineers".into(),
+        privilege: "SELECT".into(),
+    };
+    test_client(&server)
+        .apply_grant(&sample_table_ref(), &grant)
+        .await
+        .expect("apply_grant happy path");
+}
+
+#[tokio::test]
+async fn revoke_grant_patches_with_remove_list() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path(
+            "/api/2.1/unity-catalog/permissions/table/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .and(body_partial_json(json!({
+            "changes": [
+                {"principal": "old_user", "remove": ["MODIFY"]}
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let grant = Grant {
+        principal: "old_user".into(),
+        privilege: "MODIFY".into(),
+    };
+    test_client(&server)
+        .revoke_grant(&sample_table_ref(), &grant)
+        .await
+        .expect("revoke_grant happy path");
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported operations (no network)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tag_table_returns_unsupported_without_network() {
+    let server = MockServer::start().await;
+    // No mock is mounted — the call must short-circuit before any HTTP
+    // request. If a future change accidentally introduces a network
+    // call, wiremock will reject the request and the test will fail
+    // with a clear diagnostic.
+    let err = test_client(&server)
+        .tag_table(&sample_table_ref(), "owner", "analytics")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+}
+
+#[tokio::test]
+async fn list_branches_returns_unsupported_without_network() {
+    let server = MockServer::start().await;
+    let err = test_client(&server)
+        .list_branches(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+}
+
+#[tokio::test]
+async fn commit_transaction_returns_unsupported_without_network() {
+    let server = MockServer::start().await;
+    let err = test_client(&server)
+        .commit_transaction(&[])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::UnsupportedOperation(_)));
+}
+
+// ---------------------------------------------------------------------------
+// 5xx → Transport
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn describe_table_500_maps_to_transport() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .describe_table(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::Transport(_)));
+}
+
+// ---------------------------------------------------------------------------
+// 401 → AuthFailed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn describe_table_401_maps_to_auth_failed() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .mount(&server)
+        .await;
+
+    let err = test_client(&server)
+        .describe_table(&sample_table_ref())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CatalogError::AuthFailed(_)));
+}


### PR DESCRIPTION
## Summary

Adds `UnityCatalogClient` — a new module in `rocky-databricks` that implements the catalog-agnostic `rocky-catalog-core::CatalogClient` trait by routing through Unity Catalog REST endpoints (`/api/2.1/unity-catalog/*`).

This is PR-4 in the catalog-first sequence (PR-3 was split into the foundation crate + Iceberg REST impl; PR-4 here brings up the Databricks Unity Catalog implementation against the same trait).

## Method coverage matrix

| Method | Backing | Endpoint |
|---|---|---|
| `describe_table` | Unity REST | `GET /tables/{full_name}` |
| `list_tables` | Unity REST | `GET /tables?catalog_name=&schema_name=` (paginated) |
| `create_table` | Unity REST | `POST /tables` (managed Delta) |
| `drop_table` | Unity REST | `DELETE /tables/{full_name}` |
| `get_grants` | Unity REST | `GET /permissions/table/{full_name}` |
| `apply_grant` | Unity REST | `PATCH /permissions/table/{full_name}` (`add[]`) |
| `revoke_grant` | Unity REST | `PATCH /permissions/table/{full_name}` (`remove[]`) |
| `tag_table` | `UnsupportedOperation` | no REST tagging endpoint on tables today |
| `commit_transaction` | `UnsupportedOperation` | no generic multi-table commit REST surface |
| `list_branches` | `UnsupportedOperation` | Unity does not model Iceberg branches/tags |

## Design notes

- `TableRef` is mapped onto Unity's rigid three-level model: `catalog` must be `Some(_)`, `namespace` must be one part (the schema). Calls violating the shape return `CatalogError::InvalidResponse` before any network hop.
- HTTP status mapping mirrors the rocky-iceberg precedent: 401 → `AuthFailed`, 403 → `PermissionDenied`, 404 → `TableNotFound` (rewritten to `NamespaceNotFound` at namespace-scoped sites), 409 → `CommitConflict`, 429/5xx → `Transport`.
- The new module reuses `crate::auth::Auth` (PAT + OAuth M2M auto-detect) and `reqwest::Client`. No retry/circuit-breaker layer — those live on `DatabricksConnector` for the SQL path.

## Scope guard

This PR is **purely additive**:

- New module `rocky_databricks::unity_catalog_client` + Cargo dep on `rocky-catalog-core`.
- No changes to `WarehouseAdapter`, no changes to existing `catalog.rs` / `permissions.rs` / `governance.rs` callers.
- `tag_table` returns `UnsupportedOperation` rather than calling SQL — keeps the new client SQL-free by design. Existing SQL-driven catalog ops (`CatalogManager::set_table_tags`, etc.) keep working unchanged. Per-method SQL fallback inside `CatalogClient` is deferred to the cleanup PR that reroutes `WarehouseAdapter` catalog-shaped methods through `self.catalog()`.

## Unity REST gap findings (confirms plan §Q5 risk-2)

Implementation experience confirms:

- **Table-tag REST endpoint** — does not exist in Databricks Unity runtime. SQL-only path remains.
- **Generic multi-table commit REST** — does not exist. Catalog-Managed Commits exist internally in UC 0.4+ but aren't exposed as a uniform multi-table commit endpoint.
- **Iceberg-style branches/tags on Unity tables** — not modeled.
- **Column-mask REST surface** — out of scope for this PR (the trait has no `set_column_mask` method); requires a future trait extension if exposed.

## Verification

- `cargo build --release --all-features` — clean.
- `cargo test --all-features` — 34 unit + 18 wiremock tests pass for the new module (1 pre-existing `auto_sweep_*` flake in `rocky-cli` from parallel state-store contention, passes with `--test-threads=1`).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `just codegen` — no drift (additive only, no `*Output` struct changes).
- `just regen-fixtures` — no drift.

## Live verify status

Ran. The two `#[ignore]`-gated live tests (`live_list_tables_in_existing_schema`, `live_describe_table_returns_columns`) exercised `list_tables` and `describe_table` against a real Databricks Unity Catalog sandbox via OAuth M2M auth — both pass. Tests read `ROCKY_TEST_DATABRICKS_*` env vars; no workspace identifiers are baked into the source.

## Test plan

- [x] Unit tests for shape projection, URL building, status mapping, type projection, body serialisation, response deserialisation, unsupported-op shortcircuiting
- [x] Wiremock integration tests for every Unity REST endpoint (happy path + 404/403/500/401 status mapping + create-table body shape + grant PATCH shapes + pagination terminator)
- [x] Live integration tests against a sandbox Unity Catalog (gated, ignored by default)
- [x] No regressions in the `rocky-databricks` existing test surface