### PR TITLE
feat: warehouse-side breaker cooldown parity for quota-exceeded signal

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -244,6 +244,10 @@ export interface DriftActionOutput {
  */
 export interface TableErrorOutput {
   asset_key: string[];
+  /**
+   * Backoff hint in whole seconds. Populated by adapters whose failure mode carries a known cooldown — currently only the Databricks and Snowflake warehouse adapters when their shared circuit breaker trips (and the breaker was configured with `retry.circuit_breaker_recovery_timeout_secs`). Orchestrators (Dagster, etc.) use it as a `retry_after` hint when scheduling a delayed re-run. Mirrors the source-side shape on [`FailedSourceOutput::cooldown_seconds`]. Absent for failure classes without an engine-supplied hint.
+   */
+  cooldown_seconds?: number | null;
   error: string;
   /**
    * Coarse classification of the failure so orchestrators can branch on kind (retry, page, surface) without parsing `error`. Defaults to [`FailureKind::Unknown`] for errors that reached the output layer type-erased.

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`rocky-cli`: warehouse-side circuit-breaker cooldown parity** — `TableErrorOutput.cooldown_seconds: Option<u64>` added to the `rocky run` JSON output, mirroring the Fivetran-side `FailedSourceOutput.cooldown_seconds` shipped in v1.42.0. Populated when a Databricks or Snowflake circuit breaker trips on a config with `retry.circuit_breaker_recovery_timeout_secs` set. Sourced from a new `pub fn recovery_timeout(&self) -> Option<Duration>` accessor on `rocky_core::circuit_breaker::CircuitBreaker`; the warehouse `ConnectorError::CircuitBreakerOpen` variants now carry `cooldown_seconds: Option<u64>` and a unified `classify_anyhow_error_with_cooldown` walker projects them onto `TableError`. **Behaviour change:** the warehouse `CircuitBreakerOpen → FailureKind` mapping flips from `Transient` → `QuotaExceeded` to match the enum's documented semantics ("Rate limit hit or a configured budget cap (retry budget, circuit breaker, account-level quota)") and the existing dagster handler keyed on `failure_kind == quota-exceeded`. Orchestrators that previously treated a tripped warehouse breaker as a fail-fast transient now get a retriable `dg.Failure` with the warehouse's configured `retry_after_seconds` instead.
+- **`rocky-core`: `CircuitBreaker::recovery_timeout()` accessor** exposes the previously-private field so warehouse adapters can mirror it onto `ConnectorError::CircuitBreakerOpen.cooldown_seconds` without re-parsing config. `None` for manual-reset-only breakers preserves the original behaviour.
+
 ## [1.42.0] — 2026-05-21
 
 Headline: **Fivetran 429-storms now trip the shared circuit breaker** instead of stalling each pod in a 6-minute in-pod backoff loop. Pairs with a structured retriable signal on the Dagster side so orchestrators learn the failure within seconds and reschedule the run past the breaker cooldown. Single-PR cut ([#624](https://github.com/rocky-data/rocky/pull/624)) — small, targeted, high-impact for downstream consumers running Fivetran replication on a shared Valkey-backed breaker.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -83,6 +83,14 @@ struct TableError {
     /// error is stringified; defaults to `Unknown` when no connector
     /// variant is in the chain (drift / governance / panic paths).
     failure_kind: crate::output::FailureKind,
+    /// Engine-supplied retry-after hint in whole seconds, populated
+    /// alongside `failure_kind` from the typed connector chain when a
+    /// warehouse circuit breaker tripped on a half-open-recovery
+    /// configuration. `None` when no cooldown is available (legacy
+    /// failures, non-breaker errors, breakers without a configured
+    /// `circuit_breaker_recovery_timeout_secs`). Mirrors the
+    /// source-side hint on `FailedSource.cooldown_seconds`.
+    cooldown_seconds: Option<u64>,
 }
 
 /// Sentinel error signalling that `rocky run` was cancelled by a shutdown
@@ -2182,8 +2190,10 @@ pub async fn run(
             }
             Ok((idx, Err(e))) => {
                 // Classify before stringification so the typed connector
-                // variant is preserved on `TableError.failure_kind`.
-                let failure_kind = classify_anyhow_error(&e);
+                // variant is preserved on `TableError.failure_kind` and
+                // the optional engine-supplied cooldown hint
+                // (warehouse-side breaker trip) is captured.
+                let (failure_kind, cooldown_seconds) = classify_anyhow_error_with_cooldown(&e);
                 let msg = format!("{e:#}");
                 if msg.contains("TABLE_OR_VIEW_NOT_FOUND") {
                     warn!(
@@ -2247,6 +2257,7 @@ pub async fn run(
                     error: msg,
                     task_index: Some(idx),
                     failure_kind,
+                    cooldown_seconds,
                 });
                 if fail_fast {
                     join_set.abort_all();
@@ -2281,6 +2292,7 @@ pub async fn run(
                     error: msg,
                     task_index: None,
                     failure_kind: FailureKind::Unknown,
+                    cooldown_seconds: None,
                 });
                 if fail_fast {
                     join_set.abort_all();
@@ -2499,7 +2511,8 @@ pub async fn run(
                         info!(table = task.table_name.as_str(), "retry succeeded");
                     }
                     Err(e) => {
-                        let failure_kind = classify_anyhow_error(&e);
+                        let (failure_kind, cooldown_seconds) =
+                            classify_anyhow_error_with_cooldown(&e);
                         let msg = format!("{e:#}");
                         warn!(
                             table = task.table_name.as_str(),
@@ -2511,6 +2524,7 @@ pub async fn run(
                             error: msg,
                             task_index: Some(idx),
                             failure_kind,
+                            cooldown_seconds,
                         });
                     }
                 }
@@ -3166,6 +3180,7 @@ pub async fn run(
             asset_key: e.asset_key.clone(),
             error: e.error.clone(),
             failure_kind: e.failure_kind,
+            cooldown_seconds: e.cooldown_seconds,
         })
         .collect();
 
@@ -5434,8 +5449,9 @@ async fn process_completed_result(
         }
         Ok((idx, Err(e))) => {
             // Classify before stringification so the typed connector
-            // variant is preserved on `TableError.failure_kind`.
-            let failure_kind = classify_anyhow_error(&e);
+            // variant is preserved on `TableError.failure_kind` (plus
+            // the optional warehouse-breaker cooldown hint).
+            let (failure_kind, cooldown_seconds) = classify_anyhow_error_with_cooldown(&e);
             let msg = format!("{e:#}");
             if msg.contains("TABLE_OR_VIEW_NOT_FOUND") {
                 warn!(
@@ -5485,6 +5501,7 @@ async fn process_completed_result(
                 error: msg,
                 task_index: Some(idx),
                 failure_kind,
+                cooldown_seconds,
             });
         }
         Err(e) => {
@@ -5515,6 +5532,7 @@ async fn process_completed_result(
                 error: msg,
                 task_index: None,
                 failure_kind: FailureKind::Unknown,
+                cooldown_seconds: None,
             });
         }
     }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -464,7 +464,17 @@ impl From<&rocky_databricks::connector::ConnectorError> for FailureKind {
                 500..=599 => FailureKind::Transient,
                 _ => FailureKind::QueryRejected,
             },
-            E::CircuitBreakerOpen { .. } => FailureKind::Transient,
+            // A tripped breaker is a *budget cap* — sustained transient
+            // pressure exhausted the retry budget — not a one-off
+            // transient blip. Match the [`FailureKind::QuotaExceeded`]
+            // doc-comment ("Rate limit hit or a configured budget cap
+            // (retry budget, circuit breaker, account-level quota)")
+            // and the Fivetran-side classification, so the dagster
+            // handler (which keys on `failure_kind == quota-exceeded`)
+            // can surface a retriable `dg.Failure` with the engine's
+            // cooldown hint instead of treating it as a fail-fast
+            // transient error.
+            E::CircuitBreakerOpen { .. } => FailureKind::QuotaExceeded,
             E::RetryBudgetExhausted { .. } => FailureKind::QuotaExceeded,
         }
     }
@@ -493,9 +503,39 @@ impl From<&rocky_snowflake::connector::ConnectorError> for FailureKind {
                 500..=599 => FailureKind::Transient,
                 _ => FailureKind::QueryRejected,
             },
-            E::CircuitBreakerOpen { .. } => FailureKind::Transient,
+            // See the databricks branch above — breaker trips are
+            // `QuotaExceeded` (budget cap), not `Transient`.
+            E::CircuitBreakerOpen { .. } => FailureKind::QuotaExceeded,
             E::RetryBudgetExhausted { .. } => FailureKind::QuotaExceeded,
         }
+    }
+}
+
+/// Extract the warehouse-reported cooldown (in whole seconds) from a
+/// typed connector error, when the variant carries one. Populated only
+/// for `CircuitBreakerOpen` against breakers configured with timed
+/// half-open recovery (`retry.circuit_breaker_recovery_timeout_secs`);
+/// every other variant returns `None`. Surfaces on
+/// [`TableErrorOutput::cooldown_seconds`] so orchestrators can derive a
+/// `retry_after` hint without re-parsing config — warehouse-side mirror
+/// of the Fivetran `FailedSourceOutput.cooldown_seconds` path.
+fn cooldown_from_databricks(err: &rocky_databricks::connector::ConnectorError) -> Option<u64> {
+    use rocky_databricks::connector::ConnectorError as E;
+    match err {
+        E::CircuitBreakerOpen {
+            cooldown_seconds, ..
+        } => *cooldown_seconds,
+        _ => None,
+    }
+}
+
+fn cooldown_from_snowflake(err: &rocky_snowflake::connector::ConnectorError) -> Option<u64> {
+    use rocky_snowflake::connector::ConnectorError as E;
+    match err {
+        E::CircuitBreakerOpen {
+            cooldown_seconds, ..
+        } => *cooldown_seconds,
+        _ => None,
     }
 }
 
@@ -527,6 +567,24 @@ fn classify_cause(cause: &(dyn std::error::Error + 'static)) -> Option<FailureKi
     None
 }
 
+/// Probe a single error link for a typed warehouse connector error and
+/// project it into both [`FailureKind`] and the optional cooldown hint.
+/// Returns `Some((kind, cooldown))` on a match, `None` otherwise — used
+/// by [`classify_anyhow_error_with_cooldown`] so a tripped warehouse
+/// breaker surfaces its `recovery_timeout` on
+/// [`TableErrorOutput::cooldown_seconds`] without re-walking the chain.
+fn classify_cause_with_cooldown(
+    cause: &(dyn std::error::Error + 'static),
+) -> Option<(FailureKind, Option<u64>)> {
+    if let Some(e) = cause.downcast_ref::<rocky_databricks::connector::ConnectorError>() {
+        return Some((e.into(), cooldown_from_databricks(e)));
+    }
+    if let Some(e) = cause.downcast_ref::<rocky_snowflake::connector::ConnectorError>() {
+        return Some((e.into(), cooldown_from_snowflake(e)));
+    }
+    None
+}
+
 pub fn classify_anyhow_error(err: &anyhow::Error) -> FailureKind {
     for cause in err.chain() {
         if let Some(kind) = classify_cause(cause) {
@@ -541,6 +599,29 @@ pub fn classify_anyhow_error(err: &anyhow::Error) -> FailureKind {
     FailureKind::Unknown
 }
 
+/// Like [`classify_anyhow_error`], but also extracts the
+/// engine-supplied cooldown hint when the typed connector variant
+/// carries one (currently only warehouse `CircuitBreakerOpen` against a
+/// breaker configured with `circuit_breaker_recovery_timeout_secs`).
+/// Returns `(FailureKind, Option<u64>)`; the cooldown is the
+/// warehouse-side analogue of `FailedSourceOutput.cooldown_seconds` and
+/// feeds [`TableErrorOutput::cooldown_seconds`] so dagster-rocky can
+/// project it onto a retriable `dg.Failure` without re-parsing
+/// `rocky.toml`.
+pub fn classify_anyhow_error_with_cooldown(err: &anyhow::Error) -> (FailureKind, Option<u64>) {
+    for cause in err.chain() {
+        if let Some(pair) = classify_cause_with_cooldown(cause) {
+            return pair;
+        }
+        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>() {
+            if let Some(pair) = classify_cause_with_cooldown(adapter_err.inner()) {
+                return pair;
+            }
+        }
+    }
+    (FailureKind::Unknown, None)
+}
+
 /// Error from a table that failed during parallel processing.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TableErrorOutput {
@@ -552,6 +633,17 @@ pub struct TableErrorOutput {
     /// layer type-erased.
     #[serde(default)]
     pub failure_kind: FailureKind,
+    /// Backoff hint in whole seconds. Populated by adapters whose
+    /// failure mode carries a known cooldown — currently only the
+    /// Databricks and Snowflake warehouse adapters when their shared
+    /// circuit breaker trips (and the breaker was configured with
+    /// `retry.circuit_breaker_recovery_timeout_secs`). Orchestrators
+    /// (Dagster, etc.) use it as a `retry_after` hint when scheduling
+    /// a delayed re-run. Mirrors the source-side shape on
+    /// [`FailedSourceOutput::cooldown_seconds`]. Absent for failure
+    /// classes without an engine-supplied hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_seconds: Option<u64>,
 }
 
 /// A table that the discovery adapter reported but that is missing from
@@ -4126,6 +4218,7 @@ mod run_record_tests {
             asset_key: vec!["s".to_string(), "broken".to_string()],
             error: "connection refused".to_string(),
             failure_kind: FailureKind::Unknown,
+            cooldown_seconds: None,
         });
 
         let started = fixed_start();
@@ -5566,11 +5659,22 @@ mod failure_kind_tests {
     }
 
     #[test]
-    fn databricks_circuit_breaker_maps_to_transient() {
+    fn databricks_circuit_breaker_maps_to_quota_exceeded() {
+        // CircuitBreakerOpen is a budget-cap signal (sustained transient
+        // pressure exhausted the breaker) — see the doc-comment on
+        // `FailureKind::QuotaExceeded` and the dagster-side handler
+        // keyed on `failure_kind == "quota-exceeded"`.
         let e = DbE::CircuitBreakerOpen {
             consecutive_failures: 5,
+            cooldown_seconds: None,
         };
-        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+        let e = DbE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: Some(120),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+        assert_eq!(cooldown_from_databricks(&e), Some(120));
     }
 
     #[test]
@@ -5639,11 +5743,20 @@ mod failure_kind_tests {
     }
 
     #[test]
-    fn snowflake_circuit_breaker_maps_to_transient() {
+    fn snowflake_circuit_breaker_maps_to_quota_exceeded() {
+        // See the databricks counterpart above — breaker trips are a
+        // budget-cap signal, not a one-off transient blip.
         let e = SnE::CircuitBreakerOpen {
             consecutive_failures: 5,
+            cooldown_seconds: None,
         };
-        assert_eq!(FailureKind::from(&e), FailureKind::Transient);
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+        let e = SnE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: Some(60),
+        };
+        assert_eq!(FailureKind::from(&e), FailureKind::QuotaExceeded);
+        assert_eq!(cooldown_from_snowflake(&e), Some(60));
     }
 
     #[test]
@@ -5678,6 +5791,81 @@ mod failure_kind_tests {
     fn classify_anyhow_returns_unknown_when_no_connector_error_in_chain() {
         let err = anyhow::anyhow!("some non-connector failure");
         assert_eq!(classify_anyhow_error(&err), FailureKind::Unknown);
+    }
+
+    // ---- classify_anyhow_error_with_cooldown chain walk ------------------
+
+    #[test]
+    fn classify_anyhow_with_cooldown_extracts_databricks_breaker_cooldown() {
+        let conn_err = DbE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: Some(180),
+        };
+        let err = anyhow::Error::new(conn_err).context("running materialization");
+        assert_eq!(
+            classify_anyhow_error_with_cooldown(&err),
+            (FailureKind::QuotaExceeded, Some(180)),
+        );
+    }
+
+    #[test]
+    fn classify_anyhow_with_cooldown_extracts_snowflake_breaker_cooldown() {
+        let conn_err = SnE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: Some(60),
+        };
+        let err = anyhow::Error::new(conn_err).context("running materialization");
+        assert_eq!(
+            classify_anyhow_error_with_cooldown(&err),
+            (FailureKind::QuotaExceeded, Some(60)),
+        );
+    }
+
+    #[test]
+    fn classify_anyhow_with_cooldown_returns_none_when_breaker_has_no_recovery_timeout() {
+        // Manual-reset-only breakers (no `circuit_breaker_recovery_timeout_secs`
+        // configured) trip with `cooldown_seconds: None` — kind still flips
+        // to `QuotaExceeded` but the hint is absent.
+        let conn_err = DbE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: None,
+        };
+        let err = anyhow::Error::new(conn_err);
+        assert_eq!(
+            classify_anyhow_error_with_cooldown(&err),
+            (FailureKind::QuotaExceeded, None),
+        );
+    }
+
+    #[test]
+    fn classify_anyhow_with_cooldown_returns_none_for_non_breaker_failure() {
+        let conn_err = DbE::Timeout {
+            id: "s".into(),
+            seconds: 60,
+        };
+        let err = anyhow::Error::new(conn_err);
+        assert_eq!(
+            classify_anyhow_error_with_cooldown(&err),
+            (FailureKind::Transient, None),
+        );
+    }
+
+    #[test]
+    fn classify_anyhow_with_cooldown_unwraps_adapter_error_wrapping_breaker() {
+        // Mirrors the production path: ConnectorError is wrapped in
+        // AdapterError (boxed) before crossing into anyhow — the
+        // cooldown walker must descend through the wrapper just like
+        // its FailureKind-only counterpart.
+        let conn_err = DbE::CircuitBreakerOpen {
+            consecutive_failures: 5,
+            cooldown_seconds: Some(300),
+        };
+        let adapter_err = rocky_adapter_sdk::AdapterError::new(conn_err);
+        let err = anyhow::Error::new(adapter_err);
+        assert_eq!(
+            classify_anyhow_error_with_cooldown(&err),
+            (FailureKind::QuotaExceeded, Some(300)),
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/circuit_breaker.rs
+++ b/engine/crates/rocky-core/src/circuit_breaker.rs
@@ -115,6 +115,21 @@ impl CircuitBreaker {
         }
     }
 
+    /// Initial half-open recovery timeout the breaker honours after
+    /// transitioning `Closed → Open`. `None` for manual-reset-only
+    /// breakers (constructed via [`Self::new`]).
+    ///
+    /// Surfaced on warehouse-adapter `ConnectorError::CircuitBreakerOpen`
+    /// so callers downstream of the adapter (e.g. the `rocky run` JSON
+    /// output, Dagster) can derive a `retry_after` hint without
+    /// re-parsing config — mirrors
+    /// [`FivetranCircuitBreaker::cooldown_seconds`](../../../rocky_fivetran/circuit_breaker/trait.FivetranCircuitBreaker.html)
+    /// on the source-adapter side.
+    #[must_use]
+    pub fn recovery_timeout(&self) -> Option<Duration> {
+        self.recovery_timeout
+    }
+
     fn now_ms(&self) -> u64 {
         // Saturating cast: breaks after ~584 million years of uptime.
         self.epoch.elapsed().as_millis() as u64

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -38,7 +38,19 @@ pub enum ConnectorError {
     ApiError { status: u16, body: String },
 
     #[error("circuit breaker tripped after {consecutive_failures} consecutive transient failures")]
-    CircuitBreakerOpen { consecutive_failures: u32 },
+    CircuitBreakerOpen {
+        consecutive_failures: u32,
+        /// Initial half-open recovery timeout the underlying
+        /// [`CircuitBreaker`] honours before letting a trial request
+        /// through, in whole seconds. Populated from
+        /// [`CircuitBreaker::recovery_timeout`] when configured (i.e.
+        /// `retry.circuit_breaker_recovery_timeout_secs` is `Some`);
+        /// `None` for manual-reset-only breakers. Surfaces on
+        /// `TableErrorOutput.cooldown_seconds` so orchestrators can
+        /// derive a `retry_after` hint without re-parsing config —
+        /// mirrors the Fivetran source-adapter shape.
+        cooldown_seconds: Option<u64>,
+    },
 
     #[error("run-level retry budget exhausted (limit {limit}); aborting remaining retries")]
     RetryBudgetExhausted { limit: u32 },
@@ -283,6 +295,7 @@ impl DatabricksConnector {
         if let Err(e) = self.circuit_breaker.check() {
             return Err(ConnectorError::CircuitBreakerOpen {
                 consecutive_failures: e.consecutive_failures,
+                cooldown_seconds: self.circuit_breaker.recovery_timeout().map(|d| d.as_secs()),
             });
         }
 
@@ -899,6 +912,7 @@ mod tests {
     fn test_circuit_breaker_not_transient() {
         let err = ConnectorError::CircuitBreakerOpen {
             consecutive_failures: 5,
+            cooldown_seconds: None,
         };
         assert!(!is_transient(&err));
     }

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -1792,3 +1792,192 @@ async fn test_read_retention_days_empty_rows_returns_none() {
     };
     assert_eq!(governance.read_retention_days(&table).await.unwrap(), None);
 }
+
+// =============================================================================
+// Warehouse-side breaker cooldown parity — mirrors the Fivetran shared-breaker
+// storm test in rocky-fivetran/tests/resilience_tests.rs. A sustained transient
+// storm must trip the per-connector circuit breaker and surface a
+// `ConnectorError::CircuitBreakerOpen { cooldown_seconds: Some(_) }` once the
+// breaker is configured with `circuit_breaker_recovery_timeout_secs`. The
+// cooldown flows through `classify_anyhow_error_with_cooldown` →
+// `TableErrorOutput.cooldown_seconds` so the dagster `_run_filters` handler
+// can emit a retriable `dg.Failure` with the right `retry_after_seconds`
+// hint without re-parsing config.
+// =============================================================================
+
+/// Builds a connector with the breaker armed at `threshold` and a configured
+/// half-open recovery timeout — the latter is what gives `CircuitBreakerOpen`
+/// a `cooldown_seconds: Some(_)` payload to mirror back to orchestrators.
+fn breaker_connector(
+    server: &MockServer,
+    threshold: u32,
+    cooldown_secs: u64,
+) -> DatabricksConnector {
+    let auth = Auth::from_config(AuthConfig {
+        host: "test.databricks.com".into(),
+        token: Some("test-token".into()),
+        client_id: None,
+        client_secret: None,
+    })
+    .unwrap();
+
+    let config = ConnectorConfig {
+        host: "test.databricks.com".into(),
+        warehouse_id: "test-warehouse".into(),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter: false,
+            circuit_breaker_threshold: threshold,
+            circuit_breaker_recovery_timeout_secs: Some(cooldown_secs),
+            ..Default::default()
+        },
+    };
+
+    DatabricksConnector::new(config, auth).with_base_url(server.uri())
+}
+
+/// A sustained 429 storm must trip the per-connector circuit breaker. Five
+/// 429-only calls (matching `circuit_breaker_threshold=5`, `max_retries=0`)
+/// each surface as `ApiError(429)` and vote the breaker towards `Open`. The
+/// sixth call short-circuits with `CircuitBreakerOpen` carrying the
+/// configured cooldown — that cooldown is the warehouse-side mirror of
+/// `FivetranError::CircuitOpen { cooldown_seconds }` and surfaces on
+/// `TableErrorOutput.cooldown_seconds` for dagster-rocky to honour.
+#[tokio::test]
+async fn rate_limit_storm_trips_breaker() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let connector = breaker_connector(&server, 5, 180);
+
+    // Five 429-only calls vote `Remote` to the breaker; each surfaces as
+    // ApiError(429) with no retry (max_retries=0).
+    for i in 0..5u32 {
+        let err = connector
+            .execute_sql("SELECT 1")
+            .await
+            .expect_err("429 storm should error");
+        match err {
+            ConnectorError::ApiError { status: 429, .. } => {}
+            other => panic!("call {i}: expected ApiError(429), got: {other:?}"),
+        }
+    }
+
+    // Sixth call short-circuits — no HTTP, just the breaker projection.
+    let err = connector
+        .execute_sql("SELECT 1")
+        .await
+        .expect_err("CircuitBreakerOpen must short-circuit after trip");
+    match err {
+        ConnectorError::CircuitBreakerOpen {
+            consecutive_failures,
+            cooldown_seconds,
+        } => {
+            assert!(
+                consecutive_failures >= 5,
+                "expected ≥5 consecutive failures, got {consecutive_failures}"
+            );
+            assert_eq!(
+                cooldown_seconds,
+                Some(180),
+                "cooldown must mirror the configured recovery_timeout"
+            );
+        }
+        other => panic!("expected CircuitBreakerOpen, got: {other:?}"),
+    }
+}
+
+/// A burst below `circuit_breaker_threshold` must NOT trip the breaker.
+/// Regression for the inverse property of the storm test — single bursts
+/// stay absorbed by per-call retries / single-failure surfacing.
+#[tokio::test]
+async fn rate_limit_below_threshold_does_not_trip_breaker() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let connector = breaker_connector(&server, 5, 180);
+
+    // Four 429s — below threshold=5 — must each surface as ApiError(429),
+    // never CircuitBreakerOpen.
+    for i in 0..4u32 {
+        let err = connector
+            .execute_sql("SELECT 1")
+            .await
+            .expect_err("429 should error");
+        match err {
+            ConnectorError::ApiError { status: 429, .. } => {}
+            ConnectorError::CircuitBreakerOpen { .. } => {
+                panic!("call {i}: breaker tripped below threshold=5")
+            }
+            other => panic!("call {i}: expected ApiError(429), got: {other:?}"),
+        }
+    }
+}
+
+/// Manual-reset-only breakers (no `circuit_breaker_recovery_timeout_secs`
+/// configured) still trip on a storm, but `CircuitBreakerOpen.cooldown_seconds`
+/// is `None` — dagster falls back to its `_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS`
+/// constant in that case.
+#[tokio::test]
+async fn breaker_trip_without_recovery_timeout_emits_none_cooldown() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    // Same shape as `breaker_connector` but with `recovery_timeout_secs = None`.
+    let auth = Auth::from_config(AuthConfig {
+        host: "test.databricks.com".into(),
+        token: Some("test-token".into()),
+        client_id: None,
+        client_secret: None,
+    })
+    .unwrap();
+    let config = ConnectorConfig {
+        host: "test.databricks.com".into(),
+        warehouse_id: "test-warehouse".into(),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter: false,
+            circuit_breaker_threshold: 5,
+            circuit_breaker_recovery_timeout_secs: None,
+            ..Default::default()
+        },
+    };
+    let connector = DatabricksConnector::new(config, auth).with_base_url(server.uri());
+
+    for _ in 0..5u32 {
+        let _ = connector.execute_sql("SELECT 1").await;
+    }
+    let err = connector
+        .execute_sql("SELECT 1")
+        .await
+        .expect_err("CircuitBreakerOpen must short-circuit after trip");
+    match err {
+        ConnectorError::CircuitBreakerOpen {
+            cooldown_seconds: None,
+            ..
+        } => {}
+        other => {
+            panic!("expected CircuitBreakerOpen {{ cooldown_seconds: None, .. }}, got: {other:?}")
+        }
+    }
+}

--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -42,7 +42,19 @@ pub enum ConnectorError {
     ApiError { status: u16, body: String },
 
     #[error("circuit breaker tripped after {consecutive_failures} consecutive transient failures")]
-    CircuitBreakerOpen { consecutive_failures: u32 },
+    CircuitBreakerOpen {
+        consecutive_failures: u32,
+        /// Initial half-open recovery timeout the underlying
+        /// [`CircuitBreaker`] honours before letting a trial request
+        /// through, in whole seconds. Populated from
+        /// [`CircuitBreaker::recovery_timeout`] when configured (i.e.
+        /// `retry.circuit_breaker_recovery_timeout_secs` is `Some`);
+        /// `None` for manual-reset-only breakers. Surfaces on
+        /// `TableErrorOutput.cooldown_seconds` so orchestrators can
+        /// derive a `retry_after` hint without re-parsing config —
+        /// mirrors the Fivetran source-adapter shape.
+        cooldown_seconds: Option<u64>,
+    },
 
     #[error("run-level retry budget exhausted (limit {limit}); aborting remaining retries")]
     RetryBudgetExhausted { limit: u32 },
@@ -294,6 +306,7 @@ impl SnowflakeConnector {
         if let Err(e) = self.circuit_breaker.check() {
             return Err(ConnectorError::CircuitBreakerOpen {
                 consecutive_failures: e.consecutive_failures,
+                cooldown_seconds: self.circuit_breaker.recovery_timeout().map(|d| d.as_secs()),
             });
         }
 
@@ -960,6 +973,7 @@ mod tests {
     fn test_not_transient_circuit_breaker() {
         let err = ConnectorError::CircuitBreakerOpen {
             consecutive_failures: 5,
+            cooldown_seconds: None,
         };
         assert!(!is_transient(&err));
     }

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -1092,3 +1092,182 @@ async fn test_statement_execute_span_emitted() {
         .expect("expected `statement.kind` attribute on statement.execute span");
     assert_eq!(kind.1, "query");
 }
+
+// =============================================================================
+// Warehouse-side breaker cooldown parity — mirrors the Fivetran shared-breaker
+// storm test in rocky-fivetran/tests/resilience_tests.rs. A sustained transient
+// storm must trip the per-connector circuit breaker and surface a
+// `ConnectorError::CircuitBreakerOpen { cooldown_seconds: Some(_) }` once the
+// breaker is configured with `circuit_breaker_recovery_timeout_secs`. The
+// cooldown flows through `classify_anyhow_error_with_cooldown` →
+// `TableErrorOutput.cooldown_seconds` so the dagster `_run_filters` handler
+// can emit a retriable `dg.Failure` with the right `retry_after_seconds`
+// hint without re-parsing config.
+// =============================================================================
+
+/// Builds a connector with the breaker armed at `threshold` and a configured
+/// half-open recovery timeout — the latter is what gives `CircuitBreakerOpen`
+/// a `cooldown_seconds: Some(_)` payload to mirror back to orchestrators.
+fn breaker_connector(
+    server: &MockServer,
+    threshold: u32,
+    cooldown_secs: u64,
+) -> SnowflakeConnector {
+    let auth = Auth::from_config(AuthConfig {
+        account: "test_account".into(),
+        username: None,
+        password: None,
+        oauth_token: Some("test-sf-token".into()),
+        private_key_path: None,
+        pat: None,
+    })
+    .unwrap();
+
+    let config = ConnectorConfig {
+        account: "test_account".into(),
+        warehouse: "COMPUTE_WH".into(),
+        database: Some("TEST_DB".into()),
+        schema: Some("PUBLIC".into()),
+        role: Some("SYSADMIN".into()),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter: false,
+            circuit_breaker_threshold: threshold,
+            circuit_breaker_recovery_timeout_secs: Some(cooldown_secs),
+            ..Default::default()
+        },
+    };
+
+    SnowflakeConnector::new(config, auth).with_base_url(server.uri())
+}
+
+#[tokio::test]
+async fn rate_limit_storm_trips_breaker() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let connector = breaker_connector(&server, 5, 240);
+
+    for i in 0..5u32 {
+        let err = connector
+            .execute_sql("SELECT 1")
+            .await
+            .expect_err("429 storm should error");
+        match err {
+            ConnectorError::ApiError { status: 429, .. } => {}
+            other => panic!("call {i}: expected ApiError(429), got: {other:?}"),
+        }
+    }
+
+    let err = connector
+        .execute_sql("SELECT 1")
+        .await
+        .expect_err("CircuitBreakerOpen must short-circuit after trip");
+    match err {
+        ConnectorError::CircuitBreakerOpen {
+            consecutive_failures,
+            cooldown_seconds,
+        } => {
+            assert!(
+                consecutive_failures >= 5,
+                "expected ≥5 consecutive failures, got {consecutive_failures}"
+            );
+            assert_eq!(
+                cooldown_seconds,
+                Some(240),
+                "cooldown must mirror the configured recovery_timeout"
+            );
+        }
+        other => panic!("expected CircuitBreakerOpen, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_below_threshold_does_not_trip_breaker() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let connector = breaker_connector(&server, 5, 240);
+
+    for i in 0..4u32 {
+        let err = connector
+            .execute_sql("SELECT 1")
+            .await
+            .expect_err("429 should error");
+        match err {
+            ConnectorError::ApiError { status: 429, .. } => {}
+            ConnectorError::CircuitBreakerOpen { .. } => {
+                panic!("call {i}: breaker tripped below threshold=5")
+            }
+            other => panic!("call {i}: expected ApiError(429), got: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn breaker_trip_without_recovery_timeout_emits_none_cooldown() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+        .mount(&server)
+        .await;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: "test_account".into(),
+        username: None,
+        password: None,
+        oauth_token: Some("test-sf-token".into()),
+        private_key_path: None,
+        pat: None,
+    })
+    .unwrap();
+    let config = ConnectorConfig {
+        account: "test_account".into(),
+        warehouse: "COMPUTE_WH".into(),
+        database: Some("TEST_DB".into()),
+        schema: Some("PUBLIC".into()),
+        role: Some("SYSADMIN".into()),
+        timeout: Duration::from_secs(30),
+        retry: RetryConfig {
+            max_retries: 0,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter: false,
+            circuit_breaker_threshold: 5,
+            circuit_breaker_recovery_timeout_secs: None,
+            ..Default::default()
+        },
+    };
+    let connector = SnowflakeConnector::new(config, auth).with_base_url(server.uri());
+
+    for _ in 0..5u32 {
+        let _ = connector.execute_sql("SELECT 1").await;
+    }
+    let err = connector
+        .execute_sql("SELECT 1")
+        .await
+        .expect_err("CircuitBreakerOpen must short-circuit after trip");
+    match err {
+        ConnectorError::CircuitBreakerOpen {
+            cooldown_seconds: None,
+            ..
+        } => {}
+        other => {
+            panic!("expected CircuitBreakerOpen {{ cooldown_seconds: None, .. }}, got: {other:?}")
+        }
+    }
+}

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`_run_filters`: honour engine-supplied `TableError.cooldown_seconds`** for the `retry_after_seconds` hint on quota-exceeded breaches. Closes the warehouse-side parity gap PR #624 documented as a follow-up: when a Databricks or Snowflake circuit breaker trips on a config with `circuit_breaker_recovery_timeout_secs` set, the engine now stamps the warehouse's configured cooldown onto each breach error; the dagster handler reads it (preferring the largest reported cooldown when multiple are present) and projects it onto `dg.Failure.metadata.retry_after_seconds` instead of the hard-coded 300s constant. The constant is retained as a fallback for two cases: (a) manual-reset-only breakers (no `recovery_timeout` configured) emit `None`, (b) older engine binaries don't yet emit the field. Three new tests pin (a) engine-cooldown-wins, (b) largest-cooldown-wins when multiple breaches surface, (c) fallback for `None`.
+- **`TableError.cooldown_seconds: int | None = None`** added to the hand-written Pydantic model in `dagster_rocky/types.py`. Default-`None` preserves byte-stable parsing of fixtures captured before the warehouse-cooldown-parity cut.
+- **`types_generated/run_schema.py`** regenerated to surface the new optional `TableErrorOutput.cooldown_seconds` field shipped in the matching engine cut.
+
 ## [1.40.0] — 2026-05-21
 
 Companion to engine `v1.42.0`. Ships the dagster-side half of the Fivetran 429 self-healing fix ([#624](https://github.com/rocky-data/rocky/pull/624)): when the engine surfaces a `quota-exceeded` `TableError` (sustained 429s tripping the shared Fivetran circuit breaker), the component now yields partial materializations from succeeded filters and raises a retriable `dg.Failure` with a `retry_after_seconds` metadata hint so user-configured `RetryPolicy` schedules the next attempt past the breaker cooldown. Picks up the regenerated `discover_schema.py` for the new `FailedSourceOutput.cooldown_seconds` field.

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -101,13 +101,15 @@ _VALIDATION_ERROR_PREVIEW_BYTES: int = 1500
 #: code-server pod on large model trees.
 _COLUMN_LINEAGE_MAX_WORKERS: int = 8
 
-#: Default cooldown surfaced as the ``retry_after_seconds`` metadata
-#: hint when a run terminates with a ``quota-exceeded`` failure_kind.
-#: Matches ``rocky_fivetran::circuit_breaker::CircuitConfig::default().cooldown``
-#: on the engine side — i.e. the initial cooldown a tripped Fivetran
-#: shared breaker honours before transitioning ``Open → HalfOpen``.
-#: Used because ``TableError`` does not currently carry the per-error
-#: cooldown; threading the exact value through is a follow-up.
+#: Fallback cooldown for the ``retry_after_seconds`` metadata hint when
+#: a run terminates with a ``quota-exceeded`` ``failure_kind`` but the
+#: engine-side ``TableError.cooldown_seconds`` is absent — i.e. when
+#: the warehouse breaker that tripped wasn't configured with a
+#: ``circuit_breaker_recovery_timeout_secs``, or the engine binary is
+#: older than the warehouse-cooldown-parity cut. Matches
+#: ``rocky_fivetran::circuit_breaker::CircuitConfig::default().cooldown``
+#: (300s) on the engine side. When ``TableError.cooldown_seconds`` is
+#: populated, that value wins over this constant.
 _FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS: int = 300
 
 #: Wire-form failure_kind for the Fivetran-storm signal — emitted by
@@ -1901,10 +1903,11 @@ def _run_filters(
         )
         _log_run_diagnostics(context, result)
         results.append(result)
-        if _has_quota_breach(result):
-            cooldown_seconds = _FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS
+        breach_cooldown = _quota_breach_cooldown(result)
+        if breach_cooldown is not None:
+            cooldown_seconds = breach_cooldown
             context.log.warning(
-                f"Fivetran shared circuit breaker tripped during filter '{f}' "
+                f"Circuit breaker tripped during filter '{f}' "
                 f"(`failure_kind == quota-exceeded`); skipping remaining filters "
                 f"and surfacing a retriable failure with retry_after_seconds={cooldown_seconds}."
             )
@@ -1915,11 +1918,38 @@ def _run_filters(
 def _has_quota_breach(result: RunResult) -> bool:
     """True when ``result.errors`` contains a quota-exceeded entry.
 
-    Single source of truth for the Fivetran-storm signal so callers
-    don't drift on the wire string. See
-    :data:`_QUOTA_EXCEEDED_FAILURE_KIND`.
+    Single source of truth for the storm signal so callers don't drift on
+    the wire string. See :data:`_QUOTA_EXCEEDED_FAILURE_KIND`. Used by
+    tests; runtime callers should prefer :func:`_quota_breach_cooldown`
+    which also returns the engine-supplied cooldown hint.
     """
     return any(err.failure_kind == _QUOTA_EXCEEDED_FAILURE_KIND for err in result.errors)
+
+
+def _quota_breach_cooldown(result: RunResult) -> int | None:
+    """Return the cooldown to honour for a quota-exceeded breach, or
+    ``None`` if no breach occurred.
+
+    Prefers the engine-supplied ``TableError.cooldown_seconds`` (the
+    warehouse breaker's configured ``recovery_timeout``, or the Fivetran
+    breaker's ``CircuitConfig.cooldown``) over the
+    :data:`_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS` fallback. The
+    fallback covers two cases: (a) the breaker that tripped wasn't
+    configured with a recovery timeout, so the engine emits
+    ``cooldown_seconds: None``; (b) an older engine binary doesn't yet
+    emit the field. When multiple quota-exceeded errors are present
+    (rare — the engine breaks out of the run on first trip), the largest
+    populated cooldown wins so we honour the most conservative backoff.
+    """
+    breach_cooldowns = [
+        err.cooldown_seconds
+        for err in result.errors
+        if err.failure_kind == _QUOTA_EXCEEDED_FAILURE_KIND
+    ]
+    if not breach_cooldowns:
+        return None
+    populated = [c for c in breach_cooldowns if c is not None]
+    return max(populated) if populated else _FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS
 
 
 def _quota_breach_failure(cooldown_seconds: int) -> dg.Failure:
@@ -1928,12 +1958,21 @@ def _quota_breach_failure(cooldown_seconds: int) -> dg.Failure:
     ``allow_retries=True`` lets Dagster's :class:`RetryPolicy` reschedule the
     run; ``retry_after_seconds`` is a metadata hint orchestrators can read to
     delay the next attempt past the breaker cooldown.
+
+    The breach signal originates from either the Fivetran shared circuit
+    breaker (sustained 429s on discover-time fetches) or a warehouse
+    circuit breaker (Databricks or Snowflake — sustained transient
+    pressure on a run-time SQL statement). The ``cooldown_seconds`` is
+    the engine's configured ``recovery_timeout`` for whichever breaker
+    tripped, or :data:`_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS` when
+    the engine didn't supply one (older binary, manual-reset-only
+    breaker).
     """
     return dg.Failure(
         description=(
-            "Fivetran shared circuit breaker tripped (sustained 429s exhausted "
-            f"the per-call retry budget); backing off {cooldown_seconds}s before "
-            "the next attempt."
+            "Circuit breaker tripped (sustained transient pressure exhausted "
+            f"the per-call retry budget); backing off {cooldown_seconds}s "
+            "before the next attempt."
         ),
         allow_retries=True,
         metadata={

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -241,6 +241,14 @@ class TableError(BaseModel):
     #: Defaults to ``"unknown"`` for older engine binaries that omit the
     #: field.
     failure_kind: str = "unknown"
+    #: Engine-supplied retry-after hint in whole seconds. Populated when a
+    #: warehouse circuit breaker tripped on a half-open-recovery config —
+    #: the warehouse-side mirror of ``FailedSource.cooldown_seconds``.
+    #: ``None`` for failures without an engine-supplied hint, and for
+    #: older engine binaries that don't yet emit the field. Read by
+    #: ``_run_filters`` to project the engine's cooldown onto the
+    #: retriable :class:`dg.Failure` instead of the hard-coded fallback.
+    cooldown_seconds: int | None = None
 
 
 class ExcludedTable(BaseModel):

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -375,6 +375,10 @@ class TableErrorOutput(BaseModel):
     """
 
     asset_key: list[str]
+    cooldown_seconds: conint(ge=0) | None = None
+    """
+    Backoff hint in whole seconds. Populated by adapters whose failure mode carries a known cooldown — currently only the Databricks and Snowflake warehouse adapters when their shared circuit breaker trips (and the breaker was configured with `retry.circuit_breaker_recovery_timeout_secs`). Orchestrators (Dagster, etc.) use it as a `retry_after` hint when scheduling a delayed re-run. Mirrors the source-side shape on [`FailedSourceOutput::cooldown_seconds`]. Absent for failure classes without an engine-supplied hint.
+    """
     error: str
     failure_kind: (
         FailureKind1

--- a/integrations/dagster/tests/test_execution.py
+++ b/integrations/dagster/tests/test_execution.py
@@ -704,3 +704,132 @@ def test_quota_exceeded_failure_kind_raises_retriable_failure(
     assert failure_data.user_failure_data.label == "quota-exceeded" or any(
         v.value == "quota-exceeded" for v in metadata.values() if hasattr(v, "value")
     ), "failure_kind tag must be carried on the dg.Failure metadata"
+
+
+def test_quota_exceeded_with_engine_cooldown_honours_engine_value(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """Run-side warehouse-breaker parity: when the engine supplies a
+    per-error ``TableError.cooldown_seconds`` (the warehouse breaker
+    was configured with ``circuit_breaker_recovery_timeout_secs``), the
+    component must surface that exact value on
+    ``retry_after_seconds`` instead of falling back to
+    :data:`_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS`.
+
+    Mirrors the warehouse-side mirror of PR #624: a Databricks /
+    Snowflake breaker trip lands a ``quota-exceeded`` ``TableError``
+    with the warehouse's configured cooldown, and the dagster handler
+    threads it through to ``dg.Failure.metadata.retry_after_seconds`` so
+    Dagster's :class:`RetryPolicy` honours the warehouse's view instead
+    of the Fivetran-default.
+    """
+    defs = _build_defs(discover_json, tmp_path)
+    run_result = RunResult.model_validate_json(run_json)
+
+    from dagster_rocky.types import TableError  # noqa: PLC0415
+
+    # Engine reports a 90s cooldown on the breach — that wins over the
+    # 300s _FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS fallback.
+    run_result.errors = [
+        TableError(
+            asset_key=["fivetran", "acme", "us_west", "shopify", "payments"],
+            error="databricks circuit breaker tripped",
+            failure_kind="quota-exceeded",
+            cooldown_seconds=90,
+        )
+    ]
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+
+    exec_result = _materialize_subset(defs, run_result, [orders_key])
+
+    assert not exec_result.success
+    failure_events = [e for e in exec_result.all_events if e.event_type_value == "STEP_FAILURE"]
+    assert failure_events
+    failure_data = failure_events[0].event_specific_data
+    metadata = failure_data.user_failure_data.metadata if failure_data.user_failure_data else {}
+    assert metadata["retry_after_seconds"].value == 90, (
+        "engine-supplied TableError.cooldown_seconds must win over the "
+        "_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS fallback"
+    )
+
+
+def test_quota_exceeded_with_largest_cooldown_when_multiple_breaches(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """When more than one ``quota-exceeded`` error is present, the
+    component picks the largest engine-supplied cooldown so we honour
+    the most conservative backoff.
+
+    This is a defensive case — the engine breaks out of the run on the
+    first breaker trip — but the contract is "the longest reported
+    cooldown wins" and is worth pinning so a future engine change that
+    surfaces multiple breaches doesn't silently under-back-off.
+    """
+    defs = _build_defs(discover_json, tmp_path)
+    run_result = RunResult.model_validate_json(run_json)
+
+    from dagster_rocky.types import TableError  # noqa: PLC0415
+
+    run_result.errors = [
+        TableError(
+            asset_key=["fivetran", "acme", "us_west", "shopify", "payments"],
+            error="databricks breaker tripped (60s cooldown)",
+            failure_kind="quota-exceeded",
+            cooldown_seconds=60,
+        ),
+        TableError(
+            asset_key=["fivetran", "acme", "us_west", "shopify", "refunds"],
+            error="snowflake breaker tripped (180s cooldown)",
+            failure_kind="quota-exceeded",
+            cooldown_seconds=180,
+        ),
+    ]
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+
+    exec_result = _materialize_subset(defs, run_result, [orders_key])
+
+    assert not exec_result.success
+    failure_events = [e for e in exec_result.all_events if e.event_type_value == "STEP_FAILURE"]
+    failure_data = failure_events[0].event_specific_data
+    metadata = failure_data.user_failure_data.metadata if failure_data.user_failure_data else {}
+    assert metadata["retry_after_seconds"].value == 180, (
+        "largest engine-supplied cooldown must win when multiple breaches are present"
+    )
+
+
+def test_quota_exceeded_with_none_cooldown_falls_back_to_default(
+    discover_json: str, run_json: str, tmp_path: Path
+):
+    """A breach where every error carries ``cooldown_seconds=None``
+    (manual-reset-only breaker, or an older engine binary) must fall
+    back to :data:`_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS`.
+
+    Back-compat: prior to this PR every quota-exceeded error landed
+    without a cooldown field, and the dagster handler used the 300s
+    default. That behaviour must persist for ``None``-cooldown errors.
+    """
+    defs = _build_defs(discover_json, tmp_path)
+    run_result = RunResult.model_validate_json(run_json)
+
+    from dagster_rocky.types import TableError  # noqa: PLC0415
+
+    run_result.errors = [
+        TableError(
+            asset_key=["fivetran", "acme", "us_west", "shopify", "payments"],
+            error="breaker tripped without recovery_timeout configured",
+            failure_kind="quota-exceeded",
+            cooldown_seconds=None,
+        )
+    ]
+    orders_key = dg.AssetKey(["fivetran", "acme", "us_west", "shopify", "orders"])
+
+    exec_result = _materialize_subset(defs, run_result, [orders_key])
+
+    assert not exec_result.success
+    failure_events = [e for e in exec_result.all_events if e.event_type_value == "STEP_FAILURE"]
+    failure_data = failure_events[0].event_specific_data
+    metadata = failure_data.user_failure_data.metadata if failure_data.user_failure_data else {}
+    assert metadata["retry_after_seconds"].value == 300, (
+        "None engine-supplied cooldown must fall back to "
+        "_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS (300)"
+    )

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -943,6 +943,15 @@
           },
           "type": "array"
         },
+        "cooldown_seconds": {
+          "description": "Backoff hint in whole seconds. Populated by adapters whose failure mode carries a known cooldown — currently only the Databricks and Snowflake warehouse adapters when their shared circuit breaker trips (and the breaker was configured with `retry.circuit_breaker_recovery_timeout_secs`). Orchestrators (Dagster, etc.) use it as a `retry_after` hint when scheduling a delayed re-run. Mirrors the source-side shape on [`FailedSourceOutput::cooldown_seconds`]. Absent for failure classes without an engine-supplied hint.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "error": {
           "type": "string"
         },


### PR DESCRIPTION
## Summary

Closes the follow-up flagged in PR #624's dagster-side note: warehouse circuit-breaker trips (Databricks / Snowflake) now surface their configured `recovery_timeout` end-to-end so the dagster handler honours the warehouse's view of the cooldown instead of falling back to the Fivetran-default 300s constant.

**Behaviour change worth flagging.** Warehouse `CircuitBreakerOpen → FailureKind` flips from `Transient` → `QuotaExceeded`. Matches the enum's documented semantics (\"Rate limit hit or a configured budget cap (retry budget, circuit breaker, account-level quota)\") and the dagster handler keyed on `failure_kind == \"quota-exceeded\"`. Orchestrators that previously treated a tripped warehouse breaker as a fail-fast transient now get a retriable `dg.Failure` with the warehouse's configured `retry_after_seconds` instead.

### Engine

- `rocky_core::circuit_breaker::CircuitBreaker::recovery_timeout()` accessor exposes the previously-private field so warehouse adapters can mirror it onto `ConnectorError::CircuitBreakerOpen`.
- `rocky_databricks` / `rocky_snowflake` `ConnectorError::CircuitBreakerOpen` variants extended with `cooldown_seconds: Option<u64>`. Populated from `self.circuit_breaker.recovery_timeout().map(|d| d.as_secs())`; `None` for manual-reset-only breakers preserves the original behaviour.
- `TableErrorOutput.cooldown_seconds: Option<u64>` added to `rocky run --output json`, mirroring `FailedSourceOutput.cooldown_seconds`.
- New `classify_anyhow_error_with_cooldown` walker projects the typed connector chain into `(FailureKind, Option<u64>)` in one pass — used by `commands/run.rs` for the four `TableError` construction sites.

### Dagster

- `TableError.cooldown_seconds: int | None = None` added to the hand-written Pydantic model. Default-`None` preserves byte-stable parsing.
- `_run_filters` now calls a new `_quota_breach_cooldown(result)` helper that prefers the engine-supplied per-error cooldown over the `_FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS` (300s) fallback. Fallback retained for (a) manual-reset-only breakers, (b) older engine binaries that don't emit the field. Largest cooldown wins when multiple breaches surface.
- `_run_filters_pipes` (Pipes-mode execution path) is intentionally untouched — PR #624 left pipes-mode out of the quota-handling story because Pipes has its own error semantics. Threading the signal through `dg.PipesSubprocessClient` is a separate follow-up.

### Tests

- 3 new wiremock tests per warehouse (6 total): storm-trips-breaker, below-threshold-doesn't-trip, recovery_timeout=None emits None cooldown.
- 5 new `output.rs` tests for the `(FailureKind, Option<u64>)` walker — extraction from bare connector, through anyhow context, through the AdapterError wrapper, plus the `None` fallback for non-breaker variants.
- 3 new dagster tests: engine-cooldown-wins, largest-cooldown-wins-on-multi-breach, None-fallback-to-300.

### Codegen cascade

`just codegen` ran end-to-end. 3 generated files updated: `schemas/run.schema.json`, `integrations/dagster/src/dagster_rocky/types_generated/run_schema.py`, `editors/vscode/src/types/generated/run.ts`. No `editors/vscode/package-lock.json` drift. `just regen-fixtures` ran with no drift — the playground POC is replication-only and doesn't trip warehouse breakers.

### Out of scope (future follow-ups)

- BigQuery breaker — BQ doesn't have a 429-style breaker today.
- `_run_filters_pipes` quota threading — separate carve-out (Pipes has its own error semantics).

### Pre-existing flakes

3 snowflake wiremock tests (`test_statement_failed`, `test_statement_execute_span_emitted`, `test_password_auth_omits_token_type_header`) fail on `main` as well — global event-bus / span-subscriber parallelism flakes unrelated to this change. Verified by stashing changes and re-running.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --workspace` — all green (besides 3 pre-existing snowflake flakes)
- [x] `cargo test -p rocky-databricks --features test-support --test wiremock_tests -- rate_limit_storm_trips_breaker rate_limit_below_threshold_does_not_trip_breaker breaker_trip_without_recovery_timeout_emits_none_cooldown` — 3/3 pass
- [x] `cargo test -p rocky-snowflake --features test-support --test wiremock_tests -- rate_limit_storm_trips_breaker rate_limit_below_threshold_does_not_trip_breaker breaker_trip_without_recovery_timeout_emits_none_cooldown` — 3/3 pass
- [x] `uv run pytest` (dagster) — 563/563 pass
- [x] `uv run python -m ruff format --check src/ tests/` clean
- [x] `uv run ruff check src/ tests/` clean
- [x] `just codegen` clean (idempotent)
- [x] `just regen-fixtures` — no drift