### PR TITLE
feat(dagster): RockyResource.discover(emit_fivetran_state_to=...) kwarg

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.38.0] — 2026-05-20
+
+One small addition this cut: `RockyResource.discover()` now accepts an optional `emit_fivetran_state_to: str | Path | None` kwarg that passes through to the engine's `rocky discover --emit-fivetran-state-to <PATH>` flag (shipped in engine `v1.38.0`). Designed for orchestrator hooks that ship Rocky's canonical Fivetran view to a downstream consumer (S3, Valkey, a sibling sensor) without re-fetching from the Fivetran API — the engine writes the envelope atomically (tmp + rename) and idempotently (blake3 sentinel; mtime stable on no-op rewrite), so a watcher can rely on the file path without coordinating with Rocky. The envelope is only delivered to the file; `DiscoverResult` is unchanged.
+
+### Added
+
+- **`RockyResource.discover(emit_fivetran_state_to=...)`**. New optional kwarg. `str` and `pathlib.Path` inputs both work — `Path` is stringified at argv-build time. Composes cleanly with the existing `pipeline` kwarg (`--pipeline` first, `--emit-fivetran-state-to` second). Four new tests in `tests/test_resource.py` pin: omit-by-default, `str` pass-through, `Path` coercion, and composition with `pipeline`.
+
 ## [1.37.0] — 2026-05-19
 
 Companion release to engine `v1.39.0`. Pure codegen cascade plus one test-only tightening — no new dagster API surface. The regenerated Pydantic models in `dagster_rocky/types_generated/` pick up the engine's `rocky import-dbt` unit-test bridge ([#594](https://github.com/rocky-data/rocky/pull/594)): `ImportDbtOutput` gains the optional `unit_tests_found / unit_tests_converted / unit_tests_skipped` counters and `ImportWarningCategory` gains two new variants (`orphan_unit_test`, `unsupported_unit_test_format`). Strictly additive — re-exported from `dagster_rocky.types` so existing consumers see no breakage.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.37.0"
+version = "1.38.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -30,6 +30,7 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, Annotated, Any, Literal, TypeVar
 
 import dagster as dg
@@ -1368,16 +1369,35 @@ class RockyResource(dg.ConfigurableResource):
     # Discovery & execution (always CLI)                                 #
     # ------------------------------------------------------------------ #
 
-    def discover(self, *, pipeline: str | None = None) -> DiscoverResult:
+    def discover(
+        self,
+        *,
+        pipeline: str | None = None,
+        emit_fivetran_state_to: str | Path | None = None,
+    ) -> DiscoverResult:
         """Run ``rocky discover`` and return the parsed result.
 
         Args:
             pipeline: Pipeline name (required when multiple pipelines are
                 defined in ``rocky.toml``).
+            emit_fivetran_state_to: Optional path to write the canonical
+                :class:`FivetranStateEnvelope` to as a side effect, via the
+                CLI's ``--emit-fivetran-state-to`` flag. Rocky writes the
+                envelope atomically (tmp + rename) and idempotently — a
+                sibling ``<path>.blake3`` sentinel file holds the previous
+                envelope's hash, so unchanged upstream state produces no
+                write and ``stat(2)`` watchers don't fire. Designed for
+                orchestrator hooks that ship Rocky's view of a destination
+                to a downstream consumer (S3, Valkey, a sibling sensor)
+                without re-fetching from the Fivetran API. The envelope is
+                **only** delivered to the file — it is not included in the
+                returned :class:`DiscoverResult`.
         """
         args = ["discover"]
         if pipeline is not None:
             args.extend(["--pipeline", pipeline])
