### PR TITLE
feat(rocky-databricks): delegate describe_table + list_tables through Unity REST when wired

### DIFF
--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -34,6 +34,10 @@ required-features = ["test-support"]
 name = "unity_catalog_client_wiremock"
 required-features = ["test-support"]
 
+[[test]]
+name = "catalog_first_delegation"
+required-features = ["test-support"]
+
 [dev-dependencies]
 rocky-core = { path = "../rocky-core" }
 rocky-ir = { path = "../rocky-ir" }

--- a/engine/crates/rocky-databricks/src/adapter.rs
+++ b/engine/crates/rocky-databricks/src/adapter.rs
@@ -5,21 +5,35 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
+use rocky_catalog_core::{
+    CatalogClient, CatalogError, TableRef as CatalogTableRef, TableSchema as CatalogTableSchema,
+};
 use rocky_core::traits::{
     AdapterError, AdapterResult, BatchCheckAdapter, ChunkChecksum, ExecutionStats, FreshnessResult,
     PkRange, QueryResult, RowCountResult, SqlDialect, WarehouseAdapter,
 };
 use rocky_ir::{ColumnInfo, TableRef};
+use tracing::debug;
 
 use crate::batch::{self, BatchTableRef};
 use crate::connector::DatabricksConnector;
 use crate::dialect::DatabricksSqlDialect;
+use crate::unity_catalog_client::UnityCatalogClient;
 
 /// Databricks warehouse adapter wrapping [`DatabricksConnector`] behind the
 /// [`WarehouseAdapter`] trait.
+///
+/// An optional [`UnityCatalogClient`] can be wired in via
+/// [`DatabricksWarehouseAdapter::with_catalog_client`] to route read-side
+/// catalog operations (today: [`WarehouseAdapter::describe_table`] and
+/// [`WarehouseAdapter::list_tables`]) through Unity's REST surface instead
+/// of `DESCRIBE TABLE` / `information_schema` SQL. The SQL path remains the
+/// default and the fallback whenever the REST attempt returns
+/// [`CatalogError::UnsupportedOperation`] or [`CatalogError::Transport`].
 pub struct DatabricksWarehouseAdapter {
     connector: DatabricksConnector,
     dialect: DatabricksSqlDialect,
+    catalog_client: Option<UnityCatalogClient>,
 }
 
 impl DatabricksWarehouseAdapter {
@@ -27,13 +41,91 @@ impl DatabricksWarehouseAdapter {
         Self {
             connector,
             dialect: DatabricksSqlDialect,
+            catalog_client: None,
         }
+    }
+
+    /// Attach a [`UnityCatalogClient`] for REST-backed catalog reads.
+    ///
+    /// When set, [`WarehouseAdapter::describe_table`] and
+    /// [`WarehouseAdapter::list_tables`] try the Unity REST path first and
+    /// fall back to the existing SQL path on
+    /// [`CatalogError::UnsupportedOperation`] or
+    /// [`CatalogError::Transport`]. Any other catalog error (auth,
+    /// permission, table-not-found, malformed response) is surfaced as
+    /// [`AdapterError`] without falling through, so credential or shape
+    /// problems on the REST side aren't silently masked.
+    #[must_use]
+    pub fn with_catalog_client(mut self, client: UnityCatalogClient) -> Self {
+        self.catalog_client = Some(client);
+        self
     }
 
     /// Access the underlying connector (for adapter-specific operations).
     pub fn connector(&self) -> &DatabricksConnector {
         &self.connector
     }
+
+    /// Access the optionally-wired Unity REST catalog client.
+    pub fn catalog_client(&self) -> Option<&UnityCatalogClient> {
+        self.catalog_client.as_ref()
+    }
+}
+
+/// Project a warehouse-side three-part [`rocky_ir::TableRef`] onto the
+/// catalog-agnostic [`rocky_catalog_core::TableRef`] shape.
+///
+/// Unity is rigidly `catalog.schema.table`, so the IR's three fields map
+/// straight onto `catalog = Some(_)`, `namespace = [schema]`, `name = table`.
+/// Adapters that target multi-level Iceberg namespaces would project
+/// differently; this helper is Databricks-specific.
+fn ir_to_catalog_ref(table: &TableRef) -> CatalogTableRef {
+    CatalogTableRef {
+        catalog: Some(table.catalog.clone()),
+        namespace: vec![table.schema.clone()],
+        name: table.table.clone(),
+    }
+}
+
+/// Project a [`CatalogTableSchema`] onto the engine's `Vec<ColumnInfo>` shape.
+///
+/// The trait carries `name + type_str + nullable` per column; the warehouse-
+/// side `ColumnInfo` carries `name + data_type + nullable`. The projection is
+/// one-to-one — no caller of [`WarehouseAdapter::describe_table`] reads any
+/// REST-richer field (storage location, owner, etc.) so this lossless
+/// mapping is sufficient.
+fn catalog_schema_to_column_info(schema: CatalogTableSchema) -> Vec<ColumnInfo> {
+    schema
+        .columns
+        .into_iter()
+        .map(|c| ColumnInfo {
+            name: c.name,
+            data_type: c.type_str,
+            nullable: c.nullable,
+        })
+        .collect()
+}
+
+/// Whether a [`CatalogError`] should fall through to the SQL path.
+///
+/// Only [`CatalogError::UnsupportedOperation`] and
+/// [`CatalogError::Transport`] are recoverable here:
+///
+/// - `UnsupportedOperation` is the catalog telling us it doesn't serve this
+///   surface over REST (today: any catalog that wires a stub client).
+/// - `Transport` is a network / 5xx blip that the SQL path may navigate
+///   around (the SQL connector has its own retry layer).
+///
+/// All other variants — `AuthFailed`, `PermissionDenied`, `TableNotFound`,
+/// `NamespaceNotFound`, `InvalidResponse`, `CommitConflict` — are
+/// deterministic catalog answers we'd rather surface than mask by silently
+/// routing to SQL (e.g. a Unity-side auth misconfig should not look like a
+/// successful SQL describe).
+fn catalog_error_is_fallback(err: &CatalogError) -> bool {
+    matches!(
+        err,
+        CatalogError::UnsupportedOperation(_) | CatalogError::Transport(_)
+    )
 }
 
 #[async_trait]
