### PR TITLE
feat(vscode): inline row preview + live compiled-SQL panel

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -124,6 +124,16 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Show inline cost annotations (CodeLens) above model files. Data is fetched from `rocky optimize` on activation and refreshed via the **Rocky: Refresh Cost Annotations** command."
+        },
+        "rocky.preview.rowLimit": {
+          "type": "number",
+          "default": 100,
+          "markdownDescription": "Maximum rows returned by **Rocky: Preview** (`rocky preview rows --limit`)."
+        },
+        "rocky.preview.allowWarehouse": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Allow row previews to execute against a non-DuckDB warehouse (Databricks/Snowflake/BigQuery/Trino). May incur query cost — you're still asked to confirm each run. DuckDB previews run locally and ignore this setting."
         }
       }
     },
@@ -132,6 +142,18 @@
         "command": "rocky.commandPalette",
         "title": "Rocky Command Palette",
         "category": "Rocky"
+      },
+      {
+        "command": "rocky.previewModel",
+        "title": "Preview Model Rows",
+        "category": "Rocky",
+        "icon": "$(table)"
+      },
+      {
+        "command": "rocky.showCompiledSql",
+        "title": "Open Compiled SQL",
+        "category": "Rocky",
+        "icon": "$(open-preview)"
       },
       {
         "command": "rocky.codeLens.runModel",
@@ -447,9 +469,24 @@
           "title": "Rocky",
           "icon": "icons/rocky-activity-bar.svg"
         }
+      ],
+      "panel": [
+        {
+          "id": "rockyPanel",
+          "title": "Rocky",
+          "icon": "icons/rocky-activity-bar.svg"
+        }
       ]
     },
     "views": {
+      "rockyPanel": [
+        {
+          "id": "rocky.queryResults",
+          "name": "Query Results",
+          "type": "webview",
+          "contextualTitle": "Rocky Query Results"
+        }
+      ],
       "rocky": [
         {
           "id": "rocky.getStarted",
@@ -668,6 +705,16 @@
           "command": "rocky.optimize",
           "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
           "group": "rocky@3"
+        },
+        {
+          "command": "rocky.previewModel",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@4"
+        },
+        {
+          "command": "rocky.showCompiledSql",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@5"
         }
       ]
     },
@@ -703,6 +750,12 @@
         "command": "rocky.commandPalette",
         "key": "ctrl+shift+r",
         "mac": "cmd+shift+r"
+      },
+      {
+        "command": "rocky.previewModel",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && (resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//))"
       }
     ],
     "walkthroughs": [

--- a/editors/vscode/src/__tests__/previewRowsCore.test.ts
+++ b/editors/vscode/src/__tests__/previewRowsCore.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+  window: {
+    createOutputChannel: () => ({
+      appendLine: () => {},
+      show: () => {},
+      dispose: () => {},
+    }),
+  },
+  workspace: {
+    getConfiguration: () => ({ get: (_k: string, d: unknown) => d }),
+    workspaceFolders: undefined,
+  },
+  ProgressLocation: { Notification: 15 },
+  ViewColumn: { Beside: 2 },
+}));
+
+import { RockyCliError } from "../rockyCli";
+import {
+  buildPreviewArgs,
+  parseErrorEnvelope,
+  toGridData,
+} from "../commands/previewRowsCore";
+import type { PreviewRowsOutput } from "../types/generated/preview_rows";
+
+describe("buildPreviewArgs", () => {
+  it("model only", () => {
+    expect(buildPreviewArgs("stg_orders", undefined, 100, false)).toEqual([
+      "preview",
+      "rows",
+      "--model",
+      "stg_orders",
+      "--limit",
+      "100",
+      "--output",
+      "json",
+    ]);
+  });
+
+  it("includes --cte only when provided", () => {
+    const args = buildPreviewArgs("m", "my_cte", 5, false);
+    expect(args).toContain("--cte");
+    expect(args[args.indexOf("--cte") + 1]).toBe("my_cte");
+  });
+
+  it("appends --allow-warehouse only when allowed", () => {
+    expect(buildPreviewArgs("m", undefined, 100, false)).not.toContain(
+      "--allow-warehouse",
+    );
+    expect(buildPreviewArgs("m", undefined, 100, true)).toContain(
+      "--allow-warehouse",
+    );
+  });
+});
+
+describe("parseErrorEnvelope", () => {
+  const envelope = (stdout: string): RockyCliError =>
+    new RockyCliError("failed", "stderr text", 1, undefined, stdout);
+
+  it("parses the error_kind envelope from stdout", () => {
+    const err = envelope(
+      JSON.stringify({ error_kind: "warehouse_gated", adapter_kind: "databricks" }),
+    );
+    expect(parseErrorEnvelope(err)).toEqual({
+      error_kind: "warehouse_gated",
+      adapter_kind: "databricks",
+    });
+  });
+
+  it("returns undefined when stdout is not JSON", () => {
+    expect(parseErrorEnvelope(envelope("boom, not json"))).toBeUndefined();
+  });
+
+  it("returns undefined when JSON lacks error_kind", () => {
+    expect(parseErrorEnvelope(envelope('{"rows": []}'))).toBeUndefined();
+  });
+
+  it("returns undefined for a non-RockyCliError", () => {
+    expect(parseErrorEnvelope(new Error("nope"))).toBeUndefined();
+  });
+});
+
+describe("toGridData", () => {
+  it("maps PreviewRowsOutput into the grid payload", () => {
+    const out: PreviewRowsOutput = {
+      version: "1.43.0",
+      command: "preview-rows",
+      model: "accounts",
+      cte: null,
+      columns: ["id", "owner_email"],
+      rows: [["1", "***hashed***"]],
+      row_count: 1,
+      limit_applied: 100,
+      truncated: false,
+      executed_sql: "SELECT id, sha2(owner_email, 256) AS owner_email FROM ...",
+      adapter_kind: "duckdb",
+      duration_ms: 12,
+    };
+    const grid = toGridData(out);
+    expect(grid.columns).toEqual(["id", "owner_email"]);
+    expect(grid.rows).toEqual([["1", "***hashed***"]]);
+    expect(grid.meta).toMatchObject({
+      rowCount: 1,
+      truncated: false,
+      adapterKind: "duckdb",
+      model: "accounts",
+      cte: null,
+      executedSql: out.executed_sql,
+    });
+  });
+});

