### PR TITLE
fix(vscode): LSP lifecycle + non-project guard + CLI maxBuffer + server.path

### DIFF
--- a/editors/vscode/src/__tests__/costCodeLens.test.ts
+++ b/editors/vscode/src/__tests__/costCodeLens.test.ts
@@ -72,6 +72,15 @@ vi.mock("../output", () => ({
   getOutputChannel: () => ({ appendLine: vi.fn() }),
 }));
 
+// `views/getStartedView` exposes the hasRockyProject() / onDidChangeRockyProject
+// signal used to gate CLI invocations. Tests assume a Rocky project is
+// present so the provider actually fetches data; the onDidChange event is a
+// no-op subscription.
+vi.mock("../views/getStartedView", () => ({
+  hasRockyProject: (): boolean => true,
+  onDidChangeRockyProject: () => ({ dispose: (): void => undefined }),
+}));
+
 // ---------------------------------------------------------------------------
 // Imports — must follow vi.mock calls (hoisting works, but named bindings need
 // to come AFTER the mock declarations so the mock factory runs first)

--- a/editors/vscode/src/__tests__/driftDiagnostics.test.ts
+++ b/editors/vscode/src/__tests__/driftDiagnostics.test.ts
@@ -136,6 +136,15 @@ vi.mock("../output", () => ({
   }),
 }));
 
+// `views/getStartedView` exposes the hasRockyProject() / onDidChangeRockyProject
+// signal that gates CLI invocations. Tests assume a project is detected so
+// the open/save handlers actually shell out; onDidChangeRockyProject is a
+// no-op subscription here (the registration count assertion accounts for it).
+vi.mock("../views/getStartedView", () => ({
+  hasRockyProject: (): boolean => true,
+  onDidChangeRockyProject: () => ({ dispose: (): void => undefined }),
+}));
+
 import * as vscode from "vscode";
 import { runRockyJson } from "../rockyCli";
 import { registerDriftDiagnostics } from "../driftDiagnostics";
@@ -171,12 +180,13 @@ describe("registerDriftDiagnostics", () => {
     expect(vscode.workspace.onDidCloseTextDocument).toHaveBeenCalled();
   });
 
