### PR TITLE
feat(examples): add mcp-grounding POC — data-grounded model authoring

### DIFF
--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -90,9 +90,9 @@ Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive 
 | [11-strategy-showcase](pocs/02-performance/11-strategy-showcase) | Three strategies side-by-side on one source: `full_refresh` + `incremental` + `merge`, with a cheat-sheet README |
 | [12-replication-table-overrides](pocs/02-performance/12-replication-table-overrides) | `[[table_overrides]]` — per-table `strategy`/`merge_keys`/`timestamp_column`/`enabled` overrides with glob matching and most-specific-match-wins resolution |
 
-### 03 — AI (5 POCs · `ANTHROPIC_API_KEY` required)
+### 03 — AI (6 POCs · `ANTHROPIC_API_KEY` for 01–05, DuckDB for 06)
 
-AI-powered model generation, intent extraction, schema sync, test generation, schema-grounded validation.
+AI-powered model generation, intent extraction, schema sync, test generation, schema-grounded validation, and MCP data-grounding.
 
 | POC | Feature |
 |---|---|
@@ -101,6 +101,7 @@ AI-powered model generation, intent extraction, schema sync, test generation, sc
 | [03-ai-sync-schema-evolution](pocs/03-ai/03-ai-sync-schema-evolution) | `rocky ai-sync` proposes downstream updates after upstream schema changes |
 | [04-ai-test-generation](pocs/03-ai/04-ai-test-generation) | `rocky ai-test --all --save` generates SQL assertions from intent + schema |
 | [05-schema-grounded-validation](pocs/03-ai/05-schema-grounded-validation) | **Trust arc 5** — `ValidationContext` schema grounding + compile-verify retry loop |
