### PR TITLE
fix(rocky-cli): wire valkey feature into shipped binary

### DIFF
--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -79,4 +79,63 @@ jobs:
       - name: Check CLI adapter boundary
         run: bash ../scripts/lint-adapter-boundary.sh
 
+  # Regression guard for the `valkey` Cargo feature on rocky-fivetran +
+  # rocky-cache. The release workflow builds with default features only, so
+  # `cargo test --all-features` above can't catch a dropped dep-edge flag —
+  # workspace-level --all-features force-enables every feature regardless of
+  # how rocky-cli wires its deps. This job mirrors the exact release-build
+  # invocation and then exercises the tiered cache backend via `rocky doctor`,
+  # which fails-loud if the feature isn't compiled in.
+  #
+  # Root cause when this guard was added: v1.39.0 linux release shipped
+  # without `--features valkey`, every EKS code-server cold-started with
+  # `failed to build [adapter.fivetran.cache] backend` (gold-dev 2026-05-20).
+  release-build-smoke:
+    name: Release-build smoke (valkey feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: engine
+      - name: Free disk space and add swap
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo fallocate -l 4G /mnt/swapfile && sudo chmod 600 /mnt/swapfile && sudo mkswap /mnt/swapfile && sudo swapon /mnt/swapfile || true
+      - run: sudo apt-get update && sudo apt-get install -y cmake
+      # Mirror engine-release.yml exactly: default features only, no --features flags.
+      - name: Build rocky with release flags
+        run: cargo build --release --bin rocky
+      - name: Doctor must build tiered cache backend
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          cat > "$tmp/rocky.toml" <<'TOML'
+          [adapter.test_databricks]
+          type = "databricks"
+          host = "x"
+          http_path = "x"
+          token = "x"
+
+          [adapter.test_fivetran]
+          type = "fivetran"
+          kind = "discovery"
+          destination_id = "x"
+          api_key = "x"
+          api_secret = "x"
+
+          [adapter.test_fivetran.cache]
+          backend = "tiered"
+          file_root = "/tmp/rocky-cache-smoke"
+          object_store_url = "s3://test-bucket/cache/"
+          valkey_url = "rediss://localhost:6379"
+          TOML
+          out=$(./target/release/rocky --config "$tmp/rocky.toml" --state-path "$tmp/state.redb" --output json doctor --check auth 2>&1) || true
+          echo "$out"
+          if echo "$out" | grep -q "failed to build \[adapter.test_fivetran.cache\] backend"; then
+            echo "::error::valkey feature is missing from the shipped binary. Check engine/crates/rocky-cli/Cargo.toml for features=[\"valkey\"] on rocky-fivetran and rocky-cache."
+            exit 1
+          fi
+
   # Coverage and audit moved to engine-weekly.yml to reduce per-PR cost.

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -22,10 +22,10 @@ rocky-duckdb = { path = "../rocky-duckdb", optional = true }
 rocky-snowflake = { path = "../rocky-snowflake" }
 rocky-bigquery = { path = "../rocky-bigquery" }
 rocky-trino = { path = "../rocky-trino" }
-rocky-fivetran = { path = "../rocky-fivetran" }
+rocky-fivetran = { path = "../rocky-fivetran", features = ["valkey"] }
 rocky-airbyte = { path = "../rocky-airbyte" }
 rocky-iceberg = { path = "../rocky-iceberg" }
-rocky-cache = { path = "../rocky-cache" }
+rocky-cache = { path = "../rocky-cache", features = ["valkey"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- The shipped `rocky` binary depends on `rocky-fivetran` and `rocky-cache` without enabling either crate's optional `valkey` cargo feature, so every prebuilt release on the GitHub release page rejects `[adapter.fivetran.cache] backend = "tiered"` (and the parallel `valkey` / stampede / circuit-breaker backends) with `cache config: backend = "tiered" requires building rocky-fivetran with the \`valkey\` feature`.
- Two-line fix on the `rocky-cli` dep edges to enable `features = ["valkey"]` — matches the existing design (optional leaf-crate features, the CLI binary opts in). Every future release picks it up with no workflow change.
- Adds a `release-build-smoke` CI job that mirrors the release-workflow flags (`cargo build --release --bin rocky`, default features only) and runs `rocky doctor --check auth` against a tiered-backend config. Greps for the specific construction error and fails the build if it ever reappears. `cargo test --all-features` can't catch this — workspace-level `--all-features` force-enables every feature regardless of how dep edges are wired, which masks a dropped flag.

## Impact

The four `[adapter.fivetran.*]` resilience backends (`cache`, `ratelimit`, `stampede`, `circuit_breaker`) all surface this failure at config-load time when their backend is set to `tiered` or `valkey`. None of the Valkey-backed paths are reachable from a stock release binary today. The error is structured as a `failed to build` adapter-construction error, so downstream tools that only forward error descriptions (without metadata) make it look like a generic adapter failure.

## Test plan

- [x] `cargo build --release --bin rocky` in this worktree compiles cleanly with the new feature wiring (10m 21s cold build).
- [x] `rocky doctor --check auth` against a tiered-backend config now constructs the cache backend successfully (auth check fails on placeholder credentials with `401 Unauthorized` — different failure, expected, proves the cache backend itself built).
- [x] The new `release-build-smoke` CI job mirrors the release-workflow flags and would fail-loud on the original defect.
- [ ] Merge → tag `engine-v1.39.1` → republish release binaries.