### PR TITLE
feat(examples/bigquery): promote POC from compile-only to live rocky run

### DIFF
--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
@@ -1,13 +1,18 @@
 # 05-bigquery-native-queries — BigQuery Adapter
 
 > **Category:** 07-adapters
-> **Credentials:** GCP Service Account JSON or ADC (`GOOGLE_APPLICATION_CREDENTIALS` or `BIGQUERY_TOKEN`)
-> **Runtime:** ~3–5 minutes against the EU sandbox
+> **Credentials:** GCP Service Account JSON or ADC (`GOOGLE_APPLICATION_CREDENTIALS` or `BIGQUERY_TOKEN`). Optional — the compile smoke runs without them.
+> **Runtime:** seconds (compile smoke) or ~3–5 minutes (full live tour) against the EU sandbox
 > **Rocky features:** BigQuery adapter, backtick quoting, region-qualified `INFORMATION_SCHEMA`, time-interval DML transactions, MERGE bootstrap, drift evolution (add / type-change / safe-widen), cost cross-check
 
 ## What it shows
 
-Rocky's BigQuery adapter end-to-end against a real GCP project — every BigQuery-specific surface the adapter exercises in production, verified live. The top-level `./run.sh` orchestrates six live scenarios under `live/`, each runnable independently.
+Rocky's BigQuery adapter end-to-end against a real GCP project. The top-level `./run.sh` operates in two modes:
+
+1. **Compile smoke** (always). Type-checks the BigQuery model frontmatter against the current `rocky` binary. Runs without credentials, so the credential-free POC sweep (`scripts/run-all-duckdb.sh`) covers it.
+2. **Live demo** (when BigQuery credentials are present). Materializes a full-refresh transformation against the sandbox, captures the `rocky run` receipt to `expected/run.json`, and queries the target table back to prove the row landed.
+
+Six independent live drivers under `live/` cover every BigQuery-specific surface Rocky exercises in production. The top-level script runs the full-refresh demo as the primary receipt; the others are runnable individually.
 
 ## Why it's distinctive
 
@@ -23,7 +28,10 @@ Rocky's BigQuery adapter end-to-end against a real GCP project — every BigQuer
 ```
 .
 ├── README.md                          this file
-├── run.sh                             orchestrates every live driver below
+├── run.sh                             compile smoke + (creds → live demo)
+├── expected/
+│   ├── compile.json                   `rocky compile` output
+│   └── run.json                       `rocky run` receipt (live mode only)
 └── live/                              live drivers (one per scenario)
     ├── README.md
     ├── run.sh                         full-refresh CTAS
@@ -36,13 +44,18 @@ Rocky's BigQuery adapter end-to-end against a real GCP project — every BigQuer
     └── cost-cross-check/              bytes_scanned vs `bq show -j` totalBytesBilled
 ```
 
-Each `live/<scenario>/run.sh` is independent: own `live.rocky.toml`, own model(s), own `hc_phase*` dataset, trap-cleanup on exit. They can run in any order or individually; the top-level `./run.sh` just chains them.
+Each `live/<scenario>/run.sh` is independent: own `live.rocky.toml`, own model(s), own `hc_phase*` dataset, trap-cleanup on exit. They can run in any order. The top-level `./run.sh` runs the full-refresh live demo directly; the other surfaces are runnable individually under `live/`.
 
 ## Prerequisites
 
+Compile smoke (always):
+
 - `rocky` on PATH
-- `bq` CLI on PATH (used by every driver for seed + cleanup)
-- `python3` on PATH (used by drivers for JSON assertions)
+
+Live demo + tour (when credentials are set):
+
+- `bq` CLI on PATH (used for seed, verification, cleanup)
+- `python3` on PATH (used for JSON assertions)
 - GCP project with BigQuery API enabled
 - One of:
   - `GOOGLE_APPLICATION_CREDENTIALS` — path to Service Account JSON key
