### PR TITLE
docs(release): cover data_tests: alias + manifest unit-test bridge + POC 19

### DIFF
--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -586,11 +586,16 @@ Then compare row counts, column types, and data values between the dbt-generated
 
 ## 9. Convert dbt Tests to Rocky Tests and Contracts
 
-`rocky import-dbt` already translates the four canonical dbt generic tests into Rocky `[[tests]]` blocks on each model sidecar. Anything beyond that — column-level type/nullability contracts, project-defined generics, singular tests — needs a manual step.
+`rocky import-dbt` translates two kinds of dbt tests onto Rocky sidecars:
+
+- The **four canonical column-level generic tests** (`unique`, `not_null`, `accepted_values`, `relationships`) — emitted as `[[tests]]` blocks on each model sidecar.
+- **Unit tests from `manifest.unit_tests`** (dbt 1.8+) — emitted as `[[test]]` blocks on the matching model sidecar. Manifest-only; the regex path does not see unit tests.
+
+Anything else — column-level type/nullability contracts, project-defined generics, singular tests — still needs a manual step.
 
 ### Generic test mapping
 
-For these dbt tests in `schema.yml`:
+For these dbt tests in `schema.yml` (dbt 1.7+ also accepts `data_tests:`, which the importer reads as a synonym for `tests:`):
 
 ```yaml
 models:
@@ -644,6 +649,52 @@ column = "customer_id"
 | `relationships` | `type = "relationships"` + `to_table` + `to_column` + `column` |
 
 Anything else (`dbt_utils.*`, `dbt_expectations.*`, project-defined generics, model-level tests) is surfaced as an `UnsupportedTest` warning with the model, column, and test name. Rewrite those as a Rocky `expression` test or a quality-pipeline check — the importer does not stub them in the emitted TOML.
+
+### dbt unit tests (manifest path)
+
+If your dbt project has compiled to a `manifest.json` and declares `unit_tests:` blocks (dbt 1.8+), `rocky import-dbt --manifest target/manifest.json` walks `manifest.unit_tests` and emits each entry as a `[[test]]` block in the matching model's sidecar TOML. `ref('upstream_model')` / `source('s', 't')` wrappers on `given.input` are stripped to bare references.
+
+```yaml
+# dbt: models/fct_orders.yml
+unit_tests:
+  - name: stamps_status_when_completed
+    model: fct_orders
+    given:
+      - input: ref('stg_orders')
+        rows:
+          - { order_id: 1, status: 'completed' }
+    expect:
+      format: dict
+      rows:
+        - { order_id: 1, status: 'completed' }
+```
+
+```toml
+# Rocky: models/fct_orders.toml — emitted by `rocky import-dbt`
+[[test]]
+name = "stamps_status_when_completed"
+
+[[test.given]]
+ref = "stg_orders"
+
+[[test.given.rows]]
+order_id = 1
+status = "completed"
+
+[test.expect]
+ordered = false
+
+[[test.expect.rows]]
+order_id = 1
+status = "completed"
+```
+
+The importer also surfaces three new counters on the `--output json` payload and in `MIGRATION-NOTES.md` — `unit_tests_found`, `unit_tests_converted`, `unit_tests_skipped` — plus two warning variants:
+
+- `OrphanUnitTest` — the unit test targets a model the importer didn't pick up. Skipped and counted as skipped.
+- `UnsupportedUnitTestFormat` — `expect.format = "csv"` / `"sql"`, fixture references, or any other shape Rocky's `UnitTestDef` doesn't yet model. Skipped.
+
+CSV / SQL fixtures and `overrides:` blocks are deferred until Rocky's runtime test runner grows the matching surface; emitted `[[test]]` blocks deserialize through Rocky today but aren't yet wired into `rocky test` execution.
 
 ### Column-level contracts (manual)
 

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -256,10 +256,15 @@ pub fn import_from_manifest(manifest: &DbtManifest, default_target: &TargetConfi
 }
 
 /// Walk a dbt project's `models/` tree for `schema.yml` files, convert any
-/// `tests:` entries to canonical Rocky [`TestDecl`]s, attach them to the
-/// matching imported model, and emit structured warnings for tests outside
-/// the four canonical built-ins. Counter fields on [`ImportResult`] are
-/// updated in place.
+/// `tests:` / `data_tests:` entries to canonical Rocky [`TestDecl`]s, attach
+/// them to the matching imported model, and emit structured warnings for
+/// tests outside the four canonical built-ins. Counter fields on
+/// [`ImportResult`] are updated in place.
+///
+/// Both spellings of the key are accepted (`data_tests:` is dbt 1.7+; the
+/// legacy `tests:` form still works on the dbt side and on the Rocky
+/// importer). Unit tests from `manifest.unit_tests` are handled separately
+/// by [`apply_dbt_unit_tests`].
 ///
 /// The caller passes the dbt project root (or any directory the YAMLs live
 /// under). Both the `models/` regex path and the manifest path use this

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -132,9 +132,9 @@ Hooks, webhooks, remote state, checkpoint/resume, Valkey cache, Dagster DAG mode
 | [09-idempotency-key](pocs/05-orchestration/09-idempotency-key) | `rocky run --idempotency-key` dedup — second run with the same key yields `status = "skipped_idempotent"` |
 | [10-state-retention-sweep](pocs/05-orchestration/10-state-retention-sweep) | `[state.retention]` + `rocky state retention sweep` — manual + end-of-run auto-sweep of run history / lineage / audit domains |
 
-### 06 — Developer Experience (17 POCs · DuckDB)
+### 06 — Developer Experience (19 POCs · DuckDB)
 
-Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff, run-watch, dbt-import failure modes.
+Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, portability lint, SQL types, PR-preview, lineage-diff, run-watch, dbt-import failure modes, view strategy, dbt unit-test import.
 
 | POC | Feature |
 |---|---|
@@ -155,6 +155,8 @@ Lineage, HTTP API, dbt import, shadow mode, CI, hybrid workflows, trace Gantt, p
 | [15-semantic-breaking-change-gate](pocs/06-developer-experience/15-semantic-breaking-change-gate) | `rocky ci-diff --semantic` (informational) + `rocky branch promote --base-ref / --allow-breaking` — pre-promote gate blocks column drops; override is recorded as a `BreakingChangesAllowed` audit event |
 | [16-history-rolling-stats](pocs/06-developer-experience/16-history-rolling-stats) | `rocky history --model <name> --rolling-stats --window N` — per-model mean / std-dev / z-score / composite `health_score` over the rolling window |
 | [17-trace-replay-cost-combo](pocs/06-developer-experience/17-trace-replay-cost-combo) | One `RunRecord`, three views — `rocky trace` + `rocky cost` + `rocky replay` all project from the same run id |
+| [18-view-strategy](pocs/06-developer-experience/18-view-strategy) | `[strategy] type = "view"` — model compiles to `CREATE OR REPLACE VIEW <target>` on every warehouse |
+| [19-import-dbt-unit-tests](pocs/06-developer-experience/19-import-dbt-unit-tests) | `rocky import-dbt --manifest` walks `manifest.unit_tests` into Rocky `[[test]]` sidecars; `data_tests:` accepted as alias for `tests:` on column tests (dbt 1.7+) |
 
 ### 07 — Adapters (7 POCs · mixed)
 

--- a/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/README.md
+++ b/examples/playground/pocs/06-developer-experience/03-import-dbt-validate/README.md
@@ -21,6 +21,12 @@ Two commands for migrating off dbt:
 That example shows hand-written before/after equivalents. This POC
 demonstrates the **automated** import path on a real (small) dbt project.
 
+`dbt_project/models/schema.yml` uses the legacy `tests:` key. As of engine
+v1.39.0 the importer also accepts the dbt-1.7+ `data_tests:` spelling on the
+same column tests — swap one for the other and the import is identical.
+See sibling POC `19-import-dbt-unit-tests/` for the manifest path that also
+imports `manifest.unit_tests` entries onto Rocky `[[test]]` sidecars.
+
 ## Layout
 
 ```

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/README.md
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/README.md
@@ -1,0 +1,116 @@
+# 19-import-dbt-unit-tests — `rocky import-dbt` unit-test bridge + `data_tests:` alias
+
+> **Category:** 06-developer-experience
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 5s
+> **Rocky features:** `rocky import-dbt`, manifest path, `manifest.unit_tests` → `[[test]]` sidecars
+
+## What it shows
+
+Two pieces of `rocky import-dbt` coverage added in engine v1.39.0:
+
+1. **`data_tests:` accepted as an alias for `tests:`** on column-level YAML tests.
+   dbt 1.7+ renamed the column-test key from `tests:` to `data_tests:` (the legacy
+   spelling still works on the dbt side). Before v1.39.0 the importer only saw the
+   legacy key, so any modern dbt project converted to zero column tests. This POC's
+   `schema.yml` uses `data_tests:` exclusively to pin the alias in a runnable demo.
+
+2. **`manifest.unit_tests` → Rocky `[[test]]` sidecars.** The manifest path now walks
+   `manifest.unit_tests` and emits each entry as a `[[test]]` block on the matching
+   model's sidecar TOML. `ref('upstream')` / `source('a', 'b')` wrappers on
+   `given.input` are stripped to bare references. CSV / SQL fixtures are deliberately
+   out of scope and surface as `UnsupportedUnitTestFormat` warnings.
+
+## Why it's distinctive vs `03-import-dbt-validate/`
+
+POC 03 exercises the regex path (`--no-manifest`) and the canonical-four column-test
+mapping with the legacy `tests:` key. This POC exercises the **manifest** path on a
+deliberately dbt-1.8-shaped input: `data_tests:` for column tests + a `unit_tests`
+block in `target/manifest.json` covering happy path, source-wrapped input, and a
+deliberately unsupported CSV fixture.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── run.sh            end-to-end demo (no creds, no toolchain — uses a hand-authored manifest)
+├── dbt_project/
+│   ├── dbt_project.yml
+│   ├── models/
+│   │   ├── stg_orders.sql
+│   │   ├── fct_revenue.sql
+│   │   └── schema.yml          # data_tests: alias (column tests)
+│   └── target/
+│       └── manifest.json       # nodes + unit_tests block (dbt-1.8 schema v12)
+└── imported/                   # output dir (regenerated each run, gitignored)
+```
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+=== rocky import-dbt --manifest (emit Rocky repo + walk manifest.unit_tests) ===
+{
+  "version": "<rocky-version>",
+  "command": "import-dbt",
+  ...
+  "unit_tests_found": 3,
+  "unit_tests_converted": 2,
+  "unit_tests_skipped": 1,
+  ...
+}
+
+=== Emitted models/stg_orders.toml (data_tests: alias + unit test) ===
+name = "stg_orders"
+...
+[[tests]]
+type = "unique"
+column = "order_id"
+
+[[test]]
+name = "stamps_status_when_completed"
+[[test.given]]
+ref = "raw.orders"
+[[test.given.rows]]
+amount = 50
+customer_id = 100
+order_id = 1
+status = "Completed"
+# ... more given.rows ...
+[test.expect]
+ordered = false
+[[test.expect.rows]]
+status = "completed"
+# ...
+
+=== Assertions ===
+ok  All assertions passed.
+```
+
+## What happened
+
+1. `rocky import-dbt --manifest` reads `target/manifest.json`, walks `nodes` (models)
+   and `unit_tests`, and emits a Rocky repo under `imported/`.
+2. `apply_dbt_tests` (called from both the regex and manifest paths) reads
+   `dbt_project/models/schema.yml`, recognises `data_tests:` via the new serde alias,
+   and emits canonical-four `[[tests]]` blocks on `stg_orders.toml`.
+3. `apply_dbt_unit_tests` walks `manifest.unit_tests`, strips `ref(...)` / `source(...)`
+   wrappers on `given.input`, and emits `[[test]]` blocks on the matching model
+   sidecar. The CSV-format fixture surfaces as an `UnsupportedUnitTestFormat`
+   warning and bumps `unit_tests_skipped` by one.
+4. New counters (`unit_tests_found / unit_tests_converted / unit_tests_skipped`) show
+   up on the `--output json` payload (`ImportDbtOutput`) and in `MIGRATION-NOTES.md`.
+
+## Related
+
+- Migration guide: [`/guides/migrate-from-dbt/`](https://rocky-data.dev/guides/migrate-from-dbt/) — Section 9 covers both features.
+- Source: `engine/crates/rocky-compiler/src/import/{dbt.rs, dbt_manifest.rs, dbt_tests.rs, dbt_sources.rs}`
+- Sibling POCs:
+  - [`03-import-dbt-validate/`](../03-import-dbt-validate/) — regex path, legacy `tests:` key
+  - [`14-import-dbt-failure-modes/`](../14-import-dbt-failure-modes/) — out-of-scope dbt features (Jinja, non-canonical tests)

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/dbt_project.yml
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/dbt_project.yml
@@ -1,0 +1,12 @@
+name: ecommerce
+version: '1.0.0'
+config-version: 2
+
+profile: ecommerce
+
+model-paths: ["models"]
+target-path: "target"
+
+models:
+  ecommerce:
+    +materialized: table

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/fct_revenue.sql
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/fct_revenue.sql
@@ -1,0 +1,6 @@
+SELECT
+    customer_id,
+    SUM(amount) AS total_revenue,
+    COUNT(*) AS order_count
+FROM stg_orders
+GROUP BY customer_id

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/schema.yml
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/schema.yml
@@ -1,0 +1,64 @@
+version: 2
+
+# Demonstrates two import-dbt features added in engine v1.39.0:
+#
+#  1. `data_tests:` accepted as an alias for the legacy `tests:` key.
+#     dbt 1.7+ renamed the column-level key; both spellings now flow
+#     into the same canonical-four mapping (unique / not_null /
+#     accepted_values / relationships).
+#
+#  2. `unit_tests:` (declared here for readability; the importer reads
+#     them from `target/manifest.json`'s `unit_tests` block — see
+#     run.sh).
+models:
+  - name: stg_orders
+    description: Staged orders, one row per order, with a normalised status.
+    columns:
+      - name: order_id
+        data_tests:
+          - unique
+          - not_null
+      - name: customer_id
+        data_tests:
+          - not_null
+      - name: status
+        data_tests:
+          - accepted_values:
+              values: ['pending', 'completed', 'shipped']
+
+  - name: fct_revenue
+    description: Per-customer revenue rollup.
+    columns:
+      - name: customer_id
+        data_tests:
+          - unique
+          - not_null
+
+unit_tests:
+  - name: stamps_status_when_completed
+    model: stg_orders
+    description: status normalises to lower-case for any case-mix input
+    given:
+      - input: source('raw', 'orders')
+        rows:
+          - { order_id: 1, customer_id: 100, amount: 50, status: 'Completed' }
+          - { order_id: 2, customer_id: 100, amount: 75, status: 'SHIPPED' }
+    expect:
+      rows:
+        - { order_id: 1, customer_id: 100, amount: 50, status: 'completed' }
+        - { order_id: 2, customer_id: 100, amount: 75, status: 'shipped' }
+      format: dict
+
+  - name: rolls_up_revenue_per_customer
+    model: fct_revenue
+    given:
+      - input: ref('stg_orders')
+        rows:
+          - { order_id: 1, customer_id: 100, amount: 50, status: 'completed' }
+          - { order_id: 2, customer_id: 100, amount: 75, status: 'shipped' }
+          - { order_id: 3, customer_id: 200, amount: 30, status: 'completed' }
+    expect:
+      rows:
+        - { customer_id: 100, total_revenue: 125, order_count: 2 }
+        - { customer_id: 200, total_revenue: 30, order_count: 1 }
+      format: dict

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/stg_orders.sql
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/models/stg_orders.sql
@@ -1,0 +1,7 @@
+SELECT
+    order_id,
+    customer_id,
+    amount,
+    LOWER(status) AS status
+FROM raw.orders
+WHERE status != 'cancelled'

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/target/manifest.json
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/dbt_project/target/manifest.json
@@ -1,0 +1,132 @@
+{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/manifest/v12/manifest.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2026-05-19T00:00:00Z",
+    "project_name": "ecommerce"
+  },
+  "nodes": {
+    "model.ecommerce.stg_orders": {
+      "unique_id": "model.ecommerce.stg_orders",
+      "name": "stg_orders",
+      "resource_type": "model",
+      "compiled_code": "SELECT\n    order_id,\n    customer_id,\n    amount,\n    LOWER(status) AS status\nFROM raw.orders\nWHERE status != 'cancelled'",
+      "raw_code": "SELECT\n    order_id,\n    customer_id,\n    amount,\n    LOWER(status) AS status\nFROM {{ source('raw', 'orders') }}\nWHERE status != 'cancelled'",
+      "depends_on": {
+        "nodes": ["source.ecommerce.raw.orders"],
+        "macros": []
+      },
+      "config": {
+        "materialized": "table"
+      },
+      "columns": {
+        "order_id":    { "name": "order_id" },
+        "customer_id": { "name": "customer_id" },
+        "amount":      { "name": "amount" },
+        "status":      { "name": "status" }
+      },
+      "description": "Staged orders, one row per order, with a normalised status.",
+      "tags": [],
+      "schema": "staging",
+      "database": "warehouse"
+    },
+    "model.ecommerce.fct_revenue": {
+      "unique_id": "model.ecommerce.fct_revenue",
+      "name": "fct_revenue",
+      "resource_type": "model",
+      "compiled_code": "SELECT\n    customer_id,\n    SUM(amount) AS total_revenue,\n    COUNT(*) AS order_count\nFROM warehouse.staging.stg_orders\nGROUP BY customer_id",
+      "raw_code": "SELECT\n    customer_id,\n    SUM(amount) AS total_revenue,\n    COUNT(*) AS order_count\nFROM {{ ref('stg_orders') }}\nGROUP BY customer_id",
+      "depends_on": {
+        "nodes": ["model.ecommerce.stg_orders"],
+        "macros": []
+      },
+      "config": {
+        "materialized": "table"
+      },
+      "columns": {
+        "customer_id":   { "name": "customer_id" },
+        "total_revenue": { "name": "total_revenue" },
+        "order_count":   { "name": "order_count" }
+      },
+      "description": "Per-customer revenue rollup.",
+      "tags": [],
+      "schema": "marts",
+      "database": "warehouse"
+    }
+  },
+  "sources": {
+    "source.ecommerce.raw.orders": {
+      "unique_id": "source.ecommerce.raw.orders",
+      "name": "orders",
+      "source_name": "raw",
+      "database": "warehouse",
+      "schema": "raw"
+    }
+  },
+  "unit_tests": {
+    "unit_test.ecommerce.stg_orders.stamps_status_when_completed": {
+      "unique_id": "unit_test.ecommerce.stg_orders.stamps_status_when_completed",
+      "name": "stamps_status_when_completed",
+      "model": "stg_orders",
+      "given": [
+        {
+          "input": "source('raw', 'orders')",
+          "rows": [
+            { "order_id": 1, "customer_id": 100, "amount": 50, "status": "Completed" },
+            { "order_id": 2, "customer_id": 100, "amount": 75, "status": "SHIPPED" }
+          ]
+        }
+      ],
+      "expect": {
+        "rows": [
+          { "order_id": 1, "customer_id": 100, "amount": 50, "status": "completed" },
+          { "order_id": 2, "customer_id": 100, "amount": 75, "status": "shipped" }
+        ],
+        "format": "dict"
+      },
+      "description": "status normalises to lower-case for any case-mix input",
+      "tags": []
+    },
+    "unit_test.ecommerce.fct_revenue.rolls_up_revenue_per_customer": {
+      "unique_id": "unit_test.ecommerce.fct_revenue.rolls_up_revenue_per_customer",
+      "name": "rolls_up_revenue_per_customer",
+      "model": "fct_revenue",
+      "given": [
+        {
+          "input": "ref('stg_orders')",
+          "rows": [
+            { "order_id": 1, "customer_id": 100, "amount": 50, "status": "completed" },
+            { "order_id": 2, "customer_id": 100, "amount": 75, "status": "shipped" },
+            { "order_id": 3, "customer_id": 200, "amount": 30, "status": "completed" }
+          ]
+        }
+      ],
+      "expect": {
+        "rows": [
+          { "customer_id": 100, "total_revenue": 125, "order_count": 2 },
+          { "customer_id": 200, "total_revenue": 30,  "order_count": 1 }
+        ],
+        "format": "dict"
+      },
+      "tags": []
+    },
+    "unit_test.ecommerce.fct_revenue.csv_fixture_skipped": {
+      "unique_id": "unit_test.ecommerce.fct_revenue.csv_fixture_skipped",
+      "name": "csv_fixture_skipped",
+      "model": "fct_revenue",
+      "given": [
+        {
+          "input": "ref('stg_orders')",
+          "rows": "order_id,customer_id,amount,status\n1,100,50,completed\n",
+          "format": "csv"
+        }
+      ],
+      "expect": {
+        "rows": "customer_id,total_revenue,order_count\n100,50,1\n",
+        "format": "csv"
+      },
+      "description": "Deliberate CSV fixture — surfaces as UnsupportedUnitTestFormat",
+      "tags": []
+    }
+  }
+}