--- a/editors/vscode/src/__tests__/resultGrid.test.ts
+++ b/editors/vscode/src/__tests__/resultGrid.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({}));
+
+import { coerceCell } from "../webviews/resultGrid";
+
+describe("coerceCell", () => {
+  it("renders null/undefined as empty", () => {
+    expect(coerceCell(null)).toBe("");
+    expect(coerceCell(undefined)).toBe("");
+  });
+
+  it("passes strings through verbatim", () => {
+    expect(coerceCell("owner1@test.org")).toBe("owner1@test.org");
+    expect(coerceCell("")).toBe("");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(coerceCell(42)).toBe("42");
+    expect(coerceCell(0)).toBe("0");
+    expect(coerceCell(true)).toBe("true");
+  });
+
+  it("renders objects and arrays as compact JSON", () => {
+    expect(coerceCell({ a: 1, b: "x" })).toBe('{"a":1,"b":"x"}');
+    expect(coerceCell([1, 2, 3])).toBe("[1,2,3]");
+  });
+});

--- a/editors/vscode/src/codeLens.ts
+++ b/editors/vscode/src/codeLens.ts
@@ -45,7 +45,9 @@ export class RockyCodeLensProvider implements vscode.CodeLensProvider {
     this.emitter.fire();
   }
 
