### PR TITLE
fix(engine): SCD2 NULL-distinct + Databricks atomic partial-apply diff

### DIFF
--- a/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/bigquery.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/bigquery.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `tgtwarehouse`.`snapshots__demo`.`dim_customers_histo
 
 -- --- next statement ---
 
-MERGE INTO `tgtwarehouse`.`snapshots__demo`.`dim_customers_history` AS target USING `tgtwarehouse`.`marts__demo`.`dim_customers` AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at != target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
+MERGE INTO `tgtwarehouse`.`snapshots__demo`.`dim_customers_history` AS target USING `tgtwarehouse`.`marts__demo`.`dim_customers` AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at IS DISTINCT FROM target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
 ;
 
 -- --- next statement ---

--- a/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/databricks.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/databricks.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS tgtwarehouse.snapshots__demo.dim_customers_history AS
 
 -- --- next statement ---
 
-MERGE INTO tgtwarehouse.snapshots__demo.dim_customers_history AS target USING tgtwarehouse.marts__demo.dim_customers AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at != target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
+MERGE INTO tgtwarehouse.snapshots__demo.dim_customers_history AS target USING tgtwarehouse.marts__demo.dim_customers AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at IS DISTINCT FROM target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
 ;
 
 -- --- next statement ---

--- a/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/duckdb.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/duckdb.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS tgtwarehouse.snapshots__demo.dim_customers_history AS
 
 -- --- next statement ---
 
-MERGE INTO tgtwarehouse.snapshots__demo.dim_customers_history AS target USING tgtwarehouse.marts__demo.dim_customers AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at != target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
+MERGE INTO tgtwarehouse.snapshots__demo.dim_customers_history AS target USING tgtwarehouse.marts__demo.dim_customers AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at IS DISTINCT FROM target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
 ;
 
 -- --- next statement ---

--- a/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/snowflake.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/12-snapshot-scd2/snowflake.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS "tgtwarehouse"."snapshots__demo"."dim_customers_histo
 
 -- --- next statement ---
 
-MERGE INTO "tgtwarehouse"."snapshots__demo"."dim_customers_history" AS target USING "tgtwarehouse"."marts__demo"."dim_customers" AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at != target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
+MERGE INTO "tgtwarehouse"."snapshots__demo"."dim_customers_history" AS target USING "tgtwarehouse"."marts__demo"."dim_customers" AS source ON target.customer_id = source.customer_id AND target.valid_to IS NULL WHEN MATCHED AND source.updated_at IS DISTINCT FROM target.updated_at THEN UPDATE SET valid_to = CURRENT_TIMESTAMP WHEN NOT MATCHED THEN INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)
 ;
 
 -- --- next statement ---

--- a/engine/crates/rocky-core/src/snapshots.rs
+++ b/engine/crates/rocky-core/src/snapshots.rs
@@ -212,13 +212,22 @@ pub fn generate_snapshot_sql(
     let join_cond = build_join_condition(&config.unique_key, "target", "source");
 
     // Build the change-detection predicate for WHEN MATCHED.
+    //
+    // Both strategies must be NULL-safe: bare SQL `!=` returns NULL on
+    // either side being NULL, which evaluates as false and silently drops
+    // rows that transition NULL ↔ value on the tracked column(s). The
+    // Check strategy already used `IS DISTINCT FROM` directly; the
+    // Timestamp strategy used bare `!=` and was buggy. Routing both
+    // through the dialect's `null_safe_neq` keeps the two branches
+    // consistent and lets non-ANSI dialects (e.g. MySQL) override.
     let change_predicate = match &config.strategy {
-        SnapshotStrategy::Timestamp { updated_at } => {
-            format!("source.{updated_at} != target.{updated_at}")
-        }
+        SnapshotStrategy::Timestamp { updated_at } => dialect.null_safe_neq(
+            &format!("source.{updated_at}"),
+            &format!("target.{updated_at}"),
+        ),
         SnapshotStrategy::Check { check_columns } => check_columns
             .iter()
-            .map(|c| format!("source.{c} IS DISTINCT FROM target.{c}"))
+            .map(|c| dialect.null_safe_neq(&format!("source.{c}"), &format!("target.{c}")))
             .collect::<Vec<_>>()
             .join(" OR "),
     };
@@ -607,8 +616,14 @@ mod tests {
             "should only match current rows: {merge}"
         );
         assert!(
-            merge.contains("source.updated_at != target.updated_at"),
-            "timestamp strategy should compare updated_at: {merge}"
+            merge.contains("source.updated_at IS DISTINCT FROM target.updated_at"),
+            "timestamp strategy should compare updated_at via NULL-safe \
+             IS DISTINCT FROM (bare `!=` silently drops NULL↔value \
+             transitions): {merge}"
+        );
+        assert!(
+            !merge.contains("source.updated_at != target.updated_at"),
+            "bare SQL `!=` is NULL-unsafe and must not appear: {merge}"
         );
         assert!(
             merge.contains("valid_to = CURRENT_TIMESTAMP"),

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -890,12 +890,20 @@ pub fn generate_snapshot_sql(
     );
     stmts.push(bootstrap);
 
-    // Statement 2: Close changed rows (set valid_to) and insert new versions
+    // Statement 2: Close changed rows (set valid_to) and insert new versions.
+    // Change detection uses the dialect's NULL-safe inequality so rows
+    // transitioning NULL ↔ value on the watermark column are still
+    // captured — bare SQL `!=` returns NULL on either side being NULL,
+    // which evaluates as false and silently drops the row.
+    let change_predicate = dialect.null_safe_neq(
+        &format!("source.{updated_at}"),
+        &format!("target.{updated_at}"),
+    );
     let merge = format!(
         "MERGE INTO {target} AS target \
          USING {source} AS source \
          ON {join_cond} AND target.valid_to IS NULL \
-         WHEN MATCHED AND source.{updated_at} != target.{updated_at} THEN \
+         WHEN MATCHED AND {change_predicate} THEN \
            UPDATE SET valid_to = CURRENT_TIMESTAMP \
          WHEN NOT MATCHED THEN \
            INSERT (*) VALUES (source.*, CURRENT_TIMESTAMP, NULL)",
@@ -2254,6 +2262,66 @@ SELECT id, name, email FROM cat.sch.src WHERE active = true";
         assert!(
             msg.contains("found transformation"),
             "error should name the actual variant via `variant()`, got: {msg}"
+        );
+    }
+
+    /// Build a snapshot-variant ModelIr. Inline (rather than reusing
+    /// rocky-ir's test-only `sample_snapshot_model`) because the fixture
+    /// lives behind `#[cfg(test)]` in another crate.
+    fn sample_snapshot_ir() -> ModelIr {
+        use std::sync::Arc;
+        ModelIr {
+            name: Arc::from("dim_users_history"),
+            sql: String::new(),
+            typed_columns: vec![],
+            lineage_edges: vec![],
+            materialization: MaterializationStrategy::FullRefresh,
+            governance: GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            target: TargetRef {
+                catalog: "cat".into(),
+                schema: "snapshots".into(),
+                table: "dim_users_history".into(),
+            },
+            column_masks: vec![],
+            source: Some(SourceRef {
+                catalog: "cat".into(),
+                schema: "marts".into(),
+                table: "dim_users".into(),
+            }),
+            sources: vec![],
+            columns: None,
+            metadata_columns: vec![],
+            unique_key: vec![Arc::from("user_id")],
+            updated_at: Some("updated_at".into()),
+            invalidate_hard_deletes: false,
+            format: None,
+            format_options: None,
+            cost_ceiling: None,
+        }
+    }
+
+    /// SCD2 MERGE must use the dialect's NULL-safe inequality on the
+    /// `updated_at` column, not bare SQL `!=`. Bare `!=` returns NULL
+    /// when either side is NULL, evaluates as false, and silently drops
+    /// rows that transition NULL ↔ value on the watermark column.
+    #[test]
+    fn snapshot_merge_uses_null_safe_neq_on_updated_at() {
+        let ir = sample_snapshot_ir();
+        let stmts = generate_snapshot_sql(&ir, &dialect()).expect("snapshot SQL gen");
+
+        // The MERGE is the second statement (after the bootstrap CREATE).
+        let merge = &stmts[1];
+        assert!(
+            merge.contains("source.updated_at IS DISTINCT FROM target.updated_at"),
+            "MERGE must use IS DISTINCT FROM for NULL-safe change detection, got: {merge}"
+        );
+        assert!(
+            !merge.contains("source.updated_at != target.updated_at"),
+            "bare SQL `!=` is NULL-unsafe and must not appear in MERGE, got: {merge}"
         );
     }
 }

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -868,6 +868,25 @@ pub trait SqlDialect: Send + Sync {
         "CURRENT_TIMESTAMP"
     }
 