@@ -50,20 +63,28 @@ Each `live/<scenario>/run.sh` is independent: own `live.rocky.toml`, own model(s
 
 ## Run
 
-Full tour:
+Compile smoke only (no credentials required):
 
 ```bash
-export GCP_PROJECT_ID="<your-gcp-project-id>"
+./run.sh
+```
+
+This always exits 0 after type-checking the BigQuery models. It is what the credential-free POC sweep runs.
+
+Compile smoke plus live demo:
+
+```bash
+export GCP_PROJECT_ID="<your-gcp-project-id>"   # BIGQUERY_TEST_PROJECT also accepted
 export GOOGLE_APPLICATION_CREDENTIALS="<path-to-service-account-json>"
 export BQ_LOCATION="EU"   # optional; default EU
 ./run.sh
 ```
 
-`GCP_PROJECT_ID` is templated into each driver's `live.rocky.toml` and model
-files at runtime via a `__GCP_PROJECT__` placeholder — no project ID is
-checked into the repo. See [`live/README.md`](./live/README.md) for details.
+The script creates the `hc_phase4_poc` dataset, runs `rocky run --output json`, captures the receipt to `expected/run.json`, queries the target table back to confirm the row landed, and drops the dataset on exit (success or failure).
 
-Or one scenario at a time:
+`GCP_PROJECT_ID` is templated into the staged `live.rocky.toml` and model files at runtime via a `__GCP_PROJECT__` placeholder; no project ID is checked into the repo. See [`live/README.md`](./live/README.md) for details.
+
+Full BigQuery surface tour — one scenario at a time:
 
 ```bash
 ./live/run.sh                   # full-refresh
@@ -73,6 +94,25 @@ Or one scenario at a time:
 ./live/drift/run.sh
 ./live/cost-cross-check/run.sh
 ```
+
+Each driver creates its own `hc_phase*_*` dataset, runs end-to-end, and cleans up on exit.
+
+## Expected output
+
+The live demo prints a subset of the run receipt for fast inspection:
+
+```
+==> rocky run receipt (subset)
+    asset_key       : <project>.hc_phase4_poc.full_refresh_demo
+    strategy        : full_refresh
+    duration_ms     : 1748
+    bytes_scanned   : 0
+    cost_usd        : 0.0
+    job_ids         : ['job_...']
+    status          : Success
+```
+
+`bytes_scanned` and `cost_usd` are zero because the full-refresh model is a constant `SELECT` literal with no source — BigQuery exempts such queries from the 10 MB minimum bill. Real scans surface non-zero figures; see `live/merge/run.sh` and `live/cost-cross-check/run.sh` for runs that exercise the cost path.
 
 ## Conformance audit
 

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/run.sh
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/run.sh
@@ -1,55 +1,163 @@
 #!/usr/bin/env bash
-# BigQuery adapter — end-to-end live tour.
+# BigQuery adapter — POC entrypoint.
 #
-# Runs each live driver under `live/<scenario>/` in sequence against a
-# real GCP project. Six scenarios cover every BigQuery-specific surface
-# Rocky exercises:
+# Two-mode script:
 #
-#   live/                     full-refresh CTAS
-#   live/time-interval/       BEGIN/DELETE/INSERT/COMMIT script per partition
-#   live/merge/               WHEN NOT MATCHED THEN INSERT ROW + first-run bootstrap
-#   live/discover/            BigQueryDiscoveryAdapter via INFORMATION_SCHEMA.SCHEMATA
-#   live/drift/               replication-from-BQ + per-table drift detection
-#                             (add_columns / drop_and_recreate / alter_column_types)
-#   live/cost-cross-check/    bytes_scanned == bq show -j totalBytesBilled
+#   1. Compile smoke (always runs, no credentials needed). Verifies the
+#      BigQuery model frontmatter type-checks against the current rocky
+#      binary. Exits 0. Picked up by the credential-free POC sweep
+#      (scripts/run-all-duckdb.sh).
 #
-# Each driver creates + drops its own `hc_phase*_*` dataset so cleanup is
-# scoped per-driver. Total runtime ~3–5 minutes against the EU sandbox.
+#   2. Live demo (runs only when BigQuery credentials are present).
+#      Materializes a full-refresh transformation against the sandbox,
+#      writes the rocky run receipt to expected/run.json, queries the
+#      target table back via `bq query` to prove the row landed, and
+#      drops the dataset on exit. Prints pointers to the remaining
+#      live drivers under live/ so the full tour is one command away.
 #
-# Required env:
+# The live drivers under live/<scenario>/ remain independently runnable
+# and continue to fail-fast on missing env vars. This top-level script
+# is the orchestration layer that makes the POC smoke-safe.
+#
+# Env vars (live mode):
 #   GCP_PROJECT_ID                  — GCP project to run against
+#                                     (BIGQUERY_TEST_PROJECT also accepted)
 #   GOOGLE_APPLICATION_CREDENTIALS  — path to SA JSON key (or BIGQUERY_TOKEN)
 # Optional:
 #   BQ_LOCATION                     — dataset location (default: EU)
 
 set -euo pipefail
 
-: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID before running this POC}"
-: "${GOOGLE_APPLICATION_CREDENTIALS:?Set GOOGLE_APPLICATION_CREDENTIALS or BIGQUERY_TOKEN}"
-
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-DRIVERS=(
-    "live/run.sh                  full-refresh"
-    "live/time-interval/run.sh    time-interval"
-    "live/merge/run.sh            merge"
-    "live/discover/run.sh         discover"
-    "live/drift/run.sh            drift (incremental + ALTER)"
-    "live/cost-cross-check/run.sh cost cross-check"
-)
+# ---------------------------------------------------------------------------
+# Mode 1: compile smoke. Always-on.
+# ---------------------------------------------------------------------------
+#
+# `rocky compile --models live/models/` reads the model SQL + sidecar TOMLs
+# directly without going through a rocky.toml, so the BigQuery `${VAR}`
+# references in live/live.rocky.toml don't need substitution. Verifies the
+# `full_refresh` strategy frontmatter type-checks against the current binary.
 