-  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+  async provideCodeLenses(
+    document: vscode.TextDocument,
+  ): Promise<vscode.CodeLens[]> {
     const ext = path.extname(document.fileName);
     if (!SUPPORTED_EXTENSIONS.has(ext)) return [];
     if (!isModelFile(document.fileName)) return [];
@@ -56,17 +58,62 @@ export class RockyCodeLensProvider implements vscode.CodeLensProvider {
     const line = findModelCommentLine(document);
     const range = new vscode.Range(line, 0, line, 0);
 
-    return [
-      makeLens(range, "$(play) Run Model", "rocky.codeLens.runModel", [
+    const lenses = [
+      makeLens(range, "$(play) Run Model", "rocky.codeLens.runModel", [modelName]),
+      makeLens(range, "$(table) Preview", "rocky.previewModel", [modelName]),
+      makeLens(range, "$(file-code) Compile Model", "rocky.codeLens.compileModel", [
         modelName,
       ]),
-      makeLens(range, "$(file-code) Compile Model", "rocky.codeLens.compileModel", [
+      makeLens(range, "$(open-preview) Compiled SQL", "rocky.showCompiledSql", [
         modelName,
       ]),
       makeLens(range, "$(beaker) Test", "rocky.test", [modelName]),
       makeLens(range, "$(graph) Lineage", "rocky.showLineage", [modelName]),
     ];
+
+    // Per-CTE preview lenses. CTE symbols are emitted by the LSP only for
+    // `.sql` models (`.rocky` files surface pipeline steps instead). If the
+    // LSP isn't ready or returns nothing, the base lenses still apply.
+    if (ext === ".sql") {
+      try {
+        const symbols = await vscode.commands.executeCommand<
+          vscode.DocumentSymbol[]
+        >("vscode.executeDocumentSymbolProvider", document.uri);
+        for (const cte of collectCteSymbols(symbols ?? [])) {
+          const cteRange = new vscode.Range(cte.line, 0, cte.line, 0);
+          lenses.push(
+            makeLens(cteRange, `$(table) Preview CTE: ${cte.name}`, "rocky.previewCte", [
+              { model: modelName, cte: cte.name },
+            ]),
+          );
+        }
+      } catch {
+        // Symbol provider unavailable — keep the base lenses.
+      }
+    }
+
+    return lenses;
   }
+}
+
+/**
+ * Recursively collect CTE symbols from a document-symbol tree. The Rocky LSP
+ * tags each CTE with `detail: "CTE"` nested under the model symbol.
+ */
+function collectCteSymbols(
+  symbols: vscode.DocumentSymbol[],
+): { name: string; line: number }[] {
+  const out: { name: string; line: number }[] = [];
+  const walk = (syms: vscode.DocumentSymbol[]): void => {
+    for (const s of syms) {
+      if (s.detail === "CTE") {
+        out.push({ name: s.name, line: s.range.start.line });
+      }
+      if (s.children && s.children.length > 0) walk(s.children);
+    }
+  };
+  walk(symbols);
+  return out;
 }
 
 function makeLens(

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -18,6 +18,7 @@ import { registerLineageSerializer, showLineage } from "./lineage";
 import { importDbt, validateMigration } from "./migration";
 import { doctor, optimize } from "./ops";
 import { previewCost, previewCreate, previewDiff } from "./preview";
+import { previewCte, previewModel } from "./previewRows";
 import { compare, discover, plan, run } from "./run";
 import { archive, compact, profileStorage } from "./storage";
 import { test } from "./test";
@@ -86,6 +87,10 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("rocky.previewCreate", previewCreate),
     vscode.commands.registerCommand("rocky.previewDiff", previewDiff),
     vscode.commands.registerCommand("rocky.previewCost", previewCost),
+
+    // Inline row preview → Query Results panel
+    vscode.commands.registerCommand("rocky.previewModel", previewModel),
+    vscode.commands.registerCommand("rocky.previewCte", previewCte),
 
     // Branch approval / promote — gated production writes from a branch
     vscode.commands.registerCommand("rocky.branchApprove", branchApprove),

--- a/editors/vscode/src/commands/previewRows.ts
+++ b/editors/vscode/src/commands/previewRows.ts
@@ -1,0 +1,109 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { getConfig, resolveProjectRoot } from "../config";
+import { RockyCliError, runRockyJsonWithProgress, showRockyError } from "../rockyCli";
+import type { PreviewRowsOutput } from "../types/generated/preview_rows";
+import { getQueryResultsProvider } from "../views";
+import {
+  buildPreviewArgs,
+  parseErrorEnvelope,
+  toGridData,
+} from "./previewRowsCore";
+import { confirmAction, ensureWorkspace, resolveModelName } from "./ui";
+
+/** Resolve a model name from a command arg or the active editor. */
+function resolveModelToPreview(arg: unknown): string | undefined {
+  const fromArg = resolveModelName(arg);
+  if (fromArg) return fromArg;
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showWarningMessage("Open a Rocky model file first.");
+    return undefined;
+  }
+  const base = path.basename(editor.document.fileName).replace(/\.(rocky|sql)$/, "");
+  return base.length > 0 ? base : undefined;
+}
+
+/** `rocky.previewModel` — preview a model's output rows. */
+export async function previewModel(arg?: unknown): Promise<void> {
+  const model = resolveModelToPreview(arg);
+  if (model) await runPreview(model, undefined);
+}
+
+/** `rocky.previewCte` — preview a single CTE's rows (from the CodeLens). */
+export async function previewCte(arg?: {
+  model?: string;
+  cte?: string;
+}): Promise<void> {
+  if (arg?.model && arg?.cte) await runPreview(arg.model, arg.cte);
+}
+
+async function runPreview(model: string, cte: string | undefined): Promise<void> {
+  if (!ensureWorkspace()) return;
+  const provider = getQueryResultsProvider();
+  if (!provider) return;
+
+  const { previewRowLimit, previewAllowWarehouse } = getConfig();
+  const cwd = resolveProjectRoot();
+  const title = cte ? `${model} · ${cte}` : model;
+
+  // Reveal the Query Results panel, then show a placeholder while we run.
+  await vscode.commands.executeCommand("rocky.queryResults.focus");
+  provider.setLoading(title);
+
+  const run = (allowWarehouse: boolean): Promise<PreviewRowsOutput> =>
+    runRockyJsonWithProgress<PreviewRowsOutput>(
+      `Previewing ${title}…`,
+      buildPreviewArgs(model, cte, previewRowLimit, allowWarehouse),
+      { cwd },
+    );
+
+  try {
+    provider.setData(title, toGridData(await run(false)));
+  } catch (err) {
+    const env = parseErrorEnvelope(err);
+
+    // Warehouse execution is gated: prompt + retry only if the user opted in.
+    if (env?.error_kind === "warehouse_gated") {
+      if (!previewAllowWarehouse) {
+        provider.setError(
+          env.message ??
+            "Preview is gated for warehouse adapters. Enable rocky.preview.allowWarehouse to run against your warehouse.",
+        );
+        return;
+      }
+      const adapter = env.adapter_kind ?? "your warehouse";
+      const confirmed = await confirmAction(
+        `Run this preview against ${adapter}? It executes a query and may incur cost.`,
+        "Run on warehouse",
+      );
+      if (!confirmed) {
+        provider.setError("Preview cancelled.");
+        return;
+      }
+      try {
+        provider.setData(title, toGridData(await run(true)));
+      } catch (retryErr) {
+        reportError(retryErr, provider);
+      }
+      return;
+    }
+
+    reportError(err, provider);
+  }
+}
+
+/** Surface a preview failure in the panel (and the output channel for raw CLI errors). */
+function reportError(
+  err: unknown,
+  provider: NonNullable<ReturnType<typeof getQueryResultsProvider>>,
+): void {
+  const env = parseErrorEnvelope(err);
+  if (env) {
+    provider.setError(env.message ?? `Preview failed (${env.error_kind}).`);
+    return;
+  }
+  const message = err instanceof RockyCliError ? err.stderr.trim() || err.message : String(err);
+  provider.setError(`Preview failed: ${message}`);
+  showRockyError("Preview failed", err);
+}

--- a/editors/vscode/src/commands/previewRowsCore.ts
+++ b/editors/vscode/src/commands/previewRowsCore.ts
@@ -1,0 +1,74 @@
+import { RockyCliError } from "../rockyCli";
+import type { PreviewRowsOutput } from "../types/generated/preview_rows";
+import type { GridData } from "../webviews/resultGrid";
+
+/**
+ * Pure, vscode-free helpers behind `rocky.previewModel` / `rocky.previewCte`.
+ * Split out from `previewRows.ts` so they're unit-testable without dragging in
+ * the editor (views, webview) import graph.
+ */
+
+/** Structured failure envelope the engine emits on stdout for preview errors. */
+export interface PreviewErrorEnvelope {
+  error_kind: string;
+  message?: string;
+  adapter_kind?: string;
+  columns?: string[];
+}
+
+/**
+ * Build the `rocky preview rows` argument vector. `--output json` is appended
+ * so the extension always gets a parseable payload (or, on failure, a
+ * parseable error envelope on stdout).
+ */
+export function buildPreviewArgs(
+  model: string,
+  cte: string | undefined,
+  limit: number,
+  allowWarehouse: boolean,
+): string[] {
+  const args = ["preview", "rows", "--model", model];
+  if (cte) args.push("--cte", cte);
+  args.push("--limit", String(limit), "--output", "json");
+  if (allowWarehouse) args.push("--allow-warehouse");
+  return args;
+}
+
+/**
+ * Parse the engine's structured error envelope out of a {@link RockyCliError}.
+ * `stdout` is populated even on non-zero exit, so the `{"error_kind": …}`
+ * payload survives. Returns `undefined` when the error isn't a recognised
+ * envelope (spawn failure, malformed JSON, plain CLI error).
+ */
+export function parseErrorEnvelope(err: unknown): PreviewErrorEnvelope | undefined {
+  if (!(err instanceof RockyCliError) || !err.stdout) return undefined;
+  try {
+    const obj: unknown = JSON.parse(err.stdout);
+    if (
+      obj !== null &&
+      typeof obj === "object" &&
+      typeof (obj as Record<string, unknown>).error_kind === "string"
+    ) {
+      return obj as PreviewErrorEnvelope;
+    }
+  } catch {
+    // stdout wasn't the JSON error envelope.
+  }
+  return undefined;
+}
+
+/** Map a `PreviewRowsOutput` into the webview grid payload. */
+export function toGridData(out: PreviewRowsOutput): GridData {
+  return {
+    columns: out.columns,
+    rows: out.rows,
+    meta: {
+      rowCount: out.row_count,
+      truncated: out.truncated,
+      executedSql: out.executed_sql,
+      adapterKind: out.adapter_kind,
+      model: out.model,
+      cte: out.cte ?? null,
+    },
+  };
+}

--- a/editors/vscode/src/compiledSqlProvider.ts
+++ b/editors/vscode/src/compiledSqlProvider.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { resolveProjectRoot } from "./config";
+import { resolveModelName } from "./commands/ui";
+import { RockyCliError, runRockyJson } from "./rockyCli";
+import type { CompileOutput } from "./types/generated/compile";
+
+/**
+ * Virtual-document scheme for the live compiled-SQL panel. A read-only
+ * `rocky-compiled:/<model>.sql` document renders the model's macro-expanded
+ * SQL beside the source and refreshes on save. Using a `.sql` URI suffix means
+ * VS Code applies SQL syntax highlighting for free — no webview needed.
+ */
+export const COMPILED_SCHEME = "rocky-compiled";
+
+/** Derive the model name from a `rocky-compiled:/<model>.sql` URI. */
+function modelFromUri(uri: vscode.Uri): string {
+  return path.basename(uri.path).replace(/\.sql$/, "");
+}
+
+/** Build the virtual URI for a model's compiled SQL. */
+function compiledUri(model: string): vscode.Uri {
+  return vscode.Uri.parse(`${COMPILED_SCHEME}:/${encodeURIComponent(model)}.sql`);
+}
+
+export class CompiledSqlProvider implements vscode.TextDocumentContentProvider {
+  private readonly emitter = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this.emitter.event;
+
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+    const model = modelFromUri(uri);
+    if (!model) return "-- (no model selected)";
+    try {
+      // `--expand-macros` is mandatory — without it `expanded_sql` is empty.
+      const out = await runRockyJson<CompileOutput>(
+        ["compile", "--model", model, "--expand-macros", "--output", "json"],
+        { cwd: resolveProjectRoot() },
+      );
+      const sql = out.expanded_sql?.[model];
+      if (sql && sql.trim().length > 0) return sql;
+      return [
+        `-- No compiled SQL for '${model}'.`,
+        "-- It may have compile errors, or be a config-only replication model",
+        "-- (replication SQL is generated at run time, not from a model file).",
+      ].join("\n");
+    } catch (err) {
+      const message =
+        err instanceof RockyCliError ? err.stderr.trim() || err.message : String(err);
+      return `-- Failed to compile '${model}':\n-- ${message.replace(/\n/g, "\n-- ")}`;
+    }
+  }
+
+  /** Force a refresh of the compiled doc for `model` (if one is open). */
+  refresh(model: string): void {
+    this.emitter.fire(compiledUri(model));
+  }
+}
+
+/** Resolve a model name from a command arg or the active editor. */
+function resolveModel(arg: unknown): string | undefined {
+  const fromArg = resolveModelName(arg);
+  if (fromArg) return fromArg;
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showWarningMessage("Open a Rocky model file first.");
+    return undefined;
+  }
+  const base = path.basename(editor.document.fileName).replace(/\.(rocky|sql)$/, "");
+  return base.length > 0 ? base : undefined;
+}
+
+/**
+ * Register the compiled-SQL content provider, the save-triggered refresh, and
+ * the `rocky.showCompiledSql` command.
+ */
+export function registerCompiledSqlProvider(context: vscode.ExtensionContext): void {
+  const provider = new CompiledSqlProvider();
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(COMPILED_SCHEME, provider),
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      // Refresh the compiled view for the saved model (no-op if not open).
+      if (!/\.(rocky|sql)$/.test(doc.fileName)) return;
+      const model = path.basename(doc.fileName).replace(/\.(rocky|sql)$/, "");
+      provider.refresh(model);
+    }),
+    vscode.commands.registerCommand("rocky.showCompiledSql", showCompiledSql),
+  );
+}
+
+/** `rocky.showCompiledSql` — open the model's compiled SQL beside the source. */
+export async function showCompiledSql(arg?: unknown): Promise<void> {
+  const model = resolveModel(arg);
+  if (!model) return;
+  const doc = await vscode.workspace.openTextDocument(compiledUri(model));
+  await vscode.window.showTextDocument(doc, {
+    viewColumn: vscode.ViewColumn.Beside,
+    preview: true,
+    preserveFocus: true,
+  });
+}

