### PR TITLE
fix(engine/rocky-snowflake): multi-statement INSERT OVERWRITE + UUID stage names

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -967,6 +967,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1802,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3366,6 +3378,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,6 +3425,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -4097,6 +4126,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 
@@ -5392,7 +5422,9 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -167,6 +167,13 @@ wasm-bindgen = "0.2"
 # Testing
 wiremock = "0.6"
 
+# UUID v4 — used by Snowflake stage-name generation to avoid collisions on
+# parallel loads. `SystemTime::now().subsec_nanos()` resolves to
+# sub-microseconds on macOS, so two concurrent `load()` calls can produce
+# identical stage names; v4 UUIDs collapse the collision probability to
+# astronomical.
+uuid = { version = "1", features = ["v4", "fast-rng"] }
+
 # OpenTelemetry (feature-gated in rocky-observe).
 # `tracing-opentelemetry` major versions track `opentelemetry` minor
 # versions: 0.32 pairs with opentelemetry 0.31 — pin the pair together.

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -24,6 +24,7 @@ jsonwebtoken = { workspace = true }
 rsa = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 test-support = []

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -392,12 +392,26 @@ impl SnowflakeConnector {
         // session parameters so Snowflake parses + runs them as one
         // transactional unit. Single-statement calls keep the parameters
         // map empty so the body is byte-identical to the pre-Bug-1 payload.
+        //
+        // For multi-statement scripts we also set `TRANSACTION_ABORT_ON_ERROR
+        // = TRUE`. Without it, a failed DML rolls back only its own changes
+        // and leaves the transaction open — subsequent statements (including
+        // the trailing `COMMIT`) are skipped, and the in-flight transaction
+        // only rolls back implicitly when the REST session ends. That
+        // session-close cleanup is incidental, not contractual: setting
+        // `ABORT_ON_ERROR` makes Snowflake roll back the entire transaction
+        // at the moment of error, which is what `insert_overwrite_partition`
+        // semantically requires.
         let statement_count = count_statements(sql);
         let mut parameters = std::collections::BTreeMap::new();
         if statement_count > 1 {
             parameters.insert(
                 "MULTI_STATEMENT_COUNT".to_string(),
                 statement_count.to_string(),
+            );
+            parameters.insert(
+                "TRANSACTION_ABORT_ON_ERROR".to_string(),
+                "TRUE".to_string(),
             );
         }
         let body = SubmitRequest {

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -80,6 +80,14 @@ struct SubmitRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     role: Option<String>,
     timeout: u64,
+    /// Snowflake session parameters threaded through the SQL REST API.
+    ///
+    /// Used to set `MULTI_STATEMENT_COUNT` when the caller submits a
+    /// semicolon-joined script. Skipped when empty so single-statement
+    /// requests stay byte-identical to the pre-multi-statement payload
+    /// (the wiremock tests pin the canonical single-statement body).
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    parameters: std::collections::BTreeMap<String, String>,
 }
 
 /// Response from the Snowflake SQL REST API.
@@ -374,6 +382,24 @@ impl SnowflakeConnector {
 
         debug!(sql, "submitting SQL statement to Snowflake");
 
+        // Snowflake's `/api/v2/statements` runs ONE statement per call by
+        // default — submitting a semicolon-joined body without
+        // `MULTI_STATEMENT_COUNT` returns code `000008` ("Multiple SQL
+        // statements in a single API call are not supported"). When the
+        // dialect emits a multi-statement script (e.g. the
+        // `BEGIN; DELETE; INSERT; COMMIT` transaction for
+        // `insert_overwrite_partition`), thread the statement count through
+        // session parameters so Snowflake parses + runs them as one
+        // transactional unit. Single-statement calls keep the parameters
+        // map empty so the body is byte-identical to the pre-Bug-1 payload.
+        let statement_count = count_statements(sql);
+        let mut parameters = std::collections::BTreeMap::new();
+        if statement_count > 1 {
+            parameters.insert(
+                "MULTI_STATEMENT_COUNT".to_string(),
+                statement_count.to_string(),
+            );
+        }
         let body = SubmitRequest {
             statement: sql.to_string(),
             warehouse: self.config.warehouse.clone(),
@@ -381,6 +407,7 @@ impl SnowflakeConnector {
             schema: self.config.schema.clone(),
             role: self.config.role.clone(),
             timeout: self.config.timeout.as_secs(),
+            parameters,
         };
 
         let request = self
@@ -469,6 +496,65 @@ impl SnowflakeConnector {
 
         Ok(())
     }
+}
+
+/// Count the number of top-level SQL statements in `sql` for Snowflake's
+/// `MULTI_STATEMENT_COUNT` session parameter.
+///
+/// Counts semicolons that terminate distinct statements, then adds 1 for the
+/// final un-terminated statement. Skips semicolons inside SQL string literals
+/// (`'...'`) and single-line comments (`-- ...`). Rocky-generated SQL never
+/// embeds semicolons in identifiers, so identifier-quoting is not considered.
+///
+/// Trailing-only whitespace after the last semicolon counts the same as a
+/// terminator (one fewer statement). Empty / whitespace-only input returns 0.
+fn count_statements(sql: &str) -> usize {
+    let mut count = 0usize;
+    let mut chars = sql.chars().peekable();
+    let mut in_string = false;
+    let mut saw_non_ws_since_terminator = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            if c == '\'' {
+                // Snowflake doubles single quotes to escape (`''`); treat as
+                // staying inside the literal.
+                if chars.peek() == Some(&'\'') {
+                    chars.next();
+                } else {
+                    in_string = false;
+                }
+            }
+            continue;
+        }
+        match c {
+            '\'' => {
+                in_string = true;
+                saw_non_ws_since_terminator = true;
+            }
+            '-' if chars.peek() == Some(&'-') => {
+                // Skip to end of line.
+                for nc in chars.by_ref() {
+                    if nc == '\n' {
+                        break;
+                    }
+                }
+            }
+            ';' => {
+                if saw_non_ws_since_terminator {
+                    count += 1;
+                }
+                saw_non_ws_since_terminator = false;
+            }
+            c if c.is_whitespace() => {}
+            _ => {
+                saw_non_ws_since_terminator = true;
+            }
+        }
+    }
+    if saw_non_ws_since_terminator {
+        count += 1;
+    }
+    count
 }
 
 fn classify_statement_kind(sql: &str) -> &'static str {
