### PR TITLE
feat(rocky-compiler): import-dbt maps view/materialized_view/microbatch + structured warnings

### DIFF
--- a/editors/vscode/src/types/generated/import_dbt.ts
+++ b/editors/vscode/src/types/generated/import_dbt.ts
@@ -6,6 +6,56 @@
  */
 
 /**
+ * Typed structured warning for dbt config that Rocky can't translate automatically. Each variant carries the source payload so the downstream UI (Dagster, VS Code) can route specific kinds into per-kind UI affordances without parsing free-form text.
+ */
+export type ImportDbtStructuredWarning =
+  | {
+      action: string;
+      dbt_materialization: string;
+      kind: "unsupported_materialization";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "dropped_databricks_tags";
+      model: string;
+      tags: {
+        [k: string]: string;
+      };
+      [k: string]: unknown;
+    }
+  | {
+      hook_kind: ImportDbtHookKind;
+      kind: "dropped_hook";
+      model: string;
+      sql: string;
+      [k: string]: unknown;
+    }
+  | {
+      dbt_value: string;
+      kind: "dropped_on_schema_change";
+      model: string;
+      rocky_equivalent: string;
+      [k: string]: unknown;
+    }
+  | {
+      first_call_site_line: number;
+      kind: "unresolvable_macro";
+      macro_name: string;
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "microbatch_missing_event_time";
+      model: string;
+      [k: string]: unknown;
+    };
+/**
+ * Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
+ */
+export type ImportDbtHookKind = "pre" | "post";
+
+/**
  * JSON output for `rocky import-dbt`.
  *
  * The `report` field is the per-model migration report from `rocky_compiler::import::report::generate_report`. We hold it as `serde_json::Value` (typed as `any` in JSON Schema) to avoid pulling `JsonSchema` derives all the way through `rocky-compiler::import`. The downstream Pydantic/TS bindings will see it as a free-form object.
@@ -32,6 +82,10 @@ export interface ImportDbtOutput {
   };
   sources_found: number;
   sources_mapped: number;
+  /**
+   * Typed structured warnings — payload-carrying variants for dbt config Rocky can't auto-translate (dropped tags, dropped hooks, unresolvable macros, etc.). Coexists with `warning_details` — orchestrators that don't know about this field still see the flat string warnings under `warning_details`.
+   */
+  structured_warnings?: ImportDbtStructuredWarning[];
   tests_converted: number;
   tests_converted_custom: number;
   tests_found: number;

--- a/editors/vscode/src/types/generated/index.ts
+++ b/editors/vscode/src/types/generated/index.ts
@@ -146,6 +146,8 @@ export type {
   ImportDbtOutput,
   ImportDbtWarning,
   ImportDbtFailure,
+  ImportDbtHookKind,
+  ImportDbtStructuredWarning,
 } from "./import_dbt";
 
 // Hooks list + test

