### PR TITLE
docs: document triple-cut #16 features + fix branch-promote/approval correctness

### DIFF
--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -51,6 +51,8 @@ Substitution happens in `rocky-core/src/config.rs` before serde sees the value.
 
 An unnamed `[adapter]` with a `type` key auto-wraps as `adapter.default`. Pipeline adapter refs default to `"default"` — so you can omit `adapter = "default"` lines everywhere.
 
+Top-level adapter fields are strict (`deny_unknown_fields` — typos are parse errors). Adapter-specific keys Rocky doesn't model go under a nested `[adapter.<name>.extra]` table, which passes through untouched for a custom or process adapter to read.
+
 ### The `kind` field
 
 `kind` declares the role an `[adapter.*]` block plays. Two valid values: `"data"` (warehouse read/write) and `"discovery"` (metadata enumeration).

--- a/docs/src/content/docs/concepts/adapters.md
+++ b/docs/src/content/docs/concepts/adapters.md
@@ -120,6 +120,10 @@ Rocky ──stdin──► Adapter Process
 Rocky ◄─stdout── Adapter Process
 ```
 
+### Discovering installed adapters
+
+Rocky follows the `cargo`-subcommand convention: any executable on your `PATH` named `rocky-<name>` registers as the process adapter `<name>` (the bundled `rocky-lsp` is filtered out). Use [`rocky adapter list`](/reference/commands/development/#rocky-adapter) to enumerate the adapters Rocky can see, and `rocky adapter info <name>` to inspect one adapter's manifest.
+
 ### Protocol flow
 
 1. Rocky sends `initialize` with config → adapter responds with `AdapterManifest`

--- a/docs/src/content/docs/guides/adapter-sdk.md
+++ b/docs/src/content/docs/guides/adapter-sdk.md
@@ -141,7 +141,7 @@ Methods worth thinking carefully about:
 
 ## Auth and connection management
 
-The SDK does not prescribe an auth trait — each adapter wires its own. The two patterns worth copying are in-tree:
+The SDK ships an optional `AuthProvider` trait that composes the `Authorization` header with any extra mandatory headers your warehouse requires, such as a user-identity header alongside a bearer token. A `StaticAuthProvider` covers the fixed-credential case. Adapters with bespoke needs can still wire their own; the two patterns worth copying are in-tree:
 
 - **`engine/crates/rocky-databricks/src/auth.rs`** — PAT-first, OAuth M2M fallback. Reads `${DATABRICKS_TOKEN}`; if absent, falls through to the `client_credentials` flow with `${DATABRICKS_CLIENT_ID}` / `${DATABRICKS_CLIENT_SECRET}`. The auto-detection logic is roughly twenty lines.
 - **`engine/crates/rocky-snowflake/src/auth.rs`** — multi-method priority: pre-supplied OAuth bearer wins, then RS256 key-pair JWT, then password. Each method reads from a distinct `${SNOWFLAKE_*}` variable so config files never carry secrets.
@@ -207,7 +207,7 @@ A dynamic registration path (declarative config + crates.io discovery) is on the
 
 These are real and surface during implementation — flagging them up front so you don't lose half a day debugging.
 
-- **Two trait surfaces exist today.** `rocky-adapter-sdk/src/traits.rs` is the public, marketed contract. `rocky-core/src/traits.rs` is a richer superset that the in-tree adapters currently use (it adds methods like `execute_statement_with_stats`, `ExplainResult`, retention APIs). For new out-of-tree adapters, target the SDK — it's the contract that will stay stable. The in-tree richer surface is migrating toward the SDK over time.
+- **The SDK trait surface now mirrors most of the in-tree one.** `rocky-adapter-sdk/src/traits.rs` is the public, marketed contract; `rocky-core/src/traits.rs` is what the in-tree adapters use. The SDK gained default-impl methods for `execute_statement_with_stats` (and `ExecutionStats`), `ping`, `explain` (and `ExplainResult`), `is_experimental`, `warehouse_name`, and `list_tables`, so out-of-tree adapters get the same shape in-tree adapters use. A few methods still differ pending cross-crate type unification — `fetch_arrow_batch`, `clone_table_for_branch`, and the `merge_into` signature, plus a handful of duplicated types (`TableRef`, `ColumnInfo`, `Grant`, `MetadataColumn`). Target the SDK surface and treat those as not-yet-stable.
 - **Identifier validation is not optional.** Anything you splice into SQL must pass `[A-Za-z0-9_]+` (or your warehouse's equivalent). The skeleton's `validate_ident` shows the pattern. SQL-injection-bearing string literals were the subject of [a real CVE-class fix](https://github.com/rocky-data/rocky/pull/293) — don't reinvent that hole.
 - **The `catalog` field in `TableRef` is always present.** Warehouses without catalogs (ClickHouse, Postgres, MySQL) get an empty string. Your dialect's `format_table_ref` is responsible for dropping it.
 - **`AdapterError` is intentionally type-erased.** Use `AdapterError::msg(...)` for ad-hoc errors, `AdapterError::new(my_err)` to wrap an `std::error::Error`, and `AdapterError::not_supported("method_name")` for capabilities your warehouse doesn't have. Don't reach for `thiserror` inside the trait impl — the SDK boxes everything.

--- a/docs/src/content/docs/guides/governance.md
+++ b/docs/src/content/docs/guides/governance.md
@@ -217,10 +217,10 @@ During `rocky apply`, for each managed catalog and schema:
 1. **Read** desired permissions from `[pipeline.<name>.target.governance.grants]` and `[pipeline.<name>.target.governance.schema_grants]`
 2. **Query** current state with `SHOW GRANTS ON CATALOG` and `SHOW GRANTS ON SCHEMA`
 3. **Compute diff**: Determine which grants to add and which to revoke
-4. **Execute** the necessary `GRANT` and `REVOKE` statements
+4. **Apply** the diff. On Databricks, Rocky reconciles catalog- and schema-level grants through the Unity Catalog permissions API as a single batched request per securable, grouped by principal. On warehouses without a REST permissions API, it emits the equivalent `GRANT` and `REVOKE` SQL. The privilege effect is identical either way; only the transport differs (you will see PATCH requests in Databricks audit logs rather than `GRANT` statements).
 
 ```sql
