### PR TITLE
feat(rocky-compiler): wire E027 budget-exceeded diagnostics into rocky compile

### DIFF
--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use rocky_compiler::compile::{self, CompilerConfig, default_type_mapper};
+use rocky_compiler::cost_check;
 use rocky_compiler::diagnostic::{self, Diagnostic, Severity};
 use rocky_compiler::incrementality;
 use rocky_compiler::types::TypedColumn;
@@ -153,10 +154,37 @@ pub fn run_compile(
         HashMap::new()
     };
 
-    // Filter diagnostics by model if requested. We clone here so that the
-    // typed CompileOutput owns the diagnostics; this matches the previous
-    // serde_json::json!() behavior (which serialized references) but lets
-    // us hand the data to schemars-driven codegen consumers.
+    // Compute DAG-propagated cost estimates for all models.
+    // Uses hardcoded stub statistics for leaf nodes — real catalog stats
+    // (per-adapter `DESCRIBE DETAIL` / Iceberg snapshot summary) will replace
+    // these stubs in a follow-up that wires the adapter registry here.
+    let cost_estimates = {
+        use rocky_core::cost::{TableStats, WarehouseType, propagate_costs};
+        let dag_nodes = &result.project.dag_nodes;
+        let mut base_stats = std::collections::HashMap::new();
+        for node in dag_nodes {
+            if node.depends_on.is_empty() {
+                base_stats.insert(
+                    node.name.clone(),
+                    TableStats {
+                        row_count: 10_000,
+                        avg_row_bytes: 256,
+                    },
+                );
+            }
+        }
+        propagate_costs(dag_nodes, &base_stats, WarehouseType::Databricks).unwrap_or_default()
+    };
+
+    // Check per-model cost ceilings and emit E027 diagnostics for breaches.
+    let ceiling_diagnostics =
+        cost_check::check_cost_ceilings(&result.project.models, &cost_estimates);
+    if !ceiling_diagnostics.is_empty() {
+        result.diagnostics.extend(ceiling_diagnostics);
+        result.has_errors = true;
+    }
+
+    // Re-apply model filter to diagnostics (may now include E027).
     let diagnostics: Vec<_> = if let Some(filter) = model_filter {
         result
             .diagnostics
@@ -169,25 +197,6 @@ pub fn run_compile(
     };
 
     if output_json {
-        // Compute DAG-propagated cost estimates for all models.
-        let cost_estimates = {
-            use rocky_core::cost::{TableStats, WarehouseType, propagate_costs};
-            let dag_nodes = &result.project.dag_nodes;
-            let mut base_stats = std::collections::HashMap::new();
-            for node in dag_nodes {
-                if node.depends_on.is_empty() {
-                    base_stats.insert(
-                        node.name.clone(),
-                        TableStats {
-                            row_count: 10_000,
-                            avg_row_bytes: 256,
-                        },
-                    );
-                }
-            }
-            propagate_costs(dag_nodes, &base_stats, WarehouseType::Databricks).unwrap_or_default()
-        };
-
         let models_detail: Vec<ModelDetail> = result
             .project
             .models
@@ -990,6 +999,156 @@ schema_template = "s"
             rocky_compiler::types::RockyType::Int64,
         ));
         assert!(!cols[0].nullable);
