### PR TITLE
feat(rocky-catalog-core): add table_stats trait method + Iceberg impl

### DIFF
--- a/engine/crates/rocky-catalog-core/src/client.rs
+++ b/engine/crates/rocky-catalog-core/src/client.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 
 use crate::error::CatalogResult;
-use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema};
+use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema, TableStats};
 
 /// A read/write client for a data catalog.
 ///
@@ -103,6 +103,30 @@ pub trait CatalogClient: Send + Sync {
     /// diverge sharply between catalogs and belong on per-adapter
     /// extension surfaces.
     async fn list_branches(&self, table: &TableRef) -> CatalogResult<Vec<BranchRef>>;
+
+    // ---------------------------------------------------------------------
+    // Statistics
+    // ---------------------------------------------------------------------
+
+    /// Return the row count, byte total, and file count for `table` as
+    /// the catalog currently reports them.
+    ///
+    /// Each field of [`TableStats`] is `Option<u64>` because catalogs
+    /// disagree on what they expose: Iceberg REST returns
+    /// `total-records` and `total-files-size` only when the writer
+    /// populated them in the current snapshot's `summary` map; Unity
+    /// Catalog REST exposes none of them and surfaces this method as
+    /// [`crate::CatalogError::UnsupportedOperation`]. Callers consuming
+    /// the result for cost estimation are expected to treat a `None`
+    /// field as "fall through to upstream-inferred estimate" rather
+    /// than a hard failure.
+    ///
+    /// The trait does not promise that the numbers are recent — they
+    /// are whatever the catalog has at read time. For Iceberg this is
+    /// the head snapshot summary; for catalogs that go through this
+    /// trait via a SQL-execution shim (out of scope today) it would be
+    /// whatever `DESCRIBE DETAIL` or `ANALYZE TABLE` last populated.
+    async fn table_stats(&self, table: &TableRef) -> CatalogResult<TableStats>;
 
     // ---------------------------------------------------------------------
     // Governance

--- a/engine/crates/rocky-catalog-core/src/lib.rs
+++ b/engine/crates/rocky-catalog-core/src/lib.rs
@@ -35,4 +35,6 @@ pub mod testing;
 
 pub use client::CatalogClient;
 pub use error::{CatalogError, CatalogResult};
-pub use types::{BranchKind, BranchRef, ColumnSchema, Grant, TableCommit, TableRef, TableSchema};
+pub use types::{
+    BranchKind, BranchRef, ColumnSchema, Grant, TableCommit, TableRef, TableSchema, TableStats,
+};

--- a/engine/crates/rocky-catalog-core/src/testing.rs
+++ b/engine/crates/rocky-catalog-core/src/testing.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 
 use crate::client::CatalogClient;
 use crate::error::{CatalogError, CatalogResult};
-use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema};
+use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema, TableStats};
 
 /// In-memory [`CatalogClient`] stub backed by a [`HashMap`] of
 /// `(namespace, table-name)` to [`TableSchema`].
@@ -40,6 +40,13 @@ use crate::types::{BranchRef, Grant, TableCommit, TableRef, TableSchema};
 #[derive(Debug, Default)]
 pub struct InMemoryCatalogClient {
     tables: Mutex<HashMap<Key, TableSchema>>,
+    /// Per-table stub stats, indexed by the same `(namespace, name)`
+    /// key as [`Self::tables`]. Populated by
+    /// [`InMemoryCatalogClient::set_table_stats`]; lookups return
+    /// [`TableStats::empty()`] when no stats are registered, matching
+    /// the "table exists but catalog reports no stats" case from real
+    /// catalogs.
+    stats: Mutex<HashMap<Key, TableStats>>,
 }
 
 /// Internal key used by the stub. Equivalent to `(namespace, name)`.
