### PR TITLE
refactor(engine/rocky-cli): extract typed-output cores from command handlers

### DIFF
--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -37,6 +37,51 @@ pub fn run_compile(
     with_seed: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
+    let (output, text_data) = compile_inner(
+        config_path,
+        state_path,
+        models_dir,
+        contracts_dir,
+        model_filter,
+        do_expand_macros,
+        target_dialect,
+        with_seed,
+        cache_ttl_override,
+    )?;
+
+    if output_json {
+        print_json(&output)?;
+    } else {
+        render_compile_text(&output, &text_data);
+    }
+
+    if output.has_errors {
+        anyhow::bail!("compilation failed with errors");
+    }
+
+    Ok(())
+}
+
+/// Compile body shared by the JSON core ([`compile_output`]) and the text
+/// renderer in [`run_compile`]. Returns the typed [`CompileOutput`] plus the
+/// extra raw data the text path needs ([`CompileTextData`]).
+///
+/// Does no stdout printing and does not bail on compilation errors.
+///
+/// `cache_ttl_override`: optional CLI `--cache-ttl <seconds>` value that
+/// replaces `[cache.schemas] ttl_seconds` for this invocation only.
+#[allow(clippy::too_many_arguments)]
+fn compile_inner(
+    config_path: Option<&Path>,
+    state_path: &Path,
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    model_filter: Option<&str>,
+    do_expand_macros: bool,
+    target_dialect: Option<Dialect>,
+    with_seed: bool,
+    cache_ttl_override: Option<u64>,
+) -> Result<(CompileOutput, CompileTextData)> {
     // `source_schemas` precedence:
     //   1. `--with-seed` wins -> seed loader (explicit user intent,
     //      used for tests/playgrounds where the cache is irrelevant).
@@ -205,128 +250,191 @@ pub fn run_compile(
         result.diagnostics.clone()
     };
 
-    if output_json {
-        let models_detail: Vec<ModelDetail> = result
-            .project
-            .models
-            .iter()
-            .map(|model| {
-                let typed_cols = result
-                    .type_check
-                    .typed_models
-                    .get(&model.config.name)
-                    .map(std::vec::Vec::as_slice)
-                    .unwrap_or_default();
-                let incrementality_hint = incrementality::infer_incrementality(
-                    &model.config.name,
-                    typed_cols,
-                    &model.sql,
-                    &model.config.strategy,
-                );
-                let cost_hint = cost_estimates.get(&model.config.name).map(|est| CostHint {
-                    estimated_rows: est.estimated_rows,
-                    estimated_bytes: est.estimated_bytes,
-                    estimated_cost_usd: est.estimated_compute_cost_usd,
-                    confidence: match est.confidence {
-                        rocky_core::cost::Confidence::High => "high".to_string(),
-                        rocky_core::cost::Confidence::Medium => "medium".to_string(),
-                        rocky_core::cost::Confidence::Low => "low".to_string(),
-                    },
-                });
-                ModelDetail {
-                    name: model.config.name.clone(),
-                    strategy: model.config.strategy.clone(),
-                    target: model.config.target.clone(),
-                    freshness: model.config.freshness.clone(),
-                    contract_source: model.contract_path.as_ref().map(|_| "auto".to_string()),
-                    incrementality_hint,
-                    cost_hint,
-                    depends_on: model.config.depends_on.clone(),
-                }
-            })
-            .collect();
-        let output = CompileOutput::new(
-            result.project.model_count(),
-            result.project.layers.len(),
-            diagnostics.clone(),
-            result.has_errors,
-            result.timings.clone(),
-        )
-        .with_models_detail(models_detail)
-        .with_expanded_sql(expanded_sql);
-        print_json(&output)?;
-    } else {
-        let error_count = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Error)
-            .count();
-        let warning_count = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Warning)
-            .count();
-
-        // Print model status
-        for model_name in &result.project.execution_order {
-            let model_diags: Vec<_> = diagnostics
-                .iter()
-                .filter(|d| d.model == *model_name)
-                .collect();
-            let has_model_errors = model_diags.iter().any(|d| d.severity == Severity::Error);
-
-            if has_model_errors {
-                println!("  \u{2717} {model_name}");
-            } else {
-                let col_count = result
-                    .type_check
-                    .typed_models
-                    .get(model_name)
-                    .map(std::vec::Vec::len)
-                    .unwrap_or(0);
-                println!("  \u{2713} {model_name} ({col_count} columns)");
+    let models_detail: Vec<ModelDetail> = result
+        .project
+        .models
+        .iter()
+        .map(|model| {
+            let typed_cols = result
+                .type_check
+                .typed_models
+                .get(&model.config.name)
+                .map(std::vec::Vec::as_slice)
+                .unwrap_or_default();
+            let incrementality_hint = incrementality::infer_incrementality(
+                &model.config.name,
+                typed_cols,
+                &model.sql,
+                &model.config.strategy,
+            );
+            let cost_hint = cost_estimates.get(&model.config.name).map(|est| CostHint {
+                estimated_rows: est.estimated_rows,
+                estimated_bytes: est.estimated_bytes,
+                estimated_cost_usd: est.estimated_compute_cost_usd,
+                confidence: match est.confidence {
+                    rocky_core::cost::Confidence::High => "high".to_string(),
+                    rocky_core::cost::Confidence::Medium => "medium".to_string(),
+                    rocky_core::cost::Confidence::Low => "low".to_string(),
+                },
+            });
+            ModelDetail {
+                name: model.config.name.clone(),
+                strategy: model.config.strategy.clone(),
+                target: model.config.target.clone(),
+                freshness: model.config.freshness.clone(),
+                contract_source: model.contract_path.as_ref().map(|_| "auto".to_string()),
+                incrementality_hint,
+                cost_hint,
+                depends_on: model.config.depends_on.clone(),
             }
-        }
+        })
+        .collect();
 
-        // Print expanded SQL when --expand-macros is set (text mode).
-        if !expanded_sql.is_empty() {
-            println!();
-            for model_name in &result.project.execution_order {
-                if let Some(sql) = expanded_sql.get(model_name) {
-                    println!("  -- {model_name} (expanded)");
-                    for line in sql.lines() {
-                        println!("  {line}");
-                    }
-                    println!();
-                }
-            }
-        }
-
-        // Build a source map from model files so miette can render source spans.
-        let source_map: HashMap<String, String> = result
+    // Data the text renderer needs from the raw `CompileResult` but which is
+    // not carried on `CompileOutput`: execution order, per-model typed-column
+    // counts, and the file_path -> SQL source map (for miette spans).
+    let text_data = CompileTextData {
+        execution_order: result.project.execution_order.clone(),
+        typed_column_counts: result
+            .type_check
+            .typed_models
+            .iter()
+            .map(|(name, cols)| (name.clone(), cols.len()))
+            .collect(),
+        source_map: result
             .project
             .models
             .iter()
             .map(|m| (m.file_path.clone(), m.sql.clone()))
+            .collect(),
+    };
+
+    let output = CompileOutput::new(
+        result.project.model_count(),
+        result.project.layers.len(),
+        diagnostics,
+        result.has_errors,
+        result.timings.clone(),
+    )
+    .with_models_detail(models_detail)
+    .with_expanded_sql(expanded_sql);
+
+    Ok((output, text_data))
+}
+
+/// Extra data the `rocky compile` text renderer needs from the raw
+/// `CompileResult` but which is intentionally not carried on the
+/// `JsonSchema`-backed [`CompileOutput`].
+///
+/// Internal-only — never serialized — so it can change freely without
+/// touching the JSON schema cascade.
+struct CompileTextData {
+    /// Model names in execution (topological) order.
+    execution_order: Vec<String>,
+    /// Per-model count of resolved typed columns.
+    typed_column_counts: HashMap<String, usize>,
+    /// `file_path -> model SQL`, used so miette can render source spans.
+    source_map: HashMap<String, String>,
+}
+
+/// Side-effect-free core of `rocky compile`: compile the project, run the
+/// portability lint, expand macros, compute cost ceilings, and assemble the
+/// typed [`CompileOutput`].
+///
+/// Does no stdout printing and does not bail on compilation errors — the
+/// `has_errors` flag rides on the returned struct so an in-process caller can
+/// inspect the diagnostics. The `run_compile` wrapper prints and bails.
+///
+/// `cache_ttl_override`: optional CLI `--cache-ttl <seconds>` value that
+/// replaces `[cache.schemas] ttl_seconds` for this invocation only.
+// Reusable typed-output core for a future in-process caller (MCP server). No
+// internal call site yet — the `run_compile` wrapper uses `compile_inner`
+// directly so it can also render text mode.
+#[allow(dead_code, clippy::too_many_arguments)]
+pub(crate) fn compile_output(
+    config_path: Option<&Path>,
+    state_path: &Path,
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    model_filter: Option<&str>,
+    do_expand_macros: bool,
+    target_dialect: Option<Dialect>,
+    with_seed: bool,
+    cache_ttl_override: Option<u64>,
+) -> Result<CompileOutput> {
+    let (output, _text_data) = compile_inner(
+        config_path,
+        state_path,
+        models_dir,
+        contracts_dir,
+        model_filter,
+        do_expand_macros,
+        target_dialect,
+        with_seed,
+        cache_ttl_override,
+    )?;
+    Ok(output)
+}
+
+/// Render the text-mode output for `rocky compile`. Mirrors the historical
+/// inline `else` branch byte-for-byte.
+fn render_compile_text(output: &CompileOutput, text_data: &CompileTextData) {
+    let error_count = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    let warning_count = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warning)
+        .count();
+
+    // Print model status
+    for model_name in &text_data.execution_order {
+        let model_diags: Vec<_> = output
+            .diagnostics
+            .iter()
+            .filter(|d| d.model == *model_name)
             .collect();
+        let has_model_errors = model_diags.iter().any(|d| d.severity == Severity::Error);
 
-        // Render diagnostics with miette (rich source spans when available)
-        if !diagnostics.is_empty() {
-            let rendered = diagnostic::render_diagnostics(&diagnostics, &source_map);
-            print!("{rendered}");
+        if has_model_errors {
+            println!("  \u{2717} {model_name}");
+        } else {
+            let col_count = text_data
+                .typed_column_counts
+                .get(model_name)
+                .copied()
+                .unwrap_or(0);
+            println!("  \u{2713} {model_name} ({col_count} columns)");
         }
-
-        println!(
-            "  Compiled: {} models, {} errors, {} warnings",
-            result.project.model_count(),
-            error_count,
-            warning_count,
-        );
     }
 
-    if result.has_errors {
-        anyhow::bail!("compilation failed with errors");
+    // Print expanded SQL when --expand-macros is set (text mode).
+    if !output.expanded_sql.is_empty() {
+        println!();
+        for model_name in &text_data.execution_order {
+            if let Some(sql) = output.expanded_sql.get(model_name) {
+                println!("  -- {model_name} (expanded)");
+                for line in sql.lines() {
+                    println!("  {line}");
+                }
+                println!();
+            }
+        }
     }
 
-    Ok(())
+    // Render diagnostics with miette (rich source spans when available)
+    if !output.diagnostics.is_empty() {
+        let rendered = diagnostic::render_diagnostics(&output.diagnostics, &text_data.source_map);
+        print!("{rendered}");
+    }
+
+    println!(
+        "  Compiled: {} models, {} errors, {} warnings",
+        output.models, error_count, warning_count,
+    );
 }
 
 /// Build an error-severity P001 diagnostic from a portability issue.

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -82,8 +82,6 @@ pub fn run_lineage(
         .model_schema(model_name)
         .context(format!("model '{model_name}' not found"))?;
 
-    let direction = if downstream { "downstream" } else { "upstream" };
-
     // `--format dot` is lineage-specific and only produces DOT, so it wins
     // over the global `--output json` (which defaults to `json`). Without
     // this, `rocky lineage <m> --format dot` silently emits JSON.
@@ -91,106 +89,10 @@ pub fn run_lineage(
 
     if output_json && !emit_dot {
         if let Some(col) = col_name {
-            let trace_edges = if downstream {
-                result
-                    .semantic_graph
-                    .trace_column_downstream(model_name, col)
-            } else {
-                result.semantic_graph.trace_column(model_name, col)
-            };
-            let trace: Vec<LineageEdgeRecord> =
-                trace_edges.iter().map(|e| to_edge_record(e)).collect();
-            let output = ColumnLineageOutput {
-                version: VERSION.to_string(),
-                command: "lineage".to_string(),
-                model: model_name.to_string(),
-                column: col.to_string(),
-                direction: direction.to_string(),
-                trace,
-            };
+            let output = column_lineage_output(&result, model_name, col, downstream)?;
             print_json(&output)?;
         } else {
-            let edges: Vec<LineageEdgeRecord> = result
-                .semantic_graph
-                .edges
-                .iter()
-                .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
-                .map(to_edge_record)
-                .collect();
-            // Look up typed columns for this model from the typecheck
-            // pass so each `LineageColumnDef` can carry its inferred
-            // `data_type`. The typed schema may be absent (e.g. on a
-            // model that failed typecheck) or report `RockyType::Unknown`
-            // for columns it couldn't resolve — both map to `None`.
-            let typed_cols = result.type_check.typed_models.get(model_name);
-            let columns: Vec<LineageColumnDef> = schema
-                .columns
-                .iter()
-                .map(|c| {
-                    let data_type = typed_cols
-                        .and_then(|cols| cols.iter().find(|t| t.name == c.name))
-                        .filter(|t| !matches!(t.data_type, rocky_ir::types::RockyType::Unknown))
-                        .map(|t| t.data_type.to_string());
-                    LineageColumnDef {
-                        name: c.name.clone(),
-                        data_type,
-                    }
-                })
-                .collect();
-            // Per-node metadata for the focal model + every distinct
-            // endpoint of `edges`. Project models contribute a
-            // `target_schema` from their declared target config; nodes
-            // not present in `project.models` are treated as external
-            // sources and carry their qualified reference string as
-            // `source_id` so the VS Code lineage subgraph drill-in can
-            // cluster them without parsing the qualified name.
-            let mut node_ids: Vec<String> = Vec::new();
-            let mut seen_nodes: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            if seen_nodes.insert(model_name.to_string()) {
-                node_ids.push(model_name.to_string());
-            }
-            for edge in result
-                .semantic_graph
-                .edges
-                .iter()
-                .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
-            {
-                for endpoint in [&edge.source.model, &edge.target.model] {
-                    let name = endpoint.to_string();
-                    if seen_nodes.insert(name.clone()) {
-                        node_ids.push(name);
-                    }
-                }
-            }
-            let nodes: Vec<LineageNodeDef> = node_ids
-                .into_iter()
-                .map(|id| {
-                    if let Some(model) = result.project.model(&id) {
-                        LineageNodeDef {
-                            model: id,
-                            target_schema: Some(model.config.target.schema.clone()),
-                            source_id: None,
-                        }
-                    } else {
-                        LineageNodeDef {
-                            model: id.clone(),
-                            target_schema: None,
-                            source_id: Some(id),
-                        }
-                    }
-                })
-                .collect();
-            let output = LineageOutput {
-                version: VERSION.to_string(),
-                command: "lineage".to_string(),
-                model: model_name.to_string(),
-                columns,
-                upstream: schema.upstream.clone(),
-                downstream: schema.downstream.clone(),
-                edges,
-                nodes,
-            };
+            let output = lineage_output(&result, model_name)?;
             print_json(&output)?;
         }
     } else if emit_dot {
@@ -284,4 +186,146 @@ pub fn run_lineage(
     }
 
     Ok(())
+}
+
+/// Side-effect-free core producing the model-level [`LineageOutput`] (the
+/// no-`--column` case). Mirrors the JSON-branch assembly in [`run_lineage`]
+/// without printing.
+///
+/// `result` is a completed compile; `model_name` is the focal model. Errors
+/// when the model is absent from the semantic graph.
+// Reusable typed-output core for a future in-process caller. No internal call
+// site beyond `run_lineage`'s JSON branch yet.
+#[allow(dead_code)]
+pub(crate) fn lineage_output(
+    result: &compile::CompileResult,
+    model_name: &str,
+) -> Result<LineageOutput> {
+    let schema = result
+        .semantic_graph
+        .model_schema(model_name)
+        .context(format!("model '{model_name}' not found"))?;
+
+    let edges: Vec<LineageEdgeRecord> = result
+        .semantic_graph
+        .edges
+        .iter()
+        .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
+        .map(to_edge_record)
+        .collect();
+    // Look up typed columns for this model from the typecheck pass so each
+    // `LineageColumnDef` can carry its inferred `data_type`. The typed schema
+    // may be absent (e.g. on a model that failed typecheck) or report
+    // `RockyType::Unknown` for columns it couldn't resolve — both map to `None`.
+    let typed_cols = result.type_check.typed_models.get(model_name);
+    let columns: Vec<LineageColumnDef> = schema
+        .columns
+        .iter()
+        .map(|c| {
+            let data_type = typed_cols
+                .and_then(|cols| cols.iter().find(|t| t.name == c.name))
+                .filter(|t| !matches!(t.data_type, rocky_ir::types::RockyType::Unknown))
+                .map(|t| t.data_type.to_string());
+            LineageColumnDef {
+                name: c.name.clone(),
+                data_type,
+            }
+        })
+        .collect();
+    // Per-node metadata for the focal model + every distinct endpoint of
+    // `edges`. Project models contribute a `target_schema` from their declared
+    // target config; nodes not present in `project.models` are treated as
+    // external sources and carry their qualified reference string as
+    // `source_id` so the VS Code lineage subgraph drill-in can cluster them
+    // without parsing the qualified name.
+    let mut node_ids: Vec<String> = Vec::new();
+    let mut seen_nodes: std::collections::HashSet<String> = std::collections::HashSet::new();
+    if seen_nodes.insert(model_name.to_string()) {
+        node_ids.push(model_name.to_string());
+    }
+    for edge in result
+        .semantic_graph
+        .edges
+        .iter()
+        .filter(|e| &*e.target.model == model_name || &*e.source.model == model_name)
+    {
+        for endpoint in [&edge.source.model, &edge.target.model] {
+            let name = endpoint.to_string();
+            if seen_nodes.insert(name.clone()) {
+                node_ids.push(name);
+            }
+        }
+    }
+    let nodes: Vec<LineageNodeDef> = node_ids
+        .into_iter()
+        .map(|id| {
+            if let Some(model) = result.project.model(&id) {
+                LineageNodeDef {
+                    model: id,
+                    target_schema: Some(model.config.target.schema.clone()),
+                    source_id: None,
+                }
+            } else {
+                LineageNodeDef {
+                    model: id.clone(),
+                    target_schema: None,
+                    source_id: Some(id),
+                }
+            }
+        })
+        .collect();
+
+    Ok(LineageOutput {
+        version: VERSION.to_string(),
+        command: "lineage".to_string(),
+        model: model_name.to_string(),
+        columns,
+        upstream: schema.upstream.clone(),
+        downstream: schema.downstream.clone(),
+        edges,
+        nodes,
+    })
+}
+
+/// Side-effect-free core producing the column-level [`ColumnLineageOutput`]
+/// (the `--column` / `model.column` case). Mirrors the JSON-branch assembly in
+/// [`run_lineage`] without printing.
+///
+/// `downstream` selects the trace direction: `true` traces consumers, `false`
+/// traces sources.
+// Reusable typed-output core for a future in-process caller. No internal call
+// site beyond `run_lineage`'s JSON branch yet.
+#[allow(dead_code)]
+pub(crate) fn column_lineage_output(
+    result: &compile::CompileResult,
+    model_name: &str,
+    column: &str,
+    downstream: bool,
+) -> Result<ColumnLineageOutput> {
+    // Assert the model exists so the column core matches `run_lineage`'s
+    // model-not-found behaviour (the wrapper resolves `schema` before
+    // dispatch).
+    result
+        .semantic_graph
+        .model_schema(model_name)
+        .context(format!("model '{model_name}' not found"))?;
+
+    let direction = if downstream { "downstream" } else { "upstream" };
+    let trace_edges = if downstream {
+        result
+            .semantic_graph
+            .trace_column_downstream(model_name, column)
+    } else {
+        result.semantic_graph.trace_column(model_name, column)
+    };
+    let trace: Vec<LineageEdgeRecord> = trace_edges.iter().map(|e| to_edge_record(e)).collect();
+
+    Ok(ColumnLineageOutput {
+        version: VERSION.to_string(),
+        command: "lineage".to_string(),
+        model: model_name.to_string(),
+        column: column.to_string(),
+        direction: direction.to_string(),
+        trace,
+    })
 }

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -4,12 +4,20 @@ use anyhow::{Context, Result};
 
 use crate::output::*;
 
-/// Execute `rocky list pipelines`.
-pub fn list_pipelines(config_path: &Path, json: bool) -> Result<()> {
+/// Side-effect-free core of `rocky list pipelines`: load the config and
+/// assemble the typed [`ListPipelinesOutput`] without printing.
+// Reusable typed-output core for a future in-process caller. No internal call
+// site yet beyond `list_pipelines`' JSON branch.
+#[allow(dead_code)]
+pub(crate) fn list_pipelines_output(config_path: &Path) -> Result<ListPipelinesOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
+    Ok(ListPipelinesOutput::new(build_pipeline_entries(&cfg)))
+}
 
-    let entries: Vec<ListPipelineEntry> = cfg
-        .pipelines
+/// Build the pipeline-entry rows from a loaded config. Shared between the
+/// typed-output core and the text-rendering path.
+fn build_pipeline_entries(cfg: &rocky_core::config::RockyConfig) -> Vec<ListPipelineEntry> {
+    cfg.pipelines
         .iter()
         .map(|(name, pc)| {
             let source_adapter = match pc {
@@ -27,7 +35,14 @@ pub fn list_pipelines(config_path: &Path, json: bool) -> Result<()> {
                 concurrency: pc.execution().concurrency.to_string(),
             }
         })
-        .collect();
+        .collect()
+}
+
+/// Execute `rocky list pipelines`.
+pub fn list_pipelines(config_path: &Path, json: bool) -> Result<()> {
+    let cfg = rocky_core::config::load_rocky_config(config_path)?;
+
+    let entries = build_pipeline_entries(&cfg);
 
     if json {
         print_json(&ListPipelinesOutput::new(entries))?;
@@ -58,19 +73,32 @@ pub fn list_pipelines(config_path: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Execute `rocky list adapters`.
-pub fn list_adapters(config_path: &Path, json: bool) -> Result<()> {
+/// Side-effect-free core of `rocky list adapters`: load the config and
+/// assemble the typed [`ListAdaptersOutput`] without printing.
+// Reusable typed-output core for a future in-process caller.
+#[allow(dead_code)]
+pub(crate) fn list_adapters_output(config_path: &Path) -> Result<ListAdaptersOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
+    Ok(ListAdaptersOutput::new(build_adapter_entries(&cfg)))
+}
 
-    let entries: Vec<ListAdapterEntry> = cfg
-        .adapters
+/// Build the adapter-entry rows from a loaded config.
+fn build_adapter_entries(cfg: &rocky_core::config::RockyConfig) -> Vec<ListAdapterEntry> {
+    cfg.adapters
         .iter()
         .map(|(name, ac)| ListAdapterEntry {
             name: name.clone(),
             adapter_type: ac.adapter_type.clone(),
             host: ac.host.clone(),
         })
-        .collect();
+        .collect()
+}
+
+/// Execute `rocky list adapters`.
+pub fn list_adapters(config_path: &Path, json: bool) -> Result<()> {
+    let cfg = rocky_core::config::load_rocky_config(config_path)?;
+
+    let entries = build_adapter_entries(&cfg);
 
     if json {
         print_json(&ListAdaptersOutput::new(entries))?;
@@ -92,12 +120,17 @@ pub fn list_adapters(config_path: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Execute `rocky list models`.
-///
-/// Loads models from the given directory and all immediate subdirectories
-/// (handles the common `models/{layer}/*.sql` layout). Each subdirectory
-/// is scanned independently so per-directory `_defaults.toml` files work.
-pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
+/// Side-effect-free core of `rocky list models`: load the models directory
+/// and assemble the typed [`ListModelsOutput`] without printing.
+// Reusable typed-output core for a future in-process caller.
+#[allow(dead_code)]
+pub(crate) fn list_models_output(models_dir: &Path) -> Result<ListModelsOutput> {
+    Ok(ListModelsOutput::new(build_model_entries(models_dir)?))
+}
+
+/// Build the model-entry rows by loading the models directory (with the
+/// one-level subdirectory scan).
+fn build_model_entries(models_dir: &Path) -> Result<Vec<ListModelEntry>> {
     let models = load_all_models(models_dir)?;
 
     let entries: Vec<ListModelEntry> = models
@@ -130,6 +163,16 @@ pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
             }
         })
         .collect();
+    Ok(entries)
+}
+
+/// Execute `rocky list models`.
+///
+/// Loads models from the given directory and all immediate subdirectories
+/// (handles the common `models/{layer}/*.sql` layout). Each subdirectory
+/// is scanned independently so per-directory `_defaults.toml` files work.
+pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
+    let entries = build_model_entries(models_dir)?;
 
     if json {
         print_json(&ListModelsOutput::new(entries))?;
@@ -160,12 +203,18 @@ pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Execute `rocky list sources`.
-pub fn list_sources(config_path: &Path, json: bool) -> Result<()> {
+/// Side-effect-free core of `rocky list sources`: load the config and
+/// assemble the typed [`ListSourcesOutput`] without printing.
+// Reusable typed-output core for a future in-process caller.
+#[allow(dead_code)]
+pub(crate) fn list_sources_output(config_path: &Path) -> Result<ListSourcesOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
+    Ok(ListSourcesOutput::new(build_source_entries(&cfg)))
+}
 
-    let entries: Vec<ListSourceEntry> = cfg
-        .pipelines
+/// Build the source-entry rows from a loaded config (replication pipelines only).
+fn build_source_entries(cfg: &rocky_core::config::RockyConfig) -> Vec<ListSourceEntry> {
+    cfg.pipelines
         .iter()
         .filter_map(|(name, pc)| {
             let repl = pc.as_replication()?;
@@ -180,7 +229,14 @@ pub fn list_sources(config_path: &Path, json: bool) -> Result<()> {
                 components: pattern.components.clone(),
             })
         })
-        .collect();
+        .collect()
+}
+
+/// Execute `rocky list sources`.
+pub fn list_sources(config_path: &Path, json: bool) -> Result<()> {
+    let cfg = rocky_core::config::load_rocky_config(config_path)?;
+
+    let entries = build_source_entries(&cfg);
 
     if json {
         print_json(&ListSourcesOutput::new(entries))?;

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -424,6 +424,201 @@ pub async fn plan(
     Ok(())
 }
 
+/// Resolve a standalone [`SqlDialect`](rocky_core::traits::SqlDialect) for the
+/// SQL preview, keyed by an adapter-type string (`"databricks"`, `"snowflake"`,
+/// `"bigquery"`, `"trino"`, `"duckdb"`).
+///
+/// These dialects are pure formatters — they need no live connection — so the
+/// preview can render warehouse-accurate SQL offline. DuckDB is only available
+/// when the `duckdb` feature is enabled (the default); without it, and for any
+/// unknown / missing adapter type, we fall back to the Databricks dialect and
+/// log a `tracing::warn!` so the preview still produces SQL.
+fn dialect_for_adapter_type(adapter_type: &str) -> Box<dyn rocky_core::traits::SqlDialect> {
+    match adapter_type {
+        "databricks" => Box::new(rocky_databricks::dialect::DatabricksSqlDialect),
+        "snowflake" => Box::new(rocky_snowflake::dialect::SnowflakeSqlDialect),
+        "bigquery" => Box::new(rocky_bigquery::dialect::BigQueryDialect),
+        "trino" => Box::new(rocky_trino::dialect::TrinoDialect),
+        #[cfg(feature = "duckdb")]
+        "duckdb" => Box::new(rocky_duckdb::dialect::DuckDbSqlDialect),
+        other => {
+            tracing::warn!(
+                adapter_type = other,
+                "plan_preview: no standalone dialect for this adapter type — \
+                 falling back to the Databricks dialect for the SQL preview"
+            );
+            Box::new(rocky_databricks::dialect::DatabricksSqlDialect)
+        }
+    }
+}
+
+/// Map a transformation [`MaterializationStrategy`] to the `purpose` label used
+/// on a [`PlannedStatement`] in the SQL preview.
+fn strategy_purpose(strategy: &MaterializationStrategy) -> &'static str {
+    match strategy {
+        MaterializationStrategy::FullRefresh => "full_refresh",
+        MaterializationStrategy::Incremental { .. } => "incremental",
+        MaterializationStrategy::Merge { .. } => "merge",
+        MaterializationStrategy::View => "view",
+        MaterializationStrategy::MaterializedView => "materialized_view",
+        MaterializationStrategy::DynamicTable { .. } => "dynamic_table",
+        MaterializationStrategy::TimeInterval { .. } => "time_interval",
+        MaterializationStrategy::Ephemeral => "ephemeral",
+        MaterializationStrategy::DeleteInsert { .. } => "delete_insert",
+        MaterializationStrategy::Microbatch { .. } => "microbatch",
+        MaterializationStrategy::ContentAddressed { .. } => "content_addressed",
+    }
+}
+
+/// Side-effect-free SQL preview core: compile the project in-process and render
+/// the SQL each compiled transformation model **would** emit, returning a
+/// [`PlanOutput`] whose only populated field is `statements`.
+///
+/// This is the offline, adapter-free analogue of [`plan`] for an in-process
+/// caller (MCP server): no warehouse connection, no discovery, no governance
+/// preview, no plan persistence. Discovery/governance/`plan_id`/
+/// `execution_layers` stay empty/`None`/default.
+///
+/// ## Dialect
+///
+/// The dialect is sourced from the project's configured target adapter type
+/// (via `config_path`) when available; otherwise it defaults to DuckDB (or the
+/// Databricks fallback when the `duckdb` feature is off). See
+/// [`dialect_for_adapter_type`].
+///
+/// ## Replication-only projects
+///
+/// This core covers compiled (transformation) models only. If the project has
+/// no compiled models (replication-only, or `models/` holds only stubs), the
+/// returned `PlanOutput` has empty `statements` and a `tracing::info!` note —
+/// the live `rocky plan` discovery path is the surface for replication SQL.
+// Reusable typed-output core for a future in-process caller. No internal call
+// site yet — `rocky plan` uses the full live `plan()` path.
+#[allow(dead_code)]
+pub(crate) fn plan_preview_output(
+    config_path: Option<&Path>,
+    models_dir: &Path,
+    filter: Option<&str>,
+    env: Option<&str>,
+) -> Result<PlanOutput> {
+    use rocky_compiler::compile::{self, CompilerConfig};
+
+    let mut output = PlanOutput::new(filter.unwrap_or("").to_string());
+    output.env = env.map(str::to_string);
+
+    // Resolve the preview dialect from the configured target adapter type.
+    // No config / unresolvable target → DuckDB (or the Databricks fallback
+    // when the `duckdb` feature is off).
+    let adapter_type = config_path
+        .and_then(|p| rocky_core::config::load_rocky_config(p).ok())
+        .and_then(|cfg| {
+            // Prefer the default replication pipeline's target adapter; fall
+            // back to the first adapter declared in the config.
+            let target_adapter_name = registry::resolve_replication_pipeline(&cfg, None)
+                .ok()
+                .map(|(_, pipeline)| pipeline.target.adapter.clone());
+            target_adapter_name
+                .and_then(|name| cfg.adapters.get(&name).map(|a| a.adapter_type.clone()))
+                .or_else(|| cfg.adapters.values().next().map(|a| a.adapter_type.clone()))
+        })
+        .unwrap_or_else(|| "duckdb".to_string());
+    let dialect = dialect_for_adapter_type(&adapter_type);
+
+    // Compile the project in-process (offline — no source schemas, no cache).
+    let config = CompilerConfig {
+        models_dir: models_dir.to_path_buf(),
+        contracts_dir: None,
+        source_schemas: std::collections::HashMap::new(),
+        source_column_info: std::collections::HashMap::new(),
+        mask: std::collections::BTreeMap::new(),
+        allow_unmasked: vec![],
+        project_freshness_default: false,
+    };
+    let result = match compile::compile(&config) {
+        Ok(r) => r,
+        // `NoModels` is the replication-only signal: the models directory holds
+        // no compiled models. That is not an error for the preview — return
+        // empty statements with a note. Every other compile failure (parse,
+        // semantic-graph, contract-load) propagates so an in-process caller
+        // sees the real problem.
+        Err(rocky_compiler::compile::CompileError::Project(
+            rocky_compiler::project::ProjectError::NoModels { .. },
+        )) => {
+            tracing::info!(
+                models_dir = %models_dir.display(),
+                "plan_preview: project has no compiled models — replication SQL preview \
+                 requires the live `rocky plan` discovery path; returning empty statements"
+            );
+            return Ok(output);
+        }
+        Err(e) => {
+            return Err(anyhow::Error::from(e).context("failed to compile models for plan preview"));
+        }
+    };
+
+    if result.project.models.is_empty() {
+        tracing::info!(
+            models_dir = %models_dir.display(),
+            "plan_preview: project has no compiled models — returning empty statements"
+        );
+        return Ok(output);
+    }
+
+    // Project the compile result to typed IR, reusing the shared
+    // `project_ir_from_compile` helper so we don't re-derive IR by hand.
+    let project_ir = super::ci_diff::project_ir_from_compile(&result);
+
+    for model_ir in &project_ir.models {
+        let model_name = model_ir.name.as_ref();
+        if let Some(f) = filter {
+            if model_name != f {
+                continue;
+            }
+        }
+
+        let target_label = if model_ir.target.catalog.is_empty() {
+            format!("{}.{}", model_ir.target.schema, model_ir.target.table)
+        } else {
+            format!(
+                "{}.{}.{}",
+                model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
+            )
+        };
+        let purpose = strategy_purpose(&model_ir.materialization);
+
+        // `warehouse = None`: the offline preview has no live adapter, so
+        // Snowflake DynamicTable models cannot resolve a compute warehouse and
+        // ContentAddressed models route through the iceberg writer rather than
+        // SQL gen. Both surface as `SqlGenError::InvalidRequest` — skip them
+        // with a note rather than failing the whole preview.
+        match sql_gen::generate_transformation_sql_with_warehouse(model_ir, dialect.as_ref(), None)
+        {
+            Ok(stmts) => {
+                // Ephemeral models return `Ok(vec![])` (inlined as CTEs) — no
+                // statement to preview. Multi-statement strategies
+                // (DeleteInsert, lakehouse DDL) emit one row each.
+                for sql in stmts {
+                    output.statements.push(PlannedStatement {
+                        purpose: purpose.to_string(),
+                        target: target_label.clone(),
+                        sql,
+                    });
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    model = model_name,
+                    strategy = purpose,
+                    error = %e,
+                    "plan_preview: skipping model whose SQL cannot be rendered offline"
+                );
+            }
+        }
+    }
+
+    Ok(output)
+}
+
 /// Compile the models directory, build a `RunPlan` payload, persist it to
 /// `.rocky/plans/<plan_id>.json`, and return
 /// `Some((payload, plan_id, persisted_at))`.
@@ -1430,6 +1625,152 @@ ssn = "confidential"
         assert_eq!(MaskStrategy::Redact.as_str(), "redact");
         assert_eq!(MaskStrategy::Partial.as_str(), "partial");
         assert_eq!(MaskStrategy::None.as_str(), "none");
+    }
+
+    // ------------------------------------------------------------------
+    // plan_preview_output — offline, adapter-free SQL preview core.
+    // ------------------------------------------------------------------
+
+    /// A project with one full-refresh transformation model yields exactly one
+    /// CTAS statement, and only `statements` is populated (governance /
+    /// plan_id / execution_layers stay empty).
+    #[test]
+    fn plan_preview_renders_full_refresh_ctas() {
+        let tmp = TempDir::new().unwrap();
+        let (cfg_path, models_dir) = write_project(
+            &tmp,
+            r#"
+[adapter.default]
+type = "duckdb"
+database = ":memory:"
+"#,
+            &[(
+                "users",
+                r#"name = "users"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "c"
+schema = "s"
+table = "users"
+"#,
+            )],
+        );
+
+        let out = plan_preview_output(Some(&cfg_path), &models_dir, None, None).unwrap();
+        assert_eq!(out.statements.len(), 1, "one model → one statement");
+        assert_eq!(out.statements[0].purpose, "full_refresh");
+        assert_eq!(out.statements[0].target, "c.s.users");
+        let sql = out.statements[0].sql.to_uppercase();
+        assert!(
+            sql.contains("CREATE") && sql.contains("TABLE"),
+            "full_refresh should render CTAS, got: {}",
+            out.statements[0].sql
+        );
+        // Preview core touches statements only.
+        assert!(out.classification_actions.is_empty());
+        assert!(out.mask_actions.is_empty());
+        assert!(out.retention_actions.is_empty());
+        assert!(out.plan_id.is_none());
+        assert!(out.execution_layers.is_empty());
+    }
+
+    /// The `filter` arg narrows the preview to a single model by name and is
+    /// copied onto `PlanOutput.filter`.
+    #[test]
+    fn plan_preview_filter_narrows_to_one_model() {
+        let tmp = TempDir::new().unwrap();
+        let model_a = r#"name = "a"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "c"
+schema = "s"
+table = "a"
+"#;
+        let model_b = r#"name = "b"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "c"
+schema = "s"
+table = "b"
+"#;
+        let (cfg_path, models_dir) = write_project(
+            &tmp,
+            r#"
+[adapter.default]
+type = "duckdb"
+database = ":memory:"
+"#,
+            &[("a", model_a), ("b", model_b)],
+        );
+
+        let out = plan_preview_output(Some(&cfg_path), &models_dir, Some("a"), None).unwrap();
+        assert_eq!(out.filter, "a");
+        assert_eq!(out.statements.len(), 1);
+        assert_eq!(out.statements[0].target, "c.s.a");
+    }
+
+    /// A `models/` directory with no compiled models (replication-only)
+    /// returns empty statements rather than erroring.
+    #[test]
+    fn plan_preview_replication_only_returns_empty_statements() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("rocky.toml");
+        fs::write(
+            &cfg_path,
+            r#"
+[adapter.default]
+type = "duckdb"
+database = ":memory:"
+"#,
+        )
+        .unwrap();
+        // models_dir exists but holds no model sidecars.
+        let models_dir = tmp.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+
+        let out = plan_preview_output(Some(&cfg_path), &models_dir, None, None).unwrap();
+        assert!(
+            out.statements.is_empty(),
+            "no compiled models → empty statements"
+        );
+        assert!(out.plan_id.is_none());
+    }
+
+    /// With no config, the preview still renders SQL using the default
+    /// dialect (DuckDB under the default feature set).
+    #[test]
+    fn plan_preview_without_config_uses_default_dialect() {
+        let tmp = TempDir::new().unwrap();
+        let models_dir = tmp.path().join("models");
+        fs::create_dir_all(&models_dir).unwrap();
+        fs::write(models_dir.join("m.sql"), "-- model: m\nSELECT 1 AS id").unwrap();
+        fs::write(
+            models_dir.join("m.toml"),
+            r#"name = "m"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "c"
+schema = "s"
+table = "m"
+"#,
+        )
+        .unwrap();
+
+        let out = plan_preview_output(None, &models_dir, None, None).unwrap();
+        assert_eq!(out.statements.len(), 1);
+        assert_eq!(out.statements[0].target, "c.s.m");
     }
 
     // ------------------------------------------------------------------

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -15,6 +15,27 @@ use crate::output::{
 };
 use crate::registry::{self, AdapterRegistry};
 
+/// Side-effect-free core of `rocky test` (DuckDB-based local tests): run the
+/// tests and assemble the typed [`TestOutput`] without printing.
+///
+/// The `run_test` wrapper calls this and prints; an in-process caller (MCP
+/// server) can obtain the struct directly.
+// Reusable typed-output core for a future in-process caller. No internal call
+// site yet — `run_test` re-runs the test runner so it can also render text.
+#[allow(dead_code)]
+pub(crate) fn test_output(models_dir: &Path, contracts_dir: Option<&Path>) -> Result<TestOutput> {
+    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir)?;
+    let failures: Vec<TestFailure> = result
+        .failures
+        .iter()
+        .map(|(name, error)| TestFailure {
+            name: name.clone(),
+            error: error.clone(),
+        })
+        .collect();
+    Ok(TestOutput::new(result.total, result.passed, failures))
+}
+
 /// Execute `rocky test` (DuckDB-based local tests).
 pub fn run_test(
     models_dir: &Path,


### PR DESCRIPTION
## What

Splits the typed-`*Output` assembly out of the `run_*` CLI handlers into side-effect-free `pub(crate)` cores, so an in-process caller can get the struct without triggering stdout. Pure refactor — no behavior change, no new output structs, no schema/codegen change.

- `compile_output`, `test_output`, `lineage_output` / `column_lineage_output`, `list_{pipelines,adapters,models,sources}_output`.
- New **`plan_preview_output`** — the offline, adapter-free analogue of `rocky plan`: compiles in-process and renders each compiled model's SQL via `sql_gen::generate_transformation_sql_with_warehouse` (no warehouse, no discovery, no plan persistence). Dialect is sourced from the configured target adapter (defaults to DuckDB); replication-only projects return empty statements with a note.

The `run_*` wrappers now call these cores and handle printing; text/DOT output paths are unchanged.

## Why

Prerequisite for the upcoming `rocky mcp` server (next PR), whose tools need to return the typed outputs in-process rather than re-parsing stdout. Landing it as a standalone refactor keeps that diff reviewable and this one mechanical.

The cores carry `#[allow(dead_code)]` until the server wires them in.

## Test

`cargo test -p rocky-cli`: 590 passed, 0 failed. fmt/clippy clean. `just codegen` produces zero diff (no schema touched). Also verified `compile --output table` stdout is byte-identical before/after for `quickstart` + `window-functions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)