### PR TITLE
feat(vscode): run-trace timeline panel

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -308,6 +308,12 @@
         "icon": "$(list-tree)"
       },
       {
+        "command": "rocky.trace",
+        "title": "Trace Latest Run",
+        "category": "Rocky",
+        "icon": "$(pulse)"
+      },
+      {
         "command": "rocky.previewCreate",
         "title": "Rocky: Preview Create (PR diff)",
         "category": "Rocky"
@@ -766,6 +772,11 @@
           "command": "rocky.dag",
           "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
           "group": "rocky@7"
+        },
+        {
+          "command": "rocky.trace",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@8"
         }
       ]
     },

--- a/editors/vscode/src/__tests__/runTracePanel.test.ts
+++ b/editors/vscode/src/__tests__/runTracePanel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({}));
+
+import { barGeometry, formatMs } from "../webviews/runTracePanel";
+
+describe("formatMs", () => {
+  it("formats sub-second, second, and minute durations", () => {
+    expect(formatMs(340)).toBe("340ms");
+    expect(formatMs(1200)).toBe("1.2s");
+    expect(formatMs(65_000)).toBe("1m 5s");
+  });
+});
+
+describe("barGeometry", () => {
+  it("places a bar by its offset and duration", () => {
+    expect(barGeometry(500, 250, 1000)).toEqual({ leftPct: 50, widthPct: 25 });
+  });
+  it("spans the full track when it covers the whole run", () => {
+    expect(barGeometry(0, 1000, 1000)).toEqual({ leftPct: 0, widthPct: 100 });
+  });
+  it("floors width so tiny models stay visible", () => {
+    const g = barGeometry(0, 0, 1000);
+    expect(g.widthPct).toBe(0.5);
+  });
+  it("falls back to full width when total duration is zero", () => {
+    expect(barGeometry(0, 0, 0)).toEqual({ leftPct: 0, widthPct: 100 });
+  });
+  it("never overflows the track", () => {
+    const g = barGeometry(900, 500, 1000);
+    expect(g.leftPct + g.widthPct).toBeLessThanOrEqual(100);
+  });
+});

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -23,6 +23,7 @@ import { previewCost, previewCreate, previewDiff } from "./preview";
 import { previewCte, previewModel } from "./previewRows";
 import { compare, discover, plan, run } from "./run";
 import { archive, compact, profileStorage } from "./storage";
+import { trace } from "./trace";
 import { test } from "./test";
 
 /**
@@ -90,6 +91,9 @@ export function registerCommands(context: vscode.ExtensionContext): void {
 
     // Execution plan (topological run schedule)
     vscode.commands.registerCommand("rocky.dag", showDag),
+
+    // Run trace (timeline of the latest run)
+    vscode.commands.registerCommand("rocky.trace", trace),
 
     // Preview (PR-bundle)
     vscode.commands.registerCommand("rocky.previewCreate", previewCreate),

--- a/editors/vscode/src/commands/trace.ts
+++ b/editors/vscode/src/commands/trace.ts
@@ -1,0 +1,26 @@
+import { resolveProjectRoot } from "../config";
+import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
+import type { TraceOutput } from "../types/generated/trace";
+import { showRunTrace } from "../webviews/runTracePanel";
+import { ensureWorkspace } from "./ui";
+
+/**
+ * `rocky.trace` — show the execution timeline of the latest run.
+ *
+ * Traces `latest` (the most recent run in the state store) and renders a gantt
+ * of per-model timing + parallel lanes. Read-only — reads run history, runs
+ * nothing.
+ */
+export async function trace(): Promise<void> {
+  if (!ensureWorkspace()) return;
+  try {
+    const result = await runRockyJsonWithProgress<TraceOutput>(
+      "Tracing latest run…",
+      ["trace", "latest", "--output", "json"],
+      { cwd: resolveProjectRoot() },
+    );
+    showRunTrace(result);
+  } catch (err) {
+    showRockyError("Run trace failed", err);
+  }
+}

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -75,6 +75,14 @@ suite("Rocky Extension", () => {
     );
   });
 
