### PR TITLE
chore(vscode): bump engines triangle to vscode 1.120

### DIFF
--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -84,7 +84,7 @@ icons/
 ### TypeScript
 - Target: ES2022, Module: CommonJS
 - Strict mode enabled
-- VS Code API minimum: 1.105.0 (must match the version pinned in `src/test/runTest.ts`; test runner activates against that exact build)
+- VS Code API minimum: 1.120.0 (must match the version pinned in `src/test/runTest.ts`; test runner activates against that exact build)
 - Use `cp.execFile()` for subprocess calls (not `cp.exec()` — no shell injection)
 - Use `vscode.window.withProgress()` for long-running commands
 - Escape HTML in webview content via `escapeHtml()`

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -15,7 +15,7 @@
         "@dagrejs/dagre": "^3.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.0",
-        "@types/vscode": "1.116.0",
+        "@types/vscode": "1.120.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.9.1",
         "d3": "^7.9.0",
@@ -29,7 +29,7 @@
         "vitest": "^4.1.6"
       },
       "engines": {
-        "vscode": "^1.116.0"
+        "vscode": "^1.120.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1698,9 +1698,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.116.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
-      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
     "directory": "editors/vscode"
   },
   "engines": {
-    "vscode": "^1.116.0"
+    "vscode": "^1.120.0"
   },
   "icon": "icons/rocky-icon-128.png",
   "galleryBanner": {
@@ -789,7 +789,7 @@
     "@dagrejs/dagre": "^3.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.0",
-    "@types/vscode": "1.116.0",
+    "@types/vscode": "1.120.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.9.1",
     "d3": "^7.9.0",

--- a/editors/vscode/src/test/runTest.ts
+++ b/editors/vscode/src/test/runTest.ts
@@ -17,7 +17,7 @@ async function main() {
     // Keep this in sync with `engines.vscode` in package.json — a test host
     // older than `engines.vscode` fails to activate the extension silently,
     // which shows up as "0 commands registered" in the suite.
-    const version = process.env.VSCODE_TEST_VERSION ?? "1.116.0";
+    const version = process.env.VSCODE_TEST_VERSION ?? "1.120.0";
 
     await runTests({
       version,


### PR DESCRIPTION
## Summary

- Bump `engines.vscode`, `@types/vscode`, and the `runTest.ts` test-host pin from `1.116.0` to `1.120.0` together so the three stay in lockstep.
- `@vscode/test-electron` stays at `^2.5.2` (npm latest — supports the new VS Code range).
- Refresh the `editors/vscode/CLAUDE.md` "VS Code API minimum" note that documents this triangle (it was already stale at `1.105.0`).

Supersedes #567, which only bumped `@types/vscode` and would have left `engines.vscode` and the test pin behind.

### Triangle values

| Pin | Before | After |
|---|---|---|
| `engines.vscode` | `^1.116.0` | `^1.120.0` |
| `@types/vscode` | `1.116.0` | `1.120.0` |
| `@vscode/test-electron` | `^2.5.2` | `^2.5.2` |
| `runTest.ts` VS Code pin | `"1.116.0"` | `"1.120.0"` |

## Test plan

- [x] `npm install` in `editors/vscode/` (lockfile regenerated and committed)
- [x] `npm run compile` (TypeScript clean against `@types/vscode` 1.120)
- [x] `npm run test:unit` (vitest: 106/106 passing)
- [ ] CI green (full Electron integration runs on the matrix)