### PR TITLE
fix(dagster): atomic state writes + pipes timeout + component resolver fields + apply failure surfacing

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -69,7 +69,7 @@ from .observability import (
     optimize_metadata_for_keys,
     retention_observations,
 )
-from .resource import RockyResource
+from .resource import DEFAULT_TIMEOUT_SECONDS, Resolver, RockyResource
 from .sensor import rocky_source_sensor
 from .translator import RockyDagsterTranslator
 from .types import (
@@ -249,6 +249,27 @@ def _reject_post_state_write_hook_in_yaml(value: object) -> None:
         raise dg.DagsterInvalidConfigError(
             "post_state_write_hook cannot be set from YAML — set it programmatically "
             "on a RockyComponent subclass instead.",
+            errors=[],
+            config_value=value,
+        )
+    return None
+
+
+def _reject_resolver_callable_in_yaml(field_name: str, value: object) -> None:
+    """Mirror :func:`_reject_post_state_write_hook_in_yaml` for the three
+    per-call resolver callables forwarded to :class:`RockyResource`.
+
+    The resolvers (``shadow_suffix_fn``, ``governance_override_fn``,
+    ``idempotency_key_fn``) are arbitrary :class:`ResolverContext`
+    callables — not config-shaped values — so they cannot be expressed
+    in ``defs.yaml`` and must be set programmatically on a
+    :class:`RockyComponent` subclass.
+    """
+    if value is not None:
+        raise dg.DagsterInvalidConfigError(
+            f"{field_name} cannot be set from YAML — set it programmatically "
+            "on a RockyComponent subclass instead. See the branch_deploy module "
+            "for the canonical shadow_suffix_fn use case.",
             errors=[],
             config_value=value,
         )
@@ -438,6 +459,78 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: segment. Default ``False`` because N derived models = N CLI
     #: invocations on every code-server load.
     surface_column_lineage: bool = False
+    #: Subprocess timeout for any one ``rocky`` CLI invocation, in
+    #: seconds. Forwarded to :attr:`RockyResource.timeout_seconds` so
+    #: every ``rocky plan`` / ``rocky apply`` / ``rocky discover`` /
+    #: ``rocky compile`` invocation made by the component honours the
+    #: same wall-clock cap. Defaults to one hour, matching the
+    #: resource-level default. The Pipes apply step does **not** honour
+    #: this timeout — see :meth:`RockyResource.run_pipes` for the Pipes
+    #: timeout contract.
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    #: Optional URL for a running ``rocky serve`` instance. When set, the
+    #: resource's ``compile()`` / ``lineage()`` / ``metrics()`` calls hit
+    #: the HTTP API instead of spawning a subprocess. Forwarded to
+    #: :attr:`RockyResource.server_url`.
+    server_url: str | None = None
+    #: Optional resolver that produces a ``shadow_suffix`` per ``rocky run``
+    #: invocation. The component-backed multi-asset forwards this directly
+    #: to :attr:`RockyResource.shadow_suffix_fn`, so users following
+    #: :mod:`.branch_deploy` patterns (e.g.
+    #: :func:`branch_deploy.shadow_suffix_resolver`) get the same
+    #: branch-deploy shadowing semantics under
+    #: :class:`RockyComponent` as they do constructing a bare
+    #: :class:`RockyResource`. Set programmatically in a subclass —
+    #: callables are not YAML-resolvable, so the YAML schema for this
+    #: field accepts only ``null``.
+    shadow_suffix_fn: Annotated[
+        Resolver | None,
+        dg.Resolver(
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
+                "shadow_suffix_fn", _val
+            ),
+            model_field_type=type(None),
+            description=(
+                "Reserved — set programmatically in a subclass. Cannot be "
+                "configured from YAML; arbitrary callables are not "
+                "YAML-resolvable. See branch_deploy.shadow_suffix_resolver."
+            ),
+        ),
+    ] = None
+    #: Optional resolver for ``governance_override``. Forwarded to
+    #: :attr:`RockyResource.governance_override_fn`. Same YAML-rejection
+    #: contract as :attr:`shadow_suffix_fn`.
+    governance_override_fn: Annotated[
+        Resolver | None,
+        dg.Resolver(
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
+                "governance_override_fn", _val
+            ),
+            model_field_type=type(None),
+            description=(
+                "Reserved — set programmatically in a subclass. Cannot be "
+                "configured from YAML; arbitrary callables are not "
+                "YAML-resolvable."
+            ),
+        ),
+    ] = None
+    #: Optional resolver for ``idempotency_key``. Forwarded to
+    #: :attr:`RockyResource.idempotency_key_fn`. Same YAML-rejection
+    #: contract as :attr:`shadow_suffix_fn`.
+    idempotency_key_fn: Annotated[
+        Resolver | None,
+        dg.Resolver(
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
+                "idempotency_key_fn", _val
+            ),
+            model_field_type=type(None),
+            description=(
+                "Reserved — set programmatically in a subclass. Cannot be "
+                "configured from YAML; arbitrary callables are not "
+                "YAML-resolvable."
+            ),
+        ),
+    ] = None
     #: When ``True``, several "log and swallow" paths in :meth:`build_defs`
     #: are converted into hard failures. Use when an empty Rocky asset
     #: graph is never an acceptable outcome — better to fail the
