### PR TITLE
feat(rocky-ir): add per-model cost ceiling IR field

### DIFF
--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -47,6 +47,16 @@ pub const E024: &str = "E024";
 pub const E025: &str = "E025";
 /// Duplicate `@start_date`/`@end_date` placeholder.
 pub const E026: &str = "E026";
+/// Budget exceeded — projected spend exceeds the declared per-model cost ceiling.
+///
+/// Emitted when Rocky can determine before execution that the projected cost
+/// (USD or bytes scanned) would exceed the value declared in the model's
+/// `[budget]` sidecar block.
+///
+/// The diagnostic is constructible and serializable today but is **not yet
+/// emitted** by `propagate_costs`. Enforcement is deferred until the
+/// `CatalogClient::table_stats` provider (D-2 spike) reaches a go-decision.
+pub const E027: &str = "E027";
 
 // Warnings
 /// Unused model (no downstream consumers).
@@ -170,6 +180,31 @@ impl Diagnostic {
     pub fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
         self.suggestion = Some(suggestion.into());
         self
+    }
+
+    /// Build an E027 budget-exceeded diagnostic.
+    ///
+    /// Constructs a ready-to-emit error diagnostic for the case where the
+    /// projected USD cost for a single model run exceeds the ceiling declared
+    /// in the model's `[budget]` sidecar block.
+    ///
+    /// # Not yet called
+    ///
+    /// The builder exists today so the diagnostic code is registered and
+    /// the type-system path is verified. Actual emission from
+    /// `propagate_costs` is gated on the D-2 `CatalogClient::table_stats`
+    /// provider spike.
+    #[must_use]
+    pub fn budget_exceeded(model: &str, projected_usd: f64, ceiling_usd: f64) -> Self {
+        Self::error(
+            E027,
+            model,
+            format!("budget exceeded — projected ${projected_usd:.2} > ceiling ${ceiling_usd:.2}",),
+        )
+        .with_suggestion(format!(
+            "raise [budget] max_usd above ${ceiling_usd:.2} in the model sidecar, \
+             or optimize the query to reduce scan volume"
+        ))
     }
 
     /// Is this an error?
@@ -381,5 +416,44 @@ mod tests {
         let rendered = render_diagnostics(&[d], &std::collections::HashMap::new());
         assert!(rendered.contains("E001"));
         assert!(rendered.contains("something broke"));
+    }
+
+    #[test]
+    fn test_budget_exceeded_constructs_correctly() {
+        let d = Diagnostic::budget_exceeded("fct_orders", 12.50, 10.00);
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(d.code.as_ref(), E027);
+        assert_eq!(d.model, "fct_orders");
+        assert!(
+            d.message.contains("12.50"),
+            "message must include projected cost, got: {}",
+            d.message
+        );
+        assert!(
+            d.message.contains("10.00"),
+            "message must include ceiling cost, got: {}",
+            d.message
+        );
+        assert!(
+            d.suggestion.is_some(),
+            "budget_exceeded must include a suggestion"
+        );
+        assert!(d.is_error());
+    }
+
+    #[test]
+    fn test_budget_exceeded_serializes() {
+        let d = Diagnostic::budget_exceeded("my_model", 5.0, 3.0);
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(json.contains("E027"));
+        assert!(json.contains("my_model"));
+        // Round-trip
+        let back: Diagnostic = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.code.as_ref(), E027);
+    }
+
+    #[test]
+    fn test_e027_constant_value() {
+        assert_eq!(E027, "E027");
     }
 }

--- a/engine/crates/rocky-core/src/models.rs
+++ b/engine/crates/rocky-core/src/models.rs
@@ -12,7 +12,7 @@ use crate::retention::{RetentionParseError, RetentionPolicy};
 use crate::tests::TestDecl;
 use rocky_ir::dag::DagNode;
 use rocky_ir::{
-    GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef, TimeGrain,
+    CostBudget, GovernanceConfig, MaterializationStrategy, ModelIr, SourceRef, TargetRef, TimeGrain,
 };
 
 /// Errors from loading and parsing model files.