+| [06-mcp-grounding](pocs/03-ai/06-mcp-grounding) | `rocky mcp` server — a schema-only model compiles but reconciles wrong; sampling the data via the MCP tools fixes it (creds-free `run.sh`) |
 
 ### 04 — Governance (7 POCs · Databricks / DuckDB)
 

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/.mcp.json
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rocky": {
+      "command": "rocky",
+      "args": ["mcp", "--config", "rocky.toml"]
+    }
+  }
+}

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
@@ -1,0 +1,117 @@
+# 06-mcp-grounding — schema-only models compile but reconcile wrong; the MCP tools fix it
+
+> **Category:** 03-ai
+> **Credentials:** none — the `run.sh` is deterministic and creds-free (no LLM, no Claude Code). The optional interactive demo needs Claude Code with MCP support.
+> **Runtime:** < 5s
+> **Rocky features:** `rocky mcp` server (`inspect_schema`, `sample_rows`, `profile_column`, `compile`, `plan_preview`, `propose`), `rocky review`/`rocky apply` human gate, `rocky test --declarative`
+
+## What it shows
+
+A model can compile cleanly and still produce the wrong answer, because the schema alone hides the two things that decide correctness: the literal values in a column and the units a number is stored in. This POC makes that gap concrete, then shows how grounding the model in real data via the `rocky mcp` tools closes it.
+
+It ships two transformation models over the same source:
+
+- `revenue_naive.sql` — the plausible schema-only guess: `WHERE status = 'completed'`, `SUM(amount_cents)` treated as dollars. It compiles. It returns the wrong number.
+- `revenue_correct.sql` — written after looking at the data: `WHERE status = 'COMPLETE'`, `SUM(amount_cents) / 100.0`. It reconciles to the true total and carries a typed assertion that locks the invariant in place.
+
+## Why it's distinctive
+
+- **"It compiled" is not "it's correct."** Both models pass `rocky compile`. Schema-only verification cannot tell them apart. Only the data can.
+- **The trap is realistic.** A `WHERE status = 'completed'` that silently matches zero rows, and an `amount_cents` summed as dollars (100x too large), are two of the most common reconcile bugs in real pipelines. They are exactly what an agent that reads column names but never samples rows gets wrong.
+- **The fix is a tool, not a prompt trick.** The Rocky MCP server hands an agent `sample_rows` and `profile_column`, so it sees `'COMPLETE'` and the cents scale before it writes a filter. The correctness it learns becomes a `[[tests]]` assertion, not a comment.
+- **Materialization stays human-gated.** The agent can `propose` a plan, but a human runs `rocky review <plan-id> --approve` before `rocky apply`. The agent never ships unreviewed SQL.
+
+## The engineered scenario
+
+`data/seed.sql` seeds eight orders:
+
+| trap | reality | the schema-only guess |
+|---|---|---|
+| `status` | only ever `'COMPLETE'` (plus `'PENDING'`, `'CANCELLED'`) | `WHERE status = 'completed'` matches zero rows |
+| `amount_cents` | integer **cents** | summed as dollars, 100x too large |
+
+Five completed orders sum to `12500 + 7500 + 30000 + 5000 + 45000 = 100000` cents = **$1000.00**.
+
+- `revenue_naive` produces `revenue_usd = NULL` — the `'completed'` filter matches nothing, so `SUM` over zero rows is NULL. A confidently shipped zero.
+- `revenue_correct` produces `revenue_usd = 1000.00`.
+
+## Layout
+
+```
+.
+├── README.md                 this file
+├── .mcp.json                 registers the Rocky MCP server for Claude Code
+├── rocky.toml                DuckDB pipeline (persistent poc.duckdb)
+├── run.sh                    deterministic, creds-free reconcile-gap proof
+├── data/seed.sql             the engineered traps (uppercase status + cents)
+└── models/
+    ├── _defaults.toml        catalog=poc, schema=demo
+    ├── revenue_naive.sql      schema-only guess — compiles, reconciles wrong
+    ├── revenue_naive.toml     full_refresh, no assertion (its author never looked)
+    ├── revenue_correct.sql    data-grounded — reconciles to $1000.00
+    └── revenue_correct.toml   full_refresh + [[tests]] aggregate SUM = 1000
+```
+
+## Prerequisites
+
+- `rocky` on PATH (the script also auto-detects a local `engine/target/{release,debug}/rocky` build)
+- `duckdb` CLI for seeding and materializing (`brew install duckdb`)
+
+## Run
+
+```bash
+./run.sh
+```
+
+The script is deterministic and needs no credentials. It compiles both models (both pass), shows the source data so the traps are visible, materializes both models, reconciles them side by side, and runs `rocky test --declarative` so the grounded model's assertion goes green.
+
+> Note: the value assertion runs under `rocky test --declarative`, which executes the sidecar `[[tests]]` against the materialized target table. The default `rocky test` (no flag) only checks that a model's SQL executes — it does not evaluate `[[tests]]`. That is why `run.sh` materializes the tables first, then runs the declarative path.
+
+## Expected output
+
+```text
+==> 4. Reconcile naive vs correct
+    revenue_naive   (WHERE status='completed', cents-as-dollars) -> revenue_usd = NULL
+    revenue_correct (WHERE status='COMPLETE',  cents/100.0)      -> revenue_usd = 1000.00
+    Confirmed: the naive guess is wrong; only the grounded model is right.
+
+==> 5. rocky test --declarative — the grounded model's assertion passes
+  ✓ revenue_correct.revenue_usd [aggregate]
+  Result: 1 passed, 0 failed, 0 warned, 0 errored
+```
+
+## The interactive MCP demo (Claude Code)
+
+`run.sh` proves the gap with no agent in the loop. This section layers the live demo on top: an agent driving the Rocky MCP tools to reach `revenue_correct` on its own.
+
+`.mcp.json` registers the server:
+
+```json
+{ "mcpServers": { "rocky": { "command": "rocky", "args": ["mcp", "--config", "rocky.toml"] } } }
+```
+
+Open this directory in Claude Code (it picks up `.mcp.json`), confirm the `rocky` MCP server is connected, then give it the prompt:
+
+> Build a Rocky model for total completed-order revenue in USD from the orders source.
+
+### Expected agent trajectory
+
+1. **`inspect_schema`** — learns the source columns: `order_id`, `customer_id`, `status`, `amount_cents`, `ordered_at`. A column called `status` and one called `amount_cents` are all the schema offers.
+2. **`sample_rows`** — sees real rows. The `status` values are `'COMPLETE'` (uppercase), never `'completed'`. This is the step a schema-only agent skips.
+3. **`profile_column`** on `amount_cents` — sees the scale: values like 12500, 30000, 45000. Integer cents, not dollars.
+4. **Writes the model** — `WHERE status = 'COMPLETE'`, `SUM(amount_cents) / 100.0 AS revenue_usd`. Equivalent to `revenue_correct.sql`.
+5. **`compile`** — type-checks clean. So would the naive model; compile is necessary, not sufficient.
+6. **`plan_preview`** — reads the exact SQL that would run and confirms it matches intent.
+7. **`propose`** — records an AI-authored plan and returns a `plan_id`. The agent stops here. It does not apply.
+8. **Human review** — you run `rocky review <plan-id>` to read the breaking-change report, then `rocky review <plan-id> --approve` to sign off, then `rocky apply <plan-id>` to materialize.
+9. **`rocky test --declarative`** — the `SUM(revenue_usd) = 1000` assertion reconciles green.
+
+### Why a schema-only agent ships `revenue_naive`
+
+Without `sample_rows` and `profile_column`, the agent has only column names. `status` strongly implies a value like `'completed'`, and an agent in a hurry sees `amount_cents` and sums it. Both guesses are reasonable from the schema and both are wrong. The model compiles, so nothing flags it. The bug surfaces only when someone reconciles the number, by which point it has shipped. The MCP tools move that discovery to authoring time, and the `[[tests]]` assertion keeps it discovered.
+
+## Related
+
+- Agent workflow: the `rocky-ai-workflow` skill — the same text the MCP server ships as its `instructions`.
+- MCP server source: `engine/crates/rocky-mcp/`.
+- Sibling POCs: [`01-model-generation/`](../01-model-generation/), [`05-schema-grounded-validation/`](../05-schema-grounded-validation/).

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/data/seed.sql
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/data/seed.sql
@@ -1,0 +1,33 @@
+-- Engineered reconcile trap. Two columns carry surprises that the schema
+-- alone cannot reveal:
+--
+--   status        Only ever 'COMPLETE' (uppercase). A schema-only guess of
+--                 WHERE status = 'completed' compiles fine and returns ZERO
+--                 rows. The other statuses are 'PENDING' and 'CANCELLED'.
+--
+--   amount_cents  Stored in CENTS as an integer. Summing it as-if-dollars
+--                 overstates revenue by 100x.
+--
+-- Correct completed-order revenue:
+--   (12500 + 7500 + 30000 + 5000 + 45000) cents = 100000 cents = $1000.00
+CREATE SCHEMA IF NOT EXISTS seeds;
+
+CREATE OR REPLACE TABLE seeds.orders (
+    order_id      BIGINT,
+    customer_id   BIGINT,
+    status        VARCHAR,
+    amount_cents  BIGINT,
+    ordered_at    TIMESTAMP
+);
+
+INSERT INTO seeds.orders VALUES
+    -- Completed orders — these five make up the true revenue.
+    (1, 101, 'COMPLETE',  12500, TIMESTAMP '2026-01-02 09:14:00'),
+    (2, 102, 'COMPLETE',   7500, TIMESTAMP '2026-01-02 11:40:00'),
+    (3, 103, 'COMPLETE',  30000, TIMESTAMP '2026-01-03 08:05:00'),
+    (4, 104, 'COMPLETE',   5000, TIMESTAMP '2026-01-03 16:22:00'),
+    (5, 105, 'COMPLETE',  45000, TIMESTAMP '2026-01-04 10:01:00'),
+    -- Non-completed orders — must NOT count toward completed revenue.
+    (6, 106, 'PENDING',   90000, TIMESTAMP '2026-01-04 12:30:00'),
+    (7, 107, 'CANCELLED', 25000, TIMESTAMP '2026-01-05 14:45:00'),
+    (8, 108, 'PENDING',   18000, TIMESTAMP '2026-01-05 17:10:00');

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/models/_defaults.toml
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/models/_defaults.toml
@@ -1,0 +1,3 @@
+[target]
+catalog = "poc"
+schema = "demo"

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_correct.sql
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_correct.sql
@@ -1,0 +1,9 @@
+-- The data-grounded model.
+--
+-- Written after sampling real rows (the MCP `sample_rows` + `profile_column`
+-- tools, or a direct DuckDB query): status is uppercase 'COMPLETE', and
+-- amount_cents is in cents. Filter on the literal that exists, divide by 100
+-- to land in dollars.
+SELECT SUM(amount_cents) / 100.0 AS revenue_usd
+FROM seeds.orders
+WHERE status = 'COMPLETE'

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_correct.toml
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_correct.toml
@@ -1,0 +1,15 @@
+[strategy]
+type = "full_refresh"
+
+# The invariant learned from sampling, encoded as a typed assertion. Completed
+# revenue is exactly $1000.00 — five completed orders summing to 100000 cents.
+# `rocky test --declarative` runs SUM(revenue_usd) against the materialized
+# target table; the equality holds only for the data-grounded model. The naive
+# model carries no such assertion because its author never looked at the data.
+[[tests]]
+type = "aggregate"
+op = "sum"
+column = "revenue_usd"
+cmp = "eq"
+value = "1000"
+severity = "error"

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_naive.sql
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_naive.sql
@@ -1,0 +1,10 @@
+-- The plausible schema-only guess.
+--
+-- An agent that read the column names but never looked at the data writes
+-- exactly this: filter on the lowercase status it expected, sum the amount
+-- column as if it were dollars. It compiles. It is wrong twice over:
+--   1. status = 'completed' never matches (the data holds 'COMPLETE') → 0 rows.
+--   2. amount_cents is in cents, not dollars.
+SELECT SUM(amount_cents) AS revenue_usd
+FROM seeds.orders
+WHERE status = 'completed'

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_naive.toml
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/models/revenue_naive.toml
@@ -1,0 +1,2 @@
+[strategy]
+type = "full_refresh"

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/rocky.toml
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/rocky.toml
@@ -1,0 +1,21 @@
+# 06-mcp-grounding — schema-only authoring vs data-grounded authoring.
+#
+# Persistent DuckDB file: `rocky test --declarative` runs the [[tests]] in a
+# model sidecar against the materialized target table, so the table must
+# already exist in this file (run.sh materializes it first).
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "demo"

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/run.sh
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# 06-mcp-grounding — schema-only authoring reconciles WRONG; grounding in the
+# real data fixes it. Deterministic, credential-free: no LLM, no Claude Code.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# Prefer an explicitly-set binary, then the local feature-branch build, then
+# `rocky` on PATH.
+ROCKY_BIN="${ROCKY_BIN:-}"
+if [[ -z "$ROCKY_BIN" ]]; then
+    REPO_ROOT="$(cd "$HERE/../../../../.." && pwd)"
+    if [[ -x "$REPO_ROOT/engine/target/release/rocky" ]]; then
+        ROCKY_BIN="$REPO_ROOT/engine/target/release/rocky"
+    elif [[ -x "$REPO_ROOT/engine/target/debug/rocky" ]]; then
+        ROCKY_BIN="$REPO_ROOT/engine/target/debug/rocky"
+    else
+        ROCKY_BIN="rocky"
+    fi
+fi
+echo "==> Using rocky binary: $ROCKY_BIN ($("$ROCKY_BIN" --version))"
+
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+mkdir -p expected
+
+# --- 1. Both models compile clean -------------------------------------------
+#
+# This is the trap. Schema-only verification is satisfied by BOTH models — the
+# wrong one and the right one. "It compiled" tells you nothing about whether
+# the result reconciles.
+echo
+echo "==> 1. rocky compile — both models type-check (the naive model included)"
+"$ROCKY_BIN" compile --models models -o json > expected/compile.json 2>/dev/null
+python3 -c "import json; d=json.load(open('expected/compile.json')); print('    has_errors:', d['has_errors'], '| models:', d['models'])"
+
+# --- 2. Look at the real data -----------------------------------------------
+#
+# The two surprises a schema can't show you: status is uppercase 'COMPLETE'
+# (not 'completed'), and amount is in CENTS (not dollars).
+echo
+echo "==> 2. Sample the source — the traps a schema cannot reveal"
+duckdb poc.duckdb < data/seed.sql
+echo "    distinct status values:"
+duckdb -noheader -list poc.duckdb \
+    "SELECT '      ' || string_agg(DISTINCT status, ', ') FROM seeds.orders;"
+echo "    a few rows (note amount_cents is in cents):"
+duckdb -box poc.duckdb \
+    "SELECT order_id, status, amount_cents FROM seeds.orders ORDER BY order_id LIMIT 5;"
+
+# --- 3. Materialize both models ---------------------------------------------
+#
+# `rocky test --declarative` runs the sidecar [[tests]] against the
+# materialized target table, so the tables must exist in poc.duckdb first.
+echo
+echo "==> 3. Materialize both models into poc.demo.*"
+duckdb poc.duckdb "CREATE SCHEMA IF NOT EXISTS demo;"
+duckdb poc.duckdb "CREATE OR REPLACE TABLE demo.revenue_naive   AS $(cat models/revenue_naive.sql);"
+duckdb poc.duckdb "CREATE OR REPLACE TABLE demo.revenue_correct AS $(cat models/revenue_correct.sql);"
+
+# --- 4. The reconcile gap ---------------------------------------------------
+NAIVE=$(duckdb -noheader -list poc.duckdb \
+    "SELECT COALESCE(CAST(revenue_usd AS VARCHAR), 'NULL') FROM demo.revenue_naive;")
+CORRECT=$(duckdb -noheader -list poc.duckdb \
+    "SELECT printf('%.2f', revenue_usd) FROM demo.revenue_correct;")
+
+echo
+echo "==> 4. Reconcile naive vs correct"
+echo "    revenue_naive   (WHERE status='completed', cents-as-dollars) -> revenue_usd = $NAIVE"
+echo "    revenue_correct (WHERE status='COMPLETE',  cents/100.0)      -> revenue_usd = $CORRECT"
+
+# Enforce the gap at the shell level so the story can't silently rot: the naive
+# model must NOT reconcile to the true total.
+if [[ "$NAIVE" == "1000.00" || "$NAIVE" == "1000.0" || "$NAIVE" == "1000" ]]; then
+    echo "    ERROR: naive model unexpectedly reconciled to the true total." >&2
+    exit 1
+fi
+if [[ "$CORRECT" != "1000.00" ]]; then
+    echo "    ERROR: correct model did not reconcile to the expected \$1000.00." >&2
+    exit 1
+fi
+echo "    Confirmed: the naive guess is wrong; only the grounded model is right."
+
+# --- 5. The typed assertion is green for the grounded model -----------------
+#
+# revenue_correct carries a [[tests]] aggregate assertion (SUM(revenue_usd) =
+# 1000). It passes. The naive model carries no such assertion — its author
+# never looked at the data, so there was nothing to encode.
+echo
+echo "==> 5. rocky test --declarative — the grounded model's assertion passes"
+"$ROCKY_BIN" -c rocky.toml test --models models --declarative -o json > expected/test.json
+python3 -c "
+import json
+d = json.load(open('expected/test.json'))['declarative']
+print('    aggregate assertion on revenue_correct:',
+      f\"{d['passed']} passed, {d['failed']} failed, {d['errored']} errored\")
+"
+"$ROCKY_BIN" -c rocky.toml test --models models --declarative -o table
+
+echo
+echo "POC complete: schema-only authoring compiled but reconciled WRONG"
+echo "(revenue_usd = $NAIVE); the data-grounded model reconciled to the true"
+echo "\$$CORRECT and its typed assertion is green. The interactive MCP demo"
+echo "(README.md + .mcp.json) shows an agent reaching the grounded model on"
+echo "its own via the Rocky MCP tools."

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -1,13 +1,13 @@
 # POC Catalog
 
-76 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
+77 small POCs across 8 categories. Each is self-contained — `cd` into a POC folder and run `./run.sh`.
 
 ## Categories
 
 - [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage + config layering + branch approve/promote + file-format ingest + per-tenant routing (11 POCs · DuckDB)
 - [01-quality](01-quality/) — Contracts, checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline (6 POCs · DuckDB)
 - [02-performance](02-performance/) — Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, trust-arc 2 cost+budgets, strategy showcase (11 POCs · DuckDB)
-- [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation (5 POCs · `ANTHROPIC_API_KEY`)
+- [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation, MCP data-grounding (6 POCs · `ANTHROPIC_API_KEY` for 5, DuckDB for the MCP-grounding POC)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention, auto-create schemas (7 POCs · Databricks / DuckDB)
 - [05-orchestration](05-orchestration/) — Hooks, webhooks, state, resume, Valkey cache, trust-arc 3 circuit breaker, idempotency keys, state retention sweep (10 POCs · DuckDB / docker)
 - [06-developer-experience](06-developer-experience/) — Lineage, serve, dbt migration, shadow, CI, hybrid dbt workflows, trust-arc 4 trace-Gantt, trust-arc 6 portability lint, trust-arc 7 SQL types, PR-preview, lineage-diff, catalog emit, watch inner-loop, dbt-import failure modes, semantic breaking-change gate, history rolling stats, trace+cost+replay combo, view strategy, dbt unit-test import (19 POCs · DuckDB)
@@ -17,8 +17,8 @@
 
 | POCs | Credentials |
 |---|---|
-| 63 of 76 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
-| 5 (`03-ai/*`) | `ANTHROPIC_API_KEY` |
+| 64 of 77 | None — local DuckDB (or docker-compose for MinIO / Valkey / Trino) |
+| 5 (`03-ai/01..05`) | `ANTHROPIC_API_KEY` |
 | 4 (`04-governance/01..04`) + 1 (`07-adapters/02`) | Databricks host + token |
 | 1 (`07-adapters/01`) | Snowflake account + auth |
 | 1 (`07-adapters/03`) | Fivetran API key (read-only) |


### PR DESCRIPTION
## What

A credential-free POC at `examples/playground/pocs/03-ai/06-mcp-grounding/` that makes the thesis behind the new `rocky mcp` server concrete: **a model can compile cleanly and still reconcile wrong**, because the schema hides the two things that decide correctness — the literal values in a column and the units a number is stored in.

It ships two models over the same seed:
- `revenue_naive.sql` — the schema-only guess (`WHERE status = 'completed'`, `SUM(amount_cents)` as dollars). Compiles. Returns `NULL` (the `'completed'` filter matches zero rows — the data only ever has `'COMPLETE'`).
- `revenue_correct.sql` — written after looking at the data (`WHERE status = 'COMPLETE'`, `SUM(amount_cents) / 100.0`). Reconciles to **$1000.00** and carries a `[[tests]]` assertion that locks the invariant in.

`./run.sh` is deterministic and creds-free: it compiles both (both pass), shows the source traps, materializes both, reconciles them side by side, and runs `rocky test --declarative` green. `.mcp.json` + the README layer the interactive Claude-Code demo on top (the agent driving `inspect_schema` → `sample_rows` → `profile_column` → correct SQL → `propose` → human `review`/`apply`).

## Why

It's the proof of the reconcile narrative: "it compiled" is not "it's correct," and the MCP grounding tools move that discovery to authoring time. It also exercises the full human-gated path — the agent can `propose` but never `apply` unreviewed.

## Test

`./run.sh` exits 0 (naive → NULL, correct → $1000.00, declarative assertion green). Auto-included in the credential-free smoke suite (`scripts/run-all-duckdb.sh`): suite stays green at **62 passed / 0 failed / 16 skipped**. No engine/Rust changes — config + SQL + shell + markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)