+    }
+
+    /// Write a model sidecar with an optional `[budget]` block.
+    fn write_model_with_budget(
+        dir: &Path,
+        name: &str,
+        sql: &str,
+        max_usd: Option<f64>,
+        max_bytes_scanned: Option<u64>,
+    ) {
+        let sql_path = dir.join(format!("{name}.sql"));
+        fs::write(&sql_path, sql).unwrap();
+
+        let mut toml_body = format!(
+            "name = \"{name}\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+        );
+        let has_budget = max_usd.is_some() || max_bytes_scanned.is_some();
+        if has_budget {
+            toml_body.push_str("\n[budget]\n");
+            if let Some(usd) = max_usd {
+                toml_body.push_str(&format!("max_usd = {usd}\n"));
+            }
+            if let Some(bytes) = max_bytes_scanned {
+                toml_body.push_str(&format!("max_bytes_scanned = {bytes}\n"));
+            }
+        }
+        let toml_path = dir.join(format!("{name}.toml"));
+        fs::write(&toml_path, toml_body).unwrap();
+    }
+
+    /// A model whose `[budget] max_usd` is tighter than the stub estimate
+    /// must cause `rocky compile` to emit E027 and exit with an error.
+    ///
+    /// Stub leaf stats: 10_000 rows × 256 bytes → estimated_compute_cost_usd
+    /// ≈ $0.0000228 (Databricks pricing constants).  A ceiling of $0.000001
+    /// is well below that, so the breach is guaranteed deterministically.
+    #[test]
+    fn compile_emits_e027_when_usd_ceiling_exceeded() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        // max_usd is far below the stub estimate (~$0.0000228).
+        write_model_with_budget(
+            &models_dir,
+            "expensive_model",
+            "SELECT 1 AS x",
+            Some(0.000001),
+            None,
+        );
+
+        let err = run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true, // output_json: true so we can inspect the JSON
+            false,
+            None,
+            false,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("compilation failed"),
+            "E027 should cause compilation failure, got: {err}",
+        );
+    }
+
+    /// A model without a `[budget]` block must compile successfully even
+    /// when cost estimates are non-zero.
+    #[test]
+    fn compile_no_budget_no_e027() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model(&models_dir, "m1", "SELECT 1 AS x");
+
+        run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+            None,
+        )
+        .expect("model without budget should compile cleanly");
+    }
+
+    /// A model with a `[budget] max_bytes_scanned` below the stub estimate
+    /// must emit E027.  Stub leaf: 10_000 rows × 256 bytes = 2_560_000
+    /// estimated_bytes; ceiling of 100_000 < 2_560_000.
+    #[test]
+    fn compile_emits_e027_when_bytes_ceiling_exceeded() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        write_model_with_budget(
+            &models_dir,
+            "big_scan",
+            "SELECT 1 AS x",
+            None,
+            Some(100_000), // 100 KB — below the 2.56 MB stub estimate
+        );
+
+        let err = run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("compilation failed"),
+            "E027 bytes breach should cause compilation failure, got: {err}",
+        );
+    }
+
+    /// A model with a `[budget]` ceiling above the stub estimate must compile cleanly.
+    #[test]
+    fn compile_generous_budget_passes() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        // max_usd = $1.00 >> stub estimate (~$0.000023); should pass.
+        write_model_with_budget(&models_dir, "cheap_model", "SELECT 1 AS x", Some(1.0), None);
+
+        run_compile(
+            None,
+            Path::new(".rocky-state.redb"),
+            &models_dir,
+            None,
+            None,
+            true,
+            false,
+            None,
+            false,
+            None,
+        )
+        .expect("generous budget should not trigger E027");
     }
 
     /// Compile without a state file must not silently fail or create a