-for entry in "${DRIVERS[@]}"; do
-    # Split on first whitespace into path + label.
-    path="${entry%% *}"
-    label="${entry#* }"
-    label="${label#"${label%%[![:space:]]*}"}"
+echo "==> compile smoke (no credentials required)"
+mkdir -p expected
+rocky compile --models live/models/ --output json 2>/dev/null > expected/compile.json
+echo "    rocky compile: ok"
+
+# Accept either GCP_PROJECT_ID (existing POC convention) or
+# BIGQUERY_TEST_PROJECT (live integration-test convention). Default the
+# canonical name from the test convention so the rest of the script can
+# read GCP_PROJECT_ID uniformly.
+PROJECT="${GCP_PROJECT_ID:-${BIGQUERY_TEST_PROJECT:-}}"
+CREDS="${GOOGLE_APPLICATION_CREDENTIALS:-${BIGQUERY_TOKEN:-}}"
+
+if [[ -z "$PROJECT" || -z "$CREDS" ]]; then
     echo
-    echo "============================================================"
-    echo "==> $label  ($path)"
-    echo "============================================================"
-    "$HERE/$path"
-done
+    echo "==> live demo: SKIPPED (BigQuery credentials not set)"
+    echo "    Set GCP_PROJECT_ID (or BIGQUERY_TEST_PROJECT) plus"
+    echo "    GOOGLE_APPLICATION_CREDENTIALS to exercise the live path."
+    echo
+    echo "POC compile smoke complete."
+    exit 0
+fi
+
+# Normalize the canonical name so the existing live drivers (which read
+# GCP_PROJECT_ID) inherit the right value when chained below.
+export GCP_PROJECT_ID="$PROJECT"
+
+# ---------------------------------------------------------------------------
+# Mode 2: live demo. Full-refresh run against the sandbox.
+# ---------------------------------------------------------------------------
+#
+# Mirrors live/run.sh but captures the run receipt at the POC root
+# (expected/run.json) — that's the user-facing artifact a reader of the
+# POC sees first. The follow-up `bq query` proves the row landed in the
+# warehouse, not just that the rocky CLI exited 0.
+
+LOCATION="${BQ_LOCATION:-EU}"
+DATASET="hc_phase4_poc"
+
+drop_dataset() {
+    bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+       rm -r -f -d "$DATASET" 2>/dev/null || true
+}
+
+drop_dataset
+trap drop_dataset EXIT
 
 echo
