### PR TITLE
feat(engine/rocky-mcp): build_model MCP prompt + workspace MSRV → 1.88

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --check
 ```
 
-The engine is a Cargo workspace with 23 members — 21 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.85). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
+The engine is a Cargo workspace with 23 members — 21 library crates plus the `rocky` and `rocky-lsp` binaries (Rust edition 2024, MSRV 1.88). Run a single crate's tests with `cargo test -p rocky-core`. End-to-end tests in `crates/rocky-core/tests/e2e.rs` use DuckDB and need no credentials.
 
 ### Dagster integration (`integrations/dagster/`)
 

--- a/docs/src/content/docs/advanced/contributing.md
+++ b/docs/src/content/docs/advanced/contributing.md
@@ -88,7 +88,7 @@ just --list      # All recipes
 ## Coding Standards
 
 ### Rust
-- **Edition**: 2024 (MSRV 1.85)
+- **Edition**: 2024 (MSRV 1.88)
 - **Error handling**: `thiserror` for library errors, `anyhow` for binary/CLI errors
 - **Logging**: `tracing` crate (not `println!`)
 - **SQL safety**: All identifiers validated via `rocky-sql/validation.rs` before interpolation

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ Direct downloads from the [releases page](https://github.com/rocky-data/rocky/re
 
 ## Build from source
 
-Requires Rust 1.85+ (edition 2024).
+Requires Rust 1.88+ (edition 2024).
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git

--- a/engine/.claude/skills/rust-dep-hygiene/SKILL.md
+++ b/engine/.claude/skills/rust-dep-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-dep-hygiene
-description: Dependency hygiene for the Rocky engine workspace — how to add/update deps via [workspace.dependencies], MSRV 1.85 policy, cargo-audit / cargo-deny / cargo-machete usage, and how the weekly security audit surfaces advisories.
+description: Dependency hygiene for the Rocky engine workspace — how to add/update deps via [workspace.dependencies], MSRV 1.88 policy, cargo-audit / cargo-deny / cargo-machete usage, and how the weekly security audit surfaces advisories.
 ---
 
 # Dependency hygiene for the Rocky engine
@@ -45,20 +45,22 @@ cargo update                            # Everything — use with care, always r
 
 Major version bumps require editing `engine/Cargo.toml` directly and checking the changelog for breaking changes. Pin the version in `[workspace.dependencies]`, not in individual crates.
 
-## MSRV (1.85, Rust 2024 edition)
+## MSRV (1.88, Rust 2024 edition)
 
 `engine/Cargo.toml` declares:
 
 ```toml
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 ```
+
+> Bumped 1.85.1 → 1.88 on 2026-05-24: the `rocky-mcp` crate's `rmcp 1.7` tree (`rmcp-macros` → `darling 0.23`, plus `time 0.3.47`) requires rustc 1.88, so the effective workspace MSRV was already 1.88.
 
 **Rules:**
 
-1. **Don't use features newer than 1.85** in any engine crate. If a stable feature lands in 1.86+, either wait for the next MSRV bump or gate your usage behind something that compiles on 1.85.
-2. **Dependencies can have their own MSRV.** If a dep requires Rust 1.87 and Rocky is on 1.85, you have two choices: pin an older version of the dep (check `cargo tree` and the dep's changelog) or propose an MSRV bump.
+1. **Don't use features newer than 1.88** in any engine crate. If a stable feature lands in 1.89+, either wait for the next MSRV bump or gate your usage behind something that compiles on 1.88.
+2. **Dependencies can have their own MSRV.** If a dep requires Rust 1.90 and Rocky is on 1.88, you have two choices: pin an older version of the dep (check `cargo tree` and the dep's changelog) or propose an MSRV bump.
 3. **Bumping MSRV is a policy change.** Don't do it unilaterally. Propose to Hugo, note the reason (typically: a dep dropped support for the old MSRV), and bump both the `[workspace.package]` line **and** the CI toolchain installer in `.github/workflows/engine-ci.yml` in the same PR.
 4. **Edition bumps** (2024 → 2027 when that exists) are separate from MSRV bumps and even rarer. Don't conflate them.
 

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -112,7 +112,7 @@ table = "fct_orders"
 
 ## Crate Architecture
 
-22-crate Cargo workspace (24 members incl. `rocky` + `rocky-lsp` binaries). Rust edition 2024, MSRV 1.85:
+22-crate Cargo workspace (24 members incl. `rocky` + `rocky-lsp` binaries). Rust edition 2024, MSRV 1.88:
 
 ```
 rocky-core         — Warehouse-agnostic engine: adapter traits, DAG executor, models, checks, contracts, config, state

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -6,7 +6,7 @@ Rust SQL transformation engine. Replaces dbt's core responsibilities (DAG resolu
 
 ## Project Structure
 