@@ -588,6 +674,52 @@ fn classify_error(err: &ConnectorError) -> ErrorClass {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_count_statements_single() {
+        assert_eq!(count_statements("SELECT 1"), 1);
+        assert_eq!(count_statements("SELECT 1;"), 1);
+        assert_eq!(count_statements("  SELECT 1  ;  "), 1);
+    }
+
+    #[test]
+    fn test_count_statements_empty() {
+        assert_eq!(count_statements(""), 0);
+        assert_eq!(count_statements("   "), 0);
+        assert_eq!(count_statements(";;;"), 0);
+    }
+
+    #[test]
+    fn test_count_statements_multi() {
+        let script = "BEGIN;\nDELETE FROM t WHERE x = 1;\nINSERT INTO t SELECT 2;\nCOMMIT";
+        assert_eq!(count_statements(script), 4);
+        // Trailing semicolon after COMMIT should still count 4.
+        let script = "BEGIN;\nDELETE FROM t WHERE x = 1;\nINSERT INTO t SELECT 2;\nCOMMIT;";
+        assert_eq!(count_statements(script), 4);
+    }
+
+    #[test]
+    fn test_count_statements_ignores_semicolon_in_string_literal() {
+        // Snowflake's API treats `';'` as part of a string literal, not a
+        // statement terminator. Our counter must agree, otherwise
+        // MULTI_STATEMENT_COUNT will be off-by-one and the request fails.
+        let sql = "INSERT INTO t VALUES ('a;b;c'); INSERT INTO t VALUES ('d')";
+        assert_eq!(count_statements(sql), 2);
+    }
+
+    #[test]
+    fn test_count_statements_ignores_semicolon_in_doubled_quote_string() {
+        // `'it''s'` is one literal containing `it's` — embedded semicolons
+        // inside the literal still shouldn't terminate.
+        let sql = "INSERT INTO t VALUES ('it''s;ok'); SELECT 1";
+        assert_eq!(count_statements(sql), 2);
+    }
+
+    #[test]
+    fn test_count_statements_ignores_semicolon_in_line_comment() {
+        let sql = "-- here; is; a; comment\nSELECT 1; SELECT 2";
+        assert_eq!(count_statements(sql), 2);
+    }
 
     #[test]
     fn test_classify_statement_kind_query() {

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -409,10 +409,7 @@ impl SnowflakeConnector {
                 "MULTI_STATEMENT_COUNT".to_string(),
                 statement_count.to_string(),
             );
-            parameters.insert(
-                "TRANSACTION_ABORT_ON_ERROR".to_string(),
-                "TRUE".to_string(),
-            );
+            parameters.insert("TRANSACTION_ABORT_ON_ERROR".to_string(), "TRUE".to_string());
         }
         let body = SubmitRequest {
             statement: sql.to_string(),

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -186,17 +186,26 @@ impl SqlDialect for SnowflakeSqlDialect {
         select_sql: &str,
     ) -> AdapterResult<Vec<String>> {
         // Snowflake has no native partition-replace operation. We wrap a
-        // DELETE + INSERT in an explicit transaction; the runtime issues
-        // each statement as a separate REST API call (Snowflake's SQL
-        // Statement Execution API runs one statement per call by default
-        // and rejects multi-statement bodies without MULTI_STATEMENT_COUNT).
-        // On any failure mid-batch the runtime issues `ROLLBACK`.
-        Ok(vec![
-            "BEGIN".into(),
-            format!("DELETE FROM {target} WHERE {partition_filter}"),
-            format!("INSERT INTO {target}\n{select_sql}"),
-            "COMMIT".into(),
-        ])
+        // DELETE + INSERT in an explicit `BEGIN ... COMMIT` transaction.
+        //
+        // Snowflake's `/api/v2/statements` runs ONE statement per call by
+        // default — every call opens an independent session, so emitting
+        // BEGIN/DELETE/INSERT/COMMIT as four separate REST calls is silently
+        // non-transactional: each call autocommits, `BEGIN` is discarded, the
+        // `DELETE` autocommits, and the trailing `COMMIT`/`ROLLBACK` is a
+        // no-op. To get true atomicity we submit the four statements as a
+        // single semicolon-joined script in one call; the connector sets
+        // `MULTI_STATEMENT_COUNT` in `parameters` so Snowflake accepts the
+        // multi-statement body and runs them in one session. On any
+        // sub-statement error Snowflake auto-rolls-back the in-flight
+        // transaction. This mirrors BigQuery's `BEGIN TRANSACTION; ...;
+        // COMMIT TRANSACTION` single-script form.
+        Ok(vec![format!(
+            "BEGIN;\n\
+             DELETE FROM {target} WHERE {partition_filter};\n\
+             INSERT INTO {target}\n{select_sql};\n\
+             COMMIT"
+        )])
     }
 
     fn regex_match_predicate(
@@ -551,10 +560,14 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_overwrite_partition_four_statement_transaction() {
-        // Snowflake's REST API runs one statement per call by default — so we
-        // emit 4 statements: BEGIN; DELETE; INSERT; COMMIT. The runtime
-        // executes them in order and rolls back on partial failure.
+    fn test_insert_overwrite_partition_single_script_transaction() {
+        // Snowflake's `/api/v2/statements` runs one statement per call by
+        // default; each call is its own session, so emitting BEGIN/DELETE/
+        // INSERT/COMMIT as four separate calls is silently non-transactional.
+        // Emit a single semicolon-joined script — the connector sets
+        // `MULTI_STATEMENT_COUNT` so Snowflake runs all four in one session
+        // and auto-rolls-back on partial failure. Mirrors BigQuery's
+        // single-script transaction form.
         let d = dialect();
         let stmts = d
             .insert_overwrite_partition(
@@ -563,11 +576,18 @@ mod tests {
                 "SELECT order_date, COUNT(*) FROM stg_orders GROUP BY 1",
             )
             .unwrap();
-        assert_eq!(stmts.len(), 4, "Snowflake emits BEGIN/DELETE/INSERT/COMMIT");
-        assert_eq!(stmts[0], "BEGIN");
-        assert!(stmts[1].starts_with("DELETE FROM warehouse.marts.fct_daily_orders WHERE "));
-        assert!(stmts[1].contains("order_date >= '2026-04-07 00:00:00'"));
-        assert!(stmts[2].starts_with("INSERT INTO warehouse.marts.fct_daily_orders"));
-        assert_eq!(stmts[3], "COMMIT");
+        assert_eq!(
+            stmts.len(),
+            1,
+            "Snowflake emits one semicolon-joined script"
+        );
+        let script = &stmts[0];
+        assert!(script.starts_with("BEGIN;\n"));
+        assert!(script.contains(
+            "DELETE FROM warehouse.marts.fct_daily_orders WHERE \
+             order_date >= '2026-04-07 00:00:00' AND order_date < '2026-04-08 00:00:00';"
+        ));
+        assert!(script.contains("INSERT INTO warehouse.marts.fct_daily_orders"));
+        assert!(script.ends_with("COMMIT"));
     }
 }

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -196,10 +196,18 @@ impl SqlDialect for SnowflakeSqlDialect {
         // no-op. To get true atomicity we submit the four statements as a
         // single semicolon-joined script in one call; the connector sets
         // `MULTI_STATEMENT_COUNT` in `parameters` so Snowflake accepts the
-        // multi-statement body and runs them in one session. On any
-        // sub-statement error Snowflake auto-rolls-back the in-flight
-        // transaction. This mirrors BigQuery's `BEGIN TRANSACTION; ...;
-        // COMMIT TRANSACTION` single-script form.
+        // multi-statement body and runs them in one session.
+        //
+        // The connector ALSO sets `TRANSACTION_ABORT_ON_ERROR = TRUE` for
+        // multi-statement bodies. Without that parameter, a failed DML in
+        // a Snowflake transaction rolls back only its own changes and leaves
+        // the transaction open — subsequent statements (including the
+        // trailing `COMMIT`) are skipped, and the in-flight transaction only
+        // unwinds implicitly when the REST session ends. That session-close
+        // cleanup is incidental, not contractual: `ABORT_ON_ERROR` makes
+        // Snowflake roll back the whole transaction at error-time, which
+        // is what partition-replace semantically requires. Mirrors BigQuery's
+        // single-script `BEGIN TRANSACTION; ...; COMMIT TRANSACTION` form.
         Ok(vec![format!(
             "BEGIN;\n\
              DELETE FROM {target} WHERE {partition_filter};\n\

--- a/engine/crates/rocky-snowflake/src/stage.rs
+++ b/engine/crates/rocky-snowflake/src/stage.rs
@@ -163,24 +163,24 @@ pub fn copy_into_sql(target_ref: &str, stage: &StageName) -> String {
     format!("COPY INTO {target_ref} FROM {}", stage.reference())
 }
 
-/// Generate a short, unique stage name (suffix of nanos-since-epoch + random salt).
+/// Generate a unique stage name suffixed with a v4 UUID.
 ///
-/// Used to avoid collisions when multiple pipelines run concurrently.
+/// Used to avoid collisions when multiple pipelines run concurrently. The
+/// previous implementation suffixed `SystemTime::now().subsec_nanos()`, but
+/// macOS resolves `subsec_nanos()` at sub-microsecond granularity (not true
+/// nanoseconds), so two parallel `load()` calls hitting `generate_stage_name`
+/// in the same microsecond produced identical stage names — leading to
+/// cross-table contamination when both COPY INTOs read from the same stage.
+///
+/// A v4 UUID's `simple()` formatting (32 lowercase hex chars, no hyphens) is
+/// alphanumeric and passes [`StageName`]'s identifier validation. The 122-bit
+/// random payload collapses the collision probability to astronomical even
+/// under unbounded concurrency.
 pub fn generate_stage_name() -> StageName {
-    // `SystemTime::now()` is not injection-safe in theory, but we only use
-    // nanos + a simple hash — no user input is interpolated here.
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or(0);
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
     // Already-validated name (alphanumeric + underscore): safe to construct
     // directly.
-    StageName(format!("ROCKY_LOAD_{secs}_{nanos}"))
+    StageName(format!("ROCKY_LOAD_{suffix}"))
 }
 
 #[cfg(test)]
@@ -315,5 +315,58 @@ mod tests {
         assert!(n.as_str().starts_with("ROCKY_LOAD_"));
         // Should pass validation.
         assert!(StageName::new(n.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_generate_stage_name_unique_under_tight_loop() {
+        // Tight serial loop — the previous implementation could collide here
+        // because `SystemTime::now().subsec_nanos()` resolves at
+        // sub-microsecond granularity on macOS. The v4 UUID suffix collapses
+        // the collision probability to astronomical regardless of timing.
+        let n = 1_000;
+        let mut names = std::collections::HashSet::with_capacity(n);
+        for _ in 0..n {
+            let name = generate_stage_name().as_str().to_string();
+            assert!(
+                names.insert(name.clone()),
+                "duplicate stage name {name} generated in tight loop"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_stage_name_unique_under_thread_race() {
+        // True parallel race — N threads each generate M names; the
+        // combined set must have N*M distinct entries.
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+
+        let threads = 8;
+        let per_thread = 200;
+        let collected: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut handles = Vec::with_capacity(threads);
+        for _ in 0..threads {
+            let collected = Arc::clone(&collected);
+            handles.push(thread::spawn(move || {
+                let mut local = Vec::with_capacity(per_thread);
+                for _ in 0..per_thread {
+                    local.push(generate_stage_name().as_str().to_string());
+                }
+                collected.lock().unwrap().extend(local);
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker thread panicked");
+        }
+        let all = collected.lock().unwrap();
+        let unique: std::collections::HashSet<&String> = all.iter().collect();
+        assert_eq!(
+            unique.len(),
+            threads * per_thread,
+            "expected {} unique names across {} threads, got {}",
+            threads * per_thread,
+            threads,
+            unique.len(),
+        );
     }
 }

--- a/engine/crates/rocky-snowflake/tests/insert_overwrite_partition_live.rs
+++ b/engine/crates/rocky-snowflake/tests/insert_overwrite_partition_live.rs
@@ -1,0 +1,264 @@
+//! Live Snowflake conformance tests for `insert_overwrite_partition`.
+//!
+//! `#[ignore]`-gated because they require a real Snowflake account.
+//! Run locally with:
+//!
+//! ```bash
+//! SNOWFLAKE_ACCOUNT=<your-account> \
+//! SNOWFLAKE_WAREHOUSE=<your-warehouse> \
+//! SNOWFLAKE_TEST_DATABASE=<your-database> \
+//! # one of:
+//! SNOWFLAKE_OAUTH_TOKEN=<your-oauth-token> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PASSWORD=<pwd> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-pem> \
+//! cargo test -p rocky-snowflake --test insert_overwrite_partition_live \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! **What this pins.** Snowflake's `/api/v2/statements` runs ONE statement per
+//! call by default — every call opens an independent session, so emitting
+//! BEGIN/DELETE/INSERT/COMMIT as four separate REST calls is silently
+//! non-transactional: each call autocommits, `BEGIN` is discarded, the
+//! `DELETE` autocommits, and the trailing `COMMIT`/`ROLLBACK` is a no-op.
+//!
+//! The dialect now returns a single semicolon-joined script, and the
+//! connector sets `MULTI_STATEMENT_COUNT` so Snowflake parses and runs all
+//! four statements as one transactional unit. This test plants a SQL-level
+//! failure between DELETE and INSERT (the INSERT projects a type-mismatched
+//! literal into a numeric column) and asserts that the partition's
+//! pre-existing rows are still present after the failure — proving the
+//! DELETE was rolled back rather than autocommitted.
+//!
+//! Schemas use the `hc_iop_*` prefix per Hugo's Databricks/Snowflake
+//! convention; the per-run microsecond suffix isolates parallel runs.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+
+fn adapter_from_env() -> Option<(SnowflakeWarehouseAdapter, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    let connector = SnowflakeConnector::new(config, auth);
+    Some((SnowflakeWarehouseAdapter::new(connector), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn create_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""
+        ))
+        .await
+        .expect("create schema");
+}
+
+async fn drop_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"
+        ))
+        .await;
+}
+
+async fn seed_fact(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str, table: &str) {
+    // Two partitions: '2026-04-07' and '2026-04-08'. The
+    // insert_overwrite_partition script targets only the '2026-04-08'
+    // partition; the other partition's rows must remain untouched
+    // regardless of test outcome.
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE \"{database}\".\"{schema}\".\"{table}\" \
+             (\"order_date\" DATE, \"qty\" NUMBER(10, 0))"
+        ))
+        .await
+        .expect("create fact table");
+    adapter
+        .execute_statement(&format!(
+            "INSERT INTO \"{database}\".\"{schema}\".\"{table}\" \
+             (\"order_date\", \"qty\") VALUES \
+             (DATE '2026-04-07', 11), \
+             (DATE '2026-04-07', 12), \
+             (DATE '2026-04-08', 21), \
+             (DATE '2026-04-08', 22), \
+             (DATE '2026-04-08', 23)"
+        ))
+        .await
+        .expect("seed rows");
+}
+
+async fn count_rows_in_partition(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+    date_literal: &str,
+) -> Option<i64> {
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT COUNT(*) AS \"n\" FROM \"{database}\".\"{schema}\".\"{table}\" \
+             WHERE \"order_date\" = DATE '{date_literal}'"
+        ))
+        .await
+        .ok()?;
+    let cell = result.rows.first()?.first()?.clone();
+    cell.as_i64()
+        .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// Verification gate for Bug 1: `insert_overwrite_partition` is transactional.
+///
+/// Builds the four-statement script via the dialect (the production code path)
+/// but substitutes the INSERT's SELECT with a SQL-level failure that fires
+/// AFTER the DELETE would have committed under the old non-transactional
+/// implementation. Asserts the pre-existing partition rows survive — proving
+/// Snowflake auto-rolled back the DELETE because the script ran in one
+/// session with `MULTI_STATEMENT_COUNT=4`.
+#[tokio::test]
+#[ignore]
+async fn live_insert_overwrite_partition_rolls_back_on_partial_failure() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("hc_iop_{suffix}");
+    let table = "fct_daily_orders";
+
+    create_schema(&adapter, &database, &schema).await;
+    seed_fact(&adapter, &database, &schema, table).await;
+
+    let target = format!("\"{database}\".\"{schema}\".\"{table}\"");
+    let partition_filter = "\"order_date\" = DATE '2026-04-08'";
+    // Deliberately bad SELECT: projects a string literal into the numeric
+    // `qty` column. Snowflake raises a type-conversion error at the INSERT
+    // statement, AFTER the script's DELETE has run. Without the
+    // MULTI_STATEMENT_COUNT fix, the DELETE would have autocommitted and the
+    // partition would be empty.
+    let bad_select = "SELECT DATE '2026-04-08' AS \"order_date\", 'not_a_number' AS \"qty\"";
+
+    let stmts = adapter
+        .dialect()
+        .insert_overwrite_partition(&target, partition_filter, bad_select)
+        .expect("dialect should build script");
+    assert_eq!(
+        stmts.len(),
+        1,
+        "Snowflake insert_overwrite_partition should emit a single \
+         semicolon-joined script (got {} stmts)",
+        stmts.len(),
+    );
+    let script = &stmts[0];
+    // Execute the script as the runner does — one REST call.
+    let exec_result = adapter.execute_statement(script).await;
+
+    // Capture state BEFORE cleanup so failed assertions still leave a
+    // clean sandbox.
+    let target_partition_count =
+        count_rows_in_partition(&adapter, &database, &schema, table, "2026-04-08").await;
+    let other_partition_count =
+        count_rows_in_partition(&adapter, &database, &schema, table, "2026-04-07").await;
+
+    drop_schema(&adapter, &database, &schema).await;
+
+    assert!(
+        exec_result.is_err(),
+        "script with malformed INSERT should fail end-to-end, got Ok"
+    );
+    assert_eq!(
+        target_partition_count,
+        Some(3),
+        "rolled-back DELETE: 2026-04-08 partition must still hold its 3 seeded rows; \
+         got {target_partition_count:?}. If this is 0, BEGIN/DELETE/INSERT/COMMIT ran \
+         as four independent sessions and the DELETE autocommitted (Bug 1 regression)."
+    );
+    assert_eq!(
+        other_partition_count,
+        Some(2),
+        "non-targeted partition 2026-04-07 must be unchanged; got {other_partition_count:?}"
+    );
+}
+
+/// Happy-path gate: a well-formed script commits all 4 statements as one
+/// transaction, replacing the target partition while leaving the other
+/// partition untouched.
+#[tokio::test]
+#[ignore]
+async fn live_insert_overwrite_partition_commits_on_success() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("hc_iop_ok_{suffix}");
+    let table = "fct_daily_orders";
+
+    create_schema(&adapter, &database, &schema).await;
+    seed_fact(&adapter, &database, &schema, table).await;
+
+    let target = format!("\"{database}\".\"{schema}\".\"{table}\"");
+    let partition_filter = "\"order_date\" = DATE '2026-04-08'";
+    // Good SELECT: emits exactly one row into the target partition.
+    let good_select = "SELECT DATE '2026-04-08' AS \"order_date\", 999 AS \"qty\"";
+
+    let stmts = adapter
+        .dialect()
+        .insert_overwrite_partition(&target, partition_filter, good_select)
+        .expect("dialect should build script");
+    let script = &stmts[0];
+    let exec_result = adapter.execute_statement(script).await;
+
+    let target_partition_count =
+        count_rows_in_partition(&adapter, &database, &schema, table, "2026-04-08").await;
+    let other_partition_count =
+        count_rows_in_partition(&adapter, &database, &schema, table, "2026-04-07").await;
+
+    drop_schema(&adapter, &database, &schema).await;
+
+    exec_result.expect("happy-path script should commit");
+    assert_eq!(
+        target_partition_count,
+        Some(1),
+        "committed INSERT replaces target partition with one new row, got {target_partition_count:?}"
+    );
+    assert_eq!(
+        other_partition_count,
+        Some(2),
+        "non-targeted partition 2026-04-07 must be unchanged; got {other_partition_count:?}"
+    );
+}


### PR DESCRIPTION
## Bug 1 — `insert_overwrite_partition` was silently non-transactional

`engine/crates/rocky-snowflake/src/dialect.rs:182-200` returned
`["BEGIN", "DELETE ...", "INSERT ...", "COMMIT"]` as four separate
statements. The runner at `engine/crates/rocky-cli/src/commands/run.rs:4405-4435`
issues each via its own `warehouse.execute_statement` REST call, and
`engine/crates/rocky-snowflake/src/connector.rs:377-384` doesn't plumb
a sessionId across submissions.

Snowflake's `/api/v2/statements` opens an independent session per call,
so:
- `BEGIN` was silently discarded
- `DELETE` autocommitted
- `COMMIT` / `ROLLBACK` were no-ops

On any failure mid-batch the partition's pre-existing rows were already
gone with no rollback path.

**Fix.** Emit a single semicolon-joined script (mirroring BigQuery's
`engine/crates/rocky-bigquery/src/dialect.rs:149-167`) and have the
connector set `MULTI_STATEMENT_COUNT` in the request's session
`parameters` so Snowflake parses + runs all four statements in one
session with proper auto-rollback on partial failure. Single-statement
calls keep an empty `parameters` map so the on-wire body is
byte-identical to today.

## Bug 2 — Stage name collisions on parallel loads

`engine/crates/rocky-snowflake/src/stage.rs:169-184` claimed
"nanos + a simple hash / random salt" in the doc-comment but only
emitted `ROCKY_LOAD_{secs}_{subsec_nanos}`. macOS resolves
`SystemTime::now().subsec_nanos()` at sub-microsecond granularity, so
two parallel `load()` calls landing in the same microsecond produced
identical stage names → cross-table contamination.

**Fix.** Suffix with `uuid::Uuid::new_v4().simple()` (32 lowercase hex
chars, alphanumeric so `StageName`'s identifier validation still
passes). 122 random bits collapse collision probability to
astronomical. Doc-comment rewritten to match reality. `uuid` added to
workspace deps (previously only a transitive).

## Tests

- New live integration tests at
  `engine/crates/rocky-snowflake/tests/insert_overwrite_partition_live.rs`,
  gated on `SNOWFLAKE_*` env vars + `#[ignore]`:
  - `live_insert_overwrite_partition_rolls_back_on_partial_failure` —
    plants a SQL-level failure between DELETE and INSERT and asserts
    the partition's seeded rows survive. Fails under the old code.
  - `live_insert_overwrite_partition_commits_on_success` — happy-path
    commit gate.
- New unit tests for `count_statements()` covering single/empty/multi
  statements, semicolons inside string literals, doubled-quote escapes,
  and single-line comments.
- New stage-name uniqueness tests across a tight serial loop (1k names)
  and an 8-thread parallel race (1.6k names) — both expect zero
  collisions.
- Existing dialect unit test rewritten from 4-statement assertion to
  single-script form.

All 144 unit tests + 23 wiremock tests pass. Both live tests pass
against a real Snowflake sandbox.