@@ -62,6 +69,17 @@ impl InMemoryCatalogClient {
     /// Construct an empty stub.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Register stub statistics for `table`.
+    ///
+    /// Test helper used by downstream crates to feed deterministic
+    /// stats into a cost-propagation test without standing up a real
+    /// catalog. Overwrites any previously registered stats for the same
+    /// `(namespace, name)` key.
+    pub fn set_table_stats(&self, table: &TableRef, stats: TableStats) {
+        let mut guard = self.stats.lock().expect("stats mutex poisoned");
+        guard.insert(Key::from_ref(table), stats);
     }
 }
 
@@ -102,6 +120,26 @@ impl CatalogClient for InMemoryCatalogClient {
             .remove(&Key::from_ref(table))
             .map(|_| ())
             .ok_or_else(|| CatalogError::TableNotFound(format_table(table)))
+    }
+
+    async fn table_stats(&self, table: &TableRef) -> CatalogResult<TableStats> {
+        // The stub honours stats explicitly registered via
+        // [`Self::set_table_stats`]; otherwise the table is required to
+        // exist (`describe_table`-style semantics) and we return the
+        // empty-stats baseline — mirrors what a catalog returns when a
+        // table exists but the writer never populated the summary keys.
+        let stats_guard = self.stats.lock().expect("stats mutex poisoned");
+        let key = Key::from_ref(table);
+        if let Some(stats) = stats_guard.get(&key) {
+            return Ok(stats.clone());
+        }
+        drop(stats_guard);
+        let tables_guard = self.tables.lock().expect("tables mutex poisoned");
+        if tables_guard.contains_key(&key) {
+            Ok(TableStats::empty())
+        } else {
+            Err(CatalogError::TableNotFound(format_table(table)))
+        }
     }
 
     async fn commit_transaction(&self, _commits: &[TableCommit]) -> CatalogResult<()> {

--- a/engine/crates/rocky-catalog-core/src/types.rs
+++ b/engine/crates/rocky-catalog-core/src/types.rs
@@ -119,6 +119,52 @@ pub struct ColumnSchema {
     pub nullable: bool,
 }
 
+/// Per-table statistics that a catalog can serve back without running a
+/// scan-cost query against the warehouse.
+///
+/// Every field is `Option<u64>` because catalogs vary in what they
+/// natively expose. Iceberg REST returns `total-records` and
+/// `total-files-size` in a snapshot's `summary` map when the writer
+/// populated them — older or pre-aggregation snapshots may omit either.
+/// Unity Catalog's REST surface does not serve table stats at all, so
+/// [`crate::CatalogClient::table_stats`] returns
+/// [`crate::CatalogError::UnsupportedOperation`] from that impl; the
+/// SQL-driven stats path (`DESCRIBE DETAIL` for bytes, `ANALYZE TABLE`
+/// or `SELECT COUNT(*)` for rows) lives on the per-adapter surface
+/// rather than this trait.
+///
+/// Callers that need the cost-model's `rocky_core::cost::TableStats`
+/// (which requires both `row_count` and `avg_row_bytes`) convert at the
+/// binding site: skip the model when either field is `None`,
+/// `propagate_costs` then falls through to upstream-inferred estimates
+/// for that node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableStats {
+    /// Total row count across all files in the current snapshot, if the
+    /// catalog reports it.
+    pub row_count: Option<u64>,
+    /// Total size in bytes across all data files in the current
+    /// snapshot, if the catalog reports it.
+    pub total_bytes: Option<u64>,
+    /// Number of data files in the current snapshot, if the catalog
+    /// reports it.
+    pub file_count: Option<u64>,
+}
+
+impl TableStats {
+    /// Construct an empty `TableStats` with every field `None`.
+    ///
+    /// Used by implementations that want to populate fields
+    /// individually as they parse the catalog response.
+    pub fn empty() -> Self {
+        Self {
+            row_count: None,
+            total_bytes: None,
+            file_count: None,
+        }
+    }
+}
+
 /// One table's contribution to a multi-table transaction.
 ///
 /// A [`crate::CatalogClient::commit_transaction`] call applies a slice of