@@ -690,6 +690,21 @@ impl Model {
             },
         };
 
+        // Collapse a fully-absent budget (both cost fields None) into
+        // cost_ceiling = None to keep the recipe-hash clean. Policy-only
+        // sidecars (e.g. only `on_breach = "warn"` set) also yield None.
+        let cost_ceiling = self.config.budget.as_ref().and_then(|b| {
+            let candidate = CostBudget {
+                max_usd: b.max_usd,
+                max_bytes_scanned: b.max_bytes_scanned,
+            };
+            if candidate.is_empty() {
+                None
+            } else {
+                Some(candidate)
+            }
+        });
+
         ModelIr {
             name: std::sync::Arc::from(self.config.name.as_str()),
             sql: self.sql.clone(),
@@ -725,6 +740,7 @@ impl Model {
             invalidate_hard_deletes: false,
             format: self.config.format.clone(),
             format_options: self.config.format_options.clone(),
+            cost_ceiling,
         }
     }
 }
@@ -2176,5 +2192,70 @@ SELECT 1
         assert_eq!(model.config.target.table, "stg_orders");
         assert_eq!(model.config.name_declared, "stg_orders");
         assert_eq!(model.config.target_table_declared, "stg_orders");
+    }
+
+    // ----- cost_ceiling / CostBudget sidecar tests -----
+
+    #[test]
+    fn test_sidecar_budget_populates_cost_ceiling() {
+        let content = r#"---toml
+[target]
+catalog = "analytics"
+schema = "marts"
+
+[budget]
+max_usd = 5.0
+---
+
+SELECT 1
+"#;
+        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let ir = model.to_model_ir();
+        let ceiling = ir
+            .cost_ceiling
+            .expect("cost_ceiling must be Some when [budget] max_usd is set");
+        assert_eq!(ceiling.max_usd, Some(5.0));
+        assert_eq!(ceiling.max_bytes_scanned, None);
+    }
+
+    #[test]
+    fn test_sidecar_budget_policy_only_yields_none_cost_ceiling() {
+        // A sidecar with only `on_breach` set (no cost dimensions) must NOT
+        // produce a cost_ceiling — collapsing vacuous budgets keeps recipe-hashes clean.
+        let content = r#"---toml
+[target]
+catalog = "analytics"
+schema = "marts"
+
+[budget]
+on_breach = "warn"
+---
+
+SELECT 1
+"#;
+        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let ir = model.to_model_ir();
+        assert!(
+            ir.cost_ceiling.is_none(),
+            "policy-only [budget] must yield cost_ceiling = None"
+        );
+    }
+
+    #[test]
+    fn test_sidecar_no_budget_yields_none_cost_ceiling() {
+        let content = r#"---toml
+[target]
+catalog = "analytics"
+schema = "marts"
+---
+
+SELECT 1
+"#;
+        let model = parse_model_inline(content, "fct_orders.sql", None).unwrap();
+        let ir = model.to_model_ir();
+        assert!(
+            ir.cost_ceiling.is_none(),
+            "absent [budget] block must yield cost_ceiling = None"
+        );
     }
 }

--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -446,6 +446,40 @@ pub struct ColumnMask {
     pub strategy: crate::mask::MaskStrategy,
 }
 