--- a/engine/crates/rocky-cli/src/commands/import_dbt.rs
+++ b/engine/crates/rocky-cli/src/commands/import_dbt.rs
@@ -30,7 +30,7 @@ use anyhow::Result;
 
 use rocky_compiler::import::{
     dbt,
-    dbt::{ImportResult, WarningCategory},
+    dbt::{HookKind, ImportDbtStructuredWarning as CompilerStructuredWarning, ImportResult},
     dbt_manifest, dbt_profiles,
     dbt_profiles::{AdapterKind, ProfileResolution, StubReason},
     emit,
@@ -40,7 +40,8 @@ use rocky_compiler::import::{
 use rocky_core::models::TargetConfig;
 
 use crate::output::{
-    ImportDbtEmission, ImportDbtFailure, ImportDbtOutput, ImportDbtWarning, print_json,
+    ImportDbtEmission, ImportDbtFailure, ImportDbtHookKind, ImportDbtOutput,
+    ImportDbtStructuredWarning, ImportDbtWarning, print_json,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -100,6 +101,12 @@ pub fn run_import_dbt(
             })
             .collect();
 
+        let structured_warnings: Vec<ImportDbtStructuredWarning> = import_result
+            .structured_warnings
+            .iter()
+            .map(to_cli_structured_warning)
+            .collect();
+
         let failed_details: Vec<ImportDbtFailure> = import_result
             .failed
             .iter()
@@ -145,6 +152,7 @@ pub fn run_import_dbt(
                 .map(|m| m.name.clone())
                 .collect(),
             warning_details,
+            structured_warnings,
             failed_details,
             report: serde_json::to_value(&migration_report).unwrap_or(serde_json::Value::Null),
             emission: Some(emission_payload),
@@ -266,14 +274,68 @@ fn run_importer(
     }
 }
 
-fn collect_view_flattened_models(result: &ImportResult) -> BTreeSet<String> {
-    result
-        .warnings
-        .iter()
-        .filter(|w| {
-            w.category == WarningCategory::UnsupportedMaterialization
-                && w.message.contains("'view'")
-        })
-        .map(|w| w.model.clone())
-        .collect()
+fn collect_view_flattened_models(_result: &ImportResult) -> BTreeSet<String> {
+    // Wave 2: `view` maps to `StrategyConfig::View` directly, so there's
+    // no longer a flattening step to compensate for at emit time. The
+    // BTreeSet is retained on `EmitInputs` for back-compat and always
+    // empty here.
+    BTreeSet::new()
+}
+
+/// Translate a `rocky-compiler`-side structured warning into the
+/// CLI-output flavor (which has `JsonSchema` derives + serde tags
+/// suitable for codegen cascade).
+fn to_cli_structured_warning(w: &CompilerStructuredWarning) -> ImportDbtStructuredWarning {
+    match w {
+        CompilerStructuredWarning::UnsupportedMaterialization {
+            model,
+            dbt_materialization,
+            action,
+        } => ImportDbtStructuredWarning::UnsupportedMaterialization {
+            model: model.clone(),
+            dbt_materialization: dbt_materialization.clone(),
+            action: action.clone(),
+        },
+        CompilerStructuredWarning::DroppedDatabricksTags { model, tags } => {
+            ImportDbtStructuredWarning::DroppedDatabricksTags {
+                model: model.clone(),
+                tags: tags.clone(),
+            }
+        }
+        CompilerStructuredWarning::DroppedHook {
+            model,
+            hook_kind,
+            sql,
+        } => ImportDbtStructuredWarning::DroppedHook {
+            model: model.clone(),
+            hook_kind: match hook_kind {
+                HookKind::Pre => ImportDbtHookKind::Pre,
+                HookKind::Post => ImportDbtHookKind::Post,
+            },
+            sql: sql.clone(),
+        },
+        CompilerStructuredWarning::DroppedOnSchemaChange {
+            model,
+            dbt_value,
+            rocky_equivalent,
+        } => ImportDbtStructuredWarning::DroppedOnSchemaChange {
+            model: model.clone(),
+            dbt_value: dbt_value.clone(),
+            rocky_equivalent: rocky_equivalent.clone(),
+        },
+        CompilerStructuredWarning::UnresolvableMacro {
+            model,
+            macro_name,
+            first_call_site_line,
+        } => ImportDbtStructuredWarning::UnresolvableMacro {
+            model: model.clone(),
+            macro_name: macro_name.clone(),
+            first_call_site_line: *first_call_site_line,
+        },
+        CompilerStructuredWarning::MicrobatchMissingEventTime { model } => {
+            ImportDbtStructuredWarning::MicrobatchMissingEventTime {
+                model: model.clone(),
+            }
+        }
+    }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2702,6 +2702,13 @@ pub struct ImportDbtOutput {
     pub macros_detected: usize,
     pub imported_models: Vec<String>,
     pub warning_details: Vec<ImportDbtWarning>,
+    /// Typed structured warnings — payload-carrying variants for dbt
+    /// config Rocky can't auto-translate (dropped tags, dropped hooks,
+    /// unresolvable macros, etc.). Coexists with `warning_details` —
+    /// orchestrators that don't know about this field still see the
+    /// flat string warnings under `warning_details`.
+    #[serde(default)]
+    pub structured_warnings: Vec<ImportDbtStructuredWarning>,
     pub failed_details: Vec<ImportDbtFailure>,
     /// Free-form per-model migration report payload.
     pub report: serde_json::Value,
@@ -2749,6 +2756,62 @@ pub struct ImportDbtWarning {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<String>,
+}
+
+/// Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportDbtHookKind {
+    Pre,
+    Post,
+}
+
+/// Typed structured warning for dbt config that Rocky can't translate
+/// automatically. Each variant carries the source payload so the
+/// downstream UI (Dagster, VS Code) can route specific kinds into
+/// per-kind UI affordances without parsing free-form text.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ImportDbtStructuredWarning {
+    /// A dbt materialization with no direct Rocky equivalent. The
+    /// importer fell back to the closest match (typically
+    /// `full_refresh`).
+    UnsupportedMaterialization {
+        model: String,
+        dbt_materialization: String,
+        action: String,
+    },
+    /// `databricks_tags` block dropped — Rocky's `[classification]`
+    /// block + `rocky-databricks` governance surface covers the same
+    /// use case but requires manual config.
+    DroppedDatabricksTags {
+        model: String,
+        tags: std::collections::BTreeMap<String, String>,
+    },
+    /// `pre_hook` or `post_hook` dropped — Rocky supports lifecycle
+    /// hooks via the `[[hook]]` block in `rocky.toml`.
+    DroppedHook {
+        model: String,
+        hook_kind: ImportDbtHookKind,
+        sql: String,
+    },
+    /// `on_schema_change` dropped — Rocky exposes the equivalent via
+    /// per-pipeline `[drift]` policy.
+    DroppedOnSchemaChange {
+        model: String,
+        dbt_value: String,
+        rocky_equivalent: String,
+    },
+    /// A custom Jinja macro call survived `dbt compile` — defined
+    /// out-of-tree. The user needs to hand-port the macro.
+    UnresolvableMacro {
+        model: String,
+        macro_name: String,
+        first_call_site_line: usize,
+    },
+    /// A microbatch model is missing the required `event_time` field —
+    /// the importer fell back to `full_refresh`.
+    MicrobatchMissingEventTime { model: String },
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/engine/crates/rocky-cli/tests/import_dbt_emit.rs
+++ b/engine/crates/rocky-cli/tests/import_dbt_emit.rs
@@ -9,7 +9,8 @@
 //! - `seeds/` mirrors the source `seeds/` verbatim.
 //! - `MIGRATION-NOTES.md` exists and lists the known limitations.
 //! - The translated model sidecars use the documented mapping
-//!   (`view → ephemeral`, `incremental → merge|incremental`, default → full_refresh).
+//!   (`view → view`, `materialized_view → materialized_view`,
+//!   `incremental → merge|incremental`, default → full_refresh).
 //! - `dbt_packages/` and `snapshots/` trees are left untouched (no models, no failures).
 //! - A model with `{% if target.name %}` lands as imported + JinjaControlFlow warning
 //!   with the `dbt-jinja-not-translated` marker in the emitted SQL.
@@ -20,8 +21,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use rocky_compiler::import::{
-    dbt::{self, ImportResult},
-    dbt_profiles,
+    dbt, dbt_profiles,
     emit::{self, EmitInputs, OverwritePolicy},
 };
 use rocky_core::config;
@@ -29,18 +29,6 @@ use rocky_core::models::{StrategyConfig, TargetConfig};
 
 fn fixture_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/dbt-rich")
-}
-
-fn collect_view_flattened(result: &ImportResult) -> BTreeSet<String> {
-    result
-        .warnings
-        .iter()
-        .filter(|w| {
-            matches!(w.category, dbt::WarningCategory::UnsupportedMaterialization)
-                && w.message.contains("'view'")
-        })
-        .map(|w| w.model.clone())
-        .collect()
 }
 
 #[test]
@@ -77,10 +65,12 @@ fn emit_runnable_repo_from_rich_fixture() {
         "fct_orders should be in imported models"
     );
 
-    let view_models = collect_view_flattened(&result);
+    // Wave 2: `view → StrategyConfig::View` directly; no flattening
+    // compensation needed at emit time.
     assert!(
-        view_models.contains("stg_customers"),
-        "stg_customers materialized='view' should be flagged for ephemeral rewrite"
+        result.imported.iter().any(|m| m.name == "stg_customers"
+            && matches!(m.config.strategy, StrategyConfig::View)),
+        "stg_customers materialized='view' should map to StrategyConfig::View"
     );
 
     let emission = emit::emit_repo(&EmitInputs {
@@ -91,7 +81,7 @@ fn emit_runnable_repo_from_rich_fixture() {
         default_catalog: &default_target.catalog,
         default_schema: &default_target.schema,
         import: &result,
-        view_models_to_make_ephemeral: view_models,
+        view_models_to_make_ephemeral: BTreeSet::new(),
         adapter_override_label: None,
     })
     .expect("emit_repo writes a runnable repo");
@@ -159,12 +149,12 @@ fn emit_runnable_repo_from_rich_fixture() {
         assert!(toml.exists(), "{name}.toml exists");
     }
 
-    // Strategy mapping check.
+    // Strategy mapping check. Wave 2: view → view (was: view → ephemeral).
     let stg_customers_toml =
         std::fs::read_to_string(models_dir.join("stg_customers.toml")).unwrap();
     assert!(
-        stg_customers_toml.contains("type = \"ephemeral\""),
-        "view → ephemeral mapping must apply"
+        stg_customers_toml.contains("type = \"view\""),
+        "view → view mapping must apply, got: {stg_customers_toml}"
     );
     let stg_orders_toml = std::fs::read_to_string(models_dir.join("stg_orders.toml")).unwrap();
     // incremental + unique_key → merge in the existing importer
@@ -201,7 +191,7 @@ fn emit_runnable_repo_from_rich_fixture() {
         .unwrap();
     assert!(matches!(
         stg_customers.config.strategy,
-        StrategyConfig::Ephemeral
+        StrategyConfig::View
     ));
     let fct_orders = models
         .iter()

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -17,14 +17,15 @@
 //! **Not supported (produces diagnostics):**
 //! - Custom Jinja macros, `{% for %}`, `{{ var() }}`, Python models
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use regex::Regex;
+use rocky_ir::TimeGrain;
 
 use rocky_core::models::{ModelConfig, StrategyConfig, TargetConfig};
 
-use super::dbt_manifest::{self, DbtManifest, DbtManifestNode, UniqueKeyValue};
+use super::dbt_manifest::{self, DbtManifest, DbtManifestNode, DbtNodeConfig, UniqueKeyValue};
 use super::dbt_project::{self, DbtProjectConfig};
 use super::dbt_sources;
 
@@ -68,6 +69,67 @@ pub struct ImportWarning {
     pub suggestion: Option<String>,
 }
 
+/// Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookKind {
+    Pre,
+    Post,
+}
+
+/// A structured warning carrying typed payload data for dbt-side config
+/// that Rocky can't translate automatically. Surfaces in
+/// `ImportDbtOutput.structured_warnings` so callers (Dagster, vscode) can
+/// route specific kinds (e.g. dropped tags, dropped hooks) into UI
+/// affordances without parsing free-form `message` text.
+///
+/// Coexists with the flat `ImportWarning` surface — string warnings stay
+/// for back-compat with existing orchestrators.
+#[derive(Debug, Clone)]
+pub enum ImportDbtStructuredWarning {
+    /// dbt materialization that has no direct Rocky equivalent. The
+    /// importer fell back to the closest match (typically `FullRefresh`).
+    UnsupportedMaterialization {
+        model: String,
+        dbt_materialization: String,
+        action: String,
+    },
+    /// dbt-databricks `databricks_tags` block was dropped — Rocky's
+    /// `[classification]` block + `rocky-databricks` governance surface
+    /// covers the same use case but requires manual config.
+    DroppedDatabricksTags {
+        model: String,
+        tags: BTreeMap<String, String>,
+    },
+    /// A `pre_hook` or `post_hook` was dropped — Rocky supports lifecycle
+    /// hooks via the `[[hook]]` block in `rocky.toml` but the importer
+    /// doesn't auto-translate per-model dbt hooks.
+    DroppedHook {
+        model: String,
+        hook_kind: HookKind,
+        sql: String,
+    },
+    /// `on_schema_change` was dropped — Rocky exposes the equivalent
+    /// behavior via per-pipeline `[drift]` policy.
+    DroppedOnSchemaChange {
+        model: String,
+        dbt_value: String,
+        rocky_equivalent: String,
+    },
+    /// A custom Jinja macro call survived compilation (i.e. dbt's compile
+    /// step didn't inline it because it's defined out-of-tree). The user
+    /// has to hand-port the macro or rewrite the model.
+    UnresolvableMacro {
+        model: String,
+        macro_name: String,
+        first_call_site_line: usize,
+    },
+    /// A microbatch model is missing `event_time` — dbt-databricks
+    /// requires this field. The importer falls back to `FullRefresh` and
+    /// surfaces the gap so the user can either add `event_time` to the
+    /// dbt source or pick a non-microbatch strategy.
+    MicrobatchMissingEventTime { model: String },
+}
+
 /// A model that failed to import.
 #[derive(Debug, Clone)]
 pub struct ImportFailure {
@@ -79,8 +141,13 @@ pub struct ImportFailure {
 pub struct ImportResult {
     /// Successfully imported models (name, SQL, config).
     pub imported: Vec<ImportedModel>,
-    /// Structured warnings.
+    /// Free-form warnings — string `message` + category enum. Existing
+    /// orchestrator-visible surface; kept stable for back-compat.
     pub warnings: Vec<ImportWarning>,
+    /// Typed structured warnings — payload-carrying variants that
+    /// downstream UIs can pattern-match on (e.g. dropped tags, dropped
+    /// hooks). New in Wave 2.
+    pub structured_warnings: Vec<ImportDbtStructuredWarning>,
     /// Models that could not be imported.
     pub failed: Vec<ImportFailure>,
     /// Number of dbt source definitions found.
@@ -130,6 +197,7 @@ pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfi
     let mut result = ImportResult {
         imported: Vec::new(),
         warnings: Vec::new(),
+        structured_warnings: Vec::new(),
         failed: Vec::new(),
         sources_found: manifest.sources.len(),
         sources_mapped: manifest.sources.len(),
@@ -264,9 +332,26 @@ fn import_manifest_node(
         }
     };
 
-    // Map strategy from manifest config
-    let (strategy, strategy_warnings) = manifest_config_to_strategy(&node.config, &node.name);
+    // Map strategy from manifest config — covers all dbt materializations
+    // (`table`, `view`, `materialized_view`, `incremental`, `ephemeral`,
+    // `microbatch`) plus the `incremental_strategy` discriminator.
+    let StrategyMappingOutput {
+        strategy,
+        warnings: strategy_warnings,
+        structured,
+    } = map_manifest_strategy(&node.config, &node.name);
     result.warnings.extend(strategy_warnings);
+    result.structured_warnings.extend(structured);
+
+    // Surface dbt-databricks specifics that Rocky doesn't auto-translate
+    // (databricks_tags, pre/post hooks, on_schema_change). Emitted as
+    // structured warnings so the downstream UI can route them.
+    collect_dropped_config_warnings(&node.config, &node.name, result);
+
+    // Detect unresolvable Jinja macros that survived `dbt compile`. dbt's
+    // compile step inlines in-tree macros, so anything still present
+    // points at an out-of-tree macro the user needs to hand-port.
+    collect_unresolvable_macros(&sql, &node.name, result);
 
     // Map dependencies
     let depends_on = dbt_manifest::depends_on_to_rocky(&node.depends_on.nodes);
@@ -316,57 +401,396 @@ fn import_manifest_node(
     });
 }
 
-fn manifest_config_to_strategy(
-    config: &super::dbt_manifest::DbtNodeConfig,
-    model_name: &str,
-) -> (StrategyConfig, Vec<ImportWarning>) {
-    let mut warnings = Vec::new();
+/// Output of mapping a dbt node config to a Rocky strategy. Returns the
+/// chosen [`StrategyConfig`] plus both warning kinds (the back-compat
+/// string warnings + the new structured variants).
+struct StrategyMappingOutput {
+    strategy: StrategyConfig,
+    warnings: Vec<ImportWarning>,
+    structured: Vec<ImportDbtStructuredWarning>,
+}
 
-    match config.materialized.as_str() {
-        "incremental" => {
-            if let Some(ref uk) = config.unique_key {
-                let keys = match uk {
-                    UniqueKeyValue::Single(s) => vec![s.clone()],
-                    UniqueKeyValue::Multiple(v) => v.clone(),
-                };
-                (
-                    StrategyConfig::Merge {
-                        unique_key: keys,
-                        update_columns: None,
-                    },
-                    warnings,
-                )
-            } else {
-                (
-                    StrategyConfig::Incremental {
-                        timestamp_column: "updated_at".to_string(),
-                    },
-                    warnings,
-                )
-            }
-        }
-        "view" => {
-            warnings.push(ImportWarning {
-                model: model_name.to_string(),
-                category: WarningCategory::UnsupportedMaterialization,
-                message: "materialized='view' not supported — using full_refresh".to_string(),
-                suggestion: Some(
-                    "consider using materialized='table' or 'incremental' in Rocky".to_string(),
-                ),
-            });
-            (StrategyConfig::FullRefresh, warnings)
-        }
+/// Map a dbt node config to a Rocky [`StrategyConfig`].
+///
+/// Covers `table` / `view` / `materialized_view` / `incremental`
+/// (across all `incremental_strategy` values) / `ephemeral` /
+/// `microbatch`. Unknown materializations fall back to `FullRefresh` with
+/// a warning.
+fn map_manifest_strategy(config: &DbtNodeConfig, model_name: &str) -> StrategyMappingOutput {
+    let mut warnings = Vec::new();
+    let mut structured = Vec::new();
+
+    let strategy = match config.materialized.as_str() {
+        "table" => StrategyConfig::FullRefresh,
+        "view" => StrategyConfig::View,
+        "materialized_view" => StrategyConfig::MaterializedView,
         "ephemeral" => {
             warnings.push(ImportWarning {
                 model: model_name.to_string(),
                 category: WarningCategory::UnsupportedMaterialization,
-                message: "materialized='ephemeral' not supported — using full_refresh".to_string(),
-                suggestion: Some("inline the SQL into downstream models".to_string()),
+                message: "materialized='ephemeral' has no Rocky equivalent — using full_refresh"
+                    .to_string(),
+                suggestion: Some(
+                    "ephemeral models inline into downstream queries; consider folding the SQL into the consumer or keeping it as a `full_refresh` table".to_string(),
+                ),
             });
-            (StrategyConfig::FullRefresh, warnings)
+            structured.push(ImportDbtStructuredWarning::UnsupportedMaterialization {
+                model: model_name.to_string(),
+                dbt_materialization: "ephemeral".to_string(),
+                action: "fell back to full_refresh".to_string(),
+            });
+            StrategyConfig::FullRefresh
         }
-        _ => (StrategyConfig::FullRefresh, warnings),
+        "incremental" => map_incremental_strategy(config, model_name, &mut warnings),
+        "microbatch" => map_microbatch_strategy(config, model_name, &mut warnings, &mut structured),
+        other => {
+            warnings.push(ImportWarning {
+                model: model_name.to_string(),
+                category: WarningCategory::UnsupportedMaterialization,
+                message: format!(
+                    "materialized='{other}' not recognized by Rocky — using full_refresh"
+                ),
+                suggestion: Some(
+                    "set `type` in the emitted strategy block to a Rocky-supported value (full_refresh / incremental / merge / view / materialized_view / dynamic_table / time_interval / delete_insert / microbatch)".to_string(),
+                ),
+            });
+            structured.push(ImportDbtStructuredWarning::UnsupportedMaterialization {
+                model: model_name.to_string(),
+                dbt_materialization: other.to_string(),
+                action: "fell back to full_refresh".to_string(),
+            });
+            StrategyConfig::FullRefresh
+        }
+    };
+
+    StrategyMappingOutput {
+        strategy,
+        warnings,
+        structured,
     }
+}
+
+/// Map `materialized='incremental'` + `incremental_strategy=<...>` to the
+/// appropriate Rocky strategy variant.
+fn map_incremental_strategy(
+    config: &DbtNodeConfig,
+    model_name: &str,
+    warnings: &mut Vec<ImportWarning>,
+) -> StrategyConfig {
+    let unique_keys: Option<Vec<String>> = config.unique_key.as_ref().map(|uk| match uk {
+        UniqueKeyValue::Single(s) => vec![s.clone()],
+        UniqueKeyValue::Multiple(v) => v.clone(),
+    });
+
+    // Default discriminator: `append` if no unique_key, else `merge`.
+    // dbt-databricks treats unique_key as implying merge semantics when
+    // incremental_strategy is unset.
+    let strategy_kind = config
+        .incremental_strategy
+        .as_deref()
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_else(|| {
+            if unique_keys.is_some() {
+                "merge".to_string()
+            } else {
+                "append".to_string()
+            }
+        });
+
+    match strategy_kind.as_str() {
+        "merge" => match unique_keys {
+            Some(keys) if !keys.is_empty() => StrategyConfig::Merge {
+                unique_key: keys,
+                update_columns: None,
+            },
+            _ => {
+                warnings.push(ImportWarning {
+                    model: model_name.to_string(),
+                    category: WarningCategory::UnsupportedMaterialization,
+                    message: "incremental_strategy='merge' requires unique_key — falling back to incremental(updated_at)".to_string(),
+                    suggestion: Some(
+                        "add unique_key to the model config or pick a non-merge incremental_strategy".to_string(),
+                    ),
+                });
+                StrategyConfig::Incremental {
+                    timestamp_column: "updated_at".to_string(),
+                }
+            }
+        },
+        "append" => StrategyConfig::Incremental {
+            timestamp_column: "updated_at".to_string(),
+        },
+        "delete+insert" | "delete_insert" => {
+            let partition_by = config.partition_by.clone().or_else(|| unique_keys.clone());
+            match partition_by {
+                Some(keys) => StrategyConfig::DeleteInsert { partition_by: keys },
+                None => {
+                    warnings.push(ImportWarning {
+                        model: model_name.to_string(),
+                        category: WarningCategory::UnsupportedMaterialization,
+                        message: "incremental_strategy='delete+insert' has no partition_by or unique_key — emitted placeholder partition column".to_string(),
+                        suggestion: Some(
+                            "set `partition_by = ['<column>']` in the dbt config or override the emitted Rocky sidecar's [strategy] block".to_string(),
+                        ),
+                    });
+                    StrategyConfig::DeleteInsert {
+                        partition_by: vec!["partition_key".to_string()],
+                    }
+                }
+            }
+        }
+        "insert_overwrite" => {
+            // insert_overwrite is partition-overwrite semantics — map to
+            // DeleteInsert by default. Time-partition variants need
+            // time_interval which the user can opt into explicitly.
+            let partition_by = config.partition_by.clone();
+            let final_partition_by = match partition_by {
+                Some(keys) => {
+                    warnings.push(ImportWarning {
+                        model: model_name.to_string(),
+                        category: WarningCategory::UnsupportedMaterialization,
+                        message: "incremental_strategy='insert_overwrite' mapped to delete_insert — review partition semantics".to_string(),
+                        suggestion: Some(
+                            "if the model is time-partitioned, set `type = \"time_interval\"` instead and define `time_column` / `granularity`".to_string(),
+                        ),
+                    });
+                    keys
+                }
+                None => {
+                    warnings.push(ImportWarning {
+                        model: model_name.to_string(),
+                        category: WarningCategory::UnsupportedMaterialization,
+                        message: "incremental_strategy='insert_overwrite' has no partition_by — emitted placeholder partition column".to_string(),
+                        suggestion: Some(
+                            "set `partition_by = ['<column>']` in the dbt config or override the emitted Rocky sidecar's [strategy] block".to_string(),
+                        ),
+                    });
+                    vec!["partition_key".to_string()]
+                }
+            };
+            StrategyConfig::DeleteInsert {
+                partition_by: final_partition_by,
+            }
+        }
+        "microbatch" => {
+            // Re-dispatch through the microbatch path so we get the
+            // same event_time validation + granularity translation.
+            let mut structured = Vec::new();
+            map_microbatch_strategy(config, model_name, warnings, &mut structured)
+        }
+        other => {
+            warnings.push(ImportWarning {
+                model: model_name.to_string(),
+                category: WarningCategory::UnsupportedMaterialization,
+                message: format!(
+                    "incremental_strategy='{other}' not recognized — falling back to incremental(updated_at)"
+                ),
+                suggestion: Some(
+                    "use one of: append, merge, delete+insert, insert_overwrite, microbatch".to_string(),
+                ),
+            });
+            StrategyConfig::Incremental {
+                timestamp_column: "updated_at".to_string(),
+            }
+        }
+    }
+}
+
+/// Map `materialized='microbatch'` (or `incremental_strategy='microbatch'`)
+/// to [`StrategyConfig::Microbatch`]. Emits a
+/// [`ImportDbtStructuredWarning::MicrobatchMissingEventTime`] + falls back
+/// to `FullRefresh` if `event_time` is absent.
+fn map_microbatch_strategy(
+    config: &DbtNodeConfig,
+    model_name: &str,
+    warnings: &mut Vec<ImportWarning>,
+    structured: &mut Vec<ImportDbtStructuredWarning>,
+) -> StrategyConfig {
+    let Some(event_time) = config.event_time.clone() else {
+        warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: "microbatch model is missing required `event_time` config — falling back to full_refresh".to_string(),
+            suggestion: Some(
+                "add `event_time = '<timestamp_column>'` to the model's dbt config block".to_string(),
+            ),
+        });
+        structured.push(ImportDbtStructuredWarning::MicrobatchMissingEventTime {
+            model: model_name.to_string(),
+        });
+        return StrategyConfig::FullRefresh;
+    };
+    let granularity = config
+        .batch_size
+        .as_deref()
+        .map(|s| batch_size_to_grain(s, model_name, warnings))
+        .unwrap_or(TimeGrain::Day);
+
+    StrategyConfig::Microbatch {
+        timestamp_column: event_time,
+        granularity,
+    }
+}
+
+/// Translate a dbt `batch_size` string to a Rocky [`TimeGrain`]. Falls
+/// back to `Day` on unrecognized values with a warning.
+fn batch_size_to_grain(
+    raw: &str,
+    model_name: &str,
+    warnings: &mut Vec<ImportWarning>,
+) -> TimeGrain {
+    match raw.to_ascii_lowercase().as_str() {
+        "hour" => TimeGrain::Hour,
+        "day" => TimeGrain::Day,
+        "month" => TimeGrain::Month,
+        "year" => TimeGrain::Year,
+        other => {
+            warnings.push(ImportWarning {
+                model: model_name.to_string(),
+                category: WarningCategory::UnsupportedMaterialization,
+                message: format!(
+                    "batch_size='{other}' not recognized — defaulting to `day` granularity"
+                ),
+                suggestion: Some("set batch_size to one of: hour, day, month, year".to_string()),
+            });
+            TimeGrain::Day
+        }
+    }
+}
+
+/// Collect structured warnings for dbt config Rocky can't auto-translate
+/// (databricks_tags, pre/post hooks, on_schema_change). These are
+/// dropped-on-purpose with an explicit pointer at the Rocky equivalent.
+fn collect_dropped_config_warnings(
+    config: &DbtNodeConfig,
+    model_name: &str,
+    result: &mut ImportResult,
+) {
+    if !config.databricks_tags.is_empty() {
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::DroppedDatabricksTags {
+                model: model_name.to_string(),
+                tags: config.databricks_tags.clone(),
+            });
+        result.warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: format!(
+                "{} databricks tag(s) dropped — Rocky's [classification] block + rocky-databricks governance surface covers the same use case",
+                config.databricks_tags.len()
+            ),
+            suggestion: Some(
+                "copy the dropped tags into the model sidecar's [classification] block, or configure them via rocky-databricks governance".to_string(),
+            ),
+        });
+    }
+
+    for sql in &config.pre_hook {
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::DroppedHook {
+                model: model_name.to_string(),
+                hook_kind: HookKind::Pre,
+                sql: sql.clone(),
+            });
+        result.warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: "pre_hook dropped — Rocky supports lifecycle hooks via the [[hook]] block in rocky.toml".to_string(),
+            suggestion: Some(
+                "translate the pre-hook SQL into an `[[hook]] event = \"on_model_start\"` entry in the emitted rocky.toml".to_string(),
+            ),
+        });
+    }
+
+    for sql in &config.post_hook {
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::DroppedHook {
+                model: model_name.to_string(),
+                hook_kind: HookKind::Post,
+                sql: sql.clone(),
+            });
+        result.warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: "post_hook dropped — Rocky supports lifecycle hooks via the [[hook]] block in rocky.toml".to_string(),
+            suggestion: Some(
+                "translate the post-hook SQL into an `[[hook]] event = \"on_model_end\"` entry in the emitted rocky.toml".to_string(),
+            ),
+        });
+    }
+
+    if let Some(value) = config.on_schema_change.as_deref() {
+        let rocky_equivalent = on_schema_change_to_rocky(value);
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::DroppedOnSchemaChange {
+                model: model_name.to_string(),
+                dbt_value: value.to_string(),
+                rocky_equivalent: rocky_equivalent.clone(),
+            });
+        result.warnings.push(ImportWarning {
+            model: model_name.to_string(),
+            category: WarningCategory::UnsupportedMaterialization,
+            message: format!(
+                "on_schema_change='{value}' dropped — Rocky exposes the equivalent via per-pipeline [drift] policy ({rocky_equivalent})"
+            ),
+            suggestion: Some(
+                "set the matching [drift] policy in the pipeline section of the emitted rocky.toml".to_string(),
+            ),
+        });
+    }
+}
+
+/// Translate dbt's `on_schema_change` values to a human-readable Rocky
+/// drift-policy hint. Used for the structured warning's
+/// `rocky_equivalent` field.
+fn on_schema_change_to_rocky(value: &str) -> String {
+    match value.to_ascii_lowercase().as_str() {
+        "ignore" => "drift policy 'ignore' (skip drift detection)".to_string(),
+        "fail" => "drift policy 'strict' (fail on drift)".to_string(),
+        "append_new_columns" => {
+            "drift policy 'evolve' (allow safe widening + new columns)".to_string()
+        }
+        "sync_all_columns" => "drift policy 'evolve' with column-removal allowed".to_string(),
+        other => format!("(no direct equivalent for '{other}' — set [drift] manually)"),
+    }
+}
+
+/// Detect Jinja macro calls that survived `dbt compile` and surface each
+/// distinct macro as an `UnresolvableMacro` structured warning. dbt
+/// resolves in-tree macros at compile time, so anything still present
+/// points at an out-of-tree macro (e.g. a custom org-wide library).
+fn collect_unresolvable_macros(sql: &str, model_name: &str, result: &mut ImportResult) {
+    let usages = super::dbt_macros::detect_macros(sql);
+    if usages.is_empty() {
+        return;
+    }
+    // Track first occurrence per (package, name) so we emit one warning
+    // per macro, not per call site. dbt projects often call the same
+    // macro 100+ times within a single model body.
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for u in &usages {
+        let full_name = match &u.package {
+            Some(pkg) => format!("{pkg}.{}", u.name),
+            None => u.name.clone(),
+        };
+        if !seen.insert(full_name.clone()) {
+            continue;
+        }
+        let line = sql[..u.span.0].matches('\n').count() + 1;
+        result
+            .structured_warnings
+            .push(ImportDbtStructuredWarning::UnresolvableMacro {
+                model: model_name.to_string(),
+                macro_name: full_name,
+                first_call_site_line: line,
+            });
+    }
+    result.macros_detected += seen.len();
+    result.macros_unsupported += seen.len();
 }
 
 // ---------------------------------------------------------------------------