-  it("pushes collection + code action provider + acceptDrift command + 3 listeners + config listener into subscriptions", () => {
+  it("pushes collection + code action provider + acceptDrift command + 3 listeners + config + project listener into subscriptions", () => {
     const ctx = makeContext();
     registerDriftDiagnostics(ctx);
     // collection + codeActionsProvider + acceptDrift cmd +
-    // onDidOpen + onDidSave + onDidClose + onDidChangeConfiguration = 7
-    expect(ctx.subscriptions.length).toBe(7);
+    // onDidOpen + onDidSave + onDidClose + onDidChangeConfiguration +
+    // onDidChangeRockyProject = 8
+    expect(ctx.subscriptions.length).toBe(8);
   });
 
   it("registers a code actions provider for rocky diagnostics", () => {

--- a/editors/vscode/src/__tests__/rockyCli.test.ts
+++ b/editors/vscode/src/__tests__/rockyCli.test.ts
@@ -26,6 +26,7 @@ vi.mock("vscode", () => ({
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
+  spawn: vi.fn(),
 }));
 
 // Imports must follow vi.mock so the mocked modules are bound.
@@ -45,6 +46,7 @@ type ExecCallback = (
 ) => void;
 
 const execFileMock = cp.execFile as unknown as ReturnType<typeof vi.fn>;
+const spawnMock = cp.spawn as unknown as ReturnType<typeof vi.fn>;
 
 function fakeChild(): { kill: ReturnType<typeof vi.fn> } {
   return { kill: vi.fn() };
@@ -265,5 +267,179 @@ describe("getCliVersion", () => {
     mockSuccess("rocky 1.27.0");
     expect(await getCliVersion()).toBe("1.27.0");
     expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unbounded-output spawn path — used for catalog/history/optimize/discover so
+// large warehouse output doesn't hit execFile's 16 MiB maxBuffer cap.
+// ---------------------------------------------------------------------------
+
+interface FakeChildHandlers {
+  stdout: { on: ReturnType<typeof vi.fn> };
+  stderr: { on: ReturnType<typeof vi.fn> };
+  on: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+interface FakeSpawnDriver {
+  emitStdout: (chunk: string) => void;
+  emitStderr: (chunk: string) => void;
+  emitClose: (code: number | null, signal?: string | null) => void;
+  emitError: (err: Error) => void;
+  child: FakeChildHandlers;
+}
+
+function mockSpawnOnce(): FakeSpawnDriver {
+  const stdoutListeners: ((chunk: Buffer) => void)[] = [];
+  const stderrListeners: ((chunk: Buffer) => void)[] = [];
+  const closeListeners: ((code: number | null, signal?: string | null) => void)[] = [];
+  const errorListeners: ((err: Error) => void)[] = [];
+
+  const child: FakeChildHandlers = {
+    stdout: {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === "data") stdoutListeners.push(cb);
+      }),
+    },
+    stderr: {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === "data") stderrListeners.push(cb);
+      }),
+    },
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === "close") {
+        closeListeners.push(
+          cb as (code: number | null, signal?: string | null) => void,
+        );
+      } else if (event === "error") {
+        errorListeners.push(cb as (err: Error) => void);
+      }
+    }),
+    kill: vi.fn(),
+  };
+
+  spawnMock.mockImplementationOnce(() => child);
+
+  return {
+    emitStdout: (chunk: string): void => {
+      for (const l of stdoutListeners) l(Buffer.from(chunk, "utf8"));
+    },
+    emitStderr: (chunk: string): void => {
+      for (const l of stderrListeners) l(Buffer.from(chunk, "utf8"));
+    },
+    emitClose: (code: number | null, signal: string | null = null): void => {
+      for (const l of closeListeners) l(code, signal);
+    },
+    emitError: (err: Error): void => {
+      for (const l of errorListeners) l(err);
+    },
+    child,
+  };
+}
+
+describe("runRocky (unbounded subcommands → spawn)", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    spawnMock.mockReset();
+  });
+
+  it("routes `catalog` through spawn, not execFile", async () => {
+    const driver = mockSpawnOnce();
+    const promise = runRocky(["catalog", "--output", "json"]);
+    driver.emitStdout('{"rows":42}');
+    driver.emitClose(0);
+    const result = await promise;
+    expect(result.stdout).toBe('{"rows":42}');
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock.mock.calls[0][0]).toBe("/usr/local/bin/rocky");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["catalog", "--output", "json"]);
+  });
+
+  it.each(["catalog", "history", "optimize", "discover"])(
+    "routes `%s` through spawn",
+    async (subcommand) => {
+      const driver = mockSpawnOnce();
+      const promise = runRocky([subcommand]);
+      driver.emitStdout('{"ok":true}');
+      driver.emitClose(0);
+      await promise;
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps bounded subcommands (compile, run, doctor) on execFile", async () => {
+    mockSuccess('{"ok":true}');
+    await runRocky(["compile"]);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores top-level flags when classifying the subcommand", async () => {
+    const driver = mockSpawnOnce();
+    const promise = runRocky(["--verbose", "catalog"]);
+    driver.emitStdout("{}");
+    driver.emitClose(0);
+    await promise;
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("accumulates multiple stdout chunks into a single payload", async () => {
+    const driver = mockSpawnOnce();
+    const promise = runRocky(["catalog"]);
+    driver.emitStdout('{"part1": "');
+    driver.emitStdout('value", "part2": ');
+    driver.emitStdout('"more"}');
+    driver.emitClose(0);
+    const result = await promise;
+    expect(result.stdout).toBe('{"part1": "value", "part2": "more"}');
+  });
+
+  it("rejects with RockyCliError on non-zero exit and preserves stdout", async () => {
+    const driver = mockSpawnOnce();
+    const promise = runRocky(["catalog"]);
+    driver.emitStdout('{"partial":true}');
+    driver.emitStderr("catalog: warehouse offline");
+    driver.emitClose(2);
+    await expect(promise).rejects.toMatchObject({
+      stderr: "catalog: warehouse offline",
+      stdout: '{"partial":true}',
+      exitCode: 2,
+    });
+  });
+
+  it("rejects with RockyCliError on spawn `error` event (ENOENT)", async () => {
+    const driver = mockSpawnOnce();
+    const promise = runRocky(["catalog"]);
+    driver.emitError(
+      Object.assign(new Error("spawn rocky ENOENT"), { code: "ENOENT" }),
+    );
+    await expect(promise).rejects.toMatchObject({
+      exitCode: null,
+    });
+  });
+
+  it("kills the child when the abort signal fires", async () => {
+    const driver = mockSpawnOnce();
+    const controller = new AbortController();
+    void runRocky(["catalog"], { signal: controller.signal });
+    controller.abort();
+    expect(driver.child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("kills the child and rejects when the timeout fires", async () => {
+    vi.useFakeTimers();
+    try {
+      const driver = mockSpawnOnce();
+      const promise = runRocky(["catalog"], { timeoutMs: 100 });
+      vi.advanceTimersByTime(100);
+      expect(driver.child.kill).toHaveBeenCalledWith("SIGTERM");
+      // Caller still has to observe the close event before the promise settles.
+      driver.emitClose(null, "SIGTERM");
+      await expect(promise).rejects.toBeInstanceOf(RockyCliError);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/editors/vscode/src/codeLens.ts
+++ b/editors/vscode/src/codeLens.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { getConfig } from "./config";
+import { shellQuote } from "./shell";
 
 const SUPPORTED_EXTENSIONS = new Set([".rocky", ".sql"]);
 
@@ -82,23 +83,14 @@ function makeLens(
 }
 
 /**
- * Single-quote an argument for POSIX shells; on Windows quote with `"` and
- * double any embedded quotes. Callers route through `terminal.sendText`, which
- * goes through the user's shell, so every interpolated token must be escaped.
- */
-function shellQuote(arg: string): string {
-  if (process.platform === "win32") {
-    return `"${arg.replace(/"/g, '""')}"`;
-  }
-  return `'${arg.replace(/'/g, "'\\''")}'`;
-}
-
-/**
  * Runs `rocky run --filter name=<model>` in the integrated terminal.
  */
 function runModelInTerminal(modelName: string): void {
   const cfg = getConfig();
-  const cmd = `${shellQuote(cfg.serverPath)} run --filter name=${shellQuote(modelName)} --output json`;
+  // Quote the entire `name=<model>` token together so the `name=` prefix sits
+  // inside the same shell-quoted argv slot as the value — keeps it a single
+  // argv element even if the model name contains shell metacharacters.
+  const cmd = `${shellQuote(cfg.serverPath)} run --filter ${shellQuote(`name=${modelName}`)} --output json`;
   const terminal = vscode.window.createTerminal({
     name: `Rocky: run ${modelName}`,
     iconPath: new vscode.ThemeIcon("play"),

--- a/editors/vscode/src/commands/info.ts
+++ b/editors/vscode/src/commands/info.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
-import { getWorkspaceFolder } from "../config";
+import { getConfig, getWorkspaceFolder } from "../config";
 import { getOutputChannel } from "../output";
 import { clearCliVersionCache } from "../rockyCli";
+import { shellQuote } from "../shell";
 
 const URLS = {
   documentation: "https://github.com/rocky-data/rocky#readme",
@@ -28,26 +29,28 @@ export function viewMarketplace(): Thenable<boolean> {
 
 /**
  * Open an integrated terminal in the workspace root and run a Rocky CLI
- * command. Used by the Get Started panel for `rocky init` and
+ * subcommand. Used by the Get Started panel for `rocky init` and
  * `rocky playground`. The terminal is shown so the user can watch progress
  * and answer any prompts the CLI asks.
  *
- * The command is sent via {@link vscode.Terminal.sendText} (no shell quoting
- * required for these argv-free commands).
+ * The server path comes from `rocky.server.path` (default `"rocky"`) and is
+ * shell-quoted so a user-configured path with spaces still resolves to a
+ * single argv token.
  */
-function runInTerminal(name: string, command: string): void {
+function runInTerminal(name: string, subcommand: string): void {
   const cwd = getWorkspaceFolder();
+  const { serverPath } = getConfig();
   const terminal = vscode.window.createTerminal({ name, cwd });
   terminal.show(true);
-  terminal.sendText(command);
+  terminal.sendText(`${shellQuote(serverPath)} ${subcommand}`);
 }
 
 export function init(): void {
-  runInTerminal("Rocky: Init", "rocky init");
+  runInTerminal("Rocky: Init", "init");
 }
 
 export function playground(): void {
-  runInTerminal("Rocky: Playground", "rocky playground");
+  runInTerminal("Rocky: Playground", "playground");
 }
 
 /**

--- a/editors/vscode/src/costCodeLens.ts
+++ b/editors/vscode/src/costCodeLens.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import type { OptimizeOutput, OptimizeRecommendation } from "./types/generated/optimize";
 import { getOutputChannel } from "./output";
 import { runRockyJson } from "./rockyCli";
+import { hasRockyProject, onDidChangeRockyProject } from "./views/getStartedView";
 
 const COST_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -107,8 +108,16 @@ export class CostCodeLensProvider implements vscode.CodeLensProvider {
    * Trigger a data fetch, then fire `onDidChangeCodeLenses` so VS Code
    * re-evaluates every open model file. Safe to call repeatedly — the second
    * call while a fetch is in-flight will just see the freshly-populated cache.
+   *
+   * No-ops (without fetching) when the workspace has no `rocky.toml`, so the
+   * extension never shells out to `rocky optimize` in a non-Rocky project.
    */
   async refresh(): Promise<void> {
+    if (!hasRockyProject()) {
+      invalidateCostCache();
+      this.emitter.fire();
+      return;
+    }
     await fetchCostData();
     this.emitter.fire();
   }
@@ -191,9 +200,22 @@ export function registerCostCodeLensProvider(
         provider.fireChange();
       }
     }),
+
+    // When the project-detection signal flips (e.g. the user just ran
+    // `rocky init` and a rocky.toml appears), trigger a fresh fetch so cost
+    // lenses light up without requiring a manual refresh.
+    onDidChangeRockyProject((has) => {
+      if (has) {
+        void provider.refresh();
+      } else {
+        invalidateCostCache();
+        provider.fireChange();
+      }
+    }),
   );
 
-  // Initial background fetch — silently no-ops if rocky optimize fails.
+  // Initial background fetch — `refresh()` itself gates on hasRockyProject(),
+  // so this is a no-op in workspaces without a rocky.toml.
   void provider.refresh();
 
   return provider;

--- a/editors/vscode/src/driftDiagnostics.ts
+++ b/editors/vscode/src/driftDiagnostics.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { runRockyJson, RockyCliError } from "./rockyCli";
 import { getOutputChannel } from "./output";
 import type { CompileOutput, Diagnostic, Severity } from "./types/generated/compile";
+import { hasRockyProject, onDidChangeRockyProject } from "./views/getStartedView";
 
 const SUPPORTED_EXTENSIONS = new Set([".rocky", ".sql"]);
 
@@ -207,9 +208,18 @@ export function registerDriftDiagnostics(
       .get<boolean>("diagnostics.enabled", true);
   }
 
+  /**
+   * The CLI can only run when both the user has diagnostics enabled and a
+   * Rocky project is present in the workspace — otherwise `rocky compile`
+   * just fails with "no rocky.toml found".
+   */
+  function shouldRunCli(): boolean {
+    return isDiagnosticsEnabled() && hasRockyProject();
+  }
+
   /** Schedule a debounced diagnostic refresh (500ms). */
   function scheduleRefresh(document: vscode.TextDocument): void {
-    if (!isDiagnosticsEnabled()) {
+    if (!shouldRunCli()) {
       collection.clear();
       return;
     }
@@ -230,7 +240,7 @@ export function registerDriftDiagnostics(
   // Refresh on file open.
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
-      if (!isDiagnosticsEnabled()) return;
+      if (!shouldRunCli()) return;
       void refreshDiagnostics(document, collection);
     }),
   );
@@ -266,8 +276,28 @@ export function registerDriftDiagnostics(
     }),
   );
 
-  // Run on any already-open model files at activation time.
-  if (isDiagnosticsEnabled()) {
+  // When the workspace gains or loses a rocky.toml, re-sweep open documents
+  // (gain) or clear stale diagnostics (loss).
+  context.subscriptions.push(
+    onDidChangeRockyProject((has) => {
+      if (!has) {
+        collection.clear();
+        for (const timer of pendingTimers.values()) clearTimeout(timer);
+        pendingTimers.clear();
+        return;
+      }
+      if (!isDiagnosticsEnabled()) return;
+      for (const document of vscode.workspace.textDocuments) {
+        void refreshDiagnostics(document, collection);
+      }
+    }),
+  );
+
+  // Run on any already-open model files at activation time — but only when
+  // a Rocky project is present. `hasRockyProject()` resolves to true
+  // asynchronously after activation; the onDidChangeRockyProject listener
+  // above catches that transition.
+  if (shouldRunCli()) {
     for (const document of vscode.workspace.textDocuments) {
       void refreshDiagnostics(document, collection);
     }

--- a/editors/vscode/src/lspClient.ts
+++ b/editors/vscode/src/lspClient.ts
@@ -315,12 +315,18 @@ async function launchClient(): Promise<void> {
  * is `Stopped (1) | Running (2) | Starting (3)`. A Running→Stopped flip
  * outside a deliberate restart/shutdown means the server crashed; surface
  * it on the status bar and offer a Restart action.
+ *
+ * We only fire on `Running → Stopped`. A `Starting → Stopped` transition
+ * means `client.start()` rejected, and the catch block in `launchClient`
+ * already reports that via {@link handleStartupFailure}. Without this
+ * filter the user would see two error dialogs on initial startup failure.
  */
-function handleStateChange(_oldState: State, newState: State): void {
+function handleStateChange(oldState: State, newState: State): void {
   // During a deliberate stop or restart we own the status bar text and
   // {@link setLspState}, so silently ignore the transition.
   if (expectedStop) return;
   if (newState !== State.Stopped) return;
+  if (oldState !== State.Running) return;
   // The startup-failure path already calls {@link setLspState}; don't
   // double-report when start() rejected.
   if (currentLspState.status === "Failed") return;

--- a/editors/vscode/src/lspClient.ts
+++ b/editors/vscode/src/lspClient.ts
@@ -5,6 +5,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
+  State,
   TransportKind,
 } from "vscode-languageclient/node";
 import { getConfig } from "./config";
@@ -12,6 +13,23 @@ import { getOutputChannel } from "./output";
 
 let client: LanguageClient | undefined;
 let statusBarItem: vscode.StatusBarItem;
+
+/** Disposable for the current client's `onDidChangeState` subscription. */
+let stateSubscription: vscode.Disposable | undefined;
+
+/**
+ * `true` while we're deliberately stopping the client as part of a restart
+ * or shutdown. Suppresses the crash handler so a normal Running→Stopped
+ * transition doesn't flap the status bar into a "Failed" state.
+ */
+let expectedStop = false;
+
+/**
+ * In-flight restart promise. While set, additional `restartLspClient()` calls
+ * await the same promise instead of racing a second `client.stop()` /
+ * `new LanguageClient(...)` pair.
+ */
+let pendingRestart: Promise<void> | undefined;
 
 interface DiagnosticTotals {
   errors: number;
@@ -275,6 +293,13 @@ async function launchClient(): Promise<void> {
     clientOptions,
   );
 
+  // Dispose any previous state listener before subscribing on the new client
+  // — without this, listeners accumulate across every restart.
+  stateSubscription?.dispose();
+  stateSubscription = client.onDidChangeState((event) => {
+    handleStateChange(event.oldState, event.newState);
+  });
+
   try {
     await client.start();
     statusBarItem.text = `$(check) Rocky: Ready${buildSegmentSuffix()}`;
@@ -283,6 +308,49 @@ async function launchClient(): Promise<void> {
   } catch (err) {
     handleStartupFailure(err as Error);
   }
+}
+
+/**
+ * React to LSP state transitions. The vscode-languageclient state machine
+ * is `Stopped (1) | Running (2) | Starting (3)`. A Running→Stopped flip
+ * outside a deliberate restart/shutdown means the server crashed; surface
+ * it on the status bar and offer a Restart action.
+ */
+function handleStateChange(_oldState: State, newState: State): void {
+  // During a deliberate stop or restart we own the status bar text and
+  // {@link setLspState}, so silently ignore the transition.
+  if (expectedStop) return;
+  if (newState !== State.Stopped) return;
+  // The startup-failure path already calls {@link setLspState}; don't
+  // double-report when start() rejected.
+  if (currentLspState.status === "Failed") return;
+
+  const channel = getOutputChannel();
+  channel.appendLine(
+    "Rocky language server stopped unexpectedly. Diagnostics will not refresh until it is restarted.",
+  );
+
+  statusBarItem.text = "$(error) Rocky: Stopped";
+  statusBarItem.backgroundColor = new vscode.ThemeColor(
+    "statusBarItem.errorBackground",
+  );
+  statusBarItem.tooltip = "Rocky language server stopped — click to restart";
+
+  setLspState("Failed", "Language server stopped unexpectedly");
+
+  vscode.window
+    .showErrorMessage(
+      "Rocky language server stopped unexpectedly.",
+      "Restart",
+      "Show Logs",
+    )
+    .then((choice) => {
+      if (choice === "Restart") {
+        void restartLspClient();
+      } else if (choice === "Show Logs") {
+        channel.show();
+      }
+    });
 }
 
 /**
@@ -378,15 +446,35 @@ function handleStartupFailure(err: Error): void {
 }
 
 export async function restartLspClient(): Promise<void> {
+  // Serialize concurrent restarts. Without this guard, two near-simultaneous
+  // config changes can each call `await client.stop()` (fast on an already-
+  // stopped client) and then both enter `launchClient()`, where they assign
+  // `client = new LanguageClient(...)` back-to-back. The first instance is
+  // orphaned but its child process keeps running.
+  if (pendingRestart) {
+    return pendingRestart;
+  }
+  pendingRestart = doRestart();
+  try {
+    await pendingRestart;
+  } finally {
+    pendingRestart = undefined;
+  }
+}
+
+async function doRestart(): Promise<void> {
   statusBarItem.text = "$(loading~spin) Rocky: Restarting...";
   setLspState("Restarting");
   if (client) {
+    expectedStop = true;
     try {
       await client.stop();
     } catch (err) {
       getOutputChannel().appendLine(
         `Error stopping language server: ${(err as Error).message}`,
       );
+    } finally {
+      expectedStop = false;
     }
   }
   await launchClient();
@@ -396,7 +484,14 @@ export async function restartLspClient(): Promise<void> {
 }
 
 export async function stopLspClient(): Promise<void> {
-  await client?.stop();
+  expectedStop = true;
+  try {
+    await client?.stop();
+  } finally {
+    expectedStop = false;
+  }
+  stateSubscription?.dispose();
+  stateSubscription = undefined;
   client = undefined;
   setLspState("Stopped");
 }

--- a/editors/vscode/src/rockyCli.ts
+++ b/editors/vscode/src/rockyCli.ts
@@ -1,8 +1,38 @@
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import type { ExecFileException } from "child_process";
 import * as vscode from "vscode";
 import { getConfig, getWorkspaceFolder } from "./config";
 import { getOutputChannel } from "./output";
+
+/**
+ * Subcommands whose stdout can exceed the 16 MiB `execFile` `maxBuffer` cap
+ * on a real warehouse. We route these through {@link runRockyUnbounded},
+ * which streams stdout via `spawn()` and accumulates it manually instead of
+ * relying on Node's bounded internal buffer.
+ *
+ * Keep the set conservative — anything in here pays a slightly heavier
+ * stream-assembly cost than `execFile`. Add a subcommand only when its
+ * output has a credible chance of exceeding 16 MiB.
+ */
+const UNBOUNDED_OUTPUT_SUBCOMMANDS: ReadonlySet<string> = new Set([
+  "catalog",
+  "history",
+  "optimize",
+  "discover",
+]);
+
+/**
+ * Returns `true` when {@link args} begins with a subcommand listed in
+ * {@link UNBOUNDED_OUTPUT_SUBCOMMANDS}. Top-level flags such as `--output`
+ * never count, so the check looks for the first non-flag token.
+ */
+function isUnboundedOutputCommand(args: readonly string[]): boolean {
+  for (const arg of args) {
+    if (arg.startsWith("-")) continue;
+    return UNBOUNDED_OUTPUT_SUBCOMMANDS.has(arg);
+  }
+  return false;
+}
 
 export interface RunRockyOptions {
   /** Working directory for the spawned process. Defaults to the workspace root. */
@@ -51,11 +81,18 @@ export class RockyCliError extends Error {
  *
  * Every invocation is logged to the shared "Rocky" output channel so the user
  * can audit what the extension is running.
+ *
+ * Subcommands whose output can exceed `execFile`'s 16 MiB cap (catalog,
+ * history, optimize, discover) are streamed through `spawn()` instead so the
+ * full payload survives. See {@link UNBOUNDED_OUTPUT_SUBCOMMANDS}.
  */
 export function runRocky(
   args: string[],
   opts: RunRockyOptions = {},
 ): Promise<RockyResult> {
+  if (isUnboundedOutputCommand(args)) {
+    return runRockyUnbounded(args, opts);
+  }
   const { serverPath } = getConfig();
   const cwd = opts.cwd ?? getWorkspaceFolder();
   const channel = getOutputChannel();
@@ -100,6 +137,125 @@ export function runRocky(
         resolve({ stdout, stderr });
       },
     );
+
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        child.kill("SIGTERM");
+      } else {
+        const onAbort = (): void => {
+          child.kill("SIGTERM");
+        };
+        opts.signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = (): void => {
+          opts.signal!.removeEventListener("abort", onAbort);
+        };
+      }
+    }
+  });
+}
+
+/**
+ * Stream-based counterpart to {@link runRocky}. Used for subcommands whose
+ * stdout can exceed `execFile`'s 16 MiB `maxBuffer` cap — `rocky catalog`,
+ * `rocky history`, `rocky optimize`, and `rocky discover` against a real
+ * warehouse all reproducibly cross this line.
+ *
+ * The contract matches {@link runRocky} exactly: identical `RockyResult`
+ * shape on success, identical {@link RockyCliError} shape on failure
+ * (including `stdout` captured on non-zero exit, so callers like the doctor
+ * handler still recover their JSON payload). Timeout, abort-signal, and
+ * output-channel logging all behave the same.
+ */
+function runRockyUnbounded(
+  args: string[],
+  opts: RunRockyOptions = {},
+): Promise<RockyResult> {
+  const { serverPath } = getConfig();
+  const cwd = opts.cwd ?? getWorkspaceFolder();
+  const channel = getOutputChannel();
+  const start = Date.now();
+
+  channel.appendLine(`$ ${serverPath} ${args.join(" ")}`);
+
+  return new Promise((resolve, reject) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let removeAbortListener: (() => void) | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(serverPath, args, { cwd });
+
+    const settle = (
+      err: (Error & { code?: number | string }) | null,
+      exitCode: number | string | null,
+    ): void => {
+      if (settled) return;
+      settled = true;
+      removeAbortListener?.();
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+
+      const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      const elapsed = Date.now() - start;
+
+      if (err) {
+        if (stderr) channel.appendLine(stderr.trimEnd());
+        channel.appendLine(
+          `[${elapsed}ms] command failed (exit ${exitCode ?? "?"}): ${err.message}`,
+        );
+        reject(
+          new RockyCliError(
+            err.message,
+            stderr,
+            exitCode,
+            err,
+            stdout,
+          ),
+        );
+        return;
+      }
+      channel.appendLine(`[${elapsed}ms] ok`);
+      resolve({ stdout, stderr });
+    };
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+    child.on("error", (err) => {
+      // spawn failure (e.g. ENOENT) — surfaces here instead of via `close`.
+      settle(err as Error & { code?: string }, null);
+    });
+    child.on("close", (code, signal) => {
+      if (timedOut) {
+        const err = Object.assign(new Error("Command timed out"), {
+          code: "ETIMEDOUT",
+        });
+        settle(err, code ?? signal ?? null);
+        return;
+      }
+      if (code === 0) {
+        settle(null, 0);
+        return;
+      }
+      const exitCode = code ?? signal ?? null;
+      const err = Object.assign(
+        new Error(`Command failed with exit code ${exitCode ?? "?"}`),
+        { code: exitCode ?? undefined },
+      );
+      settle(err, exitCode);
+    });
+
+    if (opts.timeoutMs && opts.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, opts.timeoutMs);
+    }
 
     if (opts.signal) {
       if (opts.signal.aborted) {

--- a/editors/vscode/src/runDecorations.ts
+++ b/editors/vscode/src/runDecorations.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { runRockyJson, RockyCliError } from "./rockyCli";
 import { getOutputChannel } from "./output";
 import type { ModelHistoryOutput } from "./types/generated";
+import { hasRockyProject, onDidChangeRockyProject } from "./views/getStartedView";
 
 const SUPPORTED_EXTENSIONS = new Set([".rocky", ".sql"]);
 
@@ -96,6 +97,10 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
 
   const modelName = path.basename(document.fileName, ext);
   if (!modelName) return;
+
+  // Skip shelling out to `rocky history` in workspaces without a rocky.toml —
+  // the CLI would fail every time and we'd spam the output channel.
+  if (!hasRockyProject()) return;
 
   // Clear existing decorations before applying new ones
   for (const dt of ALL_DECORATION_TYPES) {
@@ -248,13 +253,34 @@ export function registerRunDecorations(
     }),
   );
 
+  // When project detection flips (e.g. user runs `rocky init`), re-decorate
+  // any already-visible editors; otherwise they'd show no decorations until
+  // the user clicks away and back.
+  context.subscriptions.push(
+    onDidChangeRockyProject((has) => {
+      if (!has) {
+        for (const editor of vscode.window.visibleTextEditors) {
+          for (const dt of ALL_DECORATION_TYPES) {
+            editor.setDecorations(dt, []);
+          }
+        }
+        return;
+      }
+      for (const editor of vscode.window.visibleTextEditors) {
+        applyRunDecoration(editor);
+      }
+    }),
+  );
+
   // Dispose decoration types on deactivation
   context.subscriptions.push(
     ...ALL_DECORATION_TYPES,
     refreshEmitter,
   );
 
-  // Apply immediately if there is already an active editor
+  // Apply immediately if there is already an active editor. The function
+  // itself bails when no Rocky project is detected, and the
+  // onDidChangeRockyProject hook above re-runs it once detection finishes.
   if (vscode.window.activeTextEditor) {
     applyRunDecoration(vscode.window.activeTextEditor);
   }

--- a/editors/vscode/src/shell.ts
+++ b/editors/vscode/src/shell.ts
@@ -1,0 +1,21 @@
+/**
+ * Shell-quoting helpers shared by every site that builds a command string for
+ * `vscode.Terminal.sendText()`. The terminal pipes the string straight through
+ * the user's shell, so every interpolated token must be escaped — otherwise
+ * spaces, quotes or shell metacharacters would split the argument or run
+ * arbitrary code.
+ */
+
+/**
+ * Single-quote an argument for POSIX shells; on Windows quote with `"` and
+ * double any embedded quotes.
+ *
+ * The returned value is a single argv token after the shell parses it,
+ * regardless of whether the input contains whitespace or quotes.
+ */
+export function shellQuote(arg: string): string {
+  if (process.platform === "win32") {
+    return `"${arg.replace(/"/g, '""')}"`;
+  }
+  return `'${arg.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary

Five (plus one bonus) targeted fixes in the VS Code extension. One commit per logical group.

### Bug 1 — LSP server crashes after start are silent
`src/lspClient.ts` — after `await client.start()`, nothing subscribed to `client.onDidChangeState`. A mid-session crash of `rocky-lsp` left the status bar green and diagnostics silently stopped. Now subscribe to state transitions, flip the status bar on an unexpected `Running -> Stopped`, set `LspState.Failed`, and offer a "Restart" action. Dispose previous state subscriptions on each new launch / shutdown to avoid listener accumulation; guard with `expectedStop` so deliberate restart/shutdown transitions don't flap the bar.

### Bug 2 — Config-change LSP restart is racy
`src/lspClient.ts:206-224` and `380-396` — two near-simultaneous config changes each called `restartLspClient()`, both reached `client = new LanguageClient(...)`, orphaning the first instance (its child process kept running). Now serialize through a `pendingRestart` promise — second caller awaits the first.

### Bug 3 — CodeLens / drift / run-decorations fire CLI in non-Rocky workspaces
- `src/costCodeLens.ts:197` — initial `provider.refresh()` ran `rocky optimize` before `rocky.hasProject` resolved.
- `src/driftDiagnostics.ts:270-274` — activation iterated every open document, shelling out per file. The `onDidOpen` handler had no project gate.
- `src/runDecorations.ts:258-260` — same pattern.

Each now gates on `hasRockyProject()` and subscribes to `onDidChangeRockyProject` so behaviour lights up the moment a `rocky.toml` is detected (mirrors the existing `views/runsView.ts` pattern).

### Bug 4 — `runRocky` `maxBuffer: 16 MiB` truncates large output
`src/rockyCli.ts:75` — `execFile`'s 16 MiB cap dropped real-warehouse `rocky catalog --output json` payloads on the floor with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`. `runRocky()` now routes `catalog`/`history`/`optimize`/`discover` through a new internal `runRockyUnbounded()` helper that streams via `spawn()` and concatenates chunks. Contract is identical — same `RockyResult` / `RockyCliError` shape (stdout still captured on non-zero exit so the doctor handler still recovers its JSON payload), same timeout / abort / output-channel logging.

### Bug 5 — `rocky.init` / `rocky.playground` ignore `rocky.server.path`
`src/commands/info.ts` — hardcoded literal `"rocky init"` / `"rocky playground"` strings. Now read `getConfig().serverPath`, shell-quote it, interpolate.

### Bonus — `codeLens.ts:101` shell-quoting form
`--filter name=${shellQuote(modelName)}` placed `name=` outside the quoted region. Works today (adjacent quoted+unquoted tokens concatenate) but is fragile for future inputs; quote the whole `name=<model>` together. Extracted `shellQuote` into a shared `src/shell.ts` so `info.ts` can reuse it.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm run test:unit` — 118 passed (was 106; +12 new rockyCli spawn-path tests)
- [x] `npm run lint` — clean
- [ ] Manual: open a non-Rocky workspace, confirm output channel stays quiet (no `rocky optimize` / `rocky compile` / `rocky history` calls)
- [ ] Manual: change `rocky.server.path` twice in quick succession, confirm only one orphan-free `rocky lsp` child remains
- [ ] Manual: `kill -9` the running `rocky-lsp` process, confirm status bar flips to red with a "Restart" action
- [ ] Manual: run `rocky.init` and `rocky.playground` with `rocky.server.path` set to a custom binary, confirm the custom path is used