### PR TITLE
feat(engine): add rocky mcp server exposing read-only tools

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1223,6 +1223,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2149,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3027,6 +3067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3719,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rocky"
 version = "1.43.0"
 dependencies = [
@@ -3684,6 +3766,7 @@ dependencies = [
  "miette",
  "rocky-cli",
  "rocky-core",
+ "rocky-mcp",
  "rocky-observe",
  "serde_json",
  "tempfile",
@@ -3833,7 +3916,7 @@ dependencies = [
  "rocky-snowflake",
  "rocky-sql",
  "rocky-trino",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "strsim",
@@ -3861,7 +3944,7 @@ dependencies = [
  "rocky-lang",
  "rocky-sql",
  "salsa",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3899,7 +3982,7 @@ dependencies = [
  "rocky-duckdb",
  "rocky-ir",
  "rocky-sql",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sha2",
@@ -3992,7 +4075,7 @@ dependencies = [
  "reqwest",
  "rocky-core",
  "rocky-observe",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sha2",
@@ -4036,7 +4119,7 @@ dependencies = [
  "blake3",
  "chrono",
  "rocky-sql",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror",
@@ -4063,6 +4146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocky-mcp"
+version = "1.43.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rmcp",
+ "rocky-cli",
+ "rocky-compiler",
+ "rocky-core",
+ "rocky-duckdb",
+ "rocky-sql",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rocky-observe"
 version = "1.43.0"
 dependencies = [
@@ -4070,7 +4174,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "tempfile",
@@ -4142,7 +4246,7 @@ version = "1.43.0"
 dependencies = [
  "miette",
  "regex",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "sqlparser",
@@ -4408,7 +4512,21 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "indexmap",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4418,6 +4536,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/rocky-duckdb",
     "crates/rocky-observe",
     "crates/rocky-cli",
+    "crates/rocky-mcp",
     "crates/rocky-wasm",
     "rocky",
     "rocky-lsp",
@@ -85,6 +86,12 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 tokio = { version = "1", features = ["full"] }
+
+# MCP server (Model Context Protocol) — stdio transport only.
+# Transitively pulls schemars 1.x; the rest of the workspace uses schemars
+# 0.8. The dual-major is disjoint (rmcp's `#[tool]` param structs derive
+# schemars 1.x; Rocky's `*Output` structs derive 0.8) and compiles cleanly.
+rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2"] }

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -81,7 +81,10 @@ fn compile_project(
 }
 
 /// Typed schemas bucketed by origin for prompt rendering.
-type SchemaBuckets = (
+///
+/// `(existing-models, source-tables)`. Public so the in-process MCP server
+/// (`rocky-mcp`) can consume the same bucketing via [`build_schema_context`].
+pub type SchemaBuckets = (
     Vec<(String, Vec<TypedColumn>)>,
     Vec<(String, Vec<TypedColumn>)>,
 );
@@ -91,7 +94,10 @@ type SchemaBuckets = (
 /// dotted schema.table naming convention used in Rocky sources; anything
 /// else is treated as an existing model. This is best-effort classification
 /// — the prompt tolerates either bucket without losing correctness.
-fn build_schema_context(result: &CompileResult) -> SchemaBuckets {
+///
+/// Exposed for the in-process MCP server (`rocky-mcp`), whose `inspect_schema`
+/// tool reuses the same (models, sources) bucketing the `rocky ai` prompt uses.
+pub fn build_schema_context(result: &CompileResult) -> SchemaBuckets {
     let mut model_schemas = Vec::new();
     let mut source_tables = Vec::new();
 

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -347,11 +347,11 @@ struct CompileTextData {
 ///
 /// `cache_ttl_override`: optional CLI `--cache-ttl <seconds>` value that
 /// replaces `[cache.schemas] ttl_seconds` for this invocation only.
-// Reusable typed-output core for a future in-process caller (MCP server). No
-// internal call site yet — the `run_compile` wrapper uses `compile_inner`
-// directly so it can also render text mode.
-#[allow(dead_code, clippy::too_many_arguments)]
-pub(crate) fn compile_output(
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`). The
+// `run_compile` wrapper uses `compile_inner` directly so it can also render
+// text mode.
+#[allow(clippy::too_many_arguments)]
+pub fn compile_output(
     config_path: Option<&Path>,
     state_path: &Path,
     models_dir: &Path,

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -194,13 +194,9 @@ pub fn run_lineage(
 ///
 /// `result` is a completed compile; `model_name` is the focal model. Errors
 /// when the model is absent from the semantic graph.
-// Reusable typed-output core for a future in-process caller. No internal call
-// site beyond `run_lineage`'s JSON branch yet.
-#[allow(dead_code)]
-pub(crate) fn lineage_output(
-    result: &compile::CompileResult,
-    model_name: &str,
-) -> Result<LineageOutput> {
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`),
+// alongside `run_lineage`'s JSON branch.
+pub fn lineage_output(result: &compile::CompileResult, model_name: &str) -> Result<LineageOutput> {
     let schema = result
         .semantic_graph
         .model_schema(model_name)
@@ -293,10 +289,9 @@ pub(crate) fn lineage_output(
 ///
 /// `downstream` selects the trace direction: `true` traces consumers, `false`
 /// traces sources.
-// Reusable typed-output core for a future in-process caller. No internal call
-// site beyond `run_lineage`'s JSON branch yet.
-#[allow(dead_code)]
-pub(crate) fn column_lineage_output(
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`),
+// alongside `run_lineage`'s JSON branch.
+pub fn column_lineage_output(
     result: &compile::CompileResult,
     model_name: &str,
     column: &str,

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -6,10 +6,9 @@ use crate::output::*;
 
 /// Side-effect-free core of `rocky list pipelines`: load the config and
 /// assemble the typed [`ListPipelinesOutput`] without printing.
-// Reusable typed-output core for a future in-process caller. No internal call
-// site yet beyond `list_pipelines`' JSON branch.
-#[allow(dead_code)]
-pub(crate) fn list_pipelines_output(config_path: &Path) -> Result<ListPipelinesOutput> {
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`),
+// alongside `list_pipelines`' JSON branch.
+pub fn list_pipelines_output(config_path: &Path) -> Result<ListPipelinesOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
     Ok(ListPipelinesOutput::new(build_pipeline_entries(&cfg)))
 }
@@ -75,9 +74,8 @@ pub fn list_pipelines(config_path: &Path, json: bool) -> Result<()> {
 
 /// Side-effect-free core of `rocky list adapters`: load the config and
 /// assemble the typed [`ListAdaptersOutput`] without printing.
-// Reusable typed-output core for a future in-process caller.
-#[allow(dead_code)]
-pub(crate) fn list_adapters_output(config_path: &Path) -> Result<ListAdaptersOutput> {
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`).
+pub fn list_adapters_output(config_path: &Path) -> Result<ListAdaptersOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
     Ok(ListAdaptersOutput::new(build_adapter_entries(&cfg)))
 }
@@ -122,9 +120,8 @@ pub fn list_adapters(config_path: &Path, json: bool) -> Result<()> {
 
 /// Side-effect-free core of `rocky list models`: load the models directory
 /// and assemble the typed [`ListModelsOutput`] without printing.
-// Reusable typed-output core for a future in-process caller.
-#[allow(dead_code)]
-pub(crate) fn list_models_output(models_dir: &Path) -> Result<ListModelsOutput> {
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`).
+pub fn list_models_output(models_dir: &Path) -> Result<ListModelsOutput> {
     Ok(ListModelsOutput::new(build_model_entries(models_dir)?))
 }
 
@@ -205,9 +202,8 @@ pub fn list_models(models_dir: &Path, json: bool) -> Result<()> {
 
 /// Side-effect-free core of `rocky list sources`: load the config and
 /// assemble the typed [`ListSourcesOutput`] without printing.
-// Reusable typed-output core for a future in-process caller.
-#[allow(dead_code)]
-pub(crate) fn list_sources_output(config_path: &Path) -> Result<ListSourcesOutput> {
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`).
+pub fn list_sources_output(config_path: &Path) -> Result<ListSourcesOutput> {
     let cfg = rocky_core::config::load_rocky_config(config_path)?;
     Ok(ListSourcesOutput::new(build_source_entries(&cfg)))
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -65,7 +65,9 @@ mod watch;
 pub use adapter::{
     discover_adapters_on_path, resolve_adapter_command, run_adapter_info, run_adapter_list,
 };
-pub use ai::{run_ai, run_ai_explain, run_ai_sync, run_ai_test};
+pub use ai::{
+    SchemaBuckets, build_schema_context, run_ai, run_ai_explain, run_ai_sync, run_ai_test,
+};
 pub use apply::{run_apply, run_apply_inline_for_run};
 pub use archive::{run_archive, run_archive_apply, run_archive_catalog};
 #[cfg(feature = "duckdb")]
@@ -80,7 +82,7 @@ pub use ci::run_ci;
 pub use ci_diff::run_ci_diff;
 pub use compact::{run_compact, run_compact_apply, run_compact_catalog, run_measure_dedup};
 pub use compare::compare;
-pub use compile::run_compile;
+pub use compile::{compile_output, run_compile};
 pub use completions::run_completions;
 pub use compliance::run_compliance;
 pub use cost::run_cost;
@@ -96,16 +98,17 @@ pub use hooks::{run_hooks_list, run_hooks_test};
 pub use import_dbt::run_import_dbt;
 pub use init::init;
 pub use init_adapter::run_init_adapter;
-pub use lineage::run_lineage;
+pub use lineage::{column_lineage_output, lineage_output, run_lineage};
 pub use lineage_diff::run_lineage_diff;
 pub use list::{
-    list_adapters, list_consumers, list_deps, list_models, list_pipelines, list_sources,
+    list_adapters, list_adapters_output, list_consumers, list_deps, list_models,
+    list_models_output, list_pipelines, list_pipelines_output, list_sources, list_sources_output,
 };
 pub use load::run_load;
 pub use lsp::run_lsp;
 pub use metrics::run_metrics;
 pub use optimize::run_optimize;
-pub use plan::{PlanRunOptions, plan, plan_promote};
+pub use plan::{PlanRunOptions, plan, plan_preview_output, plan_promote};
 pub use playground::{run_playground, run_playground_with_template};
 pub use preview::{
     PreviewDiffAlgorithmSelector, run_preview_cost, run_preview_create, run_preview_diff,
@@ -129,7 +132,7 @@ pub use state::{state_clear_schema_cache, state_retention_sweep, state_show};
 #[cfg(feature = "duckdb")]
 pub use test::run_declarative_tests;
 #[cfg(feature = "duckdb")]
-pub use test::run_test;
+pub use test::{run_test, test_output};
 pub use test_adapter::{run_test_adapter, run_test_adapter_builtin};
 pub use trace::run_trace;
 pub use validate::validate;

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -492,10 +492,9 @@ fn strategy_purpose(strategy: &MaterializationStrategy) -> &'static str {
 /// no compiled models (replication-only, or `models/` holds only stubs), the
 /// returned `PlanOutput` has empty `statements` and a `tracing::info!` note —
 /// the live `rocky plan` discovery path is the surface for replication SQL.
-// Reusable typed-output core for a future in-process caller. No internal call
-// site yet — `rocky plan` uses the full live `plan()` path.
-#[allow(dead_code)]
-pub(crate) fn plan_preview_output(
+// Reusable typed-output core for the in-process MCP server (`rocky-mcp`).
+// `rocky plan` uses the full live `plan()` path.
+pub fn plan_preview_output(
     config_path: Option<&Path>,
     models_dir: &Path,
     filter: Option<&str>,

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -18,12 +18,11 @@ use crate::registry::{self, AdapterRegistry};
 /// Side-effect-free core of `rocky test` (DuckDB-based local tests): run the
 /// tests and assemble the typed [`TestOutput`] without printing.
 ///
-/// The `run_test` wrapper calls this and prints; an in-process caller (MCP
-/// server) can obtain the struct directly.
-// Reusable typed-output core for a future in-process caller. No internal call
-// site yet — `run_test` re-runs the test runner so it can also render text.
-#[allow(dead_code)]
-pub(crate) fn test_output(models_dir: &Path, contracts_dir: Option<&Path>) -> Result<TestOutput> {
+/// The `run_test` wrapper calls this and prints; the in-process MCP server
+/// (`rocky-mcp`) obtains the struct directly.
+// Reusable typed-output core for the in-process MCP server. `run_test`
+// re-runs the test runner so it can also render text.
+pub fn test_output(models_dir: &Path, contracts_dir: Option<&Path>) -> Result<TestOutput> {
     let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir)?;
     let failures: Vec<TestFailure> = result
         .failures

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -4,7 +4,7 @@ pub mod error_reporter;
 pub mod otel_guard;
 pub mod output;
 pub mod pipes;
-pub(crate) mod plan_store;
+pub mod plan_store;
 pub mod registry;
 pub(crate) mod schema_cache_writer;
 pub(crate) mod scope;

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "rocky-mcp"
+version = "1.43.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Model Context Protocol (MCP) server exposing Rocky's read-only verification and data-grounding tools over stdio."
+
+[lints]
+workspace = true
+
+[dependencies]
+rmcp = { workspace = true }
+rocky-cli = { path = "../rocky-cli" }
+rocky-core = { path = "../rocky-core" }
+rocky-sql = { path = "../rocky-sql" }
+rocky-compiler = { path = "../rocky-compiler" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+# rmcp's `#[tool]` macro generates code that references `schemars` (1.x) by
+# path, so the param structs need it as a direct dependency. This is the
+# 1.x major; the rest of the workspace pins 0.8 via [workspace.dependencies].
+schemars = "1"
+
+[dev-dependencies]
+rocky-duckdb = { path = "../rocky-duckdb" }
+tempfile = "3"
+serde_json = { workspace = true }
+# The scripted round-trip test drives the stdio server in-process with an rmcp
+# client over a duplex pipe, so it needs the client side of rmcp too.
+rmcp = { version = "1.7", features = ["server", "macros", "transport-io", "client"] }

--- a/engine/crates/rocky-mcp/src/lib.rs
+++ b/engine/crates/rocky-mcp/src/lib.rs
@@ -1,0 +1,48 @@
+//! `rocky-mcp` — a Model Context Protocol (MCP) server exposing Rocky's
+//! read-only verification and data-grounding capabilities over stdio.
+//!
+//! The differentiated value is the **typed** verification surface
+//! (`compile` / `plan_preview` / `lineage` / `test` / `inspect_schema`) — a
+//! harness can't reproduce these with a raw shell. Materialization stays
+//! human-gated: the agent can only *propose* an AI-authored plan; a human
+//! runs `rocky review --approve` + `rocky apply`.
+//!
+//! ## Statelessness
+//!
+//! Each tool call resolves the project from the server's config + models dir
+//! and **compiles fresh** via the rocky-cli cores, so it always reflects the
+//! current on-disk files. The server holds only the config path / models dir
+//! / root. A warm Salsa cache is a deferred optimization (not implemented
+//! here) — correctness-first.
+//!
+//! ## schemars dual-major note
+//!
+//! rmcp 1.7 pulls schemars 1.x; the rest of the Rocky workspace uses
+//! schemars 0.8. The two `JsonSchema` traits are disjoint. Every result
+//! struct returned inside `Json<T>` therefore derives schemars **1.x** and is
+//! built from "pure" types only (`String`, `usize`, `bool`, `Vec<_>`, local
+//! lite structs) — Rocky's 0.8-deriving `*Output` types are projected into
+//! these lite shapes at the tool boundary.
+
+mod result_types;
+mod tools;
+
+use rmcp::{ServiceExt, transport::stdio};
+
+pub use tools::RockyMcpServer;
+
+/// Serve the Rocky MCP server over stdio until the client disconnects.
+///
+/// `config_path` is the project's `rocky.toml`; the models directory is
+/// resolved as `<config-dir>/models`, matching the CLI's top-level
+/// convention. Logging goes to stderr (stdout is reserved for the MCP wire
+/// protocol).
+pub async fn serve_stdio(config_path: std::path::PathBuf) -> anyhow::Result<()> {
+    let server = RockyMcpServer::new(config_path);
+    tracing::info!("starting rocky MCP server over stdio");
+    let service = server.serve(stdio()).await.inspect_err(|e| {
+        tracing::error!("rocky MCP serve error: {e:?}");
+    })?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -1,0 +1,244 @@
+//! Lite, schemars-1.x result projections returned by the MCP tools.
+//!
+//! These deliberately mirror only the fields an agent needs, dropping
+//! token-heavy payloads (`expanded_sql`, full `models_detail`, etc.). They
+//! derive schemars 1.x (rmcp's `Json<T>` bound) and are built from Rocky's
+//! 0.8-deriving `*Output` types at the tool boundary — see the module note in
+//! `lib.rs` for why the two cannot be shared.
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// One compiler diagnostic, projected from `rocky_compiler::diagnostic::Diagnostic`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DiagnosticLite {
+    /// Diagnostic code, e.g. `"E001"`, `"W003"`, `"P001"`.
+    pub code: String,
+    /// `"Error"`, `"Warning"`, or `"Info"`.
+    pub severity: String,
+    /// Model the diagnostic is attached to.
+    pub model: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Suggested fix, when the diagnostic carries one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestion: Option<String>,
+    /// `file:line:col` source location, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<String>,
+}
+
+/// Trimmed `rocky compile` result. Drops `expanded_sql` and the full
+/// `models_detail` (token-heavy) in favour of counts + diagnostics.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CompileResult {
+    /// Whether compilation produced any error-severity diagnostics.
+    pub has_errors: bool,
+    /// Count of error-severity diagnostics.
+    pub error_count: usize,
+    /// Count of warning-severity diagnostics.
+    pub warning_count: usize,
+    /// Number of models in the project.
+    pub model_count: usize,
+    /// All diagnostics (errors + warnings + info).
+    pub diagnostics: Vec<DiagnosticLite>,
+}
+
+/// One statement in a `plan_preview` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PlannedStatementLite {
+    /// What the statement does, e.g. `"full_refresh"`, `"incremental"`.
+    pub purpose: String,
+    /// Fully-qualified target the statement writes to.
+    pub target: String,
+    /// The generated SQL.
+    pub sql: String,
+}
+
+/// `plan_preview` result — the SQL the runner would emit for the model(s).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PlanPreviewResult {
+    /// Generated statements, in execution order.
+    pub statements: Vec<PlannedStatementLite>,
+}
+
+/// One lineage edge (column → column with a transform label).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LineageEdgeLite {
+    pub source_model: String,
+    pub source_column: String,
+    pub target_model: String,
+    pub target_column: String,
+    pub transform: String,
+}
+
+/// `lineage` result. When `column` is set, `trace` holds the column-level
+/// trace and `direction` is `"upstream"`/`"downstream"`; otherwise
+/// `columns` + `upstream`/`downstream` model lists + model-level `edges`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LineageResult {
+    /// Focal model.
+    pub model: String,
+    /// Focal column, when the query was column-scoped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+    /// `"upstream"` / `"downstream"` for a column-scoped trace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+    /// Column names of the focal model (model-level query only).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub columns: Vec<String>,
+    /// Upstream model names (model-level query only).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub upstream: Vec<String>,
+    /// Downstream model names (model-level query only).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub downstream: Vec<String>,
+    /// Lineage edges: the model-level edge set, or the column trace.
+    pub edges: Vec<LineageEdgeLite>,
+}
+
+/// One failing test in a `test` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TestFailureLite {
+    pub name: String,
+    pub error: String,
+}
+
+/// `test` result — DuckDB-backed local assertions.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TestResult {
+    pub total: usize,
+    pub passed: usize,
+    pub failures: Vec<TestFailureLite>,
+}
+
+/// One row in a `list` result. Each `kind` populates a distinct subset of
+/// fields (absent fields are omitted) — no field is overloaded across kinds:
+///
+/// - **models**: `name`, `target`, `strategy`, `depends_on`.
+/// - **pipelines**: `name`, `pipeline_type`, `target_adapter`, `depends_on`.
+/// - **adapters**: `name`, `adapter_type`, `host`.
+/// - **sources**: `name` (the pipeline), `adapter`, `catalog`.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct ListEntry {
+    /// Primary identifier: the model / pipeline / adapter name, or — for
+    /// `sources` — the owning pipeline name.
+    pub name: String,
+    /// (models) Fully-qualified target table `catalog.schema.table`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// (models) Materialization strategy, e.g. `"full_refresh"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<String>,
+    /// (pipelines) Pipeline type, e.g. `"replication"`, `"transformation"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_type: Option<String>,
+    /// (pipelines) The pipeline's target adapter name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_adapter: Option<String>,
+    /// (adapters) Adapter type, e.g. `"duckdb"`, `"snowflake"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adapter_type: Option<String>,
+    /// (adapters) Connection host, when configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// (sources) Source adapter name for this replication pipeline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adapter: Option<String>,
+    /// (sources) Source catalog, when configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog: Option<String>,
+    /// (models / pipelines) Declared upstream dependencies.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+}
+
+/// `list` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ListResult {
+    /// What was listed: `"models"`, `"pipelines"`, `"adapters"`, `"sources"`.
+    pub kind: String,
+    pub entries: Vec<ListEntry>,
+}
+
+/// One typed column in an `inspect_schema` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ColumnLite {
+    pub name: String,
+    /// Rocky type, e.g. `"Int64"`, `"String"`. `"Unknown"` when unresolved.
+    pub data_type: String,
+    pub nullable: bool,
+}
+
+/// A model or source table with its typed columns.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SchemaEntry {
+    pub name: String,
+    pub columns: Vec<ColumnLite>,
+}
+
+/// `inspect_schema` result — the typed columns of every model + source.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct InspectSchemaResult {
+    pub models: Vec<SchemaEntry>,
+    pub sources: Vec<SchemaEntry>,
+}
+
+/// `sample_rows` result — a capped sample of real rows.
+///
+/// On a non-DuckDB adapter, `unavailable` is `true`, `reason` explains why,
+/// and the data fields are empty. (A single concrete schema is required:
+/// rmcp's output-schema derivation rejects an untyped union.)
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct SampleRowsResult {
+    /// `true` when the tool could not run (e.g. non-DuckDB adapter).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub unavailable: bool,
+    /// Why the tool is unavailable, when `unavailable` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Column names, in result order.
+    pub columns: Vec<String>,
+    /// Sampled rows; each cell is rendered as a string (truncated at 256
+    /// chars). Capped at 50 rows and ~16 KB serialized.
+    pub rows: Vec<Vec<String>>,
+    /// `true` when the cap (rows or bytes) clipped the result.
+    pub truncated: bool,
+}
+
+/// `profile_column` result — one-pass aggregate stats for a column.
+///
+/// On a non-DuckDB adapter, `unavailable` is `true` and `reason` explains why.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct ProfileColumnResult {
+    /// `true` when the tool could not run (e.g. non-DuckDB adapter).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub unavailable: bool,
+    /// Why the tool is unavailable, when `unavailable` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    pub rows: u64,
+    pub nulls: u64,
+    pub null_rate: f64,
+    pub distinct: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<String>,
+}
+
+/// serde `skip_serializing_if` predicate for `bool` fields.
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// `propose` result — the AI-authored plan id awaiting human review.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ProposeResult {
+    /// 64-char blake3 plan id. Apply is gated: run
+    /// `rocky review <plan_id> --approve` then `rocky apply <plan_id>`.
+    pub plan_id: String,
+    /// The models this plan would materialize.
+    pub models: Vec<String>,
+}

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1,0 +1,816 @@
+//! The Rocky MCP server: tool definitions, the `ServerHandler` impl, and the
+//! projection helpers that map Rocky's typed `*Output` cores into the lite,
+//! schemars-1.x result types in [`crate::result_types`].
+
+use std::path::{Path, PathBuf};
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo};
+use rmcp::{Json, ServerHandler, tool, tool_handler, tool_router};
+
+use rocky_cli::commands;
+use rocky_compiler::compile::{self, CompileResult as CompilerResult, CompilerConfig};
+
+use crate::result_types::*;
+
+/// The server's `instructions` — the agent-authoring workflow. Sourced from
+/// the single canonical skill so the MCP guidance never drifts from the
+/// `rocky-ai-workflow` skill. Path is relative to this source file:
+/// `crates/rocky-mcp/src` → repo root is four `..` segments.
+const INSTRUCTIONS: &str = include_str!("../../../../.claude/skills/rocky-ai-workflow/SKILL.md");
+
+/// Stateless Rocky MCP server. Holds only the project locators; every tool
+/// call recompiles from the current on-disk files (correctness over a warm
+/// cache — caching is a deferred optimization).
+#[derive(Clone)]
+pub struct RockyMcpServer {
+    config_path: PathBuf,
+    models_dir: PathBuf,
+    root: PathBuf,
+    tool_router: ToolRouter<Self>,
+}
+
+// ---------------------------------------------------------------------------
+// Tool input parameter structs (schemars 1.x — rmcp's `Parameters<T>` bound).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CompileArgs {
+    /// Optional single-model filter; compile-checks the whole project either
+    /// way but scopes the returned diagnostics to this model when set.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PlanPreviewArgs {
+    /// Optional single-model filter. When unset, previews every model.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct LineageArgs {
+    /// The focal model.
+    pub model: String,
+    /// When set, scope lineage to this column (column-level trace).
+    #[serde(default)]
+    pub column: Option<String>,
+    /// When `true`, trace downstream consumers instead of upstream sources.
+    #[serde(default)]
+    pub downstream: bool,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ListArgs {
+    /// What to list: `"models"`, `"pipelines"`, `"adapters"`, or `"sources"`.
+    pub kind: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct InspectSchemaArgs {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SampleRowsArgs {
+    /// The model whose target table to sample. Must be a compiled model.
+    pub model: String,
+    /// Sample percentage (1–100). Defaults to 10.
+    #[serde(default)]
+    pub percent: Option<u32>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ProfileColumnArgs {
+    /// The model whose target table to profile.
+    pub model: String,
+    /// The column to profile.
+    pub column: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ProposeArgs {
+    /// Single model to materialize. When unset, the plan covers every model.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Caps for the data-grounding tools.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_MAX_ROWS: usize = 50;
+const SAMPLE_MAX_BYTES: usize = 16 * 1024;
+const CELL_MAX_CHARS: usize = 256;
+
+#[tool_router(router = tool_router)]
+impl RockyMcpServer {
+    /// Build a server rooted at `config_path`'s directory; the models
+    /// directory is `<config-dir>/models` (the CLI's top-level convention).
+    pub fn new(config_path: PathBuf) -> Self {
+        let root = config_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let models_dir = root.join("models");
+        Self {
+            config_path,
+            models_dir,
+            root,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    fn state_path(&self) -> PathBuf {
+        rocky_core::state::resolve_state_path(None, &self.models_dir).path
+    }
+
+    /// Path to the project's `data/seed.sql`, if it exists. The playground
+    /// convention is `<project>/models/` + `<project>/data/seed.sql`, so the
+    /// parent of the models dir is the place to look.
+    fn seed_file(&self) -> Option<PathBuf> {
+        let p = self
+            .models_dir
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join("data")
+            .join("seed.sql");
+        p.is_file().then_some(p)
+    }
+
+    /// Compile the project in-process, returning the raw compiler result for
+    /// the lineage / inspect tools. Source schemas come from the warm schema
+    /// cache when one exists, degrading to empty on a cold cache (typecheck
+    /// then falls back to `Unknown` for source-leaf columns — the same
+    /// behaviour as `rocky compile` without a warm cache).
+    fn compile_full(&self) -> anyhow::Result<CompilerResult> {
+        let source_schemas = self.load_source_schemas();
+        let config = CompilerConfig {
+            models_dir: self.models_dir.clone(),
+            contracts_dir: None,
+            source_schemas,
+            source_column_info: std::collections::HashMap::new(),
+            ..Default::default()
+        };
+        compile::compile(&config).map_err(|e| anyhow::anyhow!("compile failed: {e}"))
+    }
+
+    /// Load typed source schemas from the persisted schema cache, honouring
+    /// `[cache.schemas]`. Returns an empty map on a cold cache / missing
+    /// config / disabled cache — the typecheck degrades to `Unknown`.
+    fn load_source_schemas(
+        &self,
+    ) -> std::collections::HashMap<String, Vec<rocky_compiler::types::TypedColumn>> {
+        use rocky_compiler::schema_cache::load_source_schemas_from_cache;
+        use rocky_core::state::StateStore;
+
+        let Ok(cfg) = rocky_core::config::load_rocky_config(&self.config_path) else {
+            return std::collections::HashMap::new();
+        };
+        if !cfg.cache.schemas.enabled {
+            return std::collections::HashMap::new();
+        }
+        let Ok(store) = StateStore::open_read_only(&self.state_path()) else {
+            return std::collections::HashMap::new();
+        };
+        load_source_schemas_from_cache(&store, chrono::Utc::now(), cfg.cache.schemas.ttl())
+            .unwrap_or_default()
+    }
+
+    // -------------------------- MUST tools ---------------------------------
+
+    #[tool(
+        description = "Type-check the Rocky project and return diagnostics (errors/warnings) \
+         plus model count. Always reflects the current on-disk models. Read diagnostics' \
+         code/span/suggestion and fix against them — this is the fast feedback loop."
+    )]
+    async fn compile(
+        &self,
+        params: Parameters<CompileArgs>,
+    ) -> Result<Json<CompileResult>, String> {
+        let model = params.0.model.as_deref();
+        // `--with-seed` hard-fails when `data/seed.sql` is absent, so opt in
+        // only when the project actually ships a seed (the playground does);
+        // otherwise rely on the warm schema cache / cold-cache degradation.
+        let with_seed = self.seed_file().is_some();
+        let output = commands::compile_output(
+            Some(&self.config_path),
+            &self.state_path(),
+            &self.models_dir,
+            None,
+            model,
+            false,
+            None,
+            with_seed,
+            None,
+        )
+        .map_err(|e| format!("{e:#}"))?;
+        Ok(Json(project_compile_result(&output)))
+    }
+
+    #[tool(
+        description = "Preview the exact SQL Rocky would execute for the project's \
+         transformation models (offline, no warehouse connection). Read it to confirm the \
+         generated SQL matches intent before proposing a materialization."
+    )]
+    async fn plan_preview(
+        &self,
+        params: Parameters<PlanPreviewArgs>,
+    ) -> Result<Json<PlanPreviewResult>, String> {
+        let model = params.0.model.as_deref();
+        let output =
+            commands::plan_preview_output(Some(&self.config_path), &self.models_dir, model, None)
+                .map_err(|e| format!("{e:#}"))?;
+        let statements = output
+            .statements
+            .into_iter()
+            .map(|s| PlannedStatementLite {
+                purpose: s.purpose,
+                target: s.target,
+                sql: s.sql,
+            })
+            .collect();
+        Ok(Json(PlanPreviewResult { statements }))
+    }
+
+    #[tool(
+        description = "Explore column-level lineage for a model. Without `column`, returns the \
+         model's columns plus upstream/downstream models and the model-level edge set. With \
+         `column`, returns the column trace; set `downstream` to trace consumers instead of sources."
+    )]
+    async fn lineage(
+        &self,
+        params: Parameters<LineageArgs>,
+    ) -> Result<Json<LineageResult>, String> {
+        let args = params.0;
+        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+
+        if let Some(column) = args.column.as_deref() {
+            let out =
+                commands::column_lineage_output(&result, &args.model, column, args.downstream)
+                    .map_err(|e| format!("{e:#}"))?;
+            let edges = out.trace.iter().map(edge_lite).collect();
+            Ok(Json(LineageResult {
+                model: out.model,
+                column: Some(out.column),
+                direction: Some(out.direction),
+                columns: vec![],
+                upstream: vec![],
+                downstream: vec![],
+                edges,
+            }))
+        } else {
+            let out =
+                commands::lineage_output(&result, &args.model).map_err(|e| format!("{e:#}"))?;
+            let edges = out.edges.iter().map(edge_lite).collect();
+            let columns = out.columns.into_iter().map(|c| c.name).collect();
+            Ok(Json(LineageResult {
+                model: out.model,
+                column: None,
+                direction: None,
+                columns,
+                upstream: out.upstream,
+                downstream: out.downstream,
+                edges,
+            }))
+        }
+    }
+
+    #[tool(
+        description = "Run the project's DuckDB-backed local tests (contracts + assertions) and \
+         return pass/fail counts plus per-failure detail. Use after writing or changing a model."
+    )]
+    async fn test(&self) -> Result<Json<TestResult>, String> {
+        let output = commands::test_output(&self.models_dir, None).map_err(|e| format!("{e:#}"))?;
+        let failures = output
+            .failures
+            .into_iter()
+            .map(|f| TestFailureLite {
+                name: f.name,
+                error: f.error,
+            })
+            .collect();
+        Ok(Json(TestResult {
+            total: output.total,
+            passed: output.passed,
+            failures,
+        }))
+    }
+
+    #[tool(
+        description = "List project entities. `kind` is one of: models, pipelines, adapters, sources."
+    )]
+    async fn list(&self, params: Parameters<ListArgs>) -> Result<Json<ListResult>, String> {
+        let kind = params.0.kind;
+        let entries = match kind.as_str() {
+            "models" => {
+                let out =
+                    commands::list_models_output(&self.models_dir).map_err(|e| format!("{e:#}"))?;
+                out.models
+                    .into_iter()
+                    .map(|m| ListEntry {
+                        name: m.name,
+                        target: Some(m.target),
+                        strategy: Some(m.strategy),
+                        depends_on: m.depends_on,
+                        ..Default::default()
+                    })
+                    .collect()
+            }
+            "pipelines" => {
+                let out = commands::list_pipelines_output(&self.config_path)
+                    .map_err(|e| format!("{e:#}"))?;
+                out.pipelines
+                    .into_iter()
+                    .map(|p| ListEntry {
+                        name: p.name,
+                        pipeline_type: Some(p.pipeline_type),
+                        target_adapter: Some(p.target_adapter),
+                        depends_on: p.depends_on,
+                        ..Default::default()
+                    })
+                    .collect()
+            }
+            "adapters" => {
+                let out = commands::list_adapters_output(&self.config_path)
+                    .map_err(|e| format!("{e:#}"))?;
+                out.adapters
+                    .into_iter()
+                    .map(|a| ListEntry {
+                        name: a.name,
+                        adapter_type: Some(a.adapter_type),
+                        host: a.host,
+                        ..Default::default()
+                    })
+                    .collect()
+            }
+            "sources" => {
+                let out = commands::list_sources_output(&self.config_path)
+                    .map_err(|e| format!("{e:#}"))?;
+                out.sources
+                    .into_iter()
+                    .map(|s| ListEntry {
+                        name: s.pipeline,
+                        adapter: Some(s.adapter),
+                        catalog: s.catalog,
+                        ..Default::default()
+                    })
+                    .collect()
+            }
+            other => {
+                return Err(format!(
+                    "unknown kind '{other}' — expected models, pipelines, adapters, or sources"
+                ));
+            }
+        };
+        Ok(Json(ListResult { kind, entries }))
+    }
+
+    #[tool(
+        description = "Return the typed columns of every model and source table in the project. \
+         Use this to learn what's available to select from and the upstream types — never guess \
+         column names."
+    )]
+    async fn inspect_schema(
+        &self,
+        _params: Parameters<InspectSchemaArgs>,
+    ) -> Result<Json<InspectSchemaResult>, String> {
+        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let (model_schemas, source_tables) = commands::build_schema_context(&result);
+        let to_entries = |buckets: Vec<(String, Vec<rocky_compiler::types::TypedColumn>)>| {
+            buckets
+                .into_iter()
+                .map(|(name, cols)| SchemaEntry {
+                    name,
+                    columns: cols
+                        .into_iter()
+                        .map(|c| ColumnLite {
+                            name: c.name,
+                            data_type: c.data_type.to_string(),
+                            nullable: c.nullable,
+                        })
+                        .collect(),
+                })
+                .collect::<Vec<_>>()
+        };
+        Ok(Json(InspectSchemaResult {
+            models: to_entries(model_schemas),
+            sources: to_entries(source_tables),
+        }))
+    }
+
+    // ------------------------- SHOULD tools --------------------------------
+
+    #[tool(
+        description = "Sample real rows from a model's target table (DuckDB only). Look at \
+         literal values, units, and null patterns the schema can't tell you. Capped at 50 rows / \
+         16 KB; long cells truncated. Returns {unavailable:true} on non-DuckDB adapters."
+    )]
+    async fn sample_rows(
+        &self,
+        params: Parameters<SampleRowsArgs>,
+    ) -> Result<Json<SampleRowsResult>, String> {
+        let args = params.0;
+        let percent = args.percent.unwrap_or(10).clamp(1, 100);
+
+        let prepared = match self.prepare_table_query(&args.model).await {
+            Ok(PreparedTable::Ready(p)) => p,
+            Ok(PreparedTable::Unavailable(reason)) => {
+                return Ok(Json(SampleRowsResult {
+                    unavailable: true,
+                    reason: Some(reason),
+                    ..Default::default()
+                }));
+            }
+            Err(e) => return Err(format!("{e:#}")),
+        };
+
+        // Build: SELECT * FROM <ref> <tablesample> LIMIT n. The table ref is
+        // built only from validated identifiers; never `format!`'d from raw
+        // input. `percent` is a clamped integer.
+        let sample = prepared
+            .dialect_tablesample(percent)
+            .map(|s| format!(" {s}"))
+            .unwrap_or_default();
+        let sql = format!(
+            "SELECT * FROM {}{} LIMIT {}",
+            prepared.table_ref, sample, SAMPLE_MAX_ROWS
+        );
+
+        let qr = prepared
+            .adapter
+            .execute_query(&sql)
+            .await
+            .map_err(|e| format!("sample query failed: {e}"))?;
+
+        let columns = qr.columns.clone();
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        let mut truncated = qr.rows.len() > SAMPLE_MAX_ROWS;
+        let mut bytes = 0usize;
+        for row in qr.rows.into_iter().take(SAMPLE_MAX_ROWS) {
+            let cells: Vec<String> = row.into_iter().map(render_cell).collect();
+            bytes += cells.iter().map(String::len).sum::<usize>();
+            if bytes > SAMPLE_MAX_BYTES {
+                truncated = true;
+                break;
+            }
+            rows.push(cells);
+        }
+
+        Ok(Json(SampleRowsResult {
+            unavailable: false,
+            reason: None,
+            columns,
+            rows,
+            truncated,
+        }))
+    }
+
+    #[tool(
+        description = "Profile one column of a model's target table in a single aggregate query \
+         (DuckDB only): row count, nulls, null rate, distinct count, min, max. Returns \
+         {unavailable:true} on non-DuckDB adapters."
+    )]
+    async fn profile_column(
+        &self,
+        params: Parameters<ProfileColumnArgs>,
+    ) -> Result<Json<ProfileColumnResult>, String> {
+        let args = params.0;
+
+        let prepared = match self.prepare_table_query(&args.model).await {
+            Ok(PreparedTable::Ready(p)) => p,
+            Ok(PreparedTable::Unavailable(reason)) => {
+                return Ok(Json(ProfileColumnResult {
+                    unavailable: true,
+                    reason: Some(reason),
+                    ..Default::default()
+                }));
+            }
+            Err(e) => return Err(format!("{e:#}")),
+        };
+
+        let col = rocky_sql::validation::validate_identifier(&args.column)
+            .map_err(|e| format!("invalid column identifier: {e}"))?;
+
+        let sql = format!(
+            "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n, \
+             CAST(MIN({col}) AS VARCHAR) AS min_v, CAST(MAX({col}) AS VARCHAR) AS max_v \
+             FROM {}",
+            prepared.table_ref
+        );
+
+        let qr = prepared
+            .adapter
+            .execute_query(&sql)
+            .await
+            .map_err(|e| format!("profile query failed: {e}"))?;
+        let row = qr
+            .rows
+            .first()
+            .ok_or_else(|| "profile query returned no rows".to_string())?;
+
+        let as_u64 = |v: &serde_json::Value| -> u64 {
+            match v {
+                serde_json::Value::Number(n) => n.as_u64().unwrap_or(0),
+                serde_json::Value::String(s) => s.parse().unwrap_or(0),
+                _ => 0,
+            }
+        };
+        let total = row.first().map(as_u64).unwrap_or(0);
+        let non_null = row.get(1).map(as_u64).unwrap_or(0);
+        let distinct = row.get(2).map(as_u64).unwrap_or(0);
+        let nulls = total.saturating_sub(non_null);
+        let null_rate = if total == 0 {
+            0.0
+        } else {
+            nulls as f64 / total as f64
+        };
+        let str_cell = |v: Option<&serde_json::Value>| -> Option<String> {
+            match v {
+                Some(serde_json::Value::Null) | None => None,
+                Some(serde_json::Value::String(s)) => Some(s.clone()),
+                Some(other) => Some(other.to_string()),
+            }
+        };
+
+        Ok(Json(ProfileColumnResult {
+            unavailable: false,
+            reason: None,
+            rows: total,
+            nulls,
+            null_rate,
+            distinct,
+            min: str_cell(row.get(3)),
+            max: str_cell(row.get(4)),
+        }))
+    }
+
+    #[tool(
+        description = "Propose materializing the model(s) as an AI-AUTHORED plan. This does NOT \
+         execute anything. It records a plan that a human must review and approve \
+         (`rocky review <plan_id> --approve`) before `rocky apply <plan_id>` will run it. Surface \
+         the plan_id and the review/apply path to the user; never approve on their behalf."
+    )]
+    async fn propose(
+        &self,
+        params: Parameters<ProposeArgs>,
+    ) -> Result<Json<ProposeResult>, String> {
+        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        if result.project.models.is_empty() {
+            return Err("project has no compiled models to propose".to_string());
+        }
+        let models: Vec<String> = result
+            .project
+            .models
+            .iter()
+            .map(|m| m.config.name.clone())
+            .collect();
+
+        // If a model filter was given, assert it exists so we don't write a
+        // plan that applies to nothing.
+        if let Some(model) = params.0.model.as_deref() {
+            if !models.iter().any(|m| m == model) {
+                return Err(format!("model '{model}' not found in project"));
+            }
+        }
+
+        let run_plan = build_ai_run_plan(params.0.model.clone(), &result);
+        let plan_id = rocky_cli::plan_store::write_plan(
+            &self.root,
+            rocky_cli::plan_store::PlanKind::AiAuthored,
+            &run_plan,
+        )
+        .map_err(|e| format!("failed to write AI-authored plan: {e:#}"))?;
+
+        Ok(Json(ProposeResult { plan_id, models }))
+    }
+
+    /// Resolve a model's target table into a runnable, validated table ref +
+    /// the warehouse adapter — but only on DuckDB. Other adapters return the
+    /// typed "unavailable" result so the grounding tools degrade cleanly.
+    async fn prepare_table_query(&self, model_name: &str) -> anyhow::Result<PreparedTable> {
+        let cfg = rocky_core::config::load_rocky_config(&self.config_path)?;
+        let registry = commands_adapter_registry(&cfg)?;
+        let (_, pipeline) = rocky_cli::registry::resolve_pipeline(&cfg, None)?;
+        let target_adapter = pipeline.target_adapter().to_string();
+
+        let adapter_type = registry
+            .adapter_config(&target_adapter)
+            .map(|a| a.adapter_type.clone())
+            .unwrap_or_default();
+        if adapter_type != "duckdb" {
+            return Ok(PreparedTable::Unavailable(
+                "sample_rows/profile_column are DuckDB-only in this release".to_string(),
+            ));
+        }
+
+        // Resolve the model's target coordinates by loading the models dir.
+        let result = self.compile_full()?;
+        let model = result
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == model_name)
+            .ok_or_else(|| anyhow::anyhow!("model '{model_name}' not found in project"))?;
+        let t = &model.config.target;
+
+        // Validate every identifier before composing the ref. DuckDB has no
+        // catalog level, so we emit a two-part `schema.table` name.
+        let schema = rocky_sql::validation::validate_identifier(&t.schema)
+            .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
+        let table = rocky_sql::validation::validate_identifier(&t.table)
+            .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
+        if !t.catalog.is_empty() {
+            rocky_sql::validation::validate_identifier(&t.catalog)
+                .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
+        }
+        let table_ref = format!("{schema}.{table}");
+
+        let adapter = registry.warehouse_adapter(&target_adapter)?;
+        Ok(PreparedTable::Ready(Prepared { adapter, table_ref }))
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for RockyMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::from_build_env())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions(INSTRUCTIONS.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A validated, DuckDB-runnable table reference plus the adapter to run it on.
+struct Prepared {
+    adapter: std::sync::Arc<dyn rocky_core::traits::WarehouseAdapter>,
+    table_ref: String,
+}
+
+impl Prepared {
+    fn dialect_tablesample(&self, percent: u32) -> Option<String> {
+        self.adapter.dialect().tablesample_clause(percent)
+    }
+}
+
+/// Either a runnable table query or the reason a non-DuckDB adapter makes the
+/// data-grounding tool unavailable.
+enum PreparedTable {
+    Ready(Prepared),
+    Unavailable(String),
+}
+
+/// Build the `AdapterRegistry` from the loaded config. Thin wrapper so the
+/// call site reads clearly; the registry constructor lives in rocky-cli.
+fn commands_adapter_registry(
+    cfg: &rocky_core::config::RockyConfig,
+) -> anyhow::Result<rocky_cli::registry::AdapterRegistry> {
+    rocky_cli::registry::AdapterRegistry::from_config(cfg)
+}
+
+/// Project a `CompileOutput` into the trimmed [`CompileResult`].
+fn project_compile_result(output: &rocky_cli::output::CompileOutput) -> CompileResult {
+    use rocky_compiler::diagnostic::Severity;
+    let error_count = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .count();
+    let warning_count = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.severity == Severity::Warning)
+        .count();
+    let diagnostics = output
+        .diagnostics
+        .iter()
+        .map(|d| DiagnosticLite {
+            code: d.code.to_string(),
+            severity: format!("{:?}", d.severity),
+            model: d.model.clone(),
+            message: d.message.to_string(),
+            suggestion: d.suggestion.clone(),
+            span: d
+                .span
+                .as_ref()
+                .map(|s| format!("{}:{}:{}", s.file, s.line, s.col)),
+        })
+        .collect();
+    CompileResult {
+        has_errors: output.has_errors,
+        error_count,
+        warning_count,
+        model_count: output.models,
+        diagnostics,
+    }
+}
+
+/// Project a borrowed `LineageEdgeRecord` into the lite edge shape.
+fn edge_lite(e: &rocky_cli::output::LineageEdgeRecord) -> LineageEdgeLite {
+    LineageEdgeLite {
+        source_model: e.source.model.clone(),
+        source_column: e.source.column.clone(),
+        target_model: e.target.model.clone(),
+        target_column: e.target.column.clone(),
+        transform: e.transform.clone(),
+    }
+}
+
+/// Render one query cell as a display string, truncating long values.
+fn render_cell(v: serde_json::Value) -> String {
+    let s = match v {
+        serde_json::Value::Null => "NULL".to_string(),
+        serde_json::Value::String(s) => s,
+        other => other.to_string(),
+    };
+    if s.chars().count() > CELL_MAX_CHARS {
+        let mut out: String = s.chars().take(CELL_MAX_CHARS).collect();
+        out.push('…');
+        out
+    } else {
+        s
+    }
+}
+
+/// Build an AI-authored `RunPlan` for the given model filter. Constructed
+/// inline (the `rocky plan` builder is private + entangled with discovery);
+/// every field is set explicitly so a future field addition is a compile error
+/// rather than a silent default.
+fn build_ai_run_plan(model: Option<String>, result: &CompilerResult) -> rocky_cli::output::RunPlan {
+    let models: Vec<String> = result
+        .project
+        .models
+        .iter()
+        .map(|m| m.config.name.clone())
+        .collect();
+    let execution_layers: Vec<Vec<String>> = result.project.layers.clone();
+    rocky_cli::output::RunPlan {
+        filter: None,
+        pipeline: None,
+        model,
+        branch: None,
+        partition: None,
+        partition_from: None,
+        partition_to: None,
+        latest: false,
+        missing: false,
+        lookback: None,
+        parallel: 1,
+        run_all: false,
+        env: None,
+        models_dir: None,
+        resume: None,
+        resume_latest: false,
+        shadow: false,
+        shadow_suffix: None,
+        shadow_schema: None,
+        dag: false,
+        idempotency_key: None,
+        governance_override: None,
+        models,
+        execution_layers,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_cell_passes_short_strings_through() {
+        assert_eq!(
+            render_cell(serde_json::Value::String("hello".into())),
+            "hello"
+        );
+        assert_eq!(render_cell(serde_json::Value::Null), "NULL");
+        assert_eq!(render_cell(serde_json::json!(42)), "42");
+    }
+
+    #[test]
+    fn render_cell_truncates_long_strings_with_ellipsis() {
+        let long = "a".repeat(CELL_MAX_CHARS + 100);
+        let out = render_cell(serde_json::Value::String(long));
+        // Truncated to the cap plus a single ellipsis char.
+        assert_eq!(out.chars().count(), CELL_MAX_CHARS + 1);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn caps_are_within_spec() {
+        // Hard caps from the tool spec.
+        assert_eq!(SAMPLE_MAX_ROWS, 50);
+        assert_eq!(SAMPLE_MAX_BYTES, 16 * 1024);
+        assert_eq!(CELL_MAX_CHARS, 256);
+    }
+
+    #[test]
+    fn server_resolves_models_dir_beside_config() {
+        let server = RockyMcpServer::new(PathBuf::from("/tmp/proj/rocky.toml"));
+        assert_eq!(server.models_dir, PathBuf::from("/tmp/proj/models"));
+        assert_eq!(server.root, PathBuf::from("/tmp/proj"));
+    }
+}

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1,0 +1,304 @@
+//! Scripted MCP round-trip tests — no LLM, no network.
+//!
+//! Each test serves a [`RockyMcpServer`] over an in-process duplex pipe and
+//! drives it with an rmcp client, exercising `tools/list` + `tools/call`
+//! exactly as a real harness would over stdio.
+
+use std::path::Path;
+
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rocky_mcp::RockyMcpServer;
+use tempfile::TempDir;
+
+/// Write a minimal DuckDB project: `rocky.toml` + one model + sidecar.
+/// `db_path` is the DuckDB file the adapter connects to.
+fn write_project(dir: &Path, db_path: &Path) {
+    std::fs::create_dir_all(dir.join("models")).unwrap();
+    std::fs::write(
+        dir.join("rocky.toml"),
+        format!(
+            r#"[adapter]
+type = "duckdb"
+path = "{}"
+
+[pipeline.p]
+strategy = "full_refresh"
+
+[pipeline.p.source.discovery]
+adapter = "default"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "main"
+schema_template = "out"
+"#,
+            db_path.display()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("models").join("orders.sql"),
+        "SELECT 1 AS id, 'COMPLETE' AS status\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("models").join("orders.toml"),
+        "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"orders\"\n",
+    )
+    .unwrap();
+}
+
+/// Spawn `server` on one end of a duplex pipe and return a connected client.
+async fn connect(server: RockyMcpServer) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    let (server_io, client_io) = tokio::io::duplex(64 * 1024);
+    tokio::spawn(async move {
+        if let Ok(svc) = server.serve(server_io).await {
+            let _ = svc.waiting().await;
+        }
+    });
+    ().serve(client_io).await.expect("client connects")
+}
+
+#[tokio::test]
+async fn tools_list_returns_expected_set() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut names: Vec<String> = tools.into_iter().map(|t| t.name.to_string()).collect();
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec![
+            "compile",
+            "inspect_schema",
+            "lineage",
+            "list",
+            "plan_preview",
+            "profile_column",
+            "propose",
+            "sample_rows",
+            "test",
+        ]
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn compile_returns_trimmed_shape() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let result = client
+        .call_tool(CallToolRequestParams::new("compile"))
+        .await
+        .expect("compile call");
+
+    assert_ne!(result.is_error, Some(true), "compile should not error");
+    let sc = result
+        .structured_content
+        .expect("compile returns structured content");
+    let obj = sc.as_object().unwrap();
+    // Trimmed shape: counts + diagnostics, no expanded_sql / models_detail.
+    assert_eq!(obj["has_errors"], serde_json::json!(false));
+    assert_eq!(obj["model_count"], serde_json::json!(1));
+    assert!(obj.contains_key("error_count"));
+    assert!(obj.contains_key("warning_count"));
+    assert!(obj.contains_key("diagnostics"));
+    assert!(
+        !obj.contains_key("expanded_sql"),
+        "expanded_sql must be dropped"
+    );
+    assert!(
+        !obj.contains_key("models_detail"),
+        "models_detail must be dropped"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn list_models_round_trips() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let args = serde_json::json!({ "kind": "models" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("list").with_arguments(args))
+        .await
+        .expect("list call");
+    let sc = result.structured_content.expect("structured content");
+    assert_eq!(sc["kind"], serde_json::json!("models"));
+    let entries = sc["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], serde_json::json!("orders"));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn propose_writes_ai_authored_plan() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let result = client
+        .call_tool(CallToolRequestParams::new("propose"))
+        .await
+        .expect("propose call");
+    let sc = result.structured_content.expect("structured content");
+    let plan_id = sc["plan_id"].as_str().expect("plan_id");
+    assert_eq!(plan_id.len(), 64, "blake3 hex is 64 chars");
+
+    // The plan was persisted as an AI-authored plan under .rocky/plans.
+    let plan_path = dir
+        .path()
+        .join(".rocky")
+        .join("plans")
+        .join(format!("{plan_id}.json"));
+    let plan: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&plan_path).unwrap()).unwrap();
+    assert_eq!(plan["kind"], serde_json::json!("ai_authored"));
+
+    client.cancel().await.unwrap();
+}
+
+/// Write a project whose target adapter is Snowflake (not DuckDB) so the
+/// grounding tools must report `unavailable` without touching a warehouse.
+fn write_snowflake_project(dir: &Path) {
+    std::fs::create_dir_all(dir.join("models")).unwrap();
+    std::fs::write(
+        dir.join("rocky.toml"),
+        r#"[adapter]
+type = "snowflake"
+account = "acct"
+username = "u"
+password = "p"
+warehouse = "wh"
+database = "db"
+
+[pipeline.p]
+type = "transformation"
+target = { adapter = "default" }
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("models").join("orders.sql"), "SELECT 1 AS id\n").unwrap();
+    std::fs::write(
+        dir.join("models").join("orders.toml"),
+        "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"db\"\nschema = \"out\"\ntable = \"orders\"\n",
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sample_rows_unavailable_on_non_duckdb_adapter() {
+    let dir = TempDir::new().unwrap();
+    write_snowflake_project(dir.path());
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("sample_rows").with_arguments(args))
+        .await
+        .expect("sample_rows call");
+    let sc = result.structured_content.expect("structured content");
+    assert_eq!(sc["unavailable"], serde_json::json!(true));
+    assert!(
+        sc["reason"].as_str().unwrap().contains("DuckDB-only"),
+        "reason should explain the DuckDB-only limitation"
+    );
+    // Data fields must be empty on the unavailable path.
+    assert!(sc["columns"].as_array().unwrap().is_empty());
+    assert!(sc["rows"].as_array().unwrap().is_empty());
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn profile_column_unavailable_on_non_duckdb_adapter() {
+    let dir = TempDir::new().unwrap();
+    write_snowflake_project(dir.path());
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders", "column": "id" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("profile_column").with_arguments(args))
+        .await
+        .expect("profile_column call");
+    let sc = result.structured_content.expect("structured content");
+    assert_eq!(sc["unavailable"], serde_json::json!(true));
+    assert!(sc["reason"].as_str().unwrap().contains("DuckDB-only"));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn sample_rows_returns_capped_rows_on_duckdb() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("sample.duckdb");
+    write_project(dir.path(), &db_path);
+
+    // Pre-materialize the model's target table so sample_rows has data to read.
+    // The DuckDB adapter the server builds connects to the same file.
+    {
+        use rocky_core::traits::WarehouseAdapter;
+        let adapter = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(&db_path).unwrap();
+        adapter
+            .execute_statement("CREATE SCHEMA IF NOT EXISTS out")
+            .await
+            .unwrap();
+        adapter
+            .execute_statement(
+                "CREATE OR REPLACE TABLE out.orders AS \
+                 SELECT * FROM (VALUES (1,'COMPLETE'),(2,'COMPLETE'),(3,'COMPLETE')) AS t(id,status)",
+            )
+            .await
+            .unwrap();
+    }
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders", "percent": 100 })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("sample_rows").with_arguments(args))
+        .await
+        .expect("sample_rows call");
+    let sc = result.structured_content.expect("structured content");
+    assert_ne!(sc["unavailable"], serde_json::json!(true));
+    let cols = sc["columns"].as_array().unwrap();
+    assert_eq!(cols.len(), 2, "id + status");
+    let rows = sc["rows"].as_array().unwrap();
+    assert!(!rows.is_empty(), "sampled at least one row");
+    assert!(rows.len() <= 50, "capped at 50 rows");
+
+    client.cancel().await.unwrap();
+}

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -1,0 +1,18 @@
+# cargo-deny configuration — minimal, scoped to the schemars dual-major.
+#
+# There is no `cargo deny check` in the engine CI today: the weekly security
+# audit (`.github/workflows/engine-weekly.yml`) runs `cargo audit` against the
+# advisory DB, which does not flag duplicate dependency versions. This file
+# exists so a future `cargo deny check` (or a manual audit) passes cleanly with
+# the one duplicate the MCP server introduces.
+
+[bans]
+multiple-versions = "deny"
+# rmcp 1.7 transitively pulls schemars 1.x (its `#[tool]` param-struct macros
+# derive schemars 1.x `JsonSchema`); the rest of the Rocky workspace pins
+# schemars 0.8 for the `*Output` JSON-schema cascade (dagster + vscode codegen).
+# The two majors are disjoint trait worlds and compile together cleanly, so the
+# duplicate is intentional and accepted.
+skip = [
+    { crate = "schemars", reason = "rmcp 1.7 (schemars 1.x) vs Rocky's *Output cascade (schemars 0.8) — disjoint majors, compiles cleanly" },
+]

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -15,6 +15,7 @@ otel = ["rocky-cli/otel", "rocky-observe/otel"]
 [dependencies]
 rocky-cli = { path = "../crates/rocky-cli", default-features = false }
 rocky-core = { path = "../crates/rocky-core" }
+rocky-mcp = { path = "../crates/rocky-mcp" }
 rocky-observe = { path = "../crates/rocky-observe" }
 anyhow = { workspace = true }
 miette = { workspace = true }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1412,6 +1412,20 @@ enum Command {
         /// Target shell: bash, elvish, fish, powershell, or zsh
         shell: clap_complete::Shell,
     },
+
+    /// Run the Model Context Protocol (MCP) server over stdio.
+    ///
+    /// Exposes Rocky's read-only verification and data-grounding tools
+    /// (compile, plan_preview, lineage, test, list, inspect_schema,
+    /// sample_rows, profile_column, propose) so any MCP-capable agent harness
+    /// can drive Rocky. Long-running: serves until the client disconnects.
+    /// Materialization stays human-gated — the `propose` tool only writes an
+    /// AI-authored plan; a human runs `rocky review --approve` + `rocky apply`.
+    Mcp {
+        /// Pipeline config file the server resolves the project from.
+        #[arg(long, default_value = "rocky.toml")]
+        config: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2921,6 +2935,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             rocky_cli::commands::run_completions::<Cli>(shell, &mut std::io::stdout());
             Ok(())
         }
+        Command::Mcp { config } => rocky_mcp::serve_stdio(config).await,
     };
 
     // SIGINT: map `commands::Interrupted` to the conventional shell exit


### PR DESCRIPTION
## What

A new `rocky mcp` command — an MCP server (stdio, via the official `rmcp` 1.7 SDK) exposing Rocky's typed verification and data-grounding tools to any agent harness (Claude Code, Cursor, Dagster agents).

**9 tools:**
- **Verification** (the differentiated surface): `compile` (trimmed diagnostics), `plan_preview` (offline SQL preview), `lineage`, `test`, `list`, `inspect_schema`.
- **Data grounding** (DuckDB-only this release; typed `unavailable` on other adapters): `sample_rows`, `profile_column`.
- `propose` — writes an AI-authored plan, returns its `plan_id`. The only mutation path; no `run`/`apply`/`seed`/`snapshot` exposed.

Materialization stays human-gated: `propose` → `rocky review --approve` → `rocky apply` (the #665 gate). Confirmed end-to-end — `apply` of a proposed plan is refused until reviewed.

The server's `instructions` are the merged `rocky-ai-workflow` skill (single source via `include_str!`), so a connecting agent learns the workflow without external docs.

## Why

The agent loop is the fast-improving commodity layer; Rocky's durable value is the typed verifier. Exposing it over MCP ships that verifier into every harness and rides their improvements, rather than maintaining a bespoke in-engine loop — and it's a discoverable, `claude mcp add rocky`-installable artifact.

## Notes

- **Stateless per call** (recompiles fresh, always reflects on-disk edits); a warm Salsa cache is a documented deferred optimization.
- `rmcp` transitively pulls `schemars 1.x` while the workspace uses `schemars 0.8` — disjoint majors, compiles cleanly; documented + skipped in a new `engine/deny.toml`.
- Tool results are trimmed projections (the raw `*Output` structs are token-heavy), built on the `pub`-widened cores from #668.
- Grounding-tool SQL is built only from `rocky_sql::validation`-validated identifiers + a clamped integer percent.
- **Descoped to follow-up**: the Claude-Code POC (`06-mcp-grounding/`) and a `build_model` MCP prompt. The scripted round-trip test covers the regression-guard purpose.
- **MSRV unverified on 1.85.1**: engine-CI builds on `stable` and the 1.85.1 toolchain isn't installed locally. A one-time `cargo +1.85.1 build -p rocky-mcp` would confirm the rmcp/schemars-1.x tree; if it needs >1.85.1, bump the workspace MSRV deliberately or raise this crate's `rust-version`.

## Test

`cargo test -p rocky-mcp`: 4 unit + 7 integration, including a scripted in-process stdio round-trip (tools/list, trimmed compile, DuckDB `sample_rows`, non-DuckDB unavailable gating, propose-writes-ai-authored). `cargo test -p rocky-cli`: 598 pass (pub-widening intact). fmt/clippy clean; `just codegen` zero-drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)