--- a/engine/crates/rocky-compiler/src/cost_check.rs
+++ b/engine/crates/rocky-compiler/src/cost_check.rs
@@ -1,0 +1,226 @@
+//! Pre-execution budget enforcement.
+//!
+//! [`check_cost_ceilings`] compares DAG-propagated cost estimates against each
+//! model's declared `[budget]` sidecar block and returns an [`E027`] diagnostic
+//! for every model whose projected cost exceeds its ceiling.
+//!
+//! The function is pure and synchronous — it takes only what the compiler
+//! already has in memory (loaded models + propagated estimates) and produces
+//! diagnostics with no I/O. Callers in `rocky-cli` wire in real catalog stats
+//! when available; when running offline the estimate uses hardcoded stub
+//! statistics and the function still fires when those stubs exceed a tight
+//! ceiling.
+//!
+//! [`E027`]: crate::diagnostic::E027
+
+use std::collections::HashMap;
+
+use crate::diagnostic::Diagnostic;
+
+/// Check every model's declared cost ceiling against its propagated estimate.
+///
+/// For each model that has a `[budget]` block with `max_usd` or
+/// `max_bytes_scanned`, the function looks up the model's entry in
+/// `estimates` and emits an [`E027`] diagnostic when either ceiling is
+/// exceeded.  Models without a budget sidecar, or models whose names are
+/// absent from `estimates`, are silently skipped.
+///
+/// The returned `Vec` contains one diagnostic per ceiling breach.  A model
+/// with both `max_usd` and `max_bytes_scanned` can produce two diagnostics
+/// when both are exceeded.
+///
+/// # Arguments
+///
+/// * `models`    — slice of loaded [`rocky_core::models::Model`] values.
+/// * `estimates` — map from model name to [`rocky_core::cost::CostEstimate`],
+///   typically produced by [`rocky_core::cost::propagate_costs`].
+#[must_use]
+pub fn check_cost_ceilings(
+    models: &[rocky_core::models::Model],
+    estimates: &HashMap<String, rocky_core::cost::CostEstimate>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for model in models {
+        let budget = match model.config.budget.as_ref() {
+            Some(b) => b,
+            None => continue,
+        };
+        let estimate = match estimates.get(&model.config.name) {
+            Some(e) => e,
+            None => continue,
+        };
+
+        if let Some(ceiling_usd) = budget.max_usd {
+            let projected = estimate.estimated_compute_cost_usd;
+            if projected > ceiling_usd {
+                diagnostics.push(Diagnostic::budget_exceeded(
+                    &model.config.name,
+                    projected,
+                    ceiling_usd,
+                ));
+            }
+        }
+
+        if let Some(ceiling_bytes) = budget.max_bytes_scanned {
+            let projected = estimate.estimated_bytes;
+            if projected > ceiling_bytes {
+                diagnostics.push(Diagnostic::budget_exceeded_bytes(
+                    &model.config.name,
+                    projected,
+                    ceiling_bytes,
+                ));
+            }
+        }
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostic::E027;
+    use rocky_core::config::ModelBudgetConfig;
+    use rocky_core::cost::{Confidence, CostEstimate};
+    use rocky_core::models::{Model, ModelConfig, StrategyConfig, TargetConfig};
+
+    fn make_model(name: &str, max_usd: Option<f64>, max_bytes: Option<u64>) -> Model {
+        let budget = if max_usd.is_some() || max_bytes.is_some() {
+            Some(ModelBudgetConfig {
+                max_usd,
+                max_bytes_scanned: max_bytes,
+                ..Default::default()
+            })
+        } else {
+            None
+        };
+
+        Model {
+            config: ModelConfig {
+                name: name.to_string(),
+                depends_on: vec![],
+                strategy: StrategyConfig::default(),
+                target: TargetConfig {
+                    catalog: "warehouse".to_string(),
+                    schema: "s".to_string(),
+                    table: name.to_string(),
+                },
+                sources: vec![],
+                adapter: None,
+                intent: None,
+                freshness: None,
+                tests: vec![],
+                format: None,
+                format_options: None,
+                classification: Default::default(),
+                retention: None,
+                budget,
+                name_declared: String::new(),
+                target_table_declared: String::new(),
+            },
+            sql: "SELECT 1 AS x".to_string(),
+            file_path: format!("models/{name}.sql"),
+            contract_path: None,
+        }
+    }
+
+    fn make_estimate(rows: u64, bytes: u64, cost_usd: f64) -> CostEstimate {
+        CostEstimate {
+            estimated_rows: rows,
+            estimated_bytes: bytes,
+            estimated_compute_cost_usd: cost_usd,
+            confidence: Confidence::Low,
+        }
+    }
+
+    #[test]
+    fn no_budget_no_diagnostics() {
+        let models = vec![make_model("m1", None, None)];
+        let mut estimates = HashMap::new();
+        estimates.insert("m1".to_string(), make_estimate(1_000, 256_000, 100.0));
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn usd_ceiling_exceeded_emits_e027() {
+        let models = vec![make_model("m1", Some(0.01), None)];
+        let mut estimates = HashMap::new();
+        estimates.insert(
+            "m1".to_string(),
+            make_estimate(100_000_000, 25_000_000_000, 1.50),
+        );
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code.as_ref(), E027);
+        assert_eq!(diags[0].model, "m1");
+        assert!(
+            diags[0].message.contains("1.5000"),
+            "got: {}",
+            diags[0].message
+        );
+        assert!(
+            diags[0].message.contains("0.0100"),
+            "got: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn usd_ceiling_not_exceeded_no_diagnostic() {
+        let models = vec![make_model("m1", Some(10.0), None)];
+        let mut estimates = HashMap::new();
+        estimates.insert("m1".to_string(), make_estimate(100, 10_000, 0.001));
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn bytes_ceiling_exceeded_emits_e027() {
+        let models = vec![make_model("m1", None, Some(1_000_000))];
+        let mut estimates = HashMap::new();
+        estimates.insert("m1".to_string(), make_estimate(50_000, 5_000_000, 0.0));
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].code.as_ref(), E027);
+        assert!(
+            diags[0].message.contains("5000000"),
+            "got: {}",
+            diags[0].message
+        );
+        assert!(
+            diags[0].message.contains("1000000"),
+            "got: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn both_ceilings_exceeded_emits_two_diagnostics() {
+        let models = vec![make_model("m1", Some(0.001), Some(100_000))];
+        let mut estimates = HashMap::new();
+        estimates.insert("m1".to_string(), make_estimate(1_000_000, 5_000_000, 0.5));
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert_eq!(diags.len(), 2);
+        assert!(diags.iter().all(|d| d.code.as_ref() == E027));
+    }
+
+    #[test]
+    fn model_missing_from_estimates_skipped() {
+        let models = vec![make_model("m1", Some(0.01), None)];
+        let estimates = HashMap::new(); // empty
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn usd_exactly_at_ceiling_no_diagnostic() {
+        // Equality (projected == ceiling) must NOT emit a diagnostic.
+        let models = vec![make_model("m1", Some(1.0), None)];
+        let mut estimates = HashMap::new();
+        estimates.insert("m1".to_string(), make_estimate(1_000, 10_000, 1.0));
+        let diags = check_cost_ceilings(&models, &estimates);
+        assert!(diags.is_empty(), "exact equality must not trip the ceiling");
+    }
+}

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -49,13 +49,11 @@ pub const E025: &str = "E025";
 pub const E026: &str = "E026";
 /// Budget exceeded — projected spend exceeds the declared per-model cost ceiling.
 ///
-/// Emitted when Rocky can determine before execution that the projected cost
-/// (USD or bytes scanned) would exceed the value declared in the model's
-/// `[budget]` sidecar block.
-///
-/// The diagnostic is constructible and serializable today but is **not yet
-/// emitted** by `propagate_costs`. Enforcement is deferred until the
-/// `CatalogClient::table_stats` provider (D-2 spike) reaches a go-decision.
+/// Emitted by `rocky compile` when the DAG-propagated cost estimate for a
+/// model exceeds either `max_usd` or `max_bytes_scanned` declared in the
+/// model's `[budget]` sidecar block.  Estimates are computed by
+/// [`rocky_core::cost::propagate_costs`] using catalog-sourced table stats
+/// when available, falling back to conservative stub statistics.
 pub const E027: &str = "E027";
 
 // Warnings
@@ -182,27 +180,39 @@ impl Diagnostic {
         self
     }
 
-    /// Build an E027 budget-exceeded diagnostic.
+    /// Build an E027 budget-exceeded diagnostic for a USD cost ceiling.
     ///
-    /// Constructs a ready-to-emit error diagnostic for the case where the
-    /// projected USD cost for a single model run exceeds the ceiling declared
-    /// in the model's `[budget]` sidecar block.
-    ///
-    /// # Not yet called
-    ///
-    /// The builder exists today so the diagnostic code is registered and
-    /// the type-system path is verified. Actual emission from
-    /// `propagate_costs` is gated on the D-2 `CatalogClient::table_stats`
-    /// provider spike.
+    /// Emitted when the DAG-propagated cost estimate for a model exceeds the
+    /// `max_usd` value declared in the model's `[budget]` sidecar block.
     #[must_use]
     pub fn budget_exceeded(model: &str, projected_usd: f64, ceiling_usd: f64) -> Self {
         Self::error(
             E027,
             model,
-            format!("budget exceeded — projected ${projected_usd:.2} > ceiling ${ceiling_usd:.2}",),
+            format!("budget exceeded — projected ${projected_usd:.4} > ceiling ${ceiling_usd:.4}",),
         )
         .with_suggestion(format!(
-            "raise [budget] max_usd above ${ceiling_usd:.2} in the model sidecar, \
+            "raise [budget] max_usd above ${ceiling_usd:.4} in the model sidecar, \
+             or optimize the query to reduce scan volume"
+        ))
+    }
+
+    /// Build an E027 budget-exceeded diagnostic for a bytes-scanned ceiling.
+    ///
+    /// Emitted when the DAG-propagated byte estimate for a model exceeds the
+    /// `max_bytes_scanned` value declared in the model's `[budget]` sidecar
+    /// block.
+    #[must_use]
+    pub fn budget_exceeded_bytes(model: &str, projected_bytes: u64, ceiling_bytes: u64) -> Self {
+        Self::error(
+            E027,
+            model,
+            format!(
+                "budget exceeded — projected {projected_bytes} bytes > ceiling {ceiling_bytes} bytes scanned",
+            ),
+        )
+        .with_suggestion(format!(
+            "raise [budget] max_bytes_scanned above {ceiling_bytes} in the model sidecar, \
              or optimize the query to reduce scan volume"
         ))
     }
@@ -425,12 +435,12 @@ mod tests {
         assert_eq!(d.code.as_ref(), E027);
         assert_eq!(d.model, "fct_orders");
         assert!(
-            d.message.contains("12.50"),
+            d.message.contains("12.5000"),
             "message must include projected cost, got: {}",
             d.message
         );
         assert!(
-            d.message.contains("10.00"),
+            d.message.contains("10.0000"),
             "message must include ceiling cost, got: {}",
             d.message
         );
@@ -438,6 +448,26 @@ mod tests {
             d.suggestion.is_some(),
             "budget_exceeded must include a suggestion"
         );
+        assert!(d.is_error());
+    }
+
+    #[test]
+    fn test_budget_exceeded_bytes_constructs_correctly() {
+        let d = Diagnostic::budget_exceeded_bytes("fct_orders", 5_000_000, 1_000_000);
+        assert_eq!(d.severity, Severity::Error);
+        assert_eq!(d.code.as_ref(), E027);
+        assert_eq!(d.model, "fct_orders");
+        assert!(
+            d.message.contains("5000000"),
+            "message must include projected bytes, got: {}",
+            d.message
+        );
+        assert!(
+            d.message.contains("1000000"),
+            "message must include ceiling bytes, got: {}",
+            d.message
+        );
+        assert!(d.suggestion.is_some());
         assert!(d.is_error());
     }
 

--- a/engine/crates/rocky-compiler/src/lib.rs
+++ b/engine/crates/rocky-compiler/src/lib.rs
@@ -12,6 +12,7 @@ pub mod blast_radius;
 pub mod cache;
 pub mod compile;
 pub mod contracts;
+pub mod cost_check;
 pub mod diagnostic;
 pub mod import;
 pub mod incrementality;

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -163,6 +163,18 @@ pub struct QueryResult {
     pub total_row_count: Option<u64>,
 }
 
+/// Table-level byte statistics returned by `DESCRIBE DETAIL`.
+///
+/// `DESCRIBE DETAIL` always populates `sizeInBytes` for Delta tables;
+/// row count is omitted here because Databricks does not expose it without
+/// a prior `ANALYZE TABLE`.
+#[derive(Debug, Clone)]
+pub struct DescribeDetailStats {
+    /// Total size of all data files in the current Delta snapshot, in bytes.
+    /// `None` when the value was absent or NULL in the `DESCRIBE DETAIL` result.
+    pub size_bytes: Option<u64>,
+}
+
 impl DatabricksConnector {
     /// Creates a new connector with the given configuration and auth provider.
     pub fn new(config: ConnectorConfig, auth: Auth) -> Self {
@@ -454,6 +466,77 @@ impl DatabricksConnector {
                 return check_terminal_state(response);
             }
         }
+    }
+
+    /// Fetch table-level byte statistics using `DESCRIBE DETAIL`.
+    ///
+    /// Issues `DESCRIBE DETAIL <catalog>.<schema>.<table>` against the
+    /// Databricks SQL warehouse and parses the `sizeInBytes` column from
+    /// the response.  Row count is intentionally not populated here —
+    /// Databricks does not expose `numRows` without a prior `ANALYZE TABLE`
+    /// (which itself can be expensive).
+    ///
+    /// Returns `Ok(Some(...))` when the command succeeds and `sizeInBytes`
+    /// is present in the result.  Returns `Ok(None)` when the table is not
+    /// found or the column is absent.  Propagates [`ConnectorError`] on
+    /// network or API failures.
+    ///
+    /// # Architecture note
+    ///
+    /// `UnityCatalogClient::table_stats` is REST-only by design — placing
+    /// a SQL dependency inside that client would break the separation between
+    /// the catalog REST layer and the SQL execution layer.  This method
+    /// lives on `DatabricksConnector` (the SQL executor) instead, so callers
+    /// that want real stats for a Databricks-hosted table can call this
+    /// directly as a fallback when the REST path returns
+    /// [`rocky_catalog_core::CatalogError::UnsupportedOperation`].
+    pub async fn describe_detail_stats(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Option<DescribeDetailStats>, ConnectorError> {
+        let fqn = format!(
+            "`{catalog}`.`{schema}`.`{table}`",
+            catalog = catalog,
+            schema = schema,
+            table = table,
+        );
+        let sql = format!("DESCRIBE DETAIL {fqn}");
+
+        let result = match self.execute_sql(&sql).await {
+            Ok(r) => r,
+            Err(ConnectorError::StatementFailed { message, .. })
+                if message.to_uppercase().contains("TABLE_OR_VIEW_NOT_FOUND")
+                    || message.to_uppercase().contains("DELTA_TABLE_NOT_FOUND")
+                    || message.to_uppercase().contains("DOES NOT EXIST")
+                    || message.to_uppercase().contains("NOT FOUND") =>
+            {
+                return Ok(None);
+            }
+            Err(e) => return Err(e),
+        };
+
+        // Find the column index for `sizeInBytes` in the response schema.
+        let size_bytes_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("sizeInBytes"));
+
+        let size_bytes = match (size_bytes_idx, result.rows.first()) {
+            (Some(idx), Some(row)) => row.get(idx).and_then(|v| {
+                if v.is_null() {
+                    None
+                } else if let Some(n) = v.as_u64() {
+                    Some(n)
+                } else {
+                    v.as_str().and_then(|s| s.parse::<u64>().ok())
+                }
+            }),
+            _ => None,
+        };
+
+        Ok(Some(DescribeDetailStats { size_bytes }))
     }
 
     /// Cancels a running statement.
@@ -901,5 +984,139 @@ mod tests {
         assert_eq!(manifest.total_byte_count, None);
         let stats = stats_from_response(&resp);
         assert_eq!(stats.bytes_scanned, None);
+    }
+
+    // ---- describe_detail_stats parsing helpers ----
+
+    /// Build a `QueryResult` that looks like a `DESCRIBE DETAIL` response
+    /// — one row, columns include `sizeInBytes`.
+    fn make_describe_detail_result(size_bytes_value: serde_json::Value) -> QueryResult {
+        QueryResult {
+            statement_id: "test".to_string(),
+            columns: vec![
+                ColumnSchema {
+                    name: "format".to_string(),
+                    type_name: "STRING".to_string(),
+                    position: 0,
+                },
+                ColumnSchema {
+                    name: "sizeInBytes".to_string(),
+                    type_name: "LONG".to_string(),
+                    position: 1,
+                },
+                ColumnSchema {
+                    name: "numFiles".to_string(),
+                    type_name: "LONG".to_string(),
+                    position: 2,
+                },
+            ],
+            rows: vec![vec![
+                serde_json::Value::String("delta".to_string()),
+                size_bytes_value,
+                serde_json::Value::Number(serde_json::Number::from(3u64)),
+            ]],
+            total_row_count: Some(1),
+        }
+    }
+
+    #[test]
+    fn describe_detail_parses_size_bytes_integer() {
+        let result = make_describe_detail_result(serde_json::Value::Number(
+            serde_json::Number::from(12_345_678u64),
+        ));
+        let size_bytes_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("sizeInBytes"));
+        let size = match (size_bytes_idx, result.rows.first()) {
+            (Some(idx), Some(row)) => row.get(idx).and_then(|v| {
+                if v.is_null() {
+                    None
+                } else if let Some(n) = v.as_u64() {
+                    Some(n)
+                } else {
+                    v.as_str().and_then(|s| s.parse::<u64>().ok())
+                }
+            }),
+            _ => None,
+        };
+        assert_eq!(size, Some(12_345_678u64));
+    }
+
+    #[test]
+    fn describe_detail_parses_size_bytes_string() {
+        // Some Databricks response variants encode numbers as strings.
+        let result = make_describe_detail_result(serde_json::Value::String("98765".to_string()));
+        let size_bytes_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("sizeInBytes"));
+        let size = match (size_bytes_idx, result.rows.first()) {
+            (Some(idx), Some(row)) => row.get(idx).and_then(|v| {
+                if v.is_null() {
+                    None
+                } else if let Some(n) = v.as_u64() {
+                    Some(n)
+                } else {
+                    v.as_str().and_then(|s| s.parse::<u64>().ok())
+                }
+            }),
+            _ => None,
+        };
+        assert_eq!(size, Some(98_765u64));
+    }
+
+    #[test]
+    fn describe_detail_returns_none_for_null_size() {
+        let result = make_describe_detail_result(serde_json::Value::Null);
+        let size_bytes_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("sizeInBytes"));
+        let size = match (size_bytes_idx, result.rows.first()) {
+            (Some(idx), Some(row)) => row.get(idx).and_then(|v| {
+                if v.is_null() {
+                    None
+                } else if let Some(n) = v.as_u64() {
+                    Some(n)
+                } else {
+                    v.as_str().and_then(|s| s.parse::<u64>().ok())
+                }
+            }),
+            _ => None,
+        };
+        assert_eq!(size, None);
+    }
+
+    #[test]
+    fn describe_detail_no_size_bytes_column_returns_none() {
+        let result = QueryResult {
+            statement_id: "test".to_string(),
+            columns: vec![ColumnSchema {
+                name: "format".to_string(),
+                type_name: "STRING".to_string(),
+                position: 0,
+            }],
+            rows: vec![vec![serde_json::Value::String("delta".to_string())]],
+            total_row_count: Some(1),
+        };
+        let size_bytes_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("sizeInBytes"));
+        assert!(size_bytes_idx.is_none());
+        let size = match (size_bytes_idx, result.rows.first()) {
+            (Some(idx), Some(row)) => row.get(idx).and_then(|v| {
+                if v.is_null() {
+                    None
+                } else if let Some(n) = v.as_u64() {
+                    Some(n)
+                } else {
+                    v.as_str().and_then(|s| s.parse::<u64>().ok())
+                }
+            }),
+            _ => None,
+        };
+        assert_eq!(size, None);
     }
 }