--- a/engine/crates/rocky-databricks/src/unity_catalog_client.rs
+++ b/engine/crates/rocky-databricks/src/unity_catalog_client.rs
@@ -111,7 +111,7 @@ use tracing::debug;
 
 use rocky_catalog_core::{
     BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant, TableCommit,
-    TableRef, TableSchema,
+    TableRef, TableSchema, TableStats,
 };
 
 use crate::auth::{Auth, AuthError};
@@ -675,6 +675,32 @@ impl CatalogClient for UnityCatalogClient {
         ))
     }
 
+    async fn table_stats(&self, _table: &TableRef) -> CatalogResult<TableStats> {
+        // Unity Catalog REST exposes no table-stats surface:
+        //
+        // - `GET /api/2.1/unity-catalog/tables/{full_name}` returns
+        //   schema + storage metadata only (modelled by `TableInfo`
+        //   above); no row count, no byte total, no file count.
+        // - `INFORMATION_SCHEMA.TABLES` on Databricks does not carry
+        //   `row_count` or `table_size_bytes` columns (verified live
+        //   2026-05-20 against the dev_hcv2_uniform.information_schema
+        //   sandbox).
+        // - The only working paths to stats are
+        //   `DESCRIBE DETAIL <table>.sizeInBytes` (bytes, no ANALYZE
+        //   prereq) and `DESCRIBE EXTENDED <table>` (parses the
+        //   `Statistics` row, present only after `ANALYZE TABLE
+        //   COMPUTE STATISTICS`). Both run through the SQL Statement
+        //   Execution API, which lives on
+        //   [`crate::connector::DatabricksConnector`], not here. This
+        //   client is REST-only by design (see module-level doc).
+        //
+        // Consistent with `tag_table` / `commit_transaction` /
+        // `list_branches`: REST gap, caller routes via the SQL path.
+        Err(CatalogError::UnsupportedOperation(
+            "Unity Catalog REST exposes no stats endpoint; route via DatabricksConnector SQL (DESCRIBE DETAIL / ANALYZE TABLE)",
+        ))
+    }
+
     async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
         // Unity has no general-purpose table-tag REST endpoint in
         // Databricks runtime — `ALTER TABLE SET TAGS` SQL is the only
