### PR TITLE
fix(engine/rocky-snowflake): drift safe-widening allowlist + ALTER COLUMN quoting

### DIFF
--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -339,6 +339,94 @@ impl SqlDialect for SnowflakeSqlDialect {
             .join(", ");
         Ok(format!("COALESCE(HASH({arg_list}), 0)"))
     }
+
+    /// Snowflake's `DESCRIBE TABLE` returns native type names
+    /// (`NUMBER(p,s)`, `VARCHAR(n)`, `TIMESTAMP_NTZ`), not the
+    /// Databricks-flavored names the default allowlist matches.
+    /// Override so drift evolution doesn't fall through to
+    /// `DropAndRecreate` on safe widenings.
+    ///
+    /// Snowflake's `ALTER COLUMN ... SET DATA TYPE` accepts:
+    /// - `NUMBER(p1,s) -> NUMBER(p2,s)` where `p2 >= p1` (precision
+    ///   widening, scale preserved).
+    /// - `VARCHAR(n) -> VARCHAR(m)` where `m >= n` (length widening).
+    ///
+    /// Family changes (`NUMBER -> VARCHAR`, `TIMESTAMP_NTZ ->
+    /// TIMESTAMP_TZ`) and scale changes on `NUMBER` are not allowed
+    /// by `ALTER COLUMN`, so treating them as unsafe avoids a
+    /// partial-execution failure.
+    fn is_safe_type_widening(&self, source_type: &str, target_type: &str) -> bool {
+        is_safe_number_widening(target_type, source_type)
+            || is_safe_snowflake_varchar_widening(target_type, source_type)
+    }
+
+    /// Snowflake folds unquoted identifiers to UPPERCASE at parse time.
+    /// The default `alter_column_type_sql` interpolates `column` without
+    /// quotes, which silently breaks against any column created with
+    /// quoted lowercase names. `format_table_ref` already quotes the
+    /// table parts; this override does the same for the column.
+    fn alter_column_type_sql(
+        &self,
+        table_ref: &str,
+        column: &str,
+        new_type: &str,
+    ) -> AdapterResult<String> {
+        validation::validate_identifier(column).map_err(AdapterError::new)?;
+        rocky_core::sql_gen::validate_sql_type(new_type).map_err(AdapterError::new)?;
+        let col_q = self.quote_identifier(column);
+        Ok(format!(
+            "ALTER TABLE {table_ref} ALTER COLUMN {col_q} TYPE {new_type}"
+        ))
+    }
+}
+
+/// `NUMBER(p1,s) -> NUMBER(p2,s)` where `p2 >= p1` (precision widens,
+/// scale must match). Snowflake's `DESCRIBE TABLE` returns `NUMBER` as
+/// the canonical name even when the column was declared as `DECIMAL`,
+/// `NUMERIC`, `INT`, or `BIGINT`, so this is the surface to match.
+fn is_safe_number_widening(target: &str, source: &str) -> bool {
+    fn parse_number(t: &str) -> Option<(u32, u32)> {
+        let t = t.trim();
+        if !t.starts_with("NUMBER(") || !t.ends_with(')') {
+            return None;
+        }
+        let inner = &t[7..t.len() - 1];
+        let parts: Vec<&str> = inner.split(',').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+        let p = parts[0].trim().parse::<u32>().ok()?;
+        let s = parts[1].trim().parse::<u32>().ok()?;
+        Some((p, s))
+    }
+
+    if let (Some((tp, ts)), Some((sp, ss))) = (parse_number(target), parse_number(source)) {
+        sp >= tp && ss == ts
+    } else {
+        false
+    }
+}
+
+/// `VARCHAR(n) -> VARCHAR(m)` where `m >= n`.
+///
+/// Snowflake aliases `STRING`, `TEXT`, `CHAR`, `CHARACTER` to `VARCHAR`,
+/// and `DESCRIBE TABLE` returns the canonical `VARCHAR(n)` regardless
+/// of which alias was used at create time. Parsing only `VARCHAR(`
+/// covers every text-column case.
+fn is_safe_snowflake_varchar_widening(target: &str, source: &str) -> bool {
+    fn parse_varchar(t: &str) -> Option<u32> {
+        let t = t.trim();
+        if !t.starts_with("VARCHAR(") || !t.ends_with(')') {
+            return None;
+        }
+        t[8..t.len() - 1].trim().parse::<u32>().ok()
+    }
+
+    if let (Some(tn), Some(sn)) = (parse_varchar(target), parse_varchar(source)) {
+        sn >= tn
+    } else {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -646,5 +734,95 @@ mod tests {
         ));
         assert!(script.contains("INSERT INTO warehouse.marts.fct_daily_orders"));
         assert!(script.ends_with("COMMIT"));
+    }
+
+    // Trait signature: `is_safe_type_widening(source_type, target_type)`
+    // where `source_type` is the NEW desired type and `target_type` is
+    // the CURRENT warehouse type. Widening means current -> new, so
+    // call sites read `(new, current)`.
+
+    #[test]
+    fn is_safe_type_widening_number_precision_widens() {
+        let d = dialect();
+        // Warehouse currently NUMBER(10,0); want NUMBER(38,0).
+        assert!(d.is_safe_type_widening("NUMBER(38,0)", "NUMBER(10,0)"));
+        assert!(d.is_safe_type_widening("NUMBER(20,2)", "NUMBER(10,2)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_number_narrowing_rejected() {
+        let d = dialect();
+        // Narrowing loses data.
+        assert!(!d.is_safe_type_widening("NUMBER(10,0)", "NUMBER(38,0)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_number_scale_change_rejected() {
+        let d = dialect();
+        // Snowflake's ALTER COLUMN refuses scale changes even if precision
+        // widens. Reject so drift skips ALTER and uses DropAndRecreate.
+        assert!(!d.is_safe_type_widening("NUMBER(10,4)", "NUMBER(10,2)"));
+        assert!(!d.is_safe_type_widening("NUMBER(20,4)", "NUMBER(10,2)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_varchar_length_widens() {
+        let d = dialect();
+        // Warehouse currently VARCHAR(100); want VARCHAR(1000).
+        assert!(d.is_safe_type_widening("VARCHAR(1000)", "VARCHAR(100)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_varchar_narrowing_rejected() {
+        let d = dialect();
+        assert!(!d.is_safe_type_widening("VARCHAR(100)", "VARCHAR(1000)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_family_change_rejected() {
+        let d = dialect();
+        // Snowflake's ALTER COLUMN can't change type families.
+        assert!(!d.is_safe_type_widening("VARCHAR(100)", "NUMBER(10,0)"));
+        assert!(!d.is_safe_type_widening("NUMBER(10,0)", "VARCHAR(100)"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_databricks_names_rejected() {
+        let d = dialect();
+        // Default Databricks-flavored allowlist would accept these. On
+        // Snowflake, DESCRIBE never returns these names; if they show up
+        // they're from a wrong-dialect source, not a safe Snowflake widening.
+        assert!(!d.is_safe_type_widening("STRING", "BIGINT"));
+        assert!(!d.is_safe_type_widening("BIGINT", "INT"));
+    }
+
+    #[test]
+    fn alter_column_type_sql_quotes_column() {
+        let d = dialect();
+        let sql = d
+            .alter_column_type_sql("\"db\".\"sch\".\"tbl\"", "id", "NUMBER(38,0)")
+            .unwrap();
+        assert_eq!(
+            sql,
+            "ALTER TABLE \"db\".\"sch\".\"tbl\" ALTER COLUMN \"id\" TYPE NUMBER(38,0)"
+        );
+    }
+
+    #[test]
+    fn alter_column_type_sql_rejects_bad_identifier() {
+        let d = dialect();
+        let err = d
+            .alter_column_type_sql("\"db\".\"sch\".\"tbl\"", "bad; DROP", "NUMBER(38,0)")
+            .unwrap_err();
+        assert!(err.to_string().contains("identifier"));
+    }
+
+    #[test]
+    fn is_safe_type_widening_malformed_input_rejected() {
+        let d = dialect();
+        // Garbage in, false out (not a panic).
+        assert!(!d.is_safe_type_widening("NUMBER(38,0)", "NUMBER("));
+        assert!(!d.is_safe_type_widening("NUMBER(38,0)", "NUMBER(abc,0)"));
+        assert!(!d.is_safe_type_widening("VARCHAR(100)", "VARCHAR()"));
     }
 }

--- a/engine/crates/rocky-snowflake/tests/drift_widening_live.rs
+++ b/engine/crates/rocky-snowflake/tests/drift_widening_live.rs
@@ -1,0 +1,249 @@
+//! Live Snowflake conformance test for the safe-type-widening drift path.
+//!
+//! `#[ignore]`-gated because it requires a real Snowflake account.
+//! Run locally with:
+//!
+//! ```bash
+//! SNOWFLAKE_ACCOUNT=<your-account> \
+//! SNOWFLAKE_WAREHOUSE=<your-warehouse> \
+//! SNOWFLAKE_TEST_DATABASE=<your-database> \
+//! # one of:
+//! SNOWFLAKE_PAT=<your-pat> \
+//! # or other supported auth modes per clone_live.rs
+//! cargo test -p rocky-snowflake --test drift_widening_live -- --ignored --nocapture
+//! ```
+//!
+//! What this test pins:
+//!
+//! 1. `SnowflakeSqlDialect::is_safe_type_widening` recognizes the
+//!    canonical Snowflake widenings, so `detect_drift` returns
+//!    `AlterColumnTypes` instead of `DropAndRecreate` on a real
+//!    Snowflake table.
+//! 2. The ALTER SQL produced by the default `alter_column_type_sql`
+//!    impl (`ALTER COLUMN col TYPE new_type`) is accepted by Snowflake
+//!    for the widening case. Closes the
+//!    `feedback_sql_dialect_live_execute_tests` discipline gap.
+//!
+//! Without this test, the existing unit tests in `dialect.rs` would
+//! pass but the integration would still ship the
+//! drift-falls-through-to-DropAndRecreate bug the recon memo flagged.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::drift::detect_drift;
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::dialect::SnowflakeSqlDialect;
+
+fn adapter_from_env() -> Option<(SnowflakeWarehouseAdapter, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    let connector = SnowflakeConnector::new(config, auth);
+    Some((SnowflakeWarehouseAdapter::new(connector), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &SnowflakeWarehouseAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_drift_safe_widening_alters_in_place() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+
+    let schema = format!("rocky_drift_widening_{}", schema_suffix());
+    let table = "widening_target";
+
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+
+    // Create the table with the narrower types we expect to widen.
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"{table}\" (\
+                \"id\" NUMBER(10,0), \
+                \"name\" VARCHAR(100)\
+            )"
+        ),
+    )
+    .await;
+
+    let table_ref = TableRef {
+        catalog: database.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+
+    // DESCRIBE returns the canonical Snowflake type names. These are
+    // the "target" (current) types in detect_drift's vocabulary.
+    let current_columns = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table");
+
+    let mut id_current = String::new();
+    let mut name_current = String::new();
+    for col in &current_columns {
+        match col.name.as_str() {
+            "id" => id_current = col.data_type.clone(),
+            "name" => name_current = col.data_type.clone(),
+            _ => {}
+        }
+    }
+    assert!(
+        id_current.starts_with("NUMBER("),
+        "expected NUMBER(...) for id, got {id_current}"
+    );
+    assert!(
+        name_current.starts_with("VARCHAR("),
+        "expected VARCHAR(...) for name, got {name_current}"
+    );
+
+    // Source-side (declared / new) types: widening both columns.
+    let desired_columns = vec![
+        ColumnInfo {
+            name: "id".to_string(),
+            data_type: "NUMBER(38,0)".to_string(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "name".to_string(),
+            data_type: "VARCHAR(1000)".to_string(),
+            nullable: true,
+        },
+    ];
+
+    let dialect = SnowflakeSqlDialect;
+    let result = detect_drift(&table_ref, &desired_columns, &current_columns, &dialect);
+
+    println!(
+        "detect_drift -> action={:?} drifted={:?}",
+        result.action, result.drifted_columns
+    );
+
+    // Drop the schema before asserting so a failed assertion still
+    // leaves the sandbox clean.
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    assert_eq!(
+        result.action,
+        DriftAction::AlterColumnTypes,
+        "Snowflake drift should classify NUMBER(10,0) -> NUMBER(38,0) \
+         and VARCHAR(100) -> VARCHAR(1000) as safe widenings, not \
+         DropAndRecreate. Drifted: {:?}",
+        result.drifted_columns
+    );
+
+    // Recreate so we can exercise the ALTER path end-to-end.
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"{table}\" (\
+                \"id\" NUMBER(10,0), \
+                \"name\" VARCHAR(100)\
+            )"
+        ),
+    )
+    .await;
+
+    // Generate the ALTER SQL via the dialect and execute it against
+    // Snowflake. This is the receipt that the SQL form Rocky emits is
+    // actually accepted by the warehouse.
+    let table_str = dialect
+        .format_table_ref(&database, &schema, table)
+        .expect("format_table_ref");
+    let alter_id = dialect
+        .alter_column_type_sql(&table_str, "id", "NUMBER(38,0)")
+        .expect("alter_column_type_sql id");
+    let alter_name = dialect
+        .alter_column_type_sql(&table_str, "name", "VARCHAR(1000)")
+        .expect("alter_column_type_sql name");
+
+    println!("emitting: {alter_id}");
+    exec(&adapter, &alter_id).await;
+    println!("emitting: {alter_name}");
+    exec(&adapter, &alter_name).await;
+
+    let widened = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table after alter");
+
+    let mut id_new = String::new();
+    let mut name_new = String::new();
+    for col in &widened {
+        match col.name.as_str() {
+            "id" => id_new = col.data_type.clone(),
+            "name" => name_new = col.data_type.clone(),
+            _ => {}
+        }
+    }
+
+    // Cleanup before assertions.
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    assert_eq!(id_new, "NUMBER(38,0)", "id column after ALTER");
+    assert_eq!(name_new, "VARCHAR(1000)", "name column after ALTER");
+
+    println!(
+        "OK: drift classified safe; ALTER accepted by Snowflake; \
+         id {id_current} -> {id_new}, name {name_current} -> {name_new}"
+    );
+}


### PR DESCRIPTION
## Summary

`SnowflakeSqlDialect` did not override `is_safe_type_widening` or `alter_column_type_sql`. Two correctness gaps surfaced from the 2026-05-23 adapter recon and were verified end-to-end by the new live test:

1. **The default allowlist matches Databricks/Spark type names** (`BIGINT`, `STRING`). Snowflake's `DESCRIBE TABLE` returns native names (`NUMBER(p,s)`, `VARCHAR(n)`). Result: drift on a Snowflake table fell through to `DropAndRecreate` even on safe widenings like `NUMBER(10,0)` to `NUMBER(38,0)`. This is the data-loss disaster the README markets Rocky against.
2. **The default `alter_column_type_sql` interpolates the column name unquoted.** Snowflake folds unquoted identifiers to uppercase at parse time, so the ALTER fails with `invalid identifier 'ID'` on any column created with quoted lowercase names.

## Fix

Two overrides on `SnowflakeSqlDialect`:

- `is_safe_type_widening` recognizes `NUMBER(p1,s)` to `NUMBER(p2,s)` precision widening (scale preserved) and `VARCHAR(n)` to `VARCHAR(m)` length widening. Family changes and scale changes return false; the drift detector falls back to `DropAndRecreate` for those.
- `alter_column_type_sql` double-quotes the column name to defeat case-fold, matching what `format_table_ref` already does for the table parts.

Same shape as BigQuery PR #332 / #333 closed the equivalent gap.

## Test plan

- [x] 8 dialect unit tests cover the override logic (precision widening, narrowing rejected, scale change rejected, length widening, family change rejected, Databricks names rejected, malformed input rejected, ALTER COLUMN quoting + bad-identifier rejection).
- [x] Live integration test at `tests/drift_widening_live.rs` (env-gated, `#[ignore]`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test -p rocky-snowflake --lib` 154 passed, 0 failed.
- [x] Live test against the Snowflake sandbox:

```
detect_drift -> action=AlterColumnTypes drifted=[
  DriftedColumn { name: "id", source_type: "NUMBER(38,0)", target_type: "NUMBER(10,0)" },
  DriftedColumn { name: "name", source_type: "VARCHAR(1000)", target_type: "VARCHAR(100)" }
]
emitting: ALTER TABLE "..." ALTER COLUMN "id" TYPE NUMBER(38,0)
emitting: ALTER TABLE "..." ALTER COLUMN "name" TYPE VARCHAR(1000)
OK: drift classified safe; ALTER accepted by Snowflake;
    id NUMBER(10,0) -> NUMBER(38,0), name VARCHAR(100) -> VARCHAR(1000)
```