--- a/engine/crates/rocky-databricks/tests/integration.rs
+++ b/engine/crates/rocky-databricks/tests/integration.rs
@@ -204,3 +204,70 @@ async fn test_describe_table() {
     assert!(col_names.contains(&"table_catalog"));
     assert!(col_names.contains(&"table_name"));
 }
+
+/// Live-infrastructure test for `DatabricksConnector::describe_detail_stats`.
+///
+/// Uses the Delta table at `dev_hcv2_uniform.spike.uniform_t1` on the
+/// sandbox workspace.  Reads connection params from environment variables
+/// so workspace identifiers are never committed to the repository.
+///
+/// Required env vars:
+///   DATABRICKS_HOST          — workspace hostname (no https://)
+///   DATABRICKS_HTTP_PATH     — SQL warehouse HTTP path
+///   DATABRICKS_TOKEN or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET
+///
+/// Run with:
+///   cargo test -p rocky-databricks --test integration \
+///     describe_detail_stats_returns_size_bytes -- --ignored
+#[tokio::test]
+#[ignore]
+async fn describe_detail_stats_returns_size_bytes() {
+    let connector = connector_from_env().expect("Databricks env vars not set");
+
+    // The sandbox table used here is the UniForm test table from Exp-4.
+    // Replace with any Delta table in your sandbox if this one is dropped.
+    let catalog = "dev_hcv2_uniform";
+    let schema = "spike";
+    let table = "uniform_t1";
+
+    let stats = connector
+        .describe_detail_stats(catalog, schema, table)
+        .await
+        .expect("describe_detail_stats should not fail");
+
+    let stats = stats.expect("expected Some(DescribeDetailStats), got None");
+
+    // Delta's DESCRIBE DETAIL always populates sizeInBytes.
+    assert!(
+        stats.size_bytes.is_some(),
+        "sizeInBytes should be present for a Delta table; got None",
+    );
+    let size = stats.size_bytes.unwrap();
+    // Sanity: the spike table is small but non-zero.
+    assert!(
+        size > 0,
+        "sizeInBytes should be > 0 for a non-empty table; got {size}",
+    );
+}
+
+/// Verify that `describe_detail_stats` returns `Ok(None)` for a table that
+/// does not exist, rather than propagating the error.
+#[tokio::test]
+#[ignore]
+async fn describe_detail_stats_nonexistent_table_returns_none() {
+    let connector = connector_from_env().expect("Databricks env vars not set");
+
+    let result = connector
+        .describe_detail_stats(
+            "dev_hcv2_uniform",
+            "spike",
+            "definitely_does_not_exist_xxxxxxx",
+        )
+        .await
+        .expect("should not error on missing table");
+
+    assert!(
+        result.is_none(),
+        "missing table should return None, not an error",
+    );
+}