@@ -421,6 +845,7 @@ pub fn import_dbt_project(
     let mut result = ImportResult {
         imported: Vec::new(),
         warnings: Vec::new(),
+        structured_warnings: Vec::new(),
         failed: Vec::new(),
         sources_found,
         sources_mapped,
@@ -615,13 +1040,18 @@ fn import_single_model(
                     };
                 }
                 "view" => {
+                    strategy = StrategyConfig::View;
+                }
+                "materialized_view" => {
+                    strategy = StrategyConfig::MaterializedView;
+                }
+                "ephemeral" => {
                     warnings.push(ImportWarning {
                         model: name.to_string(),
                         category: WarningCategory::UnsupportedMaterialization,
-                        message: "project config materialized='view' — using full_refresh"
-                            .to_string(),
+                        message: "project config materialized='ephemeral' has no Rocky equivalent — using full_refresh".to_string(),
                         suggestion: Some(
-                            "override per-model with `type = \"full_refresh\"` or `\"ephemeral\"` in the sidecar".to_string(),
+                            "override per-model with `type = \"full_refresh\"` or fold the SQL into downstream models".to_string(),
                         ),
                     });
                 }
@@ -769,64 +1199,109 @@ fn extract_timestamp_from_where(block: &str) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// Extract strategy from dbt `{{ config() }}` block.
+///
+/// Parses the `materialized` + `incremental_strategy` + `unique_key`
+/// fields, dispatching through [`map_manifest_strategy`] so the regex
+/// path stays in sync with the manifest path. Other config fields
+/// (`event_time`, `batch_size`, `databricks_tags`, `pre_hook`,
+/// `post_hook`, `on_schema_change`) are best-effort — the regex path
+/// gives up on multi-line / structured values and falls back to the
+/// manifest path for richer recovery.
+///
+/// Returns the chosen [`StrategyConfig`] plus a list of free-form
+/// warning messages.
+///
+/// Note: structured warnings produced by [`map_manifest_strategy`] are
+/// discarded here on purpose — the regex path emits string warnings
+/// only (the manifest path is the canonical surface for
+/// structured-warning consumers).
 fn extract_dbt_config(content: &str) -> (StrategyConfig, Vec<String>) {
-    let mut warnings = Vec::new();
+    let mut messages = Vec::new();
 
     let config_re = Regex::new(r"\{\{\s*config\s*\(([^)]*)\)\s*\}\}").unwrap();
-    if let Some(captures) = config_re.captures(content) {
-        let config_str = &captures[1];
+    let Some(captures) = config_re.captures(content) else {
+        return (StrategyConfig::FullRefresh, messages);
+    };
 
-        // Parse materialized
-        let mat_re = Regex::new(r#"materialized\s*=\s*['"](\w+)['"]"#).unwrap();
-        let materialized = mat_re
-            .captures(config_str)
-            .map(|c| c[1].to_string())
-            .unwrap_or_else(|| "table".to_string());
+    let config_str = &captures[1];
 
-        match materialized.as_str() {
-            "incremental" => {
-                // Extract unique_key for merge strategy
-                let key_re = Regex::new(r#"unique_key\s*=\s*['"](\w+)['"]"#).unwrap();
-                if let Some(key_cap) = key_re.captures(config_str) {
-                    return (
-                        StrategyConfig::Merge {
-                            unique_key: vec![key_cap[1].to_string()],
-                            update_columns: None,
-                        },
-                        warnings,
-                    );
-                }
-                // Incremental without unique_key -> append
-                let ts_re = Regex::new(r#"(?:incremental_strategy|timestamp)\s*=\s*['"](\w+)['"]"#)
-                    .unwrap();
-                let ts_col = ts_re
-                    .captures(config_str)
-                    .map(|c| c[1].to_string())
-                    .unwrap_or_else(|| "updated_at".to_string());
-                (
-                    StrategyConfig::Incremental {
-                        timestamp_column: ts_col,
-                    },
-                    warnings,
-                )
-            }
-            "view" => {
-                warnings.push(
-                    "materialized='view' not supported in Rocky — using full_refresh".to_string(),
-                );
-                (StrategyConfig::FullRefresh, warnings)
-            }
-            "ephemeral" => {
-                warnings.push(
-                    "materialized='ephemeral' not supported — using full_refresh".to_string(),
-                );
-                (StrategyConfig::FullRefresh, warnings)
-            }
-            _ => (StrategyConfig::FullRefresh, warnings),
-        }
-    } else {
-        (StrategyConfig::FullRefresh, warnings)
+    // Parse materialized
+    let mat_re = Regex::new(r#"materialized\s*=\s*['"](\w+)['"]"#).unwrap();
+    let materialized = mat_re
+        .captures(config_str)
+        .map(|c| c[1].to_string())
+        .unwrap_or_else(|| "table".to_string());
+
+    // Parse unique_key — accepts string-form (`unique_key='id'`) or
+    // single-line list (`unique_key=['user_id', 'date']`).
+    let unique_key = parse_dbt_unique_key(config_str);
+
+    // Parse incremental_strategy as the strategy discriminator (NOT a
+    // column name). This fixes the long-standing bug where
+    // `incremental_strategy='merge'` was treated as
+    // `timestamp_column = 'merge'`.
+    let incremental_strategy = single_string_value(config_str, "incremental_strategy");
+
+    // dbt-microbatch fields
+    let event_time = single_string_value(config_str, "event_time");
+    let batch_size = single_string_value(config_str, "batch_size");
+    let lookback = single_string_value(config_str, "lookback").and_then(|s| s.parse::<u32>().ok());
+
+    // Build a synthetic DbtNodeConfig — the regex path doesn't recover
+    // databricks_tags / hooks / on_schema_change (they're multi-line in
+    // practice), so they're left empty.
+    let synthetic = DbtNodeConfig {
+        materialized: materialized.clone(),
+        schema: None,
+        unique_key,
+        incremental_strategy,
+        event_time,
+        batch_size,
+        lookback,
+        partition_by: None,
+        databricks_tags: BTreeMap::new(),
+        pre_hook: Vec::new(),
+        post_hook: Vec::new(),
+        on_schema_change: None,
+    };
+
+    let mapping = map_manifest_strategy(&synthetic, "<regex-path>");
+    for w in mapping.warnings {
+        messages.push(w.message);
     }
+
+    (mapping.strategy, messages)
+}
+
+/// Parse `unique_key=...` from a dbt config block. Accepts both
+/// `unique_key='id'` and `unique_key=['user_id', 'date']` shapes.
+/// Returns `None` if the field is absent or malformed.
+fn parse_dbt_unique_key(config_str: &str) -> Option<UniqueKeyValue> {
+    let single = Regex::new(r#"unique_key\s*=\s*['"](\w+)['"]"#).unwrap();
+    if let Some(c) = single.captures(config_str) {
+        return Some(UniqueKeyValue::Single(c[1].to_string()));
+    }
+    let list = Regex::new(r#"unique_key\s*=\s*\[([^\]]+)\]"#).unwrap();
+    if let Some(c) = list.captures(config_str) {
+        let raw = c.get(1).map(|m| m.as_str()).unwrap_or("");
+        let keys: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().trim_matches(|c| c == '\'' || c == '"').to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !keys.is_empty() {
+            return Some(UniqueKeyValue::Multiple(keys));
+        }
+    }
+    None
+}
+
+/// Best-effort extraction of `key='value'` from a dbt config block.
+/// Returns `None` if the key is absent.
+fn single_string_value(config_str: &str, key: &str) -> Option<String> {
+    let pattern = format!(r#"\b{key}\s*=\s*['"]([^'"]+)['"]"#);
+    let re = Regex::new(&pattern).ok()?;
+    re.captures(config_str).map(|c| c[1].to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -949,11 +1424,63 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_config_view_warning() {
+    fn test_extract_config_view_maps_to_view_strategy() {
+        // Wave 2: `materialized='view'` now maps to StrategyConfig::View
+        // (no warning) instead of FullRefresh + warning.
         let input = "{{ config(materialized='view') }}";
+        let (strategy, warnings) = extract_dbt_config(input);
+        assert!(matches!(strategy, StrategyConfig::View));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_extract_config_materialized_view() {
+        // Wave 2: `materialized='materialized_view'` now maps to
+        // StrategyConfig::MaterializedView (previously: dropped silently).
+        let input = "{{ config(materialized='materialized_view') }}";
+        let (strategy, _) = extract_dbt_config(input);
+        assert!(matches!(strategy, StrategyConfig::MaterializedView));
+    }
+
+    #[test]
+    fn test_extract_config_ephemeral_warns() {
+        let input = "{{ config(materialized='ephemeral') }}";
         let (strategy, warnings) = extract_dbt_config(input);
         assert!(matches!(strategy, StrategyConfig::FullRefresh));
         assert!(!warnings.is_empty());
+    }
+
+    #[test]
+    fn test_extract_config_merge_with_unique_key_list() {
+        // Regression: `incremental_strategy='merge'` + `unique_key=['user_id']`
+        // must map to StrategyConfig::Merge, NOT to
+        // `Incremental { timestamp_column: "merge" }`.
+        let input = "{{ config(materialized='incremental', incremental_strategy='merge', unique_key=['user_id']) }}";
+        let (strategy, _) = extract_dbt_config(input);
+        match strategy {
+            StrategyConfig::Merge {
+                unique_key,
+                update_columns: _,
+            } => assert_eq!(unique_key, vec!["user_id"]),
+            other => panic!("expected Merge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_config_incremental_strategy_is_not_a_column_name() {
+        // Pin the parse-bug fix: `incremental_strategy='merge'` previously
+        // captured 'merge' as a timestamp column. Assert that does NOT
+        // happen anymore.
+        let input = "{{ config(materialized='incremental', incremental_strategy='merge') }}";
+        let (strategy, _) = extract_dbt_config(input);
+        // Without unique_key, this should fall back to Incremental(updated_at)
+        // because merge requires unique_key — but the timestamp must not be 'merge'.
+        if let StrategyConfig::Incremental { timestamp_column } = strategy {
+            assert_ne!(
+                timestamp_column, "merge",
+                "BUG REGRESSION: incremental_strategy must NOT be parsed as a timestamp column"
+            );
+        }
     }
 
     #[test]
@@ -1152,7 +1679,9 @@ FROM raw.orders
     }
 
     #[test]
-    fn test_import_from_manifest_view_warning() {
+    fn test_import_from_manifest_view_maps_to_view() {
+        // Wave 2: `materialized='view'` now maps to StrategyConfig::View
+        // directly (previously: FullRefresh + warning).
         let manifest_json = serde_json::json!({
             "metadata": { "project_name": "proj" },
             "nodes": {
@@ -1185,9 +1714,19 @@ FROM raw.orders
         };
         let result = import_from_manifest(&manifest, &target);
 
-        assert!(result.warnings.iter().any(|w| {
-            w.category == WarningCategory::UnsupportedMaterialization && w.message.contains("view")
-        }));
+        assert_eq!(result.imported.len(), 1);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::View
+        ));
+        // No "view not supported" warning anymore.
+        assert!(
+            result
+                .warnings
+                .iter()
+                .all(|w| !w.message.contains("'view'")),
+            "view should no longer emit an 'unsupported' warning"
+        );
     }
 
     // --- Full project import tests ---
@@ -1335,5 +1874,462 @@ FROM {{ ref('stg_events') }}
         assert!(result.warnings.iter().any(|w| {
             w.category == WarningCategory::MissingSource && w.message.contains("missing")
         }));
+    }
+
+    // ---------------------------------------------------------------------
+    // Wave 2: dbt materialization mapping tests
+    // ---------------------------------------------------------------------
+
+    /// Helper: parse a manifest from a JSON value and run import.
+    fn import_from_manifest_json(manifest_json: &serde_json::Value) -> ImportResult {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("manifest.json");
+        std::fs::write(&path, manifest_json.to_string()).unwrap();
+        let manifest = dbt_manifest::parse_manifest(&path).unwrap();
+        let target = TargetConfig {
+            catalog: "w".to_string(),
+            schema: "s".to_string(),
+            table: String::new(),
+        };
+        import_from_manifest(&manifest, &target)
+    }
+
+    #[test]
+    fn test_manifest_view_maps_to_view_strategy() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.dim_customers": {
+                    "unique_id": "model.p.dim_customers",
+                    "name": "dim_customers",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "view" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(result.imported.len(), 1);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::View
+        ));
+    }
+
+    #[test]
+    fn test_manifest_materialized_view_maps_to_materialized_view() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.fct_revenue_mv": {
+                    "unique_id": "model.p.fct_revenue_mv",
+                    "name": "fct_revenue_mv",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "materialized_view" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(result.imported.len(), 1);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::MaterializedView
+        ));
+    }
+
+    #[test]
+    fn test_manifest_microbatch_maps_to_microbatch() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.events_daily": {
+                    "unique_id": "model.p.events_daily",
+                    "name": "events_daily",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "microbatch",
+                        "event_time": "event_ts",
+                        "batch_size": "day"
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert_eq!(result.imported.len(), 1);
+        match &result.imported[0].config.strategy {
+            StrategyConfig::Microbatch {
+                timestamp_column,
+                granularity,
+            } => {
+                assert_eq!(timestamp_column, "event_ts");
+                assert_eq!(*granularity, TimeGrain::Day);
+            }
+            other => panic!("expected Microbatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_manifest_microbatch_missing_event_time_warns_and_falls_back() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.broken_microbatch": {
+                    "unique_id": "model.p.broken_microbatch",
+                    "name": "broken_microbatch",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "microbatch", "batch_size": "hour" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::FullRefresh
+        ));
+        assert!(
+            result.structured_warnings.iter().any(|w| matches!(
+                w,
+                ImportDbtStructuredWarning::MicrobatchMissingEventTime { model } if model == "broken_microbatch"
+            )),
+            "missing event_time must emit a structured warning"
+        );
+    }
+
+    #[test]
+    fn test_manifest_ephemeral_emits_warning() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.eph": {
+                    "unique_id": "model.p.eph",
+                    "name": "eph",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "ephemeral" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        assert!(matches!(
+            result.imported[0].config.strategy,
+            StrategyConfig::FullRefresh
+        ));
+        assert!(result.structured_warnings.iter().any(|w| matches!(
+            w,
+            ImportDbtStructuredWarning::UnsupportedMaterialization { dbt_materialization, .. }
+                if dbt_materialization == "ephemeral"
+        )));
+    }
+
+    #[test]
+    fn test_incremental_strategy_merge_regression() {
+        // Pin the parse-bug fix: a manifest with
+        // `incremental_strategy='merge'` + `unique_key=['user_id']` must
+        // map to StrategyConfig::Merge, NOT
+        // `Incremental { timestamp_column: "merge" }`.
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.fct_users": {
+                    "unique_id": "model.p.fct_users",
+                    "name": "fct_users",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "incremental",
+                        "incremental_strategy": "merge",
+                        "unique_key": ["user_id"]
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        match &result.imported[0].config.strategy {
+            StrategyConfig::Merge {
+                unique_key,
+                update_columns: _,
+            } => {
+                assert_eq!(unique_key, &vec!["user_id".to_string()]);
+            }
+            other => panic!(
+                "BUG REGRESSION: expected Merge {{ unique_key: ['user_id'] }}, got {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_incremental_strategy_append_maps_to_incremental() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.events_append": {
+                    "unique_id": "model.p.events_append",
+                    "name": "events_append",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "incremental",
+                        "incremental_strategy": "append"
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        match &result.imported[0].config.strategy {
+            StrategyConfig::Incremental { timestamp_column } => {
+                assert_ne!(timestamp_column, "merge");
+                assert_ne!(timestamp_column, "append");
+            }
+            other => panic!("expected Incremental, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_incremental_strategy_delete_insert_maps_to_delete_insert() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.partitioned": {
+                    "unique_id": "model.p.partitioned",
+                    "name": "partitioned",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "incremental",
+                        "incremental_strategy": "delete+insert",
+                        "unique_key": ["dt"],
+                        "partition_by": ["dt"]
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        match &result.imported[0].config.strategy {
+            StrategyConfig::DeleteInsert { partition_by } => {
+                assert_eq!(partition_by, &vec!["dt".to_string()]);
+            }
+            other => panic!("expected DeleteInsert, got {other:?}"),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Wave 2: structured warning tests
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_dropped_databricks_tags_warning() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.dim_users": {
+                    "unique_id": "model.p.dim_users",
+                    "name": "dim_users",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "table",
+                        "databricks_tags": { "owner": "data-team", "pii": "true" }
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        let found = result
+            .structured_warnings
+            .iter()
+            .find_map(|w| match w {
+                ImportDbtStructuredWarning::DroppedDatabricksTags { model, tags }
+                    if model == "dim_users" =>
+                {
+                    Some(tags.clone())
+                }
+                _ => None,
+            })
+            .expect("expected DroppedDatabricksTags warning");
+        assert_eq!(found.get("owner").map(String::as_str), Some("data-team"));
+        assert_eq!(found.get("pii").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn test_dropped_hook_warning() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.fct_orders": {
+                    "unique_id": "model.p.fct_orders",
+                    "name": "fct_orders",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "table",
+                        "pre_hook": "ANALYZE TABLE foo COMPUTE STATISTICS",
+                        "post_hook": ["GRANT SELECT ON {{ this }} TO ROLE analyst"]
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        let pre = result.structured_warnings.iter().find(|w| {
+            matches!(
+                w,
+                ImportDbtStructuredWarning::DroppedHook { hook_kind, sql, .. }
+                    if *hook_kind == HookKind::Pre && sql.contains("ANALYZE TABLE")
+            )
+        });
+        assert!(pre.is_some(), "expected pre_hook structured warning");
+        let post = result.structured_warnings.iter().find(|w| {
+            matches!(
+                w,
+                ImportDbtStructuredWarning::DroppedHook { hook_kind, sql, .. }
+                    if *hook_kind == HookKind::Post && sql.contains("GRANT SELECT")
+            )
+        });
+        assert!(post.is_some(), "expected post_hook structured warning");
+    }
+
+    #[test]
+    fn test_dropped_on_schema_change_warning() {
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.dim_x": {
+                    "unique_id": "model.p.dim_x",
+                    "name": "dim_x",
+                    "resource_type": "model",
+                    "compiled_code": "SELECT 1",
+                    "raw_code": "SELECT 1",
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": {
+                        "materialized": "incremental",
+                        "unique_key": "id",
+                        "on_schema_change": "append_new_columns"
+                    },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        let found = result.structured_warnings.iter().find_map(|w| match w {
+            ImportDbtStructuredWarning::DroppedOnSchemaChange {
+                dbt_value,
+                rocky_equivalent,
+                model,
+            } if model == "dim_x" => Some((dbt_value.clone(), rocky_equivalent.clone())),
+            _ => None,
+        });
+        let (dbt_value, rocky_equivalent) = found.expect("expected DroppedOnSchemaChange warning");
+        assert_eq!(dbt_value, "append_new_columns");
+        assert!(rocky_equivalent.contains("evolve"));
+    }
+
+    #[test]
+    fn test_unresolvable_macro_warning() {
+        // Synthetic: a compiled_sql with a {{ custom_macro(...) }} call
+        // that dbt's compile step couldn't inline (i.e. the macro is
+        // defined out-of-tree). The importer surfaces this as an
+        // UnresolvableMacro structured warning with the call-site line.
+        let compiled_sql = "SELECT id,\n  {{ custom_helper('a', 'b') }} AS computed\nFROM raw.t";
+        let manifest = serde_json::json!({
+            "metadata": { "project_name": "p" },
+            "nodes": {
+                "model.p.uses_macro": {
+                    "unique_id": "model.p.uses_macro",
+                    "name": "uses_macro",
+                    "resource_type": "model",
+                    "compiled_code": compiled_sql,
+                    "raw_code": compiled_sql,
+                    "depends_on": { "nodes": [], "macros": [] },
+                    "config": { "materialized": "table" },
+                    "columns": {}, "tags": [], "schema": "s", "database": "d"
+                }
+            },
+            "sources": {}
+        });
+        let result = import_from_manifest_json(&manifest);
+        let found = result.structured_warnings.iter().find_map(|w| match w {
+            ImportDbtStructuredWarning::UnresolvableMacro {
+                model,
+                macro_name,
+                first_call_site_line,
+            } if model == "uses_macro" => Some((macro_name.clone(), *first_call_site_line)),
+            _ => None,
+        });
+        let (macro_name, line) = found.expect("expected UnresolvableMacro warning");
+        assert_eq!(macro_name, "custom_helper");
+        assert_eq!(line, 2, "macro is on line 2 of the compiled SQL");
+    }
+
+    #[test]
+    fn test_batch_size_to_grain_unknown_warns_default_day() {
+        let mut warnings = Vec::new();
+        let g = batch_size_to_grain("week", "m", &mut warnings);
+        assert_eq!(g, TimeGrain::Day);
+        assert!(!warnings.is_empty());
+    }
+
+    #[test]
+    fn test_batch_size_to_grain_each_supported() {
+        let mut warnings = Vec::new();
+        assert_eq!(
+            batch_size_to_grain("hour", "m", &mut warnings),
+            TimeGrain::Hour
+        );
+        assert_eq!(
+            batch_size_to_grain("day", "m", &mut warnings),
+            TimeGrain::Day
+        );
+        assert_eq!(
+            batch_size_to_grain("month", "m", &mut warnings),
+            TimeGrain::Month
+        );
+        assert_eq!(
+            batch_size_to_grain("year", "m", &mut warnings),
+            TimeGrain::Year
+        );
+        assert!(warnings.is_empty());
     }
 }

--- a/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_manifest.rs
@@ -60,6 +60,28 @@ pub struct DbtNodeConfig {
     pub schema: Option<String>,
     pub unique_key: Option<UniqueKeyValue>,
     pub incremental_strategy: Option<String>,
+    /// `event_time` field (dbt 1.8+ microbatch).
+    pub event_time: Option<String>,
+    /// `batch_size` field (dbt 1.8+ microbatch). One of
+    /// `hour` / `day` / `month` / `year`.
+    pub batch_size: Option<String>,
+    /// `lookback` field (dbt 1.8+ microbatch). Number of prior batches to
+    /// recompute on each run.
+    pub lookback: Option<u32>,
+    /// `partition_by` — list of partition column names. dbt-databricks +
+    /// other warehouse-specific configs accept either a single string or a
+    /// list; both forms normalize here.
+    pub partition_by: Option<Vec<String>>,
+    /// `databricks_tags` — key/value tag pairs (dbt-databricks).
+    pub databricks_tags: std::collections::BTreeMap<String, String>,
+    /// `pre_hook` — SQL statements run before the model materializes.
+    /// Accepts dbt's string-or-list shape.
+    pub pre_hook: Vec<String>,
+    /// `post_hook` — SQL statements run after the model materializes.
+    pub post_hook: Vec<String>,
+    /// `on_schema_change` — dbt-databricks drift policy. One of `ignore`,
+    /// `fail`, `append_new_columns`, `sync_all_columns`.
+    pub on_schema_change: Option<String>,
 }
 
 /// unique_key can be a single string or a list.
@@ -156,6 +178,26 @@ struct RawNodeConfig {
     unique_key: Option<serde_json::Value>,
     #[serde(default)]
     incremental_strategy: Option<String>,
+    #[serde(default)]
+    event_time: Option<String>,
+    #[serde(default)]
+    batch_size: Option<String>,
+    #[serde(default)]
+    lookback: Option<u32>,
+    #[serde(default)]
+    partition_by: Option<serde_json::Value>,
+    #[serde(default)]
+    databricks_tags: Option<std::collections::BTreeMap<String, String>>,
+    #[serde(default)]
+    pre_hook: Option<serde_json::Value>,
+    #[serde(default, rename = "pre-hook")]
+    pre_hook_dashed: Option<serde_json::Value>,
+    #[serde(default)]
+    post_hook: Option<serde_json::Value>,
+    #[serde(default, rename = "post-hook")]
+    post_hook_dashed: Option<serde_json::Value>,
+    #[serde(default)]
+    on_schema_change: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -251,6 +293,23 @@ fn convert_node(raw: RawNode) -> DbtManifestNode {
         _ => None,
     });
 
+    let partition_by = config.partition_by.and_then(json_string_or_list);
+
+    let pre_hook = json_string_or_list(
+        config
+            .pre_hook
+            .or(config.pre_hook_dashed)
+            .unwrap_or(serde_json::Value::Null),
+    )
+    .unwrap_or_default();
+    let post_hook = json_string_or_list(
+        config
+            .post_hook
+            .or(config.post_hook_dashed)
+            .unwrap_or(serde_json::Value::Null),
+    )
+    .unwrap_or_default();
+
     let columns = raw
         .columns
         .into_iter()
@@ -280,12 +339,40 @@ fn convert_node(raw: RawNode) -> DbtManifestNode {
             schema: config.schema,
             unique_key,
             incremental_strategy: config.incremental_strategy,
+            event_time: config.event_time,
+            batch_size: config.batch_size,
+            lookback: config.lookback,
+            partition_by,
+            databricks_tags: config.databricks_tags.unwrap_or_default(),
+            pre_hook,
+            post_hook,
+            on_schema_change: config.on_schema_change,
         },
         columns,
         description: raw.description.filter(|d| !d.is_empty()),
         tags: raw.tags,
         schema: raw.schema.unwrap_or_default(),
         database: raw.database.unwrap_or_default(),
+    }
+}
+
+/// Normalize a manifest field that dbt accepts as either a single string
+/// or a list of strings into `Option<Vec<String>>`. Returns `None` for
+/// null, empty list, or non-string values.
+fn json_string_or_list(v: serde_json::Value) -> Option<Vec<String>> {
+    match v {
+        serde_json::Value::String(s) if !s.is_empty() => Some(vec![s]),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr
+                .into_iter()
+                .filter_map(|v| match v {
+                    serde_json::Value::String(s) if !s.is_empty() => Some(s),
+                    _ => None,
+                })
+                .collect();
+            if items.is_empty() { None } else { Some(items) }
+        }
+        _ => None,
     }
 }
 

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use rocky_core::models::{ModelConfig, StrategyConfig};
 use rocky_core::tests::{TestDecl, TestSeverity, TestType};
 
-use super::dbt::{ImportResult, ImportedModel, WarningCategory};
+use super::dbt::{ImportResult, ImportedModel};
 use super::dbt_profiles::ProfileResolution;
 
 /// Outcome of emitting a Rocky repo on disk.
@@ -68,11 +68,12 @@ pub struct EmitInputs<'a> {
     pub default_catalog: &'a str,
     pub default_schema: &'a str,
     pub import: &'a ImportResult,
-    /// Extra models that need their `view → ephemeral` mapping applied at
-    /// emit time. The caller has already constructed `import.imported`
-    /// using the regex/manifest path (where `view` flattens to
-    /// `full_refresh`); this set lets the emitter rewrite the strategy
-    /// to `Ephemeral` after the fact without forking the import path.
+    /// Legacy: extra models whose `view` materialization was flattened to
+    /// `full_refresh` by an older version of the importer. The Wave 2
+    /// `view → StrategyConfig::View` mapping eliminates this code path
+    /// for new imports, but the field is retained as the BTreeSet
+    /// surface for callers that still pass it (always empty in
+    /// post-Wave-2 callers).
     pub view_models_to_make_ephemeral: BTreeSet<String>,
     /// Adapter override applied via `--target-adapter`, if any. Drives
     /// MIGRATION-NOTES wording.
@@ -103,12 +104,18 @@ pub fn emit_repo(inputs: &EmitInputs<'_>) -> Result<EmissionResult, String> {
         translated += 1;
     }
 
-    // Collect `materialized` values that fell through to FullRefresh-with-TODO.
-    for w in &inputs.import.warnings {
-        if w.category == WarningCategory::UnsupportedMaterialization
-            && !unknown_materializations.contains(&w.model)
+    // Collect models whose dbt materialization had no Rocky equivalent
+    // and fell back to FullRefresh. Sourced from the typed structured
+    // warnings (Wave 2) so we don't false-flag models that hit warnings
+    // for unrelated reasons (dropped tags, hooks, on_schema_change).
+    for w in &inputs.import.structured_warnings {
+        if let super::dbt::ImportDbtStructuredWarning::UnsupportedMaterialization {
+            model, ..
+        } = w
         {
-            unknown_materializations.push(w.model.clone());
+            if !unknown_materializations.contains(model) {
+                unknown_materializations.push(model.clone());
+            }
         }
     }
 
@@ -136,6 +143,7 @@ pub fn emit_repo(inputs: &EmitInputs<'_>) -> Result<EmissionResult, String> {
             tests_skipped: inputs.import.tests_found,
             macros_detected: inputs.import.macros_detected,
             warnings: &inputs.import.warnings,
+            structured_warnings: &inputs.import.structured_warnings,
             failed: &inputs.import.failed,
             unknown_materializations: &unknown_materializations,
             profile: inputs.profile,
@@ -273,10 +281,38 @@ fn render_model_sidecar(config: &ModelConfig) -> String {
         StrategyConfig::Ephemeral => {
             out.push_str("type = \"ephemeral\"\n");
         }
-        // The remaining variants don't arise from the dbt importer
-        // (TimeInterval, DeleteInsert, Microbatch). If we ever hit one,
-        // fall back to full_refresh — the dbt importer doesn't currently
-        // produce them so there's no test to break.
+        StrategyConfig::View => {
+            out.push_str("type = \"view\"\n");
+        }
+        StrategyConfig::MaterializedView => {
+            out.push_str("type = \"materialized_view\"\n");
+        }
+        StrategyConfig::DynamicTable { target_lag } => {
+            out.push_str("type = \"dynamic_table\"\n");
+            out.push_str(&format!("target_lag = \"{target_lag}\"\n"));
+        }
+        StrategyConfig::Microbatch {
+            timestamp_column,
+            granularity,
+        } => {
+            out.push_str("type = \"microbatch\"\n");
+            out.push_str(&format!("timestamp_column = \"{timestamp_column}\"\n"));
+            let g = match granularity {
+                rocky_ir::TimeGrain::Hour => "hour",
+                rocky_ir::TimeGrain::Day => "day",
+                rocky_ir::TimeGrain::Month => "month",
+                rocky_ir::TimeGrain::Year => "year",
+            };
+            out.push_str(&format!("granularity = \"{g}\"\n"));
+        }
+        StrategyConfig::DeleteInsert { partition_by } => {
+            out.push_str("type = \"delete_insert\"\n");
+            let keys: Vec<String> = partition_by.iter().map(|k| format!("\"{k}\"")).collect();
+            out.push_str(&format!("partition_by = [{}]\n", keys.join(", ")));
+        }
+        // TimeInterval + ContentAddressed don't arise from the dbt
+        // importer today; if we ever hit one, fall back to full_refresh
+        // (the user can hand-edit the sidecar).
         _ => {
             out.push_str("type = \"full_refresh\"\n");
         }
@@ -447,10 +483,97 @@ struct MigrationContext<'a> {
     tests_skipped: usize,
     macros_detected: usize,
     warnings: &'a [super::dbt::ImportWarning],
+    structured_warnings: &'a [super::dbt::ImportDbtStructuredWarning],
     failed: &'a [super::dbt::ImportFailure],
     unknown_materializations: &'a [String],
     profile: &'a ProfileResolution,
     adapter_override_label: Option<&'a str>,
+}
+
+/// Render the structured-warnings block of `MIGRATION-NOTES.md`. Each
+/// variant gets a per-model bullet that includes the dropped payload
+/// (tag values, hook SQL, macro names) so the user can paste it
+/// directly into the Rocky config.
+fn write_structured_warnings(
+    out: &mut String,
+    warnings: &[super::dbt::ImportDbtStructuredWarning],
+) {
+    use super::dbt::{HookKind, ImportDbtStructuredWarning as W};
+    // Group warnings by model to keep the output scannable.
+    let mut by_model: std::collections::BTreeMap<&str, Vec<&W>> = std::collections::BTreeMap::new();
+    for w in warnings {
+        let model = match w {
+            W::UnsupportedMaterialization { model, .. }
+            | W::DroppedDatabricksTags { model, .. }
+            | W::DroppedHook { model, .. }
+            | W::DroppedOnSchemaChange { model, .. }
+            | W::UnresolvableMacro { model, .. }
+            | W::MicrobatchMissingEventTime { model } => model.as_str(),
+        };
+        by_model.entry(model).or_default().push(w);
+    }
+    for (model, items) in by_model {
+        out.push_str(&format!("### `{model}`\n\n"));
+        for w in items {
+            match w {
+                W::UnsupportedMaterialization {
+                    dbt_materialization,
+                    action,
+                    ..
+                } => {
+                    out.push_str(&format!(
+                        "- **Unsupported materialization** `{dbt_materialization}` — {action}\n"
+                    ));
+                }
+                W::DroppedDatabricksTags { tags, .. } => {
+                    out.push_str(
+                        "- **Dropped `databricks_tags`** — copy into the model sidecar's `[classification]` block or wire via `rocky-databricks` governance:\n",
+                    );
+                    for (k, v) in tags {
+                        out.push_str(&format!("  - `{k}` = `{v}`\n"));
+                    }
+                }
+                W::DroppedHook { hook_kind, sql, .. } => {
+                    let event = match hook_kind {
+                        HookKind::Pre => "on_model_start",
+                        HookKind::Post => "on_model_end",
+                    };
+                    let kind_label = match hook_kind {
+                        HookKind::Pre => "pre_hook",
+                        HookKind::Post => "post_hook",
+                    };
+                    out.push_str(&format!(
+                        "- **Dropped `{kind_label}`** — translate into `[[hook]] event = \"{event}\"` in `rocky.toml`:\n"
+                    ));
+                    out.push_str(&format!("  ```sql\n  {sql}\n  ```\n"));
+                }
+                W::DroppedOnSchemaChange {
+                    dbt_value,
+                    rocky_equivalent,
+                    ..
+                } => {
+                    out.push_str(&format!(
+                        "- **Dropped `on_schema_change = '{dbt_value}'`** — set Rocky `[drift]` policy: {rocky_equivalent}\n"
+                    ));
+                }
+                W::UnresolvableMacro {
+                    macro_name,
+                    first_call_site_line,
+                    ..
+                } => {
+                    out.push_str(&format!(
+                        "- **Unresolvable Jinja macro** `{macro_name}()` first called at line {first_call_site_line} — hand-port the macro logic\n"
+                    ));
+                }
+                W::MicrobatchMissingEventTime { .. } => {
+                    out.push_str(
+                        "- **Microbatch missing `event_time`** — fell back to `full_refresh`. Add `event_time = '<timestamp_column>'` to the model's dbt config block\n",
+                    );
+                }
+            }
+        }
+        out.push('\n');
+    }
 }
 
 fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), String> {
@@ -540,6 +663,14 @@ fn write_migration_notes(path: &Path, ctx: &MigrationContext<'_>) -> Result<(), 
     }
     out.push('\n');
 
+    if !ctx.structured_warnings.is_empty() {
+        out.push_str("## Items to translate manually\n\n");
+        out.push_str(
+            "The dbt config below couldn't be auto-translated. Each entry points at the matching Rocky surface.\n\n",
+        );
+        write_structured_warnings(&mut out, ctx.structured_warnings);
+    }
+
     if !ctx.warnings.is_empty() {
         out.push_str("## Warnings\n\n");
         for w in ctx.warnings {
@@ -610,6 +741,7 @@ mod tests {
         ImportResult {
             imported,
             warnings: vec![],
+            structured_warnings: vec![],
             failed: vec![],
             sources_found: 0,
             sources_mapped: 0,

--- a/engine/crates/rocky-compiler/src/import/report.rs
+++ b/engine/crates/rocky-compiler/src/import/report.rs
@@ -484,6 +484,7 @@ mod tests {
         ImportResult {
             imported,
             warnings,
+            structured_warnings: vec![],
             failed,
             sources_found,
             sources_mapped,

--- a/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/__init__.py
@@ -176,7 +176,12 @@ from .apply_schema import ApplyOutput
 from .profile_storage_schema import EncodingRecommendationOutput, ProfileStorageOutput
 
 # Import-dbt command
-from .import_dbt_schema import ImportDbtFailure, ImportDbtOutput, ImportDbtWarning
+from .import_dbt_schema import (
+    ImportDbtFailure,
+    ImportDbtHookKind,
+    ImportDbtOutput,
+    ImportDbtWarning,
+)
 
 # Hooks list + test
 from .hooks_list_schema import HookEntry, HooksListOutput
@@ -388,6 +393,7 @@ __all__ = [
     "ImportDbtOutput",
     "ImportDbtWarning",
     "ImportDbtFailure",
+    "ImportDbtHookKind",
     # hooks
     "HooksListOutput",
     "HookEntry",

--- a/integrations/dagster/src/dagster_rocky/types_generated/import_dbt_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/import_dbt_schema.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, conint
+from pydantic import BaseModel, Field, conint
 
 
 class ImportDbtEmission(BaseModel):
@@ -58,6 +59,102 @@ class ImportDbtFailure(BaseModel):
     reason: str
 
 
+class ImportDbtHookKind(StrEnum):
+    """
+    Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].
+    """
+
+    pre = "pre"
+    post = "post"
+
+
+class Kind(StrEnum):
+    unsupported_materialization = "unsupported_materialization"
+
+
+class ImportDbtStructuredWarning1(BaseModel):
+    """
+    A dbt materialization with no direct Rocky equivalent. The importer fell back to the closest match (typically `full_refresh`).
+    """
+
+    action: str
+    dbt_materialization: str
+    kind: Kind
+    model: str
+
+
+class Kind33(StrEnum):
+    dropped_databricks_tags = "dropped_databricks_tags"
+
+
+class ImportDbtStructuredWarning2(BaseModel):
+    """
+    `databricks_tags` block dropped — Rocky's `[classification]` block + `rocky-databricks` governance surface covers the same use case but requires manual config.
+    """
+
+    kind: Kind33
+    model: str
+    tags: dict[str, str]
+
+
+class Kind34(StrEnum):
+    dropped_hook = "dropped_hook"
+
+
+class ImportDbtStructuredWarning3(BaseModel):
+    """
+    `pre_hook` or `post_hook` dropped — Rocky supports lifecycle hooks via the `[[hook]]` block in `rocky.toml`.
+    """
+
+    hook_kind: ImportDbtHookKind
+    kind: Kind34
+    model: str
+    sql: str
+
+
+class Kind35(StrEnum):
+    dropped_on_schema_change = "dropped_on_schema_change"
+
+
+class ImportDbtStructuredWarning4(BaseModel):
+    """
+    `on_schema_change` dropped — Rocky exposes the equivalent via per-pipeline `[drift]` policy.
+    """
+
+    dbt_value: str
+    kind: Kind35
+    model: str
+    rocky_equivalent: str
+
+
+class Kind36(StrEnum):
+    unresolvable_macro = "unresolvable_macro"
+
+
+class ImportDbtStructuredWarning5(BaseModel):
+    """
+    A custom Jinja macro call survived `dbt compile` — defined out-of-tree. The user needs to hand-port the macro.
+    """
+
+    first_call_site_line: conint(ge=0)
+    kind: Kind36
+    macro_name: str
+    model: str
+
+
+class Kind37(StrEnum):
+    microbatch_missing_event_time = "microbatch_missing_event_time"
+
+
+class ImportDbtStructuredWarning6(BaseModel):
+    """
+    A microbatch model is missing the required `event_time` field — the importer fell back to `full_refresh`.
+    """
+
+    kind: Kind37
+    model: str
+
+
 class ImportDbtWarning(BaseModel):
     category: str
     message: str
@@ -91,6 +188,20 @@ class ImportDbtOutput(BaseModel):
     """
     sources_found: conint(ge=0)
     sources_mapped: conint(ge=0)
+    structured_warnings: (
+        list[
+            ImportDbtStructuredWarning1
+            | ImportDbtStructuredWarning2
+            | ImportDbtStructuredWarning3
+            | ImportDbtStructuredWarning4
+            | ImportDbtStructuredWarning5
+            | ImportDbtStructuredWarning6
+        ]
+        | None
+    ) = Field([], validate_default=True)
+    """
+    Typed structured warnings — payload-carrying variants for dbt config Rocky can't auto-translate (dropped tags, dropped hooks, unresolvable macros, etc.). Coexists with `warning_details` — orchestrators that don't know about this field still see the flat string warnings under `warning_details`.
+    """
     tests_converted: conint(ge=0)
     tests_converted_custom: conint(ge=0)
     tests_found: conint(ge=0)

--- a/integrations/dagster/src/dagster_rocky/types_generated/plan_promote_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/plan_promote_schema.py
@@ -83,7 +83,7 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind33(StrEnum):
+class Kind39(StrEnum):
     model_added = "model_added"
 
 
@@ -92,11 +92,11 @@ class BreakingChange36(BaseModel):
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind33
+    kind: Kind39
     model: str
 
 
-class Kind34(StrEnum):
+class Kind40(StrEnum):
     column_dropped = "column_dropped"
 
 
@@ -107,11 +107,11 @@ class BreakingChange37(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind34
+    kind: Kind40
     model: str
 
 
-class Kind35(StrEnum):
+class Kind41(StrEnum):
     column_added = "column_added"
 
 
@@ -122,12 +122,12 @@ class BreakingChange38(BaseModel):
 
     column: str
     data_type: str
-    kind: Kind35
+    kind: Kind41
     model: str
     nullable: bool
 
 
-class Kind36(StrEnum):
+class Kind42(StrEnum):
     column_type_changed = "column_type_changed"
 
 
@@ -137,7 +137,7 @@ class BreakingChange39(BaseModel):
     """
 
     column: str
-    kind: Kind36
+    kind: Kind42
     model: str
     narrowing: bool
     """
@@ -147,7 +147,7 @@ class BreakingChange39(BaseModel):
     old_type: str
 
 
-class Kind37(StrEnum):
+class Kind43(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
@@ -157,13 +157,13 @@ class BreakingChange40(BaseModel):
     """
 
     column: str
-    kind: Kind37
+    kind: Kind43
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind38(StrEnum):
+class Kind44(StrEnum):
     column_reordered = "column_reordered"
 
 
@@ -173,13 +173,13 @@ class BreakingChange41(BaseModel):
     """
 
     column: str
-    kind: Kind38
+    kind: Kind44
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind39(StrEnum):
+class Kind45(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
@@ -188,13 +188,13 @@ class BreakingChange42(BaseModel):
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind39
+    kind: Kind45
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind40(StrEnum):
+class Kind46(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
@@ -207,13 +207,13 @@ class BreakingChange43(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind40
+    kind: Kind46
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind41(StrEnum):
+class Kind47(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
@@ -222,13 +222,13 @@ class BreakingChange44(BaseModel):
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind41
+    kind: Kind47
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind42(StrEnum):
+class Kind48(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
@@ -237,13 +237,13 @@ class BreakingChange45(BaseModel):
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
     """
 
-    kind: Kind42
+    kind: Kind48
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind43(StrEnum):
+class Kind49(StrEnum):
     target_renamed = "target_renamed"
 
 
@@ -252,13 +252,13 @@ class BreakingChange46(BaseModel):
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind43
+    kind: Kind49
     model: str
     new: str
     old: str
 
 
-class Kind44(StrEnum):
+class Kind50(StrEnum):
     source_changed = "source_changed"
 
 
@@ -267,13 +267,13 @@ class BreakingChange47(BaseModel):
     Source reference rebound to a different table.
     """
 
-    kind: Kind44
+    kind: Kind50
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind45(StrEnum):
+class Kind51(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
@@ -283,13 +283,13 @@ class BreakingChange48(BaseModel):
     """
 
     column: str
-    kind: Kind45
+    kind: Kind51
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind46(StrEnum):
+class Kind52(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
@@ -298,13 +298,13 @@ class BreakingChange49(BaseModel):
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind46
+    kind: Kind52
     model: str
     new: str
     old: str
 
 
-class Kind47(StrEnum):
+class Kind53(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
@@ -313,7 +313,7 @@ class BreakingChange50(BaseModel):
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind47
+    kind: Kind53
     model: str
 
 

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind49(StrEnum):
+class Kind55(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind49
+    kind: Kind55
 
 
 class PreviewModelDiff(BaseModel):

--- a/schemas/import_dbt.schema.json
+++ b/schemas/import_dbt.schema.json
@@ -78,6 +78,174 @@
       ],
       "type": "object"
     },
+    "ImportDbtHookKind": {
+      "description": "Lifecycle hook kind for [`ImportDbtStructuredWarning::DroppedHook`].",
+      "enum": [
+        "pre",
+        "post"
+      ],
+      "type": "string"
+    },
+    "ImportDbtStructuredWarning": {
+      "description": "Typed structured warning for dbt config that Rocky can't translate automatically. Each variant carries the source payload so the downstream UI (Dagster, VS Code) can route specific kinds into per-kind UI affordances without parsing free-form text.",
+      "oneOf": [
+        {
+          "description": "A dbt materialization with no direct Rocky equivalent. The importer fell back to the closest match (typically `full_refresh`).",
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "dbt_materialization": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "unsupported_materialization"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "dbt_materialization",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`databricks_tags` block dropped — Rocky's `[classification]` block + `rocky-databricks` governance surface covers the same use case but requires manual config.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "dropped_databricks_tags"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "tags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "tags"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`pre_hook` or `post_hook` dropped — Rocky supports lifecycle hooks via the `[[hook]]` block in `rocky.toml`.",
+          "properties": {
+            "hook_kind": {
+              "$ref": "#/definitions/ImportDbtHookKind"
+            },
+            "kind": {
+              "enum": [
+                "dropped_hook"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "sql": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "hook_kind",
+            "kind",
+            "model",
+            "sql"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`on_schema_change` dropped — Rocky exposes the equivalent via per-pipeline `[drift]` policy.",
+          "properties": {
+            "dbt_value": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "dropped_on_schema_change"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "rocky_equivalent": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "dbt_value",
+            "kind",
+            "model",
+            "rocky_equivalent"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A custom Jinja macro call survived `dbt compile` — defined out-of-tree. The user needs to hand-port the macro.",
+          "properties": {
+            "first_call_site_line": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "kind": {
+              "enum": [
+                "unresolvable_macro"
+              ],
+              "type": "string"
+            },
+            "macro_name": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first_call_site_line",
+            "kind",
+            "macro_name",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A microbatch model is missing the required `event_time` field — the importer fell back to `full_refresh`.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "microbatch_missing_event_time"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "ImportDbtWarning": {
       "properties": {
         "category": {
@@ -174,6 +342,14 @@
       "format": "uint",
       "minimum": 0.0,
       "type": "integer"
+    },
+    "structured_warnings": {
+      "default": [],
+      "description": "Typed structured warnings — payload-carrying variants for dbt config Rocky can't auto-translate (dropped tags, dropped hooks, unresolvable macros, etc.). Coexists with `warning_details` — orchestrators that don't know about this field still see the flat string warnings under `warning_details`.",
+      "items": {
+        "$ref": "#/definitions/ImportDbtStructuredWarning"
+      },
+      "type": "array"
     },
     "tests_converted": {
       "format": "uint",


### PR DESCRIPTION
## Summary

- **Materialization mapping.** `rocky import-dbt` now maps `view` to `StrategyConfig::View`, `materialized_view` to `StrategyConfig::MaterializedView`, and `microbatch` to `StrategyConfig::Microbatch { event_time, granularity }`. Previously these were silently flattened to `FullRefresh` or dropped entirely.
- **Parse-bug fix.** `incremental_strategy='merge'` was being captured as a timestamp column name. Now `incremental_strategy` is parsed as the strategy discriminator across both manifest + regex paths — `merge` → `Merge`, `append` → `Incremental`, `delete+insert` → `DeleteInsert`, `insert_overwrite` → `DeleteInsert` (with a warning to consider `time_interval`), `microbatch` → `Microbatch`.
- **Structured warnings.** New `ImportDbtStructuredWarning` enum on `ImportDbtOutput.structured_warnings` carries payload data for dbt config that can't be auto-translated: `DroppedDatabricksTags`, `DroppedHook { pre|post, sql }`, `DroppedOnSchemaChange { dbt_value, rocky_equivalent }`, `UnresolvableMacro { macro_name, first_call_site_line }`, `UnsupportedMaterialization`, `MicrobatchMissingEventTime`. Existing flat string warnings stay for back-compat. `MIGRATION-NOTES.md` gains an "Items to translate manually" section that lists the actual dropped payload (tag k/v pairs, hook SQL, etc.) so the user gets a concrete checklist.

Wave 3 — custom-macro porting framework, full `dbt_utils` / `dbt_databricks` translation — stays deferred and demand-gated.

## Test plan

- [x] `cargo test --release -p rocky-compiler -p rocky-cli --all-features` — 275 + 547 + integration tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean across the workspace
- [x] `cargo fmt --all -- --check` clean
- [x] `just codegen` no drift — new `ImportDbtStructuredWarning` + `ImportDbtHookKind` cascade to dagster Pydantic + VS Code TypeScript automatically
- [x] `just regen-fixtures` no drift
- [x] New unit tests pin each mapping (`test_manifest_view_maps_to_view_strategy`, `test_manifest_materialized_view_maps_to_materialized_view`, `test_manifest_microbatch_maps_to_microbatch`, `test_manifest_microbatch_missing_event_time_warns_and_falls_back`, `test_manifest_ephemeral_emits_warning`)
- [x] Regression test pins the parse-bug fix (`test_incremental_strategy_merge_regression`) — explicitly asserts `Merge { unique_key: ['user_id'] }`, NOT `Incremental { timestamp_column: 'merge' }`
- [x] Structured-warning tests verify payloads (`test_dropped_databricks_tags_warning`, `test_dropped_hook_warning`, `test_dropped_on_schema_change_warning`, `test_unresolvable_macro_warning`)
- [x] Existing dbt-rich integration test updated to assert `view → view` mapping (was `view → ephemeral`)
- [x] Live sanity-check against a small synthetic dbt manifest confirms the binary emits the new structured warnings + correct strategy in the generated sidecar TOML

## Notes for reviewers

- **Tests use inline `serde_json::json!{}` fixtures** in `engine/crates/rocky-compiler/src/import/dbt.rs` rather than a separate fixture directory. Keeps test data adjacent to assertions; no cross-file drift to maintain.
- **Manifest path is the canonical surface for structured warnings.** The regex-based path (used when no `manifest.json` is present) emits string warnings only — multi-line dbt config (hooks, tags) doesn't parse reliably without dbt's compiled output. This is documented on `extract_dbt_config`.
- **`view_models_to_make_ephemeral` field on `EmitInputs` retained** for back-compat. New imports always pass an empty set (the `view → View` mapping eliminates the need for the rewrite step), but the legacy field surface is preserved so existing callers don't break.