### PR TITLE
fix(playground): add explicit discovery adapter to 5 credential-gated POCs (V033)

### DIFF
--- a/examples/playground/pocs/04-governance/01-unity-catalog-grants/rocky.toml
+++ b/examples/playground/pocs/04-governance/01-unity-catalog-grants/rocky.toml
@@ -4,12 +4,23 @@ host = "${DATABRICKS_HOST}"
 http_path = "${DATABRICKS_HTTP_PATH}"
 token = "${DATABRICKS_TOKEN}"
 
+# Discovery adapter — Databricks is data-only, so we declare a
+# manual discovery adapter to satisfy the pipeline's discovery
+# binding without enumerating any source tables (the POC only
+# exercises target-side governance, not discovery).
+[adapter.local_discovery]
+type = "manual"
+kind = "discovery"
+
 [pipeline.poc]
 strategy = "full_refresh"
 
 [pipeline.poc.source]
 adapter = "databricks_prod"
 catalog = "main"
+
+[pipeline.poc.source.discovery]
+adapter = "local_discovery"
 
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"

--- a/examples/playground/pocs/04-governance/03-workspace-isolation/rocky.toml
+++ b/examples/playground/pocs/04-governance/03-workspace-isolation/rocky.toml
@@ -4,12 +4,23 @@ host = "${DATABRICKS_HOST}"
 http_path = "${DATABRICKS_HTTP_PATH}"
 token = "${DATABRICKS_TOKEN}"
 
+# Discovery adapter — Databricks is data-only, so we declare a
+# manual discovery adapter to satisfy the pipeline's discovery
+# binding without enumerating any source tables (the POC only
+# exercises target-side workspace isolation, not discovery).
+[adapter.local_discovery]
+type = "manual"
+kind = "discovery"
+
 [pipeline.poc]
 strategy = "full_refresh"
 
 [pipeline.poc.source]
 adapter = "databricks_prod"
 catalog = "main"
+
+[pipeline.poc.source.discovery]
+adapter = "local_discovery"
 
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"

--- a/examples/playground/pocs/04-governance/04-tagging-lifecycle/rocky.toml
+++ b/examples/playground/pocs/04-governance/04-tagging-lifecycle/rocky.toml
@@ -4,12 +4,23 @@ host = "${DATABRICKS_HOST}"
 http_path = "${DATABRICKS_HTTP_PATH}"
 token = "${DATABRICKS_TOKEN}"
 
+# Discovery adapter — Databricks is data-only, so we declare a
+# manual discovery adapter to satisfy the pipeline's discovery
+# binding without enumerating any source tables (the POC only
+# exercises target-side tagging, not discovery).
+[adapter.local_discovery]
+type = "manual"
+kind = "discovery"
+
 [pipeline.poc]
 strategy = "full_refresh"
 
 [pipeline.poc.source]
 adapter = "databricks_prod"
 catalog = "main"
+
+[pipeline.poc.source.discovery]
+adapter = "local_discovery"
 
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"

--- a/examples/playground/pocs/07-adapters/01-snowflake-dynamic-table/rocky.toml
+++ b/examples/playground/pocs/07-adapters/01-snowflake-dynamic-table/rocky.toml
@@ -2,12 +2,23 @@
 type = "snowflake"
 # Snowflake adapter fields are picked up from env vars by the connector
 
+# Discovery adapter — Snowflake is data-only, so we declare a
+# manual discovery adapter to satisfy the pipeline's discovery
+# binding without enumerating any source tables (the POC only
+# exercises target-side dynamic-table materialization, not discovery).
+[adapter.local_discovery]
+type = "manual"
+kind = "discovery"
+
 [pipeline.poc]
 strategy = "full_refresh"
 
 [pipeline.poc.source]
 adapter = "snowflake"
 catalog = "ANALYTICS"
+
+[pipeline.poc.source.discovery]
+adapter = "local_discovery"
 
 [pipeline.poc.source.schema_pattern]
 prefix = "RAW__"

--- a/examples/playground/pocs/07-adapters/02-databricks-materialized-view/rocky.toml
+++ b/examples/playground/pocs/07-adapters/02-databricks-materialized-view/rocky.toml
@@ -4,12 +4,23 @@ host = "${DATABRICKS_HOST}"
 http_path = "${DATABRICKS_HTTP_PATH}"
 token = "${DATABRICKS_TOKEN}"
 
+# Discovery adapter — Databricks is data-only, so we declare a
+# manual discovery adapter to satisfy the pipeline's discovery
+# binding without enumerating any source tables (the POC only
+# exercises target-side materialized-view DDL, not discovery).
+[adapter.local_discovery]
+type = "manual"
+kind = "discovery"
+
 [pipeline.poc]
 strategy = "full_refresh"
 
 [pipeline.poc.source]
 adapter = "databricks_prod"
 catalog = "main"
+
+[pipeline.poc.source.discovery]
+adapter = "local_discovery"
 
 [pipeline.poc.source.schema_pattern]
 prefix = "raw__"


### PR DESCRIPTION
## Summary

Five credential-gated POCs each declared a single DATA_ONLY adapter (Databricks or Snowflake). The engine's single-adapter discovery default auto-wires `source.discovery` to that sole adapter, but both `databricks` and `snowflake` are `DATA_ONLY` per `engine/crates/rocky-core/src/adapter_capability.rs:57-65`. The auto-bind therefore trips V033 (`source.discovery.adapter points to an adapter whose 'kind' excludes discovery`), and `rocky validate` exits 1. Each POC's `run.sh` calls `rocky validate` under `set -e`, so a user with real creds hits V033 and the POC dies before any warehouse call.

Each affected POC now declares an explicit `[adapter.local_discovery]` (`type = "manual"`, `kind = "discovery"`) and binds it via `[pipeline.poc.source.discovery] adapter = "local_discovery"`. The `manual` discovery adapter is a no-op in the CLI registry (no fields, no network calls), so it satisfies the validator and the kind invariant without affecting the POC's runtime behaviour — these POCs only exercise target-side governance / materialization, not source enumeration.

## Affected POCs

- `examples/playground/pocs/04-governance/01-unity-catalog-grants` (Databricks)
- `examples/playground/pocs/04-governance/03-workspace-isolation` (Databricks)
- `examples/playground/pocs/04-governance/04-tagging-lifecycle` (Databricks)
- `examples/playground/pocs/07-adapters/01-snowflake-dynamic-table` (Snowflake)
- `examples/playground/pocs/07-adapters/02-databricks-materialized-view` (Databricks)

## Test plan

- [x] `rocky validate` exits 0 with `valid: true` and zero error/warn messages for all 5 POCs under stub env vars
- [x] Smoke matrix still reports `58 passed / 0 failed / 17 skipped` (no regression — the 5 POCs stay in the credentials-required SKIP bucket)
- [ ] CI green