+    /// Build a NULL-safe inequality predicate: `lhs` differs from `rhs`,
+    /// treating two NULLs as equal and a single NULL as a real difference.
+    /// Used by SCD2 change detection on the watermark / check columns —
+    /// bare SQL `!=` returns NULL when either side is NULL, which silently
+    /// drops rows that transition NULL ↔ value.
+    ///
+    /// Default: `<lhs> IS DISTINCT FROM <rhs>` — supported by Snowflake,
+    /// Databricks (Spark SQL), DuckDB, Trino, and BigQuery. Dialects
+    /// without `IS DISTINCT FROM` must override (e.g. MySQL would emit
+    /// `NOT (<lhs> <=> <rhs>)`).
+    ///
+    /// Callers are responsible for SQL-validating any identifiers they
+    /// interpolate into `lhs` / `rhs` — this method does no validation of
+    /// its arguments and treats them as already-trusted SQL fragments
+    /// (table-qualified column references in the SCD2 callers).
+    fn null_safe_neq(&self, lhs: &str, rhs: &str) -> String {
+        format!("{lhs} IS DISTINCT FROM {rhs}")
+    }
+
     /// Quote a column / table identifier for safe interpolation into
     /// generated SQL. The caller has already validated `name` against
     /// the SQL-identifier allowlist; this method picks the dialect's

