### PR TITLE
chore(engine/rocky-snowflake): fix stale "stub" comment on keypair auth branch

### DIFF
--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -220,7 +220,9 @@ impl Auth {
             });
         }
 
-        // Key-pair auth (stub — will error when get_token is called)
+        // Key-pair auth: this branch only constructs the AuthInner; JWT
+        // minting + fingerprint computation + 59-minute token caching all
+        // happen in `get_token` (see lines 277-354).
         if let Some(key_path) = config.private_key_path.filter(|p| !p.is_empty()) {
             if let Some(ref username) = config.username {
                 if !username.is_empty() {


### PR DESCRIPTION
## Summary

The comment at `from_config`'s keypair branch claimed `get_token` would error when called. Keypair JWT is fully implemented at `get_token` lines 277-354 (fingerprint computation, 59-minute token caching, full mint flow). The "stub" wording misleads the next reader.

Rewrite to describe what the branch actually does: construct the `AuthInner`; the real auth work happens in `get_token`.

## Test plan

- [x] `cargo build -p rocky-snowflake` clean
- [x] `cargo clippy -p rocky-snowflake --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p rocky-snowflake` clean
- [x] No behavior change (comment-only edit)

Surfaced by the 2026-05-23 adapter polish recon at `plans/rocky-adapter-polish-recon-2026-05-23.md` §1 (C1-C item).