### PR TITLE
feat(playground): smoke matrix parse-validates credential-gated POCs with mock env vars

### DIFF
--- a/.github/workflows/engine-weekly.yml
+++ b/.github/workflows/engine-weekly.yml
@@ -80,3 +80,14 @@ jobs:
       - name: Run POC smoke tests
         working-directory: ${{ github.workspace }}
         run: bash examples/playground/scripts/run-all-duckdb.sh
+
+      # Parse-validate credential-gated POCs with mock env vars. Catches
+      # parse-time breakage (invalid strategy variants, V032/V033 adapter
+      # role mismatches, malformed [pipeline.*]) that run-all-duckdb.sh
+      # misses because credential-gated POCs short-circuit on the missing
+      # env var before `rocky validate` runs. Marked `continue-on-error`
+      # until the V033 + materialized_view sweep PRs land — see PR body.
+      - name: Parse-validate credential-gated POCs
+        working-directory: ${{ github.workspace }}
+        continue-on-error: true
+        run: bash examples/playground/scripts/run-all-parse-validate.sh

--- a/examples/playground/CLAUDE.md
+++ b/examples/playground/CLAUDE.md
@@ -114,10 +114,11 @@ rocky validate -c rocky.toml                # If POC uses pipeline path
 For the catalog as a whole:
 
 ```bash
-./scripts/run-all-duckdb.sh                 # All credential-free POCs, 60s timeout each
+./scripts/run-all-duckdb.sh                 # Credential-free POCs end-to-end, 60s timeout each
+./scripts/run-all-parse-validate.sh         # Credential-gated POCs — `rocky validate` only, with mock env vars
 ```
 
-Credential-gated POCs should fail fast with a clear `: "${VAR:?Set VAR before running}"` guard at the top of `run.sh`.
+Credential-gated POCs should fail fast with a clear `: "${VAR:?Set VAR before running}"` guard at the top of `run.sh`. The parse-validate script keys off that guard to decide which POCs to stub-validate.
 
 ## Git conventions
 

--- a/examples/playground/scripts/run-all-parse-validate.sh
+++ b/examples/playground/scripts/run-all-parse-validate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Parse-validate every credential-gated POC.
+#
+# Companion to `run-all-duckdb.sh`. That script runs credential-free POCs
+# end-to-end against DuckDB; credential-gated POCs (`: "${VAR:?...}"` guards
+# in `run.sh`) skip there and never reach `rocky validate`. Parse-time
+# breakage — invalid strategy variants in model frontmatter, V032/V033
+# adapter-kind regressions, malformed [pipeline.*] sections — therefore
+# stays silent until someone runs the POC with real creds.
+#
+# This script closes that gap: for each credential-gated POC, it stubs
+# every `${VAR}` referenced in `rocky.toml` (with the literal string
+# `stub-for-parse-validation`) and runs `rocky validate`. Authentication
+# isn't exercised — only config parsing + lint diagnostics.
+#
+# Compatible with macOS Bash 3.2 (no `mapfile`, no `${var,,}`, no
+# `[[ =~ ]]` capture groups).
+#
+# Skip rules (in order):
+#   1. POC's run.sh has no `: "${VAR:?...}"` guard — covered by
+#      run-all-duckdb.sh.
+#   2. POC is Docker-gated — needs different infra.
+#   3. POC is Rust-toolchain-gated — needs `cargo`.
+#
+# Exit status mirrors `run-all-duckdb.sh`: zero when every parsed POC
+# passes, non-zero (count of FAILs) otherwise.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+passed=0
+failed=0
+skipped=0
+fails=""
+
+for cfg in pocs/*/*/rocky.toml; do
+    poc_dir=$(dirname "$cfg")
+    run="$poc_dir/run.sh"
+    readme="$poc_dir/README.md"
+
+    if [ ! -f "$run" ]; then
+        # POC config without a runner — rare, but skip cleanly.
+        echo "--- SKIP $poc_dir (no run.sh)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Only parse-validate POCs that gate on credentials. Same fail-fast
+    # guard pattern (`: "${VAR:?...}"`) that run-all-duckdb.sh keys off
+    # for the inverse decision.
+    if ! grep -qE ': *"\$\{[A-Z_][A-Z0-9_]*:\?' "$run" 2>/dev/null; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Docker-gated POCs need a compose stack — outside this script's
+    # remit.
+    if grep -qiE 'docker[ -]compose' "$readme" 2>/dev/null; then
+        echo "--- SKIP $poc_dir (docker required)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Rust-toolchain-gated POCs (cargo invocations in run.sh) skipped
+    # for the same reason run-all-duckdb.sh skips them — parse-validate
+    # has no business pulling crates.io.
+    if grep -qE '^[[:space:]]*cargo[[:space:]]+(check|build|test|run)\b' "$run" 2>/dev/null; then
+        echo "--- SKIP $poc_dir (Rust toolchain)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    # Collect every `${VAR}` referenced in rocky.toml. Capture matches
+    # all three substitution forms (`${VAR}`, `${VAR:-default}`,
+    # `${VAR:?msg}`) and dedupes. Empty result is fine — some POCs
+    # (e.g. the AI ones) gate run.sh on ANTHROPIC_API_KEY but use a
+    # vanilla DuckDB config.
+    vars=$(grep -oE '\$\{[A-Z_][A-Z0-9_]*' "$cfg" 2>/dev/null \
+        | sed 's/^\${//' \
+        | sort -u)
+
+    # Build the env-var injection inline. `env VAR1=stub VAR2=stub ...
+    # rocky validate` keeps the stubs scoped to the single invocation
+    # without polluting the loop's environment.
+    env_args=""
+    for var in $vars; do
+        env_args="$env_args $var=stub-for-parse-validation"
+    done
+
+    echo "=== PARSE-VALIDATE $poc_dir"
+    # shellcheck disable=SC2086 # env_args is intentionally word-split
+    if env $env_args rocky -c "$cfg" validate > /tmp/parse-validate-output.log 2>&1; then
+        echo "    PASS"
+        passed=$((passed + 1))
+    else
+        echo "    FAIL — last 20 lines:"
+        tail -20 /tmp/parse-validate-output.log | sed 's/^/    /'
+        failed=$((failed + 1))
+        fails="$fails $poc_dir"
+    fi
+done
+
+echo
+echo "Summary: $passed passed, $failed failed, $skipped skipped"
+if [ -n "$fails" ]; then
+    echo "Failed POCs:"
+    for f in $fails; do
+        echo "  - $f"
+    done
+fi
+exit $failed


