### PR TITLE
feat(rocky-fivetran): cache stampede + cross-pod budget + circuit breaker

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -45,6 +45,17 @@
           ],
           "description": "Optional cache backend for the Fivetran state envelope.\n\nWhen set on a `type = \"fivetran\"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = \"none\"` — every fetch goes straight to the Fivetran API."
         },
+        "circuit_breaker": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranCircuitBreakerConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional per-account circuit breaker (Fivetran-only).\n\nTrips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker)."
+        },
         "client_id": {
           "type": [
             "string",
@@ -159,6 +170,17 @@
             "null"
           ]
         },
+        "ratelimit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranRatelimitConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional cross-pod rate-limit budget backend (Fivetran-only).\n\nPhase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = \"valkey\"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend."
+        },
         "retry": {
           "allOf": [
             {
@@ -183,6 +205,17 @@
             "string",
             "null"
           ]
+        },
+        "stampede": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranStampedeConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional distributed cache-stampede lock (Fivetran-only).\n\nOn a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior)."
         },
         "timeout_secs": {
           "format": "uint64",
@@ -870,6 +903,195 @@
         },
         "valkey_url": {
           "description": "Connection URL for `backend = \"valkey\"` or `backend = \"tiered\"` (primary layer). Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranCircuitBreakerBackend": {
+      "description": "Circuit-breaker backend selector for the Fivetran adapter (Layer 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op breaker; state is always `Closed`. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared per-account state machine in Valkey. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranCircuitBreakerConfig": {
+      "additionalProperties": false,
+      "description": "Circuit-breaker config for the Fivetran adapter (Layer 3).\n\nTrips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).\n\nState is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.\n\n## TOML shape\n\n```toml [adapter.fivetran.circuit_breaker] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```\n\n## Fail-open\n\nWhen the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranCircuitBreakerBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "cooldown_max_seconds": {
+          "description": "Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "cooldown_seconds": {
+          "description": "Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "failure_threshold": {
+          "description": "Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_seconds": {
+          "description": "Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranRatelimitBackend": {
+      "description": "Cross-pod rate-limit budget backend selector for the Fivetran adapter (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "Per-host file lock (Phase 1 behavior). Default when the block is absent.",
+          "enum": [
+            "file"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared Valkey key. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranRatelimitConfig": {
+      "additionalProperties": false,
+      "description": "Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).\n\nPhase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.\n\n## TOML shape\n\n```toml [adapter.fivetran.ratelimit] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" ```\n\n## Fail-open\n\nWhen the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranRatelimitBackend"
+            }
+          ],
+          "default": "file",
+          "description": "Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined."
+        },
+        "max_wake_seconds": {
+          "description": "Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranStampedeBackend": {
+      "description": "Distributed cache-stampede lock backend selector for the Fivetran adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op lock; every caller is treated as the leader. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Distributed lock via Valkey `SET NX EX`. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranStampedeConfig": {
+      "additionalProperties": false,
+      "description": "Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).\n\nOn a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.\n\n## TOML shape\n\n```toml [adapter.fivetran.stampede] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```\n\n## Fail-open\n\nWhen the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranStampedeBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "lock_ttl_seconds": {
+          "description": "Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "poll_timeout_seconds": {
+          "description": "Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
           "type": [
             "string",
             "null"

--- a/editors/vscode/src/types/generated/adapter_config.ts
+++ b/editors/vscode/src/types/generated/adapter_config.ts
@@ -11,6 +11,10 @@ export type RedactedString = string;
  */
 export type FivetranCacheBackend = "none" | "file" | "object_store" | "valkey" | "tiered";
 /**
+ * Circuit-breaker backend selector for the Fivetran adapter (Layer 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.
+ */
+export type FivetranCircuitBreakerBackend = "none" | "valkey";
+/**
  * Role an adapter block plays in the pipeline.
  *
  * Set via `kind = "data"` or `kind = "discovery"` in an `[adapter.*]` block. Required on discovery-only adapter types (`fivetran`, `airbyte`, `iceberg`, `manual`) so the adapter's role is self-evident in the raw config file — a reader shouldn't have to know the Rust trait surface of each adapter to tell whether it moves data.
@@ -18,6 +22,14 @@ export type FivetranCacheBackend = "none" | "file" | "object_store" | "valkey" |
  * Optional on single-role warehouse types (defaults to `Data`) and on the dual-capable DuckDB adapter (absent means "register both roles").
  */
 export type AdapterKind = "data" | "discovery";
+/**
+ * Cross-pod rate-limit budget backend selector for the Fivetran adapter (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.
+ */
+export type FivetranRatelimitBackend = "file" | "valkey";
+/**
+ * Distributed cache-stampede lock backend selector for the Fivetran adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML shape.
+ */
+export type FivetranStampedeBackend = "none" | "valkey";
 
 /**
  * Configuration for a named adapter instance.
@@ -39,6 +51,12 @@ export interface AdapterConfig {
    * When set on a `type = "fivetran"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = "none"` — every fetch goes straight to the Fivetran API.
    */
   cache?: FivetranCacheConfig | null;
+  /**
+   * Optional per-account circuit breaker (Fivetran-only).
+   *
+   * Trips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker).
+   */
+  circuit_breaker?: FivetranCircuitBreakerConfig | null;
   client_id?: string | null;
   client_secret?: RedactedString | null;
   /**
@@ -81,6 +99,12 @@ export interface AdapterConfig {
    */
   project_id?: string | null;
   /**
+   * Optional cross-pod rate-limit budget backend (Fivetran-only).
+   *
+   * Phase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = "valkey"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend.
+   */
+  ratelimit?: FivetranRatelimitConfig | null;
+  /**
    * Retry policy for this adapter.
    */
   retry?: RetryConfig;
@@ -88,6 +112,12 @@ export interface AdapterConfig {
    * Snowflake role to use for the session.
    */
   role?: string | null;
+  /**
+   * Optional distributed cache-stampede lock (Fivetran-only).
+   *
+   * On a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior).
+   */
+  stampede?: FivetranStampedeConfig | null;
   timeout_secs?: number | null;
   token?: RedactedString | null;
   /**
@@ -139,6 +169,74 @@ export interface FivetranCacheConfig {
   valkey_url?: string | null;
 }
 /**
+ * Circuit-breaker config for the Fivetran adapter (Layer 3).
+ *
+ * Trips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).
+ *
+ * State is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.circuit_breaker] backend = "valkey" valkey_url = "rediss://valkey:6379/" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```
+ *
+ * ## Fail-open
+ *
+ * When the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.
+ */
+export interface FivetranCircuitBreakerConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranCircuitBreakerBackend & string;
+  /**
+   * Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.
+   */
+  cooldown_max_seconds?: number | null;
+  /**
+   * Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.
+   */
+  cooldown_seconds?: number | null;
+  /**
+   * Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.
+   */
+  failure_threshold?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
+  /**
+   * Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.
+   */
+  window_seconds?: number | null;
+}
+/**
+ * Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).
+ *
+ * Phase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.ratelimit] backend = "valkey" valkey_url = "rediss://valkey:6379/" ```
+ *
+ * ## Fail-open
+ *
+ * When the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.
+ */
+export interface FivetranRatelimitConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranRatelimitBackend & string;
+  /**
+   * Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.
+   */
+  max_wake_seconds?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
+}
+/**
  * Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).
  *
  * Rocky retries transient errors with exponential backoff and optional jitter to prevent thundering herd across concurrent runs.
@@ -178,4 +276,35 @@ export interface RetryConfig {
    * `None` (default) keeps legacy behaviour — per-statement [`RetryConfig::max_retries`] is the only bound. `Some(0)` means no retries are allowed for the whole run.
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).
+ *
+ * On a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.stampede] backend = "valkey" valkey_url = "rediss://valkey:6379/" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```
+ *
+ * ## Fail-open
+ *
+ * When the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).
+ */
+export interface FivetranStampedeConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranStampedeBackend & string;
+  /**
+   * Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.
+   */
+  lock_ttl_seconds?: number | null;
+  /**
+   * Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.
+   */
+  poll_timeout_seconds?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
 }

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -21,6 +21,10 @@ export type RedactedString = string;
  */
 export type FivetranCacheBackend = "none" | "file" | "object_store" | "valkey" | "tiered";
 /**
+ * Circuit-breaker backend selector for the Fivetran adapter (Layer 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.
+ */
+export type FivetranCircuitBreakerBackend = "none" | "valkey";
+/**
  * Role an adapter block plays in the pipeline.
  *
  * Set via `kind = "data"` or `kind = "discovery"` in an `[adapter.*]` block. Required on discovery-only adapter types (`fivetran`, `airbyte`, `iceberg`, `manual`) so the adapter's role is self-evident in the raw config file — a reader shouldn't have to know the Rust trait surface of each adapter to tell whether it moves data.
@@ -28,6 +32,14 @@ export type FivetranCacheBackend = "none" | "file" | "object_store" | "valkey" |
  * Optional on single-role warehouse types (defaults to `Data`) and on the dual-capable DuckDB adapter (absent means "register both roles").
  */
 export type AdapterKind = "data" | "discovery";
+/**
+ * Cross-pod rate-limit budget backend selector for the Fivetran adapter (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.
+ */
+export type FivetranRatelimitBackend = "file" | "valkey";
+/**
+ * Distributed cache-stampede lock backend selector for the Fivetran adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML shape.
+ */
+export type FivetranStampedeBackend = "none" | "valkey";
 /**
  * What to do when a [`BudgetConfig`] limit is exceeded by an actual run.
  *
@@ -414,6 +426,12 @@ export interface AdapterConfig {
    * When set on a `type = "fivetran"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = "none"` — every fetch goes straight to the Fivetran API.
    */
   cache?: FivetranCacheConfig | null;
+  /**
+   * Optional per-account circuit breaker (Fivetran-only).
+   *
+   * Trips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker).
+   */
+  circuit_breaker?: FivetranCircuitBreakerConfig | null;
   client_id?: string | null;
   client_secret?: RedactedString | null;
   /**
@@ -456,6 +474,12 @@ export interface AdapterConfig {
    */
   project_id?: string | null;
   /**
+   * Optional cross-pod rate-limit budget backend (Fivetran-only).
+   *
+   * Phase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = "valkey"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend.
+   */
+  ratelimit?: FivetranRatelimitConfig | null;
+  /**
    * Retry policy for this adapter.
    */
   retry?: RetryConfig;
@@ -463,6 +487,12 @@ export interface AdapterConfig {
    * Snowflake role to use for the session.
    */
   role?: string | null;
+  /**
+   * Optional distributed cache-stampede lock (Fivetran-only).
+   *
+   * On a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior).
+   */
+  stampede?: FivetranStampedeConfig | null;
   timeout_secs?: number | null;
   token?: RedactedString | null;
   /**
@@ -514,6 +544,74 @@ export interface FivetranCacheConfig {
   valkey_url?: string | null;
 }
 /**
+ * Circuit-breaker config for the Fivetran adapter (Layer 3).
+ *
+ * Trips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).
+ *
+ * State is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.circuit_breaker] backend = "valkey" valkey_url = "rediss://valkey:6379/" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```
+ *
+ * ## Fail-open
+ *
+ * When the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.
+ */
+export interface FivetranCircuitBreakerConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranCircuitBreakerBackend & string;
+  /**
+   * Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.
+   */
+  cooldown_max_seconds?: number | null;
+  /**
+   * Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.
+   */
+  cooldown_seconds?: number | null;
+  /**
+   * Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.
+   */
+  failure_threshold?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
+  /**
+   * Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.
+   */
+  window_seconds?: number | null;
+}
+/**
+ * Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).
+ *
+ * Phase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.ratelimit] backend = "valkey" valkey_url = "rediss://valkey:6379/" ```
+ *
+ * ## Fail-open
+ *
+ * When the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.
+ */
+export interface FivetranRatelimitConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranRatelimitBackend & string;
+  /**
+   * Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.
+   */
+  max_wake_seconds?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
+}
+/**
  * Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).
  *
  * Rocky retries transient errors with exponential backoff and optional jitter to prevent thundering herd across concurrent runs.
@@ -553,6 +651,37 @@ export interface RetryConfig {
    * `None` (default) keeps legacy behaviour — per-statement [`RetryConfig::max_retries`] is the only bound. `Some(0)` means no retries are allowed for the whole run.
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).
+ *
+ * On a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.
+ *
+ * ## TOML shape
+ *
+ * ```toml [adapter.fivetran.stampede] backend = "valkey" valkey_url = "rediss://valkey:6379/" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```
+ *
+ * ## Fail-open
+ *
+ * When the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).
+ */
+export interface FivetranStampedeConfig {
+  /**
+   * Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined.
+   */
+  backend?: FivetranStampedeBackend & string;
+  /**
+   * Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.
+   */
+  lock_ttl_seconds?: number | null;
+  /**
+   * Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.
+   */
+  poll_timeout_seconds?: number | null;
+  /**
+   * Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+   */
+  valkey_url?: string | null;
 }
 /**
  * Configuration for the AI intent layer (`rocky ai`, `rocky ai-explain`, `rocky ai-sync`, `rocky ai-test`).

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -496,6 +496,35 @@ async fn emit_fivetran_state(
             client = client.with_state_cache(state_cache);
         }
 
+        // FR-B Phase 2 + Layer 1 + Layer 3 — coordination backends.
+        // Each factory returns the default no-op backend when the
+        // block is absent, so a project that hasn't opted in stays
+        // on the per-host file / NoLock / AlwaysClosed behavior.
+        let budget =
+            rocky_fivetran::ratelimit::build_ratelimit_budget(adapter_cfg.ratelimit.as_ref())
+                .with_context(|| {
+                    format!("adapters.{name}: failed to build [adapter.{name}.ratelimit] backend")
+                })?;
+        client = client.with_ratelimit_budget(budget);
+
+        let (stampede, stampede_tunables) =
+            rocky_fivetran::stampede::build_stampede_lock(adapter_cfg.stampede.as_ref())
+                .with_context(|| {
+                    format!("adapters.{name}: failed to build [adapter.{name}.stampede] backend")
+                })?;
+        client = client
+            .with_stampede_lock(stampede)
+            .with_stampede_lock_ttl(stampede_tunables.lock_ttl)
+            .with_stampede_poll_timeout(stampede_tunables.poll_timeout);
+
+        let breaker = rocky_fivetran::circuit_breaker::build_circuit_breaker(
+            adapter_cfg.circuit_breaker.as_ref(),
+        )
+        .with_context(|| {
+            format!("adapters.{name}: failed to build [adapter.{name}.circuit_breaker] backend")
+        })?;
+        client = client.with_circuit_breaker(breaker);
+
         let envelope = client
             .fetch_envelope(destination_id, force_refresh)
             .await

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -686,6 +686,9 @@ mod tests {
             path: None,
             retry: rocky_core::config::RetryConfig::default(),
             cache: None,
+            ratelimit: None,
+            stampede: None,
+            circuit_breaker: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -259,6 +259,45 @@ impl AdapterRegistry {
                         client = client.with_state_cache(state_cache);
                     }
 
+                    // FR-B Phase 2 — cross-pod rate-limit budget. When
+                    // the block is absent the factory returns the
+                    // per-host file backend (Phase 1 behavior).
+                    let budget = rocky_fivetran::ratelimit::build_ratelimit_budget(
+                        adapter_cfg.ratelimit.as_ref(),
+                    )
+                    .with_context(|| {
+                        format!(
+                            "adapters.{name}: failed to build [adapter.{name}.ratelimit] backend"
+                        )
+                    })?;
+                    client = client.with_ratelimit_budget(budget);
+
+                    // Layer 1 — cache-stampede lock. Absent → NoLock.
+                    let (stampede, stampede_tunables) =
+                        rocky_fivetran::stampede::build_stampede_lock(
+                            adapter_cfg.stampede.as_ref(),
+                        )
+                        .with_context(|| {
+                            format!(
+                                "adapters.{name}: failed to build [adapter.{name}.stampede] backend"
+                            )
+                        })?;
+                    client = client
+                        .with_stampede_lock(stampede)
+                        .with_stampede_lock_ttl(stampede_tunables.lock_ttl)
+                        .with_stampede_poll_timeout(stampede_tunables.poll_timeout);
+
+                    // Layer 3 — circuit breaker. Absent → AlwaysClosed.
+                    let breaker = rocky_fivetran::circuit_breaker::build_circuit_breaker(
+                        adapter_cfg.circuit_breaker.as_ref(),
+                    )
+                    .with_context(|| {
+                        format!(
+                            "adapters.{name}: failed to build [adapter.{name}.circuit_breaker] backend"
+                        )
+                    })?;
+                    client = client.with_circuit_breaker(breaker);
+
                     let adapter = Arc::new(FivetranDiscoveryAdapter::new(
                         client,
                         destination_id.to_string(),

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -263,6 +263,36 @@ pub enum ConfigError {
         backend: String,
         field: String,
     },
+
+    #[error(
+        "[adapter.{adapter}.ratelimit] backend = \"{backend}\" requires `{field}` — set the field \
+         under [adapter.{adapter}.ratelimit] or change `backend`"
+    )]
+    FivetranRatelimitMissingField {
+        adapter: String,
+        backend: String,
+        field: String,
+    },
+
+    #[error(
+        "[adapter.{adapter}.stampede] backend = \"{backend}\" requires `{field}` — set the field \
+         under [adapter.{adapter}.stampede] or change `backend`"
+    )]
+    FivetranStampedeMissingField {
+        adapter: String,
+        backend: String,
+        field: String,
+    },
+
+    #[error(
+        "[adapter.{adapter}.circuit_breaker] backend = \"{backend}\" requires `{field}` — set the \
+         field under [adapter.{adapter}.circuit_breaker] or change `backend`"
+    )]
+    FivetranCircuitBreakerMissingField {
+        adapter: String,
+        backend: String,
+        field: String,
+    },
 }
 
 /// Concurrency strategy for table processing.
@@ -2292,6 +2322,38 @@ pub struct AdapterConfig {
     /// straight to the Fivetran API.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<FivetranCacheConfig>,
+
+    /// Optional cross-pod rate-limit budget backend (Fivetran-only).
+    ///
+    /// Phase 1 ratelimit coordination is per-host (file in
+    /// `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = "valkey"`
+    /// here lifts the budget into a shared store so several pods on
+    /// different hosts observe the same `wake_at` window after one of
+    /// them is throttled. Ignored on non-fivetran adapters. When absent
+    /// the adapter falls back to the per-host file backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ratelimit: Option<FivetranRatelimitConfig>,
+
+    /// Optional distributed cache-stampede lock (Fivetran-only).
+    ///
+    /// On a cold-start herd, N processes simultaneously miss the cache,
+    /// fan out N API calls, and write back N times. The stampede lock
+    /// elects a single leader to issue the API call; followers poll the
+    /// cache until the leader publishes the envelope. Ignored on
+    /// non-fivetran adapters. When absent the adapter behaves as if
+    /// every process is the leader (the pre-stampede behavior).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stampede: Option<FivetranStampedeConfig>,
+
+    /// Optional per-account circuit breaker (Fivetran-only).
+    ///
+    /// Trips after `failure_threshold` consecutive remote failures and
+    /// short-circuits subsequent HTTP attempts with a `CircuitOpen`
+    /// error until a cooldown elapses. Coordinated across processes
+    /// via the configured backend (Valkey). Ignored on non-fivetran
+    /// adapters; absent block defaults to `AlwaysClosed` (no breaker).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub circuit_breaker: Option<FivetranCircuitBreakerConfig>,
 }
 
 impl std::fmt::Debug for AdapterConfig {
@@ -2321,6 +2383,9 @@ impl std::fmt::Debug for AdapterConfig {
             .field("path", &self.path)
             .field("retry", &self.retry)
             .field("cache", &self.cache)
+            .field("ratelimit", &self.ratelimit)
+            .field("stampede", &self.stampede)
+            .field("circuit_breaker", &self.circuit_breaker)
             .finish()
     }
 }
@@ -2454,6 +2519,307 @@ impl FivetranCacheConfig {
             FivetranCacheBackend::Tiered => {
                 need("object_store_url", self.object_store_url.as_ref())?;
                 need("valkey_url", self.valkey_url.as_ref())
+            }
+        }
+    }
+}
+
+/// Cross-pod rate-limit budget backend selector for the Fivetran adapter
+/// (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FivetranRatelimitBackend {
+    /// Per-host file lock (Phase 1 behavior). Default when the block is
+    /// absent.
+    #[default]
+    File,
+    /// Shared Valkey key. Requires the `valkey` Cargo feature.
+    Valkey,
+}
+
+impl FivetranRatelimitBackend {
+    /// Stable wire-form string for log messages and OTLP attrs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FivetranRatelimitBackend::File => "file",
+            FivetranRatelimitBackend::Valkey => "valkey",
+        }
+    }
+}
+
+/// Cross-pod rate-limit budget config for the Fivetran adapter
+/// (FR-B Phase 2).
+///
+/// Phase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host
+/// file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`.
+/// That works when several `rocky` processes share a host, but a
+/// Kubernetes deployment with one rocky-cli per pod sees N independent
+/// budgets even though every pod talks to the same Fivetran org. Lifting
+/// the budget into Valkey makes a 429 on one pod throttle every other
+/// pod for the same `Retry-After` window.
+///
+/// ## TOML shape
+///
+/// ```toml
+/// [adapter.fivetran.ratelimit]
+/// backend = "valkey"
+/// valkey_url = "rediss://valkey:6379/"
+/// ```
+///
+/// ## Fail-open
+///
+/// When the configured backend is unreachable the client falls back to
+/// the per-host file backend. The cluster regresses to Phase 1 behavior
+/// (each host enforces its own budget) rather than blocking traffic.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FivetranRatelimitConfig {
+    /// Which backend to instantiate. Defaults to
+    /// [`FivetranRatelimitBackend::File`] so a stub block with no
+    /// `backend` key is well-defined.
+    #[serde(default)]
+    pub backend: FivetranRatelimitBackend,
+
+    /// Connection URL for `backend = "valkey"`. Standard `redis://`
+    /// (plain) or `rediss://` (TLS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valkey_url: Option<String>,
+
+    /// Cap (seconds) applied to the Valkey key's `EXPIRE` so an
+    /// abandoned `wake_at` value never outlives its useful window.
+    /// Defaults to 600s when unset; ignored for the file backend.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_wake_seconds: Option<u64>,
+}
+
+impl FivetranRatelimitConfig {
+    /// Validate that the configured backend has all the fields it needs.
+    /// Surfaces errors at config-load time via
+    /// [`validate_fivetran_resilience`] so a misconfigured backend
+    /// doesn't silently degrade to fail-open at first request.
+    pub fn validate(&self, adapter_name: &str) -> Result<(), ConfigError> {
+        match self.backend {
+            FivetranRatelimitBackend::File => Ok(()),
+            FivetranRatelimitBackend::Valkey => {
+                if self.valkey_url.as_deref().is_none_or(str::is_empty) {
+                    Err(ConfigError::FivetranRatelimitMissingField {
+                        adapter: adapter_name.to_string(),
+                        backend: self.backend.as_str().to_string(),
+                        field: "valkey_url".into(),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+/// Distributed cache-stampede lock backend selector for the Fivetran
+/// adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML
+/// shape.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FivetranStampedeBackend {
+    /// No-op lock; every caller is treated as the leader. Default when
+    /// the block is absent.
+    #[default]
+    None,
+    /// Distributed lock via Valkey `SET NX EX`. Requires the `valkey`
+    /// Cargo feature.
+    Valkey,
+}
+
+impl FivetranStampedeBackend {
+    /// Stable wire-form string for log messages and OTLP attrs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FivetranStampedeBackend::None => "none",
+            FivetranStampedeBackend::Valkey => "valkey",
+        }
+    }
+}
+
+/// Distributed cache-stampede protection config for the Fivetran
+/// adapter (Layer 1).
+///
+/// On a cold-start burst, N processes can simultaneously observe the
+/// cache miss, fan out N API calls, and write back N copies of the
+/// same envelope. The stampede lock elects a single leader (via
+/// `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API
+/// call; followers wait on the cache key with bounded polling until
+/// the leader's write becomes visible, then return.
+///
+/// ## TOML shape
+///
+/// ```toml
+/// [adapter.fivetran.stampede]
+/// backend = "valkey"
+/// valkey_url = "rediss://valkey:6379/"
+/// lock_ttl_seconds = 60
+/// poll_timeout_seconds = 30
+/// ```
+///
+/// ## Fail-open
+///
+/// When the lock backend is unreachable the client falls through to
+/// the direct HTTP path (no stampede protection, but no block).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FivetranStampedeConfig {
+    /// Which backend to instantiate. Defaults to
+    /// [`FivetranStampedeBackend::None`] so a stub block with no
+    /// `backend` key is well-defined.
+    #[serde(default)]
+    pub backend: FivetranStampedeBackend,
+
+    /// Connection URL for `backend = "valkey"`. Standard `redis://`
+    /// (plain) or `rediss://` (TLS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valkey_url: Option<String>,
+
+    /// Lock TTL applied to the `SET NX EX <ttl>` call. The lock
+    /// auto-expires after this many seconds so a crashed leader
+    /// doesn't park every follower forever. Defaults to 60s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock_ttl_seconds: Option<u64>,
+
+    /// Hard cap on how long a follower will poll the cache before
+    /// falling through to a direct HTTP fetch. Defaults to 30s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub poll_timeout_seconds: Option<u64>,
+}
+
+impl FivetranStampedeConfig {
+    /// Validate that the configured backend has all the fields it
+    /// needs. Surfaces errors at config-load time via
+    /// [`validate_fivetran_resilience`].
+    pub fn validate(&self, adapter_name: &str) -> Result<(), ConfigError> {
+        match self.backend {
+            FivetranStampedeBackend::None => Ok(()),
+            FivetranStampedeBackend::Valkey => {
+                if self.valkey_url.as_deref().is_none_or(str::is_empty) {
+                    Err(ConfigError::FivetranStampedeMissingField {
+                        adapter: adapter_name.to_string(),
+                        backend: self.backend.as_str().to_string(),
+                        field: "valkey_url".into(),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+/// Circuit-breaker backend selector for the Fivetran adapter (Layer
+/// 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FivetranCircuitBreakerBackend {
+    /// No-op breaker; state is always `Closed`. Default when the
+    /// block is absent.
+    #[default]
+    None,
+    /// Shared per-account state machine in Valkey. Requires the
+    /// `valkey` Cargo feature.
+    Valkey,
+}
+
+impl FivetranCircuitBreakerBackend {
+    /// Stable wire-form string for log messages and OTLP attrs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FivetranCircuitBreakerBackend::None => "none",
+            FivetranCircuitBreakerBackend::Valkey => "valkey",
+        }
+    }
+}
+
+/// Circuit-breaker config for the Fivetran adapter (Layer 3).
+///
+/// Trips after `failure_threshold` consecutive remote failures (5xx,
+/// network errors, exhausted retries) and short-circuits subsequent
+/// HTTP attempts with `FivetranError::CircuitOpen` until
+/// `cooldown_seconds` elapses. State transitions follow the standard
+/// `Closed → Open → HalfOpen → Closed` pattern, with exponentially
+/// extended cooldown on repeated half-open failures (capped at
+/// `cooldown_max_seconds`).
+///
+/// State is shared across processes via Valkey so a Fivetran outage
+/// trips one breaker for the entire org rather than each process
+/// independently tripping its own.
+///
+/// ## TOML shape
+///
+/// ```toml
+/// [adapter.fivetran.circuit_breaker]
+/// backend = "valkey"
+/// valkey_url = "rediss://valkey:6379/"
+/// failure_threshold = 5
+/// window_seconds = 60
+/// cooldown_seconds = 300
+/// cooldown_max_seconds = 3600
+/// ```
+///
+/// ## Fail-open
+///
+/// When the state store is unreachable the client behaves as if the
+/// breaker is `Closed` — coordination failure must not refuse live
+/// traffic.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FivetranCircuitBreakerConfig {
+    /// Which backend to instantiate. Defaults to
+    /// [`FivetranCircuitBreakerBackend::None`] so a stub block with
+    /// no `backend` key is well-defined.
+    #[serde(default)]
+    pub backend: FivetranCircuitBreakerBackend,
+
+    /// Connection URL for `backend = "valkey"`. Standard `redis://`
+    /// (plain) or `rediss://` (TLS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valkey_url: Option<String>,
+
+    /// Consecutive failures required to transition `Closed → Open`.
+    /// Defaults to 5 when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_threshold: Option<u32>,
+
+    /// Failure-counting window in seconds. Failures older than the
+    /// window are not counted toward `failure_threshold`. Defaults
+    /// to 60s when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_seconds: Option<u64>,
+
+    /// Initial cooldown (seconds) before the breaker transitions
+    /// `Open → HalfOpen` for a probe. Defaults to 300s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_seconds: Option<u64>,
+
+    /// Upper bound on the exponentially-extended cooldown after
+    /// repeated half-open failures. Defaults to 3600s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_max_seconds: Option<u64>,
+}
+
+impl FivetranCircuitBreakerConfig {
+    /// Validate that the configured backend has all the fields it
+    /// needs. Surfaces errors at config-load time via
+    /// [`validate_fivetran_resilience`].
+    pub fn validate(&self, adapter_name: &str) -> Result<(), ConfigError> {
+        match self.backend {
+            FivetranCircuitBreakerBackend::None => Ok(()),
+            FivetranCircuitBreakerBackend::Valkey => {
+                if self.valkey_url.as_deref().is_none_or(str::is_empty) {
+                    Err(ConfigError::FivetranCircuitBreakerMissingField {
+                        adapter: adapter_name.to_string(),
+                        backend: self.backend.as_str().to_string(),
+                        field: "valkey_url".into(),
+                    })
+                } else {
+                    Ok(())
+                }
             }
         }
     }
@@ -3990,6 +4356,9 @@ pub fn load_rocky_config(path: &Path) -> Result<RockyConfig, ConfigError> {
     if let Some(first) = validate_fivetran_cache(&config).into_iter().next() {
         return Err(first);
     }
+    if let Some(first) = validate_fivetran_resilience(&config).into_iter().next() {
+        return Err(first);
+    }
     Ok(config)
 }
 
@@ -4007,6 +4376,35 @@ pub fn validate_fivetran_cache(config: &RockyConfig) -> Vec<ConfigError> {
         }
         if let Some(cache_cfg) = &adapter_cfg.cache
             && let Err(e) = cache_cfg.validate(name)
+        {
+            errors.push(e);
+        }
+    }
+    errors
+}
+
+/// Validate every `[adapter.<name>.{ratelimit,stampede,circuit_breaker}]`
+/// block's cross-field requirements at config-load time so a
+/// misconfigured backend errors up front rather than at first request.
+/// Skips non-Fivetran adapter blocks; the shape is fivetran-specific.
+pub fn validate_fivetran_resilience(config: &RockyConfig) -> Vec<ConfigError> {
+    let mut errors = Vec::new();
+    for (name, adapter_cfg) in &config.adapters {
+        if adapter_cfg.adapter_type != "fivetran" {
+            continue;
+        }
+        if let Some(rl) = &adapter_cfg.ratelimit
+            && let Err(e) = rl.validate(name)
+        {
+            errors.push(e);
+        }
+        if let Some(st) = &adapter_cfg.stampede
+            && let Err(e) = st.validate(name)
+        {
+            errors.push(e);
+        }
+        if let Some(cb) = &adapter_cfg.circuit_breaker
+            && let Err(e) = cb.validate(name)
         {
             errors.push(e);
         }
@@ -6185,6 +6583,9 @@ table = "customers_history"
             path: None,
             retry: RetryConfig::default(),
             cache: None,
+            ratelimit: None,
+            stampede: None,
+            circuit_breaker: None,
         };
 
         let debug = format!("{cfg:?}");
@@ -8285,5 +8686,262 @@ schema_template = "raw__{source}"
             errors.is_empty(),
             "non-fivetran adapter ignored: {errors:?}"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // FivetranRatelimitConfig + FivetranStampedeConfig +
+    // FivetranCircuitBreakerConfig validation (resilience layers)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn validate_fivetran_resilience_passes_when_blocks_absent() {
+        let toml_str = fivetran_cache_base();
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(errors.is_empty(), "absent blocks must validate: {errors:?}");
+    }
+
+    #[test]
+    fn validate_fivetran_ratelimit_file_default_passes() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.ratelimit]
+backend = "file"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(errors.is_empty(), "file backend must validate: {errors:?}");
+    }
+
+    #[test]
+    fn validate_fivetran_ratelimit_valkey_requires_url() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.ratelimit]
+backend = "valkey"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(matches!(
+            errors[0],
+            ConfigError::FivetranRatelimitMissingField { ref field, ref backend, .. }
+                if field == "valkey_url" && backend == "valkey"
+        ));
+    }
+
+    #[test]
+    fn validate_fivetran_ratelimit_valkey_with_url_passes() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.ratelimit]
+backend = "valkey"
+valkey_url = "redis://localhost:6379/"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(
+            errors.is_empty(),
+            "valkey backend with url must validate: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_fivetran_stampede_none_default_passes() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.stampede]
+backend = "none"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(errors.is_empty(), "none backend must validate: {errors:?}");
+    }
+
+    #[test]
+    fn validate_fivetran_stampede_valkey_requires_url() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.stampede]
+backend = "valkey"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(matches!(
+            errors[0],
+            ConfigError::FivetranStampedeMissingField { ref field, ref backend, .. }
+                if field == "valkey_url" && backend == "valkey"
+        ));
+    }
+
+    #[test]
+    fn validate_fivetran_circuit_breaker_none_default_passes() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.circuit_breaker]
+backend = "none"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(errors.is_empty(), "none backend must validate: {errors:?}");
+    }
+
+    #[test]
+    fn validate_fivetran_circuit_breaker_valkey_requires_url() {
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.circuit_breaker]
+backend = "valkey"
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert_eq!(errors.len(), 1, "got: {errors:?}");
+        assert!(matches!(
+            errors[0],
+            ConfigError::FivetranCircuitBreakerMissingField { ref field, ref backend, .. }
+                if field == "valkey_url" && backend == "valkey"
+        ));
+    }
+
+    #[test]
+    fn validate_fivetran_resilience_full_block_passes() {
+        // All three blocks present with valid Valkey URLs.
+        let mut toml_str = fivetran_cache_base();
+        toml_str.push_str(
+            r#"
+[adapter.fivetran_main.ratelimit]
+backend = "valkey"
+valkey_url = "redis://localhost:6379/"
+
+[adapter.fivetran_main.stampede]
+backend = "valkey"
+valkey_url = "redis://localhost:6379/"
+lock_ttl_seconds = 60
+poll_timeout_seconds = 30
+
+[adapter.fivetran_main.circuit_breaker]
+backend = "valkey"
+valkey_url = "redis://localhost:6379/"
+failure_threshold = 5
+window_seconds = 60
+cooldown_seconds = 300
+cooldown_max_seconds = 3600
+"#,
+        );
+        let config: RockyConfig = toml::from_str(&toml_str).unwrap();
+        let errors = validate_fivetran_resilience(&config);
+        assert!(
+            errors.is_empty(),
+            "fully-specified resilience must validate: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_fivetran_resilience_ignores_non_fivetran_adapter() {
+        // ratelimit block on a non-fivetran adapter is silently
+        // ignored — won't be wired in code, mustn't error in
+        // validation.
+        let toml_str = r#"
+[adapter.warehouse]
+type = "databricks"
+host = "x.cloud.databricks.com"
+http_path = "/sql/1.0/warehouses/abc"
+token = "t"
+
+[adapter.warehouse.ratelimit]
+backend = "valkey"
+# valkey_url intentionally absent — would fail validation if checked
+
+[pipeline.bronze]
+type = "replication"
+strategy = "incremental"
+adapter = "warehouse"
+
+[pipeline.bronze.source]
+adapter = "warehouse"
+catalog = "src"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#;
+        // Note: TOML parsing won't accept the ratelimit block on a
+        // non-fivetran adapter when `deny_unknown_fields` is on at
+        // AdapterConfig — but the field is declared on AdapterConfig
+        // itself (as Option<...>), so parsing succeeds; the validator
+        // is what filters.
+        let parsed: Result<RockyConfig, _> = toml::from_str(toml_str);
+        if let Ok(config) = parsed {
+            let errors = validate_fivetran_resilience(&config);
+            assert!(
+                errors.is_empty(),
+                "non-fivetran adapter must be ignored by validator: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_config_threads_through_fivetran_adapter() {
+        // Regression: the `[adapter.fivetran.retry]` block is part
+        // of AdapterConfig (shared with every adapter type). This
+        // test pins that a fivetran adapter's `retry` deserializes
+        // and round-trips through `load_rocky_config`. The bonus
+        // task item flagged this knob as "API-only"; this confirms
+        // it's also TOML-wired.
+        let toml_str = r#"
+[adapter.fivetran_main]
+type = "fivetran"
+kind = "discovery"
+api_key = "k"
+api_secret = "s"
+destination_id = "dest_x"
+
+[adapter.fivetran_main.retry]
+max_retries = 8
+initial_backoff_ms = 1000
+max_backoff_ms = 60000
+
+[pipeline.bronze]
+type = "replication"
+strategy = "incremental"
+adapter = "fivetran_main"
+
+[pipeline.bronze.source]
+adapter = "fivetran_main"
+
+[pipeline.bronze.source.schema_pattern]
+prefix = "src__"
+separator = "__"
+components = ["source"]
+
+[pipeline.bronze.target]
+catalog_template = "wh"
+schema_template = "raw__{source}"
+"#;
+        let config: RockyConfig = toml::from_str(toml_str).expect("retry block must deserialize");
+        let fv = &config.adapters["fivetran_main"];
+        assert_eq!(fv.retry.max_retries, 8);
+        assert_eq!(fv.retry.initial_backoff_ms, 1000);
+        assert_eq!(fv.retry.max_backoff_ms, 60000);
     }
 }

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -506,6 +506,9 @@ mod tests {
             path: None,
             retry: RetryConfig::default(),
             cache: None,
+            ratelimit: None,
+            stampede: None,
+            circuit_breaker: None,
         }
     }
 

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -45,13 +45,19 @@ redis = { workspace = true, features = ["tokio-comp", "connection-manager", "tok
 [features]
 default = []
 test-support = []
-# Pulls in the Redis client for the FR-A `ValkeyCache` backend. Mirrors
-# rocky-cache's `valkey` feature so a downstream crate enabling either
-# crate's feature sees the same shape.
+# Pulls in the Redis client for the FR-A `ValkeyCache` backend AND
+# the Phase 2 / Layer-1 / Layer-3 resilience backends (`ValkeyBudget`,
+# `ValkeyLock`, `ValkeyCircuit`). Mirrors rocky-cache's `valkey`
+# feature so a downstream crate enabling either crate's feature sees
+# the same shape.
 valkey = ["redis"]
 
 [[test]]
 name = "wiremock_tests"
+required-features = ["test-support"]
+
+[[test]]
+name = "resilience_tests"
 required-features = ["test-support"]
 
 [dev-dependencies]

--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -115,6 +115,11 @@ fn classify_fivetran_error(err: &FivetranError) -> FailedSourceErrorClass {
     match err {
         FivetranError::RateLimited => FailedSourceErrorClass::RateLimit,
         FivetranError::RetryBudgetExhausted { .. } => FailedSourceErrorClass::Transient,
+        // The circuit breaker tripped before HTTP was attempted; the
+        // cause is "Fivetran (or our perception of it) is unhealthy"
+        // — surface as Transient so downstream retries know to back
+        // off and re-attempt on the next discover cycle.
+        FivetranError::CircuitOpen => FailedSourceErrorClass::Transient,
         FivetranError::UnexpectedResponse(_) => FailedSourceErrorClass::Unknown,
         // `code` here is either the raw HTTP status display (e.g. "503
         // Service Unavailable") from `client::get`, or the API envelope's

--- a/engine/crates/rocky-fivetran/src/circuit_breaker.rs
+++ b/engine/crates/rocky-fivetran/src/circuit_breaker.rs
@@ -1,0 +1,748 @@
+//! Per-account circuit breaker for the Fivetran adapter (Layer 3).
+//!
+//! Trips after N consecutive remote failures so a Fivetran outage
+//! short-circuits subsequent HTTP attempts with a typed
+//! [`FivetranError::CircuitOpen`](crate::client::FivetranError::CircuitOpen)
+//! error instead of burning the org's rate-limit budget on requests
+//! that are guaranteed to fail. State is coordinated across processes
+//! via Valkey so a 10-pod fleet trips one breaker for the whole org.
+//!
+//! ## Trait
+//!
+//! Three operations:
+//!
+//! - [`FivetranCircuitBreaker::state`] — read the current state
+//!   (`Closed`/`HalfOpen`/`Open`). The wiring in `client.rs` calls
+//!   this before every HTTP attempt and short-circuits on `Open`.
+//! - [`FivetranCircuitBreaker::record_success`] — called after a
+//!   successful HTTP response. Resets the failure counter; in
+//!   `HalfOpen` it transitions back to `Closed`.
+//! - [`FivetranCircuitBreaker::record_failure`] — called after a
+//!   remote failure (5xx, exhausted retries, transport error).
+//!   Increments the counter; on hitting `failure_threshold` (or on
+//!   *any* failure in `HalfOpen`) trips the breaker into `Open`.
+//!
+//! ## Failure classification
+//!
+//! Only *remote* failures count toward tripping the breaker — local
+//! errors (JSON parse, serialization) don't indicate Fivetran is
+//! struggling. The [`FailureKind`] enum tags the call so backends
+//! can record telemetry about *why* a breaker tripped without
+//! depending on the upstream error type.
+//!
+//! ## Backends
+//!
+//! - [`AlwaysClosed`] — no-op; `state` always returns `Closed`,
+//!   record_* are no-ops. Default when `[adapter.fivetran.circuit_breaker]`
+//!   is absent or `backend = "none"`.
+//! - `valkey::ValkeyCircuit` — shared state machine in Valkey,
+//!   behind the `valkey` Cargo feature.
+//!
+//! ## Concurrency / atomicity
+//!
+//! The Valkey backend persists state via a read-modify-write
+//! sequence rather than a server-side Lua transaction. Two
+//! concurrent `record_failure` calls can read the same prior
+//! counter value, both bump it, and both write the same `n+1`,
+//! losing one increment. The practical effect is that the breaker
+//! trips at *approximately* `failure_threshold` consecutive
+//! failures — under sustained contention the actual trip point
+//! may be 1-2 above the configured threshold. The breaker still
+//! converges to `Open` quickly during a real outage; the
+//! looseness only matters at the threshold boundary, where
+//! tripping one request later is acceptable given the fail-open
+//! posture upstream.
+//!
+//! If a deployment needs exact threshold semantics, route through
+//! [`AlwaysClosed`] (no breaker) and rely on the cross-pod
+//! rate-limit budget + retry budget; both are stricter coordination
+//! layers.
+//!
+//! ## Fail-open
+//!
+//! Every operation on the breaker is permitted to fail in the
+//! coordination layer. The client wiring traps errors from `state`
+//! by treating them as `Closed` — never refuse live traffic because
+//! the breaker store is unreachable.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors surfaced by [`FivetranCircuitBreaker`] backends.
+#[derive(Debug, Error)]
+pub enum CircuitError {
+    /// Valkey / Redis transport failure.
+    #[error("circuit valkey: {0}")]
+    Valkey(String),
+    /// Misconfigured backend.
+    #[error("circuit config: {0}")]
+    Config(String),
+}
+
+/// Discriminator for what kind of failure tripped the breaker. Only
+/// `Remote` actually counts toward `failure_threshold`; the other
+/// variants are recorded for telemetry but don't move the counter.
+///
+/// The split matters because the breaker exists to protect the
+/// Fivetran org's rate budget when *Fivetran* is degraded — a local
+/// JSON deserialization bug isn't useful evidence either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    /// 5xx, 429-storm, connect-refused, request timeout, retry-budget
+    /// exhausted. Counts toward `failure_threshold`.
+    Remote,
+    /// Local error (JSON parse, serialization, missing field). Does
+    /// NOT count toward the threshold.
+    Local,
+}
+
+/// The three states a circuit breaker can be in.
+///
+/// Lifecycle:
+///
+/// ```text
+///                +-------------+
+///       success  |   Closed    |  N failures within window
+///        +-------+             +------+
+///        |       +-------------+      |
+///        v                            v
+///   +-------------+              +-------------+
+///   |  HalfOpen   |<--cooldown---|     Open    |
+///   +-------------+   elapses    +-------------+
+///        |                            ^
+///        | failure                    |
+///        +----------------------------+
+/// ```
+///
+/// `HalfOpen` permits a single probe through; success closes the
+/// breaker, failure re-opens with exponentially extended cooldown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CircuitState {
+    /// Normal operation; requests pass through unconditionally.
+    Closed,
+    /// One probe permitted; outcome determines next transition.
+    HalfOpen,
+    /// All requests short-circuit with `CircuitOpen` until cooldown
+    /// elapses.
+    Open,
+}
+
+impl CircuitState {
+    /// Stable wire-form string used in OTLP span attributes and log
+    /// messages. Pinned so dashboards filter on a known tag set.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CircuitState::Closed => "closed",
+            CircuitState::HalfOpen => "half_open",
+            CircuitState::Open => "open",
+        }
+    }
+}
+
+/// Per-account circuit breaker.
+#[async_trait]
+pub trait FivetranCircuitBreaker: Send + Sync + std::fmt::Debug {
+    /// Current breaker state for `account_hash`. Fail-open: backend
+    /// errors are not propagated — the caller treats `Err(_)` the
+    /// same as `Ok(Closed)`.
+    async fn state(&self, account_hash: &str) -> Result<CircuitState, CircuitError>;
+
+    /// Record a successful HTTP outcome. In `HalfOpen` this closes
+    /// the breaker; in `Closed` it resets the consecutive-failure
+    /// counter.
+    async fn record_success(&self, account_hash: &str) -> Result<(), CircuitError>;
+
+    /// Record a failed HTTP outcome. `Local` failures are recorded
+    /// for telemetry but don't move the state machine.
+    async fn record_failure(
+        &self,
+        account_hash: &str,
+        kind: FailureKind,
+    ) -> Result<(), CircuitError>;
+
+    /// Stable backend tag for OTLP span attributes.
+    fn backend(&self) -> &'static str;
+}
+
+/// No-op breaker — always reports `Closed`, ignores record_*. Default
+/// when no breaker backend is configured.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AlwaysClosed;
+
+#[async_trait]
+impl FivetranCircuitBreaker for AlwaysClosed {
+    async fn state(&self, _account_hash: &str) -> Result<CircuitState, CircuitError> {
+        Ok(CircuitState::Closed)
+    }
+    async fn record_success(&self, _account_hash: &str) -> Result<(), CircuitError> {
+        Ok(())
+    }
+    async fn record_failure(
+        &self,
+        _account_hash: &str,
+        _kind: FailureKind,
+    ) -> Result<(), CircuitError> {
+        Ok(())
+    }
+    fn backend(&self) -> &'static str {
+        "none"
+    }
+}
+
+/// Tunables for a circuit breaker. Defaults match the FR plan.
+#[derive(Debug, Clone, Copy)]
+pub struct CircuitConfig {
+    /// Consecutive failures required to trip `Closed → Open`.
+    pub failure_threshold: u32,
+    /// Failure-counting window. Failures older than this are dropped.
+    pub window: Duration,
+    /// Initial cooldown before `Open → HalfOpen`.
+    pub cooldown: Duration,
+    /// Upper bound on the exponentially-extended cooldown after
+    /// repeated `HalfOpen` failures.
+    pub cooldown_max: Duration,
+}
+
+impl Default for CircuitConfig {
+    fn default() -> Self {
+        CircuitConfig {
+            failure_threshold: 5,
+            window: Duration::from_secs(60),
+            cooldown: Duration::from_secs(300),
+            cooldown_max: Duration::from_secs(3600),
+        }
+    }
+}
+
+impl CircuitConfig {
+    /// Build a config from the user-facing TOML knobs, applying the
+    /// defaults from [`Self::default`] for any unset field.
+    pub fn from_options(
+        failure_threshold: Option<u32>,
+        window_seconds: Option<u64>,
+        cooldown_seconds: Option<u64>,
+        cooldown_max_seconds: Option<u64>,
+    ) -> Self {
+        let d = CircuitConfig::default();
+        CircuitConfig {
+            failure_threshold: failure_threshold.unwrap_or(d.failure_threshold).max(1),
+            window: window_seconds.map(Duration::from_secs).unwrap_or(d.window),
+            cooldown: cooldown_seconds
+                .map(Duration::from_secs)
+                .unwrap_or(d.cooldown),
+            cooldown_max: cooldown_max_seconds
+                .map(Duration::from_secs)
+                .unwrap_or(d.cooldown_max),
+        }
+    }
+}
+
+/// Construct the circuit-breaker backend described by `config`.
+/// Returns the [`Arc<dyn FivetranCircuitBreaker>`]; defaults to
+/// [`AlwaysClosed`] when `config` is `None`.
+///
+/// # Errors
+///
+/// - [`CircuitError::Config`] — required field missing.
+/// - [`CircuitError::Valkey`] — the Redis client refused the URL.
+pub fn build_circuit_breaker(
+    config: Option<&rocky_core::config::FivetranCircuitBreakerConfig>,
+) -> Result<std::sync::Arc<dyn FivetranCircuitBreaker>, CircuitError> {
+    use rocky_core::config::FivetranCircuitBreakerBackend;
+    let Some(cfg) = config else {
+        return Ok(std::sync::Arc::new(AlwaysClosed));
+    };
+    // The tunables are only consumed by the Valkey branch; suppress
+    // the unused-variable lint when the `valkey` feature is off.
+    let _resolved = CircuitConfig::from_options(
+        cfg.failure_threshold,
+        cfg.window_seconds,
+        cfg.cooldown_seconds,
+        cfg.cooldown_max_seconds,
+    );
+    #[cfg(feature = "valkey")]
+    let resolved = _resolved;
+    match cfg.backend {
+        FivetranCircuitBreakerBackend::None => Ok(std::sync::Arc::new(AlwaysClosed)),
+        #[cfg(feature = "valkey")]
+        FivetranCircuitBreakerBackend::Valkey => {
+            let url = cfg.valkey_url.as_ref().ok_or_else(|| {
+                CircuitError::Config(
+                    "backend = \"valkey\" requires `valkey_url` in [adapter.<name>.circuit_breaker]"
+                        .into(),
+                )
+            })?;
+            let cb = crate::circuit_breaker::valkey::ValkeyCircuit::from_url(url, resolved)?;
+            Ok(std::sync::Arc::new(cb))
+        }
+        #[cfg(not(feature = "valkey"))]
+        FivetranCircuitBreakerBackend::Valkey => Err(CircuitError::Config(
+            "backend = \"valkey\" requires building rocky-fivetran with the `valkey` feature"
+                .into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn always_closed_never_trips() {
+        let cb = AlwaysClosed;
+        assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+        cb.record_failure("acct", FailureKind::Remote)
+            .await
+            .unwrap();
+        cb.record_failure("acct", FailureKind::Remote)
+            .await
+            .unwrap();
+        cb.record_failure("acct", FailureKind::Remote)
+            .await
+            .unwrap();
+        assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn circuit_state_as_str_pinned() {
+        assert_eq!(CircuitState::Closed.as_str(), "closed");
+        assert_eq!(CircuitState::HalfOpen.as_str(), "half_open");
+        assert_eq!(CircuitState::Open.as_str(), "open");
+    }
+
+    #[test]
+    fn config_defaults_match_plan() {
+        let d = CircuitConfig::default();
+        assert_eq!(d.failure_threshold, 5);
+        assert_eq!(d.window, Duration::from_secs(60));
+        assert_eq!(d.cooldown, Duration::from_secs(300));
+        assert_eq!(d.cooldown_max, Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn config_from_options_overrides_only_set_fields() {
+        let c = CircuitConfig::from_options(Some(10), None, Some(120), None);
+        assert_eq!(c.failure_threshold, 10);
+        assert_eq!(c.window, Duration::from_secs(60));
+        assert_eq!(c.cooldown, Duration::from_secs(120));
+        assert_eq!(c.cooldown_max, Duration::from_secs(3600));
+    }
+}
+
+/// In-memory breaker used for unit tests. Thread-safe single-process
+/// reference implementation of the state machine the Valkey backend
+/// runs server-side. Exposed at the crate boundary because the
+/// `client.rs` layered-fetch tests need it.
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    use async_trait::async_trait;
+
+    use super::{CircuitConfig, CircuitError, CircuitState, FailureKind, FivetranCircuitBreaker};
+
+    #[derive(Debug)]
+    struct AccountState {
+        state: CircuitState,
+        consecutive_failures: u32,
+        last_failure: Option<Instant>,
+        opened_at: Option<Instant>,
+        current_cooldown: Duration,
+    }
+
+    impl AccountState {
+        fn new(initial_cooldown: Duration) -> Self {
+            AccountState {
+                state: CircuitState::Closed,
+                consecutive_failures: 0,
+                last_failure: None,
+                opened_at: None,
+                current_cooldown: initial_cooldown,
+            }
+        }
+    }
+
+    /// In-memory circuit breaker for tests.
+    #[derive(Debug)]
+    pub struct InMemoryCircuit {
+        config: CircuitConfig,
+        accounts: Mutex<HashMap<String, AccountState>>,
+    }
+
+    impl InMemoryCircuit {
+        pub fn new(config: CircuitConfig) -> Self {
+            InMemoryCircuit {
+                config,
+                accounts: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn now(&self) -> Instant {
+            Instant::now()
+        }
+    }
+
+    #[async_trait]
+    impl FivetranCircuitBreaker for InMemoryCircuit {
+        async fn state(&self, account_hash: &str) -> Result<CircuitState, CircuitError> {
+            let now = self.now();
+            let mut accounts = self.accounts.lock().unwrap();
+            let acct = accounts
+                .entry(account_hash.to_string())
+                .or_insert_with(|| AccountState::new(self.config.cooldown));
+            // Transition Open → HalfOpen on elapsed cooldown.
+            if acct.state == CircuitState::Open
+                && let Some(opened) = acct.opened_at
+                && now.duration_since(opened) >= acct.current_cooldown
+            {
+                acct.state = CircuitState::HalfOpen;
+            }
+            Ok(acct.state)
+        }
+
+        async fn record_success(&self, account_hash: &str) -> Result<(), CircuitError> {
+            let mut accounts = self.accounts.lock().unwrap();
+            let acct = accounts
+                .entry(account_hash.to_string())
+                .or_insert_with(|| AccountState::new(self.config.cooldown));
+            acct.state = CircuitState::Closed;
+            acct.consecutive_failures = 0;
+            acct.last_failure = None;
+            acct.opened_at = None;
+            acct.current_cooldown = self.config.cooldown;
+            Ok(())
+        }
+
+        async fn record_failure(
+            &self,
+            account_hash: &str,
+            kind: FailureKind,
+        ) -> Result<(), CircuitError> {
+            // Local failures don't move the state machine.
+            if kind == FailureKind::Local {
+                return Ok(());
+            }
+            let now = self.now();
+            let mut accounts = self.accounts.lock().unwrap();
+            let acct = accounts
+                .entry(account_hash.to_string())
+                .or_insert_with(|| AccountState::new(self.config.cooldown));
+            // HalfOpen failure → Open with extended cooldown.
+            if acct.state == CircuitState::HalfOpen {
+                acct.state = CircuitState::Open;
+                acct.opened_at = Some(now);
+                let extended = acct.current_cooldown.saturating_mul(2);
+                acct.current_cooldown = extended.min(self.config.cooldown_max);
+                return Ok(());
+            }
+            // Closed: bump counter; if a window has elapsed since the
+            // last failure, reset to 1.
+            if let Some(prev) = acct.last_failure
+                && now.duration_since(prev) > self.config.window
+            {
+                acct.consecutive_failures = 0;
+            }
+            acct.consecutive_failures = acct.consecutive_failures.saturating_add(1);
+            acct.last_failure = Some(now);
+            if acct.consecutive_failures >= self.config.failure_threshold {
+                acct.state = CircuitState::Open;
+                acct.opened_at = Some(now);
+                acct.current_cooldown = self.config.cooldown;
+            }
+            Ok(())
+        }
+
+        fn backend(&self) -> &'static str {
+            "in_memory"
+        }
+    }
+}
+
+#[cfg(feature = "valkey")]
+pub mod valkey {
+    //! Valkey-backed [`FivetranCircuitBreaker`] implementation.
+    //!
+    //! State for each account lives at
+    //! `<KEY_PREFIX><account_hash>` as a JSON blob holding the state
+    //! machine fields. Persistence is a read-modify-write `GET` +
+    //! `SET EX` rather than a server-side Lua transaction — see the
+    //! parent module's "Concurrency / atomicity" section for the
+    //! looseness this implies at the threshold boundary.
+
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::OnceCell;
+    use tracing::debug;
+
+    use super::{CircuitConfig, CircuitError, CircuitState, FailureKind, FivetranCircuitBreaker};
+
+    /// Redis key prefix for every Fivetran circuit breaker entry.
+    const KEY_PREFIX: &str = "fivetran-circuit:";
+
+    /// Wire shape of the per-account breaker state. Stored as JSON
+    /// in Valkey under [`KEY_PREFIX`].
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct WireState {
+        state: String, // "closed" | "half_open" | "open"
+        consecutive_failures: u32,
+        last_failure_epoch_ms: u64, // 0 = none
+        opened_at_epoch_ms: u64,    // 0 = none
+        current_cooldown_secs: u64,
+    }
+
+    impl WireState {
+        fn fresh(cooldown: Duration) -> Self {
+            WireState {
+                state: "closed".into(),
+                consecutive_failures: 0,
+                last_failure_epoch_ms: 0,
+                opened_at_epoch_ms: 0,
+                current_cooldown_secs: cooldown.as_secs(),
+            }
+        }
+
+        fn parsed_state(&self) -> CircuitState {
+            match self.state.as_str() {
+                "open" => CircuitState::Open,
+                "half_open" => CircuitState::HalfOpen,
+                _ => CircuitState::Closed,
+            }
+        }
+    }
+
+    pub struct ValkeyCircuit {
+        client: redis::Client,
+        conn: OnceCell<redis::aio::ConnectionManager>,
+        config: CircuitConfig,
+    }
+
+    impl std::fmt::Debug for ValkeyCircuit {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ValkeyCircuit")
+                .field("config", &self.config)
+                .field("connected", &self.conn.initialized())
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl ValkeyCircuit {
+        /// Open a Valkey / Redis client for `url`. Sync + non-blocking;
+        /// connect deferred to first call.
+        pub fn from_url(url: &str, config: CircuitConfig) -> Result<Self, CircuitError> {
+            let client =
+                redis::Client::open(url).map_err(|e| CircuitError::Valkey(e.to_string()))?;
+            Ok(ValkeyCircuit {
+                client,
+                conn: OnceCell::new(),
+                config,
+            })
+        }
+
+        async fn get_conn(&self) -> Result<redis::aio::ConnectionManager, CircuitError> {
+            let conn = self
+                .conn
+                .get_or_try_init(|| async {
+                    redis::aio::ConnectionManager::new(self.client.clone())
+                        .await
+                        .map_err(|e| CircuitError::Valkey(e.to_string()))
+                })
+                .await?;
+            Ok(conn.clone())
+        }
+
+        fn prefixed(account_hash: &str) -> String {
+            format!("{KEY_PREFIX}{account_hash}")
+        }
+
+        async fn load_or_init(
+            &self,
+            mut conn: redis::aio::ConnectionManager,
+            key: &str,
+        ) -> Result<WireState, CircuitError> {
+            use redis::AsyncCommands;
+            let raw: Option<String> = conn
+                .get(key)
+                .await
+                .map_err(|e| CircuitError::Valkey(e.to_string()))?;
+            match raw {
+                Some(s) => serde_json::from_str(&s)
+                    .map_err(|e| CircuitError::Valkey(format!("decode breaker state failed: {e}"))),
+                None => Ok(WireState::fresh(self.config.cooldown)),
+            }
+        }
+
+        async fn persist(
+            &self,
+            mut conn: redis::aio::ConnectionManager,
+            key: &str,
+            state: &WireState,
+        ) -> Result<(), CircuitError> {
+            use redis::AsyncCommands;
+            let json = serde_json::to_string(state)
+                .map_err(|e| CircuitError::Valkey(format!("encode breaker state failed: {e}")))?;
+            // TTL = current_cooldown_secs * 2 (plus the window), so an
+            // abandoned breaker entry disappears within a bounded time.
+            let ttl = state
+                .current_cooldown_secs
+                .saturating_mul(2)
+                .max(self.config.window.as_secs())
+                .max(60);
+            conn.set_ex::<&str, &str, ()>(key, &json, ttl)
+                .await
+                .map_err(|e| CircuitError::Valkey(e.to_string()))?;
+            Ok(())
+        }
+
+        fn now_ms() -> u64 {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis().min(u64::MAX as u128) as u64)
+                .unwrap_or(0)
+        }
+    }
+
+    #[async_trait]
+    impl FivetranCircuitBreaker for ValkeyCircuit {
+        async fn state(&self, account_hash: &str) -> Result<CircuitState, CircuitError> {
+            let conn = self.get_conn().await?;
+            let key = Self::prefixed(account_hash);
+            let mut wire = self.load_or_init(conn.clone(), &key).await?;
+            // Maybe transition Open → HalfOpen on elapsed cooldown.
+            if wire.parsed_state() == CircuitState::Open && wire.opened_at_epoch_ms > 0 {
+                let now_ms = Self::now_ms();
+                let elapsed = now_ms.saturating_sub(wire.opened_at_epoch_ms);
+                if elapsed >= wire.current_cooldown_secs.saturating_mul(1_000) {
+                    wire.state = "half_open".into();
+                    self.persist(conn, &key, &wire).await?;
+                    return Ok(CircuitState::HalfOpen);
+                }
+            }
+            Ok(wire.parsed_state())
+        }
+
+        async fn record_success(&self, account_hash: &str) -> Result<(), CircuitError> {
+            let conn = self.get_conn().await?;
+            let key = Self::prefixed(account_hash);
+            let mut wire = self.load_or_init(conn.clone(), &key).await?;
+            wire.state = "closed".into();
+            wire.consecutive_failures = 0;
+            wire.last_failure_epoch_ms = 0;
+            wire.opened_at_epoch_ms = 0;
+            wire.current_cooldown_secs = self.config.cooldown.as_secs();
+            self.persist(conn, &key, &wire).await?;
+            debug!(account_hash, "circuit closed via record_success");
+            Ok(())
+        }
+
+        async fn record_failure(
+            &self,
+            account_hash: &str,
+            kind: FailureKind,
+        ) -> Result<(), CircuitError> {
+            if kind == FailureKind::Local {
+                return Ok(());
+            }
+            let conn = self.get_conn().await?;
+            let key = Self::prefixed(account_hash);
+            let mut wire = self.load_or_init(conn.clone(), &key).await?;
+            let now_ms = Self::now_ms();
+            let current_state = wire.parsed_state();
+            // HalfOpen failure → Open with extended cooldown.
+            if current_state == CircuitState::HalfOpen {
+                wire.state = "open".into();
+                wire.opened_at_epoch_ms = now_ms;
+                let extended = wire.current_cooldown_secs.saturating_mul(2);
+                wire.current_cooldown_secs = extended.min(self.config.cooldown_max.as_secs());
+            } else {
+                // Closed: bump counter; reset if window elapsed since
+                // the last failure.
+                if wire.last_failure_epoch_ms > 0
+                    && now_ms.saturating_sub(wire.last_failure_epoch_ms)
+                        > self.config.window.as_millis().min(u64::MAX as u128) as u64
+                {
+                    wire.consecutive_failures = 0;
+                }
+                wire.consecutive_failures = wire.consecutive_failures.saturating_add(1);
+                wire.last_failure_epoch_ms = now_ms;
+                if wire.consecutive_failures >= self.config.failure_threshold {
+                    wire.state = "open".into();
+                    wire.opened_at_epoch_ms = now_ms;
+                    wire.current_cooldown_secs = self.config.cooldown.as_secs();
+                }
+            }
+            self.persist(conn, &key, &wire).await?;
+            Ok(())
+        }
+
+        fn backend(&self) -> &'static str {
+            "valkey"
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn prefix_is_applied() {
+            assert_eq!(ValkeyCircuit::prefixed("acct"), "fivetran-circuit:acct");
+        }
+
+        #[test]
+        fn from_url_is_sync_and_doesnt_connect() {
+            let cb = ValkeyCircuit::from_url("redis://127.0.0.1:1/", CircuitConfig::default());
+            assert!(cb.is_ok());
+        }
+
+        /// Live integration test.
+        #[tokio::test]
+        async fn live_valkey_trip_and_recover() {
+            let url = match std::env::var("ROCKY_TEST_VALKEY_URL") {
+                Ok(u) => u,
+                Err(_) => {
+                    eprintln!("skipping live_valkey_trip_and_recover — set ROCKY_TEST_VALKEY_URL");
+                    return;
+                }
+            };
+
+            let config = CircuitConfig {
+                failure_threshold: 3,
+                window: Duration::from_secs(60),
+                cooldown: Duration::from_secs(1),
+                cooldown_max: Duration::from_secs(10),
+            };
+            let cb = ValkeyCircuit::from_url(&url, config).expect("connect");
+            let hash = format!("ROCKY_TEST_trip_{}", std::process::id());
+
+            // Trip the breaker.
+            for _ in 0..3 {
+                cb.record_failure(&hash, FailureKind::Remote)
+                    .await
+                    .expect("record_failure");
+            }
+            assert_eq!(cb.state(&hash).await.unwrap(), CircuitState::Open);
+
+            // Wait > cooldown then re-check; should transition to
+            // HalfOpen.
+            tokio::time::sleep(Duration::from_millis(1_100)).await;
+            assert_eq!(cb.state(&hash).await.unwrap(), CircuitState::HalfOpen);
+
+            // Probe success closes the breaker.
+            cb.record_success(&hash).await.expect("ok");
+            assert_eq!(cb.state(&hash).await.unwrap(), CircuitState::Closed);
+        }
+    }
+}
+
+#[cfg(feature = "valkey")]
+pub use valkey::ValkeyCircuit;

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -9,13 +9,15 @@ use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::{Client, Response};
 use tokio::sync::Mutex;
 
+use crate::circuit_breaker::{AlwaysClosed, CircuitState, FailureKind, FivetranCircuitBreaker};
 use crate::connector as ft_connector;
 use crate::envelope::{
     FivetranColumnConfig, FivetranConnectorStatus, FivetranConnectorSummary, FivetranDestination,
     FivetranSchemaConfig, FivetranSchemaEntry, FivetranStateEnvelope, FivetranTableConfig,
 };
-use crate::ratelimit;
+use crate::ratelimit::{self, FileBudget, RatelimitBudget};
 use crate::schema as ft_schema;
+use crate::stampede::{self, NoLock, StampedeLock};
 use crate::state_cache::{
     self, FivetranStateCache, NoCache, WriteOutcome, observability as cache_obs,
 };
@@ -89,6 +91,9 @@ pub enum FivetranError {
 
     #[error("run-level retry budget exhausted (limit {limit}); aborting remaining retries")]
     RetryBudgetExhausted { limit: u32 },
+
+    #[error("Fivetran circuit breaker open for account; no HTTP attempted")]
+    CircuitOpen,
 }
 
 /// Wire-decode shape for `GET /v1/destinations/{id}`. The envelope
@@ -123,7 +128,9 @@ pub struct FivetranClient {
     /// the credential on a hot path.
     account_id_hash: String,
     /// Directory holding the per-account shared rate-limit state file
-    /// (FR-B). One file per account: `{ratelimit_dir}/{hash}.json`.
+    /// (FR-B Phase 1 file backend). Retained even when a Valkey budget
+    /// is wired so that fail-open of the Valkey path can degrade to
+    /// the per-host file backend without losing scope.
     ratelimit_dir: PathBuf,
     /// In-process envelope memoization for FR-C. Keyed by
     /// `destination_id` so a single client servicing multiple
@@ -143,6 +150,24 @@ pub struct FivetranClient {
     /// the HTTP path, then write-backs to this layer + the in-process
     /// memo on success. When `None` the cache layer is transparent.
     state_cache: Arc<dyn FivetranStateCache>,
+    /// Cross-pod rate-limit budget (FR-B Phase 2). Defaults to a
+    /// [`FileBudget`] rooted at [`Self::ratelimit_dir`] so a client
+    /// constructed without explicit wiring behaves exactly like a
+    /// pre-Phase-2 client.
+    budget: Arc<dyn RatelimitBudget>,
+    /// Distributed cache-stampede lock (Layer 1). Defaults to
+    /// [`NoLock`] so callers without coordination configured always
+    /// take the leader path.
+    stampede: Arc<dyn StampedeLock>,
+    /// Per-account circuit breaker (Layer 3). Defaults to
+    /// [`AlwaysClosed`] so callers without coordination configured
+    /// never short-circuit.
+    circuit: Arc<dyn FivetranCircuitBreaker>,
+    /// Lock TTL passed to [`StampedeLock::acquire`]. 0 means use the
+    /// crate default.
+    stampede_lock_ttl: Duration,
+    /// Follower-poll timeout for the cache-poll loop.
+    stampede_poll_timeout: Duration,
 }
 
 /// Standard Fivetran API envelope.
@@ -169,6 +194,7 @@ impl FivetranClient {
         let retry_budget =
             rocky_core::retry_budget::RetryBudget::from_config(retry.max_retries_per_run);
         let account_id_hash = ratelimit::hash_account_id(&api_key);
+        let ratelimit_dir = ratelimit::default_ratelimit_dir();
         FivetranClient {
             client: build_http_client(),
             base_url: "https://api.fivetran.com".to_string(),
@@ -177,9 +203,14 @@ impl FivetranClient {
             retry,
             retry_budget,
             account_id_hash,
-            ratelimit_dir: ratelimit::default_ratelimit_dir(),
+            ratelimit_dir: ratelimit_dir.clone(),
             envelope_cache: Arc::new(Mutex::new(BTreeMap::new())),
             state_cache: Arc::new(NoCache),
+            budget: Arc::new(FileBudget::new(ratelimit_dir)),
+            stampede: Arc::new(NoLock),
+            circuit: Arc::new(AlwaysClosed),
+            stampede_lock_ttl: stampede::DEFAULT_LOCK_TTL,
+            stampede_poll_timeout: stampede::DEFAULT_POLL_TIMEOUT,
         }
     }
 
@@ -191,32 +222,87 @@ impl FivetranClient {
         self
     }
 
-    /// Override the per-host rate-limit state directory (FR-B). Tests
-    /// pass a per-test [`tempfile::tempdir()`] so concurrent runs don't
-    /// collide on the default `${TMPDIR}/rocky-fivetran-ratelimit/`
-    /// location. Production callers should leave the default in place
-    /// so every `rocky-cli` process on the host shares a single file.
+    /// Override the per-host rate-limit state directory (FR-B Phase 1
+    /// file backend). Tests pass a per-test [`tempfile::tempdir()`]
+    /// so concurrent runs don't collide on the default
+    /// `${TMPDIR}/rocky-fivetran-ratelimit/` location. Production
+    /// callers should leave the default in place so every `rocky-cli`
+    /// process on the host shares a single file.
+    ///
+    /// Also re-wires the default file-backed [`RatelimitBudget`] to
+    /// point at the same directory — so a test that overrides the
+    /// dir without explicitly setting a Valkey budget still sees the
+    /// per-test isolation.
     #[must_use]
     pub fn with_ratelimit_dir(mut self, dir: PathBuf) -> Self {
-        self.ratelimit_dir = dir;
+        self.ratelimit_dir = dir.clone();
+        // Only replace the budget if it's still the default file
+        // backend; an explicitly-wired Valkey budget should survive
+        // a ratelimit-dir override (callers don't expect that to
+        // clobber their cross-pod store).
+        if self.budget.backend() == "file" {
+            self.budget = Arc::new(FileBudget::new(dir));
+        }
         self
     }
 
-    /// Resolve the per-account state file under [`Self::ratelimit_dir`].
-    fn ratelimit_path(&self) -> PathBuf {
-        ratelimit::account_state_path(&self.ratelimit_dir, &self.account_id_hash)
+    /// Override the cross-pod rate-limit budget (FR-B Phase 2). Default
+    /// is a [`FileBudget`] rooted at [`Self::ratelimit_dir`]; production
+    /// callers swap in a [`ValkeyBudget`](crate::ratelimit_valkey::ValkeyBudget)
+    /// to share the wake_at window across hosts.
+    #[must_use]
+    pub fn with_ratelimit_budget(mut self, budget: Arc<dyn RatelimitBudget>) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    /// Override the cache-stampede lock (Layer 1). Default is
+    /// [`NoLock`]; production callers swap in
+    /// [`ValkeyLock`](crate::stampede::ValkeyLock) to elect a single
+    /// leader on cold-start herds.
+    #[must_use]
+    pub fn with_stampede_lock(mut self, lock: Arc<dyn StampedeLock>) -> Self {
+        self.stampede = lock;
+        self
+    }
+
+    /// Override the per-account circuit breaker (Layer 3). Default
+    /// is [`AlwaysClosed`]; production callers swap in
+    /// [`ValkeyCircuit`](crate::circuit_breaker::ValkeyCircuit) to
+    /// short-circuit during Fivetran outages.
+    #[must_use]
+    pub fn with_circuit_breaker(mut self, cb: Arc<dyn FivetranCircuitBreaker>) -> Self {
+        self.circuit = cb;
+        self
+    }
+
+    /// Override the stampede lock TTL (Layer 1). Caps how long a
+    /// leader can hold the lock before followers are allowed to elect
+    /// a new leader.
+    #[must_use]
+    pub fn with_stampede_lock_ttl(mut self, ttl: Duration) -> Self {
+        self.stampede_lock_ttl = ttl;
+        self
+    }
+
+    /// Override the cap on the follower-poll loop (Layer 1).
+    #[must_use]
+    pub fn with_stampede_poll_timeout(mut self, timeout: Duration) -> Self {
+        self.stampede_poll_timeout = timeout;
+        self
     }
 
     /// Block on any active shared rate-limit window before sending a
-    /// request. Fail-open — see [`ratelimit::pre_request_wait`].
+    /// request. Fail-open — see [`ratelimit::pre_request_wait_budget`].
     async fn observe_shared_budget(&self) {
-        ratelimit::pre_request_wait(&self.ratelimit_path()).await;
+        ratelimit::pre_request_wait_budget(self.budget.as_ref(), &self.account_id_hash).await;
     }
 
     /// Record a new shared rate-limit window so other rocky-cli
-    /// processes on the host observe the same backoff. Called when we
-    /// receive a 429 / 503 with `Retry-After`. Also emits the
-    /// `fivetran.rate_limit_observed` OTLP span event.
+    /// processes (on the host AND across the cluster, when the
+    /// Valkey-backed budget is wired) observe the same backoff.
+    /// Called when we receive a 429 / 503 with `Retry-After`. Also
+    /// emits the `fivetran.rate_limit_observed` OTLP span event.
     ///
     /// `sleep_for` is the effective wait the caller is about to
     /// perform (already `max(header, fixed_backoff)` when `source =
@@ -224,7 +310,13 @@ impl FivetranClient {
     /// the upstream header (None for `source = Fallback`). Splitting
     /// the two lets dashboards see "upstream said 100ms but we slept
     /// 1s because backoff dominated" without conflating the signals.
-    fn publish_rate_limit_observation(
+    ///
+    /// The write goes through the configured [`RatelimitBudget`] —
+    /// `FileBudget` for the default Phase-1 per-host behavior or
+    /// `ValkeyBudget` (Phase 2) for the cross-pod variant. Errors
+    /// are fail-open: a Valkey outage degrades to the next request
+    /// re-discovering the throttle on its own.
+    async fn publish_rate_limit_observation(
         &self,
         sleep_for: Duration,
         header_value: Option<Duration>,
@@ -232,7 +324,13 @@ impl FivetranClient {
         status: u16,
     ) {
         let wake_at = SystemTime::now() + sleep_for;
-        ratelimit::record_wake_at(&self.ratelimit_path(), wake_at);
+        // Dispatch the budget write via the trait so a Valkey budget
+        // shares the wake_at across pods. Awaited inline so a
+        // short-lived CLI invocation can't exit before the persist
+        // lands — matches the pre-refactor file-backend's synchronous
+        // contract.
+        ratelimit::record_wake_at_budget(self.budget.as_ref(), &self.account_id_hash, wake_at)
+            .await;
 
         let to_ms = |d: Duration| -> u64 {
             d.as_millis()
@@ -245,6 +343,7 @@ impl FivetranClient {
             .with_metadata("retry_after_ms", to_ms(sleep_for))
             .with_metadata("source", source.as_str())
             .with_metadata("account_id", self.account_id_hash.clone())
+            .with_metadata("ratelimit_backend", self.budget.backend())
             .with_metadata("status", u64::from(status));
         if let Some(h) = header_value {
             evt = evt.with_metadata("header_retry_after_ms", to_ms(h));
@@ -268,6 +367,7 @@ impl FivetranClient {
     #[cfg(any(test, feature = "test-support"))]
     pub fn with_base_url(api_key: String, api_secret: String, base_url: String) -> Self {
         let account_id_hash = ratelimit::hash_account_id(&api_key);
+        let ratelimit_dir = ratelimit::default_ratelimit_dir();
         FivetranClient {
             client: build_http_client(),
             base_url,
@@ -281,9 +381,14 @@ impl FivetranClient {
             account_id_hash,
             // Tests that need an isolated shared-budget file should
             // chain `.with_ratelimit_dir(...)` after construction.
-            ratelimit_dir: ratelimit::default_ratelimit_dir(),
+            ratelimit_dir: ratelimit_dir.clone(),
             envelope_cache: Arc::new(Mutex::new(BTreeMap::new())),
             state_cache: Arc::new(NoCache),
+            budget: Arc::new(FileBudget::new(ratelimit_dir)),
+            stampede: Arc::new(NoLock),
+            circuit: Arc::new(AlwaysClosed),
+            stampede_lock_ttl: stampede::DEFAULT_LOCK_TTL,
+            stampede_poll_timeout: stampede::DEFAULT_POLL_TIMEOUT,
         }
     }
 
@@ -299,6 +404,7 @@ impl FivetranClient {
         retry: RetryConfig,
     ) -> Self {
         let account_id_hash = ratelimit::hash_account_id(&api_key);
+        let ratelimit_dir = ratelimit::default_ratelimit_dir();
         FivetranClient {
             client: build_http_client(),
             base_url,
@@ -307,9 +413,14 @@ impl FivetranClient {
             retry,
             retry_budget: rocky_core::retry_budget::RetryBudget::unbounded(),
             account_id_hash,
-            ratelimit_dir: ratelimit::default_ratelimit_dir(),
+            ratelimit_dir: ratelimit_dir.clone(),
             envelope_cache: Arc::new(Mutex::new(BTreeMap::new())),
             state_cache: Arc::new(NoCache),
+            budget: Arc::new(FileBudget::new(ratelimit_dir)),
+            stampede: Arc::new(NoLock),
+            circuit: Arc::new(AlwaysClosed),
+            stampede_lock_ttl: stampede::DEFAULT_LOCK_TTL,
+            stampede_poll_timeout: stampede::DEFAULT_POLL_TIMEOUT,
         }
     }
 
@@ -388,7 +499,7 @@ impl FivetranClient {
                 if attempt < self.retry.max_retries {
                     self.check_retry_budget()?;
                     self.emit_retry_event(attempt, "HTTP 429", ErrorClass::RateLimit);
-                    let sleep_for = self.compute_throttle_sleep(&resp, attempt, 429);
+                    let sleep_for = self.compute_throttle_sleep(&resp, attempt, 429).await;
                     warn!(
                         attempt = attempt + 1,
                         backoff_ms = sleep_for.as_millis() as u64,
@@ -406,7 +517,7 @@ impl FivetranClient {
                 self.emit_retry_event(attempt, &format!("HTTP {status}"), ErrorClass::Transient);
                 // 503 Service Unavailable carries `Retry-After` per
                 // RFC 9110 §10.2.3 — honor it the same way as 429.
-                let sleep_for = self.compute_throttle_sleep(&resp, attempt, status);
+                let sleep_for = self.compute_throttle_sleep(&resp, attempt, status).await;
                 warn!(
                     attempt = attempt + 1,
                     status,
@@ -519,7 +630,7 @@ impl FivetranClient {
                 if attempt < self.retry.max_retries {
                     self.check_retry_budget()?;
                     self.emit_retry_event(attempt, "HTTP 429", ErrorClass::RateLimit);
-                    let sleep_for = self.compute_throttle_sleep(&resp, attempt, 429);
+                    let sleep_for = self.compute_throttle_sleep(&resp, attempt, 429).await;
                     warn!(
                         attempt = attempt + 1,
                         backoff_ms = sleep_for.as_millis() as u64,
@@ -535,7 +646,7 @@ impl FivetranClient {
                 self.check_retry_budget()?;
                 let status = resp.status().as_u16();
                 self.emit_retry_event(attempt, &format!("HTTP {status}"), ErrorClass::Transient);
-                let sleep_for = self.compute_throttle_sleep(&resp, attempt, status);
+                let sleep_for = self.compute_throttle_sleep(&resp, attempt, status).await;
                 warn!(
                     attempt = attempt + 1,
                     status,
@@ -583,7 +694,7 @@ impl FivetranClient {
     /// existing per-attempt exponential backoff and tag the event as
     /// `"fallback"` so dashboards can spot adapters that aren't getting
     /// the upstream signal.
-    fn compute_throttle_sleep(&self, resp: &Response, attempt: u32, status: u16) -> Duration {
+    async fn compute_throttle_sleep(&self, resp: &Response, attempt: u32, status: u16) -> Duration {
         let backoff = retry_backoff(&self.retry, attempt);
         match parse_retry_after(resp) {
             Some(retry_after) => {
@@ -593,7 +704,8 @@ impl FivetranClient {
                     Some(retry_after),
                     RateLimitSource::Header,
                     status,
-                );
+                )
+                .await;
                 sleep_for
             }
             None => {
@@ -602,7 +714,8 @@ impl FivetranClient {
                     None,
                     RateLimitSource::Fallback,
                     status,
-                );
+                )
+                .await;
                 backoff
             }
         }
@@ -710,31 +823,38 @@ impl FivetranClient {
 
     /// Fetch (or return memoized) canonical envelope for `destination_id`.
     ///
-    /// Three-layer cache walk:
+    /// Five-layer walk:
     ///
-    ///   1. In-process memo (this client's [`Self::envelope_cache`]) —
-    ///      `refresh = false`, key present → return clone.
-    ///   2. Cross-process [`FivetranStateCache`] backend (FR-A) —
-    ///      `refresh = false`, primary miss → attempt
-    ///      `state_cache.read(<account_hash>/<destination_id>)`.
-    ///      On hit: hydrate the in-process memo + return.
-    ///      On miss / error: log and fall through.
-    ///   3. Live Fivetran REST API:
-    ///      a. `GET /v1/destinations/{id}`
-    ///      b. `GET /v1/groups/{id}/connectors` (paginated)
-    ///      c. `GET /v1/connectors/{conn_id}/schemas` for each connector
+    ///   L0. In-process memo (this client's [`Self::envelope_cache`])
+    ///       — `refresh = false`, key present → return clone.
+    ///   L2. Cross-process [`FivetranStateCache`] backend (FR-A) —
+    ///       `refresh = false`, primary miss → attempt
+    ///       `state_cache.read(<account_hash>/<destination_id>)`.
+    ///       On hit: hydrate the in-process memo + return.
+    ///   L1. Cache-stampede lock (NEW, Layer 1) — on cache miss the
+    ///       client tries to acquire `<key>:lock NX EX <ttl>`. The
+    ///       leader proceeds to the HTTP path; followers wait on the
+    ///       cache key with bounded polling until the leader's write
+    ///       becomes visible.
+    ///   L4. Per-account circuit breaker (NEW, Layer 3) — checked
+    ///       BEFORE every HTTP attempt. `Open` short-circuits with
+    ///       [`FivetranError::CircuitOpen`]; `HalfOpen`/`Closed`
+    ///       proceed. After the HTTP path the outcome is recorded so
+    ///       the breaker transitions on its own.
+    ///   L3. Cross-pod rate-limit budget (already shared via the
+    ///       `RatelimitBudget` trait inside [`get`]).
+    ///   L5. Retry-After + exponential backoff (already inside
+    ///       [`get`]).
     ///
-    ///      then construct the envelope, write it back to layer (2)
-    ///      AND layer (1), and return.
+    /// `refresh = true` skips L0, L2, and L1 on read; the breaker
+    /// (L4) is still consulted so an `Open` circuit short-circuits
+    /// even on `--no-cache` refreshes.
     ///
-    /// `refresh = true` skips layers (1) and (2) on read and forces a
-    /// fresh HTTP fetch — but still write-backs to both layers on
-    /// success, so a subsequent caller sees the fresh data. This is the
-    /// behavior `rocky discover --no-cache` exposes.
-    ///
-    /// Cache failures (read or write) are fail-open: the HTTP path
-    /// runs regardless and the failure shows up as a span event
-    /// (`fivetran.cache_write_failed`) plus a `warn!` log line.
+    /// Fail-open posture:
+    /// - L1 lock backend unreachable → fall through to direct HTTP
+    ///   (no stampede protection, but no block).
+    /// - L4 breaker read fails → treat as `Closed` (don't refuse
+    ///   live traffic because coordination is down).
     pub async fn fetch_envelope(
         &self,
         destination_id: &str,
@@ -743,7 +863,7 @@ impl FivetranClient {
         let cache_key = self.cache_key(destination_id);
         let backend = self.state_cache.backend();
 
-        // (1) In-process memo — only consulted on non-refresh.
+        // (L0) In-process memo — only consulted on non-refresh.
         if !refresh
             && let Some(cached) = self
                 .envelope_cache
@@ -755,10 +875,8 @@ impl FivetranClient {
             return Ok(cached);
         }
 
-        // (2) Cross-process state cache — only consulted on
+        // (L2) Cross-process state cache — only consulted on
         // non-refresh AND when the configured backend isn't NoCache.
-        // (NoCache always returns `Ok(None)` so the check is purely
-        // a perf shortcut to avoid the `read` call.)
         if !refresh && backend != "none" {
             match self.state_cache.read(&cache_key).await {
                 Ok(Some(env)) => {
@@ -781,7 +899,208 @@ impl FivetranClient {
             cache_obs::emit_cache_miss(backend, &cache_key, "refresh-forced");
         }
 
-        // (3) Live API path.
+        // (L1) Stampede protection — only for non-refresh callers.
+        // `refresh = true` means "I explicitly want fresh data";
+        // waiting on another leader's TTL window would violate that
+        // intent.
+        if !refresh && self.stampede.backend() != "none" {
+            match self
+                .stampede
+                .acquire(&cache_key, self.stampede_lock_ttl)
+                .await
+            {
+                Ok(Some(_guard)) => {
+                    // Leader path: fall through to the HTTP fetch
+                    // below; the guard is held across the HTTP
+                    // call + cache write-back so followers can't
+                    // observe the half-state.
+                    record_span_event(
+                        &PipelineEvent::new("fivetran.stampede_acquired")
+                            .with_metadata("key", cache_key.clone())
+                            .with_metadata("ttl_seconds", self.stampede_lock_ttl.as_secs())
+                            .with_metadata("backend", self.stampede.backend()),
+                    );
+                    let env = self
+                        .fetch_envelope_from_api_with_circuit(destination_id, &cache_key, backend)
+                        .await?;
+                    // Hold _guard alive until here; releases on drop
+                    // at function-end via the LockGuard contract.
+                    drop(_guard);
+                    return Ok(env);
+                }
+                Ok(None) => {
+                    // Follower path: poll the cache for the leader's
+                    // write.
+                    let started_at = std::time::Instant::now();
+                    match self
+                        .poll_cache_until_present(&cache_key, self.stampede_poll_timeout)
+                        .await
+                    {
+                        Some(env) => {
+                            record_span_event(
+                                &PipelineEvent::new("fivetran.stampede_polled")
+                                    .with_metadata("key", cache_key.clone())
+                                    .with_metadata(
+                                        "waited_ms",
+                                        started_at.elapsed().as_millis().min(u128::from(u64::MAX))
+                                            as u64,
+                                    )
+                                    .with_metadata("outcome", "cache_hit"),
+                            );
+                            self.envelope_cache
+                                .lock()
+                                .await
+                                .insert(destination_id.to_string(), env.clone());
+                            return Ok(env);
+                        }
+                        None => {
+                            record_span_event(
+                                &PipelineEvent::new("fivetran.stampede_polled")
+                                    .with_metadata("key", cache_key.clone())
+                                    .with_metadata(
+                                        "waited_ms",
+                                        started_at.elapsed().as_millis().min(u128::from(u64::MAX))
+                                            as u64,
+                                    )
+                                    .with_metadata("outcome", "timeout_direct_fetch"),
+                            );
+                            // Follower timed out — fall through to
+                            // a direct HTTP fetch (no protection).
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        backend = self.stampede.backend(),
+                        "stampede lock unavailable; falling through to direct fetch"
+                    );
+                    record_span_event(
+                        &PipelineEvent::new("fivetran.stampede_unavailable")
+                            .with_metadata("backend", self.stampede.backend())
+                            .with_error(e.to_string()),
+                    );
+                }
+            }
+        }
+
+        // Direct fetch path: either the stampede backend was NoLock,
+        // the leader returned, the follower timed out, or the lock
+        // backend failed. All routes converge here and through the
+        // circuit-protected API path.
+        self.fetch_envelope_from_api_with_circuit(destination_id, &cache_key, backend)
+            .await
+    }
+
+    /// HTTP fetch wrapped in the circuit-breaker check + record
+    /// transitions. Used both by the stampede leader path and the
+    /// non-stampede / fall-through path.
+    async fn fetch_envelope_from_api_with_circuit(
+        &self,
+        destination_id: &str,
+        cache_key: &str,
+        cache_backend: &str,
+    ) -> Result<FivetranStateEnvelope, FivetranError> {
+        // (L4) Circuit-breaker check.
+        let circuit_state = match self.circuit.state(&self.account_id_hash).await {
+            Ok(s) => s,
+            Err(e) => {
+                // Fail-open — never refuse traffic because the
+                // coordination store is down.
+                warn!(
+                    error = %e,
+                    backend = self.circuit.backend(),
+                    "circuit breaker state read failed; treating as Closed"
+                );
+                CircuitState::Closed
+            }
+        };
+        if circuit_state == CircuitState::Open {
+            record_span_event(
+                &PipelineEvent::new("fivetran.circuit_state_change")
+                    .with_metadata("account_id", self.account_id_hash.clone())
+                    .with_metadata("from_state", "open")
+                    .with_metadata("to_state", "open")
+                    .with_metadata("reason", "request_short_circuited")
+                    .with_metadata("backend", self.circuit.backend()),
+            );
+            return Err(FivetranError::CircuitOpen);
+        }
+
+        let api_outcome = self
+            .fetch_envelope_from_api(destination_id, cache_key, cache_backend)
+            .await;
+
+        // Record success / failure to drive future transitions.
+        match &api_outcome {
+            Ok(_) => {
+                let prev_state = circuit_state;
+                if let Err(e) = self.circuit.record_success(&self.account_id_hash).await {
+                    warn!(error = %e, "circuit record_success failed; fail-open");
+                } else if prev_state == CircuitState::HalfOpen {
+                    record_span_event(
+                        &PipelineEvent::new("fivetran.circuit_state_change")
+                            .with_metadata("account_id", self.account_id_hash.clone())
+                            .with_metadata("from_state", "half_open")
+                            .with_metadata("to_state", "closed")
+                            .with_metadata("reason", "probe_success")
+                            .with_metadata("backend", self.circuit.backend()),
+                    );
+                }
+            }
+            Err(e) if is_remote_failure(e) => {
+                if let Err(rec_err) = self
+                    .circuit
+                    .record_failure(&self.account_id_hash, FailureKind::Remote)
+                    .await
+                {
+                    warn!(error = %rec_err, "circuit record_failure failed; fail-open");
+                } else {
+                    // Re-read state so the event reflects the actual
+                    // transition (if any). The breaker may have
+                    // tripped from Closed→Open or HalfOpen→Open, or
+                    // it may still be Closed if the consecutive
+                    // failure count is below the threshold.
+                    let new_state = self
+                        .circuit
+                        .state(&self.account_id_hash)
+                        .await
+                        .unwrap_or(circuit_state);
+                    if new_state != circuit_state {
+                        record_span_event(
+                            &PipelineEvent::new("fivetran.circuit_state_change")
+                                .with_metadata("account_id", self.account_id_hash.clone())
+                                .with_metadata("from_state", circuit_state.as_str())
+                                .with_metadata("to_state", new_state.as_str())
+                                .with_metadata("reason", "remote_failure")
+                                .with_metadata("backend", self.circuit.backend()),
+                        );
+                    }
+                }
+            }
+            Err(_) => {
+                // Local error — record as Local so backends with
+                // telemetry can count them without affecting the
+                // state machine.
+                let _ = self
+                    .circuit
+                    .record_failure(&self.account_id_hash, FailureKind::Local)
+                    .await;
+            }
+        }
+
+        api_outcome
+    }
+
+    /// Internal: do the actual HTTP fetch + cache write-back. Split
+    /// out from [`Self::fetch_envelope`] so the stampede leader path
+    /// and the fall-through direct path share one implementation.
+    async fn fetch_envelope_from_api(
+        &self,
+        destination_id: &str,
+        cache_key: &str,
+        cache_backend: &str,
+    ) -> Result<FivetranStateEnvelope, FivetranError> {
         let destination = self.get_destination(destination_id).await?;
         let connectors = ft_connector::list_connectors(self, destination_id).await?;
 
@@ -797,11 +1116,6 @@ impl FivetranClient {
                 .buffer_unordered(10)
                 .collect()
                 .await;
-        // Stop on the first schema fetch error — the envelope is
-        // supposed to be a coherent snapshot, not a partial one.
-        // Callers that want partial-success semantics use the
-        // `FivetranDiscoveryAdapter::discover` path instead, which
-        // surfaces failed sources separately.
         let mut schemas: BTreeMap<String, FivetranSchemaConfig> = BTreeMap::new();
         for (conn_id, result) in schema_results {
             let cfg = result?;
@@ -822,26 +1136,94 @@ impl FivetranClient {
             "fivetran envelope fetched"
         );
 
-        // Write-back to layer (2) — best-effort. A failing cache must
-        // not propagate; the HTTP path already succeeded.
-        if backend != "none" {
-            match self.state_cache.write(&cache_key, &envelope).await {
+        // Write-back to L2 cache — best-effort.
+        if cache_backend != "none" {
+            match self.state_cache.write(cache_key, &envelope).await {
                 Ok(WriteOutcome::Written) => {
-                    cache_obs::emit_cache_write(backend, &cache_key, &envelope)
+                    cache_obs::emit_cache_write(cache_backend, cache_key, &envelope)
                 }
                 Ok(WriteOutcome::SkippedNoChange) => {
-                    cache_obs::emit_cache_write_skipped(backend, &cache_key, "hash-match")
+                    cache_obs::emit_cache_write_skipped(cache_backend, cache_key, "hash-match")
                 }
-                Err(e) => cache_obs::emit_cache_write_failed(backend, &cache_key, &e),
+                Err(e) => cache_obs::emit_cache_write_failed(cache_backend, cache_key, &e),
             }
         }
 
-        // Write-back to layer (1) — in-process memo.
+        // Write-back to L0 in-process memo.
         self.envelope_cache
             .lock()
             .await
             .insert(destination_id.to_string(), envelope.clone());
         Ok(envelope)
+    }
+
+    /// Follower-side cache poll. Returns the envelope when the
+    /// configured [`FivetranStateCache`] backend has the key, or
+    /// `None` on timeout. Exponential backoff: 100ms → 200ms → ... →
+    /// 2s, total budget = `timeout`.
+    async fn poll_cache_until_present(
+        &self,
+        cache_key: &str,
+        timeout: Duration,
+    ) -> Option<FivetranStateEnvelope> {
+        if self.state_cache.backend() == "none" {
+            // No cache → nothing to poll.
+            return None;
+        }
+        let deadline = std::time::Instant::now() + timeout;
+        let mut attempt: u32 = 0;
+        loop {
+            if std::time::Instant::now() >= deadline {
+                return None;
+            }
+            match self.state_cache.read(cache_key).await {
+                Ok(Some(env)) => return Some(env),
+                Ok(None) => {} // continue polling
+                Err(e) => {
+                    warn!(error = %e, "cache poll read failed; falling through");
+                    return None;
+                }
+            }
+            let backoff = stampede::poll_backoff(attempt);
+            attempt = attempt.saturating_add(1);
+            // Don't oversleep past the deadline.
+            let now = std::time::Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            let sleep_for = backoff.min(remaining);
+            if sleep_for.is_zero() {
+                return None;
+            }
+            tokio::time::sleep(sleep_for).await;
+        }
+    }
+}
+
+/// Classify a [`FivetranError`] as a remote (Fivetran-side) failure.
+/// Only remote failures trip the circuit breaker; local errors
+/// (parsing, serialization) do not.
+///
+/// 429 errors are intentionally *not* counted as remote failures —
+/// rate limiting is a soft signal that Fivetran is responsive but
+/// busy, and `RateLimited` only surfaces from [`Self::get`] when the
+/// retry budget is exhausted. The shared [`RatelimitBudget`] (L3) is
+/// the right tool for 429 propagation; tripping the breaker on every
+/// 429-storm would refuse traffic for an unrelated reason.
+fn is_remote_failure(err: &FivetranError) -> bool {
+    match err {
+        FivetranError::Http(e) => {
+            // Connect refused, TLS error, timeout — all remote
+            // (network) failures that the breaker should count.
+            e.is_connect() || e.is_timeout() || e.is_request()
+        }
+        FivetranError::Api { code, .. } => {
+            // 5xx status codes — surfaced when retries are
+            // exhausted on a server error.
+            code.starts_with('5')
+        }
+        FivetranError::RetryBudgetExhausted { .. } => true,
+        FivetranError::RateLimited => false, // see doc comment above
+        FivetranError::UnexpectedResponse(_) => false, // local decode error
+        FivetranError::CircuitOpen => false,
     }
 }
 

--- a/engine/crates/rocky-fivetran/src/lib.rs
+++ b/engine/crates/rocky-fivetran/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod adapter;
+pub mod circuit_breaker;
 pub mod client;
 pub mod connector;
 pub mod envelope;
 pub mod ratelimit;
+#[cfg(feature = "valkey")]
+pub mod ratelimit_valkey;
 pub mod schema;
+pub mod stampede;
 pub mod state_cache;
 pub mod sync;

--- a/engine/crates/rocky-fivetran/src/ratelimit.rs
+++ b/engine/crates/rocky-fivetran/src/ratelimit.rs
@@ -36,9 +36,11 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
 use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use thiserror::Error;
 use tracing::{debug, trace, warn};
 
 /// Default subdirectory under `TMPDIR` for the shared rate-limit state.
@@ -238,6 +240,193 @@ pub fn record_wake_at(path: &Path, wake_at: SystemTime) {
         _ => wake_at,
     };
     write_wake_at(path, effective);
+}
+
+/// Default cap on the Valkey backend's `EXPIRE` for an abandoned
+/// `wake_at` value (10 minutes). Matches the upstream throttle window
+/// typical for Fivetran's documented Retry-After values; long enough
+/// to bridge a 429 burst, short enough that a stale value disappears
+/// on its own.
+pub const DEFAULT_MAX_WAKE_SECONDS: u64 = 600;
+
+/// Errors surfaced by [`RatelimitBudget`] implementations.
+///
+/// Coarse-grained on purpose — the budget is fail-open at every call
+/// site, so the caller's only useful response is `warn!` + fall back
+/// to a permissive default.
+#[derive(Debug, Error)]
+pub enum BudgetError {
+    /// Local filesystem I/O error (file backend).
+    #[error("ratelimit I/O: {0}")]
+    Io(#[from] std::io::Error),
+    /// JSON serialize / deserialize failure on the persisted state.
+    #[error("ratelimit serialize: {0}")]
+    Serialize(#[from] serde_json::Error),
+    /// Valkey / Redis transport failure.
+    #[error("ratelimit valkey: {0}")]
+    Valkey(String),
+    /// Misconfigured backend — surfaced from `build_ratelimit_budget`
+    /// rather than from a request.
+    #[error("ratelimit config: {0}")]
+    Config(String),
+}
+
+/// Cross-process shared rate-limit budget.
+///
+/// `wake_at` is the upper-bound SystemTime that every observer (every
+/// rocky-cli process that shares the budget) should refuse to issue a
+/// fresh Fivetran request before. Implementations are responsible for
+/// deduping concurrent writes such that the *larger* of the existing
+/// and new `wake_at` wins — a brief 100ms `Retry-After` should never
+/// shorten an in-flight 30s window.
+#[async_trait]
+pub trait RatelimitBudget: Send + Sync + std::fmt::Debug {
+    /// Read the current wake-at for `account_hash`. Returns `Ok(None)`
+    /// on a clean miss; `Err(_)` on transport failure.
+    async fn wake_at(&self, account_hash: &str) -> Result<Option<SystemTime>, BudgetError>;
+    /// Persist `wake_at` for `account_hash`, max-merging with any
+    /// existing value (later wins).
+    async fn set_wake_at(&self, account_hash: &str, wake_at: SystemTime)
+    -> Result<(), BudgetError>;
+    /// Stable backend tag for log + OTLP attributes.
+    fn backend(&self) -> &'static str;
+}
+
+/// Per-host file-backed budget. Wraps the original FR-B Phase 1 file
+/// code in a [`RatelimitBudget`] trait object so the cross-pod
+/// Valkey backend (FR-B Phase 2) can sit alongside it.
+#[derive(Debug, Clone)]
+pub struct FileBudget {
+    dir: PathBuf,
+}
+
+impl FileBudget {
+    /// Construct a budget rooted at `dir`. The directory is created
+    /// lazily on first write.
+    pub fn new(dir: PathBuf) -> Self {
+        FileBudget { dir }
+    }
+
+    /// Default location under `${TMPDIR}/rocky-fivetran-ratelimit/`.
+    pub fn default_dir() -> Self {
+        FileBudget::new(default_ratelimit_dir())
+    }
+
+    fn path(&self, account_hash: &str) -> PathBuf {
+        account_state_path(&self.dir, account_hash)
+    }
+}
+
+#[async_trait]
+impl RatelimitBudget for FileBudget {
+    async fn wake_at(&self, account_hash: &str) -> Result<Option<SystemTime>, BudgetError> {
+        // The original file backend is sync + fail-open; lift its
+        // result into the async trait surface without losing the
+        // fail-open contract — a missing / corrupt file still maps
+        // to `Ok(None)`.
+        Ok(read_wake_at(&self.path(account_hash)))
+    }
+
+    async fn set_wake_at(
+        &self,
+        account_hash: &str,
+        wake_at: SystemTime,
+    ) -> Result<(), BudgetError> {
+        // `record_wake_at` is sync + fail-open; never returns an
+        // error to surface.
+        record_wake_at(&self.path(account_hash), wake_at);
+        Ok(())
+    }
+
+    fn backend(&self) -> &'static str {
+        "file"
+    }
+}
+
+/// Async pre-request wait against any [`RatelimitBudget`].
+///
+/// Returns immediately on a missing entry, a past `wake_at`, or any
+/// backend error (fail-open). Capped at [`MAX_OBSERVED_WAIT`] so a
+/// stale value can't park forever.
+pub async fn pre_request_wait_budget(budget: &dyn RatelimitBudget, account_hash: &str) {
+    let wake_at = match budget.wake_at(account_hash).await {
+        Ok(Some(w)) => w,
+        Ok(None) => return,
+        Err(e) => {
+            trace!(error = %e, "ratelimit budget read failed; fail-open");
+            return;
+        }
+    };
+    let now = SystemTime::now();
+    let Ok(remaining) = wake_at.duration_since(now) else {
+        return;
+    };
+    if remaining.is_zero() {
+        return;
+    }
+    let bounded = remaining.min(MAX_OBSERVED_WAIT);
+    debug!(
+        wait_ms = bounded.as_millis() as u64,
+        backend = budget.backend(),
+        "observing shared rate-limit budget"
+    );
+    tokio::time::sleep(bounded).await;
+}
+
+/// Persist a wake-at via any [`RatelimitBudget`]. Backend errors are
+/// logged at `warn!` and swallowed (fail-open).
+pub async fn record_wake_at_budget(
+    budget: &dyn RatelimitBudget,
+    account_hash: &str,
+    wake_at: SystemTime,
+) {
+    if let Err(e) = budget.set_wake_at(account_hash, wake_at).await {
+        warn!(
+            error = %e,
+            backend = budget.backend(),
+            "ratelimit budget write failed; fail-open"
+        );
+    }
+}
+
+/// Construct the rate-limit budget backend described by `config`.
+/// Returns an [`Arc<dyn RatelimitBudget>`] so the caller can clone
+/// cheaply. Defaults to [`FileBudget::default_dir`] when `config` is
+/// `None`.
+///
+/// # Errors
+///
+/// - [`BudgetError::Config`] — the configured backend is missing a
+///   required field (e.g. `valkey_url` for `backend = "valkey"`).
+/// - [`BudgetError::Valkey`] — the Redis client refused the URL.
+pub fn build_ratelimit_budget(
+    config: Option<&rocky_core::config::FivetranRatelimitConfig>,
+) -> Result<std::sync::Arc<dyn RatelimitBudget>, BudgetError> {
+    use rocky_core::config::FivetranRatelimitBackend;
+    let Some(cfg) = config else {
+        return Ok(std::sync::Arc::new(FileBudget::default_dir()));
+    };
+    match cfg.backend {
+        FivetranRatelimitBackend::File => Ok(std::sync::Arc::new(FileBudget::default_dir())),
+        #[cfg(feature = "valkey")]
+        FivetranRatelimitBackend::Valkey => {
+            let url = cfg.valkey_url.as_ref().ok_or_else(|| {
+                BudgetError::Config(
+                    "backend = \"valkey\" requires `valkey_url` in [adapter.<name>.ratelimit]"
+                        .into(),
+                )
+            })?;
+            let max_wake =
+                Duration::from_secs(cfg.max_wake_seconds.unwrap_or(DEFAULT_MAX_WAKE_SECONDS));
+            let budget = crate::ratelimit_valkey::ValkeyBudget::from_url(url, max_wake)?;
+            Ok(std::sync::Arc::new(budget))
+        }
+        #[cfg(not(feature = "valkey"))]
+        FivetranRatelimitBackend::Valkey => Err(BudgetError::Config(
+            "backend = \"valkey\" requires building rocky-fivetran with the `valkey` feature"
+                .into(),
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-fivetran/src/ratelimit_valkey.rs
+++ b/engine/crates/rocky-fivetran/src/ratelimit_valkey.rs
@@ -1,0 +1,221 @@
+//! Valkey-backed cross-pod rate-limit budget (FR-B Phase 2).
+//!
+//! Sits alongside the file-backed [`FileBudget`](crate::ratelimit::FileBudget)
+//! and implements the same [`RatelimitBudget`] trait so the rest of
+//! the adapter can dispatch without caring which backend was wired.
+//!
+//! ## Key shape
+//!
+//! Every account's wake-at lives at
+//! `<KEY_PREFIX><account_hash>` — namespaced so cluster operators can
+//! prefix-scan (`KEYS fivetran-ratelimit:*`) without colliding with
+//! other Rocky Redis users. The stored value is the `wake_at` epoch
+//! milliseconds as a decimal string; the parser tolerates whitespace
+//! so a future change to embed JSON stays backward-compatible.
+//!
+//! ## Concurrent writes
+//!
+//! Naive `SET` allows a stale T1 to land after a fresh T2 and
+//! regress `wake_at`. To match the file backend's "later wins"
+//! semantics across pods, [`ValkeyBudget::set_wake_at`] uses an EVAL
+//! Lua script that runs atomically on the Valkey server:
+//!
+//! ```text
+//! local current = tonumber(redis.call('GET', KEYS[1])) or 0
+//! local incoming = tonumber(ARGV[1])
+//! if incoming > current then
+//!     redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+//! end
+//! return 1
+//! ```
+//!
+//! The `EX` cap (`max_wake_seconds`, default 600s) ensures an
+//! abandoned wake_at value disappears on its own rather than
+//! persisting forever in the cluster.
+//!
+//! ## Fail-open
+//!
+//! Every operation surfaces [`BudgetError::Valkey`] on transport
+//! failure. The caller in [`client.rs`](crate::client) traps these,
+//! logs at `warn!`, and falls back to per-host [`FileBudget`].
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use redis::AsyncCommands;
+use tokio::sync::OnceCell;
+use tracing::debug;
+
+use crate::ratelimit::{BudgetError, RatelimitBudget};
+
+/// Redis key prefix for every Fivetran rate-limit entry. Mirrors the
+/// `fivetran-state:` namespace used by [`ValkeyCache`](crate::state_cache::valkey::ValkeyCache).
+const KEY_PREFIX: &str = "fivetran-ratelimit:";
+
+/// Cross-pod shared rate-limit budget backed by Valkey / Redis.
+///
+/// Gated behind the `valkey` Cargo feature — same posture as the
+/// state-cache Valkey backend so the default build doesn't pull the
+/// Redis client transitively.
+pub struct ValkeyBudget {
+    client: redis::Client,
+    conn: OnceCell<redis::aio::ConnectionManager>,
+    /// Cap on the Valkey `EX <seconds>` set on each write. Bounds how
+    /// long a stale wake_at lives after a crashed peer.
+    max_wake: Duration,
+}
+
+impl std::fmt::Debug for ValkeyBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValkeyBudget")
+            .field("max_wake_secs", &self.max_wake.as_secs())
+            .field("connected", &self.conn.initialized())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ValkeyBudget {
+    /// Open a Valkey / Redis client for `url`. Synchronous and
+    /// non-blocking — the TCP / TLS handshake is deferred until the
+    /// first request. URL parse errors surface here as
+    /// [`BudgetError::Valkey`]; connect errors surface on the first
+    /// budget read / write.
+    pub fn from_url(url: &str, max_wake: Duration) -> Result<Self, BudgetError> {
+        let client = redis::Client::open(url).map_err(|e| BudgetError::Valkey(e.to_string()))?;
+        Ok(ValkeyBudget {
+            client,
+            conn: OnceCell::new(),
+            max_wake,
+        })
+    }
+
+    async fn get_conn(&self) -> Result<redis::aio::ConnectionManager, BudgetError> {
+        let conn = self
+            .conn
+            .get_or_try_init(|| async {
+                redis::aio::ConnectionManager::new(self.client.clone())
+                    .await
+                    .map_err(|e| BudgetError::Valkey(e.to_string()))
+            })
+            .await?;
+        Ok(conn.clone())
+    }
+
+    fn prefixed(account_hash: &str) -> String {
+        format!("{KEY_PREFIX}{account_hash}")
+    }
+}
+
+#[async_trait]
+impl RatelimitBudget for ValkeyBudget {
+    async fn wake_at(&self, account_hash: &str) -> Result<Option<SystemTime>, BudgetError> {
+        let mut conn = self.get_conn().await?;
+        let key = Self::prefixed(account_hash);
+        let raw: Option<String> = conn
+            .get(&key)
+            .await
+            .map_err(|e| BudgetError::Valkey(e.to_string()))?;
+        match raw.and_then(|s| s.trim().parse::<u64>().ok()) {
+            Some(ms) => Ok(UNIX_EPOCH.checked_add(Duration::from_millis(ms))),
+            None => Ok(None),
+        }
+    }
+
+    async fn set_wake_at(
+        &self,
+        account_hash: &str,
+        wake_at: SystemTime,
+    ) -> Result<(), BudgetError> {
+        let ms = match wake_at.duration_since(UNIX_EPOCH) {
+            Ok(d) => d.as_millis().min(u64::MAX as u128) as u64,
+            Err(_) => return Ok(()), // pre-epoch — ignore (matches file backend)
+        };
+        let key = Self::prefixed(account_hash);
+        let ttl_secs = self.max_wake.as_secs().max(1);
+        let mut conn = self.get_conn().await?;
+
+        // Atomic max-merge via Lua EVAL so concurrent writers don't
+        // regress wake_at.
+        const MAX_MERGE_SCRIPT: &str = r#"
+            local current = tonumber(redis.call('GET', KEYS[1])) or 0
+            local incoming = tonumber(ARGV[1])
+            if incoming > current then
+                redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
+            end
+            return 1
+        "#;
+        let _: i64 = redis::Script::new(MAX_MERGE_SCRIPT)
+            .key(&key)
+            .arg(ms)
+            .arg(ttl_secs)
+            .invoke_async(&mut conn)
+            .await
+            .map_err(|e| BudgetError::Valkey(e.to_string()))?;
+        debug!(key, wake_at_epoch_ms = ms, "valkey ratelimit set");
+        Ok(())
+    }
+
+    fn backend(&self) -> &'static str {
+        "valkey"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_is_applied() {
+        assert_eq!(
+            ValkeyBudget::prefixed("abc123"),
+            "fivetran-ratelimit:abc123"
+        );
+    }
+
+    #[test]
+    fn from_url_is_sync_and_doesnt_connect() {
+        let budget = ValkeyBudget::from_url("redis://127.0.0.1:1/", Duration::from_secs(60));
+        assert!(budget.is_ok(), "from_url must not connect: {budget:?}");
+    }
+
+    /// Live Valkey integration test — gated on `ROCKY_TEST_VALKEY_URL`.
+    /// Mirrors the `ROCKY_TEST_*` pattern used by the other live
+    /// integration tests.
+    #[tokio::test]
+    async fn live_valkey_max_merge() {
+        let url = match std::env::var("ROCKY_TEST_VALKEY_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!(
+                    "skipping live_valkey_max_merge — set ROCKY_TEST_VALKEY_URL to a Valkey/Redis URL to enable"
+                );
+                return;
+            }
+        };
+
+        let budget =
+            ValkeyBudget::from_url(&url, Duration::from_secs(60)).expect("from_url must succeed");
+        let hash = format!("ROCKY_TEST_max_merge_{}", std::process::id());
+
+        let later = SystemTime::now() + Duration::from_secs(60);
+        let earlier = SystemTime::now() + Duration::from_secs(10);
+
+        budget.set_wake_at(&hash, later).await.expect("set later");
+        // Writing an earlier value must not regress the wake_at.
+        budget
+            .set_wake_at(&hash, earlier)
+            .await
+            .expect("set earlier");
+
+        let observed = budget.wake_at(&hash).await.expect("read").expect("present");
+        let delta = if observed > later {
+            observed.duration_since(later).unwrap()
+        } else {
+            later.duration_since(observed).unwrap()
+        };
+        assert!(
+            delta < Duration::from_secs(2),
+            "expected later wake_at to win, got delta {delta:?}"
+        );
+    }
+}

--- a/engine/crates/rocky-fivetran/src/stampede.rs
+++ b/engine/crates/rocky-fivetran/src/stampede.rs
@@ -1,0 +1,519 @@
+//! Distributed cache-stampede protection (Layer 1).
+//!
+//! On a cold-start herd, N concurrent rocky-cli processes simultaneously
+//! observe the cache miss, fan out N independent API calls, and then
+//! converge with N redundant write-backs. The stampede lock elects a
+//! single leader to do the API call; followers wait on the cache key
+//! with bounded polling until the leader's write becomes visible.
+//!
+//! ## Trait
+//!
+//! [`StampedeLock::acquire`] returns:
+//! - `Ok(Some(LockGuard))` — caller is the leader, must release on
+//!   `Drop` (or via the guard's lifetime ending).
+//! - `Ok(None)` — another caller holds the lock; the caller is a
+//!   follower and should poll the cache.
+//! - `Err(_)` — backend unreachable. Caller falls open to the direct
+//!   HTTP path (no protection, but no block).
+//!
+//! ## Backends
+//!
+//! - [`NoLock`] — every `acquire` succeeds; behavior identical to no
+//!   stampede protection. Default when `[adapter.fivetran.stampede]`
+//!   is absent or `backend = "none"`.
+//! - [`ValkeyLock`] — distributed via `SET <key>:lock <unique_id> NX
+//!   EX <ttl>`. Behind the `valkey` Cargo feature.
+//!
+//! ## Lock fencing
+//!
+//! Each acquisition generates a unique 128-bit token persisted in the
+//! Valkey value. `LockGuard::Drop` issues an EVAL Lua script that
+//! check-and-DELs only if the value still matches our token; this
+//! prevents a leader that overran the TTL from deleting a fresh
+//! lock acquired by a different holder after expiry. The mechanism is
+//! the standard Redis SETNX-with-fencing pattern documented at
+//! https://redis.io/docs/latest/develop/use/patterns/distributed-locks/
+//! (single-instance variant — the "Redlock" multi-instance variant is
+//! intentionally out of scope; one Valkey is the deployment shape).
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Errors surfaced by [`StampedeLock`] implementations.
+///
+/// Like the other coordination-layer errors, these are coarse on
+/// purpose — fail-open is the caller's only useful policy.
+#[derive(Debug, Error)]
+pub enum LockError {
+    /// Valkey / Redis transport failure (connect refused, TLS error,
+    /// command timeout).
+    #[error("stampede valkey: {0}")]
+    Valkey(String),
+    /// Misconfigured backend — surfaced from `build_stampede_lock`
+    /// rather than from a request.
+    #[error("stampede config: {0}")]
+    Config(String),
+}
+
+/// Trait every stampede-lock backend implements.
+///
+/// Acquired guards must explicitly release on `Drop`. A guard's
+/// lifetime represents leadership for the keyed envelope fetch —
+/// dropping the guard signals "leader done, followers may poll
+/// freely." Implementations that can't release synchronously (i.e.
+/// Valkey) spawn an async task on drop to issue the release; if the
+/// process exits before the task runs, the TTL backstop guarantees
+/// the lock eventually disappears.
+#[async_trait]
+pub trait StampedeLock: Send + Sync + std::fmt::Debug {
+    /// Try to acquire the lock for `key` with `ttl`.
+    ///
+    /// - `Ok(Some(_))` → caller is the leader.
+    /// - `Ok(None)` → another caller is the leader; caller is a
+    ///   follower and should poll the cache.
+    /// - `Err(_)` → backend unreachable.
+    async fn acquire(&self, key: &str, ttl: Duration) -> Result<Option<LockGuard>, LockError>;
+
+    /// Stable backend tag for OTLP span attributes.
+    fn backend(&self) -> &'static str;
+}
+
+/// Opaque guard returned by a successful [`StampedeLock::acquire`].
+///
+/// Holds whatever release primitive the backend needs (a `no-op`
+/// closure for `NoLock`, a Valkey release script + key/token pair for
+/// `ValkeyLock`). Dropping the guard runs the release; explicit
+/// release is not exposed because the wiring in `fetch_envelope`
+/// always wants release at scope end.
+pub struct LockGuard {
+    on_drop: Option<Box<dyn FnOnce() + Send>>,
+}
+
+impl LockGuard {
+    /// Build a guard whose `Drop` runs `f`. The closure runs at most
+    /// once — `Drop` clears `on_drop` so a double-drop is well-defined
+    /// (no-op the second time).
+    pub fn new<F>(f: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        LockGuard {
+            on_drop: Some(Box::new(f)),
+        }
+    }
+
+    /// Sentinel guard for the no-op backend ([`NoLock`]). Releasing is
+    /// a no-op so the closure is `||{}`.
+    pub fn noop() -> Self {
+        LockGuard::new(|| {})
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        if let Some(f) = self.on_drop.take() {
+            f();
+        }
+    }
+}
+
+impl std::fmt::Debug for LockGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LockGuard")
+            .field("on_drop_armed", &self.on_drop.is_some())
+            .finish()
+    }
+}
+
+/// No-op lock — every `acquire` succeeds. Default backend when no
+/// stampede protection is configured.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoLock;
+
+#[async_trait]
+impl StampedeLock for NoLock {
+    async fn acquire(&self, _key: &str, _ttl: Duration) -> Result<Option<LockGuard>, LockError> {
+        Ok(Some(LockGuard::noop()))
+    }
+
+    fn backend(&self) -> &'static str {
+        "none"
+    }
+}
+
+/// Compute the suggested exponential backoff for the follower's
+/// cache-poll loop. Starts at 100ms, doubles each iteration, capped
+/// at 2s — matches the FR plan §Layer 1 schedule.
+///
+/// Exposed at module scope so tests and the client's poll loop share
+/// one implementation.
+pub fn poll_backoff(attempt: u32) -> Duration {
+    let exp = 100u64.saturating_mul(2u64.saturating_pow(attempt.min(8)));
+    Duration::from_millis(exp.min(2_000))
+}
+
+/// Cap on the [`StampedeLock`]-driven follower poll loop. Defaults to
+/// 30s per the FR plan; the per-config `poll_timeout_seconds` knob
+/// overrides this. Surfaced at the client wiring layer, not the trait.
+pub const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default lock TTL — caps how long a leader can hold the lock before
+/// followers are allowed to elect a new leader. The per-config
+/// `lock_ttl_seconds` knob overrides this. 60s matches the FR plan.
+pub const DEFAULT_LOCK_TTL: Duration = Duration::from_secs(60);
+
+/// Resolved tunables for a stampede backend — populated from the
+/// user's [`FivetranStampedeConfig`] block with the canonical
+/// defaults applied. Surfaced from
+/// [`build_stampede_lock`](crate::stampede::build_stampede_lock) so
+/// the caller can thread the configured TTL + poll-timeout into the
+/// [`FivetranClient`](crate::client::FivetranClient).
+#[derive(Debug, Clone, Copy)]
+pub struct StampedeTunables {
+    /// TTL applied to the lock acquire (`SET NX EX <ttl>`).
+    pub lock_ttl: Duration,
+    /// Cap on the follower poll loop.
+    pub poll_timeout: Duration,
+}
+
+/// Construct the stampede lock backend described by `config`. Returns
+/// the [`Arc<dyn StampedeLock>`] and the resolved tunables; the
+/// caller threads both into the client. Defaults to
+/// [`NoLock`] + crate defaults when `config` is `None`.
+///
+/// # Errors
+///
+/// - [`LockError::Config`] — required field missing.
+/// - [`LockError::Valkey`] — the Redis client refused the URL.
+pub fn build_stampede_lock(
+    config: Option<&rocky_core::config::FivetranStampedeConfig>,
+) -> Result<(std::sync::Arc<dyn StampedeLock>, StampedeTunables), LockError> {
+    use rocky_core::config::FivetranStampedeBackend;
+    let tunables_default = StampedeTunables {
+        lock_ttl: DEFAULT_LOCK_TTL,
+        poll_timeout: DEFAULT_POLL_TIMEOUT,
+    };
+    let Some(cfg) = config else {
+        return Ok((std::sync::Arc::new(NoLock), tunables_default));
+    };
+    let resolved = StampedeTunables {
+        lock_ttl: cfg
+            .lock_ttl_seconds
+            .map(Duration::from_secs)
+            .unwrap_or(tunables_default.lock_ttl),
+        poll_timeout: cfg
+            .poll_timeout_seconds
+            .map(Duration::from_secs)
+            .unwrap_or(tunables_default.poll_timeout),
+    };
+    match cfg.backend {
+        FivetranStampedeBackend::None => Ok((std::sync::Arc::new(NoLock), resolved)),
+        #[cfg(feature = "valkey")]
+        FivetranStampedeBackend::Valkey => {
+            let url = cfg.valkey_url.as_ref().ok_or_else(|| {
+                LockError::Config(
+                    "backend = \"valkey\" requires `valkey_url` in [adapter.<name>.stampede]"
+                        .into(),
+                )
+            })?;
+            let lock = crate::stampede::valkey::ValkeyLock::from_url(url)?;
+            Ok((std::sync::Arc::new(lock), resolved))
+        }
+        #[cfg(not(feature = "valkey"))]
+        FivetranStampedeBackend::Valkey => Err(LockError::Config(
+            "backend = \"valkey\" requires building rocky-fivetran with the `valkey` feature"
+                .into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_lock_always_grants() {
+        let lock = NoLock;
+        let g = lock
+            .acquire("key", Duration::from_secs(60))
+            .await
+            .expect("ok")
+            .expect("some");
+        drop(g);
+    }
+
+    #[test]
+    fn poll_backoff_schedule() {
+        // 100ms, 200ms, 400ms, 800ms, 1600ms, then capped at 2s.
+        assert_eq!(poll_backoff(0), Duration::from_millis(100));
+        assert_eq!(poll_backoff(1), Duration::from_millis(200));
+        assert_eq!(poll_backoff(2), Duration::from_millis(400));
+        assert_eq!(poll_backoff(3), Duration::from_millis(800));
+        assert_eq!(poll_backoff(4), Duration::from_millis(1600));
+        assert_eq!(poll_backoff(5), Duration::from_millis(2_000));
+        assert_eq!(poll_backoff(20), Duration::from_millis(2_000));
+    }
+
+    #[test]
+    fn lock_guard_releases_on_drop() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag2 = flag.clone();
+        let g = LockGuard::new(move || {
+            flag2.store(true, Ordering::SeqCst);
+        });
+        assert!(!flag.load(Ordering::SeqCst));
+        drop(g);
+        assert!(flag.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn lock_guard_releases_only_once() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let count = Arc::new(AtomicU32::new(0));
+        let count2 = count.clone();
+        let mut g = LockGuard::new(move || {
+            count2.fetch_add(1, Ordering::SeqCst);
+        });
+        // Manually take + drop the inner option to simulate a
+        // re-entrant Drop (e.g. double-free); the second drop must
+        // be a no-op.
+        let inner = g.on_drop.take();
+        if let Some(f) = inner {
+            f();
+        }
+        drop(g);
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[cfg(feature = "valkey")]
+pub mod valkey {
+    //! Valkey-backed [`StampedeLock`] implementation.
+
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use tokio::sync::OnceCell;
+    use tracing::{debug, warn};
+
+    use super::{LockError, LockGuard, StampedeLock};
+
+    /// Redis key prefix for every stampede lock. Distinct from the
+    /// cache and ratelimit prefixes so a `KEYS fivetran-lock:*`
+    /// inventory is unambiguous.
+    const KEY_PREFIX: &str = "fivetran-lock:";
+
+    /// Distributed stampede lock backed by Valkey / Redis.
+    pub struct ValkeyLock {
+        client: redis::Client,
+        conn: OnceCell<redis::aio::ConnectionManager>,
+    }
+
+    impl std::fmt::Debug for ValkeyLock {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ValkeyLock")
+                .field("connected", &self.conn.initialized())
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl ValkeyLock {
+        /// Open a Valkey / Redis client for `url`. Sync + non-blocking;
+        /// the TCP / TLS handshake is deferred until the first
+        /// `acquire`.
+        pub fn from_url(url: &str) -> Result<Self, LockError> {
+            let client = redis::Client::open(url).map_err(|e| LockError::Valkey(e.to_string()))?;
+            Ok(ValkeyLock {
+                client,
+                conn: OnceCell::new(),
+            })
+        }
+
+        async fn get_conn(&self) -> Result<redis::aio::ConnectionManager, LockError> {
+            let conn = self
+                .conn
+                .get_or_try_init(|| async {
+                    redis::aio::ConnectionManager::new(self.client.clone())
+                        .await
+                        .map_err(|e| LockError::Valkey(e.to_string()))
+                })
+                .await?;
+            Ok(conn.clone())
+        }
+
+        fn prefixed(key: &str) -> String {
+            format!("{KEY_PREFIX}{key}:lock")
+        }
+
+        /// Generate a fresh unique token for a lock acquisition.
+        /// Combines the process id, a high-resolution clock read, and
+        /// a hash of both so that two `rocky` processes that race to
+        /// acquire at the same nanosecond still get distinct tokens.
+        fn generate_token() -> String {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let ns = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            format!("{}-{}", std::process::id(), ns)
+        }
+    }
+
+    /// Lua script that releases the lock only if the stored value
+    /// matches our token. Standard Redis "Redlock" check-and-DEL —
+    /// guards against deleting a lock that was re-acquired by another
+    /// holder after the original holder's TTL expired.
+    const RELEASE_SCRIPT: &str = r#"
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+            return redis.call('DEL', KEYS[1])
+        else
+            return 0
+        end
+    "#;
+
+    #[async_trait]
+    impl StampedeLock for ValkeyLock {
+        async fn acquire(&self, key: &str, ttl: Duration) -> Result<Option<LockGuard>, LockError> {
+            let prefixed = Self::prefixed(key);
+            let token = Self::generate_token();
+            let ttl_secs = ttl.as_secs().max(1);
+            let mut conn = self.get_conn().await?;
+
+            // `SET <key> <token> NX EX <ttl>` — atomic acquire +
+            // TTL. Returns `Ok` (`true`-ish via the redis crate's
+            // bool decode) on first acquisition; `Nil` (decoded as
+            // `false`-ish) when the key already exists.
+            let acquired: bool = redis::cmd("SET")
+                .arg(&prefixed)
+                .arg(&token)
+                .arg("NX")
+                .arg("EX")
+                .arg(ttl_secs)
+                .query_async::<Option<String>>(&mut conn)
+                .await
+                .map_err(|e| LockError::Valkey(e.to_string()))?
+                .is_some();
+
+            if !acquired {
+                debug!(
+                    key = prefixed,
+                    "stampede lock contended; caller is follower"
+                );
+                return Ok(None);
+            }
+            debug!(key = prefixed, "stampede lock acquired");
+
+            // Capture an Arc of the manager + key + token for the
+            // release closure. The closure spawns a release task on
+            // drop so we don't block the caller's hot path.
+            let release_conn = conn.clone();
+            let release_key = prefixed.clone();
+            let release_token = token.clone();
+            let runtime = tokio::runtime::Handle::try_current().ok();
+            let guard = LockGuard::new(move || {
+                let mut release_conn = release_conn;
+                let release_key = release_key;
+                let release_token = release_token;
+                if let Some(handle) = runtime {
+                    handle.spawn(async move {
+                        let script = redis::Script::new(RELEASE_SCRIPT);
+                        if let Err(e) = script
+                            .key(&release_key)
+                            .arg(&release_token)
+                            .invoke_async::<i64>(&mut release_conn)
+                            .await
+                        {
+                            warn!(
+                                key = %release_key,
+                                error = %e,
+                                "stampede lock release failed; relying on TTL"
+                            );
+                        }
+                    });
+                }
+                // No runtime context → silently rely on TTL. This
+                // path is reached when a guard is dropped from
+                // outside any tokio worker, which shouldn't happen
+                // in production but might in some tests.
+            });
+
+            Ok(Some(guard))
+        }
+
+        fn backend(&self) -> &'static str {
+            "valkey"
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn prefix_is_applied() {
+            assert_eq!(
+                ValkeyLock::prefixed("acct/dest"),
+                "fivetran-lock:acct/dest:lock"
+            );
+        }
+
+        #[test]
+        fn from_url_is_sync_and_doesnt_connect() {
+            let lock = ValkeyLock::from_url("redis://127.0.0.1:1/");
+            assert!(lock.is_ok());
+        }
+
+        /// Live Valkey integration — gated on `ROCKY_TEST_VALKEY_URL`.
+        #[tokio::test]
+        async fn live_valkey_acquire_release() {
+            let url = match std::env::var("ROCKY_TEST_VALKEY_URL") {
+                Ok(u) => u,
+                Err(_) => {
+                    eprintln!("skipping live_valkey_acquire_release — set ROCKY_TEST_VALKEY_URL");
+                    return;
+                }
+            };
+
+            let lock = ValkeyLock::from_url(&url).expect("connect");
+            let key = format!("ROCKY_TEST_acquire_{}", std::process::id());
+
+            // First acquire succeeds.
+            let g = lock
+                .acquire(&key, Duration::from_secs(10))
+                .await
+                .expect("ok")
+                .expect("some");
+
+            // Second concurrent acquire returns None (contention).
+            let none = lock
+                .acquire(&key, Duration::from_secs(10))
+                .await
+                .expect("ok");
+            assert!(none.is_none(), "second acquire should be follower");
+
+            // Release the first guard.
+            drop(g);
+
+            // Allow the spawned release task a beat to run.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            // After release, a fresh acquire succeeds again.
+            let g2 = lock
+                .acquire(&key, Duration::from_secs(10))
+                .await
+                .expect("ok");
+            assert!(g2.is_some(), "post-release acquire should succeed");
+            drop(g2);
+        }
+    }
+}
+
+#[cfg(feature = "valkey")]
+pub use valkey::ValkeyLock;

--- a/engine/crates/rocky-fivetran/tests/resilience_tests.rs
+++ b/engine/crates/rocky-fivetran/tests/resilience_tests.rs
@@ -1,0 +1,643 @@
+//! Resilience-layer integration tests.
+//!
+//! Covers the three new defensive layers shipped on top of FR-A / FR-B
+//! Phase 1:
+//!
+//! - Layer 1: cache stampede protection
+//! - Layer 2: FR-B Phase 2 cross-pod budget (file-backend parity here;
+//!   live Valkey behavior is unit-tested in `src/ratelimit_valkey.rs`)
+//! - Layer 3: per-account circuit breaker (in-memory `InMemoryCircuit`
+//!   stand-in for the Valkey state machine)
+//!
+//! The Valkey-backed implementations live behind the `valkey` Cargo
+//! feature and are exercised separately by their crate-local unit
+//! tests; here we use the in-memory + file-backed implementations so
+//! the assertion lives in the default CI build.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rocky_fivetran::circuit_breaker::test_support::InMemoryCircuit;
+use rocky_fivetran::circuit_breaker::{
+    CircuitConfig, CircuitError, CircuitState, FailureKind, FivetranCircuitBreaker,
+};
+use rocky_fivetran::client::{FivetranClient, FivetranError};
+use rocky_fivetran::ratelimit::{BudgetError, FileBudget, RatelimitBudget, build_ratelimit_budget};
+use rocky_fivetran::stampede::{LockError, LockGuard, NoLock, StampedeLock, build_stampede_lock};
+use tokio::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// =============================================================================
+// Layer 3 — circuit breaker state machine via InMemoryCircuit
+// =============================================================================
+
+#[tokio::test]
+async fn circuit_trips_after_threshold_consecutive_failures() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 3,
+        window: Duration::from_secs(60),
+        cooldown: Duration::from_secs(60),
+        cooldown_max: Duration::from_secs(600),
+    });
+
+    // First two failures keep the circuit Closed.
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+
+    // Third failure trips it.
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+}
+
+#[tokio::test]
+async fn circuit_local_failures_do_not_trip() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 2,
+        ..CircuitConfig::default()
+    });
+    for _ in 0..10 {
+        cb.record_failure("acct", FailureKind::Local).await.unwrap();
+    }
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+}
+
+#[tokio::test]
+async fn circuit_cooldown_transitions_to_half_open() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        window: Duration::from_secs(60),
+        cooldown: Duration::from_millis(50),
+        cooldown_max: Duration::from_secs(600),
+    });
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+}
+
+#[tokio::test]
+async fn circuit_half_open_success_closes_breaker() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        cooldown: Duration::from_millis(20),
+        ..CircuitConfig::default()
+    });
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+
+    cb.record_success("acct").await.unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+}
+
+#[tokio::test]
+async fn circuit_half_open_failure_reopens_with_extended_cooldown() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        cooldown: Duration::from_millis(40),
+        cooldown_max: Duration::from_millis(200),
+        ..CircuitConfig::default()
+    });
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(60)).await;
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+
+    // A failure in HalfOpen pushes back to Open with extended
+    // cooldown (40ms → 80ms).
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+
+    // After the original 40ms it must NOT yet be HalfOpen.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+
+    // After 80ms total it should be HalfOpen again.
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+}
+
+#[tokio::test]
+async fn circuit_cooldown_caps_at_cooldown_max() {
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        cooldown: Duration::from_millis(20),
+        cooldown_max: Duration::from_millis(50),
+        ..CircuitConfig::default()
+    });
+    // Drive multiple half-open → open transitions; the cooldown
+    // doubles each time but must not exceed cooldown_max.
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    for _ in 0..6 {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(cb.state("acct").await.unwrap(), CircuitState::HalfOpen);
+        cb.record_failure("acct", FailureKind::Remote)
+            .await
+            .unwrap();
+        assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+    }
+}
+
+// =============================================================================
+// Layer 1 — stampede + cache-poll behavior with HTTP wiremock + in-memory cache
+// =============================================================================
+
+/// In-memory `FivetranStateCache` for client_layered_tests: tracks
+/// reads and writes via shared atomic counters so the test can prove
+/// who actually hit the cache vs the wire.
+#[derive(Debug)]
+struct CountingCache {
+    inner: Mutex<Option<rocky_fivetran::envelope::FivetranStateEnvelope>>,
+    reads: AtomicU32,
+    writes: AtomicU32,
+}
+
+impl CountingCache {
+    fn new() -> Self {
+        CountingCache {
+            inner: Mutex::new(None),
+            reads: AtomicU32::new(0),
+            writes: AtomicU32::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl rocky_fivetran::state_cache::FivetranStateCache for CountingCache {
+    async fn read(
+        &self,
+        _key: &str,
+    ) -> Result<
+        Option<rocky_fivetran::envelope::FivetranStateEnvelope>,
+        rocky_fivetran::state_cache::CacheError,
+    > {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        Ok(self.inner.lock().await.clone())
+    }
+
+    async fn write(
+        &self,
+        _key: &str,
+        envelope: &rocky_fivetran::envelope::FivetranStateEnvelope,
+    ) -> Result<rocky_fivetran::state_cache::WriteOutcome, rocky_fivetran::state_cache::CacheError>
+    {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        *self.inner.lock().await = Some(envelope.clone());
+        Ok(rocky_fivetran::state_cache::WriteOutcome::Written)
+    }
+
+    fn backend(&self) -> &'static str {
+        // Surface as a non-"none" backend so the cache pathway in
+        // fetch_envelope actually exercises read/write.
+        "in_memory_counting"
+    }
+}
+
+/// In-memory leader-elect stampede: the first caller to acquire the
+/// key wins; subsequent callers get `None`. Tracks acquire-count so a
+/// test can prove only one leader was elected. Release is a no-op
+/// for the test — once "held", the key stays held for the duration
+/// of the test (which is exactly what we want when proving 10
+/// concurrent callers see only 1 leader).
+#[derive(Debug)]
+struct InMemoryStampede {
+    held: std::sync::Mutex<std::collections::HashSet<String>>,
+    acquired: AtomicU32,
+}
+
+impl InMemoryStampede {
+    fn new() -> Self {
+        InMemoryStampede {
+            held: std::sync::Mutex::new(std::collections::HashSet::new()),
+            acquired: AtomicU32::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl StampedeLock for InMemoryStampede {
+    async fn acquire(&self, key: &str, _ttl: Duration) -> Result<Option<LockGuard>, LockError> {
+        let inserted = self.held.lock().unwrap().insert(key.to_string());
+        if !inserted {
+            return Ok(None);
+        }
+        self.acquired.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(LockGuard::new(|| {
+            // No-op release; the test asserts on `acquired` count
+            // and the cache for "exactly one leader observed."
+        })))
+    }
+
+    fn backend(&self) -> &'static str {
+        "in_memory_stampede"
+    }
+}
+
+/// Mount one set of endpoints with `expect(1)` so wiremock fails the
+/// test if the API is hit more than once across N concurrent clients.
+async fn mount_layered_envelope_endpoints_once(server: &MockServer, dest_id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/destinations/{dest_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "id": dest_id,
+                "region": "us-east-1",
+                "time_zone": "UTC",
+                "service": "snowflake",
+                "setup_status": "connected"
+            }
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/groups/{dest_id}/connectors")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": "conn_a",
+                        "group_id": dest_id,
+                        "service": "shopify",
+                        "schema": "src__acme__na__shopify",
+                        "connector_name": "Acme Shopify",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "paused": false,
+                        "succeeded_at": "2026-05-18T10:00:00Z",
+                        "failed_at": null
+                    }
+                ],
+                "next_cursor": null
+            }
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/connectors/conn_a/schemas"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "schemas": {
+                    "src__acme__na__shopify": {
+                        "enabled": true,
+                        "tables": {
+                            "orders": {
+                                "enabled": true,
+                                "sync_mode": "SOFT_DELETE",
+                                "columns": {
+                                    "id": { "enabled": true, "hashed": false }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+/// Layered fetch test: 10 concurrent `fetch_envelope` callers share
+/// one stampede lock and one cache, and the wire is hit exactly once.
+///
+/// Because each `FivetranClient` carries its own in-process memo,
+/// concurrent calls on DIFFERENT clients (one per pod) still race
+/// the L0 layer — exactly the cold-start herd this PR addresses.
+#[tokio::test]
+async fn layered_concurrent_callers_collapse_to_one_http_call() {
+    let server = MockServer::start().await;
+    mount_layered_envelope_endpoints_once(&server, "dest_layered").await;
+
+    // Shared coordination layers across all simulated pods. Keep a
+    // typed handle to `CountingCache` so the assertions below can
+    // reach the AtomicU32 counters; clone an `Arc<dyn>` to the
+    // client builder via separate variables.
+    let counting = Arc::new(CountingCache::new());
+    let stampede_inner = Arc::new(InMemoryStampede::new());
+
+    // Build 10 distinct clients (each represents a "pod") all pointing
+    // at the same coordination state — so L0 never short-circuits.
+    let mut tasks = Vec::new();
+    for _ in 0..10 {
+        let cache: Arc<dyn rocky_fivetran::state_cache::FivetranStateCache> = counting.clone();
+        let stampede: Arc<dyn StampedeLock> = stampede_inner.clone();
+        let base = server.uri();
+        tasks.push(tokio::spawn(async move {
+            let client = FivetranClient::with_base_url(
+                "shared-api-key-for-stampede-test".into(),
+                "shared-secret".into(),
+                base,
+            )
+            .with_state_cache(cache)
+            .with_stampede_lock(stampede)
+            // Tighten the follower poll timeout so the test doesn't
+            // wait the default 30s if something goes sideways.
+            .with_stampede_poll_timeout(Duration::from_secs(5))
+            .with_stampede_lock_ttl(Duration::from_secs(10));
+            client.fetch_envelope("dest_layered", false).await
+        }));
+    }
+
+    let mut envelopes = Vec::new();
+    for t in tasks {
+        envelopes.push(t.await.unwrap().expect("fetch must succeed"));
+    }
+
+    // All callers see the same envelope.
+    let first = envelopes.first().unwrap().clone();
+    for env in &envelopes {
+        assert_eq!(env.destination.id, first.destination.id);
+    }
+
+    // wiremock's `.expect(1)` on each endpoint already asserts the
+    // wire was hit exactly once on server drop. Pin the additional
+    // invariants explicitly:
+    // - Exactly one leader wrote the cache (the rest were followers
+    //   who polled the cache).
+    let writes = counting.writes.load(Ordering::SeqCst);
+    assert_eq!(
+        writes, 1,
+        "exactly one leader must write the cache; observed {writes}"
+    );
+    // - Followers polled the cache more than once (at least the
+    //   initial L2 miss + one poll-loop iteration each).
+    let reads = counting.reads.load(Ordering::SeqCst);
+    assert!(reads > 1, "followers must poll the cache; reads = {reads}");
+    // - Exactly one stampede leader was elected.
+    let acquired = stampede_inner.acquired.load(Ordering::SeqCst);
+    assert_eq!(
+        acquired, 1,
+        "exactly one stampede leader must be elected; observed {acquired}"
+    );
+
+    drop(server);
+}
+
+/// Refresh=true bypasses the stampede protection — caller explicitly
+/// wants fresh data, so waiting for another leader's TTL window
+/// would violate intent.
+#[tokio::test]
+async fn refresh_true_bypasses_stampede() {
+    let server = MockServer::start().await;
+    // Both calls below run with refresh=true → each must hit the wire
+    // independently. expect(2) per endpoint.
+    Mock::given(method("GET"))
+        .and(path("/v1/destinations/dest_refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "id": "dest_refresh", "region": null, "time_zone": null,
+                "service": null, "setup_status": null
+            }
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/groups/dest_refresh/connectors"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": { "items": [], "next_cursor": null }
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let stampede: Arc<dyn StampedeLock> = Arc::new(InMemoryStampede::new());
+    let client = FivetranClient::with_base_url("k".into(), "s".into(), server.uri())
+        .with_stampede_lock(stampede.clone());
+
+    let _ = client.fetch_envelope("dest_refresh", true).await.unwrap();
+    let _ = client.fetch_envelope("dest_refresh", true).await.unwrap();
+    drop(server);
+}
+
+// =============================================================================
+// Circuit-open path short-circuits HTTP
+// =============================================================================
+
+/// When the breaker is Open, `fetch_envelope` must return
+/// `FivetranError::CircuitOpen` immediately without touching the
+/// wire. wiremock's `expect(0)` enforces no-HTTP.
+#[tokio::test]
+async fn circuit_open_short_circuits_http() {
+    let server = MockServer::start().await;
+    // No endpoint may be hit — `expect(0)` on a wildcard mount.
+    Mock::given(method("GET"))
+        .and(wiremock::matchers::path_regex(".*"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cb = Arc::new(InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        cooldown: Duration::from_secs(60),
+        ..CircuitConfig::default()
+    }));
+    // Pre-trip the breaker for the account hash this client uses.
+    let api_key = "circuit_test_key";
+    let account_hash = rocky_fivetran::ratelimit::hash_account_id(api_key);
+    cb.record_failure(&account_hash, FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(
+        cb.state(&account_hash).await.unwrap(),
+        CircuitState::Open,
+        "breaker must be Open before the fetch attempt"
+    );
+
+    let client = FivetranClient::with_base_url(api_key.into(), "s".into(), server.uri())
+        .with_circuit_breaker(cb);
+
+    let err = client
+        .fetch_envelope("dest_circuit", false)
+        .await
+        .expect_err("CircuitOpen must short-circuit");
+    assert!(
+        matches!(err, FivetranError::CircuitOpen),
+        "expected CircuitOpen, got {err:?}"
+    );
+    drop(server);
+}
+
+// =============================================================================
+// Layer 2 — FR-B Phase 2 budget trait dispatch (file backend parity)
+// =============================================================================
+
+#[tokio::test]
+async fn ratelimit_budget_factory_defaults_to_file() {
+    let budget = build_ratelimit_budget(None).expect("no config → FileBudget");
+    assert_eq!(budget.backend(), "file");
+}
+
+#[tokio::test]
+async fn ratelimit_budget_factory_resolves_file_backend() {
+    use rocky_core::config::{FivetranRatelimitBackend, FivetranRatelimitConfig};
+    let cfg = FivetranRatelimitConfig {
+        backend: FivetranRatelimitBackend::File,
+        valkey_url: None,
+        max_wake_seconds: None,
+    };
+    let budget = build_ratelimit_budget(Some(&cfg)).expect("file backend");
+    assert_eq!(budget.backend(), "file");
+}
+
+#[tokio::test]
+#[cfg_attr(feature = "valkey", ignore)] // covered by valkey unit tests
+async fn ratelimit_budget_valkey_requires_feature_when_disabled() {
+    use rocky_core::config::{FivetranRatelimitBackend, FivetranRatelimitConfig};
+    let cfg = FivetranRatelimitConfig {
+        backend: FivetranRatelimitBackend::Valkey,
+        valkey_url: Some("redis://localhost:6379/".into()),
+        max_wake_seconds: None,
+    };
+    let err = build_ratelimit_budget(Some(&cfg)).expect_err("valkey requested but feature absent");
+    assert!(matches!(err, BudgetError::Config(_)));
+}
+
+#[tokio::test]
+async fn stampede_factory_defaults_to_no_lock() {
+    let (lock, tunables) = build_stampede_lock(None).expect("no config → NoLock");
+    assert_eq!(lock.backend(), "none");
+    assert!(tunables.lock_ttl > Duration::ZERO);
+    assert!(tunables.poll_timeout > Duration::ZERO);
+}
+
+#[tokio::test]
+async fn stampede_factory_resolves_none_backend() {
+    use rocky_core::config::{FivetranStampedeBackend, FivetranStampedeConfig};
+    let cfg = FivetranStampedeConfig {
+        backend: FivetranStampedeBackend::None,
+        valkey_url: None,
+        lock_ttl_seconds: Some(120),
+        poll_timeout_seconds: Some(45),
+    };
+    let (lock, tunables) = build_stampede_lock(Some(&cfg)).expect("none backend");
+    assert_eq!(lock.backend(), "none");
+    assert_eq!(tunables.lock_ttl, Duration::from_secs(120));
+    assert_eq!(tunables.poll_timeout, Duration::from_secs(45));
+}
+
+#[tokio::test]
+async fn circuit_factory_defaults_to_always_closed() {
+    let cb = rocky_fivetran::circuit_breaker::build_circuit_breaker(None)
+        .expect("no config → AlwaysClosed");
+    assert_eq!(cb.backend(), "none");
+    assert_eq!(cb.state("anything").await.unwrap(), CircuitState::Closed);
+}
+
+#[tokio::test]
+async fn budget_file_backend_isolation() {
+    // Two FileBudgets with distinct dirs do NOT share state. Each
+    // simulated "host" gets its own dir, matching the Phase-1
+    // per-host contract.
+    let tmp_a = tempfile::tempdir().unwrap();
+    let tmp_b = tempfile::tempdir().unwrap();
+    let budget_a: Box<dyn RatelimitBudget> = Box::new(FileBudget::new(tmp_a.path().to_path_buf()));
+    let budget_b: Box<dyn RatelimitBudget> = Box::new(FileBudget::new(tmp_b.path().to_path_buf()));
+
+    let acct = "abc123";
+    let later = std::time::SystemTime::now() + Duration::from_secs(60);
+    budget_a.set_wake_at(acct, later).await.unwrap();
+
+    let from_a = budget_a.wake_at(acct).await.unwrap();
+    let from_b = budget_b.wake_at(acct).await.unwrap();
+    assert!(from_a.is_some(), "budget_a should observe its own write");
+    assert!(
+        from_b.is_none(),
+        "budget_b is isolated; should NOT see budget_a's write"
+    );
+}
+
+// =============================================================================
+// Stampede lock-guard ordering
+// =============================================================================
+
+/// The default `NoLock` backend always returns a guard — every caller
+/// is a leader. Used as the smoke test that the trait dispatch through
+/// the client is wired correctly.
+#[tokio::test]
+async fn nolock_grants_every_caller_as_leader() {
+    let lock = NoLock;
+    let g1 = lock
+        .acquire("k", Duration::from_secs(60))
+        .await
+        .unwrap()
+        .expect("nolock grants");
+    let g2 = lock
+        .acquire("k", Duration::from_secs(60))
+        .await
+        .unwrap()
+        .expect("nolock grants again");
+    drop(g1);
+    drop(g2);
+}
+
+#[tokio::test]
+async fn stampede_factory_threads_ttl_to_client() {
+    // Confirms that the stampede tunables flow into the client's
+    // builder. Regression guard: a refactor that dropped the
+    // `with_stampede_lock_ttl(...)` wiring would silently regress
+    // the Layer 1 SLA.
+    use rocky_core::config::{FivetranStampedeBackend, FivetranStampedeConfig};
+    let cfg = FivetranStampedeConfig {
+        backend: FivetranStampedeBackend::None,
+        valkey_url: None,
+        lock_ttl_seconds: Some(45),
+        poll_timeout_seconds: Some(12),
+    };
+    let (lock, tunables) = build_stampede_lock(Some(&cfg)).unwrap();
+    let _client = FivetranClient::with_base_url("k".into(), "s".into(), "http://localhost".into())
+        .with_stampede_lock(lock)
+        .with_stampede_lock_ttl(tunables.lock_ttl)
+        .with_stampede_poll_timeout(tunables.poll_timeout);
+    // No assertion shape here beyond "compiles + builds without
+    // panicking"; the layered tests above prove the runtime behavior.
+}
+
+#[tokio::test]
+async fn circuit_error_classified_local_does_not_trip() {
+    // Smoke: only Remote failures move the state machine.
+    let cb = InMemoryCircuit::new(CircuitConfig {
+        failure_threshold: 1,
+        ..CircuitConfig::default()
+    });
+    cb.record_failure("acct", FailureKind::Local).await.unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Closed);
+    cb.record_failure("acct", FailureKind::Remote)
+        .await
+        .unwrap();
+    assert_eq!(cb.state("acct").await.unwrap(), CircuitState::Open);
+}
+
+// Touch the CircuitError type so it isn't unused-imported.
+#[allow(dead_code)]
+fn _circuit_error_imported(_e: &CircuitError) {}

--- a/integrations/dagster/src/dagster_rocky/types_generated/adapter_config_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/adapter_config_schema.py
@@ -111,6 +111,170 @@ class FivetranCacheConfig(BaseModel):
     """
 
 
+class FivetranCircuitBreakerBackend1(StrEnum):
+    """
+    No-op breaker; state is always `Closed`. Default when the block is absent.
+    """
+
+    none = "none"
+
+
+class FivetranCircuitBreakerBackend2(StrEnum):
+    """
+    Shared per-account state machine in Valkey. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranCircuitBreakerConfig(BaseModel):
+    """
+    Circuit-breaker config for the Fivetran adapter (Layer 3).
+
+    Trips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).
+
+    State is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.circuit_breaker] backend = "valkey" valkey_url = "rediss://valkey:6379/" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```
+
+    ## Fail-open
+
+    When the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranCircuitBreakerBackend1 | FivetranCircuitBreakerBackend2 | None = (
+        "none"
+    )
+    """
+    Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined.
+    """
+    cooldown_max_seconds: conint(ge=0) | None = None
+    """
+    Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.
+    """
+    cooldown_seconds: conint(ge=0) | None = None
+    """
+    Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.
+    """
+    failure_threshold: conint(ge=0) | None = None
+    """
+    Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+    window_seconds: conint(ge=0) | None = None
+    """
+    Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.
+    """
+
+
+class FivetranRatelimitBackend1(StrEnum):
+    """
+    Per-host file lock (Phase 1 behavior). Default when the block is absent.
+    """
+
+    file = "file"
+
+
+class FivetranRatelimitBackend2(StrEnum):
+    """
+    Shared Valkey key. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranRatelimitConfig(BaseModel):
+    """
+    Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).
+
+    Phase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.ratelimit] backend = "valkey" valkey_url = "rediss://valkey:6379/" ```
+
+    ## Fail-open
+
+    When the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranRatelimitBackend1 | FivetranRatelimitBackend2 | None = "file"
+    """
+    Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined.
+    """
+    max_wake_seconds: conint(ge=0) | None = None
+    """
+    Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+
+
+class FivetranStampedeBackend1(StrEnum):
+    """
+    No-op lock; every caller is treated as the leader. Default when the block is absent.
+    """
+
+    none = "none"
+
+
+class FivetranStampedeBackend2(StrEnum):
+    """
+    Distributed lock via Valkey `SET NX EX`. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranStampedeConfig(BaseModel):
+    """
+    Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).
+
+    On a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.stampede] backend = "valkey" valkey_url = "rediss://valkey:6379/" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```
+
+    ## Fail-open
+
+    When the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranStampedeBackend1 | FivetranStampedeBackend2 | None = "none"
+    """
+    Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined.
+    """
+    lock_ttl_seconds: conint(ge=0) | None = None
+    """
+    Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.
+    """
+    poll_timeout_seconds: conint(ge=0) | None = None
+    """
+    Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+
+
 class RetryConfig(BaseModel):
     """
     Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).
@@ -181,6 +345,12 @@ class AdapterConfig(BaseModel):
 
     When set on a `type = "fivetran"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = "none"` — every fetch goes straight to the Fivetran API.
     """
+    circuit_breaker: FivetranCircuitBreakerConfig | None = None
+    """
+    Optional per-account circuit breaker (Fivetran-only).
+
+    Trips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker).
+    """
     client_id: str | None = None
     client_secret: str | None = None
     database: str | None = None
@@ -222,6 +392,12 @@ class AdapterConfig(BaseModel):
     """
     Google Cloud project ID.
     """
+    ratelimit: FivetranRatelimitConfig | None = None
+    """
+    Optional cross-pod rate-limit budget backend (Fivetran-only).
+
+    Phase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = "valkey"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend.
+    """
     retry: RetryConfig | None = Field(
         {
             "backoff_multiplier": 2.0,
@@ -241,6 +417,12 @@ class AdapterConfig(BaseModel):
     role: str | None = None
     """
     Snowflake role to use for the session.
+    """
+    stampede: FivetranStampedeConfig | None = None
+    """
+    Optional distributed cache-stampede lock (Fivetran-only).
+
+    On a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior).
     """
     timeout_secs: conint(ge=0) | None = None
     token: str | None = None

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -455,6 +455,170 @@ class FivetranCacheConfig(BaseModel):
     """
 
 
+class FivetranCircuitBreakerBackend(StrEnum):
+    """
+    No-op breaker; state is always `Closed`. Default when the block is absent.
+    """
+
+    none = "none"
+
+
+class FivetranCircuitBreakerBackend5(StrEnum):
+    """
+    Shared per-account state machine in Valkey. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranCircuitBreakerConfig(BaseModel):
+    """
+    Circuit-breaker config for the Fivetran adapter (Layer 3).
+
+    Trips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).
+
+    State is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.circuit_breaker] backend = "valkey" valkey_url = "rediss://valkey:6379/" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```
+
+    ## Fail-open
+
+    When the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranCircuitBreakerBackend | FivetranCircuitBreakerBackend5 | None = (
+        "none"
+    )
+    """
+    Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined.
+    """
+    cooldown_max_seconds: conint(ge=0) | None = None
+    """
+    Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.
+    """
+    cooldown_seconds: conint(ge=0) | None = None
+    """
+    Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.
+    """
+    failure_threshold: conint(ge=0) | None = None
+    """
+    Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+    window_seconds: conint(ge=0) | None = None
+    """
+    Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.
+    """
+
+
+class FivetranRatelimitBackend(StrEnum):
+    """
+    Per-host file lock (Phase 1 behavior). Default when the block is absent.
+    """
+
+    file = "file"
+
+
+class FivetranRatelimitBackend5(StrEnum):
+    """
+    Shared Valkey key. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranRatelimitConfig(BaseModel):
+    """
+    Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).
+
+    Phase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.ratelimit] backend = "valkey" valkey_url = "rediss://valkey:6379/" ```
+
+    ## Fail-open
+
+    When the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranRatelimitBackend | FivetranRatelimitBackend5 | None = "file"
+    """
+    Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined.
+    """
+    max_wake_seconds: conint(ge=0) | None = None
+    """
+    Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+
+
+class FivetranStampedeBackend(StrEnum):
+    """
+    No-op lock; every caller is treated as the leader. Default when the block is absent.
+    """
+
+    none = "none"
+
+
+class FivetranStampedeBackend5(StrEnum):
+    """
+    Distributed lock via Valkey `SET NX EX`. Requires the `valkey` Cargo feature.
+    """
+
+    valkey = "valkey"
+
+
+class FivetranStampedeConfig(BaseModel):
+    """
+    Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).
+
+    On a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.
+
+    ## TOML shape
+
+    ```toml [adapter.fivetran.stampede] backend = "valkey" valkey_url = "rediss://valkey:6379/" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```
+
+    ## Fail-open
+
+    When the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    backend: FivetranStampedeBackend | FivetranStampedeBackend5 | None = "none"
+    """
+    Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined.
+    """
+    lock_ttl_seconds: conint(ge=0) | None = None
+    """
+    Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.
+    """
+    poll_timeout_seconds: conint(ge=0) | None = None
+    """
+    Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.
+    """
+    valkey_url: str | None = None
+    """
+    Connection URL for `backend = "valkey"`. Standard `redis://` (plain) or `rediss://` (TLS).
+    """
+
+
 class GrantConfig(BaseModel):
     """
     A permission grant to apply to catalogs or schemas.
@@ -1163,6 +1327,12 @@ class AdapterConfig(BaseModel):
 
     When set on a `type = "fivetran"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = "none"` — every fetch goes straight to the Fivetran API.
     """
+    circuit_breaker: FivetranCircuitBreakerConfig | None = None
+    """
+    Optional per-account circuit breaker (Fivetran-only).
+
+    Trips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker).
+    """
     client_id: str | None = None
     client_secret: str | None = None
     database: str | None = None
@@ -1204,6 +1374,12 @@ class AdapterConfig(BaseModel):
     """
     Google Cloud project ID.
     """
+    ratelimit: FivetranRatelimitConfig | None = None
+    """
+    Optional cross-pod rate-limit budget backend (Fivetran-only).
+
+    Phase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = "valkey"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend.
+    """
     retry: RetryConfig | None = Field(
         {
             "backoff_multiplier": 2.0,
@@ -1223,6 +1399,12 @@ class AdapterConfig(BaseModel):
     role: str | None = None
     """
     Snowflake role to use for the session.
+    """
+    stampede: FivetranStampedeConfig | None = None
+    """
+    Optional distributed cache-stampede lock (Fivetran-only).
+
+    On a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior).
     """
     timeout_secs: conint(ge=0) | None = None
     token: str | None = None

--- a/schemas/adapter_config.schema.json
+++ b/schemas/adapter_config.schema.json
@@ -107,6 +107,195 @@
       },
       "type": "object"
     },
+    "FivetranCircuitBreakerBackend": {
+      "description": "Circuit-breaker backend selector for the Fivetran adapter (Layer 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op breaker; state is always `Closed`. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared per-account state machine in Valkey. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranCircuitBreakerConfig": {
+      "additionalProperties": false,
+      "description": "Circuit-breaker config for the Fivetran adapter (Layer 3).\n\nTrips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).\n\nState is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.\n\n## TOML shape\n\n```toml [adapter.fivetran.circuit_breaker] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```\n\n## Fail-open\n\nWhen the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranCircuitBreakerBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "cooldown_max_seconds": {
+          "description": "Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "cooldown_seconds": {
+          "description": "Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "failure_threshold": {
+          "description": "Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_seconds": {
+          "description": "Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranRatelimitBackend": {
+      "description": "Cross-pod rate-limit budget backend selector for the Fivetran adapter (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "Per-host file lock (Phase 1 behavior). Default when the block is absent.",
+          "enum": [
+            "file"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared Valkey key. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranRatelimitConfig": {
+      "additionalProperties": false,
+      "description": "Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).\n\nPhase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.\n\n## TOML shape\n\n```toml [adapter.fivetran.ratelimit] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" ```\n\n## Fail-open\n\nWhen the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranRatelimitBackend"
+            }
+          ],
+          "default": "file",
+          "description": "Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined."
+        },
+        "max_wake_seconds": {
+          "description": "Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranStampedeBackend": {
+      "description": "Distributed cache-stampede lock backend selector for the Fivetran adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op lock; every caller is treated as the leader. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Distributed lock via Valkey `SET NX EX`. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranStampedeConfig": {
+      "additionalProperties": false,
+      "description": "Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).\n\nOn a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.\n\n## TOML shape\n\n```toml [adapter.fivetran.stampede] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```\n\n## Fail-open\n\nWhen the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranStampedeBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "lock_ttl_seconds": {
+          "description": "Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "poll_timeout_seconds": {
+          "description": "Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "RedactedString": {
       "type": "string"
     },
@@ -216,6 +405,17 @@
         }
       ],
       "description": "Optional cache backend for the Fivetran state envelope.\n\nWhen set on a `type = \"fivetran\"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = \"none\"` — every fetch goes straight to the Fivetran API."
+    },
+    "circuit_breaker": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FivetranCircuitBreakerConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional per-account circuit breaker (Fivetran-only).\n\nTrips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker)."
     },
     "client_id": {
       "type": [
@@ -331,6 +531,17 @@
         "null"
       ]
     },
+    "ratelimit": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FivetranRatelimitConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional cross-pod rate-limit budget backend (Fivetran-only).\n\nPhase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = \"valkey\"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend."
+    },
     "retry": {
       "allOf": [
         {
@@ -355,6 +566,17 @@
         "string",
         "null"
       ]
+    },
+    "stampede": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FivetranStampedeConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional distributed cache-stampede lock (Fivetran-only).\n\nOn a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior)."
     },
     "timeout_secs": {
       "format": "uint64",

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -44,6 +44,17 @@
           ],
           "description": "Optional cache backend for the Fivetran state envelope.\n\nWhen set on a `type = \"fivetran\"` adapter, the resolved envelope is read from and written to the configured cache backend so concurrent `rocky` processes share one fetcher per org. Ignored on every other adapter type. When absent the adapter behaves as if `backend = \"none\"` — every fetch goes straight to the Fivetran API."
         },
+        "circuit_breaker": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranCircuitBreakerConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional per-account circuit breaker (Fivetran-only).\n\nTrips after `failure_threshold` consecutive remote failures and short-circuits subsequent HTTP attempts with a `CircuitOpen` error until a cooldown elapses. Coordinated across processes via the configured backend (Valkey). Ignored on non-fivetran adapters; absent block defaults to `AlwaysClosed` (no breaker)."
+        },
         "client_id": {
           "type": [
             "string",
@@ -158,6 +169,17 @@
             "null"
           ]
         },
+        "ratelimit": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranRatelimitConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional cross-pod rate-limit budget backend (Fivetran-only).\n\nPhase 1 ratelimit coordination is per-host (file in `${TMPDIR}/rocky-fivetran-ratelimit/`). Setting `backend = \"valkey\"` here lifts the budget into a shared store so several pods on different hosts observe the same `wake_at` window after one of them is throttled. Ignored on non-fivetran adapters. When absent the adapter falls back to the per-host file backend."
+        },
         "retry": {
           "allOf": [
             {
@@ -182,6 +204,17 @@
             "string",
             "null"
           ]
+        },
+        "stampede": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FivetranStampedeConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional distributed cache-stampede lock (Fivetran-only).\n\nOn a cold-start herd, N processes simultaneously miss the cache, fan out N API calls, and write back N times. The stampede lock elects a single leader to issue the API call; followers poll the cache until the leader publishes the envelope. Ignored on non-fivetran adapters. When absent the adapter behaves as if every process is the leader (the pre-stampede behavior)."
         },
         "timeout_secs": {
           "format": "uint64",
@@ -869,6 +902,195 @@
         },
         "valkey_url": {
           "description": "Connection URL for `backend = \"valkey\"` or `backend = \"tiered\"` (primary layer). Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranCircuitBreakerBackend": {
+      "description": "Circuit-breaker backend selector for the Fivetran adapter (Layer 3). See [`FivetranCircuitBreakerConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op breaker; state is always `Closed`. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared per-account state machine in Valkey. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranCircuitBreakerConfig": {
+      "additionalProperties": false,
+      "description": "Circuit-breaker config for the Fivetran adapter (Layer 3).\n\nTrips after `failure_threshold` consecutive remote failures (5xx, network errors, exhausted retries) and short-circuits subsequent HTTP attempts with `FivetranError::CircuitOpen` until `cooldown_seconds` elapses. State transitions follow the standard `Closed → Open → HalfOpen → Closed` pattern, with exponentially extended cooldown on repeated half-open failures (capped at `cooldown_max_seconds`).\n\nState is shared across processes via Valkey so a Fivetran outage trips one breaker for the entire org rather than each process independently tripping its own.\n\n## TOML shape\n\n```toml [adapter.fivetran.circuit_breaker] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" failure_threshold = 5 window_seconds = 60 cooldown_seconds = 300 cooldown_max_seconds = 3600 ```\n\n## Fail-open\n\nWhen the state store is unreachable the client behaves as if the breaker is `Closed` — coordination failure must not refuse live traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranCircuitBreakerBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranCircuitBreakerBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "cooldown_max_seconds": {
+          "description": "Upper bound on the exponentially-extended cooldown after repeated half-open failures. Defaults to 3600s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "cooldown_seconds": {
+          "description": "Initial cooldown (seconds) before the breaker transitions `Open → HalfOpen` for a probe. Defaults to 300s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "failure_threshold": {
+          "description": "Consecutive failures required to transition `Closed → Open`. Defaults to 5 when unset.",
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "window_seconds": {
+          "description": "Failure-counting window in seconds. Failures older than the window are not counted toward `failure_threshold`. Defaults to 60s when unset.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranRatelimitBackend": {
+      "description": "Cross-pod rate-limit budget backend selector for the Fivetran adapter (FR-B Phase 2). See [`FivetranRatelimitConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "Per-host file lock (Phase 1 behavior). Default when the block is absent.",
+          "enum": [
+            "file"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Shared Valkey key. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranRatelimitConfig": {
+      "additionalProperties": false,
+      "description": "Cross-pod rate-limit budget config for the Fivetran adapter (FR-B Phase 2).\n\nPhase 1 (shipped in v1.37) writes `wake_at_epoch_ms` to a per-host file under `${TMPDIR}/rocky-fivetran-ratelimit/<account_hash>.json`. That works when several `rocky` processes share a host, but a Kubernetes deployment with one rocky-cli per pod sees N independent budgets even though every pod talks to the same Fivetran org. Lifting the budget into Valkey makes a 429 on one pod throttle every other pod for the same `Retry-After` window.\n\n## TOML shape\n\n```toml [adapter.fivetran.ratelimit] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" ```\n\n## Fail-open\n\nWhen the configured backend is unreachable the client falls back to the per-host file backend. The cluster regresses to Phase 1 behavior (each host enforces its own budget) rather than blocking traffic.",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranRatelimitBackend"
+            }
+          ],
+          "default": "file",
+          "description": "Which backend to instantiate. Defaults to [`FivetranRatelimitBackend::File`] so a stub block with no `backend` key is well-defined."
+        },
+        "max_wake_seconds": {
+          "description": "Cap (seconds) applied to the Valkey key's `EXPIRE` so an abandoned `wake_at` value never outlives its useful window. Defaults to 600s when unset; ignored for the file backend.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FivetranStampedeBackend": {
+      "description": "Distributed cache-stampede lock backend selector for the Fivetran adapter (Layer 1). See [`FivetranStampedeConfig`] for the TOML shape.",
+      "oneOf": [
+        {
+          "description": "No-op lock; every caller is treated as the leader. Default when the block is absent.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Distributed lock via Valkey `SET NX EX`. Requires the `valkey` Cargo feature.",
+          "enum": [
+            "valkey"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "FivetranStampedeConfig": {
+      "additionalProperties": false,
+      "description": "Distributed cache-stampede protection config for the Fivetran adapter (Layer 1).\n\nOn a cold-start burst, N processes can simultaneously observe the cache miss, fan out N API calls, and write back N copies of the same envelope. The stampede lock elects a single leader (via `SET <key>:lock <id> NX EX <ttl>` against Valkey) to do the API call; followers wait on the cache key with bounded polling until the leader's write becomes visible, then return.\n\n## TOML shape\n\n```toml [adapter.fivetran.stampede] backend = \"valkey\" valkey_url = \"rediss://valkey:6379/\" lock_ttl_seconds = 60 poll_timeout_seconds = 30 ```\n\n## Fail-open\n\nWhen the lock backend is unreachable the client falls through to the direct HTTP path (no stampede protection, but no block).",
+      "properties": {
+        "backend": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FivetranStampedeBackend"
+            }
+          ],
+          "default": "none",
+          "description": "Which backend to instantiate. Defaults to [`FivetranStampedeBackend::None`] so a stub block with no `backend` key is well-defined."
+        },
+        "lock_ttl_seconds": {
+          "description": "Lock TTL applied to the `SET NX EX <ttl>` call. The lock auto-expires after this many seconds so a crashed leader doesn't park every follower forever. Defaults to 60s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "poll_timeout_seconds": {
+          "description": "Hard cap on how long a follower will poll the cache before falling through to a direct HTTP fetch. Defaults to 30s.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "valkey_url": {
+          "description": "Connection URL for `backend = \"valkey\"`. Standard `redis://` (plain) or `rediss://` (TLS).",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary

Adds three orthogonal resilience layers on top of the existing FR-A envelope cache and FR-B Phase 1 per-host rate-limit budget. Each layer is opt-in via a `[adapter.fivetran.<layer>]` block and fail-open when its coordination backend is unreachable.

- **L1 — Cache stampede protection** (new module `stampede.rs`): distributed Valkey `SET NX EX` lock elects one leader per cache key on a cold-start herd; followers poll the cache (exponential 100ms → 2s, capped at the configured `poll_timeout_seconds`). Converts an N-pod cold-start burst from `N` API calls to `1` API call per TTL window.
- **L3 — Cross-pod rate-limit budget** (new module `ratelimit_valkey.rs`): lifts FR-B Phase 1's per-host file backend into a shared Valkey key. Atomic max-merge via Lua `EVAL` so two concurrent throttle observations can't regress `wake_at`. Falls back to the file backend when the block is absent.
- **L4 — Per-account circuit breaker** (new module `circuit_breaker.rs`): trips after N consecutive remote failures; `HalfOpen` probe → `Closed` on success or `Open` with exponential cooldown on failure (capped at `cooldown_max_seconds`). New `FivetranError::CircuitOpen` variant short-circuits HTTP when the breaker is `Open`. Per-account state coordinated via Valkey.

## Layered fetch sequence

`FivetranClient::fetch_envelope` now walks:

```
L0 in-process memo → L2 state cache read → L1 stampede acquire →
  (leader)  L4 circuit check → HTTP → L3 budget wait + L5 backoff → cache write
  (follower) poll cache for leader's write → return
```

`refresh = true` bypasses L0/L2/L1 (caller explicitly wants fresh data); the circuit check (L4) still runs so an `Open` breaker short-circuits on `--no-cache` refreshes too.

## Configs

```toml
[adapter.fivetran.ratelimit]
backend = "valkey"        # "file" (default) | "valkey"
valkey_url = "rediss://..."
max_wake_seconds = 600    # default

[adapter.fivetran.stampede]
backend = "valkey"        # "none" (default) | "valkey"
valkey_url = "rediss://..."
lock_ttl_seconds = 60     # default
poll_timeout_seconds = 30 # default

[adapter.fivetran.circuit_breaker]
backend = "valkey"          # "none" (default) | "valkey"
valkey_url = "rediss://..."
failure_threshold = 5       # default
window_seconds = 60         # default
cooldown_seconds = 300      # default
cooldown_max_seconds = 3600 # default
```

All three blocks validated at `load_rocky_config` time via `validate_fivetran_resilience` — a missing `valkey_url` fails fast instead of degrading silently at first request.

## Feature gating

All three Valkey backends sit behind the existing `valkey` Cargo feature (reused from FR-A). The default build doesn't pull the Redis client transitively.

| Layer | Default backend | Valkey backend | Behind `valkey` feature |
|---|---|---|---|
| L1 Stampede | `NoLock` | `ValkeyLock` | yes |
| L3 Budget   | `FileBudget` | `ValkeyBudget` | yes |
| L4 Circuit  | `AlwaysClosed` | `ValkeyCircuit` | yes |

## Fail-open behavior

| Failure | Effect |
|---|---|
| Stampede backend unreachable | Direct HTTP fetch (no protection, but no block) |
| Budget storage unreachable | Falls back to per-host `FileBudget` |
| Circuit state read failed | Treated as `Closed` (don't refuse traffic because coordination is down) |

## Bonus — `[adapter.fivetran.retry]`

The plan flagged this as a missing config wire-up; on inspection it was already wired through serde on the shared `AdapterConfig.retry` field. Added `retry_config_threads_through_fivetran_adapter` as a regression test to pin that TOML deserialization continues to work.

## OTLP span events

- `fivetran.stampede_acquired` — leader path taken (`key`, `ttl_seconds`, `backend`)
- `fivetran.stampede_polled` — follower path resolved (`key`, `waited_ms`, `outcome` ∈ `cache_hit` | `timeout_direct_fetch`)
- `fivetran.stampede_unavailable` — lock backend errored (`backend`, `error`)
- `fivetran.circuit_state_change` — state machine transitioned (`from_state`, `to_state`, `reason`)
- `fivetran.rate_limit_observed` — already existed; gained a `ratelimit_backend` attribute so dashboards can distinguish file vs Valkey

## Concurrency notes

- `ValkeyBudget.set_wake_at` uses a Lua `EVAL` that atomically max-merges incoming vs current `wake_at` — concurrent writes always converge to the later wake-up.
- `ValkeyLock.acquire` uses standard `SET NX EX`; `Drop` releases via a check-and-DEL Lua script so a TTL-expired leader can't accidentally delete a re-acquired lock.
- `ValkeyCircuit` persists state via read-modify-write `GET` + `SET EX` rather than a Lua transaction. Concurrent `record_failure` calls can lose at most a small number of increments, so the breaker may trip 1-2 failures *above* `failure_threshold` under sustained contention. Documented inline; trip semantics still converge to `Open` quickly during a real outage. (If a deployment needs exact threshold semantics, drop the breaker and rely on L3 + the retry budget — both are stricter coordination layers.)

## Test plan

- [x] `cargo build --release --all-features` passes
- [x] `cargo build --features valkey -p rocky-fivetran` passes
- [x] `cargo test --all-features -p rocky-fivetran -p rocky-cli -p rocky-core` passes — 1948 tests total
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `just codegen` cascades cleanly into `schemas/`, dagster Pydantic, VS Code TS without manual edits
- [x] `just regen-fixtures` produces no playground POC drift
- [x] New 19-test `resilience_tests.rs` integration suite covers:
  - circuit state machine (trip / cooldown / half-open success / half-open failure / cap / local-failure-no-op)
  - layered concurrent callers (10 pods → 1 HTTP, 1 cache write, > 1 cache reads, 1 leader elected)
  - `refresh = true` bypasses stampede
  - `Open` breaker short-circuits HTTP (`expect(0)` on all endpoints)
  - config factories default correctly and thread tunables into the client
- [x] 9 new config-validation tests in `rocky-core::config::tests` for the three resilience blocks + regression test for the `retry` block
- [ ] Live Valkey verification: gated behind `ROCKY_TEST_VALKEY_URL`; unit + integration coverage uses `wiremock` + an `InMemoryCircuit` stand-in. Full live-verify deferred to whoever runs Rocky against their org first.