--- a/engine/crates/rocky-databricks/src/governance.rs
+++ b/engine/crates/rocky-databricks/src/governance.rs
@@ -124,7 +124,16 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
             grants_to_add: grants.to_vec(),
             grants_to_revoke: vec![],
         };
-        perm_mgr.apply_diff(&diff).await.map_err(AdapterError::new)
+        // `apply_diff` no longer aborts on the first failed statement —
+        // it collects per-grant errors so this batch entry point still
+        // surfaces them as a single `AdapterError` while preserving the
+        // partial-apply visibility for diagnostic logs.
+        perm_mgr
+            .apply_diff(&diff)
+            .await
+            .map_err(AdapterError::new)?
+            .into_result()
+            .map_err(AdapterError::new)
     }
 
     async fn revoke_grants(&self, grants: &[Grant]) -> AdapterResult<()> {
@@ -133,7 +142,12 @@ impl GovernanceAdapter for DatabricksGovernanceAdapter {
             grants_to_add: vec![],
             grants_to_revoke: grants.to_vec(),
         };
-        perm_mgr.apply_diff(&diff).await.map_err(AdapterError::new)
+        perm_mgr
+            .apply_diff(&diff)
+            .await
+            .map_err(AdapterError::new)?
+            .into_result()
+            .map_err(AdapterError::new)
     }
 
     async fn bind_workspace(

--- a/engine/crates/rocky-databricks/src/permissions.rs
+++ b/engine/crates/rocky-databricks/src/permissions.rs
@@ -82,13 +82,16 @@ impl WorkspaceBindingDiff {
 /// workspace bindings. `rocky plan` / `rocky run` group these deltas
 /// together because both flow from the same governance block.
 ///
-/// `applied` reports which grant changes actually landed and which
-/// failed mid-batch — added so callers can surface partial-apply
-/// outcomes without losing visibility into the underlying diff.
+/// `apply_diff` reports per-grant outcomes via [`AppliedPermissionDiff`]
+/// (and surfaces failures as [`PermissionError::PartialApply`]) — those
+/// outcomes are collapsed into a single error at the `reconcile` boundary
+/// so `AccessDiff` only carries the desired-vs-current delta. If a future
+/// caller wants the structured outcome, expose `applied` here and have
+/// `reconcile_with_bindings` thread it through instead of calling
+/// [`AppliedPermissionDiff::into_result`].
 #[derive(Debug, Clone, Default)]
 pub struct AccessDiff {
     pub permissions: PermissionDiff,
-    pub applied: AppliedPermissionDiff,
     pub bindings: WorkspaceBindingDiff,
 }
 
@@ -310,14 +313,19 @@ impl<'a> PermissionManager<'a> {
 
     /// Full reconciliation: get current grants, compute diff, apply.
     ///
-    /// Returns the desired-vs-current [`PermissionDiff`] together with
-    /// the [`AppliedPermissionDiff`] outcome so callers can tell which
-    /// changes landed and which need a retry on the next run.
+    /// Returns the desired-vs-current [`PermissionDiff`]. Per-grant
+    /// warehouse failures are collapsed into
+    /// [`PermissionError::PartialApply`] via [`apply_diff`]'s structured
+    /// outcome; this surfaces the failure to the caller without leaking
+    /// the catalog into a half-applied state silently. If a future caller
+    /// needs the structured `AppliedPermissionDiff` outcome (e.g. to
+    /// thread `granted`/`revoked`/`failed` into a run summary), call
+    /// [`apply_diff`] directly instead of `reconcile`.
     pub async fn reconcile(
         &self,
         desired: &[Grant],
         target: &GrantTarget,
-    ) -> Result<(PermissionDiff, AppliedPermissionDiff), PermissionError> {
+    ) -> Result<PermissionDiff, PermissionError> {
         let current = match target {
             GrantTarget::Catalog(cat) => self.get_catalog_grants(cat).await?,
             GrantTarget::Schema { catalog, schema } => {
@@ -326,8 +334,13 @@ impl<'a> PermissionManager<'a> {
         };
 
         let diff = Self::compute_diff(desired, &current);
-        let applied = self.apply_diff(&diff).await?;
-        Ok((diff, applied))
+        // Collapse the structured `AppliedPermissionDiff` into a flat
+        // `Result<(), _>`: per-grant failures surface as
+        // `PermissionError::PartialApply` so the caller can't silently
+        // ignore them. The desired-vs-current `diff` is still returned
+        // for the `AccessDiff` summary.
+        self.apply_diff(&diff).await?.into_result()?;
+        Ok(diff)
     }
 
     /// Computes the binding diff between desired and current workspace bindings.
@@ -428,7 +441,7 @@ impl<'a> PermissionManager<'a> {
         ws_mgr: Option<&WorkspaceManager>,
         desired_bindings: &[WorkspaceBindingDesired],
     ) -> Result<AccessDiff, PermissionError> {
-        let (permissions, applied) = self.reconcile(desired_grants, target).await?;
+        let permissions = self.reconcile(desired_grants, target).await?;
 
         let bindings = match (ws_mgr, target) {
             (Some(mgr), GrantTarget::Catalog(catalog)) => {
@@ -452,7 +465,6 @@ impl<'a> PermissionManager<'a> {
 
         Ok(AccessDiff {
             permissions,
-            applied,
             bindings,
         })
     }

--- a/engine/crates/rocky-databricks/src/permissions.rs
+++ b/engine/crates/rocky-databricks/src/permissions.rs
@@ -159,7 +159,10 @@ impl AppliedPermissionDiff {
             .take(3)
             .map(|f| {
                 let verb = if f.adding { "GRANT" } else { "REVOKE" };
-                format!("{verb} {} to {}: {}", f.grant.permission, f.grant.principal, f.error)
+                format!(
+                    "{verb} {} to {}: {}",
+                    f.grant.permission, f.grant.principal, f.error
+                )
             })
             .collect::<Vec<_>>()
             .join("; ");

--- a/engine/crates/rocky-databricks/src/permissions.rs
+++ b/engine/crates/rocky-databricks/src/permissions.rs
@@ -26,6 +26,18 @@ pub enum PermissionError {
 
     #[error("workspace binding error: {0}")]
     Workspace(#[from] WorkspaceError),
+
+    /// One or more GRANT/REVOKE statements failed mid-batch. Surfaces
+    /// from [`PermissionManager::apply_diff`] at call sites that want a
+    /// `Result<(), _>`-shaped error instead of inspecting the full
+    /// [`AppliedPermissionDiff`]. Carries a count + the per-grant error
+    /// list so the failure is greppable in logs.
+    #[error("{n_failed} grant statement(s) failed: {summary}")]
+    PartialApply {
+        n_failed: usize,
+        summary: String,
+        failures: Vec<FailedGrant>,
+    },
 }
 
 /// Permissions that Rocky manages. Others (OWNERSHIP, ALL PRIVILEGES, CREATE SCHEMA) are skipped.
@@ -69,10 +81,91 @@ impl WorkspaceBindingDiff {
 /// Combined reconcile result for a single catalog covering grants and
 /// workspace bindings. `rocky plan` / `rocky run` group these deltas
 /// together because both flow from the same governance block.
+///
+/// `applied` reports which grant changes actually landed and which
+/// failed mid-batch — added so callers can surface partial-apply
+/// outcomes without losing visibility into the underlying diff.
 #[derive(Debug, Clone, Default)]
 pub struct AccessDiff {
     pub permissions: PermissionDiff,
+    pub applied: AppliedPermissionDiff,
     pub bindings: WorkspaceBindingDiff,
+}
+
+/// A grant whose GRANT / REVOKE statement returned an error.
+///
+/// Surfaces alongside the successful grants in [`AppliedPermissionDiff`]
+/// so callers can re-reconcile the failed subset (e.g. on the next
+/// `rocky run`) without losing track of what already landed.
+#[derive(Debug, Clone)]
+pub struct FailedGrant {
+    pub grant: Grant,
+    /// Whether the grant was being applied (`true` = GRANT) or removed
+    /// (`false` = REVOKE). Captured so the next reconcile pass knows
+    /// which side it belongs to.
+    pub adding: bool,
+    /// The error message from the warehouse. Kept as `String` so the
+    /// struct stays `Clone` and the result can flow up through
+    /// `AccessDiff` into the run summary.
+    pub error: String,
+}
+
+/// Outcome of applying a [`PermissionDiff`]: a record of which GRANT /
+/// REVOKE statements actually landed, plus the ones that failed.
+///
+/// The previous [`PermissionManager::apply_diff`] returned
+/// `Result<(), PermissionError>` and aborted on the first failure — that
+/// left the catalog in a half-applied state with no record of which
+/// rows had landed, making safe retries impossible. Returning this
+/// structured result lets the caller surface the failed subset in the
+/// run summary and feed it back into the next reconcile pass (the
+/// diff is order-independent because [`compute_diff`] is idempotent).
+#[derive(Debug, Clone, Default)]
+pub struct AppliedPermissionDiff {
+    /// GRANT statements that succeeded.
+    pub granted: Vec<Grant>,
+    /// REVOKE statements that succeeded.
+    pub revoked: Vec<Grant>,
+    /// Grants whose GRANT or REVOKE statement failed.
+    pub failed: Vec<FailedGrant>,
+}
+
+impl AppliedPermissionDiff {
+    /// True when every desired GRANT and REVOKE landed cleanly.
+    pub fn is_clean(&self) -> bool {
+        self.failed.is_empty()
+    }
+
+    /// True when no statements ran (either the diff was empty or every
+    /// one failed without any successes).
+    pub fn is_empty(&self) -> bool {
+        self.granted.is_empty() && self.revoked.is_empty() && self.failed.is_empty()
+    }
+
+    /// Converts this outcome into a `Result<(), PermissionError>` for
+    /// call sites that don't carry the structured diff up the stack
+    /// (the `apply_grants` / `revoke_grants` reconciler entry points).
+    /// Returns `Ok(())` if clean, otherwise [`PermissionError::PartialApply`].
+    pub fn into_result(self) -> Result<(), PermissionError> {
+        if self.failed.is_empty() {
+            return Ok(());
+        }
+        let summary = self
+            .failed
+            .iter()
+            .take(3)
+            .map(|f| {
+                let verb = if f.adding { "GRANT" } else { "REVOKE" };
+                format!("{verb} {} to {}: {}", f.grant.permission, f.grant.principal, f.error)
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        Err(PermissionError::PartialApply {
+            n_failed: self.failed.len(),
+            summary,
+            failures: self.failed,
+        })
+    }
 }
 
 impl<'a> PermissionManager<'a> {
@@ -140,29 +233,91 @@ impl<'a> PermissionManager<'a> {
         }
     }
 
-    /// Applies a permission diff (GRANT + REVOKE statements).
-    pub async fn apply_diff(&self, diff: &PermissionDiff) -> Result<(), PermissionError> {
+    /// Applies a permission diff (GRANT + REVOKE statements) and
+    /// reports the outcome.
+    ///
+    /// Unlike the previous shape (`Result<(), PermissionError>`, abort
+    /// on first error), this method runs every GRANT and REVOKE
+    /// independently, collects the failures in
+    /// [`AppliedPermissionDiff::failed`], and only returns `Err` for
+    /// errors that surface *before* any warehouse statement runs
+    /// (e.g. a SQL identifier failing validation in `format_grant_sql`
+    /// / `format_revoke_sql`). Warehouse-side failures land in
+    /// `failed` so the caller can surface them in the run summary and
+    /// retry on the next reconcile.
+    ///
+    /// Atomicity rationale: Databricks does not expose a SQL-level
+    /// transaction for GRANT/REVOKE on Unity Catalog, and the
+    /// per-statement permissions PATCH endpoint
+    /// ([`crate::unity_catalog_client::UnityCatalogClient::patch_permissions`])
+    /// only covers the `table` securable today — catalog and schema
+    /// grants still flow through `execute_statement`. The next-best
+    /// guarantee is "no statement silently lost": run every change,
+    /// report what failed.
+    pub async fn apply_diff(
+        &self,
+        diff: &PermissionDiff,
+    ) -> Result<AppliedPermissionDiff, PermissionError> {
+        let mut applied = AppliedPermissionDiff::default();
+
         for grant in &diff.grants_to_add {
+            // Validation errors (bad identifier shape) surface *before*
+            // any statement reaches the warehouse — propagate them so
+            // the caller fails fast on misconfigured input.
             let sql = format_grant_sql(grant)?;
             debug!(principal = grant.principal, permission = %grant.permission, "granting");
-            self.connector.execute_statement(&sql).await?;
+            match self.connector.execute_statement(&sql).await {
+                Ok(_) => applied.granted.push(grant.clone()),
+                Err(e) => {
+                    debug!(
+                        principal = grant.principal,
+                        permission = %grant.permission,
+                        error = %e,
+                        "grant statement failed; continuing batch"
+                    );
+                    applied.failed.push(FailedGrant {
+                        grant: grant.clone(),
+                        adding: true,
+                        error: e.to_string(),
+                    });
+                }
+            }
         }
 
         for grant in &diff.grants_to_revoke {
             let sql = format_revoke_sql(grant)?;
             debug!(principal = grant.principal, permission = %grant.permission, "revoking");
-            self.connector.execute_statement(&sql).await?;
+            match self.connector.execute_statement(&sql).await {
+                Ok(_) => applied.revoked.push(grant.clone()),
+                Err(e) => {
+                    debug!(
+                        principal = grant.principal,
+                        permission = %grant.permission,
+                        error = %e,
+                        "revoke statement failed; continuing batch"
+                    );
+                    applied.failed.push(FailedGrant {
+                        grant: grant.clone(),
+                        adding: false,
+                        error: e.to_string(),
+                    });
+                }
+            }
         }
 
-        Ok(())
+        Ok(applied)
     }
 
     /// Full reconciliation: get current grants, compute diff, apply.
+    ///
+    /// Returns the desired-vs-current [`PermissionDiff`] together with
+    /// the [`AppliedPermissionDiff`] outcome so callers can tell which
+    /// changes landed and which need a retry on the next run.
     pub async fn reconcile(
         &self,
         desired: &[Grant],
         target: &GrantTarget,
-    ) -> Result<PermissionDiff, PermissionError> {
+    ) -> Result<(PermissionDiff, AppliedPermissionDiff), PermissionError> {
         let current = match target {
             GrantTarget::Catalog(cat) => self.get_catalog_grants(cat).await?,
             GrantTarget::Schema { catalog, schema } => {
@@ -171,8 +326,8 @@ impl<'a> PermissionManager<'a> {
         };
 
         let diff = Self::compute_diff(desired, &current);
-        self.apply_diff(&diff).await?;
-        Ok(diff)
+        let applied = self.apply_diff(&diff).await?;
+        Ok((diff, applied))
     }
 
     /// Computes the binding diff between desired and current workspace bindings.
@@ -273,7 +428,7 @@ impl<'a> PermissionManager<'a> {
         ws_mgr: Option<&WorkspaceManager>,
         desired_bindings: &[WorkspaceBindingDesired],
     ) -> Result<AccessDiff, PermissionError> {
-        let permissions = self.reconcile(desired_grants, target).await?;
+        let (permissions, applied) = self.reconcile(desired_grants, target).await?;
 
         let bindings = match (ws_mgr, target) {
             (Some(mgr), GrantTarget::Catalog(catalog)) => {
@@ -297,6 +452,7 @@ impl<'a> PermissionManager<'a> {
 
         Ok(AccessDiff {
             permissions,
+            applied,
             bindings,
         })
     }
@@ -384,6 +540,55 @@ fn format_target(target: &GrantTarget) -> Result<String, PermissionError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn applied_diff_into_result_clean_passes() {
+        let applied = AppliedPermissionDiff {
+            granted: vec![Grant {
+                principal: "u".into(),
+                permission: Permission::Select,
+                target: GrantTarget::Catalog("c".into()),
+            }],
+            revoked: vec![],
+            failed: vec![],
+        };
+        assert!(applied.is_clean());
+        applied.into_result().expect("clean diff must be Ok");
+    }
+
+    #[test]
+    fn applied_diff_into_result_failures_surface_as_partial_apply() {
+        let grant = Grant {
+            principal: "u@d.com".into(),
+            permission: Permission::Modify,
+            target: GrantTarget::Catalog("c".into()),
+        };
+        let applied = AppliedPermissionDiff {
+            granted: vec![],
+            revoked: vec![],
+            failed: vec![FailedGrant {
+                grant: grant.clone(),
+                adding: true,
+                error: "principal not found".into(),
+            }],
+        };
+        assert!(!applied.is_clean());
+        match applied.into_result().expect_err("failed diff must be Err") {
+            PermissionError::PartialApply {
+                n_failed,
+                summary,
+                failures,
+            } => {
+                assert_eq!(n_failed, 1);
+                assert!(summary.contains("GRANT"));
+                assert!(summary.contains("principal not found"));
+                assert_eq!(failures.len(), 1);
+                assert_eq!(failures[0].grant.principal, "u@d.com");
+                assert!(failures[0].adding);
+            }
+            other => panic!("expected PartialApply, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_parse_managed_permissions() {

--- a/engine/crates/rocky-duckdb/tests/scd2_null_safe.rs
+++ b/engine/crates/rocky-duckdb/tests/scd2_null_safe.rs
@@ -1,0 +1,170 @@
+//! Live-execute coverage for the SCD2 NULL-safe change-detection fix.
+//!
+//! Pins the contract that the dialect's `null_safe_neq` actually
+//! captures NULL ↔ value transitions on the watermark column — bare
+//! SQL `!=` returns NULL on either side being NULL and silently drops
+//! the row from the MERGE's `WHEN MATCHED` branch.
+//!
+//! Lesson recap: string-content dialect tests can hide warehouse-
+//! rejected SQL; the dialect-level fix needs a live-execute test to
+//! prove the predicate evaluates correctly, not just generates.
+
+use rocky_core::snapshots::{SnapshotConfig, SnapshotStrategy, generate_snapshot_sql};
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+use rocky_duckdb::dialect::DuckDbSqlDialect;
+use rocky_ir::{SourceRef, TargetRef};
+
+/// Dialect contract: `null_safe_neq` must evaluate truthy for the three
+/// NULL ↔ value cases that bare `!=` would silently drop, and falsy for
+/// equal / both-null. Live-execute against DuckDB to ensure the emitted
+/// predicate is a real boolean, not NULL (which would evaluate as false
+/// in a WHEN MATCHED branch).
+#[tokio::test]
+async fn duckdb_null_safe_neq_captures_null_value_transitions() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().expect("in-memory DuckDB");
+    let dialect = DuckDbSqlDialect;
+
+    // Two-column probe table mirroring the SCD2 MERGE's
+    // `source.updated_at != target.updated_at` shape.
+    adapter
+        .execute_statement("CREATE TABLE probe (src TIMESTAMP, tgt TIMESTAMP, label VARCHAR)")
+        .await
+        .expect("create probe table");
+
+    // Five rows exercising every NULL/value combination.
+    adapter
+        .execute_statement(
+            "INSERT INTO probe VALUES \
+             (TIMESTAMP '2024-01-02 00:00:00', TIMESTAMP '2024-01-01 00:00:00', 'both_v'), \
+             (TIMESTAMP '2024-01-01 00:00:00', TIMESTAMP '2024-01-01 00:00:00', 'equal'),  \
+             (NULL,                            TIMESTAMP '2024-01-01 00:00:00', 'src_null'), \
+             (TIMESTAMP '2024-01-01 00:00:00', NULL,                            'tgt_null'), \
+             (NULL,                            NULL,                            'both_n')",
+        )
+        .await
+        .expect("seed probe rows");
+
+    let predicate = dialect.null_safe_neq("src", "tgt");
+    let sql = format!("SELECT label FROM probe WHERE {predicate} ORDER BY label");
+    let result = adapter
+        .execute_query(&sql)
+        .await
+        .expect("execute null-safe-neq probe");
+
+    let matched: Vec<String> = result
+        .rows
+        .iter()
+        .map(|r| {
+            r.first()
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or_default()
+        })
+        .collect();
+
+    assert_eq!(
+        matched,
+        vec![
+            "both_v".to_string(),
+            "src_null".to_string(),
+            "tgt_null".to_string(),
+        ],
+        "null_safe_neq must capture both-value, src-null, and tgt-null \
+         transitions; never equal or both-null. Got: {matched:?}"
+    );
+}
+
+/// End-to-end contract: a row whose tracked column transitions from
+/// NULL → value is captured by the generated SCD2 change predicate.
+/// Drives `generate_snapshot_sql` to produce the predicate against the
+/// DuckDB dialect, then exercises the predicate directly via a join +
+/// UPDATE (DuckDB's MERGE doesn't accept `INSERT (*) VALUES (source.*,
+/// ...)` — the SCD2 generator targets Databricks/Snowflake MERGE
+/// surfaces, where this lives in production). The UPDATE shape is the
+/// part this fix actually touched.
+#[tokio::test]
+async fn scd2_change_predicate_captures_null_to_value_on_duckdb() {
+    let adapter = DuckDbWarehouseAdapter::in_memory().expect("in-memory DuckDB");
+    let dialect = DuckDbSqlDialect;
+
+    // Seed a synthetic source / target pair: target holds the
+    // pre-transition NULL updated_at; source carries the new value.
+    adapter
+        .execute_statement(
+            "CREATE TABLE source (id INTEGER, updated_at TIMESTAMP); \
+             INSERT INTO source VALUES \
+                (1, TIMESTAMP '2024-06-01 12:00:00'), \
+                (2, NULL),                            \
+                (3, TIMESTAMP '2024-06-01 12:00:00')",
+        )
+        .await
+        .expect("create source");
+    adapter
+        .execute_statement(
+            "CREATE TABLE target (id INTEGER, updated_at TIMESTAMP, is_current BOOLEAN); \
+             INSERT INTO target VALUES \
+                (1, NULL,                            TRUE), \
+                (2, TIMESTAMP '2024-05-01 00:00:00', TRUE), \
+                (3, TIMESTAMP '2024-06-01 12:00:00', TRUE)",
+        )
+        .await
+        .expect("create target");
+
+    // Build the same change-detection predicate the SCD2 generator
+    // would emit on the Timestamp strategy.
+    let config = SnapshotConfig {
+        source: SourceRef {
+            catalog: String::new(),
+            schema: "main".into(),
+            table: "source".into(),
+        },
+        target: TargetRef {
+            catalog: String::new(),
+            schema: "main".into(),
+            table: "target".into(),
+        },
+        unique_key: vec!["id".into()],
+        strategy: SnapshotStrategy::Timestamp {
+            updated_at: "updated_at".into(),
+        },
+        invalidate_hard_deletes: false,
+    };
+    let stmts = generate_snapshot_sql(&config, &dialect).expect("snapshot SQL");
+    let merge_sql = &stmts[0];
+    assert!(
+        merge_sql.contains("source.updated_at IS DISTINCT FROM target.updated_at"),
+        "generated MERGE must use IS DISTINCT FROM, got: {merge_sql}"
+    );
+
+    // Exercise the predicate against the seeded data: rows 1 and 2 have
+    // NULL ↔ value transitions, row 3 is equal — only rows 1 and 2
+    // should match. Bare SQL `!=` would only report row 3 (which
+    // happens to be equal — so it would report zero rows changed,
+    // dropping rows 1 and 2 silently).
+    let predicate = dialect.null_safe_neq("source.updated_at", "target.updated_at");
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT target.id FROM source \
+             INNER JOIN target ON target.id = source.id \
+             WHERE {predicate} ORDER BY target.id"
+        ))
+        .await
+        .expect("scan predicate");
+    let matched: Vec<i64> = result
+        .rows
+        .iter()
+        .map(|r| {
+            r[0].as_i64()
+                .or_else(|| r[0].as_str().and_then(|s| s.parse().ok()))
+                .expect("id cell")
+        })
+        .collect();
+    assert_eq!(
+        matched,
+        vec![1, 2],
+        "null-safe change predicate must catch NULL→value (id=1) and \
+         value→NULL (id=2); never equal (id=3). bare SQL `!=` would \
+         drop both NULL transitions and report empty. Got: {matched:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Two engine correctness fixes. The third originally-scoped fix (ai-sync upstream-change detection) was deliberately skipped — see notes below.

### Bug 1 — SCD2 MERGE drops NULL-distinct updates

`engine/crates/rocky-core/src/sql_gen.rs:898` emitted bare SQL `!=` for the SCD2 watermark comparison. SQL `NULL != X` evaluates to NULL → false, so rows transitioning NULL ↔ non-NULL on `updated_at` weren't being closed/inserted.

Fixed by emitting dialect-aware NULL-safe inequality (`IS DISTINCT FROM` on all 5 supported warehouses).

> **⚠️ Release-note worthy:** any production SCD2 pipeline running on the buggy `!=` (Timestamp strategy) will, on its first run post-upgrade, finally close + version all the NULL↔value transitions it had been silently dropping. Expect a one-time catch-up burst of writes proportional to how many of those transitions accumulated. Not a defect — but worth a heads-up in the release notes.

### Bug 3 — Databricks `apply_diff` is non-atomic

`PermissionManager::apply_diff` ran GRANT/REVOKE sequentially and aborted on the first warehouse-side error, leaving the catalog in a half-applied state with no record of what had landed.

Restructured so every statement runs independently; per-grant failures collect into a new `AppliedPermissionDiff { granted, revoked, failed }`. Per review feedback, `reconcile()` collapses that outcome to `Result<PermissionDiff, _>` and surfaces failures as a new `PermissionError::PartialApply` variant — so callers can't silently swallow partial-apply outcomes. `apply_diff` itself keeps the structured return for any future caller that wants the granular view.

Atomicity rationale (documented in the doc-comment): Databricks doesn't expose a SQL-level transaction for GRANT/REVOKE on Unity Catalog; the per-securable PATCH permissions endpoint only covers `table` today. The next-best guarantee is "no statement silently lost": run every change, report what failed, let the next reconcile clean up.

### Bug 2 — ai-sync upstream-change detection — DEFERRED

`engine/crates/rocky-cli/src/commands/ai.rs:297` still has `let upstream_changes = Vec::new(); // TODO`. Implementing this requires loading the previous compilation snapshot from the state store and diffing against the current `result.project`. Confirmed via review that no "previous compilation" state-store accessor exists today (verified `read_schema_cache_entry` is for source-table schemas, not the `CompileResult.type_check.typed_models` map `detect_schema_changes` needs). Punting to a follow-up.

## Test plan

- [x] `cargo test -p rocky-core` — SCD2 unit + live-execute test passing
- [x] `cargo test -p rocky-databricks` — 175 passing
- [x] `cargo clippy -p rocky-databricks --all-targets -- -D warnings` — clean
- [ ] Live Databricks reconcile against the `hc_` sandbox (to be run before un-drafting)