### PR TITLE
feat(vscode): governance compliance panel

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -296,6 +296,12 @@
         "category": "Rocky"
       },
       {
+        "command": "rocky.compliance",
+        "title": "Check Governance Compliance",
+        "category": "Rocky",
+        "icon": "$(shield)"
+      },
+      {
         "command": "rocky.previewCreate",
         "title": "Rocky: Preview Create (PR diff)",
         "category": "Rocky"
@@ -715,6 +721,11 @@
           "command": "rocky.showCompiledSql",
           "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
           "group": "rocky@5"
+        },
+        {
+          "command": "rocky.compliance",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@6"
         }
       ]
     },

--- a/editors/vscode/src/__tests__/compliancePanel.test.ts
+++ b/editors/vscode/src/__tests__/compliancePanel.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({}));
+
+import {
+  complianceVerdict,
+  formatEnvStatuses,
+} from "../webviews/compliancePanel";
+
+describe("complianceVerdict", () => {
+  it("ok when every classified column resolves to a strategy", () => {
+    expect(
+      complianceVerdict({
+        total_classified: 3,
+        total_masked: 3,
+        total_exceptions: 0,
+      }),
+    ).toBe("ok");
+  });
+
+  it("fail when there are exceptions", () => {
+    expect(
+      complianceVerdict({
+        total_classified: 3,
+        total_masked: 1,
+        total_exceptions: 2,
+      }),
+    ).toBe("fail");
+  });
+
+  it("warn when unmasked columns are allow-listed (the gap)", () => {
+    // 3 classified, 1 masked, 0 exceptions → 2 allow-listed unresolved.
+    expect(
+      complianceVerdict({
+        total_classified: 3,
+        total_masked: 1,
+        total_exceptions: 0,
+      }),
+    ).toBe("warn");
+  });
+});
+
+describe("formatEnvStatuses", () => {
+  it("joins env statuses and flags unenforced ones", () => {
+    expect(
+      formatEnvStatuses([
+        { env: "default", masking_strategy: "hash", enforced: true },
+        { env: "prod", masking_strategy: "unresolved", enforced: false },
+      ]),
+    ).toBe("default: hash · prod: unresolved ⚠");
+  });
+
+  it("handles a single env", () => {
+    expect(
+      formatEnvStatuses([
+        { env: "default", masking_strategy: "redact", enforced: true },
+      ]),
+    ).toBe("default: redact");
+  });
+});

--- a/editors/vscode/src/commands/governance.ts
+++ b/editors/vscode/src/commands/governance.ts
@@ -1,0 +1,25 @@
+import { resolveProjectRoot } from "../config";
+import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
+import type { ComplianceOutput } from "../types/generated/compliance";
+import { showCompliance } from "../webviews/compliancePanel";
+import { ensureWorkspace } from "./ui";
+
+/**
+ * `rocky.compliance` — run the static governance check and render the rollup.
+ *
+ * `rocky compliance` is a purely static resolver (classification sidecars vs
+ * `[mask]` policy, no warehouse calls), so this is cheap to run on demand.
+ */
+export async function compliance(): Promise<void> {
+  if (!ensureWorkspace()) return;
+  try {
+    const result = await runRockyJsonWithProgress<ComplianceOutput>(
+      "Checking governance compliance…",
+      ["compliance", "--output", "json"],
+      { cwd: resolveProjectRoot() },
+    );
+    showCompliance(result);
+  } catch (err) {
+    showRockyError("Compliance check failed", err);
+  }
+}

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -13,6 +13,7 @@ import {
   reportBug,
   viewMarketplace,
 } from "./info";
+import { compliance } from "./governance";
 import { catalog, history, metrics } from "./inspect";
 import { registerLineageSerializer, showLineage } from "./lineage";
 import { importDbt, validateMigration } from "./migration";
@@ -82,6 +83,9 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     // Health & analysis
     vscode.commands.registerCommand("rocky.doctor", doctor),
     vscode.commands.registerCommand("rocky.optimize", optimize),
+
+    // Governance
+    vscode.commands.registerCommand("rocky.compliance", compliance),
 
     // Preview (PR-bundle)
     vscode.commands.registerCommand("rocky.previewCreate", previewCreate),

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -59,6 +59,14 @@ suite("Rocky Extension", () => {
     assert.deepStrictEqual(missing, [], `Missing commands: ${missing.join(", ")}`);
   });
 