@@ -477,6 +570,12 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     # ------------------------------------------------------------------ #
 
     def _get_rocky_resource(self) -> RockyResource:
+        # Thread every field RockyResource accepts so users adopting
+        # RockyComponent get parity with a bare RockyResource. Skipping
+        # any of these caused silent footguns — most notably users
+        # following the branch_deploy.shadow_suffix_resolver pattern who
+        # then adopted RockyComponent would lose shadowing and write to
+        # production tables on PR runs.
         return RockyResource(
             binary_path=self.binary_path,
             config_path=self.config_path,
@@ -485,6 +584,11 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             contracts_dir=self.contracts_dir,
             strict_doctor=self.strict_doctor,
             strict_doctor_checks=self.strict_doctor_checks,
+            timeout_seconds=self.timeout_seconds,
+            server_url=self.server_url,
+            shadow_suffix_fn=self.shadow_suffix_fn,
+            governance_override_fn=self.governance_override_fn,
+            idempotency_key_fn=self.idempotency_key_fn,
         )
 
     def _get_translator(self) -> RockyDagsterTranslator:

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import os
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -567,7 +568,16 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 state["dag"] = dag_payload
 
         state_path.parent.mkdir(parents=True, exist_ok=True)
-        state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        # Atomic write: serialise to a sibling ``.tmp`` file then ``os.replace``
+        # into place. A SIGKILL / OOM / disk-full event mid-``write_text``
+        # would otherwise leave the canonical state file truncated, and the
+        # next :meth:`build_defs_from_state` would fail to JSON-parse it and
+        # ship an empty graph. ``os.replace`` is atomic on POSIX and Windows
+        # provided both paths sit on the same filesystem; keeping the tmp
+        # file as a sibling under ``state_path.parent`` guarantees that.
+        tmp_path = state_path.with_suffix(state_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        os.replace(tmp_path, state_path)
 
         if self.post_state_write_hook is not None:
             try:

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -486,9 +486,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     shadow_suffix_fn: Annotated[
         Resolver | None,
         dg.Resolver(
-            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
-                "shadow_suffix_fn", _val
-            ),
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml("shadow_suffix_fn", _val),
             model_field_type=type(None),
             description=(
                 "Reserved — set programmatically in a subclass. Cannot be "
@@ -503,9 +501,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     governance_override_fn: Annotated[
         Resolver | None,
         dg.Resolver(
-            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
-                "governance_override_fn", _val
-            ),
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml("governance_override_fn", _val),
             model_field_type=type(None),
             description=(
                 "Reserved — set programmatically in a subclass. Cannot be "
@@ -520,9 +516,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     idempotency_key_fn: Annotated[
         Resolver | None,
         dg.Resolver(
-            lambda _ctx, _val: _reject_resolver_callable_in_yaml(
-                "idempotency_key_fn", _val
-            ),
+            lambda _ctx, _val: _reject_resolver_callable_in_yaml("idempotency_key_fn", _val),
             model_field_type=type(None),
             description=(
                 "Reserved — set programmatically in a subclass. Cannot be "

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -86,7 +86,15 @@ DEFAULT_HTTP_TIMEOUT_SECONDS = 30
 # Minimum Rocky binary version this dagster-rocky release is compatible with.
 # Checked lazily on first CLI invocation. If the binary is older, the resource
 # raises a ``dg.Failure`` with a clear message pointing at the install URL.
-MIN_ROCKY_VERSION = "1.0.0"
+#
+# Floor set to 1.34.0: every run-path (``run`` / ``run_streaming`` / ``run_pipes``)
+# routes through ``rocky plan`` + ``rocky apply <plan-id>`` and hard-requires a
+# content-addressed ``plan_id`` from the plan step (see ``_apply_plan`` and
+# ``run_pipes`` — both raise ``dg.Failure`` when ``plan_id is None``). Engine
+# v1.34 is the first release that content-addresses every project shape
+# (including replication-only); 1.0–1.33 binaries pass the gate then crash on
+# every run with "rocky plan did not emit a plan_id".
+MIN_ROCKY_VERSION = "1.34.0"
 
 # Number of bytes of stdout/stderr surfaced back to the operator when a Rocky
 # command returns malformed or schema-violating JSON. Enough to spot a stray

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -346,6 +346,26 @@ def _parse_run_or_apply(output: str, *, command: str) -> RunResult:
                     "plan_kind": dg.MetadataValue.text(str(payload.get("plan_kind", ""))),
                 },
             )
+        # Surface engine-reported apply failures as ``dg.Failure``. The engine
+        # may emit ``success: false`` with a parseable ``result`` payload
+        # (e.g. partial write that failed mid-way) — silently unwrapping
+        # would surface a green materialization on top of a failed apply
+        # and the operator would never see the problem in the run viewer.
+        if payload.get("success") is False:
+            inner_preview = json.dumps(inner)[:_JSON_ERROR_PREVIEW_BYTES]
+            raise dg.Failure(
+                description=(
+                    f"rocky {command} reported success=false on the apply envelope — "
+                    "the engine ran the plan but signalled the apply did not succeed. "
+                    "See metadata for the inner result payload."
+                ),
+                metadata={
+                    "command": dg.MetadataValue.text(command),
+                    "plan_id": dg.MetadataValue.text(str(payload.get("plan_id", ""))),
+                    "plan_kind": dg.MetadataValue.text(str(payload.get("plan_kind", ""))),
+                    "inner_result_preview": dg.MetadataValue.text(inner_preview),
+                },
+            )
         return _parse_rocky_json(json.dumps(inner), RunResult, command=command)
 
     # Legacy fallback path — `rocky run` shape, already a RunResult.

--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -815,6 +815,10 @@ class RockyResource(dg.ConfigurableResource):
 
     # Instance-level cache for the version check (not a Dagster config field).
     _version_checked: bool = False
+    # Instance-level cache so the Pipes-timeout warning fires exactly once
+    # per resource lifetime instead of on every materialize. Not a Dagster
+    # config field.
+    _pipes_timeout_warned: bool = False
 
     # ------------------------------------------------------------------ #
     # Per-call kwarg resolvers                                           #
@@ -1955,6 +1959,48 @@ class RockyResource(dg.ConfigurableResource):
             )
         return apply_runner(["apply", plan_id])
 
+    def _maybe_warn_pipes_timeout_ignored(
+        self, context: dg.AssetExecutionContext | dg.OpExecutionContext | None
+    ) -> None:
+        """Emit a one-time warning when ``run_pipes`` is called with a
+        non-default ``timeout_seconds``.
+
+        ``dagster.PipesSubprocessClient`` owns its subprocess and exposes
+        no public kill/cancel hook, so the resource cannot enforce a
+        watchdog around the apply step in Pipes mode. Users who tuned
+        ``timeout_seconds`` (typically to cap a known-slow warehouse)
+        would expect Pipes mode to honour it; surfacing the mismatch
+        loudly in the run log avoids the silent "hangs forever" failure
+        mode. The Dagster-side knobs to use are documented in
+        :meth:`run_pipes`.
+
+        The warning fires exactly once per resource lifetime via
+        ``_pipes_timeout_warned``. Both ``context.log`` (when an
+        execution context is supplied) and the module logger receive the
+        message so it lands in the run viewer *and* in the code-server
+        / executor compute log.
+        """
+        if self.timeout_seconds == DEFAULT_TIMEOUT_SECONDS or self._pipes_timeout_warned:
+            return
+        msg = (
+            f"RockyResource.timeout_seconds={self.timeout_seconds} is "
+            "ignored by run_pipes — dagster.PipesSubprocessClient owns "
+            "the apply subprocess and exposes no kill hook. The plan "
+            "step is still watchdog-bound, but a warehouse hang during "
+            "apply will pin the Dagster step process indefinitely. "
+            "Configure a Dagster-side run timeout for hard bounding, or "
+            "use RockyResource.run_streaming() if you need the "
+            "resource-level watchdog."
+        )
+        if context is not None and getattr(context, "log", None) is not None:
+            with contextlib.suppress(Exception):
+                context.log.warning(msg)
+        _log.warning(msg)
+        # ``ConfigurableResource`` is pydantic-immutable at runtime so
+        # we set via ``object.__setattr__`` — same pattern as the
+        # adjacent ``_version_checked`` flag.
+        object.__setattr__(self, "_pipes_timeout_warned", True)
+
     def run_pipes(
         self,
         context: dg.AssetExecutionContext | dg.OpExecutionContext,
@@ -2011,6 +2057,22 @@ class RockyResource(dg.ConfigurableResource):
         ``.get_results()`` to extract the materialization events
         Dagster constructed from the Pipes messages.
 
+        **Timeout contract.** ``timeout_seconds`` does **not** apply to
+        the apply step in Pipes mode. The plan step still routes through
+        :meth:`_run_rocky` and is watchdog-bound; the apply step is
+        delegated to :class:`dagster.PipesSubprocessClient`, which owns
+        the subprocess internally and exposes no kill / cancel hook. A
+        warehouse hang during the apply step will therefore pin the
+        Dagster step process indefinitely. Configure a Dagster-side run
+        timeout (``dagster.RunRetryPolicy`` or executor-level
+        ``run_timeout``) for hard bounding. The resource emits a
+        one-time warning via the module logger on the first
+        ``run_pipes`` call when ``timeout_seconds`` is non-default, so
+        operators see the mismatch in the run log. Use
+        :meth:`run_streaming` if you need the resource-level watchdog
+        and don't strictly need Pipes-native ``MaterializationEvent``
+        emission.
+
         Args:
             context: Dagster execution context. Same as
                 :meth:`run_streaming` — required for Pipes context
@@ -2051,6 +2113,7 @@ class RockyResource(dg.ConfigurableResource):
                 propagates a Failure when the subprocess crashes
                 without sending a Pipes ``closed`` message.
         """
+        self._maybe_warn_pipes_timeout_ignored(context)
         resolved = self._apply_resolvers(
             context=context,
             method="run_pipes",

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -534,6 +535,84 @@ def test_write_state_creates_parent_dir(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     component.write_state_to_path(state_path)
     assert state_path.exists()
+
+
+def test_write_state_is_atomic_on_failed_replace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """``write_state_to_path`` must not leave a half-written canonical
+    state file behind. The implementation serialises into a sibling
+    ``.tmp`` and then ``os.replace``-s it into place.
+
+    Simulates a crash mid-replace: when ``os.replace`` raises, the
+    canonical state file at the original path is untouched. Without the
+    atomic-write pattern, a SIGKILL during the in-place ``write_text``
+    would truncate the canonical file and break the next
+    ``build_defs_from_state`` load.
+    """
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"existing": "content"}', encoding="utf-8")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated rename crash")
+
+    monkeypatch.setattr("dagster_rocky.component.os.replace", _boom)
+
+    with pytest.raises(OSError, match="simulated rename crash"):
+        component.write_state_to_path(state_path)
+
+    # Canonical state file unchanged — atomicity preserved the prior payload.
+    assert state_path.read_text(encoding="utf-8") == '{"existing": "content"}'
+
+
+def test_write_state_writes_to_tmp_then_replaces(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Verify the tmp + os.replace sequence: the temp file is created
+    as a sibling of the state file before being moved into place.
+
+    Pins the implementation contract relied on by
+    ``test_write_state_is_atomic_on_failed_replace`` — without the tmp
+    sibling lying on the same filesystem, ``os.replace`` would not be
+    atomic on POSIX or Windows.
+    """
+    discover = _make_discover_result()
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state.json"
+
+    captured: dict[str, Path] = {}
+    real_replace = os.replace
+
+    def _tracking_replace(src: str | Path, dst: str | Path) -> None:
+        captured["src"] = Path(src)
+        captured["dst"] = Path(dst)
+        real_replace(src, dst)
+
+    monkeypatch.setattr("dagster_rocky.component.os.replace", _tracking_replace)
+    component.write_state_to_path(state_path)
+
+    assert captured["dst"] == state_path
+    assert captured["src"].parent == state_path.parent
+    assert captured["src"].name.endswith(".tmp")
+    assert state_path.exists()
+    # tmp file moved out — should not still exist.
+    assert not captured["src"].exists()
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -1185,6 +1185,68 @@ def test_rocky_component_python_kwarg_post_state_write_hook_preserved(tmp_path: 
     assert calls == [tmp_path]
 
 
+def test_get_rocky_resource_threads_all_fields():
+    """``_get_rocky_resource`` must forward every field ``RockyResource``
+    accepts. Previously the component dropped ``shadow_suffix_fn``,
+    ``governance_override_fn``, ``idempotency_key_fn``, ``timeout_seconds``,
+    and ``server_url`` — users following the branch_deploy docstring
+    silently lost shadowing under :class:`RockyComponent` and PR runs
+    wrote to production tables.
+    """
+
+    def _suffix(_ctx: Any) -> str:
+        return "shadow_x"
+
+    def _override(_ctx: Any) -> dict:
+        return {"workspace_ids": ["ws-1"]}
+
+    def _idemp(_ctx: Any) -> str:
+        return "key-123"
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        timeout_seconds=42,
+        server_url="https://rocky.example/",
+        shadow_suffix_fn=_suffix,
+        governance_override_fn=_override,
+        idempotency_key_fn=_idemp,
+    )
+
+    resource = component._get_rocky_resource()
+
+    # Config-shaped fields propagate by value.
+    assert resource.timeout_seconds == 42
+    assert resource.server_url == "https://rocky.example/"
+    # Callables propagate by identity.
+    assert resource.shadow_suffix_fn is _suffix
+    assert resource.governance_override_fn is _override
+    assert resource.idempotency_key_fn is _idemp
+
+
+def test_rocky_component_yaml_rejects_resolver_callable_values():
+    """The three resolver callable fields share the post_state_write_hook
+    contract: setting them in YAML raises rather than silently dropping."""
+    from dagster.components.resolved.errors import ResolutionException
+
+    for field_name in ("shadow_suffix_fn", "governance_override_fn", "idempotency_key_fn"):
+        with pytest.raises(ResolutionException):
+            RockyComponent.resolve_from_yaml(
+                f"config_path: rocky.toml\n{field_name}: some_value\n"
+            )
+
+
+def test_rocky_component_yaml_resolves_with_default_resource_fields(tmp_path: Path):
+    """YAML payloads that omit the new fields resolve cleanly to defaults."""
+    yaml_payload = "config_path: rocky.toml\nbinary_path: rocky\n"
+    component = RockyComponent.resolve_from_yaml(yaml_payload)
+    assert component.shadow_suffix_fn is None
+    assert component.governance_override_fn is None
+    assert component.idempotency_key_fn is None
+    assert component.server_url is None
+    # Default mirrors RockyResource — one hour.
+    assert component.timeout_seconds == 3600
+
+
 def test_build_defs_survives_duplicate_table_records(tmp_path: Path, caplog):
     """Defensive: a duplicate ``(asset_key, name)`` from ``rocky discover``
     must not bring down the whole asset graph.

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -537,9 +537,7 @@ def test_write_state_creates_parent_dir(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert state_path.exists()
 
 
-def test_write_state_is_atomic_on_failed_replace(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+def test_write_state_is_atomic_on_failed_replace(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """``write_state_to_path`` must not leave a half-written canonical
     state file behind. The implementation serialises into a sibling
     ``.tmp`` and then ``os.replace``-s it into place.
@@ -574,9 +572,7 @@ def test_write_state_is_atomic_on_failed_replace(
     assert state_path.read_text(encoding="utf-8") == '{"existing": "content"}'
 
 
-def test_write_state_writes_to_tmp_then_replaces(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
+def test_write_state_writes_to_tmp_then_replaces(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Verify the tmp + os.replace sequence: the temp file is created
     as a sibling of the state file before being moved into place.
 
@@ -1230,9 +1226,7 @@ def test_rocky_component_yaml_rejects_resolver_callable_values():
 
     for field_name in ("shadow_suffix_fn", "governance_override_fn", "idempotency_key_fn"):
         with pytest.raises(ResolutionException):
-            RockyComponent.resolve_from_yaml(
-                f"config_path: rocky.toml\n{field_name}: some_value\n"
-            )
+            RockyComponent.resolve_from_yaml(f"config_path: rocky.toml\n{field_name}: some_value\n")
 
 
 def test_rocky_component_yaml_resolves_with_default_resource_fields(tmp_path: Path):

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -2041,8 +2041,9 @@ def test_verify_version_caches_result():
 
 
 def test_verify_version_semver_comparison_logic():
-    """Test that tuple comparison works correctly for semver:
-    (1, 0, 0) >= (1, 0, 0), (0, 99, 99) < (1, 0, 0), etc."""
+    """Test that tuple comparison works correctly against the live
+    ``MIN_ROCKY_VERSION`` floor — equality passes, anything strictly
+    below fails, anything strictly above passes."""
     rocky = RockyResource()
 
     # Equal to minimum — should pass
@@ -2053,22 +2054,26 @@ def test_verify_version_semver_comparison_logic():
     object.__setattr__(rocky, "_version_checked", False)
 
     # Major version ahead — should pass
-    with _patched_run(return_value=_version_completed("rocky 2.0.0")):
+    with _patched_run(return_value=_version_completed("rocky 99.0.0")):
         rocky._verify_engine_version()
 
     # Reset for next check
     object.__setattr__(rocky, "_version_checked", False)
 
-    # Minor version ahead, same major — should pass
-    with _patched_run(return_value=_version_completed("rocky 1.1.0")):
+    # One patch above the floor (same major+minor) — should pass.
+    min_major, min_minor, min_patch = (int(p) for p in MIN_ROCKY_VERSION.split("."))
+    above = f"{min_major}.{min_minor}.{min_patch + 1}"
+    with _patched_run(return_value=_version_completed(f"rocky {above}")):
         rocky._verify_engine_version()
 
     # Reset for next check
     object.__setattr__(rocky, "_version_checked", False)
 
-    # Below minimum — should fail
+    # Below minimum — should fail. ``1.0.0`` is the pre-Cluster 3 B
+    # release line that triggered this floor bump (no content-addressed
+    # plan_id support), so it's the canonical "too old" case.
     with (
-        _patched_run(return_value=_version_completed("rocky 0.99.99")),
+        _patched_run(return_value=_version_completed("rocky 1.0.0")),
         pytest.raises(dg.Failure, match="below the minimum"),
     ):
         rocky._verify_engine_version()

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1793,6 +1793,90 @@ def test_run_pipes_raises_when_engine_returns_null_plan_id():
     assert "plan_id" in str(exc.value)
 
 
+def test_run_pipes_warns_when_timeout_seconds_is_non_default(caplog):
+    """``timeout_seconds`` does not bound the apply step in Pipes mode
+    (``PipesSubprocessClient`` owns the subprocess and exposes no kill
+    hook). Surface that loudly as a one-time warning so operators see
+    the mismatch in the run log instead of silently relying on a
+    timeout that will never fire.
+    """
+    import logging
+
+    rocky = RockyResource(timeout_seconds=60)  # any non-default value
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+
+    with (
+        caplog.at_level(logging.WARNING, logger="dagster_rocky.resource"),
+        _patch_pipes_plan_step(),
+    ):
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+
+    # Module logger emits the warning.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("timeout_seconds=60" in r.message for r in warnings)
+    assert any("ignored by run_pipes" in r.message for r in warnings)
+    # Context logger also receives it so it lands in the run viewer.
+    context.log.warning.assert_called_once()
+    assert "ignored by run_pipes" in context.log.warning.call_args.args[0]
+
+
+def test_run_pipes_warning_fires_once_per_resource_lifetime(caplog):
+    """Pin the de-duplication contract — repeated ``run_pipes`` calls on
+    the same resource only emit the warning once, otherwise long-lived
+    Dagster code servers would flood their logs."""
+    import logging
+
+    rocky = RockyResource(timeout_seconds=120)
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+
+    with (
+        caplog.at_level(logging.WARNING, logger="dagster_rocky.resource"),
+        _patch_pipes_plan_step(),
+    ):
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "ignored by run_pipes" in r.message
+    ]
+    assert len(warnings) == 1
+
+
+def test_run_pipes_does_not_warn_with_default_timeout(caplog):
+    """The warning fires only when ``timeout_seconds`` was actively
+    customised. Default-config users see no log noise."""
+    import logging
+
+    rocky = RockyResource()  # default timeout_seconds
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    fake_client = MagicMock(spec=dg.PipesSubprocessClient)
+    fake_client.run = MagicMock(return_value=MagicMock())
+
+    with (
+        caplog.at_level(logging.WARNING, logger="dagster_rocky.resource"),
+        _patch_pipes_plan_step(),
+    ):
+        rocky.run_pipes(context, filter="tenant=acme", pipes_client=fake_client)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "ignored by run_pipes" in r.message
+    ]
+    assert warnings == []
+    context.log.warning.assert_not_called()
+
+
 def test_extract_plan_id_returns_none_for_malformed_payload():
     """``_extract_plan_id`` is the gate keeping malformed plan output
     from sending the apply step into a broken state. Treat any

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1800,8 +1800,6 @@ def test_run_pipes_warns_when_timeout_seconds_is_non_default(caplog):
     the mismatch in the run log instead of silently relying on a
     timeout that will never fire.
     """
-    import logging
-
     rocky = RockyResource(timeout_seconds=60)  # any non-default value
     context = MagicMock(spec=dg.AssetExecutionContext)
     context.log = MagicMock()
@@ -1827,8 +1825,6 @@ def test_run_pipes_warning_fires_once_per_resource_lifetime(caplog):
     """Pin the de-duplication contract — repeated ``run_pipes`` calls on
     the same resource only emit the warning once, otherwise long-lived
     Dagster code servers would flood their logs."""
-    import logging
-
     rocky = RockyResource(timeout_seconds=120)
     context = MagicMock(spec=dg.AssetExecutionContext)
     context.log = MagicMock()
@@ -1854,8 +1850,6 @@ def test_run_pipes_warning_fires_once_per_resource_lifetime(caplog):
 def test_run_pipes_does_not_warn_with_default_timeout(caplog):
     """The warning fires only when ``timeout_seconds`` was actively
     customised. Default-config users see no log noise."""
-    import logging
-
     rocky = RockyResource()  # default timeout_seconds
     context = MagicMock(spec=dg.AssetExecutionContext)
     context.log = MagicMock()

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -27,6 +27,7 @@ from dagster_rocky.resource import (
     DEFAULT_HTTP_TIMEOUT_SECONDS,
     MIN_ROCKY_VERSION,
     RockyResource,
+    _parse_run_or_apply,
     _redact_argv,
     _truncate_stderr_for_metadata,
     _validate_governance_override,
@@ -1593,6 +1594,51 @@ def test_metrics_uses_http_when_server_url_is_set():
 # ---------------------------------------------------------------------------
 # Phase 5 plan/apply orchestration
 # ---------------------------------------------------------------------------
+
+
+def test_parse_run_or_apply_raises_on_success_false_envelope():
+    """Engine emits ``success: false`` with a parseable ``result`` even
+    when the apply did not actually succeed. Silently unwrapping the
+    inner ``RunResult`` would surface a green materialization on top of
+    a failed apply, so ``_parse_run_or_apply`` must raise ``dg.Failure``
+    in that case.
+    """
+    inner = json.loads(_run_json())
+    envelope = json.dumps(
+        {
+            "version": "0.3.0",
+            "command": "apply",
+            "plan_id": "b" * 64,
+            "plan_kind": "run",
+            "success": False,
+            "result": inner,
+        }
+    )
+
+    with pytest.raises(dg.Failure) as excinfo:
+        _parse_run_or_apply(envelope, command="run")
+
+    desc = excinfo.value.description or ""
+    assert "success=false" in desc
+    metadata = excinfo.value.metadata or {}
+    assert metadata["plan_id"].text == "b" * 64
+    assert metadata["plan_kind"].text == "run"
+    # The inner payload preview is surfaced so operators can triage the
+    # underlying engine result without grepping the run viewer log.
+    assert "inner_result_preview" in metadata
+
+
+def test_parse_run_or_apply_unwraps_on_success_true_envelope():
+    """Pin the happy path: ``success: true`` envelopes still unwrap to
+    the inner ``RunResult`` exactly as before. Regression guard for the
+    new ``success=false`` branch."""
+    inner = json.loads(_run_json())
+    envelope = _apply_envelope_json(inner=inner)
+
+    result = _parse_run_or_apply(envelope, command="run")
+
+    assert result.command == "run"
+    assert result.tables_copied == 1
 
 
 def test_run_dispatches_plan_then_apply_when_plan_id_persisted():


### PR DESCRIPTION
## Summary

Five correctness bugs in the Dagster integration, each in its own commit for clean review.

### Bug 1 — Non-atomic state-file write (`component.py`)

`write_state_to_path` called `state_path.write_text(...)` in-place. A SIGKILL / OOM / disk-full event mid-write would leave the canonical state file truncated; the next `build_defs_from_state` load would fail to JSON-parse it and ship an empty Rocky asset graph.

**Fix:** serialise to a sibling `.tmp` then `os.replace` into place — atomic on POSIX and Windows since both paths sit on the same filesystem.

### Bug 2 — `run_pipes` apply step ignores `timeout_seconds` (`resource.py`)

`dagster.PipesSubprocessClient` owns its subprocess internally and exposes no public kill/cancel hook, so the resource cannot enforce a watchdog around the apply step in Pipes mode. Wrapping the synchronous call in an out-of-process watchdog can't kill the underlying rocky subprocess (it would leak on "timeout" while the Dagster step still hangs on the closed Pipes channel — strictly worse than today).

**Fix:** docstring update on `run_pipes` documenting the caveat and pointing at Dagster-side run-timeout knobs, plus a one-time warning on the first `run_pipes` call when `timeout_seconds` is non-default. The warning lands in both the module logger and `context.log` so it shows up in the run viewer.

### Bug 3 — `RockyComponent._get_rocky_resource` drops 5 fields (`component.py`)

The component constructed `RockyResource` with only 7 of the 12 documented fields. The missing five were `shadow_suffix_fn`, `governance_override_fn`, `idempotency_key_fn`, `timeout_seconds`, and `server_url`. Most serious gap: users following the `branch_deploy` docstring then adopting `RockyComponent` silently lost branch-deploy shadowing — PR runs wrote to production tables.

**Fix:** add all five fields to `RockyComponent`. Config-shaped (`timeout_seconds`, `server_url`) as plain pydantic attributes; the three resolver callables reuse the `post_state_write_hook` pattern (`dg.Resolver` with a rejecting closure) since arbitrary callables are not YAML-resolvable. `_get_rocky_resource` threads all five through.

### Bug 4 — `ApplyOutput.success=false` silently discarded (`resource.py`)

`_parse_run_or_apply` unwrapped the inner `result` from an apply envelope regardless of the envelope's `success` field. Engine emits `success: false` even when inner `result` is parseable; operators saw green materializations on top of failed applies.

**Fix:** when the envelope reports `success is False`, raise `dg.Failure` carrying the plan_id, plan_kind, and a preview of the inner result payload as metadata.

### Bug 5 — Engine version floor was stale (`resource.py`)

`MIN_ROCKY_VERSION = "1.0.0"`, but the run / run_streaming / run_pipes paths all route through `rocky plan` + `rocky apply <plan-id>` and hard-require a content-addressed `plan_id` from the plan step. Engine v1.34 is the first release that content-addresses every project shape. Binaries 1.0–1.33 passed the gate then crashed on every run with "rocky plan did not emit a plan_id".

**Fix:** bump floor to `1.34.0` matching the implementation's actual requirement (and the existing error message in `run_pipes`).

## Test plan

- [x] `uv run pytest tests/test_resource.py tests/test_component.py tests/test_branch_deploy.py` — 193 passed
- [x] `uv run pytest` (full suite) — 559 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] New tests pinning each bug fix:
  - `test_write_state_is_atomic_on_failed_replace` / `test_write_state_writes_to_tmp_then_replaces`
  - `test_run_pipes_warns_when_timeout_seconds_is_non_default` / `..._fires_once_per_resource_lifetime` / `..._does_not_warn_with_default_timeout`
  - `test_get_rocky_resource_threads_all_fields` / `test_rocky_component_yaml_rejects_resolver_callable_values` / `test_rocky_component_yaml_resolves_with_default_resource_fields`
  - `test_parse_run_or_apply_raises_on_success_false_envelope` / `..._unwraps_on_success_true_envelope`
  - Existing `test_verify_version_semver_comparison_logic` updated to use 1.0.0 as the canonical "too old" case