@@ -77,6 +169,38 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
     }
 
     async fn describe_table(&self, table: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
+        // Try the Unity REST path first when a catalog client is wired —
+        // `GET /api/2.1/unity-catalog/tables/{full_name}` returns the column
+        // list directly without paying the latency of a `DESCRIBE TABLE`
+        // round-trip against the SQL warehouse. Fall back to the SQL path
+        // on `UnsupportedOperation` or `Transport` errors; everything else
+        // (auth, permission, table-not-found, invalid shape) surfaces as
+        // `AdapterError` to avoid masking real REST-side problems.
+        if let Some(client) = &self.catalog_client {
+            let catalog_ref = ir_to_catalog_ref(table);
+            match client.describe_table(&catalog_ref).await {
+                Ok(schema) => {
+                    debug!(
+                        catalog = %table.catalog,
+                        schema = %table.schema,
+                        table = %table.table,
+                        "describe_table served from Unity REST"
+                    );
+                    return Ok(catalog_schema_to_column_info(schema));
+                }
+                Err(e) if catalog_error_is_fallback(&e) => {
+                    debug!(
+                        catalog = %table.catalog,
+                        schema = %table.schema,
+                        table = %table.table,
+                        error = %e,
+                        "describe_table REST path declined; falling back to SQL"
+                    );
+                }
+                Err(e) => return Err(AdapterError::new(e)),
+            }
+        }
+
         let catalog_mgr = crate::catalog::CatalogManager::new(&self.connector);
         catalog_mgr
             .describe_table(table)
@@ -85,6 +209,36 @@ impl WarehouseAdapter for DatabricksWarehouseAdapter {
     }
 
     async fn list_tables(&self, catalog: &str, schema: &str) -> AdapterResult<Vec<String>> {
+        // Same shape as `describe_table`: try the Unity REST path first
+        // (`GET /api/2.1/unity-catalog/tables?catalog_name=X&schema_name=Y`),
+        // fall back on `UnsupportedOperation` or `Transport` only. The
+        // trait contract is "table names returned lowercase" so both paths
+        // post-process identically — REST returns Unity's as-stored
+        // identifiers and we lowercase before returning.
+        if let Some(client) = &self.catalog_client {
+            let namespace = [catalog.to_string(), schema.to_string()];
+            match client.list_tables(&namespace).await {
+                Ok(tables) => {
+                    debug!(
+                        catalog,
+                        schema,
+                        count = tables.len(),
+                        "list_tables served from Unity REST"
+                    );
+                    return Ok(tables.into_iter().map(|t| t.name.to_lowercase()).collect());
+                }
+                Err(e) if catalog_error_is_fallback(&e) => {
+                    debug!(
+                        catalog,
+                        schema,
+                        error = %e,
+                        "list_tables REST path declined; falling back to SQL"
+                    );
+                }
+                Err(e) => return Err(AdapterError::new(e)),
+            }
+        }
+
         let catalog_mgr = crate::catalog::CatalogManager::new(&self.connector);
         catalog_mgr
             .list_tables(catalog, schema)
@@ -365,4 +519,131 @@ fn parse_databricks_i128(v: &serde_json::Value) -> AdapterResult<i128> {
     Err(AdapterError::msg(format!(
         "Databricks checksum_chunks result column had unexpected JSON shape: {v:?}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocky_catalog_core::{ColumnSchema as CatalogColumnSchema, TableSchema as CatalogSchema};
+
+    #[test]
+    fn ir_to_catalog_ref_projects_three_part_name() {
+        let ir = TableRef {
+            catalog: "hc_cat".into(),
+            schema: "hc_sch".into(),
+            table: "hc_tbl".into(),
+        };
+        let catalog_ref = ir_to_catalog_ref(&ir);
+        assert_eq!(catalog_ref.catalog.as_deref(), Some("hc_cat"));
+        assert_eq!(catalog_ref.namespace, vec!["hc_sch".to_string()]);
+        assert_eq!(catalog_ref.name, "hc_tbl");
+    }
+
+    #[test]
+    fn catalog_schema_to_column_info_preserves_fields() {
+        let schema = CatalogSchema {
+            columns: vec![
+                CatalogColumnSchema {
+                    name: "id".into(),
+                    type_str: "bigint".into(),
+                    nullable: false,
+                },
+                CatalogColumnSchema {
+                    name: "amount".into(),
+                    type_str: "decimal(10,2)".into(),
+                    nullable: true,
+                },
+            ],
+        };
+        let cols = catalog_schema_to_column_info(schema);
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].name, "id");
+        assert_eq!(cols[0].data_type, "bigint");
+        assert!(!cols[0].nullable);
+        assert_eq!(cols[1].name, "amount");
+        assert_eq!(cols[1].data_type, "decimal(10,2)");
+        assert!(cols[1].nullable);
+    }
+
+    #[test]
+    fn catalog_error_is_fallback_only_for_unsupported_and_transport() {
+        // Recoverable: caller should fall through to SQL.
+        assert!(catalog_error_is_fallback(
+            &CatalogError::UnsupportedOperation("nope")
+        ));
+        assert!(catalog_error_is_fallback(&CatalogError::Transport(
+            Box::new(std::io::Error::other("network blip"))
+        )));
+
+        // Non-recoverable: caller must surface as AdapterError.
+        assert!(!catalog_error_is_fallback(&CatalogError::AuthFailed(
+            "bad token".into()
+        )));
+        assert!(!catalog_error_is_fallback(&CatalogError::PermissionDenied(
+            "denied".into()
+        )));
+        assert!(!catalog_error_is_fallback(&CatalogError::TableNotFound(
+            "missing".into()
+        )));
+        assert!(!catalog_error_is_fallback(
+            &CatalogError::NamespaceNotFound("missing".into())
+        ));
+        assert!(!catalog_error_is_fallback(&CatalogError::InvalidResponse(
+            "bad json".into()
+        )));
+        assert!(!catalog_error_is_fallback(&CatalogError::CommitConflict(
+            "cas".into()
+        )));
+    }
+
+    #[test]
+    fn adapter_defaults_to_no_catalog_client() {
+        // Constructor signature must stay backward-compatible: existing
+        // `::new(connector)` call sites get SQL-only behaviour. Build a
+        // real connector pointed at an unreachable host — `::new` doesn't
+        // hit the network, so the test stays offline.
+        let auth = crate::auth::Auth::from_config(crate::auth::AuthConfig {
+            host: "offline.databricks.test".into(),
+            token: Some("offline-token".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .expect("PAT auth is infallible");
+        let config = crate::connector::ConnectorConfig {
+            host: "offline.databricks.test".into(),
+            warehouse_id: "noop".into(),
+            timeout: std::time::Duration::from_secs(1),
+            retry: Default::default(),
+        };
+        let connector = DatabricksConnector::new(config, auth);
+        let adapter = DatabricksWarehouseAdapter::new(connector);
+        assert!(
+            adapter.catalog_client().is_none(),
+            "default constructor must not wire a catalog client"
+        );
+    }
+
+    #[test]
+    fn with_catalog_client_attaches_the_client() {
+        let auth = crate::auth::Auth::from_config(crate::auth::AuthConfig {
+            host: "offline.databricks.test".into(),
+            token: Some("offline-token".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .expect("PAT auth is infallible");
+        let config = crate::connector::ConnectorConfig {
+            host: "offline.databricks.test".into(),
+            warehouse_id: "noop".into(),
+            timeout: std::time::Duration::from_secs(1),
+            retry: Default::default(),
+        };
+        let connector = DatabricksConnector::new(config, auth.clone());
+        let client = UnityCatalogClient::new("offline.databricks.test".into(), auth);
+        let adapter = DatabricksWarehouseAdapter::new(connector).with_catalog_client(client);
+        assert!(
+            adapter.catalog_client().is_some(),
+            "with_catalog_client must populate the catalog_client slot"
+        );
+    }
 }

--- a/engine/crates/rocky-databricks/tests/catalog_first_delegation.rs
+++ b/engine/crates/rocky-databricks/tests/catalog_first_delegation.rs
@@ -1,0 +1,399 @@
+//! Wire-level mock tests for `DatabricksWarehouseAdapter`'s optional
+//! Unity REST delegation of `describe_table` and `list_tables`.
+//!
+//! The adapter exposes two read-side catalog operations on the
+//! `WarehouseAdapter` trait. Without a wired `UnityCatalogClient` they go
+//! through `DESCRIBE TABLE` / `information_schema` SQL via
+//! `DatabricksConnector`. With a wired client they try Unity's REST
+//! surface first (`GET /api/2.1/unity-catalog/tables[/{full_name}]`) and
+//! fall back to SQL on `UnsupportedOperation` / `Transport` errors only.
+//!
+//! These tests pin the projection shape (REST `TableSchema` →
+//! `Vec<ColumnInfo>`, REST `Vec<TableRef>` → `Vec<String>` lowercased) and
+//! the fallback policy. Real SQL-vs-REST content parity is exercised by
+//! the live `#[ignore]` tests in `integration.rs`.
+//!
+//! Requires the `test-support` cargo feature so
+//! `UnityCatalogClient::with_base_url` is callable.
+
+use std::time::Duration;
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_databricks::adapter::DatabricksWarehouseAdapter;
+use rocky_databricks::auth::{Auth, AuthConfig};
+use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+use rocky_databricks::unity_catalog_client::UnityCatalogClient;
+use rocky_ir::TableRef;
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+fn pat_auth() -> Auth {
+    Auth::from_config(AuthConfig {
+        host: "test.databricks.com".into(),
+        token: Some("test-token".into()),
+        client_id: None,
+        client_secret: None,
+    })
+    .expect("PAT auth is infallible")
+}
+
+fn sql_connector(server: &MockServer) -> DatabricksConnector {
+    let config = ConnectorConfig {
+        host: "test.databricks.com".into(),
+        warehouse_id: "test-warehouse".into(),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            ..Default::default()
+        },
+    };
+    DatabricksConnector::new(config, pat_auth()).with_base_url(server.uri())
+}
+
+fn unity_client(server: &MockServer) -> UnityCatalogClient {
+    UnityCatalogClient::new("test.databricks.com".into(), pat_auth()).with_base_url(server.uri())
+}
+
+fn sample_ir_ref() -> TableRef {
+    TableRef {
+        catalog: "hcv2_cat".into(),
+        schema: "hcv2_sch".into(),
+        table: "hcv2_orders".into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// describe_table — delegation parity
+// ---------------------------------------------------------------------------
+
+/// REST and SQL paths return the same `Vec<ColumnInfo>` shape for the
+/// same logical table. Mocks both endpoints and asserts the adapter's
+/// output is field-equal regardless of which path was taken.
+#[tokio::test]
+async fn describe_table_rest_and_sql_paths_project_identically() {
+    let server = MockServer::start().await;
+
+    // REST path: GET /api/2.1/unity-catalog/tables/{full_name}
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "hcv2_orders",
+            "columns": [
+                {"name": "id", "type_text": "bigint", "type_name": "LONG", "nullable": false},
+                {"name": "amount", "type_text": "decimal(10,2)", "type_name": "DECIMAL", "nullable": true}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // SQL path: POST /api/2.0/sql/statements with DESCRIBE TABLE.
+    // DESCRIBE TABLE always reports `nullable = true` per the existing
+    // CatalogManager impl, so the SQL projection is permissive on
+    // nullability. That difference is documented in `catalog.rs`.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "col_name", "type_name": "STRING", "position": 0},
+                        {"name": "data_type", "type_name": "STRING", "position": 1},
+                        {"name": "comment", "type_name": "STRING", "position": 2}
+                    ]
+                },
+                "total_row_count": 2
+            },
+            "result": {
+                "data_array": [
+                    ["id", "bigint", null],
+                    ["amount", "decimal(10,2)", null]
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let table = sample_ir_ref();
+
+    // REST-routed adapter.
+    let rest_adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let rest_cols = rest_adapter
+        .describe_table(&table)
+        .await
+        .expect("REST describe_table");
+
+    // SQL-only adapter (no catalog client wired).
+    let sql_adapter = DatabricksWarehouseAdapter::new(sql_connector(&server));
+    let sql_cols = sql_adapter
+        .describe_table(&table)
+        .await
+        .expect("SQL describe_table");
+
+    // Field-by-field parity: column count, names, data types.
+    assert_eq!(rest_cols.len(), sql_cols.len());
+    for (r, s) in rest_cols.iter().zip(sql_cols.iter()) {
+        assert_eq!(r.name, s.name, "column names diverge between REST and SQL");
+        assert_eq!(r.data_type, s.data_type, "data types diverge");
+    }
+    // Names and types pinned to the fixture for one final sanity check.
+    assert_eq!(rest_cols[0].name, "id");
+    assert_eq!(rest_cols[0].data_type, "bigint");
+    assert_eq!(rest_cols[1].name, "amount");
+    assert_eq!(rest_cols[1].data_type, "decimal(10,2)");
+}
+
+/// REST path returns 401 → `CatalogError::AuthFailed` → propagated as
+/// `AdapterError`. Must NOT silently fall through to SQL — a bad token
+/// on the catalog client is a real configuration problem.
+#[tokio::test]
+async fn describe_table_rest_401_surfaces_as_error_no_sql_fallback() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Mock the SQL path so that if (incorrectly) reached, we'd see a 0-row
+    // success — making it easy to detect a regression where the adapter
+    // silently fell through to SQL on auth failure.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "should-not-be-hit",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {"schema": {"columns": []}, "total_row_count": 0},
+            "result": {"data_array": []}
+        })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let err = adapter
+        .describe_table(&sample_ir_ref())
+        .await
+        .expect_err("401 must surface, not fall through");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("auth") || msg.contains("401") || msg.contains("unauthorized"),
+        "expected auth-flavored error, got: {err}"
+    );
+}
+
+/// REST returns a 5xx → `CatalogError::Transport` → adapter falls
+/// through to the SQL path which succeeds. This is the "REST blip"
+/// graceful-degradation contract.
+#[tokio::test]
+async fn describe_table_rest_5xx_falls_back_to_sql() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/api/2.1/unity-catalog/tables/hcv2_cat.hcv2_sch.hcv2_orders",
+        ))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "col_name", "type_name": "STRING", "position": 0},
+                        {"name": "data_type", "type_name": "STRING", "position": 1},
+                        {"name": "comment", "type_name": "STRING", "position": 2}
+                    ]
+                },
+                "total_row_count": 1
+            },
+            "result": {
+                "data_array": [["id", "bigint", null]]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let cols = adapter
+        .describe_table(&sample_ir_ref())
+        .await
+        .expect("SQL path picks up after REST 5xx");
+    assert_eq!(cols.len(), 1);
+    assert_eq!(cols[0].name, "id");
+    assert_eq!(cols[0].data_type, "bigint");
+}
+
+// ---------------------------------------------------------------------------
+// list_tables — delegation parity
+// ---------------------------------------------------------------------------
+
+/// REST and SQL paths return the same `Vec<String>` set (lowercased) for
+/// the same catalog/schema. Order is not asserted — both surfaces return
+/// rows in catalog-defined order and the trait contract is about the set,
+/// not the order.
+#[tokio::test]
+async fn list_tables_rest_and_sql_paths_lowercase_consistently() {
+    let server = MockServer::start().await;
+
+    // REST: returns mixed-case identifiers. The adapter must lowercase
+    // them on both paths to honour the trait's "lowercase for
+    // case-insensitive matching" contract.
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "hcv2_cat"))
+        .and(query_param("schema_name", "hcv2_sch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tables": [
+                {"name": "ORDERS", "columns": []},
+                {"name": "Customers", "columns": []}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // SQL: information_schema.tables returns the same names — emit them
+    // mixed-case so we exercise the lowercasing step.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "schema": {
+                    "columns": [{"name": "table_name", "type_name": "STRING", "position": 0}]
+                },
+                "total_row_count": 2
+            },
+            "result": {
+                "data_array": [["ORDERS"], ["Customers"]]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let rest_adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let mut rest = rest_adapter
+        .list_tables("hcv2_cat", "hcv2_sch")
+        .await
+        .expect("REST list_tables");
+
+    let sql_adapter = DatabricksWarehouseAdapter::new(sql_connector(&server));
+    let mut sql = sql_adapter
+        .list_tables("hcv2_cat", "hcv2_sch")
+        .await
+        .expect("SQL list_tables");
+
+    rest.sort();
+    sql.sort();
+    assert_eq!(rest, sql, "REST and SQL must surface the same set");
+    assert_eq!(rest, vec!["customers".to_string(), "orders".to_string()]);
+}
+
+/// REST 404 on `list_tables` → `CatalogError::NamespaceNotFound` →
+/// surfaces as `AdapterError`. Must NOT fall through to SQL; a missing
+/// schema is a deterministic answer.
+#[tokio::test]
+async fn list_tables_rest_404_surfaces_as_error_no_sql_fallback() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "missing_cat"))
+        .and(query_param("schema_name", "missing_sch"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("no such schema"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // SQL path should NOT be hit — namespace-not-found is non-recoverable.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "should-not-be-hit",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {"schema": {"columns": []}, "total_row_count": 0},
+            "result": {"data_array": []}
+        })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let err = adapter
+        .list_tables("missing_cat", "missing_sch")
+        .await
+        .expect_err("404 must surface");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("not found") || msg.contains("404") || msg.contains("namespace"),
+        "expected namespace-not-found error, got: {err}"
+    );
+}
+
+/// REST 5xx on `list_tables` → fallback to SQL succeeds.
+#[tokio::test]
+async fn list_tables_rest_5xx_falls_back_to_sql() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/2.1/unity-catalog/tables"))
+        .and(query_param("catalog_name", "hcv2_cat"))
+        .and(query_param("schema_name", "hcv2_sch"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "statement_id": "stmt-1",
+            "status": {"state": "SUCCEEDED"},
+            "manifest": {
+                "schema": {
+                    "columns": [{"name": "table_name", "type_name": "STRING", "position": 0}]
+                },
+                "total_row_count": 1
+            },
+            "result": {
+                "data_array": [["orders"]]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = DatabricksWarehouseAdapter::new(sql_connector(&server))
+        .with_catalog_client(unity_client(&server));
+    let tables = adapter
+        .list_tables("hcv2_cat", "hcv2_sch")
+        .await
+        .expect("SQL fallback succeeds after REST 5xx");
+    assert_eq!(tables, vec!["orders".to_string()]);
+}

--- a/engine/crates/rocky-databricks/tests/integration.rs
+++ b/engine/crates/rocky-databricks/tests/integration.rs
@@ -13,6 +13,7 @@ use rocky_core::traits::WarehouseAdapter;
 use rocky_databricks::adapter::DatabricksWarehouseAdapter;
 use rocky_databricks::auth::{Auth, AuthConfig};
 use rocky_databricks::connector::{ConnectorConfig, DatabricksConnector};
+use rocky_databricks::unity_catalog_client::UnityCatalogClient;
 use rocky_ir::TableRef;
 
 fn connector_from_env() -> Option<DatabricksConnector> {
@@ -270,4 +271,185 @@ async fn describe_detail_stats_nonexistent_table_returns_none() {
         result.is_none(),
         "missing table should return None, not an error",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Catalog-first delegation parity (live)
+// ---------------------------------------------------------------------------
+//
+// These tests run two `DatabricksWarehouseAdapter` instances against the
+// same sandbox — one with a `UnityCatalogClient` wired (REST path), one
+// without (SQL path) — and assert the results are equal. They're the
+// real source of truth for the "REST and SQL paths converge" claim;
+// wiremock parity in `catalog_first_delegation.rs` only proves the
+// projection shape.
+//
+// Required env vars (mirrors the existing live-test convention):
+//   DATABRICKS_HOST
+//   DATABRICKS_HTTP_PATH
+//   DATABRICKS_TOKEN (or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET)
+//   DATABRICKS_TEST_CATALOG  — must already exist on the sandbox
+//   DATABRICKS_TEST_SCHEMA   — optional; defaults to `default`
+
+fn unity_client_from_env() -> Option<UnityCatalogClient> {
+    let host = std::env::var("DATABRICKS_HOST").ok()?;
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+    Some(UnityCatalogClient::new(host, auth))
+}
+
+/// `describe_table` returns identical column-name + data-type sequences
+/// regardless of whether the adapter routes through Unity REST or
+/// `DESCRIBE TABLE` SQL. Creates an ephemeral `hc_phase1a_` schema
+/// scoped to the test, populates a tiny table, then describes it via
+/// both adapter instances and asserts parity. Cleans up unconditionally.
+#[tokio::test]
+#[ignore]
+async fn live_describe_table_rest_and_sql_paths_agree() {
+    let connector = connector_from_env().expect("Databricks env vars not set");
+    let unity = unity_client_from_env().expect("Unity client env not set");
+
+    let catalog = std::env::var("DATABRICKS_TEST_CATALOG")
+        .or_else(|_| std::env::var("DATABRICKS_CATALOG_PREFIX"))
+        .expect("DATABRICKS_TEST_CATALOG or DATABRICKS_CATALOG_PREFIX must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let schema = format!("hc_phase1a_desc_{suffix}");
+    let table = "hc_probe";
+
+    // Use the SQL-only adapter for setup/teardown so we never depend on
+    // REST writes (which we explicitly aren't wiring in this PR).
+    let sql_adapter = DatabricksWarehouseAdapter::new(connector);
+
+    sql_adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"))
+        .await
+        .expect("create schema");
+    sql_adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {catalog}.{schema}.{table} \
+             (id BIGINT, amount DECIMAL(10,2), name STRING)"
+        ))
+        .await
+        .expect("create probe table");
+
+    let table_ref = TableRef {
+        catalog: catalog.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+
+    // Run both paths against the same logical table, capturing each
+    // result *before* any assertion so cleanup always runs even if one
+    // side errors. Mirrors the pattern in `test_clone_table_for_branch_shallow_clone`.
+    let sql_result = sql_adapter.describe_table(&table_ref).await;
+
+    // Rebuild a parallel adapter that wraps the SAME warehouse but with
+    // a `UnityCatalogClient` wired. Using a separate connector instance
+    // keeps the two adapters independent at the SQL layer.
+    let rest_connector = connector_from_env().expect("Databricks env vars not set");
+    let rest_adapter = DatabricksWarehouseAdapter::new(rest_connector).with_catalog_client(unity);
+    let rest_result = rest_adapter.describe_table(&table_ref).await;
+
+    // Cleanup unconditionally before any assertion fires.
+    let _ = sql_adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+
+    let sql_cols = sql_result.expect("SQL describe_table");
+    let rest_cols = rest_result.expect("REST describe_table");
+
+    // Compare on (name, data_type). `DESCRIBE TABLE` doesn't reliably
+    // surface nullability so the SQL path defaults to `true` — Unity
+    // reports the declared nullability faithfully. We intentionally
+    // don't assert on `nullable` because the two paths diverge by
+    // design (and no caller of `describe_table` reads it for drift
+    // detection on Databricks).
+    let sql_names: Vec<(String, String)> = sql_cols
+        .into_iter()
+        .map(|c| (c.name.to_lowercase(), c.data_type.to_lowercase()))
+        .collect();
+    let rest_names: Vec<(String, String)> = rest_cols
+        .into_iter()
+        .map(|c| (c.name.to_lowercase(), c.data_type.to_lowercase()))
+        .collect();
+
+    assert_eq!(
+        sql_names, rest_names,
+        "REST and SQL describe_table paths must agree on (name, data_type)"
+    );
+    assert!(
+        sql_names.iter().any(|(n, _)| n == "id" || n.contains("id")),
+        "probe table should surface an `id` column; got {sql_names:?}"
+    );
+}
+
+/// `list_tables` returns the same set (lowercased) regardless of path.
+/// Creates an ephemeral schema with a known table set, lists via both
+/// paths, asserts the sets are equal. Cleans up unconditionally.
+#[tokio::test]
+#[ignore]
+async fn live_list_tables_rest_and_sql_paths_agree() {
+    let connector = connector_from_env().expect("Databricks env vars not set");
+    let unity = unity_client_from_env().expect("Unity client env not set");
+
+    let catalog = std::env::var("DATABRICKS_TEST_CATALOG")
+        .or_else(|_| std::env::var("DATABRICKS_CATALOG_PREFIX"))
+        .expect("DATABRICKS_TEST_CATALOG or DATABRICKS_CATALOG_PREFIX must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let schema = format!("hc_phase1a_list_{suffix}");
+
+    let sql_adapter = DatabricksWarehouseAdapter::new(connector);
+    sql_adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}"))
+        .await
+        .expect("create schema");
+    for t in ["hc_alpha", "hc_beta", "hc_gamma"] {
+        sql_adapter
+            .execute_statement(&format!(
+                "CREATE OR REPLACE TABLE {catalog}.{schema}.{t} (id BIGINT)"
+            ))
+            .await
+            .expect("create probe table");
+    }
+
+    let sql_result = sql_adapter.list_tables(&catalog, &schema).await;
+
+    let rest_connector = connector_from_env().expect("Databricks env vars not set");
+    let rest_adapter = DatabricksWarehouseAdapter::new(rest_connector).with_catalog_client(unity);
+    let rest_result = rest_adapter.list_tables(&catalog, &schema).await;
+
+    // Cleanup unconditionally before any assertion.
+    let _ = sql_adapter
+        .execute_statement(&format!("DROP SCHEMA IF EXISTS {catalog}.{schema} CASCADE"))
+        .await;
+
+    let mut sql_tables = sql_result.expect("SQL list_tables");
+    let mut rest_tables = rest_result.expect("REST list_tables");
+    sql_tables.sort();
+    rest_tables.sort();
+
+    assert_eq!(
+        sql_tables, rest_tables,
+        "REST and SQL list_tables must surface the same set"
+    );
+    // Every probe table we created should appear on both paths.
+    for t in ["hc_alpha", "hc_beta", "hc_gamma"] {
+        assert!(
+            sql_tables.iter().any(|name| name == t),
+            "expected {t} in listing; got {sql_tables:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`DatabricksWarehouseAdapter` now optionally delegates `describe_table` and `list_tables` through `UnityCatalogClient`. The SQL path (`DESCRIBE TABLE` / `information_schema`) remains the default and the fallback whenever the REST attempt returns `CatalogError::UnsupportedOperation` or `CatalogError::Transport`. Auth, permission, table-not-found, and invalid-response errors are surfaced as `AdapterError` without falling through, so REST-side misconfigurations are not silently masked.

The constructor signature stays backward-compatible — existing `::new(connector)` call sites keep SQL-only behaviour. A new `.with_catalog_client(client)` builder method opts a callsite into REST-routed reads.

## Why partial

Only the two read-side catalog methods absorb cleanly into the `CatalogClient` trait surface. The four governance methods (`set_tags`, `get_grants`, `apply_grants`, `revoke_grants`) operate on catalog/schema/table securables with batched grants, while the current `CatalogClient` trait is table-only. Delegating them would require a trait reshape (securable-axis enum, batch shape, or a split trait), which is out of scope for this PR. Governance ops continue to use the existing SQL path through `DatabricksGovernanceAdapter` — no behavioural change.

## Test plan

- [x] Unit tests for the three projection helpers (`ir_to_catalog_ref`, `catalog_schema_to_column_info`, `catalog_error_is_fallback`) and the `with_catalog_client` builder wiring.
- [x] Wiremock parity tests in `tests/catalog_first_delegation.rs`:
  - REST + SQL paths produce identical `Vec<ColumnInfo>` shape for `describe_table`.
  - REST + SQL paths produce identical lowercased `Vec<String>` set for `list_tables` (incl. preserving the existing case-insensitive matching contract).
  - REST 401 on `describe_table` surfaces as `AdapterError` with no SQL fallback (mock asserts SQL path is hit 0 times).
  - REST 404 on `list_tables` surfaces as `AdapterError` (namespace-not-found is deterministic; no fallback).
  - REST 5xx on both methods falls through to SQL and the SQL response is returned.
- [x] Live `#[ignore]` integration tests in `tests/integration.rs` against the Databricks sandbox: both `live_describe_table_rest_and_sql_paths_agree` and `live_list_tables_rest_and_sql_paths_agree` create an ephemeral `hc_phase1a_*` schema, run both adapter instances, and assert equality (cleanup with `DROP SCHEMA ... CASCADE` is unconditional). Both passed against the sandbox.
- [x] `cargo build --workspace` clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `just codegen` produces no diff (internal refactor; no CLI schema touched).

Note: the wiremock test can only prove that the adapter projects each path's response into the expected `Vec<ColumnInfo>` / `Vec<String>` shape. Real SQL-vs-REST content parity is exercised by the live integration tests above.