-Cargo workspace with 22 library crates + 2 binary crates (`rocky` + `rocky-lsp`) — 24 members total. Rust edition 2024, MSRV 1.85:
+Cargo workspace with 22 library crates + 2 binary crates (`rocky` + `rocky-lsp`) — 24 members total. Rust edition 2024, MSRV 1.88:
 
 The `Plan` enum was deleted in the Phase 3 typed-IR migration; `ModelIr` is now the sole transformation intermediate, dispatched via `ModelIrVariant`. The IR data types (`ModelIr`, `ModelIrVariant`, `ProjectIr`, lakehouse format/options, column lineage, masks, time grains, `RockyType`) live in their own `rocky-ir` crate; `rocky-core` keeps the runtime surface (adapter traits, DAG executor, state store, drift, SQL generation, breaking-change classifier, ci-diff).
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -31,7 +31,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-rust-version = "1.85.1"
+rust-version = "1.88"
 homepage = "https://rocky-data.dev/"
 repository = "https://github.com/rocky-data/rocky"
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -121,7 +121,7 @@ curl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/instal
 irm https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.ps1 | iex
 ```
 
-**Build from source** (requires Rust 1.85+):
+**Build from source** (requires Rust 1.88+):
 
 ```bash
 git clone https://github.com/rocky-data/rocky.git

--- a/engine/crates/rocky-fivetran/src/ratelimit.rs
+++ b/engine/crates/rocky-fivetran/src/ratelimit.rs
@@ -170,7 +170,7 @@ fn write_wake_at(path: &Path, wake_at: SystemTime) {
     };
     // Use explicit-trait form so we resolve to fs4 1.x's `FileExt::lock`
     // rather than the std `File::lock` that was stabilised in Rust
-    // 1.89 — the workspace MSRV is 1.85, so we can't rely on the std
+    // 1.89 — the workspace MSRV is 1.88, so we can't rely on the std
     // method existing on every build host.
     if let Err(e) = FileExt::lock(&tmp) {
         warn!(tmp_path = %tmp_path.display(), error = %e, "ratelimit tmp lock failed; skipping write");

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -4,10 +4,23 @@
 
 use std::path::{Path, PathBuf};
 
+use rmcp::ErrorData as McpError;
+use rmcp::RoleServer;
+use rmcp::handler::server::router::prompt::PromptRouter;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo};
-use rmcp::{Json, ServerHandler, tool, tool_handler, tool_router};
+// `GetPromptRequestParams`, `PaginatedRequestParams`, and `ListPromptsResult`
+// are referenced unqualified in the code the `#[prompt_handler]` macro emits,
+// so they must be in scope here even though this module names none of them.
+use rmcp::model::{
+    GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
+    PaginatedRequestParams, PromptMessage, PromptMessageRole, ProtocolVersion, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::service::RequestContext;
+use rmcp::{
+    Json, ServerHandler, prompt, prompt_handler, prompt_router, tool, tool_handler, tool_router,
+};
 
 use rocky_cli::commands;
 use rocky_compiler::compile::{self, CompileResult as CompilerResult, CompilerConfig};
@@ -29,6 +42,7 @@ pub struct RockyMcpServer {
     models_dir: PathBuf,
     root: PathBuf,
     tool_router: ToolRouter<Self>,
+    prompt_router: PromptRouter<Self>,
 }
 
 // ---------------------------------------------------------------------------
@@ -96,6 +110,20 @@ pub struct ProposeArgs {
 }
 
 // ---------------------------------------------------------------------------
+// Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
+// MCP prompt arguments are string-typed on the wire; `Serialize` is part of
+// the prompt-macro contract (mirrors rmcp's own examples).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct BuildModelArgs {
+    /// What the user wants to build — the model's purpose in their own words
+    /// (e.g. "daily completed-orders revenue by region"). The prompt threads
+    /// this intent through Rocky's authoring loop.
+    pub intent: String,
+}
+
+// ---------------------------------------------------------------------------
 // Caps for the data-grounding tools.
 // ---------------------------------------------------------------------------
 