+  test("rocky.compliance command is registered", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(
+      commands.includes("rocky.compliance"),
+      "rocky.compliance command should be registered",
+    );
+  });
+
   test("rocky.doctor command exists", async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(

--- a/editors/vscode/src/webviews/compliancePanel.ts
+++ b/editors/vscode/src/webviews/compliancePanel.ts
@@ -1,0 +1,119 @@
+import * as vscode from "vscode";
+import type {
+  ColumnClassificationStatus,
+  ComplianceException,
+  ComplianceOutput,
+  ComplianceSummary,
+  EnvMaskingStatus,
+} from "../types/generated/compliance";
+import { buildHead, escapeHtml, makeNonce } from "./htmlUtil";
+
+/**
+ * Overall verdict for a compliance report. `fail` when any classified column
+ * is unmasked-where-expected; `warn` when columns are unmasked but explicitly
+ * allow-listed (the `total_classified − total_masked − total_exceptions` gap);
+ * `ok` when every classified column resolves to a masking strategy.
+ */
+export function complianceVerdict(summary: ComplianceSummary): "ok" | "warn" | "fail" {
+  if (summary.total_exceptions > 0) return "fail";
+  const allowListed =
+    summary.total_classified - summary.total_masked - summary.total_exceptions;
+  return allowListed > 0 ? "warn" : "ok";
+}
+
+/**
+ * Render a column's per-environment masking status as a compact string, e.g.
+ * `default: hash · prod: redact · dev: unresolved`. Pure — unit-tested.
+ */
+export function formatEnvStatuses(envs: EnvMaskingStatus[]): string {
+  return envs
+    .map((e) => `${e.env}: ${e.masking_strategy}${e.enforced ? "" : " ⚠"}`)
+    .join(" · ");
+}
+
+/** Open a webview rendering the structured output of `rocky compliance`. */
+export function showCompliance(result: ComplianceOutput): void {
+  const panel = vscode.window.createWebviewPanel(
+    "rockyCompliance",
+    "Rocky compliance",
+    vscode.ViewColumn.Beside,
+    { enableScripts: false, retainContextWhenHidden: true },
+  );
+  panel.webview.html = render(panel.webview, result);
+}
+
+function render(webview: vscode.Webview, result: ComplianceOutput): string {
+  const nonce = makeNonce();
+  const s = result.summary;
+  const verdict = complianceVerdict(s);
+  const allowListed = s.total_classified - s.total_masked - s.total_exceptions;
+
+  const exceptionRows = result.exceptions
+    .map(
+      (e: ComplianceException) => `
+      <tr>
+        <td>${escapeHtml(e.model)}</td>
+        <td>${escapeHtml(e.column)}</td>
+        <td>${escapeHtml(e.env)}</td>
+        <td>${escapeHtml(e.reason)}</td>
+      </tr>`,
+    )
+    .join("");
+
+  const perColumnRows = result.per_column
+    .map(
+      (c: ColumnClassificationStatus) => `
+      <tr>
+        <td>${escapeHtml(c.model)}</td>
+        <td>${escapeHtml(c.column)}</td>
+        <td><code>${escapeHtml(c.classification)}</code></td>
+        <td>${escapeHtml(formatEnvStatuses(c.envs))}</td>
+      </tr>`,
+    )
+    .join("");
+
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+${buildHead(webview, nonce, "Rocky compliance")}
+<body>
+  <h1>Rocky compliance <span class="badge ${verdict}">${verdict}</span></h1>
+  <p class="muted">Static governance check — classification sidecars vs <code>[mask]</code> policy. No warehouse calls.</p>
+
+  <div class="stat-grid">
+    ${stat("Classified", s.total_classified)}
+    ${stat("Masked", s.total_masked)}
+    ${stat("Exceptions", s.total_exceptions)}
+    ${stat("Allow-listed", allowListed)}
+  </div>
+
+  ${
+    exceptionRows
+      ? `<h2>Exceptions (${result.exceptions.length})</h2>
+    <p class="muted">Classified columns with no resolved masking strategy, not on the allow list.</p>
+    <table>
+      <thead><tr><th>Model</th><th>Column</th><th>Env</th><th>Reason</th></tr></thead>
+      <tbody>${exceptionRows}</tbody>
+    </table>`
+      : `<p class="badge ok">No exceptions — every classified column resolves to a masking strategy.</p>`
+  }
+
+  ${
+    perColumnRows
+      ? `<h2>Classified columns (${result.per_column.length})</h2>
+    <table>
+      <thead><tr><th>Model</th><th>Column</th><th>Tag</th><th>Masking by env</th></tr></thead>
+      <tbody>${perColumnRows}</tbody>
+    </table>`
+      : `<p class="muted">No classified columns found. Tag columns via a <code>[classification]</code> block in a model sidecar.</p>`
+  }
+</body>
+</html>`;
+}
+
+function stat(label: string, value: number): string {
+  return /* html */ `
+    <div class="stat">
+      <div class="label">${escapeHtml(label)}</div>
+      <div class="value">${value}</div>
+    </div>`;
+}


### PR DESCRIPTION
First of the **Phase-2 series** surfacing Rocky capabilities that have a CLI command but no editor UX. `rocky compliance` had none — this adds it.

## What it does

`rocky.compliance` (command palette + model context menu) runs `rocky compliance --output json` — the static governance resolver that answers *"are all classified columns masked wherever policy says they should be?"* (no warehouse calls) — and renders a webview report:

- **Verdict badge** — `ok` (every classified column resolves to a strategy), `warn` (unmasked but allow-listed), `fail` (unmasked-where-expected exceptions).
- **Summary tallies** — classified / masked / exceptions / allow-listed.
- **Exceptions table** — model · column · env · reason.
- **Per-column status** — classification tag + resolved masking strategy across every environment (unenforced flagged).

Pairs naturally with the inline-masking work already shipped (#667/#669): masking *applies* the policy at preview/run; compliance *audits* coverage. dbt has no equivalent.

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (135 tests, +5 for `complianceVerdict` / `formatEnvStatuses`) all clean. A test-electron smoke asserts `rocky.compliance` registers. Extension-only — consumes the existing `ComplianceOutput` schema, no engine change.

Full Phase-2 roadmap (the four chosen features + the remaining no-UX commands: `replay`, `trace`, `lineage-diff`, `estimate`, `dag`, branch lifecycle, etc.) is tracked in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)