### PR TITLE
feat(rocky-fivetran): tolerate connectors with no schema config in fetch_envelope

### DIFF
--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -121,6 +121,9 @@ fn classify_fivetran_error(err: &FivetranError) -> FailedSourceErrorClass {
         // off and re-attempt on the next discover cycle.
         FivetranError::CircuitOpen => FailedSourceErrorClass::Transient,
         FivetranError::UnexpectedResponse(_) => FailedSourceErrorClass::Unknown,
+        // Per-account upstream state ("every connector 404s on
+        // schema_config"); not a transient transport thing.
+        FivetranError::NoHealthyConnectors { .. } => FailedSourceErrorClass::Unknown,
         // `code` here is either the raw HTTP status display (e.g. "503
         // Service Unavailable") from `client::get`, or the API envelope's
         // `code` field (e.g. "Unauthorized"). Lead-digit + canonical-reason

--- a/engine/crates/rocky-fivetran/src/client.rs
+++ b/engine/crates/rocky-fivetran/src/client.rs
@@ -94,6 +94,11 @@ pub enum FivetranError {
 
     #[error("Fivetran circuit breaker open for account; no HTTP attempted")]
     CircuitOpen,
+
+    #[error(
+        "emit-fivetran-state: all {total} connector(s) returned missing schema_config; no healthy connectors found"
+    )]
+    NoHealthyConnectors { total: usize },
 }
 
 /// Wire-decode shape for `GET /v1/destinations/{id}`. The envelope
@@ -1116,11 +1121,47 @@ impl FivetranClient {
                 .buffer_unordered(10)
                 .collect()
                 .await;
+        // Tolerate per-connector 404s from `connectors/{id}/schemas` —
+        // a connector in `incomplete`/`broken`/paused-pre-schema state
+        // returns 404 here as normal upstream signal, not a failure.
+        // Skip the offending connector (it still appears in the
+        // `connectors` summary list with its status fields), WARN with
+        // its id, and abort only when every connector 404s (which
+        // would indicate a credential or quota problem upstream).
+        let total_schema_fetches = schema_results.len();
         let mut schemas: BTreeMap<String, FivetranSchemaConfig> = BTreeMap::new();
+        let mut skipped_count: usize = 0;
         for (conn_id, result) in schema_results {
-            let cfg = result?;
-            schemas.insert(conn_id, project_schema_config(cfg));
+            match result {
+                Ok(cfg) => {
+                    schemas.insert(conn_id, project_schema_config(cfg));
+                }
+                Err(e) if is_missing_schema_config(&e) => {
+                    skipped_count += 1;
+                    tracing::warn!(
+                        target: "rocky_fivetran::emit",
+                        connector_id = %conn_id,
+                        reason = %e,
+                        "emit-fivetran-state: skipping connector (schema_config not available); continuing"
+                    );
+                }
+                Err(e) => return Err(e),
+            }
         }
+        if total_schema_fetches > 0 && schemas.is_empty() {
+            return Err(FivetranError::NoHealthyConnectors {
+                total: total_schema_fetches,
+            });
+        }
+        tracing::info!(
+            target: "rocky_fivetran::emit",
+            written = schemas.len(),
+            skipped = skipped_count,
+            total = total_schema_fetches,
+            "emit-fivetran-state: envelope built ({} connector schemas, {} skipped due to missing schema_config)",
+            schemas.len(),
+            skipped_count
+        );
 
         let summaries: Vec<FivetranConnectorSummary> = connectors
             .into_iter()
@@ -1224,6 +1265,25 @@ fn is_remote_failure(err: &FivetranError) -> bool {
         FivetranError::RateLimited => false, // see doc comment above
         FivetranError::UnexpectedResponse(_) => false, // local decode error
         FivetranError::CircuitOpen => false,
+        // Per-account upstream state, not a transport failure — don't
+        // trip the breaker. A retry on the next discover cycle won't
+        // help unless the operator fixes the connectors upstream.
+        FivetranError::NoHealthyConnectors { .. } => false,
+    }
+}
+
+/// Recognise the missing-schema-config 404 shape from
+/// `GET /v1/connectors/{id}/schemas`. Fivetran returns 404 with a
+/// `NotFound_SchemaConfig` payload for connectors in `incomplete`,
+/// `broken`, or paused-pre-schema states — normal upstream state,
+/// not a failure condition. The HTTP non-success path in
+/// [`FivetranClient::get`] sets `code` to the status display
+/// (e.g. `"404 Not Found"`) so a leading-digit match captures the
+/// whole 404 family from this endpoint.
+fn is_missing_schema_config(err: &FivetranError) -> bool {
+    match err {
+        FivetranError::Api { code, .. } => code.starts_with("404"),
+        _ => false,
     }
 }
 