+        if emit_fivetran_state_to is not None:
+            args.extend(["--emit-fivetran-state-to", str(emit_fivetran_state_to)])
         return _parse_rocky_json(self._run_rocky(args), DiscoverResult, command="discover")
 
     def plan(

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -357,6 +357,65 @@ def test_run_passes_governance_override_as_json():
     assert '"workspace_ids"' in captured[0][idx + 1]
 
 
+def _capture_discover_args(rocky: RockyResource, discover_json: str, **kwargs: Any) -> list[str]:
+    """Invoke ``rocky.discover(**kwargs)`` against a captured-argv fake.
+
+    Returns the argv list passed to ``_run_rocky`` so callers can assert
+    flag presence / value / coercion without spinning up the full
+    Popen + parse pipeline.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run(self: RockyResource, args: list[str], allow_partial: bool = False) -> str:
+        captured.append(args)
+        return discover_json
+
+    with patch.object(RockyResource, "_run_rocky", autospec=True) as run_mock:
+        run_mock.side_effect = fake_run
+        rocky.discover(**kwargs)
+    assert captured, "_run_rocky was not called"
+    return captured[0]
+
+
+def test_discover_omits_emit_fivetran_state_to_by_default(discover_json: str):
+    """No kwarg → no ``--emit-fivetran-state-to`` flag on the argv."""
+    args = _capture_discover_args(RockyResource(), discover_json)
+    assert args == ["discover"]
+
+
+def test_discover_passes_emit_fivetran_state_to_str(discover_json: str):
+    """``str`` path lands verbatim after ``--emit-fivetran-state-to``."""
+    args = _capture_discover_args(
+        RockyResource(), discover_json, emit_fivetran_state_to="/tmp/envelope.json"
+    )
+    assert args == ["discover", "--emit-fivetran-state-to", "/tmp/envelope.json"]
+
+
+def test_discover_coerces_pathlib_emit_fivetran_state_to(discover_json: str):
+    """``Path`` input is stringified — the CLI takes a path-string, not a Path."""
+    args = _capture_discover_args(
+        RockyResource(), discover_json, emit_fivetran_state_to=Path("/tmp/envelope.json")
+    )
+    assert args == ["discover", "--emit-fivetran-state-to", "/tmp/envelope.json"]
+
+
+def test_discover_emit_fivetran_state_to_composes_with_pipeline(discover_json: str):
+    """``--pipeline`` and ``--emit-fivetran-state-to`` coexist; order matches build."""
+    args = _capture_discover_args(
+        RockyResource(),
+        discover_json,
+        pipeline="raw_replication",
+        emit_fivetran_state_to="/tmp/envelope.json",
+    )
+    assert args == [
+        "discover",
+        "--pipeline",
+        "raw_replication",
+        "--emit-fivetran-state-to",
+        "/tmp/envelope.json",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # FR-009 — governance_override.workspace_ids safety validator
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.37.0"
+version = "1.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
## Summary

Adds an optional `emit_fivetran_state_to: str | Path | None = None` kwarg to `RockyResource.discover()`. When set, passes through to the engine's `rocky discover --emit-fivetran-state-to <PATH>` flag (shipped in engine `v1.38.0`).

## Motivation

The CLI flag was added in engine `v1.38.0` for orchestrator hooks that need to ship Rocky's canonical Fivetran view to a downstream consumer (S3, Valkey, sibling sensors) without re-fetching from the Fivetran API. Until now, dagster-rocky consumers had to either drop down to `_run_rocky(["discover", "--emit-fivetran-state-to", str(path)])` (coupling to private internals) or shell out independently. This PR makes the flag first-class.

The engine writes the envelope atomically (tmp + rename) and idempotently (sibling `.blake3` sentinel — unchanged upstream state produces no write; `stat(2)` watchers don't fire on no-op rewrite), so a downstream uploader/watcher can rely on the file path as a coordination point without coupling to dagster-rocky's lifecycle.

## Design notes

- **Method kwarg, not resource field.** The path is per-invocation in practice (consumers derive it from per-process state like `destination_id` env vars), and every other dagster-rocky CLI flag maps to a method kwarg. Resource-level fields are reserved for genuinely lifecycle-scoped things (`binary_path`, `config_path`, etc.) or resolver policies (`shadow_suffix_fn` et al.).
- **Side-effect only on the file**, not in the return value. `DiscoverResult` is unchanged. The atomicity + idempotence + sentinel-file semantics are designed for filesystem-level consumers; threading the envelope back through stdout JSON would defeat those guarantees.
- **`str` and `pathlib.Path` both work.** Path inputs are stringified at argv build (CLI takes a path-string).
- **No codegen cascade.** The kwarg doesn't change any `*Output` Pydantic shape; `DiscoverResult` is untouched. `just codegen` would produce no diff.

## Test plan

- [x] `uv run pytest -q` — 548 passed (4 new + 544 existing)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [ ] After merge, tag `dagster-v1.38.0` and push → `dagster-release.yml` publishes the wheel to PyPI via OIDC

## New tests

In `tests/test_resource.py`:
- `test_discover_omits_emit_fivetran_state_to_by_default` — no kwarg → no flag on argv
- `test_discover_passes_emit_fivetran_state_to_str` — `str` path lands verbatim
- `test_discover_coerces_pathlib_emit_fivetran_state_to` — `Path` is stringified
- `test_discover_emit_fivetran_state_to_composes_with_pipeline` — composes with the existing `pipeline` kwarg