### PR TITLE
feat(vscode): lineage-diff panel (column blast radius)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -314,6 +314,12 @@
         "icon": "$(pulse)"
       },
       {
+        "command": "rocky.lineageDiff",
+        "title": "Lineage Diff vs Base",
+        "category": "Rocky",
+        "icon": "$(git-compare)"
+      },
+      {
         "command": "rocky.previewCreate",
         "title": "Rocky: Preview Create (PR diff)",
         "category": "Rocky"
@@ -777,6 +783,11 @@
           "command": "rocky.trace",
           "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
           "group": "rocky@8"
+        },
+        {
+          "command": "rocky.lineageDiff",
+          "when": "resourceLangId == rocky || (resourceLangId == sql && resourcePath =~ /\\/models\\//)",
+          "group": "rocky@9"
         }
       ]
     },

--- a/editors/vscode/src/__tests__/lineageDiffPanel.test.ts
+++ b/editors/vscode/src/__tests__/lineageDiffPanel.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({}));
+
+import {
+  diffVerdict,
+  formatBlastRadius,
+  formatColumnChange,
+} from "../webviews/lineageDiffPanel";
+
+describe("diffVerdict", () => {
+  it("clean when nothing changed", () => {
+    expect(
+      diffVerdict({ added: 0, modified: 0, removed: 0, unchanged: 5, total_models: 5 }),
+    ).toBe("clean");
+  });
+  it("warn when columns are modified or removed (downstream impact)", () => {
+    expect(
+      diffVerdict({ added: 0, modified: 1, removed: 0, unchanged: 4, total_models: 5 }),
+    ).toBe("warn");
+    expect(
+      diffVerdict({ added: 0, modified: 0, removed: 2, unchanged: 3, total_models: 5 }),
+    ).toBe("warn");
+  });
+  it("ok when the only changes are additions", () => {
+    expect(
+      diffVerdict({ added: 3, modified: 0, removed: 0, unchanged: 2, total_models: 5 }),
+    ).toBe("ok");
+  });
+});
+
+describe("formatColumnChange", () => {
+  it("shows a type transition when types are present", () => {
+    expect(
+      formatColumnChange({
+        column_name: "email",
+        change_type: "type_changed",
+        old_type: "STRING",
+        new_type: "INT",
+      }),
+    ).toBe("email: STRING → INT");
+  });
+  it("shows just the column name when there are no types", () => {
+    expect(
+      formatColumnChange({ column_name: "ssn", change_type: "removed" }),
+    ).toBe("ssn");
+  });
+});
+
+describe("formatBlastRadius", () => {
+  it("joins downstream consumers as model.column", () => {
+    expect(
+      formatBlastRadius([
+        { model: "dim_customers", column: "email" },
+        { model: "fct_revenue", column: "email_hash" },
+      ]),
+    ).toBe("dim_customers.email, fct_revenue.email_hash");
+  });
+  it("is a dash when there are no consumers", () => {
+    expect(formatBlastRadius(undefined)).toBe("—");
+    expect(formatBlastRadius([])).toBe("—");
+  });
+});

--- a/editors/vscode/src/commands/index.ts
+++ b/editors/vscode/src/commands/index.ts
@@ -17,6 +17,7 @@ import {
 import { compliance } from "./governance";
 import { catalog, history, metrics } from "./inspect";
 import { registerLineageSerializer, showLineage } from "./lineage";
+import { lineageDiff } from "./lineageDiff";
 import { importDbt, validateMigration } from "./migration";
 import { doctor, optimize } from "./ops";
 import { previewCost, previewCreate, previewDiff } from "./preview";
@@ -42,6 +43,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
 
     // Language intelligence
     vscode.commands.registerCommand("rocky.showLineage", showLineage),
+    vscode.commands.registerCommand("rocky.lineageDiff", lineageDiff),
 
     // Compile / validate / CI
     vscode.commands.registerCommand("rocky.compile", compile),

--- a/editors/vscode/src/commands/lineageDiff.ts
+++ b/editors/vscode/src/commands/lineageDiff.ts
@@ -1,0 +1,24 @@
+import { resolveProjectRoot } from "../config";
+import { runRockyJsonWithProgress, showRockyError } from "../rockyCli";
+import type { LineageDiffOutput } from "../types/generated/lineage_diff";
+import { showLineageDiff } from "../webviews/lineageDiffPanel";
+import { ensureWorkspace } from "./ui";
+
+/**
+ * `rocky.lineageDiff` — column-level blast radius of the working tree vs the
+ * base ref (`main`). Read-only (git + compile, no warehouse). The PR-review
+ * companion to the branches view.
+ */
+export async function lineageDiff(): Promise<void> {
+  if (!ensureWorkspace()) return;
+  try {
+    const result = await runRockyJsonWithProgress<LineageDiffOutput>(
+      "Diffing column lineage vs main…",
+      ["lineage-diff", "--output", "json"],
+      { cwd: resolveProjectRoot() },
+    );
+    showLineageDiff(result);
+  } catch (err) {
+    showRockyError("Lineage diff failed", err);
+  }
+}

--- a/editors/vscode/src/test/suite/extension.test.ts
+++ b/editors/vscode/src/test/suite/extension.test.ts
@@ -83,6 +83,14 @@ suite("Rocky Extension", () => {
     );
   });
 