+/// Per-model cost ceiling — the maximum allowed spend for a single run.
+///
+/// Both fields are optional; a `CostBudget` with both fields `None` is
+/// collapsed to `cost_ceiling = None` by the sidecar-to-IR conversion in
+/// `rocky-core::models::Model::to_model_ir()`. Callers that want to check
+/// whether the budget carries any constraint should use [`CostBudget::is_empty`].
+///
+/// This type carries only the *cost dimensions* (`max_usd`,
+/// `max_bytes_scanned`). Policy fields (`on_breach`, `max_duration_ms`) live
+/// on `rocky-core::config::ModelBudgetConfig` and are not part of the IR.
+///
+/// Serialized following the canonical-JSON rule: each `Option` field is
+/// omitted when `None` so the recipe-hash never sees a stale `null`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostBudget {
+    /// Maximum allowed cost in USD for a single run of this model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_usd: Option<f64>,
+    /// Maximum bytes scanned for a single run of this model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes_scanned: Option<u64>,
+}
+
+impl CostBudget {
+    /// Returns `true` when neither cost field is set.
+    ///
+    /// Used by `to_model_ir()` to avoid storing a vacuous
+    /// `Some(CostBudget { None, None })` which would pollute recipe-hashes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.max_usd.is_none() && self.max_bytes_scanned.is_none()
+    }
+}
+
 /// Per-model intermediate representation.
 ///
 /// Carries everything Rocky needs to know about a single model to generate
@@ -549,6 +583,20 @@ pub struct ModelIr {
     /// `None` for non-transformation models.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format_options: Option<LakehouseOptions>,
+    /// Declared per-model cost ceiling from the `[budget]` sidecar block.
+    ///
+    /// `None` means no ceiling was declared (or only policy fields like
+    /// `on_breach` were set — those stay in `rocky-core::config`). `Some`
+    /// means the user declared at least one cost dimension in their sidecar.
+    ///
+    /// # Runtime wiring
+    ///
+    /// TODO(D-2): wire into `propagate_costs` once the
+    /// `CatalogClient::table_stats` provider spike (D-2) reaches a
+    /// go-decision. The field is populated today; the enforcement check is
+    /// not yet called.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_ceiling: Option<CostBudget>,
 }
 
 /// Inferred variant tag for a [`ModelIr`].
@@ -625,6 +673,7 @@ impl ModelIr {
             invalidate_hard_deletes: false,
             format: None,
             format_options: None,
+            cost_ceiling: None,
         }
     }
 
@@ -668,6 +717,7 @@ impl ModelIr {
             invalidate_hard_deletes: false,
             format,
             format_options,
+            cost_ceiling: None,
         }
     }
 
@@ -708,6 +758,7 @@ impl ModelIr {
             invalidate_hard_deletes,
             format: None,
             format_options: None,
+            cost_ceiling: None,
         }
     }
 
@@ -1018,6 +1069,7 @@ mod tests {
             invalidate_hard_deletes: false,
             format: None,
             format_options: None,
+            cost_ceiling: None,
         }
     }
 
@@ -1079,6 +1131,7 @@ mod tests {
             invalidate_hard_deletes: false,
             format: None,
             format_options: None,
+            cost_ceiling: None,
         }
     }
 
@@ -1113,6 +1166,7 @@ mod tests {
             invalidate_hard_deletes: true,
             format: None,
             format_options: None,
+            cost_ceiling: None,
         }
     }
 