### PR DESCRIPTION
## Summary

- New script `examples/playground/scripts/run-all-parse-validate.sh` — companion to `run-all-duckdb.sh` that closes the credential-gated parse-time blind spot.
- Wired into `engine-weekly.yml` as a `continue-on-error` step alongside the existing POC smoke step.

## The gap

`run-all-duckdb.sh` runs each POC's `run.sh`. Credential-gated POCs (those with `: \"${VAR:?...}\"` guards) fail-fast at the guard and never reach `rocky validate`, so parse-time breakage in their `rocky.toml` or model frontmatter stays silent until a user with real creds runs the POC.

That gap is exactly what hid the `materialized_view` POC and the V033 cluster from CI: both bodies of work shipped on main with broken-on-parse configs, and only surfaced because a sweep agent walked the catalog manually.

## How the new script works

For each `examples/playground/pocs/**/rocky.toml`:

1. Skip if `run.sh` has no `: \"${VAR:?...}\"` guard — already covered by `run-all-duckdb.sh`.
2. Skip if Docker-gated (`docker compose` in `README.md`).
3. Skip if Rust-toolchain-gated (`cargo check/build/test/run` in `run.sh`).
4. Otherwise: grep every `${VAR}` ref out of the POC's `rocky.toml`, inject `VAR=stub-for-parse-validation` per match, run `rocky validate`. Report PASS / FAIL with the same summary line shape as `run-all-duckdb.sh`.

POSIX-portable (macOS Bash 3.2 compatible — no `mapfile`, no `${var,,}`, no `[[ =~ ]]` capture groups).

## Initial local state (against engine v1.37.0)

```
Summary: 7 passed, 5 failed, 60 skipped
Failed POCs:
  - pocs/04-governance/01-unity-catalog-grants
  - pocs/04-governance/03-workspace-isolation
  - pocs/04-governance/04-tagging-lifecycle
  - pocs/07-adapters/01-snowflake-dynamic-table
  - pocs/07-adapters/02-databricks-materialized-view
```

Two clusters of breakage surfaced:

- **V033** — 4 POCs declare `pipeline.poc.source.discovery.adapter = <databricks-or-snowflake-adapter>`, but those adapter types have `kind = \"data\"` not `\"discovery\"`. Cleanup PR coming in alongside this one.
- **V030** — `07-adapters/02-databricks-materialized-view` and `07-adapters/01-snowflake-dynamic-table` use model frontmatter `type = \"materialized_view\"` / `type = \"dynamic_table\"`, but the parser enum still ships only the legacy variants. The IR carries the strategies (see #585) but the frontmatter parser was missed. Sibling PR opens up those variants.

## CI wiring

Added as a third step in the existing `poc-smoke` job in `engine-weekly.yml`, marked `continue-on-error: true`. That way:

- The smoke step still reports independently — we can see which class of breakage fired.
- The weekly green-vs-red signal isn't blocked by the known-failing initial state.

Once the V033 sweep + materialized_view/dynamic_table parser fixes land, the `continue-on-error: true` can be dropped to flip the step to blocking. Tracked inline in the workflow comment.

## Test plan

- [x] Script runs locally on macOS Bash 3.2 against engine v1.37.0.
- [x] Reports the documented 5 FAILs.
- [x] Exit code matches the failure count (5), same convention as `run-all-duckdb.sh`.
- [ ] `engine-weekly.yml` step reports same numbers on Linux.
- [ ] Once sibling PRs merge, run-all-parse-validate.sh goes green; flip `continue-on-error: true` to `false` in a follow-up.