+  test("rocky.trace command is registered", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(
+      commands.includes("rocky.trace"),
+      "rocky.trace command should be registered",
+    );
+  });
+
   test("rocky.doctor command exists", async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(

--- a/editors/vscode/src/webviews/runTracePanel.ts
+++ b/editors/vscode/src/webviews/runTracePanel.ts
@@ -1,0 +1,109 @@
+import * as vscode from "vscode";
+import type { TraceModelEntry, TraceOutput } from "../types/generated/trace";
+import { buildHead, escapeHtml, makeNonce } from "./htmlUtil";
+
+/** Human-readable duration: `340ms`, `1.2s`, `1m 5s`. */
+export function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  return `${m}m ${s}s`;
+}
+
+/**
+ * Left offset + width (percent of the run's total duration) for a model's
+ * gantt bar. Width is floored at 0.5% so sub-millisecond models stay visible,
+ * and clamped so the bar never overflows the track. Pure — unit-tested.
+ */
+export function barGeometry(
+  startOffsetMs: number,
+  durationMs: number,
+  totalMs: number,
+): { leftPct: number; widthPct: number } {
+  if (totalMs <= 0) return { leftPct: 0, widthPct: 100 };
+  const leftPct = Math.max(0, Math.min(100, (startOffsetMs / totalMs) * 100));
+  const widthPct = Math.max(0.5, Math.min(100 - leftPct, (durationMs / totalMs) * 100));
+  return { leftPct, widthPct };
+}
+
+/** `failed`/`error` statuses render in the fail color; everything else ok. */
+function statusClass(status: string): "ok" | "fail" {
+  return /fail|error/i.test(status) ? "fail" : "ok";
+}
+
+/** Open a webview rendering the run timeline from `rocky trace`. */
+export function showRunTrace(result: TraceOutput): void {
+  const panel = vscode.window.createWebviewPanel(
+    "rockyRunTrace",
+    `Rocky run trace`,
+    vscode.ViewColumn.Beside,
+    { enableScripts: false, retainContextWhenHidden: true },
+  );
+  panel.webview.html = render(panel.webview, result);
+}
+
+function render(webview: vscode.Webview, result: TraceOutput): string {
+  const nonce = makeNonce();
+  const total = result.run_duration_ms;
+  const verdict = statusClass(result.status);
+
+  const rows = [...result.models]
+    .sort((a, b) => a.start_offset_ms - b.start_offset_ms)
+    .map((m: TraceModelEntry) => {
+      const { leftPct, widthPct } = barGeometry(m.start_offset_ms, m.duration_ms, total);
+      const cls = statusClass(m.status);
+      const lane = typeof m.lane === "number" ? `L${m.lane}` : "";
+      return /* html */ `
+      <tr>
+        <td>${escapeHtml(m.model_name)}</td>
+        <td class="muted">${escapeHtml(lane)}</td>
+        <td>${escapeHtml(formatMs(m.duration_ms))}</td>
+        <td class="track">
+          <div class="bar ${cls}" style="margin-left:${leftPct.toFixed(2)}%;width:${widthPct.toFixed(2)}%" title="${escapeHtml(m.status)} · ${escapeHtml(formatMs(m.duration_ms))}"></div>
+        </td>
+      </tr>`;
+    })
+    .join("");
+
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+${buildHead(webview, nonce, "Rocky run trace", traceStyles())}
+<body>
+  <h1>Run trace <span class="badge ${verdict}">${escapeHtml(result.status)}</span></h1>
+  <p class="muted">Run <code>${escapeHtml(result.run_id)}</code> · ${escapeHtml(result.trigger)} · started ${escapeHtml(result.started_at)}</p>
+
+  <div class="stat-grid">
+    ${stat("Duration", formatMs(total))}
+    ${stat("Models", result.models.length)}
+    ${stat("Lanes", result.lane_count)}
+  </div>
+
+  ${
+    rows
+      ? `<table>
+      <thead><tr><th>Model</th><th>Lane</th><th>Duration</th><th>Timeline</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`
+      : `<p class="muted">No model executions recorded for this run.</p>`
+  }
+</body>
+</html>`;
+}
+
+function stat(label: string, value: string | number): string {
+  return /* html */ `
+    <div class="stat">
+      <div class="label">${escapeHtml(label)}</div>
+      <div class="value">${escapeHtml(String(value))}</div>
+    </div>`;
+}
+
+function traceStyles(): string {
+  return `
+    td.track { width: 50%; min-width: 200px; }
+    td.track .bar { height: 14px; border-radius: 3px; min-width: 2px; }
+    .bar.ok { background: var(--vscode-testing-iconPassed); }
+    .bar.fail { background: var(--vscode-testing-iconFailed); }
+  `;
+}


### PR DESCRIPTION
Phase-2 observability — surfaces `rocky trace` (no editor UX before) as a run-timeline gantt.

## What it does

`rocky.trace` (palette + model context menu) runs `rocky trace latest --output json` — read-only, reads the latest run from the state store, executes nothing — and renders:

- **Gantt timeline** — each model positioned by `start_offset_ms` / `duration_ms` on the run's total duration, colored by status, labeled with its parallel **lane**.
- **Summary** — total duration / models / lanes; a status verdict badge.

Answers *"why was my last run slow / what ran in parallel"* — distinct from the Runs view (run list/status) and the execution-plan panel (static schedule). A "Trace this run" action on Runs-view items (a specific run-id) is a natural follow-up.

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (153 tests, +6 for `formatMs` / `barGeometry`) all clean. A test-electron smoke asserts `rocky.trace` registers. Extension-only — consumes the existing `TraceOutput` schema, no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)