### PR TITLE
feat(vscode): execution-plan panel (rocky dag)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -302,6 +302,12 @@
         "icon": "$(shield)"
       },
       {
+        "command": "rocky.dag",
+        "title": "Show Execution Plan",
+        "category": "Rocky",
+        "icon": "$(list-tree)"
+      },
+      {
         "command": "rocky.previewCreate",
         "title": "Rocky: Preview Create (PR diff)",
         "category": "Rocky"
@@ -726,6 +732,11 @@
           "command": "rocky.compliance",
           "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
           "group": "rocky@6"
+        },
+        {
+          "command": "rocky.dag",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@7"
         }
       ]
     },

--- a/editors/vscode/src/__tests__/executionPlanPanel.test.ts
+++ b/editors/vscode/src/__tests__/executionPlanPanel.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({}));
+
+import {
+  formatKindCounts,
+  maxParallelism,
+  nodeLabel,
+} from "../webviews/executionPlanPanel";
+
+describe("maxParallelism", () => {
+  it("is the widest layer", () => {
+    expect(maxParallelism([["a"], ["b", "c"], ["d"]])).toBe(2);
+  });
+  it("is 0 for an empty plan", () => {
+    expect(maxParallelism([])).toBe(0);
+  });
+});
+
+describe("formatKindCounts", () => {
+  it("renders sorted kind counts", () => {
+    expect(formatKindCounts({ transformation: 5, source: 2 })).toBe(
+      "2 source · 5 transformation",
+    );
+  });
+  it("handles a single kind", () => {
+    expect(formatKindCounts({ transformation: 1 })).toBe("1 transformation");
+  });
+});
+
+describe("nodeLabel", () => {
+  const byId = new Map([["transformation:stg_orders", "stg_orders"]]);
+  it("prefers the node label", () => {
+    expect(nodeLabel("transformation:stg_orders", byId)).toBe("stg_orders");
+  });
+  it("falls back to the id with the kind prefix stripped", () => {
+    expect(nodeLabel("source:raw.orders", byId)).toBe("raw.orders");
+  });
+});

--- a/editors/vscode/src/commands/dag.ts
+++ b/editors/vscode/src/commands/dag.ts
@@ -1,0 +1,26 @@
+import { resolveProjectRoot } from "../config";
+import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
+import type { DagOutput } from "../types/generated/dag";
+import { showExecutionPlan } from "../webviews/executionPlanPanel";
+import { ensureWorkspace } from "./ui";
+
+/**
+ * `rocky.dag` — show the pipeline's execution plan (topological waves).
+ *
+ * Purely static (compile + topo sort, no warehouse calls). Distinct from the
+ * lineage graph: this is the *run schedule* — which models execute in parallel
+ * in which order.
+ */
+export async function showDag(): Promise<void> {
+  if (!ensureWorkspace()) return;
+  try {
+    const result = await runRockyJsonWithProgress<DagOutput>(
+      "Building execution plan…",
+      ["dag", "--output", "json"],
+      { cwd: resolveProjectRoot() },
+    );
+    showExecutionPlan(result);
+  } catch (err) {
+    showRockyError("Execution plan failed", err);
+  }
+}

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -4,6 +4,7 @@ import { aiExplain, aiGenerate, aiSync, aiTest } from "./ai";
 import { branchApprove, branchPromote } from "./branch";
 import { commandPalette } from "./commandPalette";
 import { ci, compile, validate } from "./compile";
