### PR TITLE
feat(rocky-core): View + MaterializedView + DynamicTable strategies end-to-end

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2192,7 +2192,7 @@
         },
         "strategy": {
           "default": "incremental",
-          "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
+          "description": "Replication strategy. Accepted values:\n\n- `\"incremental\"` — append rows past the source-side watermark. - `\"full_refresh\"` — `CREATE OR REPLACE TABLE … AS SELECT …`. - `\"merge\"` — upserts the watermarked delta into the target via `MERGE INTO … USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set. - `\"view\"` — emits a `CREATE OR REPLACE VIEW` over the source. Every read against the target re-runs the SELECT; no row movement. - `\"materialized_view\"` — warehouse-managed materialized view. Supported on Databricks, Snowflake, and BigQuery; DuckDB/Trino surface an unsupported-dialect error. - `\"dynamic_table\"` — Snowflake-only. Not configurable at the pipeline level today (the strategy needs a `target_lag` specifier that the pipeline block doesn't expose); declare it on a transformation model's sidecar TOML instead.",
           "type": "string"
         },
         "table_overrides": {

--- a/editors/vscode/src/types/generated/compile.ts
+++ b/editors/vscode/src/types/generated/compile.ts
@@ -83,6 +83,22 @@ export type StrategyConfig =
       [k: string]: unknown;
     }
   | {
+      type: "view";
+      [k: string]: unknown;
+    }
+  | {
+      type: "materialized_view";
+      [k: string]: unknown;
+    }
+  | {
+      /**
+       * Snowflake lag specifier — alphanumeric + space only. Examples: `"1 minute"`, `"5 hours"`, `"downstream"`.
+       */
+      target_lag: string;
+      type: "dynamic_table";
+      [k: string]: unknown;
+    }
+  | {
       /**
        * Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
        */

--- a/editors/vscode/src/types/generated/dag.ts
+++ b/editors/vscode/src/types/generated/dag.ts
@@ -73,6 +73,22 @@ export type StrategyConfig =
       [k: string]: unknown;
     }
   | {
+      type: "view";
+      [k: string]: unknown;
+    }
+  | {
+      type: "materialized_view";
+      [k: string]: unknown;
+    }
+  | {
+      /**
+       * Snowflake lag specifier — alphanumeric + space only. Examples: `"1 minute"`, `"5 hours"`, `"downstream"`.
+       */
+      target_lag: string;
+      type: "dynamic_table";
+      [k: string]: unknown;
+    }
+  | {
       /**
        * Logical partition column names. Empty for unpartitioned tables. The runtime asserts this matches the table's declared partition columns at materialization time.
        */

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -795,9 +795,9 @@ export interface ReplicationPipelineConfig {
    */
   source: PipelineSourceConfig;
   /**
-   * Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+   * Replication strategy. Accepted values:
    *
-   * `"merge"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.
+   * - `"incremental"` — append rows past the source-side watermark. - `"full_refresh"` — `CREATE OR REPLACE TABLE … AS SELECT …`. - `"merge"` — upserts the watermarked delta into the target via `MERGE INTO … USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set. - `"view"` — emits a `CREATE OR REPLACE VIEW` over the source. Every read against the target re-runs the SELECT; no row movement. - `"materialized_view"` — warehouse-managed materialized view. Supported on Databricks, Snowflake, and BigQuery; DuckDB/Trino surface an unsupported-dialect error. - `"dynamic_table"` — Snowflake-only. Not configurable at the pipeline level today (the strategy needs a `target_lag` specifier that the pipeline block doesn't expose); declare it on a transformation model's sidecar TOML instead.
    */
   strategy?: string;
   /**

--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -210,6 +210,17 @@ impl SqlDialect for BigQueryDialect {
         format!("`{name}`")
     }
 
+    fn materialized_view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
+        // BigQuery supports `CREATE OR REPLACE MATERIALIZED VIEW` as of
+        // GA — the same form Databricks + Snowflake emit. Refresh schedule
+        // is configured via the OPTIONS clause; Rocky's first-pass DDL
+        // leaves it at BigQuery's default (auto-refresh on table change)
+        // so callers can layer refresh-policy DDL on top later.
+        Ok(format!(
+            "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{select_sql}"
+        ))
+    }
+
     fn row_hash_expr(&self, columns: &[String]) -> AdapterResult<String> {
         if columns.is_empty() {
             return Err(AdapterError::msg(
@@ -323,6 +334,44 @@ mod tests {
             .unwrap();
         assert!(sql.contains("MERGE INTO"));
         assert!(sql.contains("WHEN NOT MATCHED THEN INSERT ROW"));
+    }
+
+    #[test]
+    fn test_view_ddl_emits_create_or_replace_view() {
+        let d = BigQueryDialect;
+        let sql = d.view_ddl("`p`.`d`.`v`", "SELECT * FROM src").unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE VIEW `p`.`d`.`v` AS\nSELECT * FROM src"
+        );
+    }
+
+    #[test]
+    fn test_materialized_view_ddl_emits_create_or_replace_mv() {
+        let d = BigQueryDialect;
+        let sql = d
+            .materialized_view_ddl(
+                "`p`.`d`.`mv`",
+                "SELECT customer_id, SUM(total) FROM orders GROUP BY 1",
+            )
+            .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE MATERIALIZED VIEW `p`.`d`.`mv` AS\n\
+             SELECT customer_id, SUM(total) FROM orders GROUP BY 1"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_unsupported_on_bigquery() {
+        let d = BigQueryDialect;
+        let err = d
+            .dynamic_table_ddl("t", "SELECT 1", "1 minute", "wh")
+            .expect_err("BigQuery has no dynamic-table concept");
+        assert!(
+            err.to_string().contains("DYNAMIC TABLE"),
+            "error message should mention DT unsupported: {err}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -116,6 +116,9 @@ pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
                 rocky_core::models::StrategyConfig::Ephemeral => "ephemeral",
                 rocky_core::models::StrategyConfig::Microbatch { .. } => "microbatch",
                 rocky_core::models::StrategyConfig::ContentAddressed { .. } => "content_addressed",
+                rocky_core::models::StrategyConfig::View => "view",
+                rocky_core::models::StrategyConfig::MaterializedView => "materialized_view",
+                rocky_core::models::StrategyConfig::DynamicTable { .. } => "dynamic_table",
             }
             .to_string();
             ListModelEntry {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3910,7 +3910,14 @@ pub(crate) async fn execute_models(
                 }
             }
 
-            let exec_stmts = rocky_core::sql_gen::generate_transformation_sql(&model_ir, dialect)?;
+            // Thread the Snowflake compute warehouse (when applicable) so
+            // `DynamicTable` strategies can emit `WAREHOUSE = …`. Other
+            // adapters return `None` and the helper short-circuits.
+            let exec_stmts = rocky_core::sql_gen::generate_transformation_sql_with_warehouse(
+                &model_ir,
+                dialect,
+                warehouse.warehouse_name(),
+            )?;
 
             info!(
                 model = model_name.as_str(),
@@ -4020,6 +4027,7 @@ fn transformation_strategy_name(strategy: &MaterializationStrategy) -> &'static 
         MaterializationStrategy::FullRefresh => "full_refresh",
         MaterializationStrategy::Incremental { .. } => "incremental",
         MaterializationStrategy::Merge { .. } => "merge",
+        MaterializationStrategy::View => "view",
         MaterializationStrategy::MaterializedView => "materialized_view",
         MaterializationStrategy::DynamicTable { .. } => "dynamic_table",
         MaterializationStrategy::TimeInterval { .. } => "time_interval",
@@ -4535,6 +4543,17 @@ fn build_replication_strategy_with_override(
                 update_columns: ColumnSelection::All,
             })
         }
+        "view" => Ok(MaterializationStrategy::View),
+        "materialized_view" => Ok(MaterializationStrategy::MaterializedView),
+        // `dynamic_table` requires a target_lag specifier — the
+        // replication pipeline doesn't currently expose one, so we
+        // surface a clear error rather than silently dropping to
+        // full-refresh.
+        "dynamic_table" => Err(anyhow::anyhow!(
+            "dynamic_table strategy is not configurable from a replication pipeline \
+             without a target_lag specifier — declare it on a transformation model's \
+             sidecar TOML instead"
+        )),
         _ => Ok(MaterializationStrategy::FullRefresh),
     }
 }
@@ -4858,13 +4877,94 @@ async fn process_table(
                 strategy_name = "merge";
                 sql_gen::generate_merge_sql(&model_ir, dialect)?
             }
-            MaterializationStrategy::MaterializedView => {
-                strategy_name = "materialized_view";
-                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
+            MaterializationStrategy::View => {
+                // Views on a replication table create a thin DDL pointing
+                // at the source; no row movement. Only useful when the
+                // user wants a "passthrough" replication endpoint.
+                strategy_name = "view";
+                // Reuse the transformation dispatch — the strategy is the
+                // same shape on either pipeline kind. We hand-build the
+                // SELECT * FROM <source> here so `generate_view_sql`'s
+                // Transformation-variant guard is satisfied via a wrapper.
+                let select = dialect.select_clause(
+                    model_ir
+                        .columns
+                        .as_ref()
+                        .expect("Replication variant guarantees columns"),
+                    &model_ir.metadata_columns,
+                )?;
+                let source = model_ir
+                    .source
+                    .as_ref()
+                    .expect("Replication variant guarantees source");
+                let source_ref =
+                    dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+                let view_target = dialect.format_table_ref(
+                    &model_ir.target.catalog,
+                    &model_ir.target.schema,
+                    &model_ir.target.table,
+                )?;
+                let body = format!("{select}\nFROM {source_ref}");
+                dialect.view_ddl(&view_target, &body)?
             }
-            MaterializationStrategy::DynamicTable { .. } => {
+            MaterializationStrategy::MaterializedView => {
+                // Dispatch to the dialect's MV generator so DuckDB / Trino
+                // fail loud rather than silently emitting plain CTAS.
+                strategy_name = "materialized_view";
+                let select = dialect.select_clause(
+                    model_ir
+                        .columns
+                        .as_ref()
+                        .expect("Replication variant guarantees columns"),
+                    &model_ir.metadata_columns,
+                )?;
+                let source = model_ir
+                    .source
+                    .as_ref()
+                    .expect("Replication variant guarantees source");
+                let source_ref =
+                    dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+                let mv_target = dialect.format_table_ref(
+                    &model_ir.target.catalog,
+                    &model_ir.target.schema,
+                    &model_ir.target.table,
+                )?;
+                let body = format!("{select}\nFROM {source_ref}");
+                dialect.materialized_view_ddl(&mv_target, &body)?
+            }
+            MaterializationStrategy::DynamicTable { target_lag } => {
+                // Snowflake-only on the replication path. Threading the
+                // warehouse from the adapter mirrors the transformation
+                // dispatch so the SQL is identical regardless of pipeline
+                // kind. Non-Snowflake adapters surface the unsupported
+                // error from the dialect's default impl.
                 strategy_name = "dynamic_table";
-                sql_gen::generate_create_table_as_sql(&model_ir, dialect)?
+                let warehouse_name = warehouse.warehouse_name().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "dynamic_table strategy requires a compute warehouse \
+                         (Snowflake-only) — current adapter does not expose one"
+                    )
+                })?;
+                let select = dialect.select_clause(
+                    model_ir
+                        .columns
+                        .as_ref()
+                        .expect("Replication variant guarantees columns"),
+                    &model_ir.metadata_columns,
+                )?;
+                let source = model_ir
+                    .source
+                    .as_ref()
+                    .expect("Replication variant guarantees source");
+                let source_ref =
+                    dialect.format_table_ref(&source.catalog, &source.schema, &source.table)?;
+                let dt_target = dialect.format_table_ref(
+                    &model_ir.target.catalog,
+                    &model_ir.target.schema,
+                    &model_ir.target.table,
+                )?;
+                let body = format!("{select}\nFROM {source_ref}");
+                dialect.dynamic_table_ddl(&dt_target, &body, target_lag, warehouse_name)?
             }
             MaterializationStrategy::TimeInterval { .. } => {
                 // time_interval is a transformation strategy (silver-layer
@@ -6240,6 +6340,41 @@ timestamp_column = "_synced_at"
         let pipeline = parse_pipeline(r#"strategy = "full_refresh""#);
         let strategy = build_replication_strategy(&pipeline).expect("strategy build");
         assert!(matches!(strategy, MaterializationStrategy::FullRefresh));
+    }
+
+    #[test]
+    fn build_replication_strategy_view() {
+        let pipeline = parse_pipeline(r#"strategy = "view""#);
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        assert!(matches!(strategy, MaterializationStrategy::View));
+    }
+
+    #[test]
+    fn build_replication_strategy_materialized_view() {
+        // The fix to the legacy "silently fall through to full_refresh"
+        // behaviour: `materialized_view` now resolves to the right IR
+        // variant instead of dropping to FullRefresh.
+        let pipeline = parse_pipeline(r#"strategy = "materialized_view""#);
+        let strategy = build_replication_strategy(&pipeline).expect("strategy build");
+        assert!(matches!(
+            strategy,
+            MaterializationStrategy::MaterializedView
+        ));
+    }
+
+    #[test]
+    fn build_replication_strategy_dynamic_table_requires_target_lag() {
+        // dynamic_table on a replication pipeline today errors out because
+        // the strategy string can't carry a target_lag specifier. Pinning
+        // the error here so a future config-shape change must update both
+        // sides of the contract.
+        let pipeline = parse_pipeline(r#"strategy = "dynamic_table""#);
+        let err = build_replication_strategy(&pipeline)
+            .expect_err("dynamic_table without target_lag should error");
+        assert!(
+            err.to_string().contains("dynamic_table"),
+            "error should mention dynamic_table: {err}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-cli/tests/ir-golden/07-transformation-materialized-view/duckdb.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/07-transformation-materialized-view/duckdb.sql
@@ -1,2 +1,0 @@
-CREATE OR REPLACE MATERIALIZED VIEW tgtwarehouse.marts__demo.mv_orders_daily AS
-SELECT DATE(created_at) AS day, COUNT(*) AS order_count, SUM(total) AS revenue FROM tgtwarehouse.marts__demo.fct_orders GROUP BY 1

--- a/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/bigquery.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/bigquery.sql
@@ -1,5 +1,0 @@
-CREATE OR REPLACE DYNAMIC TABLE `tgtwarehouse`.`marts__demo`.`dt_orders_recent`
-  TARGET_LAG = '1 hour'
-  WAREHOUSE = compute_wh
-AS
-SELECT id, customer_id, total FROM tgtwarehouse.marts__demo.fct_orders WHERE created_at > CURRENT_DATE - INTERVAL '7' DAY

--- a/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/databricks.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/databricks.sql
@@ -1,5 +1,0 @@
-CREATE OR REPLACE DYNAMIC TABLE tgtwarehouse.marts__demo.dt_orders_recent
-  TARGET_LAG = '1 hour'
-  WAREHOUSE = compute_wh
-AS
-SELECT id, customer_id, total FROM tgtwarehouse.marts__demo.fct_orders WHERE created_at > CURRENT_DATE - INTERVAL '7' DAY

--- a/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/duckdb.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/08-transformation-dynamic-table/duckdb.sql
@@ -1,5 +1,0 @@
-CREATE OR REPLACE DYNAMIC TABLE tgtwarehouse.marts__demo.dt_orders_recent
-  TARGET_LAG = '1 hour'
-  WAREHOUSE = compute_wh
-AS
-SELECT id, customer_id, total FROM tgtwarehouse.marts__demo.fct_orders WHERE created_at > CURRENT_DATE - INTERVAL '7' DAY

--- a/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/bigquery.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/bigquery.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE VIEW `tgtwarehouse`.`marts__demo`.`v_active_customers` AS
+SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers WHERE status = 'active'

--- a/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/databricks.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/databricks.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE VIEW tgtwarehouse.marts__demo.v_active_customers AS
+SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers WHERE status = 'active'

--- a/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/duckdb.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/duckdb.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE VIEW tgtwarehouse.marts__demo.v_active_customers AS
+SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers WHERE status = 'active'

--- a/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/ir.json
+++ b/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/ir.json
@@ -1,0 +1,26 @@
+{
+  "name": "v_active_customers",
+  "sql": "SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers WHERE status = 'active'",
+  "typed_columns": [],
+  "lineage_edges": [],
+  "materialization": {
+    "strategy": "View"
+  },
+  "governance": {
+    "permissions_file": null,
+    "auto_create_catalogs": false,
+    "auto_create_schemas": false
+  },
+  "target": {
+    "catalog": "tgtwarehouse",
+    "schema": "marts__demo",
+    "table": "v_active_customers"
+  },
+  "sources": [
+    {
+      "catalog": "tgtwarehouse",
+      "schema": "marts__demo",
+      "table": "dim_customers"
+    }
+  ]
+}

--- a/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/snowflake.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/13-transformation-view/snowflake.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE VIEW "tgtwarehouse"."marts__demo"."v_active_customers" AS
+SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers WHERE status = 'active'

--- a/engine/crates/rocky-cli/tests/ir_golden.rs
+++ b/engine/crates/rocky-cli/tests/ir_golden.rs
@@ -90,6 +90,19 @@ impl DialectKind {
         DialectKind::Snowflake,
     ];
 
+    /// Warehouses that natively support `MATERIALIZED VIEW`. DuckDB has
+    /// no MV equivalent; the dialect's default trait impl surfaces an
+    /// unsupported-dialect error, so the snapshot test skips DuckDB for
+    /// MV fixtures.
+    const MV_SUPPORTED: &'static [DialectKind] = &[
+        DialectKind::Databricks,
+        DialectKind::BigQuery,
+        DialectKind::Snowflake,
+    ];
+
+    /// Warehouses that natively support `DYNAMIC TABLE`. Snowflake only.
+    const SNOWFLAKE_ONLY: &'static [DialectKind] = &[DialectKind::Snowflake];
+
     fn name(self) -> &'static str {
         match self {
             DialectKind::DuckDb => "duckdb",
@@ -123,6 +136,8 @@ enum Entry {
     ReplicationMerge,
     /// `generate_transformation_sql` — transformation, dispatches by strategy.
     Transformation,
+    /// `generate_view_sql` — transformation, plain SQL view.
+    View,
     /// `generate_materialized_view_sql` — transformation, MV.
     MaterializedView,
     /// `generate_dynamic_table_sql` — transformation, Snowflake dynamic table.
@@ -153,6 +168,7 @@ fn run_entry(
         }
         Entry::ReplicationMerge => sql_gen::generate_merge_sql(ir, dialect).map(|s| vec![s]),
         Entry::Transformation => sql_gen::generate_transformation_sql(ir, dialect),
+        Entry::View => sql_gen::generate_view_sql(ir, dialect).map(|s| vec![s]),
         Entry::MaterializedView => {
             sql_gen::generate_materialized_view_sql(ir, dialect).map(|s| vec![s])
         }
@@ -246,7 +262,11 @@ const FIXTURES: &[Fixture] = &[
         name: "07-transformation-materialized-view",
         builder: build_07_transformation_materialized_view,
         entry: Entry::MaterializedView,
-        dialects: DialectKind::ALL,
+        // DuckDB has no materialized-view concept; Wave 1 deliberately
+        // surfaces that as an unsupported-dialect error rather than
+        // emitting wrong SQL. Run the snapshot for the three warehouses
+        // that genuinely support MV.
+        dialects: DialectKind::MV_SUPPORTED,
         recipe_hash: "80307cf6df8abc20560abe3977825195a9ec4322dbce564fbe71f945ee8ad99b",
     },
     Fixture {
@@ -256,8 +276,21 @@ const FIXTURES: &[Fixture] = &[
             target_lag: "1 hour",
             warehouse: "compute_wh",
         },
-        dialects: DialectKind::ALL,
+        // Dynamic tables are Snowflake-only; the other dialects return
+        // the unsupported-dialect error from the default trait impl, which
+        // would fail the golden snapshot test. Pin the snapshot against
+        // Snowflake only.
+        dialects: DialectKind::SNOWFLAKE_ONLY,
         recipe_hash: "c313f449a16b0b08843b0b398cd4b6e66e07a8556794cab642c77f732a7d80a1",
+    },
+    Fixture {
+        name: "13-transformation-view",
+        builder: build_13_transformation_view,
+        entry: Entry::View,
+        // Plain views are supported on every Rocky-targeted warehouse;
+        // the default trait impl emits the ANSI form across all four.
+        dialects: DialectKind::ALL,
+        recipe_hash: "92b8d0b3d664dd74158f30ee293219256a237d035d77cb951d034fcf62b152a1",
     },
     Fixture {
         name: "09-transformation-time-interval-bootstrap",
@@ -632,6 +665,26 @@ fn build_11_transformation_multi_source_join() -> ModelIr {
         None,
     );
     ir.name = Arc::from("fct_order_lines");
+    ir
+}
+
+fn build_13_transformation_view() -> ModelIr {
+    let mut ir = ModelIr::transformation(
+        marts_target("v_active_customers"),
+        MaterializationStrategy::View,
+        vec![SourceRef {
+            catalog: TGT_CATALOG.into(),
+            schema: "marts__demo".into(),
+            table: "dim_customers".into(),
+        }],
+        "SELECT customer_id, name, email FROM tgtwarehouse.marts__demo.dim_customers \
+         WHERE status = 'active'"
+            .into(),
+        baseline_governance(),
+        None,
+        None,
+    );
+    ir.name = Arc::from("v_active_customers");
     ir
 }
 

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -154,6 +154,9 @@ pub fn generate_report(
             rocky_core::models::StrategyConfig::DeleteInsert { .. } => "delete_insert",
             rocky_core::models::StrategyConfig::Microbatch { .. } => "microbatch",
             rocky_core::models::StrategyConfig::ContentAddressed { .. } => "content_addressed",
+            rocky_core::models::StrategyConfig::View => "view",
+            rocky_core::models::StrategyConfig::MaterializedView => "materialized_view",
+            rocky_core::models::StrategyConfig::DynamicTable { .. } => "dynamic_table",
         };
         *by_materialization.entry(mat.to_string()).or_default() += 1;
 

--- a/engine/crates/rocky-core/src/breaking_change.rs
+++ b/engine/crates/rocky-core/src/breaking_change.rs
@@ -775,6 +775,7 @@ fn strategy_tag(s: &MaterializationStrategy) -> &'static str {
         MaterializationStrategy::FullRefresh => "full_refresh",
         MaterializationStrategy::Incremental { .. } => "incremental",
         MaterializationStrategy::Merge { .. } => "merge",
+        MaterializationStrategy::View => "view",
         MaterializationStrategy::MaterializedView => "materialized_view",
         MaterializationStrategy::DynamicTable { .. } => "dynamic_table",
         MaterializationStrategy::TimeInterval { .. } => "time_interval",

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2722,12 +2722,23 @@ impl PipelineConfig {
 // schema; everything outside the pipeline section stays strict.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ReplicationPipelineConfig {
-    /// Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+    /// Replication strategy. Accepted values:
     ///
-    /// `"merge"` upserts the watermarked delta into the target via
-    /// `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET *
-    /// WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or
-    /// `merge_keys_fallback`) to be set.
+    /// - `"incremental"` — append rows past the source-side watermark.
+    /// - `"full_refresh"` — `CREATE OR REPLACE TABLE … AS SELECT …`.
+    /// - `"merge"` — upserts the watermarked delta into the target via
+    ///   `MERGE INTO … USING (delta) ON merge_keys WHEN MATCHED UPDATE SET *
+    ///   WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or
+    ///   `merge_keys_fallback`) to be set.
+    /// - `"view"` — emits a `CREATE OR REPLACE VIEW` over the source. Every
+    ///   read against the target re-runs the SELECT; no row movement.
+    /// - `"materialized_view"` — warehouse-managed materialized view.
+    ///   Supported on Databricks, Snowflake, and BigQuery; DuckDB/Trino
+    ///   surface an unsupported-dialect error.
+    /// - `"dynamic_table"` — Snowflake-only. Not configurable at the
+    ///   pipeline level today (the strategy needs a `target_lag` specifier
+    ///   that the pipeline block doesn't expose); declare it on a
+    ///   transformation model's sidecar TOML instead.
     #[serde(default = "default_strategy")]
     pub strategy: String,
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -75,6 +75,9 @@ fn strategy_label(strategy: &StrategyConfig) -> String {
         StrategyConfig::DeleteInsert { .. } => "delete_insert".into(),
         StrategyConfig::Microbatch { .. } => "microbatch".into(),
         StrategyConfig::ContentAddressed { .. } => "content_addressed".into(),
+        StrategyConfig::View => "view".into(),
+        StrategyConfig::MaterializedView => "materialized_view".into(),
+        StrategyConfig::DynamicTable { .. } => "dynamic_table".into(),
     }
 }
 

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -275,6 +275,26 @@ pub enum StrategyConfig {
         #[serde(default = "default_microbatch_granularity")]
         granularity: TimeGrain,
     },
+    /// SQL view — no physical storage. Every read against the target
+    /// re-runs the model SELECT. Supported on every Rocky-targeted
+    /// warehouse.
+    #[serde(rename = "view")]
+    View,
+    /// Materialized view — warehouse manages refresh. Supported on
+    /// Databricks, Snowflake, and BigQuery. DuckDB / Trino surface a
+    /// "not supported" error at SQL-gen time.
+    #[serde(rename = "materialized_view")]
+    MaterializedView,
+    /// Snowflake dynamic table — warehouse manages lag-based refresh.
+    /// `target_lag` is a Snowflake lag specifier (e.g. `"1 minute"`,
+    /// `"5 hours"`, `"downstream"`). Non-Snowflake adapters surface a
+    /// "not supported" error at SQL-gen time.
+    #[serde(rename = "dynamic_table")]
+    DynamicTable {
+        /// Snowflake lag specifier — alphanumeric + space only. Examples:
+        /// `"1 minute"`, `"5 hours"`, `"downstream"`.
+        target_lag: String,
+    },
     /// Content-addressed write to a Delta UniForm table via the
     /// `rocky-iceberg` writer. The runtime executes the model SQL,
     /// converts the result to Arrow, blake3-hashes the Parquet bytes,
@@ -662,6 +682,11 @@ impl Model {
             } => MaterializationStrategy::ContentAddressed {
                 storage_prefix: storage_prefix.clone(),
                 partition_columns: partition_columns.clone(),
+            },
+            StrategyConfig::View => MaterializationStrategy::View,
+            StrategyConfig::MaterializedView => MaterializationStrategy::MaterializedView,
+            StrategyConfig::DynamicTable { target_lag } => MaterializationStrategy::DynamicTable {
+                target_lag: target_lag.clone(),
             },
         };
 
@@ -1112,6 +1137,89 @@ SELECT id, name, status FROM raw.src
                 update_columns,
                 rocky_ir::ColumnSelection::Explicit(_)
             ));
+        }
+    }
+
+    #[test]
+    fn test_parse_model_view_lowers_to_ir() {
+        // `type = "view"` deserializes via `#[serde(rename = "view")]` on
+        // `StrategyConfig::View` and lowers to `MaterializationStrategy::View`.
+        let content = r#"---toml
+name = "v_active_customers"
+depends_on = ["dim_customers"]
+
+[strategy]
+type = "view"
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "v_active_customers"
+---
+SELECT customer_id, name FROM analytics.marts.dim_customers WHERE status = 'active'
+"#;
+        let model = parse_model_inline(content, "v_active_customers.sql", None).unwrap();
+        assert!(matches!(model.config.strategy, StrategyConfig::View));
+        let ir = model.to_model_ir();
+        assert!(matches!(ir.materialization, MaterializationStrategy::View));
+    }
+
+    #[test]
+    fn test_parse_model_materialized_view_lowers_to_ir() {
+        let content = r#"---toml
+name = "mv_orders_daily"
+
+[strategy]
+type = "materialized_view"
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "mv_orders_daily"
+---
+SELECT DATE(created_at) AS day, COUNT(*) FROM analytics.marts.fct_orders GROUP BY 1
+"#;
+        let model = parse_model_inline(content, "mv_orders_daily.sql", None).unwrap();
+        assert!(matches!(
+            model.config.strategy,
+            StrategyConfig::MaterializedView
+        ));
+        let ir = model.to_model_ir();
+        assert!(matches!(
+            ir.materialization,
+            MaterializationStrategy::MaterializedView
+        ));
+    }
+
+    #[test]
+    fn test_parse_model_dynamic_table_lowers_to_ir() {
+        let content = r#"---toml
+name = "dt_orders_recent"
+
+[strategy]
+type = "dynamic_table"
+target_lag = "1 minute"
+
+[target]
+catalog = "analytics"
+schema = "marts"
+table = "dt_orders_recent"
+---
+SELECT id, customer_id, total FROM analytics.marts.fct_orders
+"#;
+        let model = parse_model_inline(content, "dt_orders_recent.sql", None).unwrap();
+        match &model.config.strategy {
+            StrategyConfig::DynamicTable { target_lag } => {
+                assert_eq!(target_lag, "1 minute");
+            }
+            other => panic!("expected DynamicTable, got {other:?}"),
+        }
+        let ir = model.to_model_ir();
+        match &ir.materialization {
+            MaterializationStrategy::DynamicTable { target_lag } => {
+                assert_eq!(target_lag, "1 minute");
+            }
+            other => panic!("expected IR DynamicTable, got {other:?}"),
         }
     }
 

--- a/engine/crates/rocky-core/src/plan_partition.rs
+++ b/engine/crates/rocky-core/src/plan_partition.rs
@@ -380,6 +380,9 @@ fn strategy_label(s: &StrategyConfig) -> &'static str {
         StrategyConfig::DeleteInsert { .. } => "delete_insert",
         StrategyConfig::Microbatch { .. } => "microbatch",
         StrategyConfig::ContentAddressed { .. } => "content_addressed",
+        StrategyConfig::View => "view",
+        StrategyConfig::MaterializedView => "materialized_view",
+        StrategyConfig::DynamicTable { .. } => "dynamic_table",
     }
 }
 

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -215,9 +215,15 @@ pub fn generate_merge_sql(
 /// Returns `Vec<String>` rather than `String` because some materialization
 /// strategies (notably `time_interval`) decompose into multiple statements
 /// that the runtime must execute in order. For single-statement strategies
-/// (`FullRefresh`, `Incremental`, `Merge`, `MaterializedView`) the vec
-/// contains exactly one entry; callers that need a single string can pattern-
-/// match `&[only]` or call `.join("\n")` if cosmetic concatenation is fine.
+/// (`FullRefresh`, `Incremental`, `Merge`, `View`, `MaterializedView`) the
+/// vec contains exactly one entry; callers that need a single string can
+/// pattern-match `&[only]` or call `.join("\n")` if cosmetic concatenation
+/// is fine.
+///
+/// `DynamicTable` requires the warehouse name; this entry returns an
+/// `InvalidRequest` for that strategy and points callers at
+/// [`generate_transformation_sql_with_warehouse`] (or the direct
+/// [`generate_dynamic_table_sql`]) for the wired-up path.
 ///
 /// # Errors
 ///
@@ -226,6 +232,28 @@ pub fn generate_merge_sql(
 pub fn generate_transformation_sql(
     model_ir: &ModelIr,
     dialect: &dyn SqlDialect,
+) -> Result<Vec<String>, SqlGenError> {
+    generate_transformation_sql_with_warehouse(model_ir, dialect, None)
+}
+
+/// Generates transformation SQL using the given dialect, with an optional
+/// compute-warehouse name for Snowflake `DynamicTable` strategies.
+///
+/// Same as [`generate_transformation_sql`] for every other strategy.
+/// `warehouse` is read from the adapter via
+/// [`crate::traits::WarehouseAdapter::warehouse_name`] at the runner
+/// dispatch site and passed through; non-Snowflake adapters return `None`
+/// and `DynamicTable` falls through to the dialect's unsupported error.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// a transformation-variant [`ModelIr`], or when `DynamicTable` is the
+/// strategy but `warehouse` is `None`.
+pub fn generate_transformation_sql_with_warehouse(
+    model_ir: &ModelIr,
+    dialect: &dyn SqlDialect,
+    warehouse: Option<&str>,
 ) -> Result<Vec<String>, SqlGenError> {
     if model_ir.variant() != ModelIrVariant::Transformation {
         return Err(variant_mismatch(model_ir, "Transformation"));
@@ -282,16 +310,21 @@ pub fn generate_transformation_sql(
             let stmt = dialect.merge_into(&target, &model_ir.sql, unique_key, update_columns)?;
             Ok(vec![stmt])
         }
+        MaterializationStrategy::View => Ok(vec![generate_view_sql(model_ir, dialect)?]),
         MaterializationStrategy::MaterializedView => {
             Ok(vec![generate_materialized_view_sql(model_ir, dialect)?])
         }
-        MaterializationStrategy::DynamicTable { .. } => {
-            // Dynamic tables require a warehouse parameter not available in the plan.
-            // Use generate_dynamic_table_sql directly when warehouse is known.
-            Err(SqlGenError::InvalidRequest(
-                "DynamicTable strategy requires calling generate_dynamic_table_sql with warehouse parameter".to_string(),
-            ))
-        }
+        MaterializationStrategy::DynamicTable { target_lag } => match warehouse {
+            Some(wh) => Ok(vec![generate_dynamic_table_sql(
+                model_ir, target_lag, wh, dialect,
+            )?]),
+            None => Err(SqlGenError::InvalidRequest(
+                "DynamicTable strategy requires a Snowflake compute warehouse — \
+                 call generate_transformation_sql_with_warehouse(... , Some(<wh>)) \
+                 or generate_dynamic_table_sql directly"
+                    .to_string(),
+            )),
+        },
         MaterializationStrategy::TimeInterval {
             time_column,
             window,
@@ -517,7 +550,39 @@ fn substitute_partition_placeholders(sql: &str, window: &PartitionWindow) -> Str
     )
 }
 
+/// Generates CREATE OR REPLACE VIEW SQL for a transformation model.
+///
+/// Delegates to the dialect's [`SqlDialect::view_ddl`] so per-warehouse
+/// quirks can be expressed there; the default trait impl emits the
+/// ANSI-portable form, which every Rocky-targeted warehouse accepts.
+///
+/// # Errors
+///
+/// Returns [`SqlGenError::InvalidRequest`] when `model_ir` was not
+/// a transformation-variant [`ModelIr`] (see [`rocky_ir::ModelIrVariant`]).
+pub fn generate_view_sql(
+    model_ir: &ModelIr,
+    dialect: &dyn SqlDialect,
+) -> Result<String, SqlGenError> {
+    if model_ir.variant() != ModelIrVariant::Transformation {
+        return Err(variant_mismatch(model_ir, "Transformation"));
+    }
+    let target = dialect.format_table_ref(
+        &model_ir.target.catalog,
+        &model_ir.target.schema,
+        &model_ir.target.table,
+    )?;
+
+    Ok(dialect.view_ddl(&target, &model_ir.sql)?)
+}
+
 /// Generates CREATE MATERIALIZED VIEW SQL for a transformation model.
+///
+/// Delegates to the dialect's [`SqlDialect::materialized_view_ddl`] so
+/// per-warehouse quirks (refresh-policy DDL, MV vs. streaming-table)
+/// stay in the dialect. The default trait impl returns an unsupported
+/// error — warehouses without an MV concept (DuckDB, Trino) surface that
+/// at SQL-gen time rather than silently emitting wrong SQL.
 ///
 /// # Errors
 ///
@@ -536,13 +601,14 @@ pub fn generate_materialized_view_sql(
         &model_ir.target.table,
     )?;
 
-    Ok(format!(
-        "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{sql}",
-        sql = model_ir.sql
-    ))
+    Ok(dialect.materialized_view_ddl(&target, &model_ir.sql)?)
 }
 
 /// Generates CREATE DYNAMIC TABLE SQL for a transformation model (Snowflake).
+///
+/// Delegates to the dialect's [`SqlDialect::dynamic_table_ddl`]. The
+/// Snowflake adapter is the only one that overrides; others return a
+/// clear unsupported error so misconfigured projects fail loud.
 ///
 /// # Errors
 ///
@@ -563,14 +629,7 @@ pub fn generate_dynamic_table_sql(
         &model_ir.target.table,
     )?;
 
-    // Validate target_lag and warehouse to prevent injection
-    validate_sql_type(target_lag)?;
-    validation::validate_identifier(warehouse)?;
-
-    Ok(format!(
-        "CREATE OR REPLACE DYNAMIC TABLE {target}\n  TARGET_LAG = '{target_lag}'\n  WAREHOUSE = {warehouse}\nAS\n{sql}",
-        sql = model_ir.sql
-    ))
+    Ok(dialect.dynamic_table_ddl(&target, &model_ir.sql, target_lag, warehouse)?)
 }
 
 /// Regenerate `(purpose, sql)` pairs for a `rocky compact` plan from its
@@ -1061,6 +1120,44 @@ mod tests {
             Ok(vec![format!(
                 "INSERT INTO {target} REPLACE WHERE {partition_filter}\n{select_sql}"
             )])
+        }
+
+        fn materialized_view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
+            // Mirror Databricks/Snowflake/BigQuery emitted form so the
+            // in-crate sql_gen tests can byte-pin without depending on
+            // the per-warehouse dialect crates.
+            Ok(format!(
+                "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{select_sql}"
+            ))
+        }
+
+        fn dynamic_table_ddl(
+            &self,
+            target: &str,
+            select_sql: &str,
+            target_lag: &str,
+            warehouse: &str,
+        ) -> AdapterResult<String> {
+            // Same shape the Snowflake dialect emits — TestDialect
+            // mirrors the cross-warehouse "happy path" for the sql_gen
+            // dispatch tests. Validate target_lag with the same alphanumeric
+            // + space allowlist the Snowflake dialect uses so injection
+            // tests covering `generate_dynamic_table_sql` still trip.
+            if target_lag.is_empty()
+                || !target_lag
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == ' ')
+            {
+                return Err(AdapterError::msg(format!(
+                    "invalid target_lag: {target_lag:?}"
+                )));
+            }
+            rocky_sql::validation::validate_identifier(warehouse).map_err(AdapterError::new)?;
+            Ok(format!(
+                "CREATE OR REPLACE DYNAMIC TABLE {target}\n  \
+                 TARGET_LAG = '{target_lag}'\n  \
+                 WAREHOUSE = {warehouse}\nAS\n{select_sql}"
+            ))
         }
     }
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -341,6 +341,17 @@ pub trait WarehouseAdapter: Send + Sync {
         false
     }
 
+    /// Compute warehouse name, if this adapter has one.
+    ///
+    /// Used by SQL generators that emit `WAREHOUSE = …` clauses (currently
+    /// only Snowflake's `CREATE DYNAMIC TABLE`). Returns `None` for
+    /// adapters without a compute-warehouse concept (Databricks routes
+    /// to a configured SQL endpoint instead, BigQuery is serverless,
+    /// DuckDB is in-process).
+    fn warehouse_name(&self) -> Option<&str> {
+        None
+    }
+
     /// List table names in a given catalog + schema.
     ///
     /// Used by `rocky discover` to verify which tables actually exist
@@ -708,6 +719,50 @@ pub trait SqlDialect: Send + Sync {
 
     /// DROP TABLE IF EXISTS.
     fn drop_table_sql(&self, table_ref: &str) -> String;
+
+    /// `CREATE OR REPLACE VIEW <target> AS <select>`.
+    ///
+    /// SQL views are supported on every Rocky-targeted warehouse — the
+    /// default impl emits the ANSI-portable form. Override only if the
+    /// warehouse uses different syntax (e.g. Trino's connector-gated
+    /// `CREATE OR REPLACE VIEW` semantics).
+    fn view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
+        Ok(format!("CREATE OR REPLACE VIEW {target} AS\n{select_sql}"))
+    }
+
+    /// `CREATE OR REPLACE MATERIALIZED VIEW <target> AS <select>`.
+    ///
+    /// Materialized views are warehouse-managed: the warehouse decides
+    /// when to refresh based on its own scheduler. Default returns an
+    /// error — DuckDB and Trino have no MV equivalent today. Databricks,
+    /// Snowflake, and BigQuery override to emit the warehouse-native form.
+    fn materialized_view_ddl(&self, _target: &str, _select_sql: &str) -> AdapterResult<String> {
+        Err(AdapterError::msg(
+            "MATERIALIZED VIEW strategy is not supported by this warehouse",
+        ))
+    }
+
+    /// `CREATE OR REPLACE DYNAMIC TABLE <target> TARGET_LAG = '<lag>' WAREHOUSE = <wh> AS <select>`.
+    ///
+    /// Dynamic tables are a Snowflake-specific construct: the warehouse
+    /// refreshes the target on a declared lag against its upstream. Default
+    /// returns an error; only the Snowflake adapter overrides.
+    ///
+    /// `target_lag` is a Snowflake lag specifier (e.g. `"1 minute"`,
+    /// `"1 hour"`, `"downstream"`); `warehouse` is the compute warehouse
+    /// that owns refresh execution. Both are validated by the implementation.
+    fn dynamic_table_ddl(
+        &self,
+        _target: &str,
+        _select_sql: &str,
+        _target_lag: &str,
+        _warehouse: &str,
+    ) -> AdapterResult<String> {
+        Err(AdapterError::msg(
+            "DYNAMIC TABLE strategy is not supported by this warehouse \
+             (Snowflake-only)",
+        ))
+    }
 
     /// CREATE CATALOG IF NOT EXISTS. Returns None if the warehouse
     /// doesn't support catalogs (e.g., DuckDB, Postgres).

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -188,6 +188,16 @@ impl SqlDialect for DatabricksSqlDialect {
         format!("`{name}`")
     }
 
+    fn materialized_view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
+        // Unity Catalog managed materialized views — refresh schedule is
+        // configured server-side via `ALTER MATERIALIZED VIEW … SET
+        // SCHEDULE …`. Rocky emits the `CREATE OR REPLACE` form so the SQL
+        // is idempotent across runs.
+        Ok(format!(
+            "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{select_sql}"
+        ))
+    }
+
     fn row_hash_expr(&self, columns: &[String]) -> AdapterResult<String> {
         if columns.is_empty() {
             return Err(AdapterError::msg(
@@ -406,6 +416,44 @@ mod tests {
         assert!(
             sql.contains("table_schema = 'staging__orders'"),
             "sql: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_view_ddl_emits_create_or_replace_view() {
+        let d = dialect();
+        let sql = d.view_ddl("cat.sch.tbl", "SELECT * FROM src").unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE VIEW cat.sch.tbl AS\nSELECT * FROM src"
+        );
+    }
+
+    #[test]
+    fn test_materialized_view_ddl_emits_create_or_replace_mv() {
+        let d = dialect();
+        let sql = d
+            .materialized_view_ddl(
+                "cat.sch.mv",
+                "SELECT customer_id, SUM(total) FROM orders GROUP BY 1",
+            )
+            .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE MATERIALIZED VIEW cat.sch.mv AS\n\
+             SELECT customer_id, SUM(total) FROM orders GROUP BY 1"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_unsupported_on_databricks() {
+        let d = dialect();
+        let err = d
+            .dynamic_table_ddl("cat.sch.dt", "SELECT 1", "1 minute", "wh")
+            .expect_err("Databricks has no dynamic-table concept");
+        assert!(
+            err.to_string().contains("DYNAMIC TABLE"),
+            "error message should mention DT unsupported: {err}"
         );
     }
 

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -221,6 +221,12 @@ impl SqlDialect for DuckDbSqlDialect {
         Ok(format!("regexp_matches({column}, '{pattern}')"))
     }
 
+    // `view_ddl` defaults to `CREATE OR REPLACE VIEW <target> AS …`, which
+    // DuckDB accepts natively — no override needed.
+    //
+    // DuckDB has no materialized-view or dynamic-table equivalent; the
+    // default trait impls emit a clear "not supported" error.
+
     fn row_hash_expr(&self, columns: &[String]) -> AdapterResult<String> {
         if columns.is_empty() {
             return Err(AdapterError::msg(
@@ -479,6 +485,73 @@ mod tests {
         assert_eq!(after.rows[0][1].as_str(), Some("new"));
         assert_eq!(after.rows[1][1].as_str(), Some("keep"));
         assert_eq!(after.rows[2][1].as_str(), Some("fresh"));
+    }
+
+    #[test]
+    fn test_view_ddl_emits_create_or_replace_view() {
+        let d = dialect();
+        let sql = d.view_ddl("sch.tbl", "SELECT * FROM src").unwrap();
+        assert_eq!(sql, "CREATE OR REPLACE VIEW sch.tbl AS\nSELECT * FROM src");
+    }
+
+    #[test]
+    fn test_materialized_view_ddl_unsupported_on_duckdb() {
+        let d = dialect();
+        let err = d
+            .materialized_view_ddl("sch.tbl", "SELECT 1")
+            .expect_err("DuckDB has no MV concept");
+        assert!(
+            err.to_string()
+                .contains("MATERIALIZED VIEW strategy is not supported"),
+            "error message should mention MV unsupported: {err}"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_unsupported_on_duckdb() {
+        let d = dialect();
+        let err = d
+            .dynamic_table_ddl("sch.tbl", "SELECT 1", "1 minute", "wh")
+            .expect_err("DuckDB has no dynamic-table concept");
+        assert!(
+            err.to_string().contains("DYNAMIC TABLE"),
+            "error message should mention DT unsupported: {err}"
+        );
+    }
+
+    #[test]
+    fn test_view_ddl_round_trips_against_live_duckdb() {
+        // Pair the byte-pinned `view_ddl` snapshot with an execute test so
+        // the SQL we generate actually parses+materialises on a live
+        // DuckDB. Mirrors the `test_merge_executes_against_live_duckdb`
+        // pattern in this file (memory:
+        // `feedback_sql_dialect_live_execute_tests`).
+        use crate::DuckDbConnector;
+        let conn = DuckDbConnector::in_memory().expect("in-memory DuckDB");
+
+        // Seed a base table the view will read from.
+        conn.execute_sql(
+            "CREATE TABLE src (id INTEGER, name VARCHAR, status VARCHAR);\n\
+             INSERT INTO src VALUES (1, 'a', 'active'), (2, 'b', 'inactive');",
+        )
+        .expect("seed src table");
+
+        // Generate the VIEW DDL the way Rocky's sql_gen would.
+        let view_sql = dialect()
+            .view_ddl(
+                "active_only",
+                "SELECT id, name FROM src WHERE status = 'active'",
+            )
+            .expect("build view DDL");
+
+        conn.execute_sql(&view_sql).expect("VIEW must execute");
+
+        // Verify the view round-trips a query (1 active row).
+        let after = conn
+            .execute_sql("SELECT id, name FROM active_only")
+            .expect("query the view");
+        assert_eq!(after.rows.len(), 1, "view should expose 1 active row");
+        assert_eq!(after.rows[0][1].as_str(), Some("a"));
     }
 
     #[test]

--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -53,7 +53,13 @@ pub enum MaterializationStrategy {
         unique_key: Vec<Arc<str>>,
         update_columns: ColumnSelection,
     },
-    /// Databricks Materialized View — warehouse manages refresh.
+    /// SQL view — no physical storage. Each query against the target
+    /// re-executes the model SELECT. Cheap to refresh, expensive to read
+    /// repeatedly. Supported on every warehouse (`CREATE OR REPLACE VIEW`).
+    View,
+    /// Materialized view — warehouse manages refresh. Supported on
+    /// Databricks, Snowflake, and BigQuery. Adapters that don't support it
+    /// surface a clear error at SQL-gen time.
     MaterializedView,
     /// Snowflake Dynamic Table — warehouse manages lag-based refresh.
     DynamicTable {

--- a/engine/crates/rocky-snowflake/src/adapter.rs
+++ b/engine/crates/rocky-snowflake/src/adapter.rs
@@ -38,6 +38,10 @@ impl WarehouseAdapter for SnowflakeWarehouseAdapter {
         &self.dialect
     }
 
+    fn warehouse_name(&self) -> Option<&str> {
+        Some(self.connector.warehouse())
+    }
+
     async fn execute_statement(&self, sql: &str) -> AdapterResult<()> {
         self.connector
             .execute_statement(sql)

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -184,6 +184,16 @@ impl SnowflakeConnector {
         self
     }
 
+    /// Compute warehouse name from the connector config.
+    ///
+    /// Surfaced to the adapter layer via
+    /// [`rocky_core::traits::WarehouseAdapter::warehouse_name`] so SQL
+    /// generators that need the warehouse (e.g. dynamic-table DDL) can
+    /// read it without depending on Snowflake-specific types.
+    pub fn warehouse(&self) -> &str {
+        &self.config.warehouse
+    }
+
     /// Creates a connector that points at a custom base URL (for testing with wiremock).
     #[cfg(any(test, feature = "test-support"))]
     #[must_use]

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -222,6 +222,42 @@ impl SqlDialect for SnowflakeSqlDialect {
         format!("\"{name}\"")
     }
 
+    fn materialized_view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
+        Ok(format!(
+            "CREATE OR REPLACE MATERIALIZED VIEW {target} AS\n{select_sql}"
+        ))
+    }
+
+    fn dynamic_table_ddl(
+        &self,
+        target: &str,
+        select_sql: &str,
+        target_lag: &str,
+        warehouse: &str,
+    ) -> AdapterResult<String> {
+        // `target_lag` is a Snowflake lag specifier — accepted values are
+        // either a duration string like `"1 minute"` / `"5 hours"` or the
+        // literal `"downstream"`. Hand-validate the allowlist here rather
+        // than reaching into rocky-core (which would invert the layering):
+        // alphanumeric + space only, non-empty.
+        if target_lag.is_empty()
+            || !target_lag
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == ' ')
+        {
+            return Err(AdapterError::msg(format!(
+                "invalid target_lag for Snowflake dynamic table: {target_lag:?} \
+                 (expected e.g. \"1 minute\", \"5 hours\", or \"downstream\")"
+            )));
+        }
+        validation::validate_identifier(warehouse).map_err(AdapterError::new)?;
+        Ok(format!(
+            "CREATE OR REPLACE DYNAMIC TABLE {target}\n  \
+             TARGET_LAG = '{target_lag}'\n  \
+             WAREHOUSE = {warehouse}\nAS\n{select_sql}"
+        ))
+    }
+
     fn row_hash_expr(&self, columns: &[String]) -> AdapterResult<String> {
         if columns.is_empty() {
             return Err(AdapterError::msg(
@@ -425,6 +461,93 @@ mod tests {
         let d = dialect();
         // Identifier-injection attempt: column name carrying a quote.
         assert!(d.row_hash_expr(&["a\"; DROP TABLE x; --".into()]).is_err());
+    }
+
+    #[test]
+    fn test_view_ddl_emits_create_or_replace_view() {
+        let d = dialect();
+        let sql = d
+            .view_ddl("\"db\".\"sch\".\"v\"", "SELECT * FROM src")
+            .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE VIEW \"db\".\"sch\".\"v\" AS\nSELECT * FROM src"
+        );
+    }
+
+    #[test]
+    fn test_materialized_view_ddl_emits_create_or_replace_mv() {
+        let d = dialect();
+        let sql = d
+            .materialized_view_ddl(
+                "\"db\".\"sch\".\"mv\"",
+                "SELECT customer_id, SUM(total) FROM orders GROUP BY 1",
+            )
+            .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE MATERIALIZED VIEW \"db\".\"sch\".\"mv\" AS\n\
+             SELECT customer_id, SUM(total) FROM orders GROUP BY 1"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_threads_warehouse() {
+        let d = dialect();
+        let sql = d
+            .dynamic_table_ddl(
+                "\"db\".\"sch\".\"dt\"",
+                "SELECT id, value FROM src",
+                "1 minute",
+                "compute_wh",
+            )
+            .unwrap();
+        // Pin the exact Snowflake syntax — refresh-policy clause + WAREHOUSE
+        // ident is positional-required.
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE DYNAMIC TABLE \"db\".\"sch\".\"dt\"\n  \
+             TARGET_LAG = '1 minute'\n  \
+             WAREHOUSE = compute_wh\nAS\n\
+             SELECT id, value FROM src"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_rejects_target_lag_injection() {
+        let d = dialect();
+        // Single-quote injection — the lag specifier is interpolated into a
+        // single-quoted SQL string so a free quote would break out.
+        let err = d
+            .dynamic_table_ddl("t", "SELECT 1", "1'; DROP TABLE x; --", "wh")
+            .expect_err("rejects target_lag carrying quotes");
+        assert!(
+            err.to_string().to_lowercase().contains("target_lag"),
+            "error should mention target_lag: {err}"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_rejects_empty_target_lag() {
+        let d = dialect();
+        let err = d
+            .dynamic_table_ddl("t", "SELECT 1", "", "wh")
+            .expect_err("rejects empty target_lag");
+        assert!(
+            err.to_string().to_lowercase().contains("target_lag"),
+            "error should mention target_lag: {err}"
+        );
+    }
+
+    #[test]
+    fn test_dynamic_table_ddl_rejects_warehouse_injection() {
+        let d = dialect();
+        let err = d
+            .dynamic_table_ddl("t", "SELECT 1", "1 minute", "wh; DROP TABLE x; --")
+            .expect_err("rejects warehouse carrying SQL");
+        // The identifier-validation error message; just make sure we
+        // surface SOMETHING rather than emitting the bad SQL.
+        let _ = err;
     }
 
     #[test]

--- a/engine/crates/rocky-trino/src/dialect.rs
+++ b/engine/crates/rocky-trino/src/dialect.rs
@@ -164,6 +164,19 @@ impl SqlDialect for TrinoDialect {
         ])
     }
 
+    // `view_ddl` defaults to `CREATE OR REPLACE VIEW <target> AS …`,
+    // which Trino accepts natively (connector-gated — Iceberg + Hive
+    // both support it) so the default impl is correct here.
+    //
+    // `materialized_view_ddl` defaults to a fail-loud error. Trino has
+    // materialized-view support through its `system` catalog for some
+    // connectors, but the surface is heterogeneous and Rocky v0 hasn't
+    // wired it up; falling back to the trait default keeps the error
+    // surface honest.
+    //
+    // `dynamic_table_ddl` is Snowflake-specific; the default error is
+    // the right behaviour for Trino.
+
     // `quote_identifier` defaults to `"name"` on the trait, which is
     // exactly Trino's quoting style — leaving the default intact.
 
@@ -304,6 +317,42 @@ mod tests {
         assert_eq!(
             d.tablesample_clause(10).unwrap(),
             "TABLESAMPLE BERNOULLI (10)"
+        );
+    }
+
+    #[test]
+    fn view_ddl_emits_create_or_replace_view() {
+        let d = TrinoDialect::new();
+        let sql = d
+            .view_ddl("\"c\".\"s\".\"v\"", "SELECT * FROM src")
+            .unwrap();
+        assert_eq!(
+            sql,
+            "CREATE OR REPLACE VIEW \"c\".\"s\".\"v\" AS\nSELECT * FROM src"
+        );
+    }
+
+    #[test]
+    fn materialized_view_ddl_unsupported_on_trino() {
+        let d = TrinoDialect::new();
+        let err = d
+            .materialized_view_ddl("\"c\".\"s\".\"mv\"", "SELECT 1")
+            .expect_err("Trino v0 doesn't wire MV");
+        assert!(
+            err.to_string().contains("MATERIALIZED VIEW"),
+            "error message should mention MV unsupported: {err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_table_ddl_unsupported_on_trino() {
+        let d = TrinoDialect::new();
+        let err = d
+            .dynamic_table_ddl("\"c\".\"s\".\"dt\"", "SELECT 1", "1 minute", "wh")
+            .expect_err("Trino has no dynamic-table concept");
+        assert!(
+            err.to_string().contains("DYNAMIC TABLE"),
+            "error message should mention DT unsupported: {err}"
         );
     }
 

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/README.md
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/README.md
@@ -1,0 +1,33 @@
+# 18 — `view` materialization strategy
+
+Smokes the `view` strategy on DuckDB: a model declared with `[strategy] type = "view"`
+in its sidecar compiles, types, and the SQL generator emits
+`CREATE OR REPLACE VIEW <target> AS <model SELECT>`.
+
+## Why distinctive
+
+The materialization-strategy catalog Rocky ships covers FullRefresh, Incremental,
+Merge, TimeInterval / Microbatch, Ephemeral, DeleteInsert, ContentAddressed —
+and the warehouse-managed `view`, `materialized_view`, and `dynamic_table`
+variants. This POC pins the cheapest of those: a plain SQL view that every
+target warehouse supports.
+
+## Layout
+
+```
+models/
+├── dim_customers.sql/toml      # full_refresh seed
+└── active_customers.sql/toml   # type = "view" — re-runs the SELECT on read
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+`rocky compile --models models` reports two models — `dim_customers`
+(`full_refresh`) and `active_customers` (`view`). The compile pass surfaces no
+diagnostics; the model output's `strategy.type` is `"view"`.

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/models/active_customers.sql
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/models/active_customers.sql
@@ -1,0 +1,3 @@
+SELECT customer_id, name, email
+FROM poc.marts.dim_customers
+WHERE status = 'active'

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/models/active_customers.toml
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/models/active_customers.toml
@@ -1,0 +1,8 @@
+depends_on = ["dim_customers"]
+
+[strategy]
+type = "view"
+
+[target]
+catalog = "poc"
+schema = "marts"

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/models/dim_customers.sql
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/models/dim_customers.sql
@@ -1,0 +1,6 @@
+SELECT
+  customer_id,
+  name,
+  email,
+  status
+FROM poc.raw__crm.customers

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/models/dim_customers.toml
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/models/dim_customers.toml
@@ -1,0 +1,6 @@
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "poc"
+schema = "marts"

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/rocky.toml
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/rocky.toml
@@ -1,0 +1,15 @@
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "marts"

--- a/examples/playground/pocs/06-developer-experience/18-view-strategy/run.sh
+++ b/examples/playground/pocs/06-developer-experience/18-view-strategy/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# 18-view-strategy — DuckDB smoke test for the `view` materialization strategy.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+mkdir -p expected
+rm -f .rocky-state.redb poc.duckdb
+
+echo "=== validate ==="
+rocky validate
+
+echo "=== compile (verifies type = \"view\" deserializes + lowers to IR) ==="
+rocky compile --models models > expected/compile.json
+head -30 expected/compile.json
+
+echo "POC complete: a view-strategy model compiles end-to-end on DuckDB."

--- a/integrations/dagster/src/dagster_rocky/types_generated/compile_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/compile_schema.py
@@ -211,10 +211,50 @@ class Type6(StrEnum):
 
 
 class Type7(StrEnum):
-    content_addressed = "content_addressed"
+    view = "view"
 
 
 class StrategyConfig8(BaseModel):
+    """
+    SQL view — no physical storage. Every read against the target re-runs the model SELECT. Supported on every Rocky-targeted warehouse.
+    """
+
+    type: Type7
+
+
+class Type8(StrEnum):
+    materialized_view = "materialized_view"
+
+
+class StrategyConfig9(BaseModel):
+    """
+    Materialized view — warehouse manages refresh. Supported on Databricks, Snowflake, and BigQuery. DuckDB / Trino surface a "not supported" error at SQL-gen time.
+    """
+
+    type: Type8
+
+
+class Type9(StrEnum):
+    dynamic_table = "dynamic_table"
+
+
+class StrategyConfig10(BaseModel):
+    """
+    Snowflake dynamic table — warehouse manages lag-based refresh. `target_lag` is a Snowflake lag specifier (e.g. `"1 minute"`, `"5 hours"`, `"downstream"`). Non-Snowflake adapters surface a "not supported" error at SQL-gen time.
+    """
+
+    target_lag: str
+    """
+    Snowflake lag specifier — alphanumeric + space only. Examples: `"1 minute"`, `"5 hours"`, `"downstream"`.
+    """
+    type: Type9
+
+
+class Type10(StrEnum):
+    content_addressed = "content_addressed"
+
+
+class StrategyConfig11(BaseModel):
     """
     Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.
     """
@@ -227,7 +267,7 @@ class StrategyConfig8(BaseModel):
     """
     Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
     """
-    type: Type7
+    type: Type10
 
 
 class TargetConfig(BaseModel):
@@ -369,6 +409,9 @@ class ModelDetail(BaseModel):
         | StrategyConfig6
         | StrategyConfig7
         | StrategyConfig8
+        | StrategyConfig9
+        | StrategyConfig10
+        | StrategyConfig11
     )
     """
     Materialization strategy as the wire-shape `StrategyConfig` (`{"type": "...", ...}`).

--- a/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
@@ -75,7 +75,7 @@ class Type(StrEnum):
     full_refresh = "full_refresh"
 
 
-class StrategyConfig9(BaseModel):
+class StrategyConfig12(BaseModel):
     """
     Materialization strategy for a model, defaulting to full refresh.
     """
@@ -83,54 +83,54 @@ class StrategyConfig9(BaseModel):
     type: Type
 
 
-class Type9(StrEnum):
+class Type12(StrEnum):
     incremental = "incremental"
 
 
-class StrategyConfig10(BaseModel):
+class StrategyConfig13(BaseModel):
     """
     Materialization strategy for a model, defaulting to full refresh.
     """
 
     timestamp_column: str
-    type: Type9
-
-
-class Type10(StrEnum):
-    merge = "merge"
-
-
-class StrategyConfig11(BaseModel):
-    """
-    Materialization strategy for a model, defaulting to full refresh.
-    """
-
-    type: Type10
-    unique_key: list[str]
-    update_columns: list[str] | None = None
-
-
-class Type11(StrEnum):
-    time_interval = "time_interval"
-
-
-class Type12(StrEnum):
-    ephemeral = "ephemeral"
-
-
-class StrategyConfig13(BaseModel):
-    """
-    Ephemeral model — inlined as CTE in downstream queries, no table created.
-    """
-
     type: Type12
 
 
 class Type13(StrEnum):
-    delete_insert = "delete_insert"
+    merge = "merge"
 
 
 class StrategyConfig14(BaseModel):
+    """
+    Materialization strategy for a model, defaulting to full refresh.
+    """
+
+    type: Type13
+    unique_key: list[str]
+    update_columns: list[str] | None = None
+
+
+class Type14(StrEnum):
+    time_interval = "time_interval"
+
+
+class Type15(StrEnum):
+    ephemeral = "ephemeral"
+
+
+class StrategyConfig16(BaseModel):
+    """
+    Ephemeral model — inlined as CTE in downstream queries, no table created.
+    """
+
+    type: Type15
+
+
+class Type16(StrEnum):
+    delete_insert = "delete_insert"
+
+
+class StrategyConfig17(BaseModel):
     """
     Delete+Insert: delete matching rows by partition key, then insert.
     """
@@ -139,18 +139,58 @@ class StrategyConfig14(BaseModel):
     """
     Column(s) used to identify the partition to delete.
     """
-    type: Type13
+    type: Type16
 
 
-class Type14(StrEnum):
+class Type17(StrEnum):
     microbatch = "microbatch"
 
 
-class Type15(StrEnum):
+class Type18(StrEnum):
+    view = "view"
+
+
+class StrategyConfig19(BaseModel):
+    """
+    SQL view — no physical storage. Every read against the target re-runs the model SELECT. Supported on every Rocky-targeted warehouse.
+    """
+
+    type: Type18
+
+
+class Type19(StrEnum):
+    materialized_view = "materialized_view"
+
+
+class StrategyConfig20(BaseModel):
+    """
+    Materialized view — warehouse manages refresh. Supported on Databricks, Snowflake, and BigQuery. DuckDB / Trino surface a "not supported" error at SQL-gen time.
+    """
+
+    type: Type19
+
+
+class Type20(StrEnum):
+    dynamic_table = "dynamic_table"
+
+
+class StrategyConfig21(BaseModel):
+    """
+    Snowflake dynamic table — warehouse manages lag-based refresh. `target_lag` is a Snowflake lag specifier (e.g. `"1 minute"`, `"5 hours"`, `"downstream"`). Non-Snowflake adapters surface a "not supported" error at SQL-gen time.
+    """
+
+    target_lag: str
+    """
+    Snowflake lag specifier — alphanumeric + space only. Examples: `"1 minute"`, `"5 hours"`, `"downstream"`.
+    """
+    type: Type20
+
+
+class Type21(StrEnum):
     content_addressed = "content_addressed"
 
 
-class StrategyConfig16(BaseModel):
+class StrategyConfig22(BaseModel):
     """
     Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.
     """
@@ -163,7 +203,7 @@ class StrategyConfig16(BaseModel):
     """
     Object-store key prefix that holds `_delta_log/` + Parquet files for the target table. Typically `s3://<bucket>/<path>/<table>` for AWS-backed deployments.
     """
-    type: Type15
+    type: Type21
 
 
 class TargetConfig(BaseModel):
@@ -198,7 +238,7 @@ class LineageEdgeRecord(BaseModel):
     """
 
 
-class StrategyConfig12(BaseModel):
+class StrategyConfig15(BaseModel):
     """
     Partition-keyed materialization. Each run targets specific partitions rather than appending past a watermark. Idempotent and backfill-friendly.
 
@@ -225,10 +265,10 @@ class StrategyConfig12(BaseModel):
     """
     Column on the model output that holds the partition value. Must be a non-nullable date or timestamp column. Validated by the compiler against the typed output schema.
     """
-    type: Type11
+    type: Type14
 
 
-class StrategyConfig15(BaseModel):
+class StrategyConfig18(BaseModel):
     """
     Microbatch: alias for time_interval with hourly defaults. dbt-compatible naming for partition-based incremental processing.
     """
@@ -241,7 +281,7 @@ class StrategyConfig15(BaseModel):
     """
     Timestamp column for micro-batch boundaries.
     """
-    type: Type14
+    type: Type17
 
 
 class DagNodeOutput(BaseModel):
@@ -280,14 +320,17 @@ class DagNodeOutput(BaseModel):
     Pipeline name from `rocky.toml`, if applicable.
     """
     strategy: (
-        StrategyConfig9
-        | StrategyConfig10
-        | StrategyConfig11
-        | StrategyConfig12
+        StrategyConfig12
         | StrategyConfig13
         | StrategyConfig14
         | StrategyConfig15
         | StrategyConfig16
+        | StrategyConfig17
+        | StrategyConfig18
+        | StrategyConfig19
+        | StrategyConfig20
+        | StrategyConfig21
+        | StrategyConfig22
         | None
     ) = None
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -613,19 +613,19 @@ class Type(StrEnum):
     replication = "replication"
 
 
-class Type17(StrEnum):
+class Type23(StrEnum):
     transformation = "transformation"
 
 
-class Type18(StrEnum):
+class Type24(StrEnum):
     quality = "quality"
 
 
-class Type19(StrEnum):
+class Type25(StrEnum):
     snapshot = "snapshot"
 
 
-class Type20(StrEnum):
+class Type26(StrEnum):
     load = "load"
 
 
@@ -649,51 +649,51 @@ class PortabilityConfig(BaseModel):
     """
 
 
-class Type21(StrEnum):
+class Type27(StrEnum):
     not_null = "not_null"
 
 
-class Type22(StrEnum):
+class Type28(StrEnum):
     unique = "unique"
 
 
-class Type23(StrEnum):
+class Type29(StrEnum):
     accepted_values = "accepted_values"
 
 
-class Type24(StrEnum):
+class Type30(StrEnum):
     relationships = "relationships"
 
 
-class Type25(StrEnum):
+class Type31(StrEnum):
     expression = "expression"
 
 
-class Type26(StrEnum):
+class Type32(StrEnum):
     row_count_range = "row_count_range"
 
 
-class Type27(StrEnum):
+class Type33(StrEnum):
     in_range = "in_range"
 
 
-class Type28(StrEnum):
+class Type34(StrEnum):
     regex_match = "regex_match"
 
 
-class Type29(StrEnum):
+class Type35(StrEnum):
     aggregate = "aggregate"
 
 
-class Type30(StrEnum):
+class Type36(StrEnum):
     composite = "composite"
 
 
-class Type31(StrEnum):
+class Type37(StrEnum):
     not_in_future = "not_in_future"
 
 
-class Type32(StrEnum):
+class Type38(StrEnum):
     older_than_n_days = "older_than_n_days"
 
 
@@ -1416,7 +1416,7 @@ class QualityAssertion1(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type21
+    type: Type27
 
 
 class QualityAssertion2(BaseModel):
@@ -1448,7 +1448,7 @@ class QualityAssertion2(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type22
+    type: Type28
 
 
 class QualityAssertion3(BaseModel):
@@ -1480,7 +1480,7 @@ class QualityAssertion3(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type23
+    type: Type29
     values: list[str]
     """
     The allowed values. Compared as string literals.
@@ -1524,7 +1524,7 @@ class QualityAssertion4(BaseModel):
     """
     Fully-qualified target table (`catalog.schema.table`).
     """
-    type: Type24
+    type: Type30
 
 
 class QualityAssertion5(BaseModel):
@@ -1560,7 +1560,7 @@ class QualityAssertion5(BaseModel):
     """
     A SQL boolean expression. Rows where `NOT (expression)` are failures.
     """
-    type: Type25
+    type: Type31
 
 
 class QualityAssertion6(BaseModel):
@@ -1600,7 +1600,7 @@ class QualityAssertion6(BaseModel):
     """
     Minimum row count (inclusive). `None` means no lower bound.
     """
-    type: Type26
+    type: Type32
 
 
 class QualityAssertion7(BaseModel):
@@ -1642,7 +1642,7 @@ class QualityAssertion7(BaseModel):
     """
     Minimum value (inclusive). `None` means no lower bound.
     """
-    type: Type27
+    type: Type33
 
 
 class QualityAssertion8(BaseModel):
@@ -1682,7 +1682,7 @@ class QualityAssertion8(BaseModel):
     """
     The regex pattern. Dialect-specific syntax — stick to the portable subset (character classes, anchors, quantifiers).
     """
-    type: Type28
+    type: Type34
 
 
 class QualityAssertion9(BaseModel):
@@ -1724,7 +1724,7 @@ class QualityAssertion9(BaseModel):
     """
     Aggregate operator.
     """
-    type: Type29
+    type: Type35
     value: str
     """
     Threshold to compare against. Parsed as `f64`.
@@ -1770,7 +1770,7 @@ class QualityAssertion10(BaseModel):
     """
     The kind of composite assertion. Currently `unique` only — kept as an enum to leave room for `not_null_any` / `not_null_all` in a later phase without another TestType.
     """
-    type: Type30
+    type: Type36
 
 
 class QualityAssertion11(BaseModel):
@@ -1802,7 +1802,7 @@ class QualityAssertion11(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type31
+    type: Type37
 
 
 class QualityAssertion12(BaseModel):
@@ -1838,7 +1838,7 @@ class QualityAssertion12(BaseModel):
     """
     N — days in the past. Must be > 0.
     """
-    type: Type32
+    type: Type38
 
 
 class QuarantineConfig(BaseModel):
@@ -2198,9 +2198,9 @@ class ReplicationPipelineConfig(BaseModel):
     """
     strategy: str | None = "incremental"
     """
-    Replication strategy: `"incremental"`, `"full_refresh"`, or `"merge"`.
+    Replication strategy. Accepted values:
 
-    `"merge"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.
+    - `"incremental"` — append rows past the source-side watermark. - `"full_refresh"` — `CREATE OR REPLACE TABLE … AS SELECT …`. - `"merge"` — upserts the watermarked delta into the target via `MERGE INTO … USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set. - `"view"` — emits a `CREATE OR REPLACE VIEW` over the source. Every read against the target re-runs the SELECT; no row movement. - `"materialized_view"` — warehouse-managed materialized view. Supported on Databricks, Snowflake, and BigQuery; DuckDB/Trino surface an unsupported-dialect error. - `"dynamic_table"` — Snowflake-only. Not configurable at the pipeline level today (the strategy needs a `target_lag` specifier that the pipeline block doesn't expose); declare it on a transformation model's sidecar TOML instead.
     """
     table_overrides: list[TableOverride] | None = None
     """
@@ -2464,7 +2464,7 @@ class PipelineConfig3(QualityPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type18
+    type: Type24
 
 
 class PipelineConfig5(LoadPipelineConfig):
@@ -2472,7 +2472,7 @@ class PipelineConfig5(LoadPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type20
+    type: Type26
 
 
 class SnapshotPipelineConfig(BaseModel):
@@ -2606,7 +2606,7 @@ class PipelineConfig2(TransformationPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type17
+    type: Type23
 
 
 class PipelineConfig4(SnapshotPipelineConfig):
@@ -2614,7 +2614,7 @@ class PipelineConfig4(SnapshotPipelineConfig):
     Pipeline configuration. The `type` field selects one of five variants — `replication` (default when omitted), `transformation`, `quality`, `snapshot`, or `load`. Each variant has its own field set; see the per-variant subschemas in `definitions`.
     """
 
-    type: Type19
+    type: Type25
 
 
 class RockyConfig(BaseModel):

--- a/schemas/compile.schema.json
+++ b/schemas/compile.schema.json
@@ -500,6 +500,56 @@
           "type": "object"
         },
         {
+          "description": "SQL view — no physical storage. Every read against the target re-runs the model SELECT. Supported on every Rocky-targeted warehouse.",
+          "properties": {
+            "type": {
+              "enum": [
+                "view"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Materialized view — warehouse manages refresh. Supported on Databricks, Snowflake, and BigQuery. DuckDB / Trino surface a \"not supported\" error at SQL-gen time.",
+          "properties": {
+            "type": {
+              "enum": [
+                "materialized_view"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Snowflake dynamic table — warehouse manages lag-based refresh. `target_lag` is a Snowflake lag specifier (e.g. `\"1 minute\"`, `\"5 hours\"`, `\"downstream\"`). Non-Snowflake adapters surface a \"not supported\" error at SQL-gen time.",
+          "properties": {
+            "target_lag": {
+              "description": "Snowflake lag specifier — alphanumeric + space only. Examples: `\"1 minute\"`, `\"5 hours\"`, `\"downstream\"`.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "dynamic_table"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "target_lag",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.",
           "properties": {
             "partition_columns": {

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -395,6 +395,56 @@
           "type": "object"
         },
         {
+          "description": "SQL view — no physical storage. Every read against the target re-runs the model SELECT. Supported on every Rocky-targeted warehouse.",
+          "properties": {
+            "type": {
+              "enum": [
+                "view"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Materialized view — warehouse manages refresh. Supported on Databricks, Snowflake, and BigQuery. DuckDB / Trino surface a \"not supported\" error at SQL-gen time.",
+          "properties": {
+            "type": {
+              "enum": [
+                "materialized_view"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Snowflake dynamic table — warehouse manages lag-based refresh. `target_lag` is a Snowflake lag specifier (e.g. `\"1 minute\"`, `\"5 hours\"`, `\"downstream\"`). Non-Snowflake adapters surface a \"not supported\" error at SQL-gen time.",
+          "properties": {
+            "target_lag": {
+              "description": "Snowflake lag specifier — alphanumeric + space only. Examples: `\"1 minute\"`, `\"5 hours\"`, `\"downstream\"`.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "dynamic_table"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "target_lag",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "Content-addressed write to a Delta UniForm table via the `rocky-iceberg` writer. The runtime executes the model SQL, converts the result to Arrow, blake3-hashes the Parquet bytes, uploads to `storage_prefix`, and emits a Delta log commit. Cross-engine reads (DuckDB iceberg_scan, etc.) require MSCK REPAIR after each commit; the runtime issues this automatically.",
           "properties": {
             "partition_columns": {

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2191,7 +2191,7 @@
         },
         "strategy": {
           "default": "incremental",
-          "description": "Replication strategy: `\"incremental\"`, `\"full_refresh\"`, or `\"merge\"`.\n\n`\"merge\"` upserts the watermarked delta into the target via `MERGE INTO ... USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set.",
+          "description": "Replication strategy. Accepted values:\n\n- `\"incremental\"` — append rows past the source-side watermark. - `\"full_refresh\"` — `CREATE OR REPLACE TABLE … AS SELECT …`. - `\"merge\"` — upserts the watermarked delta into the target via `MERGE INTO … USING (delta) ON merge_keys WHEN MATCHED UPDATE SET * WHEN NOT MATCHED INSERT *`. Requires `merge_keys` (or `merge_keys_fallback`) to be set. - `\"view\"` — emits a `CREATE OR REPLACE VIEW` over the source. Every read against the target re-runs the SELECT; no row movement. - `\"materialized_view\"` — warehouse-managed materialized view. Supported on Databricks, Snowflake, and BigQuery; DuckDB/Trino surface an unsupported-dialect error. - `\"dynamic_table\"` — Snowflake-only. Not configurable at the pipeline level today (the strategy needs a `target_lag` specifier that the pipeline block doesn't expose); declare it on a transformation model's sidecar TOML instead.",
           "type": "string"
         },
         "table_overrides": {


### PR DESCRIPTION
## Summary

- Three new materialization strategies are now declarable from a model sidecar TOML and dispatch correctly through both the replication and transformation runners: `view`, `materialized_view`, and `dynamic_table { target_lag }`.
- The `SqlDialect` trait grows `view_ddl` / `materialized_view_ddl` / `dynamic_table_ddl` methods. Default impls cover the fail-loud-unsupported case; per-dialect overrides emit warehouse-native SQL.
- Replication runner stops silently emitting `CREATE OR REPLACE TABLE … AS SELECT` for MV / DT and dispatches to the dialect generators. The previous "MV silently treated as full refresh" path is gone.

## Dialect coverage

| Dialect | `View` | `MaterializedView` | `DynamicTable` |
|---|---|---|---|
| `rocky-duckdb` | `CREATE OR REPLACE VIEW` | fail-loud-unsupported | fail-loud-unsupported |
| `rocky-databricks` | `CREATE OR REPLACE VIEW` | `CREATE OR REPLACE MATERIALIZED VIEW` | fail-loud-unsupported |
| `rocky-snowflake` | `CREATE OR REPLACE VIEW` | `CREATE OR REPLACE MATERIALIZED VIEW` | `CREATE OR REPLACE DYNAMIC TABLE … TARGET_LAG = '…' WAREHOUSE = …` (warehouse threaded via `WarehouseAdapter::warehouse_name()`) |
| `rocky-bigquery` | `CREATE OR REPLACE VIEW` | `CREATE OR REPLACE MATERIALIZED VIEW` | fail-loud-unsupported |
| `rocky-trino` | `CREATE OR REPLACE VIEW` | fail-loud-unsupported | fail-loud-unsupported |

## Codegen + bindings

`just codegen` and `just regen-fixtures` both run cleanly. The new `StrategyConfig` variants propagate into the generated Pydantic models (`integrations/dagster/src/dagster_rocky/types_generated/`), TypeScript bindings (`editors/vscode/src/types/generated/`), and JSON schemas (`schemas/compile.schema.json`, `schemas/dag.schema.json`, `schemas/rocky_project.schema.json`). Fixture corpus shows zero drift.

## Test plan

- [x] Per-dialect unit tests byte-pin the SQL output of `view_ddl` / `materialized_view_ddl` / `dynamic_table_ddl` (and the unsupported-error branches) across DuckDB, Databricks, Snowflake, BigQuery, and Trino.
- [x] DuckDB live-execute test runs the generated `view_ddl` SQL against an in-memory connector and round-trips a query through it.
- [x] Snowflake adapter tests pin warehouse-threading and reject `target_lag` injection.
- [x] IR-golden fixture #13 covers `View` across all four dialects; fixture #07 (MV) restricted to MV-supported warehouses; fixture #08 (DT) restricted to Snowflake.
- [x] Strategy-resolver tests in `rocky-cli` pin `view` / `materialized_view` / `dynamic_table` dispatch in the replication runner.
- [x] New DuckDB POC at `examples/playground/pocs/06-developer-experience/18-view-strategy/` smokes the `view` strategy end-to-end and is wired into the credential-free smoke matrix (`scripts/run-all-duckdb.sh` reports 58 passed / 0 failed / 17 skipped).
- [x] `cargo test --all-features --workspace` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `uv run pytest -q` in `integrations/dagster/` — 541 passed.
- [x] `npm run compile` in `editors/vscode/` — clean.

## Live-verify

Compile against the live Databricks sandbox confirmed `type = "materialized_view"` deserializes and lowers to IR cleanly. A full create-and-drop cycle against the sandbox was not attempted because the credential-gated POC's `rocky.toml` requires `${DATABRICKS_TOKEN}` (PAT) and the available sandbox env uses OAuth M2M; updating the POC to accept either auth shape is a small follow-up.