--- a/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/run.sh
+++ b/examples/playground/pocs/06-developer-experience/19-import-dbt-unit-tests/run.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# 19-import-dbt-unit-tests — exercise two import-dbt features added in
+# engine v1.39.0:
+#
+#   1. `data_tests:` accepted as an alias for the legacy `tests:` key on
+#      column-level YAML tests (dbt 1.7+ renamed the key; both spellings
+#      now flow into the same canonical-four mapping).
+#   2. `manifest.unit_tests` -> Rocky `[[test]]` sidecar blocks (manifest
+#      path only; the regex path does not see unit tests).
+#
+# We point the importer at a hand-authored `target/manifest.json` so the
+# POC needs no dbt / Python toolchain on PATH.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+rm -rf imported
+mkdir -p expected
+
+echo "=== rocky import-dbt --manifest (emit Rocky repo + walk manifest.unit_tests) ==="
+rocky import-dbt \
+    --dbt-project dbt_project \
+    --manifest dbt_project/target/manifest.json \
+    --output-dir imported \
+    --overwrite \
+    --output json \
+    2>&1 | tee expected/import.json
+
+echo
+echo "=== Emitted models/stg_orders.toml (data_tests: alias + unit test) ==="
+cat imported/models/stg_orders.toml
+
+echo
+echo "=== Emitted models/fct_revenue.toml (one unit test converted, one skipped) ==="
+cat imported/models/fct_revenue.toml
+
+echo
+echo "=== imported/MIGRATION-NOTES.md (unit-test counters surface here) ==="
+grep -A1 "dbt unit tests detected" imported/MIGRATION-NOTES.md || echo "(line missing)"
+
+echo
+echo "=== Assertions ==="
+fail=0
+
+# 1. data_tests: alias — stg_orders.toml must carry the canonical-four
+#    [[tests]] blocks even though schema.yml used `data_tests:` not `tests:`.
+for kind in '"unique"' '"not_null"' '"accepted_values"'; do
+    if ! grep -q "type = $kind" imported/models/stg_orders.toml; then
+        echo "FAIL: stg_orders.toml missing [[tests]] of type $kind (data_tests: alias broken?)"
+        fail=1
+    fi
+done
+
+# 2. Unit-test bridge — stg_orders must have the imported [[test]] block.
+if ! grep -q 'name = "stamps_status_when_completed"' imported/models/stg_orders.toml; then
+    echo "FAIL: stg_orders.toml missing imported [[test]] from manifest.unit_tests"
+    fail=1
+fi
+if ! grep -q 'ref = "raw.orders"' imported/models/stg_orders.toml; then
+    echo "FAIL: stg_orders.toml [[test.given]] should strip source(...) wrapper to bare ref"
+    fail=1
+fi
+
+# 3. fct_revenue gets one happy-path unit test, the CSV one is skipped.
+if ! grep -q 'name = "rolls_up_revenue_per_customer"' imported/models/fct_revenue.toml; then
+    echo "FAIL: fct_revenue.toml missing converted unit test"
+    fail=1
+fi
+if grep -q 'csv_fixture_skipped' imported/models/fct_revenue.toml; then
+    echo "FAIL: csv_fixture_skipped should not be emitted (format=csv is unsupported)"
+    fail=1
+fi
+
+# 4. JSON output must reflect the three new counters.
+found=$(grep -o '"unit_tests_found":[[:space:]]*[0-9]*' expected/import.json | head -1 | grep -oE '[0-9]+$')
+converted=$(grep -o '"unit_tests_converted":[[:space:]]*[0-9]*' expected/import.json | head -1 | grep -oE '[0-9]+$')
+skipped=$(grep -o '"unit_tests_skipped":[[:space:]]*[0-9]*' expected/import.json | head -1 | grep -oE '[0-9]+$')
+if [ "${found:-0}" -ne 3 ] || [ "${converted:-0}" -ne 2 ] || [ "${skipped:-0}" -ne 1 ]; then
+    echo "FAIL: counter mismatch — found=$found converted=$converted skipped=$skipped (want 3/2/1)"
+    fail=1
+fi
+
+# 5. UnsupportedUnitTestFormat warning surfaces for the CSV fixture.
+if ! grep -q 'UnsupportedUnitTestFormat' expected/import.json; then
+    echo "FAIL: import.json should carry an UnsupportedUnitTestFormat warning"
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "ok  All assertions passed."
+else
+    exit 1
+fi
+
+echo
+echo "POC complete: data_tests: alias + unit-test bridge demonstrated end-to-end."

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,6 +1,6 @@
 # POC Catalog
 