@@ -118,6 +146,7 @@ impl RockyMcpServer {
             models_dir,
             root,
             tool_router: Self::tool_router(),
+            prompt_router: Self::prompt_router(),
         }
     }
 
@@ -631,13 +660,93 @@ impl RockyMcpServer {
     }
 }
 
+// `prompt_router`'s `router` arg takes a string ident (unlike `tool_router`);
+// the default generated fn is already named `prompt_router`, so no arg needed.
+#[prompt_router]
+impl RockyMcpServer {
+    /// The actionable, intent-parameterized form of the server `instructions`
+    /// (the `rocky-ai-workflow` skill). Walks a connected agent through
+    /// Rocky's authoring loop for one concrete model, ending at *propose* —
+    /// the human runs `rocky review --approve` + `rocky apply`.
+    #[prompt(
+        name = "build_model",
+        description = "Guide the authoring of one Rocky model from a plain-language intent: \
+         inspect schema -> sample rows -> profile columns -> write SQL -> compile-loop -> \
+         plan preview -> propose. Stops at the human approval gate."
+    )]
+    async fn build_model(
+        &self,
+        Parameters(args): Parameters<BuildModelArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let intent = args.intent.trim();
+        let messages = vec![
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "I'll author this Rocky model SQL-first, grounding every decision in the \
+                 real data, and stop at a proposed plan for you to review and apply. \
+                 The substrate trusts my edits because the compiler checked them and you \
+                 sign off the invariants — never because they merely compiled.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                format!(
+                    "Build a Rocky model for this intent:\n\n  {intent}\n\n\
+                     Follow Rocky's authoring loop, using the MCP tools at each step:\n\n\
+                     1. inspect_schema — read every existing model and source table with its \
+                     typed columns. Never guess column names; select only what's actually there.\n\
+                     2. sample_rows — look at real rows before writing any filter or cast. The \
+                     schema tells you a column exists; it does not tell you its literal values, \
+                     its units, or its null rate.\n\
+                     3. profile_column — for any column you filter, cast, or aggregate on, \
+                     check distinct values, null rate, and domain.\n\
+                     4. Write the model as raw SQL (models/<name>.sql + a <name>.toml sidecar \
+                     for strategy + target). SQL is first-class in Rocky — do NOT reach for the \
+                     .rocky DSL unless the user explicitly asks. Keep it minimal and readable.\n\
+                     5. compile — type-check and read the diagnostics. Each carries a code, a \
+                     span, and often a suggestion. Fix against the diagnostic and recompile; \
+                     loop until clean. The compiler is your fast feedback loop — lean on it \
+                     instead of reasoning about correctness in your head.\n\
+                     6. plan_preview — read the exact SQL Rocky would execute and confirm it \
+                     matches the intent before proposing.\n\
+                     7. Encode what you learned while sampling as a contract (required/protected \
+                     columns) or a check (assertion), not just a WHERE clause — that moves the \
+                     invariant into the typed substrate so the compiler enforces it on every \
+                     future run.\n\
+                     8. propose — generate the materialization plan. It is recorded as an \
+                     AI-authored plan with a plan_id.\n\n\
+                     RECONCILE DISCIPLINE (the step that separates a model that compiles from a \
+                     model that is correct): check literal values and units against the sampled \
+                     data, not just the schema. A `WHERE status = 'completed'` that returns zero \
+                     rows because the data actually holds 'COMPLETE' compiles perfectly and is \
+                     wrong. Confirm dollars-vs-cents and UTC-vs-local from real rows.\n\n\
+                     STOP at propose. Never apply an AI-authored change directly — a bare apply \
+                     is refused by design. Surface the plan_id and the review report clearly, \
+                     then the human runs `rocky review <plan-id> --approve` to sign off the \
+                     invariants and `rocky apply <plan-id>` to execute. Do not approve on the \
+                     user's behalf unless they explicitly tell you to."
+                ),
+            ),
+        ];
+
+        Ok(GetPromptResult::new(messages)
+            .with_description(format!("Rocky model-authoring loop for: {intent}")))
+    }
+}
+
 #[tool_handler(router = self.tool_router)]
+#[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for RockyMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::from_build_env())
-            .with_protocol_version(ProtocolVersion::V_2024_11_05)
-            .with_instructions(INSTRUCTIONS.to_string())
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_prompts()
+                .build(),
+        )
+        .with_server_info(Implementation::from_build_env())
+        .with_protocol_version(ProtocolVersion::V_2024_11_05)
+        .with_instructions(INSTRUCTIONS.to_string())
     }
 }
 

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -7,7 +7,7 @@
 use std::path::Path;
 
 use rmcp::ServiceExt;