+  test("rocky.lineageDiff command is registered", async () => {
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(
+      commands.includes("rocky.lineageDiff"),
+      "rocky.lineageDiff command should be registered",
+    );
+  });
+
   test("rocky.doctor command exists", async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(

--- a/editors/vscode/src/webviews/lineageDiffPanel.ts
+++ b/editors/vscode/src/webviews/lineageDiffPanel.ts
@@ -1,0 +1,106 @@
+import * as vscode from "vscode";
+import type {
+  DiffSummary,
+  LineageColumnChange,
+  LineageDiffOutput,
+  LineageDiffResult,
+  LineageQualifiedColumn,
+} from "../types/generated/lineage_diff";
+import { buildHead, escapeHtml, makeNonce } from "./htmlUtil";
+
+/**
+ * Verdict for a lineage diff. `clean` when nothing changed; `warn` when columns
+ * were modified or removed (those have downstream blast radius); `ok` when the
+ * only changes are additions.
+ */
+export function diffVerdict(s: DiffSummary): "clean" | "ok" | "warn" {
+  if (s.added + s.modified + s.removed === 0) return "clean";
+  return s.modified + s.removed > 0 ? "warn" : "ok";
+}
+
+/** Describe a column change, e.g. `email: STRING → INT` or `ssn`. */
+export function formatColumnChange(c: LineageColumnChange): string {
+  if (c.old_type != null || c.new_type != null) {
+    return `${c.column_name}: ${c.old_type ?? "∅"} → ${c.new_type ?? "∅"}`;
+  }
+  return c.column_name;
+}
+
+/** Downstream blast radius as `model.column, model.column`, or `—` when none. */
+export function formatBlastRadius(
+  consumers: LineageQualifiedColumn[] | undefined,
+): string {
+  if (!consumers || consumers.length === 0) return "—";
+  return consumers.map((q) => `${q.model}.${q.column}`).join(", ");
+}
+
+/** Open a webview rendering the column-level lineage diff vs a base ref. */
+export function showLineageDiff(result: LineageDiffOutput): void {
+  const panel = vscode.window.createWebviewPanel(
+    "rockyLineageDiff",
+    "Rocky lineage diff",
+    vscode.ViewColumn.Beside,
+    { enableScripts: false, retainContextWhenHidden: true },
+  );
+  panel.webview.html = render(panel.webview, result);
+}
+
+function render(webview: vscode.Webview, result: LineageDiffOutput): string {
+  const nonce = makeNonce();
+  const s = result.summary;
+  const verdict = diffVerdict(s);
+
+  const changed = result.results.filter(
+    (r: LineageDiffResult) => r.column_changes.length > 0,
+  );
+
+  const sections = changed
+    .map((r: LineageDiffResult) => {
+      const rows = r.column_changes
+        .map(
+          (c: LineageColumnChange) => `
+        <tr>
+          <td><code>${escapeHtml(c.change_type)}</code></td>
+          <td>${escapeHtml(formatColumnChange(c))}</td>
+          <td>${escapeHtml(formatBlastRadius(c.downstream_consumers))}</td>
+        </tr>`,
+        )
+        .join("");
+      return /* html */ `
+      <h2>${escapeHtml(r.model_name)} <span class="muted">· ${escapeHtml(r.status)}</span></h2>
+      <table>
+        <thead><tr><th>Change</th><th>Column</th><th>Downstream blast radius</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+    })
+    .join("");
+
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+${buildHead(webview, nonce, "Rocky lineage diff")}
+<body>
+  <h1>Lineage diff <span class="badge ${verdict}">${verdict}</span></h1>
+  <p class="muted">Column-level changes from <code>${escapeHtml(result.base_ref)}</code> → <code>${escapeHtml(result.head_ref)}</code>, with downstream impact.</p>
+
+  <div class="stat-grid">
+    ${stat("Added", s.added)}
+    ${stat("Modified", s.modified)}
+    ${stat("Removed", s.removed)}
+    ${stat("Unchanged", s.unchanged)}
+  </div>
+
+  ${
+    sections ||
+    `<p class="badge ok">No column-level changes vs ${escapeHtml(result.base_ref)}.</p>`
+  }
+</body>
+</html>`;
+}
+
+function stat(label: string, value: number): string {
+  return /* html */ `
+    <div class="stat">
+      <div class="label">${escapeHtml(label)}</div>
+      <div class="value">${value}</div>
+    </div>`;
+}


### PR DESCRIPTION
Phase-2 — surfaces `rocky lineage-diff` (no editor UX before): the column-level diff of the working tree vs a base ref, with downstream blast radius. The PR-review companion to the branches view (#677).

## What it does

`rocky.lineageDiff` (palette + model context menu) runs `rocky lineage-diff --output json` (base ref defaults to `main`) — read-only (git + compile, no warehouse) — and renders:

- **Verdict** — `clean` / `ok` (additions only) / `warn` (modified or removed columns, which carry downstream impact).
- **Summary** — added / modified / removed / unchanged.
- **Per changed model** — each column change (added / removed / `STRING → INT`) and its **downstream blast radius** (`dim_customers.email, fct_revenue.email_hash`).

Answers *"what does this change break downstream"* before you open the PR.

## Verification

`npm run compile`, `npm run lint`, `npm run test:unit` (160 tests, +7 for `diffVerdict` / `formatColumnChange` / `formatBlastRadius`) all clean. A test-electron smoke asserts `rocky.lineageDiff` registers. Extension-only — consumes the existing `LineageDiffOutput` schema, no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)