-echo "POC complete: BigQuery adapter exercised end-to-end across $(echo "${#DRIVERS[@]}") scenarios."
+echo "==> live demo: full-refresh against $GCP_PROJECT_ID.$DATASET (location: $LOCATION)"
+
+# Pre-create the target dataset. `run_transformation` does not honor
+# auto_create_schemas (only the replication path does), so the dataset
+# must exist before CREATE TABLE runs. See live/README.md finding 3.
+bq --location="$LOCATION" --project_id="$GCP_PROJECT_ID" \
+   mk --dataset "$DATASET" > /dev/null
+
+# Stage live.rocky.toml + model files into a temp dir with
+# `__GCP_PROJECT__` substituted and the dataset name pointed at the
+# POC-level dataset (so the POC and the per-driver smoke don't collide).
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"; drop_dataset' EXIT
+cp live/live.rocky.toml "$STAGE/"
+cp -R live/models "$STAGE/"
+find "$STAGE" -type f \( -name "*.toml" -o -name "*.sql" \) \
+    -exec sed -i.bak \
+        -e "s|__GCP_PROJECT__|${GCP_PROJECT_ID}|g" \
+        -e "s|hc_phase1_live|${DATASET}|g" \
+        {} +
+find "$STAGE" -name "*.bak" -delete
+
+echo "==> rocky validate"
+rocky -c "$STAGE/live.rocky.toml" validate 2>/dev/null > /dev/null
+echo "    validate: ok"
+
+echo "==> rocky run --output json (receipt: expected/run.json)"
+ROCKY_SUPPRESS_DEPRECATION=1 \
+    rocky -c "$STAGE/live.rocky.toml" run --output json 2>/dev/null \
+    > expected/run.json
+echo "    run: ok"
+
+echo "==> bq query: verifying the row landed in $DATASET.full_refresh_demo"
+ACTUAL_ROWS="$(bq --project_id="$GCP_PROJECT_ID" \
+    query --use_legacy_sql=false --format=csv --quiet \
+    "SELECT COUNT(*) FROM \`${GCP_PROJECT_ID}\`.\`${DATASET}\`.\`full_refresh_demo\`" \
+    | tail -n 1)"
+
+if [[ "$ACTUAL_ROWS" != "1" ]]; then
+    echo "FAIL: expected 1 row in target, got '$ACTUAL_ROWS'"
+    exit 1
+fi
+echo "    rows materialized = 1"
+
+# Surface the rocky run receipt summary so a reader can see what the
+# JSON output looks like without opening expected/run.json by hand.
+echo "==> rocky run receipt (subset)"
+python3 - "$HERE/expected/run.json" <<'PY'
+import json, sys
+out = json.load(open(sys.argv[1]))
+mat = out["materializations"][0]
+asset = ".".join(mat.get("asset_key", []))
+strategy = mat.get("metadata", {}).get("strategy")
+print(f"    asset_key       : {asset}")
+print(f"    strategy        : {strategy}")
+print(f"    duration_ms     : {mat.get('duration_ms')}")
+print(f"    bytes_scanned   : {mat.get('bytes_scanned')}")
+print(f"    cost_usd        : {mat.get('cost_usd')}")
+print(f"    job_ids         : {mat.get('job_ids', [])}")
+print(f"    status          : {out.get('status')}")
+PY
+
+echo
+echo "POC complete: BigQuery full-refresh materialization verified live."
+echo "Receipt: $HERE/expected/run.json"
+echo
+echo "For the full BigQuery surface tour (time-interval, merge, discover,"
+echo "drift, cost cross-check), run each driver under live/:"
+echo "    ./live/run.sh"
+echo "    ./live/time-interval/run.sh"
+echo "    ./live/merge/run.sh"
+echo "    ./live/discover/run.sh"
+echo "    ./live/drift/run.sh"
+echo "    ./live/cost-cross-check/run.sh"


### PR DESCRIPTION
## Summary

The top-level `run.sh` for the BigQuery POC now runs in two modes:

1. **Compile smoke** (always). `rocky compile --models live/models/` type-checks the BigQuery model frontmatter against the current binary, with no credentials and no warehouse round-trip. Exits 0. This is what the credential-free POC sweep (`scripts/run-all-duckdb.sh`) now runs on every PR.

2. **Live demo** (when credentials are present). Accepts `GCP_PROJECT_ID` or `BIGQUERY_TEST_PROJECT` plus `GOOGLE_APPLICATION_CREDENTIALS` (or `BIGQUERY_TOKEN`). Pre-creates `hc_phase4_poc`, runs `rocky run --output json`, captures the receipt to `expected/run.json`, queries the target table back via `bq query` to confirm the row landed, and drops the dataset on exit.

The six existing live drivers under `live/<scenario>/` remain independently runnable and continue to fail-fast on missing env vars. The top-level entrypoint is now the smoke-safe orchestration layer; the per-scenario drivers cover the full BigQuery surface tour (time-interval, merge, discover, drift, cost cross-check).

## Test plan

- [x] `./run.sh` with `GCP_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS` + `BQ_LOCATION` set: full-refresh materializes, row count == 1, receipt captured. Sample receipt:
  ```
  asset_key       : <project>.hc_phase4_poc.full_refresh_demo
  strategy        : full_refresh
  duration_ms     : 2082
  bytes_scanned   : 0
  cost_usd        : 0.0
  job_ids         : ['job_EBlxNR156h_3YecwKQaIVW3oFJ33']
  status          : Success
  ```
  (`bytes_scanned` is zero because BigQuery exempts the no-source `SELECT` literal from the 10 MB minimum bill; documented in the README and exercised non-zero by `live/merge/run.sh` and `live/cost-cross-check/run.sh`.)
- [x] `./run.sh` with `BIGQUERY_TEST_PROJECT` instead of `GCP_PROJECT_ID`: same live path, different env var convention (matches the live test convention).
- [x] `./run.sh` with all env vars unset: prints skip message, exits 0, 62 ms total.
- [x] `scripts/run-all-duckdb.sh` now reports `=== RUN pocs/07-adapters/05-bigquery-native-queries / PASS` (previously SKIP).
- [x] Sandbox dataset cleaned up after every run via the existing trap pattern.
- [x] `expected/*.json` artifacts already covered by `examples/playground/.gitignore` — no workspace identifiers committed.