-use rmcp::model::CallToolRequestParams;
+use rmcp::model::{CallToolRequestParams, GetPromptRequestParams};
 use rocky_mcp::RockyMcpServer;
 use tempfile::TempDir;
 
@@ -299,6 +299,98 @@ async fn sample_rows_returns_capped_rows_on_duckdb() {
     let rows = sc["rows"].as_array().unwrap();
     assert!(!rows.is_empty(), "sampled at least one row");
     assert!(rows.len() <= 50, "capped at 50 rows");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn prompts_list_includes_build_model() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let prompts = client.list_all_prompts().await.expect("list prompts");
+    let names: Vec<String> = prompts.iter().map(|p| p.name.clone()).collect();
+    assert!(
+        names.iter().any(|n| n == "build_model"),
+        "prompts/list must include build_model, got {names:?}"
+    );
+
+    // The build_model prompt declares its single `intent` argument.
+    let build_model = prompts
+        .iter()
+        .find(|p| p.name == "build_model")
+        .expect("build_model prompt present");
+    let args = build_model
+        .arguments
+        .as_ref()
+        .expect("build_model declares arguments");
+    assert!(
+        args.iter().any(|a| a.name == "intent"),
+        "build_model must declare an `intent` argument"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn prompt_get_build_model_returns_authoring_loop() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let intent = "daily completed-orders revenue by region";
+    let args = serde_json::json!({ "intent": intent })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .get_prompt(GetPromptRequestParams::new("build_model").with_arguments(args))
+        .await
+        .expect("get_prompt build_model");
+
+    assert!(
+        !result.messages.is_empty(),
+        "build_model must return prompt messages"
+    );
+
+    // Flatten every text message into one haystack and assert on the key
+    // workflow steps + the reconcile discipline + the user's intent — wording
+    // is free to drift, but these anchors must survive copy edits.
+    use rmcp::model::PromptMessageContent;
+    let haystack: String = result
+        .messages
+        .iter()
+        .filter_map(|m| match &m.content {
+            PromptMessageContent::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    for anchor in [
+        intent,
+        "inspect_schema",
+        "sample_rows",
+        "profile_column",
+        "compile",
+        "plan_preview",
+        "propose",
+        "review",
+        "apply",
+    ] {
+        assert!(
+            haystack.contains(anchor),
+            "build_model prompt should mention `{anchor}`; full text:\n{haystack}"
+        );
+    }
+    // The reconcile discipline is the load-bearing instruction.
+    assert!(
+        haystack.to_lowercase().contains("reconcile"),
+        "build_model must emphasize the reconcile discipline"
+    );
 
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
Two `rocky-mcp` follow-ups from the AI-drivable initiative.

## `build_model` MCP prompt

The server exposed tools but no prompts. Adds one templated prompt, `build_model`, via rmcp 1.7's `#[prompt]` macros — the actionable, `intent`-parameterized form of the server's `instructions` (the `rocky-ai-workflow` skill). It walks a connected agent through the loop: `inspect_schema` → `sample_rows` → `profile_column` → write SQL (first-class, not the DSL) → `compile` (loop on diagnostics) → `plan_preview` → `propose`, stopping at the human `rocky review --approve` / `rocky apply` gate, and spells out the reconcile discipline (literal values + units vs sampled data). `#[tool_handler]` and `#[prompt_handler]` compose on the one `ServerHandler` impl; `enable_prompts()` added to the capabilities.

## Workspace MSRV 1.85.1 → 1.88

A `cargo +1.85.1 build -p rocky-mcp` check found rmcp 1.7's macro tree (`rmcp-macros` → `darling 0.23.0`, plus `time 0.3.47`) requires **rustc 1.88** — so the effective workspace MSRV was already 1.88 the moment `rocky-mcp` landed (#670). This makes the `rust-version` declaration honest and sweeps the doc references (CONTRIBUTING, installation, README, engine CLAUDE/AGENTS, the `rust-dep-hygiene` skill). Binaries ship on `stable`, so installers are unaffected; only building from source on rustc 1.85–1.87 is.

## Test

`cargo test -p rocky-mcp`: 4 unit + 9 integration, including 2 new prompt round-trip tests (`prompts/list` shows `build_model`; `prompts/get` returns the workflow messages). `cargo fmt --check` + `cargo clippy --all-targets` clean. Manifest validates at `rust-version = "1.88"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)