@@ -1531,5 +1585,91 @@ mod tests {
         assert_eq!(ModelIrVariant::Transformation.as_str(), "transformation");
         assert_eq!(ModelIrVariant::Snapshot.as_str(), "snapshot");
         assert_eq!(format!("{}", ModelIrVariant::Replication), "replication");
+    }
+
+    // ----- CostBudget / cost_ceiling tests -----
+
+    #[test]
+    fn cost_ceiling_none_omitted_from_serialization() {
+        // Canonical-JSON rule: `None` Option fields must be absent from JSON.
+        let m = sample_replication_model(); // cost_ceiling is None
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(
+            !json.contains("cost_ceiling"),
+            "absent cost_ceiling must be skipped, got: {json}"
+        );
+    }
+
+    #[test]
+    fn cost_ceiling_roundtrip_byte_stable() {
+        let mut m = sample_transformation_model();
+        m.cost_ceiling = Some(CostBudget {
+            max_usd: Some(10.0),
+            max_bytes_scanned: Some(1_000_000_000),
+        });
+        let json1 = serde_json::to_string(&m).unwrap();
+        let back: ModelIr = serde_json::from_str(&json1).unwrap();
+        let json2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(json1, json2, "cost_ceiling round-trip must be byte-stable");
+        let cb = back.cost_ceiling.unwrap();
+        assert_eq!(cb.max_usd, Some(10.0));
+        assert_eq!(cb.max_bytes_scanned, Some(1_000_000_000));
+    }
+
+    #[test]
+    fn recipe_hash_changes_when_cost_ceiling_changes() {
+        let mut m = sample_transformation_model();
+        let h1 = m.recipe_hash();
+        m.cost_ceiling = Some(CostBudget {
+            max_usd: Some(5.0),
+            max_bytes_scanned: None,
+        });
+        let h2 = m.recipe_hash();
+        assert_ne!(h1, h2, "adding cost_ceiling must change the recipe hash");
+    }
+
+    #[test]
+    fn cost_budget_is_empty() {
+        let empty = CostBudget {
+            max_usd: None,
+            max_bytes_scanned: None,
+        };
+        assert!(empty.is_empty(), "both-None CostBudget must be empty");
+
+        let with_usd = CostBudget {
+            max_usd: Some(1.0),
+            max_bytes_scanned: None,
+        };
+        assert!(
+            !with_usd.is_empty(),
+            "CostBudget with max_usd must not be empty"
+        );
+
+        let with_bytes = CostBudget {
+            max_usd: None,
+            max_bytes_scanned: Some(500_000),
+        };
+        assert!(
+            !with_bytes.is_empty(),
+            "CostBudget with max_bytes_scanned must not be empty"
+        );
+    }
+
+    #[test]
+    fn cost_budget_partial_none_omitted() {
+        // A CostBudget with only max_usd set must omit max_bytes_scanned from JSON.
+        let cb = CostBudget {
+            max_usd: Some(3.5),
+            max_bytes_scanned: None,
+        };
+        let json = serde_json::to_string(&cb).unwrap();
+        assert!(
+            json.contains("max_usd"),
+            "present max_usd must appear in JSON"
+        );
+        assert!(
+            !json.contains("max_bytes_scanned"),
+            "absent max_bytes_scanned must be skipped, got: {json}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `CostBudget` struct to `rocky-ir` with `max_usd: Option<f64>` and `max_bytes_scanned: Option<u64>` — the cost dimensions only; policy fields (`on_breach`, `max_duration_ms`) stay in the config layer
- Adds `cost_ceiling: Option<CostBudget>` to `ModelIr`, wired from the `[budget]` sidecar block via `to_model_ir()` in `rocky-core`; a policy-only sidecar (e.g. only `on_breach = "warn"`) collapses to `None` to keep recipe-hashes clean
- Allocates `E027` in the diagnostic registry and adds `Diagnostic::budget_exceeded()` as a compile-ready shell; the method constructs, serializes, and carries a suggestion but is **not yet called** by `propagate_costs` — enforcement is deferred pending the `CatalogClient::table_stats` runtime provider

## What is not in this PR

Runtime enforcement is intentionally absent. `propagate_costs` is untouched. No catalog-stats plumbing is added. The field is `Option<>` defaulting to `None`, making this fully backward-compatible.

## Test plan

- [ ] `cargo test -p rocky-ir` — 5 new CostBudget tests: `cost_ceiling_none_omitted_from_serialization`, `cost_ceiling_roundtrip_byte_stable`, `recipe_hash_changes_when_cost_ceiling_changes`, `cost_budget_is_empty`, `cost_budget_partial_none_omitted`
- [ ] `cargo test -p rocky-compiler` — 3 new diagnostic tests: `test_budget_exceeded_constructs_correctly`, `test_budget_exceeded_serializes`, `test_e027_constant_value`
- [ ] `cargo test -p rocky-core` — 3 new sidecar tests: `test_sidecar_budget_populates_cost_ceiling`, `test_sidecar_budget_policy_only_yields_none_cost_ceiling`, `test_sidecar_no_budget_yields_none_cost_ceiling`
- [ ] `cargo fmt -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `just codegen` produces no schema drift (ModelIr does not derive JsonSchema)
- [ ] `just regen-fixtures` produces no fixture drift