### PR TITLE
fix(engine): Snowflake replication-merge column threading + dialect parity

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4544,7 +4544,13 @@ fn accumulate_bytes(acc: Option<u64>, next: Option<u64>) -> Option<u64> {
 ///   reading keys from `resolved_merge_keys()` (`merge_keys` falls back to
 ///   `merge_keys_fallback`). `merge` requires keys; absence is treated as
 ///   a defensive `anyhow!` because `validate_replication_strategies` should
-///   have rejected it at config load time.
+///   have rejected it at config load time. The `ColumnSelection::All`
+///   placeholder is replaced by the explicit source-schema column list in
+///   `process_table` BEFORE the IR reaches SQL-gen — Snowflake's MERGE
+///   rejects `UPDATE SET *`, so threading discovered columns is required for
+///   adapter parity. This function stays warehouse-free; the resolution
+///   happens at the call site where `describe_table(&source_table)` is
+///   already awaited for drift detection.
 /// Anything else → `FullRefresh` (backwards-compatible fallback; see follow-up
 ///   note in PR body about tightening unknown strategy values).
 ///
@@ -4628,6 +4634,52 @@ fn build_replication_strategy_with_override(
              sidecar TOML instead"
         )),
         _ => Ok(MaterializationStrategy::FullRefresh),
+    }
+}
+
+/// Resolves `ColumnSelection::All` on a `Merge` strategy against the
+/// discovered source schema so the SQL-gen layer can emit an explicit
+/// `UPDATE SET t.col1 = s.col1, ...` clause.
+///
+/// Returns the input strategy untouched when:
+/// - the strategy is not `Merge`, OR
+/// - `source_cols` is empty (prefetch miss + describe failure).
+///
+/// The explicit form mirrors `UPDATE SET *` on Databricks/DuckDB: every
+/// source column plus every metadata column projected by SELECT. Merge
+/// keys are included — `t.id = s.id` under `ON t.id = s.id` is a no-op
+/// and matches `*` semantics on the other adapters; excluding them would
+/// be a behavior change.
+///
+/// When `source_cols` is empty, the strategy is returned with its existing
+/// `ColumnSelection::All` so other adapters preserve current behavior and
+/// Snowflake's dialect still surfaces its clear "Snowflake MERGE does not
+/// support UPDATE SET *" error.
+fn resolve_merge_update_columns(
+    strategy: &MaterializationStrategy,
+    source_cols: &[ColumnInfo],
+    metadata_columns: &[MetadataColumn],
+) -> MaterializationStrategy {
+    let MaterializationStrategy::Merge {
+        unique_key,
+        update_columns: _,
+    } = strategy
+    else {
+        return strategy.clone();
+    };
+    if source_cols.is_empty() {
+        return strategy.clone();
+    }
+    let mut cols: Vec<Arc<str>> = source_cols
+        .iter()
+        .map(|c| Arc::from(c.name.as_str()))
+        .collect();
+    for m in metadata_columns {
+        cols.push(Arc::from(m.name.as_str()));
+    }
+    MaterializationStrategy::Merge {
+        unique_key: unique_key.clone(),
+        update_columns: ColumnSelection::Explicit(cols),
     }
 }
 
