### PR TITLE
docs: lead with typed-graph positioning; add dbt Fusion awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@
 [![VS Code CI](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml/badge.svg)](https://github.com/rocky-data/rocky/actions/workflows/vscode-ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Rocky is the trust plane for your warehouse.** A typed compiler, named branches, deterministic replay, column-level lineage, contracts, and per-model cost — all running over your existing Databricks / Snowflake / BigQuery / DuckDB. Apache 2.0.
+**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.**
+
+Not a warehouse. Not a table format. Not a query engine. The trust plane for your data — a typed compiler, named branches, deterministic replay, column-level lineage, compile-time contracts, and per-model cost — running over your existing Databricks / Snowflake / BigQuery / DuckDB. Apache 2.0.
 
 Rocky exists because the disasters that cost data teams real money — silent schema drift wrecking a revenue dashboard, a column rename quietly poisoning 47 downstream models, an auditor asking who touched `fct_revenue.amount` and when, a cost spike that no one can attribute to a model — all share a common shape. They're problems the warehouse can't see and the templating engine on top of it was never asked to. Rocky owns the graph between your code and the warehouse so those problems become compile errors, blocked PRs, and signed artifacts instead of pages and post-mortems.
 
-It's built for the team running production-critical multi-tenant pipelines on Databricks today, on Snowflake or BigQuery tomorrow, who can't tolerate another silent failure. Storage and compute stay where they are.
+It's built for the team running production-critical multi-tenant pipelines on Databricks today, on Snowflake or BigQuery tomorrow, who can't tolerate another silent failure. Storage and compute stay where they are. **Rocky works on the SQL you already have** — the `.rocky` DSL is an acceleration when you want it, not a gate.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart — create a project, compile, and run 3 models in under 15s" width="900" />
@@ -26,7 +28,7 @@ It's built for the team running production-critical multi-tenant pipelines on Da
 |---|---|---|
 | Upstream changes a column type | Silent — fails downstream, hours later | `E013` at compile, blocks the PR |
 | Required column dropped from a contract | No contract concept | `E010` at compile, blocks the PR |
-| Column rename with unknown blast radius | `dbt docs` post-hoc, table-level | `rocky lineage-diff` at PR time, column-level, downstream consumers listed |
+| Column rename with unknown blast radius | `dbt docs` post-hoc, table-level (dbt Cloud Enterprise has column lineage in their UI, also post-hoc, not PR-blocking) | `rocky lineage-diff` at PR time, column-level, downstream consumers listed, blocks the merge |
 | `SELECT *` pulls a new column you didn't expect | Silent | `P002` warning, downstream consumers named |
 | Snowflake-only function written for a Databricks project | Runs in dev, fails in prod | `P001` dialect-portability lint at compile |
 | Run cost doubles, no one knows which model | Manual warehouse spelunking | `RunOutput.cost_summary` per model, every run |
@@ -34,6 +36,8 @@ It's built for the team running production-critical multi-tenant pipelines on Da
 | Sev-2 at 3 AM, half the pipeline already ran | Re-run everything | `rocky run --resume-latest` — checkpoint, three-state circuit breaker, skip what succeeded |
 
 Each row is a real failure mode, with a Rocky command that turns it into a non-event. The same primitives — typed compiler, content-addressed state, column-level lineage, per-model cost — back every row.
+
+**Already on dbt?** `rocky import-dbt` converts a vanilla dbt project to Rocky in one command. The "What dbt does" column above is dbt Core's behavior. **dbt Fusion** — dbt Labs' Rust rewrite of dbt Core (public beta) — catches some compile-time issues that dbt Core misses, but doesn't ship named branches, content-addressed deterministic replay, per-model cost attribution as a first-class column, dialect-portability lint across warehouses, or declarative governance + masking outside dbt platform's paid tiers. Those stay Rocky's surface, Apache 2.0.
 
 ## Try it in 60 seconds
 
@@ -149,7 +153,7 @@ The trust primitives — compiler, branches, replay, lineage, contracts, cost at
 
 - **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta — connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
 - **AI is a growing surface, not a finished product.** The compile-validate loop (generate → type-check → auto-fix → land) is real and shipped; the broader story (mass refactor across the DAG, auto-migration from a column type change, schema-aware assertion generation) is on the roadmap, not the changelog.
-- **Iceberg is supported as a source today.** First-class Iceberg-native writes — Rocky as the typed program over an open table format — is on the 2026 roadmap.
+- **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm — shipped end-to-end (Wave 2). First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
 - **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
 - **Orchestration: Dagster is first-class.** A `rocky serve` standalone path exists; native Airflow / Prefect integrations are not yet shipped — they're called from the CLI like any other binary.
 

--- a/docs/src/content/docs/features/all-features.md
+++ b/docs/src/content/docs/features/all-features.md
@@ -15,7 +15,7 @@ Rocky organizes its capabilities around **seven trust dimensions** — the failu
 6. **Dialect-divergence lint** — `P001` portability lint
 7. **Declarative governance** — RBAC diff, masking, classification, `rocky compliance`
 
-The capability detail follows. For positioning vs other tools, see [Comparison](/features/comparison/). For honest scope (Databricks-first, Snowflake/BigQuery Beta, Iceberg-native on the roadmap), see [Where Rocky is today](/getting-started/introduction/#where-rocky-is-today).
+The capability detail follows. For positioning vs other tools, see [Comparison](/features/comparison/). For honest scope (Databricks-first, Snowflake/BigQuery Beta, Iceberg writes via Delta UniForm shipped, first-class Iceberg-native writes on the roadmap), see [Where Rocky is today](/getting-started/introduction/#where-rocky-is-today).
 
 ## Warehouse Support
 

--- a/docs/src/content/docs/features/comparison.md
+++ b/docs/src/content/docs/features/comparison.md
@@ -5,12 +5,13 @@ sidebar:
   order: 12
 ---
 
-A factual feature-by-feature comparison of the major SQL transformation tools in the modern data stack. Features verified against official documentation and source code as of April 2026.
+A factual feature-by-feature comparison of the major SQL transformation tools in the modern data stack. Features verified against official documentation and source code as of May 2026.
 
 Quick positioning before the tables:
 
-- **vs dbt.** dbt is the incumbent, not the competitor. Rocky's path is import-compatibility (`rocky import-dbt`) plus a step-change on the failure modes dbt structurally can't catch: silent schema drift, compile-time contracts, column-level lineage at PR time, per-model cost. dbt remains the right choice for moderate-scale, low-blast-radius pipelines where Jinja templating is enough.
-- **vs SQLMesh.** SQLMesh moved correctness to the planner. **Rocky moved it to the compiler.** SQLMesh's checks are runtime-ish; Rocky's are compile-time, expressed as diagnostic codes (`E001`–`E026`) you can grep in CI logs. SQLMesh is Python-first; Rocky keeps SQL as the default surface and reaches for a DSL only when SQL doesn't fit. SQLMesh's virtual environments are a genuinely good idea — Rocky's named branches express the same workflow with column-level lineage attached. SQLMesh is more mature in years and funding; Rocky is further along on Rust-native enforcement, LSP / IDE polish, compile-time column lineage, and cost as a first-class citizen.
+- **vs dbt Core.** dbt Core is the incumbent migration funnel, not the head-to-head competitor. Rocky's path is import-compatibility (`rocky import-dbt`) plus a step-change on failure modes dbt Core structurally can't catch: silent schema drift, compile-time contracts, column-level lineage at PR time, per-model cost. dbt Core remains the right choice for moderate-scale, low-blast-radius pipelines where Jinja templating is enough.
+- **vs dbt Fusion.** dbt Fusion is dbt Labs' Rust rewrite of dbt Core (public beta since 2025-05-28). It ships SQL parsing, multi-dialect compilation, real LSP, column-level lineage in editor, ADBC drivers. Rocky's differentiation against Fusion: named branches with warehouse-native clones (Fusion's `dbt clone` is "coming soon"); content-addressed deterministic replay (not in Fusion); per-model cost attribution as a first-class column (not in Fusion); dialect-portability lint across warehouses (not in Fusion); declarative governance + masking + classification (in Fusion only as "coming soon" gated behind dbt platform paid tiers — Apache 2.0 across the whole surface in Rocky); the `.rocky` DSL as a Jinja-free typed alternative (Fusion's `dbt-jinja` confirms Fusion still uses Jinja); cross-team contracts (Fusion's contracts are model-level within a project, not cross-project).
+- **vs SQLMesh.** SQLMesh moved correctness to the planner. **dbt Fusion moved it to the compiler. Rocky owns the trust dimensions all of them leave open** — branches, replay, cost, governance, dialect portability, cross-team contracts. SQLMesh's checks are runtime-ish; Rocky's are compile-time, expressed as diagnostic codes (`E001`–`E026`) you can grep in CI logs. SQLMesh is Python-first; Rocky keeps SQL as the default surface and reaches for a DSL only when SQL doesn't fit. SQLMesh's virtual environments are a genuinely good idea — Rocky's named branches express the same workflow with column-level lineage attached. SQLMesh is more mature in years and funding; Rocky is further along on Rust-native enforcement, LSP / IDE polish, compile-time column lineage, and cost as a first-class citizen.
 - **vs warehouse-native pipelines (Databricks LakeFlow, Snowflake Dynamic Tables).** Those are warehouse-coupled and free with the platform. Rocky stays warehouse-neutral and ships a real compiler. If portability and serious tooling matter to you, Rocky wins; if they don't, the warehouse-native option may be "good enough."
 - **vs observability tools (Datafold, Monte Carlo, Anomalo).** Not competitors. Rocky prevents what these detect; they remain useful for the failure modes Rocky doesn't model. Integrate, don't replace.
 
@@ -28,11 +29,11 @@ Quick positioning before the tables:
 
 | Warehouse | Rocky | dbt-core | dbt-fusion | SQLMesh | Coalesce | Dataform |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Databricks | **Yes** | Yes | Planned | Yes | Yes | No |
-| Snowflake | **Yes** | Yes | Yes | Yes | Yes | No |
-| BigQuery | Beta | Yes | Planned | Yes | Planned | **Yes** |
-| DuckDB | **Yes** | Yes | Yes | Yes | No | No |
-| Redshift | Planned | Yes | Planned | Yes | Planned | No |
+| Databricks | **Yes** | Yes | Private preview | Yes | Yes | No |
+| Snowflake | **Yes** | Yes | GA | Yes | Yes | No |
+| BigQuery | Beta | Yes | Preview | Yes | Planned | **Yes** |
+| DuckDB | **Yes** | Yes | Beta (CLI only) | Yes | No | No |
+| Redshift | Planned | Yes | Preview | Yes | Planned | No |
 | PostgreSQL | Planned | Yes | No | Yes | No | No |
 
 ## Materialization Strategies
@@ -180,7 +181,7 @@ See [benchmarks](/features/benchmarks/) for full cost analysis and methodology.
 |---|---|
 | **Rocky** | Production-critical, multi-tenant pipelines where silent failures cost real money. Databricks-first; Snowflake/BigQuery Beta. Compile-time contracts, column-level lineage at PR time, branches + replay, per-model cost attribution. |
 | **dbt-core** | Industry standard with the largest community and adapter ecosystem. Best for moderate scale (<5k models) with Jinja templating and where post-hoc lineage is acceptable. |
-| **dbt-fusion** | Teams on Snowflake wanting faster parse times while staying in the dbt ecosystem. Compile is slower than dbt-core; best adopted once GA. |
+| **dbt-fusion** | Teams staying in the dbt ecosystem who want a Rust compiler with multi-dialect SQL validation and a real LSP. Snowflake GA; Databricks/BigQuery/Redshift in preview. Best fit when Jinja templating is acceptable and named branches, deterministic replay, per-model cost, and Apache-2.0 governance aren't load-bearing. |
 | **SQLMesh** | Teams that want correctness checks at the planner level, Python-first ergonomics, and virtual environments. Closest competitor to Rocky on intent — Rocky differs by enforcing correctness at the compiler, defaulting to SQL, and attaching column-level lineage to the compile output. |
 | **Coalesce** | Visual, low-code transformation for Snowflake-first organizations with less technical analysts. Different buyer than Rocky. |
 | **Dataform** | BigQuery-only shops wanting tight GCP integration with minimal tooling. |

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-**Rocky is the trust plane for your warehouse.** A typed compiler that owns the graph between your code and your data — branches, deterministic replay, column-level lineage, compile-time contracts, dialect-portability lint, per-model cost attribution. Storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, or DuckDB); Rocky owns everything else.
+**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.** A typed compiler that owns the graph between your code and your data — branches, deterministic replay, column-level lineage, compile-time contracts, dialect-portability lint, per-model cost attribution. The trust plane for your data: storage and compute stay with your warehouse (Databricks, Snowflake, BigQuery, or DuckDB); Rocky owns everything else.
 
 ## Why Rocky exists
 
@@ -18,7 +18,7 @@ The expensive failures in modern data platforms aren't slow queries — they're 
 - Warehouse spend doubles in a month and nobody can attribute which model caused it.
 - An auditor asks who changed `fct_revenue.amount`, when, and why — and the answer involves `git blame` and screenshots.
 
-dbt, by design, is a templating engine — it can't catch any of these at compile time. SQLMesh moved correctness to the planner. **Rocky moved it to the compiler.** Each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
+dbt Core, by design, is a templating engine — it can't catch any of these at compile time. dbt Fusion (dbt Labs' Rust rewrite of dbt Core, in public beta since 2025-05-28) catches some compile-time issues but still uses Jinja templating and doesn't ship named branches, content-addressed deterministic replay, per-model cost attribution, dialect-portability lint, or declarative governance + masking outside dbt platform paid tiers. SQLMesh moved correctness to the planner. **Rocky owns the trust dimensions all of them leave open** — each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
 
 ## Who Rocky is for
 
@@ -32,7 +32,7 @@ Rocky is **not** a fit for: greenfield analytics shops with no scale pain, singl
 
 A typed compiler that drives your warehouse. Storage and compute stay where they are. Rocky owns the graph — dependencies, compile-time types, drift handling, incremental logic, lineage, cost, contracts, governance.
 
-**Rocky is not a warehouse.** It's the trust plane in front of one.
+**Rocky is not a warehouse, not a table format, not a query engine.** It's the typed graph between your code and whichever of those you've chosen.
 
 ## Scope on the ELT spectrum
 
@@ -62,7 +62,7 @@ We are explicit about the difference between what Rocky ships and what's on the 
 - **Databricks is the production target for 2026.** SQL Statement API, Unity Catalog, OAuth M2M, adaptive concurrency, `SHALLOW CLONE` for branches — all production-grade.
 - **Snowflake, BigQuery, Trino are Beta.** Connection, execution, and the core run loop work; conformance coverage is still growing. We test against live warehouses; corner cases get reported and fixed quickly. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, [open a discussion](https://github.com/rocky-data/rocky/discussions) — we want the failure reports.
 - **AI is a growing surface.** The compile-validate loop is real and shipped. The killer demo (rename a column, regenerate 47 downstream models, regenerate assertions, run tests, ship) is the 2026 roadmap.
-- **Iceberg is a source today.** First-class Iceberg-native writes — Rocky as the typed program over an open table format — is on the 2026 roadmap.
+- **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm — shipped end-to-end (Wave 2). First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
 - **No built-in semantic layer.** Rocky's typed IR is the right home for one; until then, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
 - **Orchestration: Dagster is first-class.** `rocky serve` exists for small standalone teams. Native Airflow / Prefect integrations are not shipped — those orchestrators call Rocky like any other CLI.
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -7,7 +7,7 @@
 
 # Rocky VS Code Extension
 
-Editor support for [Rocky](https://github.com/rocky-data/rocky) — the trust plane for your warehouse. Real LSP (not Jinja-aware text completion), interactive column-level lineage, compile-time diagnostics inline, and AI model generation gated through the compiler.
+Editor support for [Rocky](https://github.com/rocky-data/rocky) — the typed graph between your code and your warehouse. Real LSP (not Jinja-aware text completion), interactive column-level lineage, compile-time diagnostics inline, and AI model generation gated through the compiler.
 
 ## Features
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,8 +1,8 @@
 # Rocky
 
-**The trust plane for your warehouse.** Rocky is a typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data — named branches, deterministic replay, column-level lineage, compile-time contracts, per-model cost attribution. A single static Rust binary; storage and compute stay where they are.
+**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.** A typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data — named branches, deterministic replay, column-level lineage, compile-time contracts, per-model cost attribution. The trust plane for your data; a single static Rust binary; storage and compute stay where they are.
 
-**Rocky is not a warehouse, and not a templating layer.** It's a real compiler with type inference, diagnostic codes, and an IDE — so the failures that quietly cost data teams the most (silent schema drift, column rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs, not pages and post-mortems.
+**Rocky is not a warehouse, not a table format, not a query engine, not a templating layer.** It's a real compiler with type inference, diagnostic codes, and an IDE — so the failures that quietly cost data teams the most (silent schema drift, column rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs, not pages and post-mortems.
 
 No Jinja. No manifest. No parse step.
 
@@ -17,7 +17,7 @@ The expensive failures in modern data platforms aren't slow queries. They're tru
 - Warehouse spend doubles in a month and nobody can attribute which model caused it.
 - An auditor asks who changed `fct_revenue.amount`, when, and why — and the answer involves `git blame` and screenshots.
 
-dbt, by design, is a templating engine — it can't catch any of these at compile time. SQLMesh moved correctness to the planner. Rocky moved it to the compiler. Each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
+dbt Core, by design, is a templating engine — it can't catch any of these at compile time. dbt Fusion (dbt Labs' Rust rewrite of dbt Core, in public beta since 2025-05-28) catches some compile-time issues but still uses Jinja templating (`dbt-jinja` is a Rust port of mini-jinja), and doesn't ship named branches, content-addressed deterministic replay, per-model cost attribution, dialect-portability lint across warehouses, or declarative governance + masking outside dbt platform paid tiers. SQLMesh moved correctness to the planner. Rocky owns the trust dimensions all of them leave open — each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
 
 ## Scope on the ELT spectrum
 

--- a/integrations/dagster/README.md
+++ b/integrations/dagster/README.md
@@ -1,6 +1,6 @@
 # dagster-rocky
 
-Dagster integration for [Rocky](https://github.com/rocky-data/rocky) — the trust plane for your warehouse.
+Dagster integration for [Rocky](https://github.com/rocky-data/rocky) — the typed graph between your code and your warehouse.
 
 `dagster-rocky` wraps the `rocky` CLI as a Dagster `ConfigurableResource` and exposes Rocky-managed
 tables as materializable Dagster assets. Compile-time contracts, column-level lineage, schema-drift


### PR DESCRIPTION
## Summary

Aligns Rocky's public copy with the 2026-05-22 vision sharpening.

- **Hero update.** Lift *"the typed graph between your code and whichever warehouse, table format, or query engine you've chosen"* to the README hero. Trust-plane framing stays in supporting copy where category formation happens at scale.
- **dbt Fusion awareness.** Validated Rocky's claims against `dbt-labs/dbt-fusion` and the dbt Fusion docs. Fusion is dbt Labs' Rust rewrite of dbt Core, public beta since 2025-05-28 — closes the "Rocky is the only Rust compiler for data" mindshare window. Public copy now qualifies dbt as dbt Core throughout, acknowledges Fusion exists, and names the trust dimensions Rocky still owns (named branches with warehouse-native clones, content-addressed deterministic replay, per-model cost as first-class column, dialect-portability lint, declarative governance Apache-2.0 vs Fusion's dbt-platform-paid, `.rocky` DSL as Jinja-free alternative, cross-team contracts).
- **Iceberg writes status.** Corrected to reflect Wave 2 shipped via Delta UniForm. First-class Iceberg-native writes without the Delta intermediate remain roadmap.
- **DSL clarification.** Added "Rocky works on the SQL you already have. The `.rocky` DSL is an acceleration when you want it, not a gate" — preempts misreads of "typed compiler" as "rewrite required."
- **dbt Cloud Enterprise precision.** Column-rename disasters row now clarifies dbt Cloud Enterprise has column lineage in their UI (post-hoc, not PR-blocking).
- **Migration callout.** `rocky import-dbt` surfaced from a feature-table line to a hero-adjacent surface under the disasters table.
- **comparison.md adapter status.** dbt-fusion's Databricks / BigQuery / Redshift adapters moved from "Planned" to preview/GA per dbt-labs/dbt-fusion releases since 2025-Q3; refreshed quick-positioning intro with a dbt Fusion section.

## Test plan

- [ ] Visual check of README hero on GitHub renders the typed-graph sentence as lead
- [ ] Astro docs build succeeds (intro + features/comparison + features/all-features pages)
- [ ] \`grep -rn "trust plane for your warehouse" --include="*.md"\` returns no matches in rocky-data
- [ ] \`grep -rn "First-class Iceberg-native writes — Rocky as the typed program" --include="*.md"\` returns no matches
- [ ] Engine README + docs/introduction.md "dbt, by design" rephrasings read naturally