### PR TITLE
fix(dagster-rocky): mirror rocky stderr to step process fd

### DIFF
--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import signal
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -388,6 +389,30 @@ def _forward_stderr_to_sink(
                 continue
             sink.append(line)
             log_line(line)
+            # Mirror to the parent process's stderr fd so Dagster's
+            # compute-log capture (which only sees the step process's
+            # actual stdout/stderr streams) preserves rocky's tracing
+            # output. Without this, the only path to the binary's
+            # stderr is the in-process ``sink`` — exposed as
+            # ``dg.Failure.metadata["stderr_tail"]`` on subprocess
+            # failure — and metadata doesn't propagate into the
+            # user-visible Dagster error chain (CI log, GraphQL
+            # locationOrLoadError, computeLogs API), so cold-start
+            # adapter-construction errors, ``rocky plan`` runtime
+            # failures, and Databricks auth errors all reduce to the
+            # opaque ``Rocky command failed (exit N)`` message with no
+            # actionable detail unless the operator can ``kubectl exec``
+            # into the failing pod. The ``log_line`` sink stays the
+            # primary surface (streaming asset → ``context.log`` shows
+            # in run viewer; buffered path → ``_log`` for module-logger
+            # consumers), but ``log_line`` routes through Python logging
+            # which is not guaranteed to land in the step process's own
+            # stderr fd — so we forward unconditionally here. Forwarding
+            # is best-effort: ``OSError`` / ``ValueError`` (e.g. closed
+            # step stderr during interpreter teardown or fd redirection)
+            # are swallowed so we never take down the reader thread.
+            with contextlib.suppress(OSError, ValueError):
+                print(line, file=sys.stderr, flush=True)
     except (OSError, ValueError) as exc:
         # OSError covers broken-pipe / EBADF / closed-file on the subprocess
         # stderr handle. ValueError covers "I/O operation on closed file"

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -193,6 +193,44 @@ def test_run_rocky_failure_metadata_carries_stderr_tail():
     assert "ERROR fatal: connection refused" in tail
 
 
+def test_run_rocky_forwards_stderr_to_step_process_fd(capfd: pytest.CaptureFixture[str]):
+    """Each non-empty stderr line is mirrored to the step process's
+    ``sys.stderr`` fd in addition to the configured ``log_line`` sink.
+
+    The forwarding exists so Dagster Cloud's compute-log capture (which
+    only reads the step process's actual stderr stream) preserves rocky's
+    tracing output. Without this mirror, the buffered code-server path
+    (``GoldRockyComponent.build_defs`` / ``_log_rocky_healthcheck``)
+    routes through the ``dagster_rocky.resource`` module logger, which
+    isn't guaranteed to land in the captured-log stream — leaving every
+    ``dg.Failure: Rocky command failed (exit N)`` opaque from the user-
+    visible Dagster error chain (CI ``dg plus deploy finish``, GraphQL
+    ``locationOrLoadError``, the run viewer's ``capturedLogs``). The
+    in-process ``stderr_tail`` metadata is still attached to the
+    Failure for callers that want a structured tail, but the line-by-
+    line mirror is what the operator actually sees in the UI / pod logs.
+    """
+    rocky = RockyResource()
+    proc = _popen_mock(
+        stdout="not json",
+        stderr_lines=[
+            "INFO discovering sources",
+            "ERROR fatal: connection refused",
+        ],
+        returncode=2,
+    )
+    with (
+        patch.object(RockyResource, "_verify_engine_version"),
+        patch("dagster_rocky.resource.subprocess.Popen", return_value=proc),
+        pytest.raises(dg.Failure),
+    ):
+        rocky._run_rocky(["discover"])
+
+    captured_stderr = capfd.readouterr().err
+    assert "INFO discovering sources" in captured_stderr
+    assert "ERROR fatal: connection refused" in captured_stderr
+
+
 def test_run_rocky_streams_stderr_to_module_logger(caplog: pytest.LogCaptureFixture):
     """Each non-empty stderr line reaches the ``dagster_rocky.resource`` logger.
 


### PR DESCRIPTION
## Summary

- `_forward_stderr_to_sink` already captures every rocky stderr line into an in-process sink (exposed as `dg.Failure.metadata[\"stderr_tail\"]`) and routes it through the caller-supplied `log_line` sink. **Neither surface is reliably visible to operators** when a rocky subprocess fails in a Dagster deployment:
  - `dg.Failure.metadata` doesn't propagate into the `PythonError.message` returned by GraphQL `locationOrLoadError`, by `dg plus deploy finish`, or by Dagster Cloud's `capturedLogs` API. The opaque `Rocky command failed (exit N)` description is the entire user-visible chain.
  - The buffered-path module logger (`dagster_rocky.resource._log`) isn't guaranteed to propagate to the step process's actual stderr fd in arbitrary deployment configurations — and in practice doesn't for dagster code-server pods, whose log capture sees only the step process's own fd-level output.
- Two-line fix in `_forward_stderr_to_sink`: in addition to the existing `sink.append` + `log_line(line)`, write each non-empty stderr line to `sys.stderr` via `print(line, file=sys.stderr, flush=True)`. That fd is exactly what Dagster's compute-log manager captures into S3 and exposes via the `capturedLogs` GraphQL field — so cold-start adapter-construction errors, `rocky plan` runtime failures, `rocky doctor` config diagnostics, etc. become visible from the run viewer, CI logs, and pod logs without `kubectl exec`.
- Forwarding is best-effort: `OSError` / `ValueError` from a closed step stderr (interpreter teardown, redirected fd) are swallowed so the reader thread never takes down the parent.

## Why this matters

Real failure pattern: a downstream Dagster Cloud deployment cold-started its code server, every `rocky` invocation exited 1 with the actionable error inside `stderr_tail`, and the operator-facing surfaces showed only `Rocky command failed (exit 1)`. Diagnosis required `kubectl exec` into the failing pod and running the binary by hand — `dg.Failure.metadata` was structurally invisible. The same burial repeats for run-pod failures: `capturedLogs` for a failed step contains the Dagster framework's own traceback but zero rocky output (verified against a 1m55s run with a non-trivial Databricks call). With this change, every subsequent operator sees rocky's actual stderr in the place they're already looking.

## Test plan

- [x] New test `test_run_rocky_forwards_stderr_to_step_process_fd` (uses `capfd`) asserts the buffered failure path mirrors each line to `sys.stderr`.
- [x] Existing tests preserved: `test_run_rocky_streams_stderr_to_module_logger`, `test_run_rocky_failure_metadata_carries_stderr_tail`, `test_run_rocky_skips_empty_stderr_lines`, `test_run_streaming_forwards_stderr_to_context_log` all still pass.
- [x] Full `integrations/dagster/` suite: **549/549 passed**.