### PR TITLE
feat(rocky-cli): wire real catalog stats into per-model cost ceiling at plan time

### DIFF
--- a/editors/vscode/src/types/generated/plan.ts
+++ b/editors/vscode/src/types/generated/plan.ts
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Severity level of a diagnostic.
+ *
+ * Serialized in PascalCase (`"Error"`, `"Warning"`, `"Info"`) to stay compatible with existing dagster fixtures and the hand-written `Severity` StrEnum in `integrations/dagster/src/dagster_rocky/types.py`.
+ */
+export type Severity = "Error" | "Warning" | "Info";
+
+/**
  * JSON output for `rocky plan`.
  *
  * `statements` enumerates the warehouse SQL Rocky would emit. The three `*_actions` collections are a parallel view of the control-plane governance work `rocky run` would do *after* a successful DAG — the classification / masking / retention reconcile pass. These never show up as SQL; they fire through [`rocky_core::traits::GovernanceAdapter`] methods (e.g. `apply_column_tags`, `apply_masking_policy`, `apply_retention_policy`). Projects without any `[classification]`, `[mask]`, or `retention` config get empty lists — the fields `skip_serializing_if = Vec::is_empty`, so JSON consumers written against the pre-Wave A shape are byte-stable.
@@ -15,6 +22,10 @@
  * `plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.
  */
 export interface PlanOutput {
+  /**
+   * Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`"warn"` or `"error"`). Empty when no ceiling was exceeded or no real stats were available.
+   */
+  budget_diagnostics?: Diagnostic[];
   /**
    * Column-tag applications the governance reconciler would issue via `apply_column_tags`. One row per `(model, column, tag)` triple declared in a model sidecar's `[classification]` block.
    */
@@ -33,6 +44,10 @@ export interface PlanOutput {
    */
   execution_layers?: string[][];
   filter: string;
+  /**
+   * `true` when at least one entry in `budget_diagnostics` has error-level severity (`on_breach = "error"`). Callers can use this flag to fail a pipeline-as-code check without inspecting individual diagnostic severities.
+   */
+  has_budget_errors?: boolean;
   /**
    * Masking-policy applications the governance reconciler would issue via `apply_masking_policy`. One row per `(model, column, tag)` where the tag resolves to a strategy for the active env. Unresolved tags are intentionally omitted — `rocky compliance` is the diagnostic surface for that gap.
    */
@@ -55,6 +70,47 @@ export interface PlanOutput {
   retention_actions?: RetentionAction[];
   statements: PlannedStatement[];
   version: string;
+  [k: string]: unknown;
+}
+/**
+ * A compiler diagnostic (error, warning, or informational message).
+ *
+ * `code` and `message` use `Arc<str>` (§P3.5) — cloning a `Diagnostic` in the LSP publish loop becomes a refcount bump. Construction still accepts any `Into<String>` / `&str` via the helper constructors below; the arc wrap happens once at construction time.
+ */
+export interface Diagnostic {
+  /**
+   * Diagnostic code (e.g., "E001", "W001").
+   */
+  code: string;
+  /**
+   * Human-readable message.
+   */
+  message: string;
+  /**
+   * Which model this diagnostic relates to.
+   */
+  model: string;
+  /**
+   * Severity level.
+   */
+  severity: Severity;
+  /**
+   * Source location (if available).
+   */
+  span?: SourceSpan | null;
+  /**
+   * Suggested fix (if any).
+   */
+  suggestion?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * Location in a source file.
+ */
+export interface SourceSpan {
+  col: number;
+  file: string;
+  line: number;
   [k: string]: unknown;
 }
 /**

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3794,6 +3794,7 @@ dependencies = [
  "rocky-airbyte",
  "rocky-bigquery",
  "rocky-cache",
+ "rocky-catalog-core",
  "rocky-compiler",
  "rocky-core",
  "rocky-databricks",

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -24,6 +24,7 @@ rocky-bigquery = { path = "../rocky-bigquery" }
 rocky-trino = { path = "../rocky-trino" }
 rocky-fivetran = { path = "../rocky-fivetran", features = ["valkey"] }
 rocky-airbyte = { path = "../rocky-airbyte" }
+rocky-catalog-core = { path = "../rocky-catalog-core" }
 rocky-iceberg = { path = "../rocky-iceberg" }
 rocky-cache = { path = "../rocky-cache", features = ["valkey"] }
 clap = { workspace = true }

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -252,6 +252,11 @@ pub async fn plan(
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("models");
+    tracing::debug!(
+        models_dir = %models_dir.display(),
+        models_dir_exists = models_dir.exists(),
+        "plan: models_dir check"
+    );
     if models_dir.exists() {
         let adapter_type = rocky_cfg
             .adapters
@@ -260,6 +265,49 @@ pub async fn plan(
             .unwrap_or("");
         populate_governance_actions(&rocky_cfg, &models_dir, env, adapter_type, &mut output)
             .context("failed to compute governance action preview")?;
+    }
+
+    // --- D-3 stage 2: per-model budget ceiling check (real catalog stats) --
+    //
+    // When models exist and the target adapter is Databricks or Iceberg, fetch
+    // per-table byte statistics from the warehouse, propagate costs through the
+    // DAG, and emit E027 diagnostics for any model whose projected cost exceeds
+    // its declared `[budget]` ceiling.
+    //
+    // This replaces the stub stats used at compile time with real catalog data.
+    // Compile stays offline; plan is the natural budget-enforcement surface.
+    //
+    // A/B/C decision: **B (rocky plan)** — plan already performs live
+    // warehouse I/O (discovery, governance) and is the pre-run validation
+    // surface.  Compile stays CI/pre-commit/LSP-safe (offline); run is too
+    // late (partial execution possible).  If catalog stats are unavailable
+    // (adapter not Databricks/Iceberg, table not found, network error) the
+    // check degrades gracefully — no diagnostic is emitted rather than
+    // blocking on missing data.
+    //
+    // Leaf-table decision: the model's own TARGET table is used as the stat
+    // source (option A in advisor review).  This proxies "current run ≈
+    // current table size," maps 1:1 to `DESCRIBE DETAIL`, and avoids the
+    // N-source aggregation problem for joins. Databricks-Unity returns only
+    // `sizeInBytes` (no row count without ANALYZE); the stat is stored as
+    // row_count=1 / avg_row_bytes=sizeInBytes so `estimated_bytes` equals
+    // the real table size.  `max_bytes_scanned` is therefore the correct
+    // ceiling lever for Databricks; `max_usd` estimates are unreliable
+    // without per-row cost data.  The live-verify target
+    // (`dev_hcv2_uniform.spike.uniform_t1`) tests the `max_bytes_scanned`
+    // path end-to-end.
+    //
+    // on_breach policy: per-model `on_breach` is honoured — "warn" → Warning
+    // diagnostic (does not set has_budget_errors), "error" → Error diagnostic
+    // (sets has_budget_errors).  Default is "warn" per `BudgetBreachAction`.
+    if models_dir.exists() {
+        let budget_diagnostics =
+            check_plan_budget(&models_dir, &pipeline.target.adapter, &adapter_registry).await;
+        let has_errors = budget_diagnostics
+            .iter()
+            .any(|d| d.severity == rocky_compiler::diagnostic::Severity::Error);
+        output.budget_diagnostics = budget_diagnostics;
+        output.has_budget_errors = has_errors;
     }
 
     // --- Plan-spine persistence (Cluster 3 B, Phase 2 + Phase 5b) ---------
@@ -350,6 +398,7 @@ pub async fn plan(
             println!();
         }
         render_governance_preview_text(&output);
+        render_budget_diagnostics_text(&output);
         if let Some(ref plan_id) = output.plan_id {
             println!();
             match output.plan_kind.as_deref() {
@@ -614,6 +663,212 @@ fn populate_governance_actions(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// D-3 stage 2 — real-catalog budget check
+// ---------------------------------------------------------------------------
+
+/// Collect per-leaf-model byte statistics from the warehouse catalog and
+/// check each model's `[budget]` ceiling against the propagated estimates.
+///
+/// Returns a (possibly empty) list of E027 diagnostics.  Severity follows
+/// the per-model `on_breach` policy (`warn` or `error`).
+///
+/// # Leaf-table convention
+///
+/// Each model's **target** table is used as the stat source.  This is a
+/// proxy for "next run ≈ current table size" and is consistent with the
+/// single-table lookup shape of `DESCRIBE DETAIL` and
+/// `CatalogClient::table_stats`.  Multi-source join aggregation is deferred
+/// to a future wave.
+///
+/// # Graceful degradation
+///
+/// - Adapter not Databricks/Iceberg → returns empty vec (no stats available)
+/// - Table not found / network error → model is skipped (no diagnostic)
+/// - `max_usd` ceiling on Databricks-Unity → stored as row_count=1 /
+///   avg_row_bytes=sizeInBytes so estimated_bytes is correct, but per-row
+///   cost is unreliable without ANALYZE data; `max_bytes_scanned` is the
+///   correct ceiling lever for Databricks
+async fn check_plan_budget(
+    models_dir: &Path,
+    target_adapter_name: &str,
+    adapter_registry: &crate::registry::AdapterRegistry,
+) -> Vec<rocky_compiler::diagnostic::Diagnostic> {
+    use rocky_catalog_core::CatalogClient as _;
+    use rocky_compiler::cost_check;
+    use rocky_core::cost::{TableStats as CostTableStats, WarehouseType, propagate_costs};
+    use std::collections::HashMap;
+
+    tracing::debug!(
+        models_dir = %models_dir.display(),
+        target_adapter_name,
+        "plan budget check: invoked"
+    );
+
+    // Compile models offline — no catalog I/O here.
+    let compile_cfg = rocky_compiler::compile::CompilerConfig {
+        models_dir: models_dir.to_path_buf(),
+        contracts_dir: None,
+        source_schemas: HashMap::new(),
+        source_column_info: HashMap::new(),
+        mask: std::collections::BTreeMap::new(),
+        allow_unmasked: vec![],
+    };
+    let result = match rocky_compiler::compile::compile(&compile_cfg) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "plan budget check: compile failed; skipping budget check"
+            );
+            return vec![];
+        }
+    };
+    if result.project.models.is_empty() {
+        return vec![];
+    }
+
+    // Determine the warehouse type for cost-model pricing constants.
+    let warehouse_type = adapter_registry
+        .adapter_config(target_adapter_name)
+        .and_then(|cfg| WarehouseType::from_adapter_type(&cfg.adapter_type))
+        .unwrap_or(WarehouseType::Databricks);
+
+    // Build base_stats by fetching real catalog data for each model's
+    // target table.  Models for which we get no stats are skipped
+    // (propagate_costs handles missing entries gracefully).
+    let mut base_stats: HashMap<String, CostTableStats> = HashMap::new();
+
+    // Databricks path: call `DESCRIBE DETAIL` via the connector.
+    let db_connector_result = adapter_registry.databricks_connector(target_adapter_name);
+    tracing::debug!(
+        target_adapter_name,
+        ok = db_connector_result.is_ok(),
+        "plan budget check: databricks_connector lookup"
+    );
+    if let Ok(db_connector) = db_connector_result {
+        for model in &result.project.models {
+            let target = &model.config.target;
+            match db_connector
+                .describe_detail_stats(&target.catalog, &target.schema, &target.table)
+                .await
+            {
+                Ok(Some(detail)) => {
+                    tracing::debug!(
+                        model = model.config.name,
+                        size_bytes = ?detail.size_bytes,
+                        "plan budget check: describe_detail_stats returned"
+                    );
+                    if let Some(size_bytes) = detail.size_bytes {
+                        // Databricks-Unity returns `sizeInBytes` but no
+                        // row count without ANALYZE.  Use row_count=1 with
+                        // avg_row_bytes=size_bytes so that
+                        // `estimate_table_scan_cost` produces
+                        // `estimated_bytes = 1 * size_bytes = size_bytes`.
+                        // `max_bytes_scanned` ceilings are the correct lever
+                        // for Databricks at plan time; `max_usd` ceilings
+                        // will estimate $0 per-row cost and should not be
+                        // relied on without ANALYZE data.
+                        base_stats.insert(
+                            model.config.name.clone(),
+                            CostTableStats {
+                                row_count: 1,
+                                avg_row_bytes: size_bytes,
+                            },
+                        );
+                    }
+                }
+                Ok(None) => {
+                    // Table not found — new model, no pre-existing table. Skip.
+                    tracing::debug!(
+                        model = model.config.name,
+                        "plan budget check: target table not found; skipping model"
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        model = model.config.name,
+                        error = %e,
+                        "plan budget check: describe_detail_stats failed; skipping model"
+                    );
+                }
+            }
+        }
+    }
+
+    // Iceberg path: call `table_stats` via the catalog-client adapter.
+    if let Some(iceberg_client) = adapter_registry.iceberg_client(target_adapter_name) {
+        for model in &result.project.models {
+            if base_stats.contains_key(&model.config.name) {
+                // Already populated by Databricks path (shouldn't happen in
+                // practice, but be explicit).
+                continue;
+            }
+            let target = &model.config.target;
+            let table_ref = rocky_catalog_core::TableRef {
+                catalog: if target.catalog.is_empty() {
+                    None
+                } else {
+                    Some(target.catalog.clone())
+                },
+                namespace: vec![target.schema.clone()],
+                name: target.table.clone(),
+            };
+            match iceberg_client.table_stats(&table_ref).await {
+                Ok(stats) => {
+                    // Convert from catalog TableStats to cost::TableStats.
+                    // Both row_count and total_bytes must be present to derive
+                    // avg_row_bytes; when either is missing we skip this model.
+                    if let (Some(row_count), Some(total_bytes)) =
+                        (stats.row_count, stats.total_bytes)
+                    {
+                        let avg_row_bytes = total_bytes.checked_div(row_count).unwrap_or(0);
+                        base_stats.insert(
+                            model.config.name.clone(),
+                            CostTableStats {
+                                row_count,
+                                avg_row_bytes,
+                            },
+                        );
+                    }
+                }
+                Err(rocky_catalog_core::CatalogError::UnsupportedOperation(_)) => {
+                    // Iceberg catalog signals no stats endpoint.  Degrade.
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        model = model.config.name,
+                        error = %e,
+                        "plan budget check: iceberg table_stats failed; skipping model"
+                    );
+                }
+            }
+        }
+    }
+
+    // If we got no real stats for any model, skip the ceiling check —
+    // the stub estimates from compile already ran.
+    if base_stats.is_empty() {
+        return vec![];
+    }
+
+    // Propagate cost estimates through the DAG using real stats.
+    let dag_nodes = &result.project.dag_nodes;
+    let estimates = match propagate_costs(dag_nodes, &base_stats, warehouse_type) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "plan budget check: propagate_costs failed; skipping budget check"
+            );
+            return vec![];
+        }
+    };
+
+    // Check ceilings; honor per-model on_breach policy.
+    cost_check::check_cost_ceilings_plan(&result.project.models, &estimates)
+}
+
 /// Render the warehouse-native SQL Rocky would emit for a retention
 /// policy, or `None` on adapters without a first-class retention knob
 /// (BigQuery, DuckDB).
@@ -693,6 +948,28 @@ fn render_governance_preview_text(output: &PlanOutput) {
             model = a.model,
             days = a.duration_days,
         );
+    }
+}
+
+/// Render budget diagnostics under the text output mode.
+///
+/// Prints E027 diagnostics (one per breached ceiling) with their severity
+/// prefix so CLI users see the same information as JSON consumers.
+fn render_budget_diagnostics_text(output: &PlanOutput) {
+    if output.budget_diagnostics.is_empty() {
+        return;
+    }
+    println!("-- budget check --");
+    for d in &output.budget_diagnostics {
+        let prefix = if d.severity == rocky_compiler::diagnostic::Severity::Error {
+            "error"
+        } else {
+            "warning"
+        };
+        println!("[{prefix}][E027] {}: {}", d.model, d.message);
+        if let Some(ref suggestion) = d.suggestion {
+            println!("  hint: {suggestion}");
+        }
     }
 }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -868,6 +868,32 @@ pub struct PlanOutput {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub retention_actions: Vec<RetentionAction>,
 
+    // ---- D-3 stage 2: pre-execution budget diagnostics ------------------
+    //
+    // E027 diagnostics emitted when `rocky plan` resolves real catalog
+    // stats (via `DESCRIBE DETAIL` / Iceberg snapshot summary) and finds
+    // a model whose projected cost exceeds its declared `[budget]`
+    // ceiling. Empty when no models have a `[budget]` block, when no
+    // real stats are available (non-Databricks / non-Iceberg adapters),
+    // or when the project has no `models/` directory.
+    //
+    // A non-empty list does NOT by itself fail `rocky plan` — severity
+    // follows the per-model `on_breach` policy (`warn` or `error`).
+    // Callers that want strict pre-flight enforcement should check
+    // `has_budget_errors` instead.
+    /// Per-model E027 budget-exceeded diagnostics produced at plan time
+    /// using real catalog statistics. Severity reflects the model's
+    /// `on_breach` policy (`"warn"` or `"error"`). Empty when no
+    /// ceiling was exceeded or no real stats were available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub budget_diagnostics: Vec<Diagnostic>,
+    /// `true` when at least one entry in `budget_diagnostics` has
+    /// error-level severity (`on_breach = "error"`). Callers can use
+    /// this flag to fail a pipeline-as-code check without inspecting
+    /// individual diagnostic severities.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub has_budget_errors: bool,
+
     // ---- Phase 2 plan-spine fields (Cluster 3 B) ------------------------
     //
     // Populated when `rocky plan` compiles a `models/` directory and
@@ -3546,6 +3572,8 @@ impl PlanOutput {
             classification_actions: vec![],
             mask_actions: vec![],
             retention_actions: vec![],
+            budget_diagnostics: vec![],
+            has_budget_errors: false,
             plan_id: None,
             plan_kind: None,
             created_at: None,

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -34,6 +34,7 @@ use rocky_airbyte::client::AirbyteClient;
 use rocky_fivetran::adapter::FivetranDiscoveryAdapter;
 use rocky_fivetran::client::FivetranClient;
 
+use rocky_iceberg::IcebergCatalogClientAdapter;
 use rocky_iceberg::adapter::IcebergDiscoveryAdapter;
 use rocky_iceberg::client::IcebergCatalogClient;
 
@@ -80,6 +81,12 @@ pub struct AdapterRegistry {
     /// `INFORMATION_SCHEMA.COLUMNS` describe query through the same
     /// authenticated HTTP client that the generic warehouse adapter uses.
     bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>>,
+    /// Iceberg catalog-client adapters keyed by adapter name.  Stored here
+    /// so the plan-time catalog-stats lookup can call
+    /// `CatalogClient::table_stats` without going through the
+    /// `IcebergDiscoveryAdapter` wrapper (which owns the underlying
+    /// `IcebergCatalogClient` and does not expose it).
+    iceberg_clients: HashMap<String, Arc<IcebergCatalogClientAdapter>>,
     adapter_configs: HashMap<String, AdapterConfig>,
 }
 
@@ -108,6 +115,7 @@ impl AdapterRegistry {
         let mut connectors = HashMap::new();
         let mut snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>> = HashMap::new();
         let mut bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>> = HashMap::new();
+        let mut iceberg_clients: HashMap<String, Arc<IcebergCatalogClientAdapter>> = HashMap::new();
         let mut adapter_configs = HashMap::new();
 
         // Cross-adapter run-level retry budget (follow-up to §P2.7). When
@@ -322,13 +330,26 @@ impl AdapterRegistry {
                     ))?;
                     let auth_token = adapter_cfg.token.as_ref().map(|s| s.expose().to_string());
 
-                    let client = IcebergCatalogClient::with_retry(
+                    let client_for_discovery = IcebergCatalogClient::with_retry(
                         catalog_url,
-                        auth_token,
+                        auth_token.clone(),
                         adapter_cfg.retry.clone(),
                     );
+                    // Construct a second, independent client with the same
+                    // config for the plan-time `CatalogClient::table_stats`
+                    // path. `IcebergDiscoveryAdapter::new` takes ownership,
+                    // so we can't share the struct without Clone; two thin
+                    // HTTP clients with the same config is the zero-friction
+                    // alternative.
+                    let stats_client =
+                        IcebergCatalogClientAdapter::new(IcebergCatalogClient::with_retry(
+                            catalog_url,
+                            auth_token,
+                            adapter_cfg.retry.clone(),
+                        ));
+                    iceberg_clients.insert(name.clone(), Arc::new(stats_client));
 
-                    let adapter = Arc::new(IcebergDiscoveryAdapter::new(client));
+                    let adapter = Arc::new(IcebergDiscoveryAdapter::new(client_for_discovery));
                     discovery.insert(name.clone(), adapter as Arc<dyn DiscoveryAdapter>);
                 }
                 "manual" => {
@@ -483,6 +504,7 @@ impl AdapterRegistry {
             connectors,
             snowflake_connectors,
             bigquery_adapters,
+            iceberg_clients,
             adapter_configs,
         })
     }
@@ -509,6 +531,18 @@ impl AdapterRegistry {
             .get(name)
             .cloned()
             .context(format!("no databricks connector named '{name}'"))
+    }
+
+    /// Return the Iceberg catalog-client adapter for the named adapter, if
+    /// one was registered.  Returns `None` for adapters that are not of
+    /// type `"iceberg"`.  The returned adapter implements
+    /// `CatalogClient::table_stats` via the Iceberg snapshot-summary path.
+    ///
+    /// Used by the plan-time catalog-stats lookup (D-3 stage 2) to call
+    /// `table_stats` without going through the `IcebergDiscoveryAdapter`
+    /// wrapper that takes ownership of the inner client.
+    pub fn iceberg_client(&self, name: &str) -> Option<Arc<IcebergCatalogClientAdapter>> {
+        self.iceberg_clients.get(name).cloned()
     }
 
     /// Get the adapter config by name.

--- a/engine/crates/rocky-compiler/src/cost_check.rs
+++ b/engine/crates/rocky-compiler/src/cost_check.rs
@@ -15,6 +15,8 @@
 
 use std::collections::HashMap;
 
+use rocky_core::config::BudgetBreachAction;
+
 use crate::diagnostic::Diagnostic;
 
 /// Check every model's declared cost ceiling against its propagated estimate.
@@ -70,6 +72,79 @@ pub fn check_cost_ceilings(
                     projected,
                     ceiling_bytes,
                 ));
+            }
+        }
+    }
+
+    diagnostics
+}
+
+/// Plan-time budget ceiling check that honours each model's `on_breach` policy.
+///
+/// Identical to [`check_cost_ceilings`] in breach detection, but emits
+/// **warning**-severity diagnostics when the model's `on_breach` field is
+/// `"warn"` (the default) and **error**-severity diagnostics when it is
+/// `"error"`.  This respects the user's declared intent: at plan time a
+/// `warn` model merely surfaces an advisory; an `error` model will set
+/// `PlanOutput::has_budget_errors = true`, signalling to CI/orchestration
+/// that this plan should not proceed.
+///
+/// At compile time (offline, no real stats) [`check_cost_ceilings`] is used
+/// unchanged — stub estimates deliberately err on the side of always-error so
+/// tests remain deterministic.  Plan time uses this variant because the
+/// estimates come from real catalog data and the user's policy should govern
+/// whether that constitutes a blocking signal.
+#[must_use]
+pub fn check_cost_ceilings_plan(
+    models: &[rocky_core::models::Model],
+    estimates: &HashMap<String, rocky_core::cost::CostEstimate>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for model in models {
+        let budget = match model.config.budget.as_ref() {
+            Some(b) => b,
+            None => continue,
+        };
+        let estimate = match estimates.get(&model.config.name) {
+            Some(e) => e,
+            None => continue,
+        };
+
+        // Resolve breach action: per-model `on_breach` when set, otherwise default (Warn).
+        let breach_action = budget.on_breach.unwrap_or(BudgetBreachAction::Warn);
+
+        if let Some(ceiling_usd) = budget.max_usd {
+            let projected = estimate.estimated_compute_cost_usd;
+            if projected > ceiling_usd {
+                let d = match breach_action {
+                    BudgetBreachAction::Error => {
+                        Diagnostic::budget_exceeded(&model.config.name, projected, ceiling_usd)
+                    }
+                    BudgetBreachAction::Warn => {
+                        Diagnostic::budget_exceeded_warn(&model.config.name, projected, ceiling_usd)
+                    }
+                };
+                diagnostics.push(d);
+            }
+        }
+
+        if let Some(ceiling_bytes) = budget.max_bytes_scanned {
+            let projected = estimate.estimated_bytes;
+            if projected > ceiling_bytes {
+                let d = match breach_action {
+                    BudgetBreachAction::Error => Diagnostic::budget_exceeded_bytes(
+                        &model.config.name,
+                        projected,
+                        ceiling_bytes,
+                    ),
+                    BudgetBreachAction::Warn => Diagnostic::budget_exceeded_bytes_warn(
+                        &model.config.name,
+                        projected,
+                        ceiling_bytes,
+                    ),
+                };
+                diagnostics.push(d);
             }
         }
     }

--- a/engine/crates/rocky-compiler/src/diagnostic.rs
+++ b/engine/crates/rocky-compiler/src/diagnostic.rs
@@ -217,6 +217,48 @@ impl Diagnostic {
         ))
     }
 
+    /// Build a **warning**-severity E027 USD budget diagnostic.
+    ///
+    /// Used at plan time when the model's `on_breach = "warn"` policy means a
+    /// ceiling breach should be surfaced as advisory rather than blocking.
+    /// The message is identical to [`Self::budget_exceeded`]; only severity
+    /// differs.
+    #[must_use]
+    pub fn budget_exceeded_warn(model: &str, projected_usd: f64, ceiling_usd: f64) -> Self {
+        Self::warning(
+            E027,
+            model,
+            format!("budget exceeded — projected ${projected_usd:.4} > ceiling ${ceiling_usd:.4}",),
+        )
+        .with_suggestion(format!(
+            "raise [budget] max_usd above ${ceiling_usd:.4} in the model sidecar, \
+             or optimize the query to reduce scan volume"
+        ))
+    }
+
+    /// Build a **warning**-severity E027 bytes-scanned budget diagnostic.
+    ///
+    /// Used at plan time when the model's `on_breach = "warn"` policy means a
+    /// ceiling breach should be surfaced as advisory rather than blocking.
+    #[must_use]
+    pub fn budget_exceeded_bytes_warn(
+        model: &str,
+        projected_bytes: u64,
+        ceiling_bytes: u64,
+    ) -> Self {
+        Self::warning(
+            E027,
+            model,
+            format!(
+                "budget exceeded — projected {projected_bytes} bytes > ceiling {ceiling_bytes} bytes scanned",
+            ),
+        )
+        .with_suggestion(format!(
+            "raise [budget] max_bytes_scanned above {ceiling_bytes} in the model sidecar, \
+             or optimize the query to reduce scan volume"
+        ))
+    }
+
     /// Is this an error?
     pub fn is_error(&self) -> bool {
         self.severity == Severity::Error

--- a/integrations/dagster/src/dagster_rocky/types_generated/plan_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/plan_schema.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from pydantic import AwareDatetime, BaseModel, conint
 
 
@@ -73,6 +75,61 @@ class RetentionAction(BaseModel):
     """
 
 
+class Severity(StrEnum):
+    """
+    Severity level of a diagnostic.
+
+    Serialized in PascalCase (`"Error"`, `"Warning"`, `"Info"`) to stay compatible with existing dagster fixtures and the hand-written `Severity` StrEnum in `integrations/dagster/src/dagster_rocky/types.py`.
+    """
+
+    Error = "Error"
+    Warning = "Warning"
+    Info = "Info"
+
+
+class SourceSpan(BaseModel):
+    """
+    Location in a source file.
+    """
+
+    col: conint(ge=0)
+    file: str
+    line: conint(ge=0)
+
+
+class Diagnostic(BaseModel):
+    """
+    A compiler diagnostic (error, warning, or informational message).
+
+    `code` and `message` use `Arc<str>` (§P3.5) — cloning a `Diagnostic` in the LSP publish loop becomes a refcount bump. Construction still accepts any `Into<String>` / `&str` via the helper constructors below; the arc wrap happens once at construction time.
+    """
+
+    code: str
+    """
+    Diagnostic code (e.g., "E001", "W001").
+    """
+    message: str
+    """
+    Human-readable message.
+    """
+    model: str
+    """
+    Which model this diagnostic relates to.
+    """
+    severity: Severity
+    """
+    Severity level.
+    """
+    span: SourceSpan | None = None
+    """
+    Source location (if available).
+    """
+    suggestion: str | None = None
+    """
+    Suggested fix (if any).
+    """
+
+
 class PlanOutput(BaseModel):
     """
     JSON output for `rocky plan`.
@@ -84,6 +141,10 @@ class PlanOutput(BaseModel):
     `plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.
     """
 
+    budget_diagnostics: list[Diagnostic] | None = None
+    """
+    Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`"warn"` or `"error"`). Empty when no ceiling was exceeded or no real stats were available.
+    """
     classification_actions: list[ClassificationAction] | None = None
     """
     Column-tag applications the governance reconciler would issue via `apply_column_tags`. One row per `(model, column, tag)` triple declared in a model sidecar's `[classification]` block.
@@ -102,6 +163,10 @@ class PlanOutput(BaseModel):
     Execution layers (topological order) as a list-of-lists of model names. Models within a layer can execute concurrently. Informational — re-derived at apply time. Empty for replication-only plans.
     """
     filter: str
+    has_budget_errors: bool | None = None
+    """
+    `true` when at least one entry in `budget_diagnostics` has error-level severity (`on_breach = "error"`). Callers can use this flag to fail a pipeline-as-code check without inspecting individual diagnostic severities.
+    """
     mask_actions: list[MaskAction] | None = None
     """
     Masking-policy applications the governance reconciler would issue via `apply_masking_policy`. One row per `(model, column, tag)` where the tag resolves to a strategy for the active env. Unresolved tags are intentionally omitted — `rocky compliance` is the diagnostic surface for that gap.

--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -24,6 +24,56 @@
       ],
       "type": "object"
     },
+    "Diagnostic": {
+      "description": "A compiler diagnostic (error, warning, or informational message).\n\n`code` and `message` use `Arc<str>` (§P3.5) — cloning a `Diagnostic` in the LSP publish loop becomes a refcount bump. Construction still accepts any `Into<String>` / `&str` via the helper constructors below; the arc wrap happens once at construction time.",
+      "properties": {
+        "code": {
+          "description": "Diagnostic code (e.g., \"E001\", \"W001\").",
+          "type": "string"
+        },
+        "message": {
+          "description": "Human-readable message.",
+          "type": "string"
+        },
+        "model": {
+          "description": "Which model this diagnostic relates to.",
+          "type": "string"
+        },
+        "severity": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Severity"
+            }
+          ],
+          "description": "Severity level."
+        },
+        "span": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SourceSpan"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Source location (if available)."
+        },
+        "suggestion": {
+          "description": "Suggested fix (if any).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "message",
+        "model",
+        "severity"
+      ],
+      "type": "object"
+    },
     "MaskAction": {
       "description": "Masking-policy application row in `PlanOutput.mask_actions`.",
       "properties": {
@@ -97,10 +147,50 @@
         "model"
       ],
       "type": "object"
+    },
+    "Severity": {
+      "description": "Severity level of a diagnostic.\n\nSerialized in PascalCase (`\"Error\"`, `\"Warning\"`, `\"Info\"`) to stay compatible with existing dagster fixtures and the hand-written `Severity` StrEnum in `integrations/dagster/src/dagster_rocky/types.py`.",
+      "enum": [
+        "Error",
+        "Warning",
+        "Info"
+      ],
+      "type": "string"
+    },
+    "SourceSpan": {
+      "description": "Location in a source file.",
+      "properties": {
+        "col": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "file": {
+          "type": "string"
+        },
+        "line": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "col",
+        "file",
+        "line"
+      ],
+      "type": "object"
     }
   },
   "description": "JSON output for `rocky plan`.\n\n`statements` enumerates the warehouse SQL Rocky would emit. The three `*_actions` collections are a parallel view of the control-plane governance work `rocky run` would do *after* a successful DAG — the classification / masking / retention reconcile pass. These never show up as SQL; they fire through [`rocky_core::traits::GovernanceAdapter`] methods (e.g. `apply_column_tags`, `apply_masking_policy`, `apply_retention_policy`). Projects without any `[classification]`, `[mask]`, or `retention` config get empty lists — the fields `skip_serializing_if = Vec::is_empty`, so JSON consumers written against the pre-Wave A shape are byte-stable.\n\n## Phase 2 additions (Cluster 3 B)\n\n`plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.",
   "properties": {
+    "budget_diagnostics": {
+      "description": "Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`\"warn\"` or `\"error\"`). Empty when no ceiling was exceeded or no real stats were available.",
+      "items": {
+        "$ref": "#/definitions/Diagnostic"
+      },
+      "type": "array"
+    },
     "classification_actions": {
       "description": "Column-tag applications the governance reconciler would issue via `apply_column_tags`. One row per `(model, column, tag)` triple declared in a model sidecar's `[classification]` block.",
       "items": {
@@ -138,6 +228,10 @@
     },
     "filter": {
       "type": "string"
+    },
+    "has_budget_errors": {
+      "description": "`true` when at least one entry in `budget_diagnostics` has error-level severity (`on_breach = \"error\"`). Callers can use this flag to fail a pipeline-as-code check without inspecting individual diagnostic severities.",
+      "type": "boolean"
     },
     "mask_actions": {
       "description": "Masking-policy applications the governance reconciler would issue via `apply_masking_policy`. One row per `(model, column, tag)` where the tag resolves to a strategy for the active env. Unresolved tags are intentionally omitted — `rocky compliance` is the diagnostic surface for that gap.",


### PR DESCRIPTION
## Summary

`rocky plan` now grounds per-model `[budget]` ceiling enforcement in real catalog statistics instead of placeholder stubs. When a model declares a `[budget] max_bytes_scanned` (or `max_usd`), `plan` fetches the target table's actual size, projects cost through the DAG, and emits `E027 budget exceeded` if the projection breaches the ceiling.

## What changed

- **`rocky plan` is the budget-enforcement surface** — chose plan (not compile or run): compile stays offline-pure (CI/pre-commit/LSP-safe); run is too late (partial execution possible); plan already does live warehouse I/O.
- **Per-leaf dispatch** with graceful degradation:
  - Iceberg leaves → `CatalogClient::table_stats` (snapshot summary; no new REST call)
  - Databricks leaves → `DatabricksConnector::describe_detail_stats` (parses `sizeInBytes` from `DESCRIBE DETAIL`; no `ANALYZE TABLE` prereq)
  - Unity REST `UnsupportedOperation`, missing tables, network errors → model skipped, no diagnostic, never blocks
- **Per-model `on_breach` policy honored** via new `check_cost_ceilings_plan`:
  - `"warn"` (default) → Warning-severity E027 (advisory)
  - `"error"` → Error-severity E027 (sets `PlanOutput::has_budget_errors`, signalling CI/orchestration to halt)
- **New diagnostic builders** — `Diagnostic::budget_exceeded_warn` + `budget_exceeded_bytes_warn` mirror the existing Error variants.
- **Registry change** — two independent `IcebergCatalogClient` instances per adapter (discovery + stats); cheap; avoids a Clone refactor on the discovery side.
- **Codegen cascade** — new `PlanOutput.budget_diagnostics` + `has_budget_errors` fields flow to `schemas/plan.schema.json`, dagster `plan_schema.py`, vscode `plan.ts`.

## Notes on stats shape

- **Databricks-Unity** returns `sizeInBytes` but no row count without `ANALYZE TABLE`. Stored as `row_count=1` / `avg_row_bytes=size_bytes` so `estimated_bytes` resolves to the real table size. `max_bytes_scanned` ceilings are the correct lever here; `max_usd` estimates are unreliable without per-row cost data on Databricks until users run ANALYZE.
- **Iceberg** snapshot summary returns both `row_count` and `total_bytes` cleanly when present; converted into the cost-model's `TableStats { row_count, avg_row_bytes }`.
- **Leaf table convention** — each model's own target table is the stat source (1:1 with `DESCRIBE DETAIL` / `table_stats`). Multi-source join aggregation is deferred.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p rocky-cli -p rocky-compiler` (547 + 301 = 848 passed, 0 failed)
- [x] `just codegen` produces only the expected drift (`plan.schema.json` + `plan_schema.py` + `plan.ts`)
- [x] `just regen-fixtures` no drift
- [ ] Live-verify on real Databricks workspace: `[budget] max_bytes_scanned = 1` against a known table → E027 fires with real `sizeInBytes`; generous budget → no diagnostic. (Underlying `describe_detail_stats` already covered by `#[ignore]` live tests in #605.)