@@ -1214,6 +1240,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn table_stats_returns_unsupported() {
+        // Unity Catalog REST exposes no stats surface. The trait
+        // contract is to fail with UnsupportedOperation before any
+        // network hop so callers route to the SQL-side stats path
+        // (DESCRIBE DETAIL / ANALYZE TABLE on DatabricksConnector).
+        // This is consistent with tag_table / commit_transaction /
+        // list_branches — all surfaces Unity REST does not natively
+        // serve.
+        let client = make_offline_client();
+        let err = client.table_stats(&sample_table_ref()).await.unwrap_err();
+        assert!(
+            matches!(err, CatalogError::UnsupportedOperation(_)),
+            "expected UnsupportedOperation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn list_branches_returns_unsupported() {
         let client = make_offline_client();
         let err = client.list_branches(&sample_table_ref()).await.unwrap_err();
@@ -1356,6 +1399,35 @@ mod live_tests {
             assert_eq!(t.namespace.len(), 1);
             assert!(!t.name.is_empty());
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires ROCKY_TEST_DATABRICKS_* env vars; run with --ignored"]
+    async fn live_table_stats_returns_unsupported_operation() {
+        // Anchor the "Unity REST exposes no stats endpoint" contract
+        // against a live workspace: the impl must short-circuit with
+        // UnsupportedOperation before any HTTP traffic. Sandbox stats
+        // (rows / bytes) come through the SQL path on
+        // DatabricksConnector, not this client.
+        let Some((host, token, catalog, schema)) = read_env() else {
+            eprintln!("skipping: ROCKY_TEST_DATABRICKS_* not set");
+            return;
+        };
+        let client = live_client(host, token);
+        let table =
+            std::env::var("ROCKY_TEST_DATABRICKS_TABLE").unwrap_or_else(|_| "hc_probe".into());
+        let err = client
+            .table_stats(&TableRef {
+                catalog: Some(catalog),
+                namespace: vec![schema],
+                name: table,
+            })
+            .await
+            .expect_err("Unity table_stats must surface as UnsupportedOperation");
+        assert!(
+            matches!(err, CatalogError::UnsupportedOperation(_)),
+            "expected UnsupportedOperation, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-iceberg/src/catalog_client.rs
+++ b/engine/crates/rocky-iceberg/src/catalog_client.rs
@@ -42,7 +42,7 @@ use serde_json::json;
 
 use rocky_catalog_core::{
     BranchKind, BranchRef, CatalogClient, CatalogError, CatalogResult, ColumnSchema, Grant,
-    TableCommit, TableRef, TableSchema,
+    TableCommit, TableRef, TableSchema, TableStats,
 };
 
 use crate::client::{
@@ -219,6 +219,32 @@ impl CatalogClient for IcebergCatalogClientAdapter {
             .collect();
         out.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(out)
+    }
+
+    async fn table_stats(&self, table: &TableRef) -> CatalogResult<TableStats> {
+        let resp = self
+            .inner
+            .load_table(&table.namespace, &table.name)
+            .await
+            .map_err(icebergerror_into_catalog)?;
+
+        let metadata = resp.metadata;
+        // Find the snapshot that matches `current-snapshot-id`. If the
+        // table has no current snapshot (freshly created) or the
+        // catalog elided the snapshots list, return empty stats — the
+        // table exists in the catalog but no summary keys are
+        // populated yet.
+        let Some(current_id) = metadata.current_snapshot_id else {
+            return Ok(TableStats::empty());
+        };
+        let Some(snapshot) = metadata
+            .snapshots
+            .iter()
+            .find(|s| s.snapshot_id == current_id)
+        else {
+            return Ok(TableStats::empty());
+        };
+        Ok(parse_snapshot_summary(&snapshot.summary))
     }
 
     async fn tag_table(&self, _table: &TableRef, _key: &str, _value: &str) -> CatalogResult<()> {
@@ -398,6 +424,37 @@ fn build_commit_table_request(commit: &TableCommit) -> CommitTableRequest {
         },
         requirements: vec![requirement],
         updates: vec![update],
+    }
+}
+
+/// Distil an Iceberg snapshot's `summary` map into a catalog-agnostic
+/// [`TableStats`].
+///
+/// The well-known keys the Iceberg spec defines for a snapshot summary
+/// are documented at
+/// <https://iceberg.apache.org/spec/#snapshot-summary>:
+/// `total-records` (cumulative row count), `total-files-size`
+/// (cumulative bytes across all data files), `total-data-files`
+/// (cumulative file count), plus delta keys (`added-records`,
+/// `deleted-records`, etc.) describing the most recent op. Only the
+/// cumulative keys go into [`TableStats`]; the delta keys are
+/// per-snapshot relative metrics and would mislead a cost-model that
+/// needs the current shape of the table.
+///
+/// Each key is independently optional — older writers may emit a
+/// subset, and the Unity-foreign-Iceberg path is known to lag spec
+/// compliance on summary completeness. Unparseable string values
+/// silently produce `None` rather than failing the whole call; the
+/// caller's cost-model treats `None` fields as "fall through to
+/// upstream-inferred estimate" rather than a hard failure.
+fn parse_snapshot_summary(summary: &std::collections::HashMap<String, String>) -> TableStats {
+    fn read_u64(summary: &std::collections::HashMap<String, String>, key: &str) -> Option<u64> {
+        summary.get(key).and_then(|s| s.parse::<u64>().ok())
+    }
+    TableStats {
+        row_count: read_u64(summary, "total-records"),
+        total_bytes: read_u64(summary, "total-files-size"),
+        file_count: read_u64(summary, "total-data-files"),
     }
 }
 

--- a/engine/crates/rocky-iceberg/src/client.rs
+++ b/engine/crates/rocky-iceberg/src/client.rs
@@ -127,6 +127,52 @@ pub struct TableMetadata {
     /// map.
     #[serde(default)]
     pub refs: HashMap<String, SnapshotReference>,
+
+    /// The snapshot id of the current snapshot. `None` on a freshly
+    /// created table that has not yet been committed against.
+    ///
+    /// Used by the catalog-agnostic `table_stats` projection to pick
+    /// the right entry out of [`Self::snapshots`] when distilling the
+    /// summary fields. The field is camel-cased on the wire as
+    /// `current-snapshot-id` per the Iceberg spec.
+    #[serde(rename = "current-snapshot-id", default)]
+    pub current_snapshot_id: Option<i64>,
+
+    /// The full snapshot history of the table.
+    ///
+    /// Each entry carries the snapshot id and a `summary` map of
+    /// writer-populated metrics (`total-records`, `total-files-size`,
+    /// `total-data-files`, etc.). The entry whose `snapshot-id`
+    /// matches [`Self::current_snapshot_id`] is the active one;
+    /// `table_stats` parses its summary into a
+    /// [`rocky_catalog_core::TableStats`]. Older catalogs may omit
+    /// the field entirely on freshly-created tables; serde defaults
+    /// the missing case to an empty vector.
+    #[serde(default)]
+    pub snapshots: Vec<Snapshot>,
+}
+
+/// One entry in [`TableMetadata::snapshots`].
+///
+/// Carries the snapshot id and the writer-populated `summary` map.
+/// Per the Iceberg spec, `summary` is an unconstrained string-to-string
+/// map; the well-known keys this client cares about are
+/// `total-records`, `total-files-size`, and `total-data-files` (all
+/// cumulative across the snapshot — *not* the deltas applied by the
+/// most recent op, which live on `added-records` / `added-files-size`
+/// in the same map). Stays a `HashMap` so unknown summary keys don't
+/// trip deser.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Snapshot {
+    /// Unique identifier for this snapshot.
+    #[serde(rename = "snapshot-id")]
+    pub snapshot_id: i64,
+    /// Writer-populated summary metrics for this snapshot. The values
+    /// are strings on the wire (Iceberg's spec models the map as
+    /// `Map<String, String>`); callers parse the relevant keys to
+    /// `u64` at consume time.
+    #[serde(default)]
+    pub summary: HashMap<String, String>,
 }
 
 /// One entry in [`TableMetadata::schemas`].

--- a/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-iceberg/tests/wiremock_tests.rs
@@ -9,7 +9,7 @@
 
 use rocky_catalog_core::{
     BranchKind, CatalogClient, CatalogError, ColumnSchema, Grant, TableCommit, TableRef,
-    TableSchema,
+    TableSchema, TableStats,
 };
 use rocky_core::source::FailedSourceErrorClass;
 use rocky_core::traits::DiscoveryAdapter;
@@ -776,6 +776,245 @@ async fn list_branches_returns_empty_when_refs_missing() {
         .await
         .expect("list_branches should succeed when refs absent");
     assert!(branches.is_empty());
+}
+
+/// `load_table` body with two snapshots; only snapshot 2 is current
+/// and carries the spec-defined summary keys. Used to verify
+/// `table_stats` picks the current snapshot's summary, not snapshot 1.
+fn load_table_body_with_snapshots() -> serde_json::Value {
+    json!({
+        "metadata-location": "s3://bucket/path/metadata.json",
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [
+                {
+                    "schema-id": 0,
+                    "fields": [
+                        { "id": 1, "name": "id", "required": true, "type": "long" }
+                    ]
+                }
+            ],
+            "current-snapshot-id": 2,
+            "snapshots": [
+                {
+                    "snapshot-id": 1,
+                    "summary": {
+                        "operation": "append",
+                        "total-records": "100",
+                        "total-files-size": "1024",
+                        "total-data-files": "1"
+                    }
+                },
+                {
+                    "snapshot-id": 2,
+                    "summary": {
+                        "operation": "append",
+                        "added-records": "150",
+                        "total-records": "250",
+                        "total-files-size": "4096",
+                        "total-data-files": "4"
+                    }
+                }
+            ]
+        }
+    })
+}
+
+#[tokio::test]
+async fn table_stats_happy_path_parses_current_snapshot_summary() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/orders"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(load_table_body_with_snapshots()))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "orders".into(),
+    };
+
+    let stats = adapter
+        .table_stats(&table)
+        .await
+        .expect("table_stats should succeed");
+
+    // Picked snapshot-id == 2 (current); snapshot 1's summary is ignored.
+    // `total-records` (cumulative) is the source-of-truth, NOT
+    // `added-records` (delta).
+    assert_eq!(stats.row_count, Some(250));
+    assert_eq!(stats.total_bytes, Some(4096));
+    assert_eq!(stats.file_count, Some(4));
+}
+
+#[tokio::test]
+async fn table_stats_returns_empty_when_no_current_snapshot() {
+    // Freshly-created Iceberg tables have no snapshots yet — the spec
+    // permits `current-snapshot-id` to be absent (or `null`).
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [
+                { "schema-id": 0, "fields": [] }
+            ]
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/empty"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "empty".into(),
+    };
+
+    let stats = adapter
+        .table_stats(&table)
+        .await
+        .expect("table_stats should succeed even with no snapshots");
+    assert_eq!(stats, TableStats::empty());
+}
+
+#[tokio::test]
+async fn table_stats_returns_partial_when_summary_keys_missing() {
+    // Writers populate the summary inconsistently — the Unity
+    // foreign-Iceberg path is known to lag spec compliance. We must
+    // surface what's there without failing the whole call when a key
+    // is absent.
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [
+                { "schema-id": 0, "fields": [] }
+            ],
+            "current-snapshot-id": 7,
+            "snapshots": [
+                {
+                    "snapshot-id": 7,
+                    "summary": {
+                        "operation": "append",
+                        "total-files-size": "2048"
+                        // total-records + total-data-files intentionally
+                        // absent
+                    }
+                }
+            ]
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/partial"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "partial".into(),
+    };
+
+    let stats = adapter
+        .table_stats(&table)
+        .await
+        .expect("partial summary should not error");
+    assert_eq!(stats.row_count, None);
+    assert_eq!(stats.total_bytes, Some(2048));
+    assert_eq!(stats.file_count, None);
+}
+
+#[tokio::test]
+async fn table_stats_ignores_unparseable_summary_values() {
+    // Catalogs occasionally emit non-numeric values (e.g. `"unknown"`,
+    // or scientific notation). Trait contract: silent fall-back to
+    // None rather than failing the whole `table_stats` call.
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "metadata": {
+            "current-schema-id": 0,
+            "schemas": [
+                { "schema-id": 0, "fields": [] }
+            ],
+            "current-snapshot-id": 1,
+            "snapshots": [
+                {
+                    "snapshot-id": 1,
+                    "summary": {
+                        "total-records": "not_a_number",
+                        "total-files-size": "1024",
+                        "total-data-files": "1.5e3"
+                    }
+                }
+            ]
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/weird"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "weird".into(),
+    };
+
+    let stats = adapter
+        .table_stats(&table)
+        .await
+        .expect("unparseable values must not error");
+    assert_eq!(stats.row_count, None, "not_a_number → None");
+    assert_eq!(stats.total_bytes, Some(1024));
+    assert_eq!(
+        stats.file_count, None,
+        "scientific notation is not a u64 → None"
+    );
+}
+
+#[tokio::test]
+async fn table_stats_404_maps_to_table_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/namespaces/analytics/tables/missing"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let client = IcebergCatalogClient::new(&server.uri(), None);
+    let adapter = IcebergCatalogClientAdapter::new(client);
+    let table = TableRef {
+        catalog: None,
+        namespace: vec!["analytics".into()],
+        name: "missing".into(),
+    };
+
+    let err = adapter
+        .table_stats(&table)
+        .await
+        .expect_err("404 should not succeed");
+    assert!(
+        matches!(err, CatalogError::TableNotFound(_)),
+        "expected TableNotFound, got {err:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Extends `CatalogClient` with `table_stats(&TableRef) -> CatalogResult<TableStats>` so catalog implementations can surface row count, byte total, and file count without a SQL round-trip. The new `TableStats` type uses `Option<u64>` per field so callers distinguish "catalog serves no stats" (returns `UnsupportedOperation`) from "catalog serves some stats" (some fields populated, others `None`).

- **Iceberg impl** parses the current snapshot's `summary` map from the existing `load_table` response — no new REST round-trip. `total-records` / `total-files-size` / `total-data-files` (the cumulative spec keys) populate `TableStats`; `added-records` (delta-only) is ignored. Unparseable values fall to `None` rather than failing the call.
- **Unity Catalog impl** returns `UnsupportedOperation` consistent with `tag_table` / `commit_transaction` / `list_branches`. The Unity REST `GET /api/2.1/unity-catalog/tables/{full_name}` payload carries no stats; the bytes/rows paths on Databricks run through the SQL Statement Execution API (`DESCRIBE DETAIL` for bytes, no `ANALYZE TABLE` prereq; `DESCRIBE EXTENDED` for rows, post-ANALYZE only), which lives on `DatabricksConnector` by design — this REST-only client stays out of the SQL path.

The trait surface lets a future cost-model binding in `rocky-compiler` consume real catalog stats when an `IcebergCatalogClientAdapter` is in scope, and route through `DatabricksConnector` SQL helpers for Unity-bound projects (out of scope here, demand-gated).

## Empirical anchors (live-verified against a sandbox)

Probes against a Databricks Unity workspace confirmed the Unity-side answer:

- `GET /api/2.1/unity-catalog/tables/{full_name}` returns columns + storage metadata only.
- `INFORMATION_SCHEMA.TABLES` on Databricks has 15 columns; none carry row count or byte size.
- `DESCRIBE DETAIL <table>` returns `numFiles` + `sizeInBytes` always (Delta protocol metadata, no `ANALYZE TABLE` prereq); `statistics` field stays `{}` until `ANALYZE`.
- `DESCRIBE EXTENDED <table>` emits a parseable `Statistics | "<n> bytes, <n> rows"` row only after `ANALYZE TABLE COMPUTE STATISTICS`.

Implication for the trait: bytes are catalog-cheap on both sides; row counts come for free on Iceberg (from the snapshot summary) but require either operator-explicit ANALYZE or a `COUNT(*)` scan on Databricks. The `Option<u64>` shape per field surfaces this asymmetry cleanly.

## Test plan

- [x] 5 new wiremock tests on the Iceberg side: happy-path summary parse + current-snapshot picking, freshly-created table with no snapshots, partial summary keys (Unity-foreign-Iceberg shape), unparseable summary values, 404 mapping
- [x] 1 unit test on the Unity side confirming `UnsupportedOperation` short-circuits before any HTTP traffic
- [x] 1 live `#[ignore]`d test gated on `ROCKY_TEST_DATABRICKS_*` env vars pinning the contract against a real workspace
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo run -- export-schemas` produces no JSON-schema drift (`TableStats` is internal to `rocky-catalog-core`)
- [x] PR-alone build verified (workspace compiles without the parallel `cost_ceiling` IR-field work this references in its memo)

## Notes

This is the implementation side of a spike whose memo lives outside the repo. The memo's verdict was SOFT-GO: Iceberg fully ships; Unity returns `UnsupportedOperation` and the Databricks SQL-side stats helper is a follow-up. The trait extension here is the surface for a future cost-model binding in `rocky-compiler` (`propagate_costs` consuming `CatalogClient::table_stats` results when a catalog is bound to the project).

A separate parallel change introduces a declarative `cost_ceiling: Option<CostBudget>` IR field. This PR does NOT depend on it for compilation — the trait method just produces `TableStats`; consumption is downstream. No call site in this PR uses `CostBudget`.