### PR TITLE
feat: ad-hoc SQL selection preview (governance-safe)

### DIFF
--- a/editors/vscode/src/__tests__/previewRowsCore.test.ts
+++ b/editors/vscode/src/__tests__/previewRowsCore.test.ts
@@ -44,6 +44,12 @@ describe("buildPreviewArgs", () => {
     expect(args[args.indexOf("--cte") + 1]).toBe("my_cte");
   });
 
+  it("includes --sql-file for ad-hoc selection preview", () => {
+    const args = buildPreviewArgs("m", undefined, 100, false, "/tmp/sel.sql");
+    expect(args).toContain("--sql-file");
+    expect(args[args.indexOf("--sql-file") + 1]).toBe("/tmp/sel.sql");
+  });
+
   it("appends --allow-warehouse only when allowed", () => {
     expect(buildPreviewArgs("m", undefined, 100, false)).not.toContain(
       "--allow-warehouse",

--- a/editors/vscode/src/commands/previewRows.ts
+++ b/editors/vscode/src/commands/previewRows.ts
@@ -1,3 +1,5 @@
+import { unlink, writeFile } from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import { getConfig, resolveProjectRoot } from "../config";
@@ -61,19 +63,51 @@ function findCteContaining(
   return undefined;
 }
 
+/** The active editor's non-empty selection text, trimmed. */
+function selectedSql(): string | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.selection.isEmpty) return undefined;
+  const text = editor.document.getText(editor.selection).trim();
+  return text.length > 0 ? text : undefined;
+}
+
 /**
  * `rocky.previewModel` — preview output rows. When invoked without an explicit
- * model (the Cmd/Ctrl+Enter keybinding or the command palette) it's
- * cursor-aware: if the cursor sits inside a CTE of a `.sql` model, that CTE is
- * previewed instead of the whole model. The model-level "Preview" CodeLens
- * passes the model name explicitly and always previews the full model.
+ * model (the Cmd/Ctrl+Enter keybinding or the command palette) it previews, in
+ * order of preference: a non-empty editor **selection** (ad-hoc), the **CTE**
+ * under the cursor (`.sql` models), else the whole **model**. The model-level
+ * "Preview" CodeLens passes the model name explicitly and always previews the
+ * full model.
  */
 export async function previewModel(arg?: unknown): Promise<void> {
   const explicit = explicitModel(arg);
   const model = explicit ?? activeEditorModel();
   if (!model) return;
-  const cte = explicit ? undefined : await cteUnderCursor();
-  await runPreview(model, cte);
+  if (explicit) {
+    await runPreview(model, undefined);
+    return;
+  }
+  const selection = selectedSql();
+  if (selection) {
+    await runAdhoc(model, selection);
+    return;
+  }
+  await runPreview(model, await cteUnderCursor());
+}
+
+/**
+ * Preview an ad-hoc SQL selection. Writes it to a temp file and runs `preview
+ * rows --sql-file` against the enclosing `model` — the engine refuses when that
+ * model has masked columns, so a selection can't leak pre-mask values.
+ */
+async function runAdhoc(model: string, sql: string): Promise<void> {
+  const tmp = path.join(os.tmpdir(), `rocky-preview-${process.pid}-${Date.now()}.sql`);
+  await writeFile(tmp, sql, "utf8");
+  try {
+    await runPreview(model, undefined, tmp);
+  } finally {
+    await unlink(tmp).catch(() => undefined);
+  }
 }
 
 /** `rocky.previewCte` — preview a single CTE's rows (from the CodeLens). */
@@ -84,14 +118,22 @@ export async function previewCte(arg?: {
   if (arg?.model && arg?.cte) await runPreview(arg.model, arg.cte);
 }
 
-async function runPreview(model: string, cte: string | undefined): Promise<void> {
+async function runPreview(
+  model: string,
+  cte: string | undefined,
+  sqlFile?: string,
+): Promise<void> {
   if (!ensureWorkspace()) return;
   const provider = getQueryResultsProvider();
   if (!provider) return;
 
   const { previewRowLimit, previewAllowWarehouse } = getConfig();
   const cwd = resolveProjectRoot();
-  const title = cte ? `${model} · ${cte}` : model;
+  const title = sqlFile
+    ? `${model} · selection`
+    : cte
+      ? `${model} · ${cte}`
+      : model;
 
   // Reveal the Query Results panel, then show a placeholder while we run.
   await vscode.commands.executeCommand("rocky.queryResults.focus");
@@ -100,7 +142,7 @@ async function runPreview(model: string, cte: string | undefined): Promise<void>
   const run = (allowWarehouse: boolean): Promise<PreviewRowsOutput> =>
     runRockyJsonWithProgress<PreviewRowsOutput>(
       `Previewing ${title}…`,
-      buildPreviewArgs(model, cte, previewRowLimit, allowWarehouse),
+      buildPreviewArgs(model, cte, previewRowLimit, allowWarehouse, sqlFile),
       { cwd },
     );
 

--- a/editors/vscode/src/commands/previewRowsCore.ts
+++ b/editors/vscode/src/commands/previewRowsCore.ts
@@ -26,9 +26,11 @@ export function buildPreviewArgs(
   cte: string | undefined,
   limit: number,
   allowWarehouse: boolean,
+  sqlFile?: string,
 ): string[] {
   const args = ["preview", "rows", "--model", model];
   if (cte) args.push("--cte", cte);
+  if (sqlFile) args.push("--sql-file", sqlFile);
   args.push("--limit", String(limit), "--output", "json");
   if (allowWarehouse) args.push("--allow-warehouse");
   return args;

--- a/engine/crates/rocky-cli/src/commands/preview_rows.rs
+++ b/engine/crates/rocky-cli/src/commands/preview_rows.rs
@@ -48,9 +48,21 @@ pub async fn run_preview_rows(
     allow_warehouse: bool,
     pipeline_name: Option<&str>,
     models_dir: &Path,
+    sql_file: Option<&Path>,
     output_json: bool,
 ) -> Result<()> {
     let start = Instant::now();
+
+    // `--sql-file` (ad-hoc selection preview) and `--cte` are mutually
+    // exclusive: ad-hoc runs the file's SQL, not a model CTE.
+    if sql_file.is_some() && cte.is_some() {
+        return Err(err(
+            output_json,
+            "invalid_arguments",
+            "--sql-file and --cte cannot be combined",
+            None,
+        ));
+    }
 
     // Validate identifiers up-front — never interpolate unvalidated input.
     rocky_sql::validation::validate_identifier(model).map_err(|_| {
@@ -221,7 +233,50 @@ pub async fn run_preview_rows(
     }
 
     let inner = expanded.trim().trim_end_matches(';').trim();
-    let final_sql = if let Some(cte_name) = cte {
+    let final_sql = if let Some(path) = sql_file {
+        // Ad-hoc selection preview. The snippet has no model-output
+        // classification to mask against, so refuse if the enclosing model has
+        // ANY masked column rather than risk leaking a pre-mask value (the same
+        // fail-safe as CTE preview).
+        if !masked.is_empty() {
+            let cols: Vec<&String> = masked.keys().collect();
+            return Err(err(
+                output_json,
+                "adhoc_masking_blocked",
+                &format!(
+                    "model '{model}' has masked columns; ad-hoc selection preview is disabled to avoid leaking pre-mask values"
+                ),
+                Some(serde_json::json!({ "columns": cols })),
+            ));
+        }
+        let raw = std::fs::read_to_string(path).map_err(|e| {
+            err(
+                output_json,
+                "adhoc_read_error",
+                &format!("failed to read selection from {}: {e}", path.display()),
+                None,
+            )
+        })?;
+        // Expand macros in the selection too (it may reference Rocky macros).
+        let ad_expanded = rocky_core::macros::expand_macros(&raw, &macro_defs).map_err(|e| {
+            err(
+                output_json,
+                "compile_error",
+                &format!("macro expansion failed: {e}"),
+                None,
+            )
+        })?;
+        let ad_trimmed = ad_expanded.trim().trim_end_matches(';').trim();
+        if !rocky_sql::parser::is_single_select(ad_trimmed) {
+            return Err(err(
+                output_json,
+                "unsupported_model_kind",
+                "selection is not a single SELECT statement",
+                None,
+            ));
+        }
+        wrap_with_limit(ad_trimmed, limit)
+    } else if let Some(cte_name) = cte {
         let isolated = rocky_sql::parser::isolate_cte(&expanded, cte_name)
             .map_err(|e| err(output_json, "cte_error", &format!("{e}"), None))?;
         wrap_with_limit(isolated.trim().trim_end_matches(';').trim(), limit)

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1558,6 +1558,13 @@ enum PreviewAction {
         /// Models directory.
         #[arg(long, default_value = "models")]
         models: PathBuf,
+        /// Preview an ad-hoc SQL snippet read from this file instead of the
+        /// model's compiled SQL (used by the editor's "Preview Selection").
+        /// `--model` still names the enclosing model: if it has masked columns,
+        /// ad-hoc preview is refused to avoid leaking pre-mask values.
+        /// Mutually exclusive with `--cte`.
+        #[arg(long)]
+        sql_file: Option<PathBuf>,
     },
 }
 
@@ -2817,6 +2824,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 allow_warehouse,
                 pipeline,
                 models,
+                sql_file,
             } => {
                 rocky_cli::commands::run_preview_rows(
                     &cli.config,
@@ -2827,6 +2835,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     allow_warehouse,
                     pipeline.as_deref(),
                     &models,
+                    sql_file.as_deref(),
                     json,
                 )
                 .await


### PR DESCRIPTION
Closes the last dbt-Fusion preview-parity gap: **Cmd/Ctrl+Enter on a non-empty SQL selection runs that snippet** in the Query Results panel. Combined engine + extension (no codegen — output shape unchanged).

## Engine

`rocky preview rows --sql-file <path> --model <enclosing>` previews an arbitrary SQL snippet (LIMIT-wrapped) against the configured adapter.

**Governance fail-safe** (the reason this needed a deliberate design): an ad-hoc snippet has no model-output classification to mask against, so if the enclosing model has *any* masked column, ad-hoc preview is **refused** (`adhoc_masking_blocked`) rather than risk leaking a pre-mask value — mirroring the CTE-preview fail-safe. Mutually exclusive with `--cte`.

Live-verified: a selection from a non-masked model runs and returns rows; a selection from the classification-POC's `accounts` model (masked `owner_email`) is refused with `adhoc_masking_blocked` + exit 1.

## Extension

Cmd/Ctrl+Enter now previews, in order of preference: a non-empty editor **selection** (ad-hoc, written to a temp file and run via `--sql-file`), the **CTE** under the cursor (`.sql` models), else the whole **model**. No new command or keybinding — it's a smarter Cmd+Enter.

## Verification

Engine: `cargo fmt`, `preview_rows` unit tests, live POC runs (both branches of the fail-safe). Extension: `npm run compile` / `lint` / `test:unit` (154 tests, +1 for the `--sql-file` arg builder). `PreviewRowsOutput` unchanged → no schema/codegen change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)