### PR TITLE
docs: pivot positioning to "trust plane for your warehouse"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,30 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Rocky** is a typed-program layer above the warehouse: branches, replay, column-level lineage, compile-time type safety, per-model cost attribution. Storage and compute stay with your warehouse — Databricks, Snowflake, BigQuery, or DuckDB. Apache 2.0.
+**Rocky is the trust plane for your warehouse.** A typed compiler, named branches, deterministic replay, column-level lineage, contracts, and per-model cost — all running over your existing Databricks / Snowflake / BigQuery / DuckDB. Apache 2.0.
+
+Rocky exists because the disasters that cost data teams real money — silent schema drift wrecking a revenue dashboard, a column rename quietly poisoning 47 downstream models, an auditor asking who touched `fct_revenue.amount` and when, a cost spike that no one can attribute to a model — all share a common shape. They're problems the warehouse can't see and the templating engine on top of it was never asked to. Rocky owns the graph between your code and the warehouse so those problems become compile errors, blocked PRs, and signed artifacts instead of pages and post-mortems.
+
+It's built for the team running production-critical multi-tenant pipelines on Databricks today, on Snowflake or BigQuery tomorrow, who can't tolerate another silent failure. Storage and compute stay where they are.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart — create a project, compile, and run 3 models in under 15s" width="900" />
 </p>
+
+## The disasters Rocky prevents
+
+| Disaster | What dbt does | What Rocky does |
+|---|---|---|
+| Upstream changes a column type | Silent — fails downstream, hours later | `E013` at compile, blocks the PR |
+| Required column dropped from a contract | No contract concept | `E010` at compile, blocks the PR |
+| Column rename with unknown blast radius | `dbt docs` post-hoc, table-level | `rocky lineage-diff` at PR time, column-level, downstream consumers listed |
+| `SELECT *` pulls a new column you didn't expect | Silent | `P002` warning, downstream consumers named |
+| Snowflake-only function written for a Databricks project | Runs in dev, fails in prod | `P001` dialect-portability lint at compile |
+| Run cost doubles, no one knows which model | Manual warehouse spelunking | `RunOutput.cost_summary` per model, every run |
+| Auditor asks: who changed `fct_revenue.amount`, when, and why? | Git blame + screenshots | `rocky replay <run_id>` — signed, content-addressed artifact of the exact code + inputs + outputs |
+| Sev-2 at 3 AM, half the pipeline already ran | Re-run everything | `rocky run --resume-latest` — checkpoint, three-state circuit breaker, skip what succeeded |
+
+Each row is a real failure mode, with a Rocky command that turns it into a non-event. The same primitives — typed compiler, content-addressed state, column-level lineage, per-model cost — back every row.
 
 ## Try it in 60 seconds
 
