### PR TITLE
feat(vscode): branches view

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -345,6 +345,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "rocky.refreshBranches",
+        "title": "Refresh Branches",
+        "category": "Rocky",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "rocky.refreshSources",
         "title": "Refresh Sources",
         "category": "Rocky",
@@ -551,6 +557,14 @@
           "visibility": "collapsed"
         },
         {
+          "id": "rocky.branches",
+          "name": "Branches",
+          "type": "tree",
+          "icon": "$(git-branch)",
+          "contextualTitle": "Rocky Branches",
+          "visibility": "collapsed"
+        },
+        {
           "id": "rocky.help",
           "name": "Help",
           "type": "tree",
@@ -658,9 +672,24 @@
           "command": "rocky.refreshPreviews",
           "when": "view == rocky.previews",
           "group": "navigation"
+        },
+        {
+          "command": "rocky.refreshBranches",
+          "when": "view == rocky.branches",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
+        {
+          "command": "rocky.branchApprove",
+          "when": "view == rocky.branches && viewItem == rockyBranch",
+          "group": "1_promote@1"
+        },
+        {
+          "command": "rocky.branchPromote",
+          "when": "view == rocky.branches && viewItem == rockyBranch",
+          "group": "1_promote@2"
+        },
         {
           "command": "rocky.compile",
           "when": "view == rocky.models && viewItem == rockyModel",

--- a/editors/vscode/src/__tests__/branchesView.test.ts
+++ b/editors/vscode/src/__tests__/branchesView.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+// branchesView extends vscode.TreeItem at module load and transitively imports
+// getStartedView, which instantiates a module-scope EventEmitter — so the mock
+// must provide both as constructors.
+vi.mock("vscode", () => ({
+  EventEmitter: class {
+    event(): { dispose(): void } {
+      return { dispose() {} };
+    }
+    fire(): void {}
+  },
+  TreeItem: class {
+    constructor(public label?: string) {}
+  },
+  TreeItemCollapsibleState: { None: 0 },
+  ThemeIcon: class {
+    constructor(public id?: string) {}
+  },
+}));
+
+import { branchDescription, branchTooltip } from "../views/branchesView";
+import type { BranchEntry } from "../types/generated/branch_list";
+
+const entry: BranchEntry = {
+  name: "fix-price",
+  created_by: "alice@example.com",
+  created_at: "2026-05-24T10:00:00Z",
+  schema_prefix: "branch__fix_price",
+  description: "tweak the price rounding",
+};
+
+describe("branchDescription", () => {
+  it("is the creator", () => {
+    expect(branchDescription(entry)).toBe("alice@example.com");
+  });
+});
+
+describe("branchTooltip", () => {
+  it("includes name, schema prefix, creator, and description", () => {
+    const t = branchTooltip(entry);
+    expect(t).toContain("Branch: fix-price");
+    expect(t).toContain("Schema prefix: branch__fix_price");
+    expect(t).toContain("Created by: alice@example.com");
+    expect(t).toContain("tweak the price rounding");
+  });
+
+  it("omits the description line when absent", () => {
+    const t = branchTooltip({ ...entry, description: null });
+    expect(t).not.toContain("tweak");
+    expect(t).toContain("Branch: fix-price");
+  });
+});

--- a/editors/vscode/src/commands/branch.ts
+++ b/editors/vscode/src/commands/branch.ts
@@ -14,13 +14,25 @@ import {
 const BRANCH_NAME_PLACEHOLDER = "e.g., fix-price";
 const FILTER_PLACEHOLDER = "e.g., client=acme";
 
-export async function branchApprove(): Promise<void> {
+/** Branch name from a Branches-view tree item (or a string), else undefined. */
+function resolveBranchName(arg: unknown): string | undefined {
+  if (typeof arg === "string" && arg.length > 0) return arg;
+  if (arg && typeof arg === "object" && "branchName" in arg) {
+    const name = (arg as { branchName?: unknown }).branchName;
+    if (typeof name === "string" && name.length > 0) return name;
+  }
+  return undefined;
+}
+
+export async function branchApprove(arg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
-  const name = await promptForInput("Branch name to approve", {
-    placeHolder: BRANCH_NAME_PLACEHOLDER,
-    required: true,
-  });
+  const name =
+    resolveBranchName(arg) ??
+    (await promptForInput("Branch name to approve", {
+      placeHolder: BRANCH_NAME_PLACEHOLDER,
+      required: true,
+    }));
   if (!name) return;
 
   const message = await promptForInput("Approval message (optional)", {
@@ -46,13 +58,15 @@ export async function branchApprove(): Promise<void> {
   }
 }
 
-export async function branchPromote(): Promise<void> {
+export async function branchPromote(arg?: unknown): Promise<void> {
   if (!ensureWorkspace()) return;
 
-  const name = await promptForInput("Branch name to promote", {
-    placeHolder: BRANCH_NAME_PLACEHOLDER,
-    required: true,
-  });
+  const name =
+    resolveBranchName(arg) ??
+    (await promptForInput("Branch name to promote", {
+      placeHolder: BRANCH_NAME_PLACEHOLDER,
+      required: true,
+    }));
   if (!name) return;
 
   const filter = await promptForInput("Filter (optional, key=value)", {

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -102,6 +102,7 @@ suite("Rocky Extension", () => {
       "rocky.refreshModels",
       "rocky.refreshRuns",
       "rocky.refreshSources",
+      "rocky.refreshBranches",
     ]) {
       assert.ok(
         commands.includes(expected),

--- a/editors/vscode/src/views/branchesView.ts
+++ b/editors/vscode/src/views/branchesView.ts
@@ -1,0 +1,108 @@
+import * as vscode from "vscode";
+import { runRockyJson } from "../rockyCli";
+import type { BranchEntry, BranchListOutput } from "../types/generated/branch_list";
+import { hasRockyProject, onDidChangeRockyProject } from "./getStartedView";
+
+/** One-line secondary label for a branch row (its creator). */
+export function branchDescription(entry: BranchEntry): string {
+  return entry.created_by;
+}
+
+/** Hover tooltip: schema prefix, creator, timestamp, and description. */
+export function branchTooltip(entry: BranchEntry): string {
+  const lines = [
+    `Branch: ${entry.name}`,
+    `Schema prefix: ${entry.schema_prefix}`,
+    `Created by: ${entry.created_by}`,
+    `Created at: ${entry.created_at}`,
+  ];
+  if (entry.description) lines.push(`\n${entry.description}`);
+  return lines.join("\n");
+}
+
+class BranchTreeItem extends vscode.TreeItem {
+  readonly branchName: string;
+  constructor(entry: BranchEntry) {
+    super(entry.name, vscode.TreeItemCollapsibleState.None);
+    this.branchName = entry.name;
+    this.description = branchDescription(entry);
+    this.tooltip = branchTooltip(entry);
+    this.contextValue = "rockyBranch";
+    this.iconPath = new vscode.ThemeIcon("git-branch");
+  }
+}
+
+class MessageItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super(message, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = "rockyBranchMessage";
+  }
+}
+
+type Node = BranchTreeItem | MessageItem;
+
+/**
+ * Tree view of registered Rocky branches, backed by `rocky branch list
+ * --output json`. Read-only; per-branch actions (approve / promote) dispatch to
+ * the existing branch commands from the item context menu.
+ */
+export class BranchesTreeProvider implements vscode.TreeDataProvider<Node> {
+  private readonly emitter = new vscode.EventEmitter<Node | undefined | void>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  private cache: BranchEntry[] | undefined;
+  private loadError: string | undefined;
+
+  refresh(): void {
+    this.cache = undefined;
+    this.loadError = undefined;
+    this.emitter.fire();
+  }
+
+  getTreeItem(element: Node): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: Node): Promise<Node[]> {
+    if (element) return [];
+    if (!hasRockyProject()) return [];
+
+    if (this.cache === undefined && this.loadError === undefined) {
+      try {
+        const result = await runRockyJson<BranchListOutput>([
+          "branch",
+          "list",
+          "--output",
+          "json",
+        ]);
+        this.cache = result.branches ?? [];
+      } catch (err) {
+        this.loadError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    if (this.loadError) return [new MessageItem("Failed to list branches")];
+    const branches = this.cache ?? [];
+    if (branches.length === 0) {
+      return [new MessageItem("No branches — create one with rocky branch create")];
+    }
+    return branches.map((b) => new BranchTreeItem(b));
+  }
+}
+
+export function registerBranchesView(
+  context: vscode.ExtensionContext,
+): BranchesTreeProvider {
+  const provider = new BranchesTreeProvider();
+  const view = vscode.window.createTreeView("rocky.branches", {
+    treeDataProvider: provider,
+  });
+  context.subscriptions.push(
+    view,
+    vscode.commands.registerCommand("rocky.refreshBranches", () =>
+      provider.refresh(),
+    ),
+    onDidChangeRockyProject(() => provider.refresh()),
+  );
+  return provider;
+}

--- a/editors/vscode/src/views/index.ts
+++ b/editors/vscode/src/views/index.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { registerBranchesView } from "./branchesView";
 import { registerExtensionInfoView } from "./extensionInfoView";
 import type { ExtensionInfoTreeProvider } from "./extensionInfoView";
 import { registerGetStartedView } from "./getStartedView";
@@ -31,6 +32,7 @@ export function registerViews(context: vscode.ExtensionContext): void {
   registerSourcesView(context);
   registerSchemaView(context);
   previewProvider = registerPreviewView(context);
+  registerBranchesView(context);
   registerHelpView(context);
   queryResultsProvider = registerQueryResultsView(context);
 }


### PR DESCRIPTION
Phase-2 series — the read-only core of the branch workflow, surfacing `rocky branch list` (no editor UX before).

## What it does

- **Branches view** (`rocky.branches`, in the Rocky activity bar) lists registered branches via `rocky branch list --output json` — name, creator, schema prefix, description — with a refresh action.
- **Approve / Promote from the tree** — the existing `rocky.branchApprove` / `rocky.branchPromote` commands are wired into each branch's context menu; they now take the branch name from the tree item, falling back to a prompt when run from the palette.

This makes Rocky's branch governance actions reachable from the sidebar and surfaces the branch registry. Branch diff/compare and create-from-editor are natural follow-ups.

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (147 tests, +3 for `branchDescription` / `branchTooltip`) all clean. A test-electron smoke asserts `rocky.refreshBranches` registers. Extension-only — consumes the existing `BranchListOutput` schema, no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)