--- Example generated SQL
+-- Equivalent SQL (the form emitted on SQL-only warehouses)
 GRANT SELECT ON CATALOG `acme_warehouse` TO `group:analysts`;
 GRANT USE SCHEMA ON SCHEMA `acme_warehouse`.`staging__us_west__shopify` TO `group:analysts`;
 REVOKE MODIFY ON CATALOG `acme_warehouse` FROM `group:temp_access`;

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -11,7 +11,7 @@ Rocky provides a single binary with subcommands for the full pipeline lifecycle.
 - **Modeling**: `compile`, `lineage`, `lineage-diff`, `test`, `ci`, `ci-diff`, `preview`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
-- **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `hooks`, `validate-migration`, `test-adapter`
+- **Development**: `playground`, `shell`, `watch`, `fmt`, `list`, `serve`, `lsp`, `import-dbt`, `init-adapter`, `adapter`, `hooks`, `validate-migration`, `test-adapter`
 - **Administration**: `history`, `replay`, `trace`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`, `compliance`, `retention-status`
 - **Diagnostics**: `doctor`, `compare`
 

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -492,7 +492,9 @@ Branch names accept `[A-Za-z0-9_.\-]` up to 64 characters. The default schema pr
 | `--message <text>` | `string` | (none) | Optional free-form note persisted in the approval artifact. |
 | `--out <path>` | `PathBuf` | `./.rocky/approvals/<branch>/<approval_id>.json` | Override the artifact destination path. |
 
-Writes a content-addressed approval artifact that binds the approver's git identity to the branch's current state hash. `rocky branch promote` later refuses to run unless the on-disk approvals satisfy the [`[branch.approval]`](/reference/configuration/#branchapproval) policy.
+Writes a content-addressed approval artifact that binds the approver's git identity to the exact bytes of the branch's models and project config. Editing, adding, or renaming any model after approval voids that approval, so `rocky branch promote` refuses to run unless the on-disk approvals still match the current state and satisfy the [`[branch.approval]`](/reference/configuration/#branchapproval) policy.
+
+> **Upgrade note (engine v1.43):** approvals created before v1.43 bound to the project config only, not the model bytes. They no longer satisfy the gate after upgrading. Run `rocky branch approve <name>` once to re-sign each branch against its current model contents.
 
 ### `branch promote` flags
 
@@ -504,9 +506,10 @@ Writes a content-addressed approval artifact that binds the approver's git ident
 | `--base-ref <ref>` | `string` | `main` | Git ref to diff against for the breaking-change gate. |
 | `--models <path>` | `PathBuf` | `models` | Models directory used by the breaking-change gate. |
 | `--skip-approval` | flag | off | Bypass the approval gate. Always emits an `approval_skipped` audit event so the bypass leaves a paper trail. |
-| `--filter <key=value>` | `string` | (none) | Filter sources by component value (e.g. `--filter client=acme`). |
+| `--pipeline <name>` | `string` | (none) | Which pipeline to promote, in a multi-pipeline project. Optional when the project defines a single pipeline. |
+| `--filter <key=value>` | `string` | (none) | Filter the promote targets. Replication pipelines filter sources by schema-pattern component (e.g. `--filter client=acme`); transformation pipelines filter models by `table`, `model`, `catalog`, or `schema`. |
 
-Enumerates the configured replication pipeline's production targets, runs the optional `[branch.approval]` gate, runs the semantic breaking-change gate against `--base-ref`, then dispatches `CREATE OR REPLACE TABLE prod.<x> AS SELECT * FROM branch__<name>.<x>` per target.
+Enumerates the pipeline's production targets and promotes each one. A replication pipeline discovers the source connector's tables through the schema-pattern templates; a transformation pipeline walks the configured `models` glob and promotes one target per model, skipping ephemeral models. It then runs the optional `[branch.approval]` gate, runs the semantic breaking-change gate against `--base-ref`, and dispatches `CREATE OR REPLACE TABLE prod.<x> AS SELECT * FROM branch__<name>.<x>` per target. Quality and snapshot pipelines are not supported and return a clear error.
 
 The breaking-change gate vetoes the promote (exit nonzero) when any finding has `severity == "breaking"` unless `--allow-breaking` is passed. Every gate decision — block, allow-via-override, or fail-open when the gate couldn't run — is recorded in the audit trail. See [`rocky ci-diff --semantic`](/reference/commands/modeling/#rocky-ci-diff) to surface the same findings informationally on every PR.
 

--- a/docs/src/content/docs/reference/commands/development.md
+++ b/docs/src/content/docs/reference/commands/development.md
@@ -436,6 +436,35 @@ Validating 12 models...
 
 ---
 
+## `rocky adapter`
+
+Discover and inspect the adapters available on your system. Rocky follows the `cargo`-subcommand convention: any executable on your `PATH` whose name starts with `rocky-` is treated as a process adapter named after the suffix, so a `rocky-snowplow` binary registers as the adapter `snowplow`.
+
+### `rocky adapter list`
+
+Walks `PATH`, runs each `rocky-*` candidate, and prints one row per discovered adapter.
+
+```bash
+rocky adapter list [--output json]
+```
+
+The table shows `NAME`, `VERSION`, `DIALECT`, and `PATH`. An adapter that fails to initialize still appears in the listing with its error, so a broken install is visible rather than silently skipped. The bundled `rocky-lsp` language server is filtered out. Passing `--output json` returns each adapter's full manifest.
+
+### `rocky adapter info <name>`
+
+Resolves `rocky-<name>` on `PATH`, runs it, and prints its manifest (name, version, SQL dialect, and the path it resolved to).
+
+```bash
+rocky adapter info snowplow
+```
+
+### Related Commands
+
+- [`rocky test-adapter`](#rocky-test-adapter) -- run the conformance suite against a discovered adapter
+- [`rocky init-adapter`](#rocky-init-adapter) -- scaffold a new adapter crate
+
+---
+
 ## `rocky test-adapter`
 
 Run conformance tests against a warehouse adapter.
@@ -448,7 +477,7 @@ rocky test-adapter [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--adapter` | string | — | Built-in adapter name (databricks, snowflake, duckdb) |
+| `--adapter` | string | — | Adapter name. Resolves a built-in adapter (`databricks`, `snowflake`, `duckdb`) first, then falls back to an installed `rocky-<name>` executable on your `PATH`. |
 | `--command` | string | — | Path to a process adapter binary |
 | `--adapter-config` | string | — | JSON config to pass to the adapter |
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -118,8 +118,20 @@ Each `[adapter.NAME]` block defines one adapter instance. The `name` is arbitrar
 |-------|------|----------|-------------|
 | `type` | string | Yes | Adapter type. One of `"databricks"`, `"snowflake"`, `"duckdb"`, `"fivetran"`, `"manual"`. |
 | `retry` | table | No | Retry policy (see [`[adapter.NAME.retry]`](#adapternameretry)). |
+| `extra` | table | No | Escape hatch for adapter-specific keys Rocky's typed config doesn't model (see below). |
 
 The remaining fields depend on the adapter type.
+
+The top-level adapter fields are strictly validated — an unrecognized key (a typo like `tooken`) is rejected rather than silently ignored. Keys that a custom or process adapter consumes but Rocky doesn't model go under a nested `[adapter.NAME.extra]` table, which passes through untouched:
+
+```toml
+[adapter.my_warehouse]
+type = "process"
+
+[adapter.my_warehouse.extra]
+default_schema = "analytics"
+x_custom_header = "service-account"
+```
 
 ### `type = "duckdb"`
 


### PR DESCRIPTION
Prepares the docs for triple-cut #16 by fixing two correctness problems the release would otherwise publish, plus the missing/stale user-facing surface for the new features. Surfaced by a documentation audit against the `[Unreleased]` CHANGELOG. Docs build verified locally (`astro build`, 77 pages, Starlight link validation green) — the docs workflow only runs on push-to-main, so it's checked here rather than after merge.

## P0 — docs contradicted shipped behavior
- **`branch promote`** was documented as replication-only; it now walks transformation pipelines too (one target per model, ephemeral skipped). Also documents the new `--pipeline` flag and corrects `--filter` (per-pipeline-type keys).
- **Branch approvals** were documented as binding to "the branch's current state hash"; they now bind to **model bytes**. Editing a model voids the approval. Adds an explicit **upgrade note**: approvals created before v1.43 no longer satisfy the gate and must be re-signed with `rocky branch approve`.

## P1 — missing or stale surface
- **`rocky adapter list` / `rocky adapter info`** + the `rocky-<name>`-on-`PATH` discovery convention (new `## rocky adapter` section in `development.md`; added to the `cli.md` command list and the `adapters.md` process-adapter section).
- **`test-adapter --adapter`** now falls back to a PATH-resolved `rocky-<name>` adapter.
- **adapter-SDK guide**: the "two trait surfaces" gotcha is refreshed (the SDK gained the six default-impl methods); the auth section now documents the new `AuthProvider` / `StaticAuthProvider`.
- **`[adapter.NAME.extra]`** escape hatch documented (`configuration.md` + the `rocky-config` skill).
- **Governance** reconciliation: clarifies Databricks routes catalog/schema grants through the Unity Catalog PATCH API, not `GRANT` SQL (the SQL example is relabeled "equivalent SQL on SQL-only warehouses").

## Deferred to fast-follow (P2/P3)
`[freshness]`/W005 reference docs, the LSP quick-fix doc, the dagster freshness field-name refresh, the Arrow trait note, and the two pre-existing broken examples (`docs-demo` `||`, `multi-layer` no-models). Tracked for after the cut.