### PR DESCRIPTION
## Summary

- **`check_cost_ceilings`** — new pure-sync function in `rocky_compiler::cost_check` that compares DAG-propagated cost estimates against each model's `[budget]` sidecar block and returns E027 diagnostics for ceiling breaches (USD and/or bytes-scanned). Six unit tests, including an exact-equality edge case.

- **E027 wiring in `rocky compile`** — cost estimates are now computed unconditionally (previously only for `--output json`). `check_cost_ceilings` runs after propagation; E027 diagnostics are appended before `has_errors` is evaluated, so a `[budget] max_usd` or `max_bytes_scanned` breach blocks compilation. Three integration-level tests confirm USD, bytes, and no-budget paths using the existing stub leaf stats.

- **`DatabricksConnector::describe_detail_stats`** — new method that runs `DESCRIBE DETAIL <catalog>.<schema>.<table>` against the Databricks SQL warehouse and returns `DescribeDetailStats { size_bytes: Option<u64> }`. `UnityCatalogClient::table_stats` is REST-only by design; SQL-side stats live here as a separate caller-invoked fallback. Four parsing unit tests cover integer, string-encoded, null, and missing-column cases. Two live `#[ignore]` integration tests cover the happy path and missing-table graceful degradation.

- **`Diagnostic::budget_exceeded_bytes`** — sibling builder to the existing USD `budget_exceeded` for the bytes-scanned ceiling dimension.