+import { showDag } from "./dag";
 import { hooksList, hooksTest } from "./hooks";
 import {
   init,
@@ -86,6 +87,9 @@ export function registerCommands(context: vscode.ExtensionContext): void {
 
     // Governance
     vscode.commands.registerCommand("rocky.compliance", compliance),
+
+    // Execution plan (topological run schedule)
+    vscode.commands.registerCommand("rocky.dag", showDag),
 
     // Preview (PR-bundle)
     vscode.commands.registerCommand("rocky.previewCreate", previewCreate),

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -67,6 +67,14 @@ suite("Rocky Extension", () => {
     );
   });
 
+  test("rocky.dag command is registered", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(
+      commands.includes("rocky.dag"),
+      "rocky.dag command should be registered",
+    );
+  });
+
   test("rocky.doctor command exists", async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(

--- a/editors/vscode/src/webviews/executionPlanPanel.ts
+++ b/editors/vscode/src/webviews/executionPlanPanel.ts
@@ -1,0 +1,94 @@
+import * as vscode from "vscode";
+import type { DagNodeOutput, DagOutput } from "../types/generated/dag";
+import { buildHead, escapeHtml, makeNonce } from "./htmlUtil";
+
+/** Widest execution layer — the max number of models that run in parallel. */
+export function maxParallelism(layers: string[][]): number {
+  return layers.reduce((m, layer) => Math.max(m, layer.length), 0);
+}
+
+/** Render `counts_by_kind` as `5 transformation · 2 source`, sorted by kind. */
+export function formatKindCounts(counts: Record<string, number>): string {
+  return Object.entries(counts)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([kind, n]) => `${n} ${kind}`)
+    .join(" · ");
+}
+
+/**
+ * Human label for a DAG node id. Prefers the node's `label`; falls back to the
+ * id with its `{kind}:` prefix stripped (e.g. `transformation:stg` → `stg`).
+ */
+export function nodeLabel(id: string, byId: Map<string, string>): string {
+  return byId.get(id) ?? id.replace(/^[^:]+:/, "");
+}
+
+/** Open a webview rendering the execution plan from `rocky dag`. */
+export function showExecutionPlan(result: DagOutput): void {
+  const panel = vscode.window.createWebviewPanel(
+    "rockyExecutionPlan",
+    "Rocky execution plan",
+    vscode.ViewColumn.Beside,
+    { enableScripts: false, retainContextWhenHidden: true },
+  );
+  panel.webview.html = render(panel.webview, result);
+}
+
+function render(webview: vscode.Webview, result: DagOutput): string {
+  const nonce = makeNonce();
+  const s = result.summary;
+  const byId = new Map<string, string>(
+    result.nodes.map((n: DagNodeOutput) => [n.id, n.label]),
+  );
+
+  const waves = result.execution_layers
+    .map((layer, i) => {
+      const chips = layer
+        .map((id) => `<span class="chip">${escapeHtml(nodeLabel(id, byId))}</span>`)
+        .join(" ");
+      const parallel = layer.length > 1 ? ` <span class="muted">· ${layer.length} in parallel</span>` : "";
+      return /* html */ `
+        <div class="wave">
+          <div class="wave-label">Wave ${i + 1}${parallel}</div>
+          <div class="chips">${chips}</div>
+        </div>`;
+    })
+    .join("");
+
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+${buildHead(webview, nonce, "Rocky execution plan", waveStyles())}
+<body>
+  <h1>Execution plan</h1>
+  <p class="muted">Topological run schedule — models in the same wave have no mutual dependencies and run in parallel.</p>
+
+  <div class="stat-grid">
+    ${stat("Models", s.total_nodes)}
+    ${stat("Waves", s.execution_layers)}
+    ${stat("Edges", s.total_edges)}
+    ${stat("Max parallel", maxParallelism(result.execution_layers))}
+  </div>
+
+  <p class="muted">${escapeHtml(formatKindCounts(s.counts_by_kind))}</p>
+
+  ${waves || `<p class="muted">No models to schedule.</p>`}
+</body>
+</html>`;
+}
+
+function stat(label: string, value: number): string {
+  return /* html */ `
+    <div class="stat">
+      <div class="label">${escapeHtml(label)}</div>
+      <div class="value">${value}</div>
+    </div>`;
+}
+
+function waveStyles(): string {
+  return `
+    .wave { display:flex; gap:12px; align-items:baseline; padding:8px 0; border-bottom:1px solid var(--vscode-panel-border); }
+    .wave-label { min-width:140px; font-weight:600; }
+    .chips { display:flex; flex-wrap:wrap; gap:6px; }
+    .chip { display:inline-block; padding:2px 8px; border-radius:4px; background:var(--vscode-editorWidget-background); border:1px solid var(--vscode-panel-border); }
+  `;
+}


### PR DESCRIPTION
Phase-2 series, surfacing another Rocky capability with no editor UX: `rocky dag`.

## What it does

`rocky.dag` (palette + model context menu) runs `rocky dag --output json` — purely static (compile + topological sort, no warehouse calls) — and renders an **execution-plan** webview:

- **Waves** — `execution_layers` rendered as ordered waves; models in the same wave have no mutual dependencies and run in parallel.
- **Summary** — models / waves / edges / max-parallelism.
- **Per-kind counts** — e.g. `2 source · 5 transformation`.

Distinct from the existing lineage graph: lineage answers *"what depends on what"*; this answers *"what's the run schedule / what runs in parallel."*

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (144 tests, +6 for `maxParallelism` / `formatKindCounts` / `nodeLabel`) all clean. A test-electron smoke asserts `rocky.dag` registers. Extension-only — consumes the existing `DagOutput` schema, no engine change.

Phase-2 remaining: ad-hoc SQL preview (awaiting governance greenlight), branch workflow, AI author-loop, the rest of observability (`replay`/`trace`/`estimate`), LSP live-buffer spike — tracked in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)