### PR TITLE
fix(engine): disable release-profile LTO to unblock the 1.43.0 binary build

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -209,7 +209,12 @@ googleapis-tonic-google-cloud-bigquery-storage-v1 = "0.33"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+# LTO disabled: rustc 1.95 emits LLVM-22 bitcode (e.g. via the
+# `googleapis-tonic-...-bigquery-storage` crate) that the release
+# linkers can't parse — Apple `ld` (libLTO ~15) and zigbuild's
+# `ld.lld` (LLVM 19) both fail with "Unknown attribute kind". Disabling
+# LTO drops the bitcode hand-off entirely. Revisit if the toolchains catch up.
+lto = false
 codegen-units = 1
 panic = "abort"
 strip = true


### PR DESCRIPTION
The `engine-v1.43.0` release build failed on **every** target. Root cause is the same across platforms: rustc 1.95 bundles LLVM 22 and `lto = "thin"` embeds LLVM-22 bitcode into the rlibs (the `googleapis-tonic-google-cloud-bigquery-storage-v1` crate from the BQ Storage Read API in #646 is the trigger), but the release linkers can't parse it:

- **macOS** (`ld`, libLTO ~LLVM 15): `Unknown attribute kind (102)`
- **Linux** (`cargo zigbuild` → `ld.lld` LLVM 19): `Unknown attribute kind (102)` — `Reader: 'LLVM 19.1.7'`

## Fix
`[profile.release] lto = "thin"` → `lto = false`. This stops rustc embedding LTO bitcode, so nothing is handed to the system linker's LTO plugin and the link succeeds regardless of the runner's LLVM version. **Validated locally**: the release `rocky` binary links with `lto = false` where it failed with `lto = "thin"`.

Since all platforms hit it, a per-target fix buys nothing — global is correct here. The cost is dropping thin-LTO from release binaries (marginal size/perf for an I/O- and warehouse-bound CLI). A `CARGO_PROFILE_RELEASE_LTO` matrix override to restore LTO on targets whose linkers catch up is a possible later optimization.

## Re-release
`engine-v1.43.0` shipped no binaries (the build failed), so once this merges I'll re-point that tag to the fixed commit and re-run `engine-release.yml`. `dagster-v1.41.0` + `vscode-v1.27.0` are already published and unaffected.