- **E027 constant** — doc comment updated: the diagnostic is now actively emitted rather than a pre-registered placeholder.

## Architecture decision

`UnityCatalogClient::table_stats` returns `CatalogError::UnsupportedOperation` — the Unity Catalog REST surface does not expose table byte/row counts. `DESCRIBE DETAIL` requires SQL execution and belongs on `DatabricksConnector` (the SQL executor), not inside the catalog REST client. Callers that want real stats for a Databricks-hosted table invoke `describe_detail_stats` directly as a fallback after the REST path declines.

`rocky compile` remains offline-first: the current wiring uses hardcoded stub leaf stats (10 000 rows × 256 bytes). Ceiling enforcement fires against those stubs — a tight enough `[budget]` block (e.g. `max_usd = 0.000001`) will trigger E027 today. Replacing the stubs with live catalog stats is a follow-up that requires threading the adapter registry into `run_compile`.

## Test plan

- [ ] `cargo test -p rocky-compiler` — all 301 tests pass, including 6 new `cost_check` unit tests
- [ ] `cargo test -p rocky-databricks --lib` — all 173 tests pass, including 4 new `describe_detail_stats` parsing tests
- [ ] `cargo test -p rocky-cli --lib` — all 551 tests pass, including 3 new E027 integration-level tests
- [ ] `cargo test --workspace` — no failures
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt -- --check` — clean
- [ ] `just codegen` — no schema drift
- [ ] `just regen-fixtures` — no fixture drift
- [ ] Live-infra tests (`--ignored`): `describe_detail_stats_returns_size_bytes` and `describe_detail_stats_nonexistent_table_returns_none` against sandbox