### PR TITLE
fix(playground): align schema-patterns POC env-var guards with rocky.toml usage

### DIFF
--- a/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/README.md
+++ b/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/README.md
@@ -1,8 +1,9 @@
 # 02-schema-patterns-multi-tenant — `src__{tenant}__{regions...}__{source}`
 
 > **Category:** 04-governance
-> **Credentials:** `DATABRICKS_HOST` + `DATABRICKS_TOKEN` required
-> **Runtime:** depends on Databricks API
+> **Credentials:** `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_HTTP_PATH`,
+> `FIVETRAN_API_KEY`, `FIVETRAN_API_SECRET`, `FIVETRAN_DESTINATION_ID` required
+> **Runtime:** depends on Databricks + Fivetran APIs
 > **Rocky features:** `source.schema_pattern` with multi-component layouts
 
 ## What it shows
@@ -24,5 +25,9 @@ to per-tenant target catalogs/schemas. Components support a variadic
 ```bash
 export DATABRICKS_HOST="..."
 export DATABRICKS_TOKEN="..."
+export DATABRICKS_HTTP_PATH="..."
+export FIVETRAN_API_KEY="..."
+export FIVETRAN_API_SECRET="..."
+export FIVETRAN_DESTINATION_ID="..."
 ./run.sh
 ```

--- a/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/run.sh
+++ b/examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/run.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 : "${DATABRICKS_HOST:?Set DATABRICKS_HOST before running this POC}"
 : "${DATABRICKS_TOKEN:?Set DATABRICKS_TOKEN before running this POC}"
+: "${DATABRICKS_HTTP_PATH:?Set DATABRICKS_HTTP_PATH before running this POC}"
 : "${FIVETRAN_API_KEY:?Set FIVETRAN_API_KEY before running this POC}"
+: "${FIVETRAN_API_SECRET:?Set FIVETRAN_API_SECRET before running this POC}"
+: "${FIVETRAN_DESTINATION_ID:?Set FIVETRAN_DESTINATION_ID before running this POC}"
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"


### PR DESCRIPTION
## Summary

`examples/playground/pocs/04-governance/02-schema-patterns-multi-tenant/rocky.toml` references six environment variables, but `run.sh` only guarded three of them. A user who satisfied the existing guards still hit `V001 Failed to parse config: environment variable 'FIVETRAN_DESTINATION_ID' not set` the moment `rocky validate` ran on line 11 of `run.sh`. The README's `Credentials` line was even more wrong — it claimed only `DATABRICKS_HOST` + `DATABRICKS_TOKEN` were required.

This PR aligns `run.sh` and `README.md` with what `rocky.toml` actually demands.

### Missing guards added to `run.sh`

- `DATABRICKS_HTTP_PATH` (referenced at `rocky.toml:4`)
- `FIVETRAN_API_SECRET` (referenced at `rocky.toml:12`)
- `FIVETRAN_DESTINATION_ID` (referenced at `rocky.toml:10`)

### README fix

- Credentials line now lists all six required env vars.
- Runtime now says `depends on Databricks + Fivetran APIs`.
- Run instructions export all six.

This is Option A from the two fix shapes considered (tighten the guards). Option B (defaulting the un-guarded vars via `${VAR:-default}` in `rocky.toml`) was rejected because the POC is intentionally credential-gated for a reason and the right shape is fail-fast.

## Test plan

- [x] `rocky -c rocky.toml validate` exits 0 with `valid: true` when all six vars are stubbed
- [x] `bash examples/playground/scripts/run-all-duckdb.sh` still reports `58 passed / 0 failed / 17 skipped` (this POC is credential-gated and SKIP'd by the smoke script)
- [x] No V033 interaction observed on this POC (it has `pipeline.poc.source.discovery.adapter = "fivetran_main"` explicitly set; any V033 across other POCs is the scope of a sibling PR)