### PR TITLE
style(engine/rocky-cli): rustfmt the governance grant-test line (unblocks fmt gate on main)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -5680,7 +5680,10 @@ mod tests {
                 name: "hcv2_cat".into()
             }
         );
-        let privileges: Vec<&str> = catalog_grants.iter().map(|g| g.privilege.as_str()).collect();
+        let privileges: Vec<&str> = catalog_grants
+            .iter()
+            .map(|g| g.privilege.as_str())
+            .collect();
         assert!(
             privileges.contains(&"USE_CATALOG"),
             "multi-word privilege must reach REST as USE_CATALOG, got {privileges:?}"


### PR DESCRIPTION
One long line in the governance grant test (`run.rs`) is not rustfmt-compliant and is sitting on `main`, so `cargo fmt --check` now fails on every branch cut from main (currently blocking #654 and #655). It slipped through the #653 merge because clippy + tests were green but `cargo fmt --check` wasn't run on the rebased tree.

This wraps the single offending line. No behaviour change — formatting only.

Merge this first; #654 and #655 go green once rebased onto it.