--- a/editors/vscode/src/config.ts
+++ b/editors/vscode/src/config.ts
@@ -6,6 +6,8 @@ export interface RockyConfig {
   serverPath: string;
   extraArgs: string[];
   inlayHintsEnabled: boolean;
+  previewRowLimit: number;
+  previewAllowWarehouse: boolean;
 }
 
 /** Reads the current Rocky settings. Always re-read; do not cache. */
@@ -15,6 +17,8 @@ export function getConfig(): RockyConfig {
     serverPath: cfg.get<string>("server.path", "rocky"),
     extraArgs: cfg.get<string[]>("server.extraArgs", []),
     inlayHintsEnabled: cfg.get<boolean>("inlayHints.enabled", true),
+    previewRowLimit: cfg.get<number>("preview.rowLimit", 100),
+    previewAllowWarehouse: cfg.get<boolean>("preview.allowWarehouse", false),
   };
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { registerChatParticipant } from "./chatParticipant";
 import { registerCodeLensProvider } from "./codeLens";
 import { registerCommands } from "./commands";
+import { registerCompiledSqlProvider } from "./compiledSqlProvider";
 import { registerCostCodeLensProvider } from "./costCodeLens";
 import { registerDriftDiagnostics } from "./driftDiagnostics";
 import { setExtensionUri } from "./extensionState";