@@ -4890,13 +4942,23 @@ async fn process_table(
         .as_deref()
         .unwrap_or(pipeline.timestamp_column.as_str())
         .to_string();
+
+    // For `strategy = "merge"`, resolve `ColumnSelection::All` against the
+    // discovered source schema BEFORE handing the IR to SQL-gen. Snowflake's
+    // MERGE rejects `UPDATE SET *` (Databricks / BigQuery / DuckDB accept it),
+    // so emitting the literal `*` from the replication runner makes
+    // Snowflake-merge unusable. We already awaited `describe_table(&source_table)`
+    // above for drift detection; `source_cols` is in scope and free. Reuse it.
+    let resolved_strategy =
+        resolve_merge_update_columns(&strategy, &source_cols, &task.metadata_columns);
+
     let model_ir = ModelIr::replication(
         TargetRef {
             catalog: task.target_catalog.clone(),
             schema: task.target_schema.clone(),
             table: task.table_name.clone(),
         },
-        strategy.clone(),
+        resolved_strategy.clone(),
         SourceRef {
             catalog: task.source_catalog.clone(),
             schema: task.source_schema.clone(),
@@ -6504,6 +6566,99 @@ merge_keys_fallback = ["fallback_only"]
             }
             other => panic!("expected Merge, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_merge_update_columns_expands_all_to_source_schema() {
+        // Snowflake's MERGE rejects `UPDATE SET *`; the replication runner
+        // resolves `ColumnSelection::All` against the discovered source
+        // schema before SQL-gen so the explicit form lands. This test pins
+        // that resolution against a representative source-schema + metadata
+        // column list, mirroring the production call site in
+        // `process_table`.
+        let strategy = MaterializationStrategy::Merge {
+            unique_key: vec![Arc::from("id")],
+            update_columns: ColumnSelection::All,
+        };
+        let source_cols = vec![
+            ColumnInfo {
+                name: "id".to_string(),
+                data_type: "INTEGER".to_string(),
+                nullable: false,
+            },
+            ColumnInfo {
+                name: "name".to_string(),
+                data_type: "STRING".to_string(),
+                nullable: true,
+            },
+            ColumnInfo {
+                name: "amount".to_string(),
+                data_type: "DECIMAL(10,2)".to_string(),
+                nullable: true,
+            },
+        ];
+        let metadata = vec![MetadataColumn {
+            name: "_loaded_at".to_string(),
+            data_type: "TIMESTAMP".to_string(),
+            value: "CURRENT_TIMESTAMP()".to_string(),
+        }];
+
+        let resolved = resolve_merge_update_columns(&strategy, &source_cols, &metadata);
+
+        match resolved {
+            MaterializationStrategy::Merge {
+                update_columns: ColumnSelection::Explicit(cols),
+                ..
+            } => {
+                let names: Vec<&str> = cols.iter().map(AsRef::as_ref).collect();
+                // Source-column order preserved; metadata appended. Merge
+                // keys included — matches `UPDATE SET *` semantics on
+                // Databricks/DuckDB.
+                assert_eq!(names, vec!["id", "name", "amount", "_loaded_at"]);
+            }
+            other => panic!("expected Merge with Explicit columns, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_merge_update_columns_falls_back_to_all_when_source_cols_empty() {
+        // Prefetch miss + describe failure: `source_cols` arrives empty.
+        // Resolving against zero columns would emit `UPDATE SET ` (invalid).
+        // Fall back to `ColumnSelection::All` so other adapters preserve
+        // current behavior and Snowflake's dialect still surfaces its clear
+        // "MERGE does not support UPDATE SET *" error.
+        let strategy = MaterializationStrategy::Merge {
+            unique_key: vec![Arc::from("id")],
+            update_columns: ColumnSelection::All,
+        };
+        let resolved = resolve_merge_update_columns(&strategy, &[], &[]);
+        assert!(matches!(
+            resolved,
+            MaterializationStrategy::Merge {
+                update_columns: ColumnSelection::All,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resolve_merge_update_columns_is_noop_for_non_merge_strategy() {
+        // Non-merge strategies pass through unchanged. The resolver is
+        // strictly a Merge-IR rewrite; Incremental/FullRefresh/etc. don't
+        // carry an `update_columns` field.
+        let strategy = MaterializationStrategy::Incremental {
+            timestamp_column: "ts".to_string(),
+        };
+        let source_cols = vec![ColumnInfo {
+            name: "id".to_string(),
+            data_type: "INTEGER".to_string(),
+            nullable: false,
+        }];
+        let resolved = resolve_merge_update_columns(&strategy, &source_cols, &[]);
+        assert!(matches!(
+            resolved,
+            MaterializationStrategy::Incremental { .. }
+        ));
     }
 
     #[test]

--- a/engine/crates/rocky-cli/tests/ir-golden/03-replication-merge/snowflake.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/03-replication-merge/snowflake.sql
@@ -3,6 +3,6 @@ USING (
 SELECT *
 FROM "srcwarehouse"."src__demo"."customers"
 ) AS s
-ON t.customer_id = s.customer_id
-WHEN MATCHED THEN UPDATE SET t.name = s.name, t.email = s.email, t.updated_at = s.updated_at
-WHEN NOT MATCHED THEN INSERT *
+ON t."customer_id" = s."customer_id"
+WHEN MATCHED THEN UPDATE SET t."name" = s."name", t."email" = s."email", t."updated_at" = s."updated_at"
+WHEN NOT MATCHED THEN INSERT ("name", "email", "updated_at") VALUES (s."name", s."email", s."updated_at")

--- a/engine/crates/rocky-cli/tests/ir-golden/05-transformation-merge/snowflake.sql
+++ b/engine/crates/rocky-cli/tests/ir-golden/05-transformation-merge/snowflake.sql
@@ -2,6 +2,6 @@ MERGE INTO "tgtwarehouse"."marts__demo"."dim_customers" AS t
 USING (
 SELECT customer_id, name, email, updated_at FROM tgtwarehouse.raw__demo.customers
 ) AS s
-ON t.customer_id = s.customer_id
-WHEN MATCHED THEN UPDATE SET t.name = s.name, t.email = s.email, t.updated_at = s.updated_at
-WHEN NOT MATCHED THEN INSERT *
+ON t."customer_id" = s."customer_id"
+WHEN MATCHED THEN UPDATE SET t."name" = s."name", t."email" = s."email", t."updated_at" = s."updated_at"
+WHEN NOT MATCHED THEN INSERT ("name", "email", "updated_at") VALUES (s."name", s."email", s."updated_at")

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -3,7 +3,8 @@
 //! Snowflake differences from Databricks:
 //! - Uses `database.schema.table` naming (not catalog)
 //! - Double-quoted identifiers for special characters
-//! - No `UPDATE SET *` in MERGE — must enumerate columns
+//! - No `UPDATE SET *` or `INSERT *` shorthand in MERGE — must enumerate
+//!   columns for both the `WHEN MATCHED` and `WHEN NOT MATCHED` branches
 //! - `SAMPLE (N ROWS)` instead of `TABLESAMPLE (N PERCENT)`
 //! - Tags via TAG objects (separate DDL)
 
@@ -62,38 +63,62 @@ impl SqlDialect for SnowflakeSqlDialect {
             validation::validate_identifier(key).map_err(AdapterError::new)?;
         }
 
+        // Snowflake folds unquoted identifiers to UPPERCASE at parse time —
+        // any lowercase / mixed-case column in the source/target table is
+        // case-sensitive and only resolves under explicit double-quoting.
+        // Mirror `format_table_ref`'s policy here: every identifier the
+        // MERGE clause references is double-quoted via `quote_identifier`.
         let on_clause = keys
             .iter()
-            .map(|k| format!("t.{k} = s.{k}"))
+            .map(|k| {
+                let q = self.quote_identifier(k);
+                format!("t.{q} = s.{q}")
+            })
             .collect::<Vec<_>>()
             .join(" AND ");
 
-        // Snowflake does NOT support `UPDATE SET *` — must enumerate columns
-        let update_clause = match update_cols {
+        // Snowflake does NOT support `UPDATE SET *` or `INSERT *` shorthand
+        // in MERGE — must enumerate columns for both branches. The replication
+        // runner resolves `ColumnSelection::All` against the discovered source
+        // schema before SQL-gen, so the call site under
+        // `commands/run.rs::process_table` always reaches us with `Explicit`.
+        // Transformation pipelines specify `update_columns` on the model
+        // sidecar TOML; absence (`All`) is a config error surfaced here.
+        let (update_clause, insert_clause) = match update_cols {
             ColumnSelection::All => {
                 return Err(AdapterError::msg(
-                    "Snowflake MERGE does not support UPDATE SET *. Use explicit update_columns.",
+                    "Snowflake MERGE does not support UPDATE SET * / INSERT *. \
+                     Use explicit update_columns.",
                 ));
             }
             ColumnSelection::Explicit(cols) => {
-                let sets = cols
-                    .iter()
-                    .map(|c| {
-                        validation::validate_identifier(c).map_err(AdapterError::new)?;
-                        Ok(format!("t.{c} = s.{c}"))
-                    })
-                    .collect::<AdapterResult<Vec<_>>>()?;
-                format!("UPDATE SET {}", sets.join(", "))
+                let mut sets = Vec::with_capacity(cols.len());
+                let mut col_list = Vec::with_capacity(cols.len());
+                let mut value_list = Vec::with_capacity(cols.len());
+                for c in cols {
+                    validation::validate_identifier(c).map_err(AdapterError::new)?;
+                    let q = self.quote_identifier(c);
+                    sets.push(format!("t.{q} = s.{q}"));
+                    col_list.push(q.clone());
+                    value_list.push(format!("s.{q}"));
+                }
+                (
+                    format!("UPDATE SET {}", sets.join(", ")),
+                    format!(
+                        "INSERT ({}) VALUES ({})",
+                        col_list.join(", "),
+                        value_list.join(", ")
+                    ),
+                )
             }
         };
 
-        // Snowflake requires explicit column list for INSERT
         Ok(format!(
             "MERGE INTO {target} AS t\n\
              USING (\n{source_sql}\n) AS s\n\
              ON {on_clause}\n\
              WHEN MATCHED THEN {update_clause}\n\
-             WHEN NOT MATCHED THEN INSERT *"
+             WHEN NOT MATCHED THEN {insert_clause}"
         ))
     }
 
@@ -377,7 +402,31 @@ mod tests {
                 &ColumnSelection::Explicit(vec!["name".into(), "status".into()]),
             )
             .unwrap();
-        assert!(sql.contains("UPDATE SET t.name = s.name, t.status = s.status"));
+        // Identifiers double-quoted so they survive Snowflake's
+        // case-fold-on-unquoted rule — source/target tables created with
+        // lowercase column names (the common case for Fivetran-loaded
+        // raw tables) only resolve under explicit quoting.
+        assert!(
+            sql.contains("ON t.\"id\" = s.\"id\""),
+            "expected double-quoted ON-clause keys, got: {sql}"
+        );
+        assert!(
+            sql.contains("UPDATE SET t.\"name\" = s.\"name\", t.\"status\" = s.\"status\""),
+            "expected double-quoted UPDATE SET cols, got: {sql}"
+        );
+        // Snowflake's MERGE rejects `INSERT *` shorthand too — the
+        // WHEN NOT MATCHED branch must emit explicit
+        // `INSERT (cols) VALUES (s.cols)`. Pin both clauses; a regression
+        // that re-introduces `INSERT *` against Snowflake fails at the
+        // parser, not at the runner.
+        assert!(
+            sql.contains("INSERT (\"name\", \"status\") VALUES (s.\"name\", s.\"status\")"),
+            "expected explicit INSERT column list with double-quoted idents, got: {sql}"
+        );
+        assert!(
+            !sql.contains("INSERT *"),
+            "Snowflake MERGE must not emit `INSERT *`, got: {sql}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-snowflake/src/lib.rs
+++ b/engine/crates/rocky-snowflake/src/lib.rs
@@ -7,7 +7,8 @@
 //! Key Snowflake differences from Databricks:
 //! - Double-quoted identifiers (not backticks)
 //! - `CREATE DATABASE` instead of `CREATE CATALOG`
-//! - Explicit column lists in MERGE (no `UPDATE SET *`)
+//! - Explicit column lists in MERGE for both branches (no `UPDATE SET *`,
+//!   no `INSERT *` shorthand)
 //! - `SAMPLE` instead of `TABLESAMPLE`
 //! - `NUMBER(p,s)` instead of `DECIMAL(p,s)` (aliases)
 //! - TAG objects for metadata (different from Databricks ALTER SET TAGS)

--- a/engine/crates/rocky-snowflake/tests/replication_merge_live.rs
+++ b/engine/crates/rocky-snowflake/tests/replication_merge_live.rs
@@ -1,0 +1,293 @@
+//! Live Snowflake conformance tests for the replication `[merge]`
+//! strategy column-resolution fix.
+//!
+//! `#[ignore]`-gated because they require a real Snowflake account.
+//! Run locally with:
+//!
+//! ```bash
+//! SNOWFLAKE_ACCOUNT=<your-account> \
+//! SNOWFLAKE_WAREHOUSE=<your-warehouse> \
+//! SNOWFLAKE_TEST_DATABASE=<your-database> \
+//! # one of:
+//! SNOWFLAKE_OAUTH_TOKEN=<your-oauth-token> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PAT=<personal-access-token> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PASSWORD=<pwd> \
+//! cargo test -p rocky-snowflake --test replication_merge_live -- --ignored --nocapture
+//! ```
+//!
+//! Pins the contract that motivates the replication-runner fix:
+//! Snowflake's MERGE rejects `UPDATE SET *` (Databricks / BigQuery /
+//! DuckDB accept it). The replication runner resolves
+//! `ColumnSelection::All` against the discovered source schema *before*
+//! handing the IR to SQL-gen so the explicit form lands.
+//!
+//! Two cases:
+//! 1. `live_merge_with_explicit_columns_is_idempotent` — runs the
+//!    dialect-emitted MERGE with `ColumnSelection::Explicit(...)` three
+//!    times against a static source. Row count stays stable; this is
+//!    the GREEN-on-fix end-state.
+//! 2. `live_merge_with_update_set_star_is_rejected_by_snowflake` —
+//!    bypasses the dialect's pre-flight check and submits a raw
+//!    `MERGE ... UPDATE SET *` script directly. Snowflake's parser
+//!    rejects it. This is the ground-truth check that proves the bug
+//!    fix is targeting a real warehouse-level rejection, not an
+//!    artifact of the Rust-side guardrail.
+//!
+//! Schemas use the `rocky_repl_merge_test_*` prefix with a microsecond
+//! timestamp suffix for per-run isolation; cleanup follows the same
+//! imperative drop-after-unit-under-test pattern as the bisection /
+//! clone live tests.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_ir::ColumnSelection;
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::dialect::SnowflakeSqlDialect;
+
+fn adapter_from_env() -> Option<(SnowflakeWarehouseAdapter, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    let connector = SnowflakeConnector::new(config, auth);
+    Some((SnowflakeWarehouseAdapter::new(connector), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn create_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""
+        ))
+        .await
+        .expect("create schema");
+}
+
+async fn drop_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"
+        ))
+        .await;
+}
+
+/// Seed a 3-row source table with `(id, name, amount)` so the merge
+/// touches a non-trivial column list (more than just the merge key).
+/// Column names are double-quoted to survive Snowflake's
+/// case-fold-on-unquoted rule and match the dialect's quoting.
+async fn seed_source(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+) {
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE \"{database}\".\"{schema}\".\"{table}\" \
+             (\"id\" INTEGER, \"name\" STRING, \"amount\" NUMBER(10, 2))"
+        ))
+        .await
+        .expect("create source table");
+    adapter
+        .execute_statement(&format!(
+            "INSERT INTO \"{database}\".\"{schema}\".\"{table}\" (\"id\", \"name\", \"amount\") \
+             VALUES (1, 'alpha', 10.50), (2, 'beta', 20.75), (3, 'gamma', 30.00)"
+        ))
+        .await
+        .expect("seed rows");
+}
+
+async fn create_empty_target(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+) {
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE \"{database}\".\"{schema}\".\"{table}\" \
+             (\"id\" INTEGER, \"name\" STRING, \"amount\" NUMBER(10, 2))"
+        ))
+        .await
+        .expect("create target table");
+}
+
+async fn count_rows(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+) -> Option<i64> {
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT COUNT(*) AS \"n\" FROM \"{database}\".\"{schema}\".\"{table}\""
+        ))
+        .await
+        .ok()?;
+    let cell = result.rows.first()?.first()?.clone();
+    cell.as_i64()
+        .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// GREEN end-state: the explicit-column MERGE the replication runner
+/// produces after the column-resolution fix is idempotent against
+/// Snowflake. Three back-to-back runs against a static source leave the
+/// target at 3 rows.
+#[tokio::test]
+#[ignore]
+async fn live_merge_with_explicit_columns_is_idempotent() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("rocky_repl_merge_test_{suffix}");
+    let source_tbl = "src_orders";
+    let target_tbl = "tgt_orders";
+
+    create_schema(&adapter, &database, &schema).await;
+    seed_source(&adapter, &database, &schema, source_tbl).await;
+    create_empty_target(&adapter, &database, &schema, target_tbl).await;
+
+    let dialect = SnowflakeSqlDialect;
+    let target_ref = dialect
+        .format_table_ref(&database, &schema, target_tbl)
+        .expect("format target ref");
+    let source_ref = dialect
+        .format_table_ref(&database, &schema, source_tbl)
+        .expect("format source ref");
+    // Mirrors the replication runner's resolved SELECT: SELECT every
+    // source column, no metadata columns for this minimal case.
+    let source_sql = format!("SELECT \"id\", \"name\", \"amount\" FROM {source_ref}");
+    let keys: Vec<Arc<str>> = vec![Arc::from("id")];
+    // Mirrors `resolve_merge_update_columns` output: source columns
+    // (including the merge key) expanded into ColumnSelection::Explicit.
+    let update_cols = ColumnSelection::Explicit(vec![
+        Arc::from("id"),
+        Arc::from("name"),
+        Arc::from("amount"),
+    ]);
+    let merge_sql = dialect
+        .merge_into(&target_ref, &source_sql, &keys, &update_cols)
+        .expect("dialect emits explicit-column MERGE");
+
+    // Run the same MERGE three times against the static source; each
+    // run is a no-op against an already-merged target.
+    let mut counts = Vec::with_capacity(3);
+    let mut last_err = None;
+    for _ in 0..3 {
+        match adapter.execute_statement(&merge_sql).await {
+            Ok(_) => counts.push(count_rows(&adapter, &database, &schema, target_tbl).await),
+            Err(e) => {
+                last_err = Some(format!("{e}"));
+                break;
+            }
+        }
+    }
+
+    drop_schema(&adapter, &database, &schema).await;
+
+    if let Some(err) = last_err {
+        panic!("MERGE statement failed against Snowflake: {err}\nSQL:\n{merge_sql}");
+    }
+    assert_eq!(
+        counts,
+        vec![Some(3), Some(3), Some(3)],
+        "3 idempotent merges should keep target row count at 3; got {counts:?}"
+    );
+}
+
+/// Ground-truth check: the broken pre-fix path (`UPDATE SET *`) is
+/// rejected by Snowflake's parser. We submit the raw broken MERGE
+/// directly, bypassing the dialect's Rust-side `UPDATE SET *` guard at
+/// `dialect.rs::merge_into`. If Snowflake ever accepts `UPDATE SET *`
+/// in a future release, this test starts failing and we know to revisit
+/// the resolution path.
+#[tokio::test]
+#[ignore]
+async fn live_merge_with_update_set_star_is_rejected_by_snowflake() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("rocky_repl_merge_test_{suffix}");
+    let source_tbl = "src_orders";
+    let target_tbl = "tgt_orders";
+
+    create_schema(&adapter, &database, &schema).await;
+    seed_source(&adapter, &database, &schema, source_tbl).await;
+    create_empty_target(&adapter, &database, &schema, target_tbl).await;
+
+    let dialect = SnowflakeSqlDialect;
+    let target_ref = dialect
+        .format_table_ref(&database, &schema, target_tbl)
+        .expect("format target ref");
+    let source_ref = dialect
+        .format_table_ref(&database, &schema, source_tbl)
+        .expect("format source ref");
+    let source_sql = format!("SELECT \"id\", \"name\", \"amount\" FROM {source_ref}");
+
+    // Hand-built MERGE with the broken `UPDATE SET *` shorthand —
+    // mirrors what the replication runner emitted BEFORE the resolution
+    // fix, before the dialect's pre-flight check ever ran.
+    let broken_merge_sql = format!(
+        "MERGE INTO {target_ref} AS t\n\
+         USING (\n{source_sql}\n) AS s\n\
+         ON t.\"id\" = s.\"id\"\n\
+         WHEN MATCHED THEN UPDATE SET *\n\
+         WHEN NOT MATCHED THEN INSERT *"
+    );
+
+    let result = adapter.execute_statement(&broken_merge_sql).await;
+    drop_schema(&adapter, &database, &schema).await;
+
+    match result {
+        Ok(_) => panic!(
+            "Snowflake accepted `MERGE ... UPDATE SET *` — adapter parity assumption broken.\n\
+             SQL:\n{broken_merge_sql}"
+        ),
+        Err(e) => {
+            let msg = format!("{e}");
+            // Snowflake's parser typically returns a syntax-error
+            // message naming the unexpected token. Loose substring
+            // match — the exact wording can vary across Snowflake
+            // releases; what matters is that the statement is rejected.
+            eprintln!("Snowflake rejected UPDATE SET * (expected): {msg}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replication's `strategy = "merge"` was unusable against Snowflake. The runner dispatched `ColumnSelection::All` to SQL-gen, which emitted `UPDATE SET *`; Databricks / BigQuery / DuckDB accept that shorthand, Snowflake rejects it. Transformation users had an escape hatch via the model TOML sidecar's `update_columns`; replication had none.

**Approach (Option B):** resolve `ColumnSelection::All` at runtime against the discovered source schema BEFORE the IR reaches SQL-gen. `process_table` already awaits `describe_table(&source_table)` for drift detection — `source_cols` is in scope and free; no new config surface, no extra round-trip. Picked over Option A (`update_columns` on `ReplicationPipelineConfig`) because the resolution is mechanical from data the runner already holds, and a new config field would push the resolution onto the user.

Live-verification surfaced two adjacent Snowflake-MERGE bugs the original spec didn't call out — without them, the column-threading fix alone doesn't unblock Snowflake replication-merge. Both are receipts from `ROCKY_TEST`:

1. **`INSERT *` rejected.** Snowflake's `WHEN NOT MATCHED` branch needs `INSERT (col1, ...) VALUES (s.col1, ...)`. The dialect comment claimed "explicit column list" but emitted `INSERT *`. Snowflake error: `syntax error line 7 at position 29 unexpected '*'`.
2. **Unquoted identifiers folded to UPPER.** Source tables created with lowercase double-quoted column names (the common case for Fivetran-loaded raw tables) don't resolve under `t.id = s.id` because Snowflake folds the unquoted `id` to `ID`. Snowflake error: `invalid identifier 'ID'`. Fix mirrors `format_table_ref`'s existing `quote_identifier` policy — every MERGE-clause identifier is double-quoted.

Split into two scoped commits so each layer is independently bisectable:
- `1e32d853` — dialect: `INSERT (...) VALUES (...)` + quoted identifiers
- `d9efbbaa` — runner: `resolve_merge_update_columns` + live `#[ignore]` test

## Why the existing transformation escape-hatch wasn't enough

`update_columns` on a model sidecar TOML doesn't apply to replication pipelines — replication has no per-table model files, so users would need a new config surface to provide the column list. Resolving from the runner-held source schema avoids that ask entirely.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -p rocky-snowflake -p rocky-core -p rocky-cli -- -D warnings` clean
- [x] `cargo test -p rocky-snowflake -p rocky-core -p rocky-cli` — 554 + 144 cli/snowflake unit tests pass; 3 new `resolve_merge_update_columns_*` tests added
- [x] `cargo test -p rocky-cli --test ir_golden` — 2 snapshots updated (`03-replication-merge/snowflake.sql`, `05-transformation-merge/snowflake.sql`) reflect the new quoted-INSERT form
- [x] `cargo build --workspace` clean
- [x] `just codegen` — zero drift (no `*Output` struct touched)
- [x] **Live-verify** against Snowflake `ROCKY_TEST` (statement handle `01c48118-0001-c951-0002-6a7a0006d302`):
  - `live_merge_with_explicit_columns_is_idempotent` — RED on `main` (Snowflake rejects `INSERT *`); GREEN on this branch. 3 back-to-back merges leave target row count stable at 3.
  - `live_merge_with_update_set_star_is_rejected_by_snowflake` — pins Snowflake's parser-level rejection of the broken pre-fix SQL.