-74 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+76 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
@@ -10,14 +10,14 @@
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention, auto-create schemas (7 POCs · Databricks / DuckDB)
 - [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys, state retention sweep (10 POCs · DuckDB / docker)
-- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop, dbt-import failure modes, semantic breaking-change gate, history rolling stats, trace+cost+replay combo (17 POCs · DuckDB)
+- [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop, dbt-import failure modes, semantic breaking-change gate, history rolling stats, trace+cost+replay combo, view strategy, dbt unit-test import (19 POCs · DuckDB)
 - [07-adapters](07-adapters/) — Snowflake, Databricks, Fivetran, custom process adapter, BigQuery, Rust-native adapter skeleton, Trino-Docker (7 POCs · mixed)
 
 ## Credentials at a glance
 
 | POCs | Credentials |
 |---|---|
-| 61 of 74 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
+| 63 of 76 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
 | 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |


### PR DESCRIPTION
## Summary

Companion doc + POC sweep for the upcoming triple-cut release (PRs #540, #592, #593, #594). Lands as a separate PR so it doesn't conflict with the release PR landing in parallel.

- **`docs/src/content/docs/guides/migrate-from-dbt.md`** — section 9 (`Convert dbt Tests to Rocky Tests and Contracts`) now covers both surfaces added this cut:
  - The four canonical column-level generic tests reachable via either `tests:` or `data_tests:` (dbt 1.7+ key, accepted as an alias since #593).
  - The `manifest.unit_tests` → `[[test]]` sidecar bridge from #594, with a worked YAML→TOML example, the three new counters (`unit_tests_found / unit_tests_converted / unit_tests_skipped`), and the two new warning variants (`OrphanUnitTest`, `UnsupportedUnitTestFormat`).
- **`engine/crates/rocky-compiler/src/import/dbt.rs`** — doc-comment on `apply_dbt_tests` mentions the `data_tests:` alias and cross-references `apply_dbt_unit_tests`.
- **New POC `06-developer-experience/19-import-dbt-unit-tests/`** — runnable manifest-path demo with `data_tests:` column tests + a `manifest.unit_tests` block covering happy path, source-wrapped input, and a deliberate CSV-fixture skip. Hand-authored manifest so no dbt / Python toolchain is needed; `./run.sh` exits 0 with 6 asserted invariants. Auto-discovered by `run-all-duckdb.sh`.
- **POC 03 `README.md`** — cross-links to POC 19 and notes the `data_tests:` alias works on the same schema.yml.
- **Catalog READMEs** — `examples/playground/README.md` + `pocs/README.md` bumped to reflect 18 (`view-strategy`, pre-existing) and 19. `docs/src/data/poc-counts.json` is auto-regenerated at docs build time.

No CLI / Pydantic / TS regeneration triggered — pure docs + POC. No `Co-Authored-By`.

## Test plan

- [x] `./run.sh` for new POC 19 exits 0, all 6 assertions pass (counter 3/2/1, CSV fixture skipped, `data_tests:` alias produces canonical `[[tests]]` blocks, `source(...)` wrapper stripped)
- [x] POC 03 still runs clean after README cross-link addition
- [x] `cargo doc --no-deps -p rocky-compiler` builds without new warnings
- [x] POC 19 detected as credential-free by `run-all-duckdb.sh` skip-logic (no `${VAR:?}` guard, no docker, no cargo)