### PR TITLE
docs: drop the production-runs stat from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,7 @@ Tag PII columns in the model sidecar; bind tags to mask strategies in `[mask]` /
 
 ## Where Rocky is today
 
-Rocky has run 927 production materializations across 14 customer pipelines on Databricks in its current line of development — alongside ~4,200 dbt runs it was deployed against. The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks.
-
-We're explicit about the rest:
+The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks. We're explicit about the rest:
 
 - **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta — connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
 - **AI is a growing surface, not a finished product.** The compile-validate loop (generate → type-check → auto-fix → land) is real and shipped; the broader story (mass refactor across the DAG, auto-migration from a column type change, schema-aware assertion generation) is on the roadmap, not the changelog.


### PR DESCRIPTION
## Summary

- Removes the "Rocky has run 927 production materializations across 14 customer pipelines on Databricks … alongside ~4,200 dbt runs" sentence from the `Where Rocky is today` section in the top-level `README.md`.
- The bullet list immediately below already carries the honest-roadmap weight; the headline stat was an unsourced numeric claim that read more like marketing copy than the surrounding voice.
- The section now opens directly with `The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks.` and goes straight into the bullets.

Follow-up to #621.

## Test plan

- [ ] Read the `Where Rocky is today` section on GitHub — confirm it flows from the heading straight into the bullet list with no orphaned stat sentence.
- [ ] Confirm no other reference to the 927/4,200 numbers exists in the tree (`git grep` shows none).