--- a/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-fivetran/tests/wiremock_tests.rs
@@ -1523,3 +1523,183 @@ fn sample_envelope_for_cache() -> rocky_fivetran::envelope::FivetranStateEnvelop
         BTreeMap::<String, FivetranSchemaConfig>::new(),
     )
 }
+
+// ---------------------------------------------------------------------------
+// FR-027: tolerate connectors with no schema config in fetch_envelope
+// ---------------------------------------------------------------------------
+
+/// Mount destination + connectors-list shared by the FR-027 tests.
+/// Three connectors: `conn_ok_a`, `conn_ok_b`, `conn_broken`. The
+/// caller mounts the per-connector `/schemas` endpoints with whatever
+/// mix of 200s and 404s the test needs.
+async fn mount_envelope_skeleton_fr027(server: &MockServer, destination_id: &str) {
+    use wiremock::ResponseTemplate;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/destinations/{destination_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "id": destination_id,
+                "region": "us-east-1",
+                "time_zone": "UTC",
+                "service": "snowflake",
+                "setup_status": "connected"
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/groups/{destination_id}/connectors")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "items": [
+                    {
+                        "id": "conn_ok_a",
+                        "group_id": destination_id,
+                        "service": "shopify",
+                        "schema": "src__acme__na__shopify",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "paused": false,
+                        "succeeded_at": "2026-04-10T10:00:00Z",
+                        "failed_at": null
+                    },
+                    {
+                        "id": "conn_ok_b",
+                        "group_id": destination_id,
+                        "service": "stripe",
+                        "schema": "src__acme__na__stripe",
+                        "status": { "setup_state": "connected", "sync_state": "scheduled" },
+                        "paused": false,
+                        "succeeded_at": "2026-04-10T10:00:00Z",
+                        "failed_at": null
+                    },
+                    {
+                        "id": "conn_broken",
+                        "group_id": destination_id,
+                        "service": "marketo",
+                        "schema": "src__acme__na__marketo",
+                        "status": { "setup_state": "incomplete", "sync_state": "paused" },
+                        "paused": true,
+                        "succeeded_at": null,
+                        "failed_at": null
+                    }
+                ],
+                "next_cursor": null
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount a 200 `/schemas` response for one connector.
+async fn mount_schema_ok(server: &MockServer, connector_id: &str) {
+    use wiremock::ResponseTemplate;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/connectors/{connector_id}/schemas")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": "Success",
+            "data": {
+                "schemas": {
+                    "src": {
+                        "enabled": true,
+                        "tables": {
+                            "orders": {
+                                "enabled": true,
+                                "sync_mode": "SOFT_DELETE",
+                                "columns": { "id": { "enabled": true, "hashed": false } }
+                            }
+                        }
+                    }
+                }
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount a 404 `NotFound_SchemaConfig` `/schemas` response — the exact
+/// shape Fivetran returns for connectors in `incomplete`/`broken`/
+/// paused-pre-schema state, per FR-027.
+async fn mount_schema_404(server: &MockServer, connector_id: &str) {
+    use wiremock::ResponseTemplate;
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/connectors/{connector_id}/schemas")))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "code": "NotFound_SchemaConfig",
+            "message": format!("Connection with id '{connector_id}' doesn't have schema config")
+        })))
+        .mount(server)
+        .await;
+}
+
+/// FR-027 acceptance: a mix of healthy + missing-schema-config
+/// connectors must produce a written envelope holding the healthy
+/// ones, while the broken connector still appears in the `connectors`
+/// summary list with its status fields.
+#[tokio::test]
+async fn fetch_envelope_skips_404_schema_connectors() {
+    let server = MockServer::start().await;
+    mount_envelope_skeleton_fr027(&server, "dest_fr027_mixed").await;
+    mount_schema_ok(&server, "conn_ok_a").await;
+    mount_schema_ok(&server, "conn_ok_b").await;
+    mount_schema_404(&server, "conn_broken").await;
+
+    let client = test_client(&server);
+    let env = client
+        .fetch_envelope("dest_fr027_mixed", false)
+        .await
+        .expect("envelope must be written when at least one connector has a schema_config");
+
+    let schema_keys: Vec<&str> = env.schemas.keys().map(String::as_str).collect();
+    assert_eq!(
+        schema_keys,
+        vec!["conn_ok_a", "conn_ok_b"],
+        "broken connector must be excluded from schemas map"
+    );
+    let connector_ids: Vec<&str> = env.connectors.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(
+        connector_ids,
+        vec!["conn_broken", "conn_ok_a", "conn_ok_b"],
+        "broken connector must still appear in connectors summary list"
+    );
+    let broken = env
+        .connectors
+        .iter()
+        .find(|c| c.id == "conn_broken")
+        .expect("broken connector must be in the summary list");
+    assert_eq!(broken.status.setup_state, "incomplete");
+    assert!(broken.paused, "broken connector's status fields preserved");
+
+    drop(server);
+}
+
+/// FR-027 acceptance: when every connector returns 404 the envelope
+/// is not written and the error surfaces as `NoHealthyConnectors`.
+#[tokio::test]
+async fn fetch_envelope_errors_when_all_schemas_404() {
+    let server = MockServer::start().await;
+    mount_envelope_skeleton_fr027(&server, "dest_fr027_all_404").await;
+    mount_schema_404(&server, "conn_ok_a").await;
+    mount_schema_404(&server, "conn_ok_b").await;
+    mount_schema_404(&server, "conn_broken").await;
+
+    let client = test_client(&server);
+    let err = client
+        .fetch_envelope("dest_fr027_all_404", false)
+        .await
+        .expect_err("envelope must error when no connector returns a schema_config");
+
+    match err {
+        FivetranError::NoHealthyConnectors { total } => {
+            assert_eq!(total, 3, "all 3 fetches accounted for in the error");
+        }
+        other => panic!("expected NoHealthyConnectors, got {other:?}"),
+    }
+
+    drop(server);
+}

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -252,6 +252,14 @@ enum Command {
         /// matches the on-disk value the JSON file is left alone,
         /// so downstream `stat(2)` watchers only fire when the
         /// upstream Fivetran state actually changed.
+        ///
+        /// Connectors whose `connectors/{id}/schemas` endpoint returns
+        /// 404 (state `incomplete`/`broken`/paused-pre-schema, etc.)
+        /// are excluded from the envelope's `schemas` map and logged
+        /// at WARN; they still appear in `connectors` with their
+        /// status fields. Exits non-zero only when every connector
+        /// returns 404, so the envelope count won't always match the
+        /// Fivetran UI total.
         #[arg(long, value_name = "PATH")]
         emit_fivetran_state_to: Option<PathBuf>,
         /// Skip the persistent state cache on read and force a fresh


### PR DESCRIPTION
## Summary

`rocky discover --emit-fivetran-state-to <PATH>` aborted with a `NotFound_SchemaConfig` API error the moment a single connector's `GET /v1/connectors/{id}/schemas` returned 404. The 404 is a normal upstream signal for connectors in `incomplete`/`broken`/paused-pre-schema state, not a failure — and the resulting all-or-nothing emit made the path unusable on any tenant with even one such connector.

This change:

- Skips the offending connector — excluded from the envelope's `schemas` map, still present in `connectors` with its status fields intact.
- Logs `WARN` per-skipped connector (`target = rocky_fivetran::emit`, includes the id and upstream reason).
- Logs an `INFO` summary at the end (`written`, `skipped`, `total` structured fields).
- Exits non-zero only when every connector returns 404, via a new `FivetranError::NoHealthyConnectors { total }` variant.

The behaviour mirrors the existing `rocky discover --with-schemas` lenience (one bad source does not abort the warm-up).

## Test plan

- [x] `cargo test -p rocky-fivetran --features test-support` — 29/29 passing, including 2 new wiremock integration tests:
  - `fetch_envelope_skips_404_schema_connectors` — 3 connectors (2 healthy, 1 returns `NotFound_SchemaConfig` 404). Envelope is written; `schemas` map holds the 2 healthy connectors, `connectors` summary still includes all 3 with their status fields preserved.
  - `fetch_envelope_errors_when_all_schemas_404` — all 3 connectors 404. Returns `FivetranError::NoHealthyConnectors { total: 3 }`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `rocky discover --help` renders the updated `--emit-fivetran-state-to` docstring noting the skip behaviour.

## Notes

- The 404 detection lives in a small `is_missing_schema_config(&FivetranError)` helper — currently keyed on `Api { code, .. }` where `code.starts_with("404")` (the HTTP-status display set in `FivetranClient::get` on non-success responses). Any future 404 surface from this endpoint is captured the same way.
- `NoHealthyConnectors` is intentionally classified as a local-side (non-remote) failure for both the circuit breaker (`is_remote_failure → false`) and the discovery-error class mapping (`FailedSourceErrorClass::Unknown`) — retrying on the next discover cycle won't help unless the operator fixes the connectors upstream.
- Envelope shape unchanged — no codegen cascade, no schema drift, no fixture regen.