@@ -33,6 +52,12 @@ rocky compile && rocky test && rocky run
 ```
 
 No credentials needed — the playground runs end-to-end on local DuckDB.
+
+## Who Rocky is for
+
+Rocky is built first for **data platform engineers running production-critical, multi-tenant pipelines on Databricks** — the team that's hit dbt's ceiling, where silent failures cost real money, and where Dagster is already the orchestrator. That's the launch wedge, and that's where Rocky is most battle-tested.
+
+The next ring out: **Snowflake and BigQuery shops** currently evaluating SQLMesh, who want correctness moved to the compiler (not the planner) and prefer SQL by default over Python-first ergonomics. Adapters are Beta today; see [Where Rocky is today](#where-rocky-is-today) below.
 
 ## See it in action
 
@@ -117,6 +142,20 @@ Tag PII columns in the model sidecar; bind tags to mask strategies in `[mask]` /
 </p>
 
 [POC — `02-performance/01-incremental-watermark`](examples/playground/pocs/02-performance/01-incremental-watermark/)
+
+## Where Rocky is today
+
+Rocky has run 927 production materializations across 14 customer pipelines on Databricks in its current line of development — alongside ~4,200 dbt runs it was deployed against. The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks.
+
+We're explicit about the rest:
+
+- **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta — connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
+- **AI is a growing surface, not a finished product.** The compile-validate loop (generate → type-check → auto-fix → land) is real and shipped; the broader story (mass refactor across the DAG, auto-migration from a column type change, schema-aware assertion generation) is on the roadmap, not the changelog.
+- **Iceberg is supported as a source today.** First-class Iceberg-native writes — Rocky as the typed program over an open table format — is on the 2026 roadmap.
+- **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
+- **Orchestration: Dagster is first-class.** A `rocky serve` standalone path exists; native Airflow / Prefect integrations are not yet shipped — they're called from the CLI like any other binary.
+
+If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions) — the roadmap is shaped by where production pipelines are actually getting hurt.
 
 ## Subprojects
 

--- a/docs/src/content/docs/dagster/introduction.md
+++ b/docs/src/content/docs/dagster/introduction.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-`dagster-rocky` bridges Rocky's Rust binary with Dagster orchestration. You keep Rocky for the SQL transformation layer (DAG resolution, incremental logic, schema drift, permissions) and gain Dagster's scheduling, retries, alerts, and asset-centric UI.
+`dagster-rocky` bridges Rocky's Rust binary with Dagster orchestration. Rocky is the **trust plane** — typed compiler, compile-time contracts, column-level lineage, schema drift detection, branches + replay, per-model cost. Dagster is the orchestrator — scheduling, retries, alerts, the asset-centric UI. The guarantees Rocky enforces at compile time surface as native Dagster events (asset checks, materializations, metadata) so the asset graph reflects the same trust contract.
 
 ## Quick start
 

--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -1,9 +1,21 @@
 ---
 title: All Features
-description: Complete list of Rocky capabilities across compilation, execution, governance, and developer experience
+description: The full capability surface organized around the seven trust dimensions Rocky enforces.
 sidebar:
   order: 11
 ---
+
+Rocky organizes its capabilities around **seven trust dimensions** — the failure modes that quietly cost data teams the most. Each dimension below maps to specific commands, diagnostic codes, and configuration knobs.
+
+1. **Typed compiler** — `rocky compile`, 35+ diagnostics
+2. **Column-level lineage** — `rocky lineage`, `rocky lineage-diff`
+3. **Branches + replay** — `rocky branch`, `rocky replay`
+4. **Cost attribution** — `RunOutput.cost_summary`, `[budget]`, `rocky cost`
+5. **AI gated through the compiler** — `rocky ai`, `rocky ai-sync`
+6. **Dialect-divergence lint** — `P001` portability lint
+7. **Declarative governance** — RBAC diff, masking, classification, `rocky compliance`
+
+The capability detail follows. For positioning vs other tools, see [Comparison](/features/comparison/). For honest scope (Databricks-first, Snowflake/BigQuery Beta, Iceberg-native on the roadmap), see [Where Rocky is today](/getting-started/introduction/#where-rocky-is-today).
 
 ## Warehouse Support
 

--- a/docs/src/content/docs/features/comparison.md
+++ b/docs/src/content/docs/features/comparison.md
@@ -7,6 +7,13 @@ sidebar:
 
 A factual feature-by-feature comparison of the major SQL transformation tools in the modern data stack. Features verified against official documentation and source code as of April 2026.
 
+Quick positioning before the tables:
+
+- **vs dbt.** dbt is the incumbent, not the competitor. Rocky's path is import-compatibility (`rocky import-dbt`) plus a step-change on the failure modes dbt structurally can't catch: silent schema drift, compile-time contracts, column-level lineage at PR time, per-model cost. dbt remains the right choice for moderate-scale, low-blast-radius pipelines where Jinja templating is enough.
+- **vs SQLMesh.** SQLMesh moved correctness to the planner. **Rocky moved it to the compiler.** SQLMesh's checks are runtime-ish; Rocky's are compile-time, expressed as diagnostic codes (`E001`–`E026`) you can grep in CI logs. SQLMesh is Python-first; Rocky keeps SQL as the default surface and reaches for a DSL only when SQL doesn't fit. SQLMesh's virtual environments are a genuinely good idea — Rocky's named branches express the same workflow with column-level lineage attached. SQLMesh is more mature in years and funding; Rocky is further along on Rust-native enforcement, LSP / IDE polish, compile-time column lineage, and cost as a first-class citizen.
+- **vs warehouse-native pipelines (Databricks LakeFlow, Snowflake Dynamic Tables).** Those are warehouse-coupled and free with the platform. Rocky stays warehouse-neutral and ships a real compiler. If portability and serious tooling matter to you, Rocky wins; if they don't, the warehouse-native option may be "good enough."
+- **vs observability tools (Datafold, Monte Carlo, Anomalo).** Not competitors. Rocky prevents what these detect; they remain useful for the failure modes Rocky doesn't model. Integrate, don't replace.
+
 ## Architecture
 
 | Feature | Rocky | dbt-core | dbt-fusion | SQLMesh | Coalesce | Dataform |
@@ -171,9 +178,9 @@ See [benchmarks](/features/benchmarks/) for full cost analysis and methodology.
 
 | Tool | Best for |
 |---|---|
-| **Rocky** | High-scale (10k-50k+) Databricks/Snowflake/BigQuery pipelines. Teams needing compile-time safety, schema drift handling, governance automation, and sub-second iteration. |
-| **dbt-core** | Industry standard with the largest community and adapter ecosystem. Best for moderate scale (<5k models) with Jinja templating. |
+| **Rocky** | Production-critical, multi-tenant pipelines where silent failures cost real money. Databricks-first; Snowflake/BigQuery Beta. Compile-time contracts, column-level lineage at PR time, branches + replay, per-model cost attribution. |
+| **dbt-core** | Industry standard with the largest community and adapter ecosystem. Best for moderate scale (<5k models) with Jinja templating and where post-hoc lineage is acceptable. |
 | **dbt-fusion** | Teams on Snowflake wanting faster parse times while staying in the dbt ecosystem. Compile is slower than dbt-core; best adopted once GA. |
-| **SQLMesh** | SQL transpilation (write once, deploy anywhere), virtual environments, and column-level lineage without warehouse queries. |
-| **Coalesce** | Visual, low-code transformation for Snowflake-first organizations with less technical analysts. |
+| **SQLMesh** | Teams that want correctness checks at the planner level, Python-first ergonomics, and virtual environments. Closest competitor to Rocky on intent — Rocky differs by enforcing correctness at the compiler, defaulting to SQL, and attaching column-level lineage to the compile output. |
+| **Coalesce** | Visual, low-code transformation for Snowflake-first organizations with less technical analysts. Different buyer than Rocky. |
 | **Dataform** | BigQuery-only shops wanting tight GCP integration with minimal tooling. |

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -1,17 +1,38 @@
 ---
 title: Introduction
-description: What Rocky is and how it compares to dbt
+description: What Rocky is, who it's for, and where it is today.
 sidebar:
   order: 1
 ---
 
-Rocky is a typed-program layer above the warehouse. Branches, replay, column-level lineage, compile-time type safety, and per-model cost attribution — primitives delivered through a single static binary that drives Databricks, Snowflake, BigQuery, or DuckDB. Things your current stack can't offer because it doesn't own the DAG.
+**Rocky is the trust plane for your warehouse.** A typed compiler that owns the graph between your code and your data — branches, deterministic replay, column-level lineage, compile-time contracts, dialect-portability lint, per-model cost attribution. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, or DuckDB); Rocky owns everything else.
+
+## Why Rocky exists
+
+The expensive failures in modern data platforms aren't slow queries — they're trust failures:
+
+- A source column type changes upstream and a revenue dashboard quietly diverges for three days.
+- An engineer renames a column on `stg_orders` and 47 downstream models break in production.
+- A `SELECT *` pulls a new column nobody designed for; a downstream join silently double-counts.
+- A Snowflake-only function lands in a Databricks-targeted project and only fails in prod.
+- Warehouse spend doubles in a month and nobody can attribute which model caused it.
+- An auditor asks who changed `fct_revenue.amount`, when, and why — and the answer involves `git blame` and screenshots.
+
+dbt, by design, is a templating engine — it can't catch any of these at compile time. SQLMesh moved correctness to the planner. **Rocky moved it to the compiler.** Each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
+
+## Who Rocky is for
+
+Rocky is built first for the **lead data platform engineer running production-critical, multi-tenant pipelines on Databricks** — where dbt has hit a ceiling, silent failures cost real money, and Dagster is already the orchestrator. That's the wedge, and that's where Rocky is most battle-tested.
+
+The next ring out is **Snowflake and BigQuery teams evaluating SQLMesh** who want correctness moved to the compiler (not the planner), and prefer SQL by default over Python-first ergonomics. The adapters work today but are Beta — see [Where Rocky is today](#where-rocky-is-today) below.
+
+Rocky is **not** a fit for: greenfield analytics shops with no scale pain, single-analyst dbt setups, or teams using a warehouse-native pipeline product (Databricks LakeFlow, Snowflake Dynamic Tables) and unwilling to give up its features for portability and compile-time safety.
 
 ## What Rocky is
 
-A typed-program layer above the warehouse. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, or DuckDB). Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost.
+A typed compiler that drives your warehouse. Storage and compute stay where they are. Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost, contracts, governance.
 
-**Rocky is not a warehouse.** It's what sits on top of one.
+**Rocky is not a warehouse.** It's the trust plane in front of one.
 
 ## Scope on the ELT spectrum
 
@@ -24,36 +45,55 @@ A typed-program layer above the warehouse. Storage and compute stay with your wa
 | Quality | ✅ | Inline assertions during `rocky apply`; no separate test step |
 | Orchestration | Partial | First-class Dagster integration; `rocky serve` for small standalone teams |
 
-## What Rocky does
+## The seven trust dimensions
 
-1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky plan --branch <name>` + `rocky apply <plan-id>` (the legacy `rocky run --branch <name>` alias is still accepted), `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
-2. **Cost attribution + budgets** — per-model cost on every run. `[budget]` block in `rocky.toml`; `budget_breach` hook event on exceed.
-3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
-4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).
-5. **Schema-grounded AI** — every AI feature gated through the compiler; generated SQL type-checks before it lands.
-6. **Polyglot correctness** — dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB (12 constructs today).
-7. **SQL as first-class with types** — type inference over raw `.sql`, `SELECT *` blast-radius lint, DAG-aware refactoring.
+1. **SQL as a typed, compiled language.** Column-level type inference across the full DAG. 35+ diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`) with actionable suggestions. Not text macros — a real compiler with a real LSP.
+2. **Compile-time column-level lineage.** Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review — the kind of CI gate that's impossible without a compiled engine.
+3. **Branches + deterministic replay.** Named branches as isolated schemas. `rocky branch create` / `rocky run --branch` / `rocky replay <run_id>`. Replay is content-addressed: inputs + code → outputs is a pure function, recorded.
+4. **Per-model cost attribution.** Cost is a column on every run record, not an afterthought dashboard. `[budget]` blocks fail the run on overspend; `budget_breach` fires the hook; `rocky preview cost` projects spend at PR time.
+5. **AI gated through the compiler.** Every AI suggestion type-checks before it lands. `rocky ai` generates → compiles → auto-fixes → ships; the `Attempts: 2` retry loop is the signature feature. (The broader AI surface — mass refactor, auto-migration on a column type change — is roadmap, not changelog. See [Where Rocky is today](#where-rocky-is-today).)
+6. **Dialect-divergence lint.** `P001` catches Snowflake-only constructs in a Databricks project, and the reverse. Useful the day you start a migration; essential the day you finish one.
+7. **Declarative governance.** RBAC as code with GRANT/REVOKE diffing, Unity Catalog tags, workspace isolation, mask strategies bound to classification tags. `rocky compliance --fail-on exception` gates CI on unmasked PII.
+
+## Where Rocky is today
+
+We are explicit about the difference between what Rocky ships and what's on the roadmap. The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks. The rest:
+
+- **Databricks is the production target for 2026.** SQL Statement API, Unity Catalog, OAuth M2M, adaptive concurrency, `SHALLOW CLONE` for branches — all production-grade.
+- **Snowflake, BigQuery, Trino are Beta.** Connection, execution, and the core run loop work; conformance coverage is still growing. We test against live warehouses; corner cases get reported and fixed quickly. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, [open a discussion](https://github.com/rocky-data/rocky/discussions) — we want the failure reports.
+- **AI is a growing surface.** The compile-validate loop is real and shipped. The killer demo (rename a column, regenerate 47 downstream models, regenerate assertions, run tests, ship) is the 2026 roadmap.
+- **Iceberg is a source today.** First-class Iceberg-native writes — Rocky as the typed program over an open table format — is on the 2026 roadmap.
+- **No built-in semantic layer.** Rocky's typed IR is the right home for one; until then, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
+- **Orchestration: Dagster is first-class.** `rocky serve` exists for small standalone teams. Native Airflow / Prefect integrations are not shipped — those orchestrators call Rocky like any other CLI.
+
+If those gaps are blockers for your team, the roadmap is shaped by where production pipelines are actually getting hurt — [tell us where](https://github.com/rocky-data/rocky/discussions).
 
 ## Practical differentiators
 
-- **Fast.** Single binary, starts in under 100ms. Compiles 500 models in seconds.
-- **Type-safe.** Column-level type inference catches schema errors at compile time.
-- **Pure SQL.** No Jinja; business logic stays in SQL.
+- **Fast.** Single binary, starts in under 100ms. Compiles 10k models in ~1 s with ~150 MB peak memory. See [benchmarks](/features/benchmarks/).
+- **Type-safe.** Column-level type inference catches schema errors at compile time, before a row is written.
+- **Pure SQL.** No Jinja; business logic stays in SQL. An optional Rocky DSL exists for the cases SQL doesn't handle well.
 - **Config-first bronze.** Source replication is driven by `rocky.toml` — zero SQL files for 1:1 copies.
-- **Embedded state.** Watermarks live in a local `redb` database, with optional S3 / Valkey sync.
+- **Embedded state.** Watermarks live in a local `redb` database, with optional S3 / Valkey sync. No manifest file.
 
-## How Rocky compares to dbt
+## How Rocky compares
+
+**Coming from dbt?** dbt is the incumbent, not the competitor. Rocky's path is import-compatibility plus an order of magnitude on the failure modes that bite production teams — schema drift, lineage at PR time, cost attribution, contracts as compile errors. Start with `rocky import-dbt` (see the [migration guide](/guides/migrate-from-dbt/)).
 
 | | dbt | Rocky |
 |---|---|---|
 | Templating | Jinja | None — pure SQL |
 | Staging models | One `.sql` per source table | Config-driven bronze (zero SQL) |
 | Dependencies | `{{ ref('model') }}` | `depends_on = ["model"]` |
-| Tests | `schema.yml` + `dbt test` | Inline checks + assertions in `rocky apply` |
+| Tests | `schema.yml` + `dbt test` | Inline checks + assertions in `rocky run` |
 | State | `manifest.json` + `target/` | Embedded `redb` database |
-| Branches | — | `rocky branch create`, `rocky plan --branch <name>` |
-| Column-level lineage | Post-hoc (`dbt docs`) | Compile-time output |
+| Branches | — | `rocky branch create`, `rocky run --branch <name>` |
+| Column-level lineage | Post-hoc (`dbt docs`) | Compile-time output, queryable per column |
+| Schema drift | Silent | `E013` at compile, blocks the PR |
 | Cost attribution | — | Per-model, every run |
+| Replay | — | Content-addressed, deterministic |
+
+**Evaluating SQLMesh?** SQLMesh moved correctness to the planner. Rocky moved it to the compiler. SQLMesh's checks are runtime-ish; Rocky's are compile-time. SQLMesh is Python-first; Rocky keeps SQL as the default and reaches for a DSL only when SQL doesn't fit. SQLMesh has virtual environments — a genuinely good idea Rocky's branches express differently. SQLMesh is more mature in years and funding; Rocky is further along on Rust-native compile-time enforcement, LSP / IDE experience, column-level lineage at compile time, and cost attribution as a first-class citizen.
 
 Full side-by-side comparison: [features/comparison](/features/comparison/).
 

--- a/docs/src/content/docs/guides/migrate-from-dbt.md
+++ b/docs/src/content/docs/guides/migrate-from-dbt.md
@@ -1,11 +1,21 @@
 ---
 title: Migrating from dbt
-description: Step-by-step guide to importing a dbt project into Rocky and adopting its compiler, type system, and contracts
+description: Run rocky import-dbt against your existing project and adopt Rocky's compiler, lineage, branches, and contracts incrementally — no rewrite.
 sidebar:
   order: 2
 ---
 
-Rocky includes a built-in importer that converts dbt SQL models to Rocky's sidecar format. This guide walks through the full migration: from importing models, to handling unsupported Jinja, to configuring your pipeline, to adopting Rocky's type system and contracts.
+**The migration is the conversion path.** Most teams adopting Rocky have a dbt project today; the day-one question is "how much rewriting?" The answer: little to none. Run `rocky import-dbt` against your existing repo, get a Rocky project on disk in seconds, and adopt the trust primitives — typed compile, contracts, column-level lineage, branches, cost — incrementally.
+
+The wedge in five steps:
+
+1. **Run `rocky import-dbt`.** Jinja `{{ ref() }}` and `{{ source() }}` resolve to bare references; configs become TOML sidecars; the importer writes `MIGRATION-NOTES.md` listing anything that didn't translate.
+2. **Run `rocky compile`.** First time through, expect real diagnostics — `E013` on type mismatches, `P002` on `SELECT *` blast radius, `P001` on dialect-portability issues. Each one is something dbt couldn't catch.
+3. **Add contracts on the boundary models.** `[contract] required_columns = […]`, `protected_columns = […]`. From here, the column rename that quietly breaks 47 downstream models becomes an `E010` in CI before it ships.
+4. **Adopt `rocky lineage-diff` in PR review.** Per-changed-column downstream blast radius. Drops into a PR comment. This is the moment your team stops reviewing changes blind.
+5. **Turn on `rocky preview cost`.** Per-PR cost projection — catch expensive plans before they ship instead of explaining them after.
+
+Everything below is the mechanics. The strategic point is above: you don't rewrite, you import and adopt.
 
 ## Prerequisites
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,14 +1,18 @@
 ---
-title: Rocky — typed-program layer above the warehouse
-description: A typed-program layer above the warehouse — branches, replay, column-level lineage, compile-time type safety, per-model cost attribution.
+title: Rocky — the trust plane for your warehouse
+description: A typed compiler over Databricks / Snowflake / BigQuery / DuckDB — branches, replay, column-level lineage, compile-time contracts, and per-model cost attribution.
 template: splash
 hero:
-  tagline: A compiled SQL transformation engine in Rust. Type-safe compilation, column-level lineage, and an AI intent layer — for data pipelines that don't break.
+  tagline: The trust plane for your warehouse — a typed compiler with branches, replay, column-level lineage, contracts, and per-model cost. Storage and compute stay where they are.
   actions:
     - text: Get Started in 60 Seconds
       link: /guides/playground/
       icon: right-arrow
       variant: primary
+    - text: Coming from dbt? Migrate in 5 steps
+      link: /guides/migrate-from-dbt/
+      icon: right-arrow
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/rocky-data/rocky
       icon: external
@@ -16,24 +20,30 @@ hero:
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
+## The disasters Rocky prevents
+
+Rocky exists because the most expensive failures in modern data platforms aren't slow queries — they're trust failures. A column type changes upstream and a revenue dashboard quietly diverges for three days. A `SELECT *` pulls a new column nobody designed for. A Snowflake-only function lands in a Databricks-targeted project and only fails in prod. Warehouse spend doubles and nobody can attribute which model caused it. An auditor asks who changed `fct_revenue.amount` and when.
+
+dbt is a templating engine; it can't catch any of these at compile time. SQLMesh moved correctness to the planner. **Rocky moved it to the compiler** — so the disasters above become `E013` diagnostics, blocked PRs, `rocky lineage-diff` comments, and content-addressed replay artifacts.
+
 <CardGrid>
-  <Card title="Type-Safe Compiler" icon="approve-check">
-    Column-level type inference and data contracts catch errors before execution.
+  <Card title="Typed compiler, not a templating engine" icon="approve-check">
+    Column-level type inference across the full DAG. 35+ diagnostic codes with actionable suggestions. `E013` blocks the PR before a row is written.
   </Card>
-  <Card title="Pure SQL or DSL" icon="document">
-    Write standard SQL with TOML config, or use the Rocky DSL for NULL-safe operators, windows, and pattern matching.
+  <Card title="Column-level lineage at compile time" icon="seti:graphql">
+    Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review.
   </Card>
-  <Card title="AI Intent Layer" icon="star">
-    Store intent as metadata. AI explains models, syncs them when upstream schemas change, and generates tests.
+  <Card title="Branches + deterministic replay" icon="random">
+    Named branches as isolated schemas. `rocky replay <run_id>` reconstructs a run bit-for-bit — inputs, code, and outputs as a content-addressed artifact.
   </Card>
-  <Card title="VS Code Extension" icon="laptop">
-    Full language server: completion, hover, go-to-definition, rename, code actions, and lineage visualization.
+  <Card title="Per-model cost attribution" icon="rocket">
+    Cost is a column on every run, not a dashboard. `[budget]` blocks fail the run on overspend. `rocky preview cost` projects spend at PR time.
   </Card>
-  <Card title="Quality Checks" icon="warning">
-    Inline pipeline checks (row count, freshness, null rate, anomaly) plus model-level assertions with severity and quarantine.
+  <Card title="AI gated through the compiler" icon="star">
+    Every AI suggestion type-checks before it lands. Generate → compile → auto-fix → ship — the closed-loop nobody else has.
   </Card>
-  <Card title="Dagster Integration" icon="puzzle">
-    Auto-discover assets, emit materializations, and translate check results — all via `dagster-rocky`.
+  <Card title="Dialect-divergence lint" icon="puzzle">
+    `P001` catches Snowflake-only constructs in a Databricks project, and the reverse. Cross-warehouse teams stop discovering portability bugs in prod.
   </Card>
 </CardGrid>
 
@@ -57,7 +67,13 @@ No credentials needed — the playground is DuckDB-backed.
 
 <video src="/trace-cost-replay-combo.mp4" controls width="720"></video>
 
+## Who Rocky is for
+
+Rocky is built first for **data platform engineers running production-critical, multi-tenant pipelines on Databricks** — the team where silent failures cost real money and dbt has hit a ceiling. The trust primitives are most battle-tested there.
+
+The next ring out: **Snowflake and BigQuery shops evaluating SQLMesh**, who want correctness moved to the compiler (not the planner) and prefer SQL by default. Adapters are Beta today — see the [introduction](/getting-started/introduction/#where-rocky-is-today) for the honest 2026 roadmap.
+
 <CardGrid>
-  <LinkCard title="Coming from dbt?" href="/guides/migrate-from-dbt/" description="Import your dbt project, convert tests to contracts, and adopt Rocky incrementally." />
-  <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="Auto-discovery, rich metadata, and check-result integration via dagster-rocky." />
+  <LinkCard title="Coming from dbt?" href="/guides/migrate-from-dbt/" description="Run rocky import-dbt against your project, get a Rocky repo on disk, ship the gains incrementally — no rewrite." />
+  <LinkCard title="Using Dagster?" href="/dagster/introduction/" description="dagster-rocky wraps the CLI as a ConfigurableResource. Auto-discovery, asset checks, Pipes — one subprocess hop." />
 </CardGrid>

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -7,7 +7,7 @@
 
 # Rocky VS Code Extension
 
-Language support for the [Rocky](https://github.com/rocky-data/rocky) SQL transformation engine — full LSP, lineage visualization, and AI model generation.
+Editor support for [Rocky](https://github.com/rocky-data/rocky) — the trust plane for your warehouse. Real LSP (not Jinja-aware text completion), interactive column-level lineage, compile-time diagnostics inline, and AI model generation gated through the compiler.
 
 ## Features
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,10 +1,23 @@
 # Rocky
 
-A typed-program layer above the warehouse: branches, replay, column-level lineage, compile-time type safety, per-model cost attribution. Single static binary; storage and compute stay with your warehouse.
+**The trust plane for your warehouse.** Rocky is a typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data — named branches, deterministic replay, column-level lineage, compile-time contracts, per-model cost attribution. A single static Rust binary; storage and compute stay where they are.
 
-**Rocky is not a warehouse.** Storage and compute stay with your warehouse; Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost.
+**Rocky is not a warehouse, and not a templating layer.** It's a real compiler with type inference, diagnostic codes, and an IDE — so the failures that quietly cost data teams the most (silent schema drift, column rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs, not pages and post-mortems.
 
 No Jinja. No manifest. No parse step.
+
+## Why Rocky exists
+
+The expensive failures in modern data platforms aren't slow queries. They're trust failures:
+
+- A source column type changes upstream and a revenue dashboard quietly diverges for three days.
+- An engineer renames a column on `stg_orders` and 47 downstream models break in production.
+- A `SELECT *` pulls a new column nobody designed for; a downstream join silently double-counts.
+- A Snowflake-only function lands in a Databricks-targeted project and only fails in prod.
+- Warehouse spend doubles in a month and nobody can attribute which model caused it.
+- An auditor asks who changed `fct_revenue.amount`, when, and why — and the answer involves `git blame` and screenshots.
+
+dbt, by design, is a templating engine — it can't catch any of these at compile time. SQLMesh moved correctness to the planner. Rocky moved it to the compiler. Each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
 
 ## Scope on the ELT spectrum
 
@@ -17,15 +30,15 @@ No Jinja. No manifest. No parse step.
 | Quality | ✅ | Inline assertions during `rocky run` |
 | Orchestration | Partial | First-class Dagster integration; `rocky serve` standalone |
 
-## What Rocky does
+## The seven trust dimensions
 
-1. **Branches + replay + column-level lineage** — `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>`. Branch and replay workflow on top of your warehouse.
-2. **Cost attribution + budgets** — per-model cost on every run; `[budget]` block in `rocky.toml`; `budget_breach` hook event.
-3. **Resume + circuit breakers** — three-state `CircuitBreaker`, checkpointed run state, deploy safety.
-4. **Observability** — `rocky trace` Gantt output, OpenTelemetry OTLP export (feature-gated).
-5. **Schema-grounded AI** — every AI feature gated through the compiler; generated SQL type-checks before it lands.
-6. **Polyglot correctness** — dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB.
-7. **SQL as first-class with types** — type inference over raw `.sql`, `SELECT *` blast-radius lint, DAG-aware refactoring.
+1. **SQL as a typed, compiled language.** Real type inference, real diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`), real LSP. Not text macros, not runtime checks — a compiler. This is the moat.
+2. **Compile-time column-level lineage.** Rocky knows the lineage of every column before a row is written. Block a PR when a downstream contract breaks. `rocky lineage-diff main` per-changed-column at PR time.
+3. **Branches + deterministic replay.** `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>` — branches are isolated schemas, replays are content-addressed artifacts. Inputs + code → outputs is a pure function, recorded.
+4. **Per-model cost attribution.** Cost is a column on every run record — not a dashboard you have to opt into. `[budget]` blocks fail the run; `budget_breach` fires the hook; `rocky preview cost` projects spend at PR time.
+5. **AI gated through the compiler.** Every AI suggestion goes through type-check before it lands. The `Attempts: 2` retry loop on `rocky ai` is the signature: generate → type-check → auto-fix → land.
+6. **Dialect-divergence lint.** Cross-warehouse teams write SQL once; `P001` catches Snowflake-only constructs in a Databricks project at compile time. Useful the day you start a migration; essential the day you finish one.
+7. **Declarative governance.** RBAC as code with GRANT/REVOKE diffing, Unity Catalog tags, workspace isolation, masking strategies bound to classification tags. Compliance becomes a CI check, not a quarterly fire drill.
 
 ## Quick start
 

--- a/integrations/dagster/README.md
+++ b/integrations/dagster/README.md
@@ -1,10 +1,11 @@
 # dagster-rocky
 
-Dagster integration for the [Rocky](https://github.com/rocky-data/rocky) SQL transformation engine.
+Dagster integration for [Rocky](https://github.com/rocky-data/rocky) — the trust plane for your warehouse.
 
 `dagster-rocky` wraps the `rocky` CLI as a Dagster `ConfigurableResource` and exposes Rocky-managed
-tables as materializable Dagster assets — complete with check results, lineage, drift detection
-and quality metrics surfaced as native Dagster events.
+tables as materializable Dagster assets. Compile-time contracts, column-level lineage, schema-drift
+detection, quality check results, and per-model cost surface as native Dagster events — so the
+guarantees Rocky enforces at compile time appear directly in the Dagster asset graph.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Reframes the customer-facing documentation surface around the brainstorm's positioning analysis. The old framing ("typed-program layer above the warehouse" / implicit "fast dbt") was a feature war Rocky structurally couldn't win. The new framing — **trust plane for your warehouse** — leads with the disasters Rocky prevents (silent schema drift, column-rename blast radius, dialect divergence, unattributed cost, auditor questions), then drops into the seven trust dimensions. Every dimension maps to a Rocky command or diagnostic code.

Positioning decisions locked in before writing:
- **Tagline:** "Trust plane for your warehouse"
- **Gap honesty:** explicit roadmap callouts in introduction.md (Databricks-first 2026, Snowflake/BigQuery Beta, AI as growing surface, no Iceberg-native writes yet, no semantic layer, Dagster-only orchestration)
- **Compete tone:** sharp framing on SQLMesh ("moved correctness to the planner. Rocky moved it to the compiler"); dbt comparison stays factual — the migration path is the wedge, not the dunk
- **Scope:** customer-facing surface only — 10 files

## Files changed

- `README.md` — new hero, "Disasters Rocky prevents" table, "Who Rocky is for" wedge, "Where Rocky is today" roadmap section
- `engine/README.md` — same pivot for the canonical product reference; seven trust dimensions replace the "What Rocky does" list
- `docs/src/content/docs/index.mdx` — hero tagline + capability cards reorganized around trust dimensions; added "Migrate from dbt" as primary CTA
- `docs/src/content/docs/getting-started/introduction.md` — leads with the disasters, names the target buyer (data platform engineers on Databricks running multi-tenant pipelines), adds the explicit "Where Rocky is today" section, sharpens SQLMesh framing
- `docs/src/content/docs/features/comparison.md` — prepended positioning paragraphs sharpening vs SQLMesh and warehouse-native pipelines (LakeFlow / Dynamic Tables); dbt row stays factual
- `docs/src/content/docs/features/all-features.md` — reordered around the seven trust dimensions
- `docs/src/content/docs/guides/migrate-from-dbt.md` — elevated from how-to to conversion hero: "you don't rewrite, you import and adopt" + five-step wedge
- `integrations/dagster/README.md`, `editors/vscode/README.md`, `docs/src/content/docs/dagster/introduction.md` — light touch to inherit the trust framing

## Test plan

- [ ] Read `README.md` end-to-end on GitHub — confirm the disasters table renders and the new section anchors resolve
- [ ] Build the docs site locally (`cd docs && npm run build`) and click through: index → getting-started/introduction → features/comparison → features/all-features → guides/migrate-from-dbt
- [ ] Confirm internal anchor `#where-rocky-is-today` resolves from index.mdx → introduction.md
- [ ] Sanity-check that the SQLMesh framing reads sharp but not combative
- [ ] Confirm no broken links (the placeholder `#` link in the "927 runs" stat was scrubbed pre-commit)
- [ ] Review the "Who Rocky is for" wedge — is the Databricks-first stance correct as written, or should Snowflake parity be promised more concretely?