@@ -29,6 +30,7 @@ export function activate(context: vscode.ExtensionContext): void {
   registerRunDecorations(context);
   registerDriftDiagnostics(context);
   registerTaskProvider(context);
+  registerCompiledSqlProvider(context);
   registerViews(context);
 }
 

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -48,6 +48,17 @@ suite("Rocky Extension", () => {
     assert.deepStrictEqual(missing, [], `Missing commands: ${missing.join(", ")}`);
   });
 
+  test("Inline-preview commands are registered", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    const expected = [
+      "rocky.previewModel",
+      "rocky.previewCte",
+      "rocky.showCompiledSql",
+    ];
+    const missing = expected.filter((c) => !commands.includes(c));
+    assert.deepStrictEqual(missing, [], `Missing commands: ${missing.join(", ")}`);
+  });
+
   test("rocky.doctor command exists", async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(

--- a/editors/vscode/src/views/index.ts
+++ b/editors/vscode/src/views/index.ts
@@ -9,9 +9,12 @@ import type { PreviewTreeProvider } from "./previewView";
 import { registerRunsView } from "./runsView";
 import { registerSchemaView } from "./schemaView";
 import { registerSourcesView } from "./sourcesView";
+import { registerQueryResultsView } from "../webviews/resultGrid";
+import type { ResultGridViewProvider } from "../webviews/resultGrid";
 
 let infoProvider: ExtensionInfoTreeProvider | undefined;
 let previewProvider: PreviewTreeProvider | undefined;
+let queryResultsProvider: ResultGridViewProvider | undefined;
 
 /**
  * Registers all eight Rocky tree views on the activity bar:
@@ -29,10 +32,15 @@ export function registerViews(context: vscode.ExtensionContext): void {
   registerSchemaView(context);
   previewProvider = registerPreviewView(context);
   registerHelpView(context);
+  queryResultsProvider = registerQueryResultsView(context);
 }
 
 export function getPreviewProvider(): PreviewTreeProvider | undefined {
   return previewProvider;
+}
+
+export function getQueryResultsProvider(): ResultGridViewProvider | undefined {
+  return queryResultsProvider;
 }
 
 export function getInfoProvider(): ExtensionInfoTreeProvider | undefined {

--- a/editors/vscode/src/webviews/resultGrid.ts
+++ b/editors/vscode/src/webviews/resultGrid.ts
@@ -1,0 +1,270 @@
+import * as vscode from "vscode";
+import { buildHead, makeNonce } from "./htmlUtil";
+
+/**
+ * Tabular payload rendered by the Query Results panel. `rows` cells are
+ * coerced to display strings via {@link coerceCell} before they reach the
+ * webview, so the webview never has to reason about JSON types.
+ */
+export interface GridData {
+  columns: string[];
+  rows: unknown[][];
+  meta?: GridMeta;
+}
+
+/** Footer/toolbar metadata shown alongside the grid. */
+export interface GridMeta {
+  rowCount?: number;
+  truncated?: boolean;
+  executedSql?: string;
+  adapterKind?: string;
+  model?: string;
+  cte?: string | null;
+}
+
+/** Message posted from host → webview. */
+type HostMessage =
+  | { type: "loading"; title: string }
+  | { type: "error"; message: string }
+  | {
+      type: "data";
+      columns: string[];
+      rows: string[][];
+      meta: GridMeta;
+      title: string;
+    };
+
+/**
+ * Coerce an arbitrary JSON cell value into a display string.
+ *
+ * `QueryResult` rows are `serde_json::Value`s, so a cell can be a string,
+ * number, bool, null, or (rarely) a nested array/object. Null renders empty;
+ * objects/arrays render as compact JSON; everything else stringifies.
+ */
+export function coerceCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Panel-area "Query Results" view (docks next to Problems/Terminal, matching
+ * dbt's preview panel). A {@link vscode.WebviewView} isn't instantiated until
+ * the view is first revealed, so the provider buffers the latest payload and
+ * flushes it on `resolveWebviewView` and on the webview's `ready` handshake —
+ * the preview command can call {@link setLoading}/{@link setData} before the
+ * panel has ever been opened.
+ */
+export class ResultGridViewProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = "rocky.queryResults";
+
+  private view: vscode.WebviewView | undefined;
+  private ready = false;
+  private pending: HostMessage | undefined;
+  private lastMeta: GridMeta | undefined;
+  private lastData: { columns: string[]; rows: string[][] } | undefined;
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  resolveWebviewView(view: vscode.WebviewView): void {
+    this.view = view;
+    this.ready = false;
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri],
+    };
+    view.webview.html = this.html(view.webview);
+
+    view.webview.onDidReceiveMessage((msg: { type?: string }) => {
+      if (msg.type === "ready") {
+        this.ready = true;
+        if (this.pending) {
+          view.webview.postMessage(this.pending);
+          this.pending = undefined;
+        }
+      } else if (msg.type === "copyTsv") {
+        void this.copyTsv();
+      } else if (msg.type === "showSql") {
+        void this.showSql();
+      }
+    });
+
+    view.onDidDispose(() => {
+      this.view = undefined;
+      this.ready = false;
+    });
+  }
+
+  /** Reveal the panel and show a spinner-y placeholder for `title`. */
+  setLoading(title: string): void {
+    this.post({ type: "loading", title });
+  }
+
+  /** Render `data` in the grid (coercing cells to display strings). */
+  setData(title: string, data: GridData): void {
+    this.lastMeta = data.meta;
+    const rows = data.rows.map((r) => r.map(coerceCell));
+    this.lastData = { columns: data.columns, rows };
+    this.post({
+      type: "data",
+      columns: data.columns,
+      rows,
+      meta: data.meta ?? {},
+      title,
+    });
+  }
+
+  /** Show an error message in the panel. */
+  setError(message: string): void {
+    this.post({ type: "error", message });
+  }
+
+  private post(msg: HostMessage): void {
+    if (this.view && this.ready) {
+      void this.view.webview.postMessage(msg);
+    } else {
+      // Buffer until the webview is resolved + ready (it flushes on `ready`).
+      this.pending = msg;
+    }
+  }
+
+  private async copyTsv(): Promise<void> {
+    if (!this.lastData) return;
+    const header = this.lastData.columns.join("\t");
+    const body = this.lastData.rows.map((r) => r.join("\t")).join("\n");
+    await vscode.env.clipboard.writeText(`${header}\n${body}`);
+    void vscode.window.showInformationMessage("Query results copied (TSV).");
+  }
+
+  private async showSql(): Promise<void> {
+    const sql = this.lastMeta?.executedSql;
+    if (!sql) return;
+    const doc = await vscode.workspace.openTextDocument({
+      content: sql,
+      language: "sql",
+    });
+    await vscode.window.showTextDocument(doc, {
+      viewColumn: vscode.ViewColumn.Beside,
+      preview: true,
+    });
+  }
+
+  private html(webview: vscode.Webview): string {
+    const nonce = makeNonce();
+    const extraStyles = `
+      #toolbar { display:flex; align-items:center; gap:12px; margin-bottom:8px; flex-wrap:wrap; }
+      #meta { color: var(--vscode-descriptionForeground); font-size:12px; }
+      #grid-wrap { overflow:auto; max-height: calc(100vh - 80px); }
+      table.grid { border-collapse: collapse; width: 100%; font-variant-numeric: tabular-nums; }
+      table.grid th { cursor: pointer; user-select: none; position: sticky; top: 0; }
+      table.grid th .arrow { color: var(--vscode-descriptionForeground); margin-left:4px; }
+      table.grid td, table.grid th { white-space: pre; max-width: 480px; overflow: hidden; text-overflow: ellipsis; }
+      .empty { color: var(--vscode-descriptionForeground); padding: 12px 0; }
+      .err { color: var(--vscode-errorForeground); padding: 12px 0; white-space: pre-wrap; }
+    `;
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+${buildHead(webview, nonce, "Query Results", extraStyles)}
+<body>
+  <div id="toolbar">
+    <span id="title"></span>
+    <span id="meta"></span>
+    <span style="flex:1"></span>
+    <button id="copy" hidden>Copy TSV</button>
+    <button id="sql" hidden>Show SQL</button>
+  </div>
+  <div id="status" class="empty">Run <strong>Preview</strong> on a model to see rows here.</div>
+  <div id="grid-wrap"></div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const $ = (id) => document.getElementById(id);
+    let state = { columns: [], rows: [], sortCol: -1, sortDir: 1 };
+
+    function cmp(a, b) {
+      const na = Number(a), nb = Number(b);
+      const numeric = a !== "" && b !== "" && !Number.isNaN(na) && !Number.isNaN(nb);
+      if (numeric) return na - nb;
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
+
+    function render() {
+      const wrap = $("grid-wrap");
+      if (!state.columns.length) { wrap.innerHTML = ""; return; }
+      let rows = state.rows;
+      if (state.sortCol >= 0) {
+        rows = rows.slice().sort((r1, r2) => state.sortDir * cmp(r1[state.sortCol], r2[state.sortCol]));
+      }
+      const thead = "<thead><tr>" + state.columns.map((c, i) => {
+        const arrow = i === state.sortCol ? (state.sortDir > 0 ? "▲" : "▼") : "";
+        return "<th data-col='" + i + "'>" + escapeHtml(c) + "<span class='arrow'>" + arrow + "</span></th>";
+      }).join("") + "</tr></thead>";
+      const tbody = "<tbody>" + rows.map((r) =>
+        "<tr>" + r.map((cell) => "<td>" + escapeHtml(cell) + "</td>").join("") + "</tr>"
+      ).join("") + "</tbody>";
+      wrap.innerHTML = "<table class='grid'>" + thead + tbody + "</table>";
+      for (const th of wrap.querySelectorAll("th")) {
+        th.addEventListener("click", () => {
+          const col = Number(th.getAttribute("data-col"));
+          if (state.sortCol === col) state.sortDir = -state.sortDir;
+          else { state.sortCol = col; state.sortDir = 1; }
+          render();
+        });
+      }
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    }
+
+    window.addEventListener("message", (ev) => {
+      const m = ev.data;
+      const status = $("status"), copy = $("copy"), sql = $("sql"), meta = $("meta"), title = $("title");
+      if (m.type === "loading") {
+        title.textContent = m.title; meta.textContent = "";
+        status.className = "empty"; status.textContent = "Running…"; status.hidden = false;
+        copy.hidden = true; sql.hidden = true; $("grid-wrap").innerHTML = "";
+      } else if (m.type === "error") {
+        title.textContent = ""; meta.textContent = "";
+        status.className = "err"; status.textContent = m.message; status.hidden = false;
+        copy.hidden = true; sql.hidden = true; $("grid-wrap").innerHTML = "";
+      } else if (m.type === "data") {
+        state = { columns: m.columns, rows: m.rows, sortCol: -1, sortDir: 1 };
+        title.textContent = m.title;
+        const bits = [];
+        if (typeof m.meta.rowCount === "number") bits.push(m.meta.rowCount + (m.meta.truncated ? "+ rows (truncated)" : " rows"));
+        if (m.meta.adapterKind) bits.push(m.meta.adapterKind);
+        if (m.meta.cte) bits.push("CTE: " + m.meta.cte);
+        meta.textContent = bits.join(" · ");
+        status.hidden = state.rows.length > 0;
+        if (!state.rows.length) { status.className = "empty"; status.textContent = "(0 rows)"; }
+        copy.hidden = false;
+        sql.hidden = !m.meta.executedSql;
+        render();
+      }
+    });
+
+    $("copy").addEventListener("click", () => vscode.postMessage({ type: "copyTsv" }));
+    $("sql").addEventListener("click", () => vscode.postMessage({ type: "showSql" }));
+    vscode.postMessage({ type: "ready" });
+  </script>
+</body>
+</html>`;
+  }
+}
+
+/** Register the Query Results panel view; returns the provider for the host to push data into. */
+export function registerQueryResultsView(
+  context: vscode.ExtensionContext,
+): ResultGridViewProvider {
+  const provider = new ResultGridViewProvider(context.extensionUri);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(
+      ResultGridViewProvider.viewType,
+      provider,
+      { webviewOptions: { retainContextWhenHidden: true } },
+    ),
+  );
+  return provider;
+}


### PR DESCRIPTION
The editor half of the inline-preview feature — builds on the `rocky preview rows` engine command (#667, merged). Together they close the dbt-Fusion-extension parity gap on inline query preview.

## Features

- **Query Results panel** (panel-area webview, docks next to Problems/Terminal like dbt's): a sortable result grid that renders `rocky preview rows --output json`, with copy-as-TSV and show-SQL. Data is pushed via `postMessage` (CSP-safe — row values are never injected into HTML); the provider buffers the latest payload until the webview signals `ready`, so a preview fired before the panel was ever opened still lands.
- **`Preview` / `Preview CTE` CodeLenses + Cmd/Ctrl+Enter** on model files. CTE lenses come from the LSP's document symbols (`.sql` models only — `.rocky` files surface pipeline steps). The **warehouse gate** is handled by catching the engine's `warehouse_gated` error envelope (parsed off `RockyCliError.stdout`) and confirming before retrying with `--allow-warehouse`, governed by `rocky.preview.allowWarehouse`.
- **Live compiled-SQL panel**: a read-only `rocky-compiled:` virtual document (free SQL highlighting, no webview) backed by `rocky compile --expand-macros --model`, refreshing on save. No engine dependency.

## Settings

- `rocky.preview.rowLimit` (default 100)
- `rocky.preview.allowWarehouse` (default false — warehouse previews always also prompt)

## Design notes

- The pure helpers (arg builder, error-envelope parsing, output→grid mapping) live in `previewRowsCore.ts` so they're unit-testable without the editor import graph.
- The result grid is hand-rolled (no grid lib) to avoid a second large webview bundle; sorting is client-side with a numeric/string heuristic.

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (130 tests, incl. new `previewRowsCore` + `resultGrid` suites) all clean; esbuild bundle succeeds. A test-electron smoke asserts the three new commands register (runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)