### PR TITLE
feat(engine/rocky-mcp): add breaking_change + dependents read-only tools

### DIFF
--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -222,7 +222,7 @@ fn compile_head(
 /// historical models with today's leaf types still detects the model-level
 /// schema drift that ci-diff is looking for, and there's no per-ref cache
 /// to restore from.
-pub(crate) fn extract_base_compile(
+pub fn extract_base_compile(
     base_ref: &str,
     models_dir: &Path,
     source_schemas: HashMap<String, Vec<rocky_compiler::types::TypedColumn>>,
@@ -587,7 +587,7 @@ pub(crate) fn compute_ci_diff(
 /// `dag` and `lineage_edges` are left empty: the classifier ignores both
 /// (they are implementation-detail fields per the
 /// `rocky_core::breaking_change` module docs).
-pub(crate) fn project_ir_from_compile(
+pub fn project_ir_from_compile(
     result: &rocky_compiler::compile::CompileResult,
 ) -> rocky_ir::ProjectIr {
     let typed = &result.type_check.typed_models;

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -79,7 +79,7 @@ pub use branch::{
 pub use catalog::{CatalogFormat, default_out_dir as catalog_default_out_dir, run_catalog};
 #[cfg(feature = "duckdb")]
 pub use ci::run_ci;
-pub use ci_diff::run_ci_diff;
+pub use ci_diff::{extract_base_compile, project_ir_from_compile, run_ci_diff};
 pub use compact::{run_compact, run_compact_apply, run_compact_catalog, run_measure_dedup};
 pub use compare::compare;
 pub use compile::{compile_output, run_compile};

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -233,6 +233,67 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
+/// One classified breaking-change finding, projected from
+/// `rocky_core::breaking_change::BreakingFinding`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct BreakingFindingLite {
+    /// The change kind discriminant, e.g. `"column_dropped"`,
+    /// `"column_type_changed"`, `"model_removed"`.
+    pub change: String,
+    /// `"breaking"`, `"warning"`, or `"info"`.
+    pub severity: String,
+    /// Externally-visible target name of the affected model
+    /// (`catalog.schema.table`).
+    pub model: String,
+    /// Affected column, for column-scoped changes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+    /// Human-readable description of the change.
+    pub message: String,
+}
+
+/// `breaking_change` result — the semantic delta between the working-tree
+/// models and the models at a base git ref.
+///
+/// When the gate could not run (the base ref or HEAD failed to compile, or the
+/// models directory is missing — typically because the project is not a git
+/// repo), `skipped_reason` is set, `has_breaking` is `false`, `breaking_count`
+/// is `0`, and `findings` is empty. A clean diff and a skipped gate are
+/// therefore distinguishable: check `skipped_reason`.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct BreakingChangeResult {
+    /// `true` when at least one finding is `breaking`-severity.
+    pub has_breaking: bool,
+    /// Count of `breaking`-severity findings.
+    pub breaking_count: usize,
+    /// All classified findings (breaking + warning + info).
+    pub findings: Vec<BreakingFindingLite>,
+    /// Why the breaking-change gate was skipped, when it could not run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_reason: Option<String>,
+}
+
+/// One downstream consumer of a model in a `dependents` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DependentEntry {
+    /// The downstream model that depends on the focal model.
+    pub model: String,
+    /// Columns of the focal model that this dependent reads. Empty when the
+    /// dependency is model-level only (no column-resolved edges).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub via_columns: Vec<String>,
+}
+
+/// `dependents` result — the reverse of `lineage`: downstream models that
+/// consume the focal model, with the focal columns each reads.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DependentsResult {
+    /// The focal model whose consumers were resolved.
+    pub model: String,
+    /// Downstream consumers, sorted by model name.
+    pub dependents: Vec<DependentEntry>,
+}
+
 /// `propose` result — the AI-authored plan id awaiting human review.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ProposeResult {

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -109,6 +109,23 @@ pub struct ProposeArgs {
     pub model: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct BreakingChangeArgs {
+    /// Git ref to compare the working tree against. Defaults to `"HEAD"`.
+    #[serde(default = "default_base_ref")]
+    pub base: String,
+}
+
+fn default_base_ref() -> String {
+    "HEAD".to_string()
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DependentsArgs {
+    /// The focal model whose downstream consumers to resolve.
+    pub model: String,
+}
+
 // ---------------------------------------------------------------------------
 // Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
 // MCP prompt arguments are string-typed on the wire; `Serialize` is part of
@@ -204,6 +221,61 @@ impl RockyMcpServer {
         };
         load_source_schemas_from_cache(&store, chrono::Utc::now(), cfg.cache.schemas.ttl())
             .unwrap_or_default()
+    }
+
+    /// Classify the semantic breaking changes between the working tree (HEAD
+    /// of the on-disk files) and the models at `base_ref`. Reuses the exact
+    /// compile + classify path `rocky review` runs: compile HEAD with the warm
+    /// source-schema cache, `extract_base_compile` the base ref, lower both to
+    /// `ProjectIr`, and `diff_project_ir`.
+    ///
+    /// On any step that prevents the gate from running (HEAD or base fails to
+    /// compile — typically because the project isn't a git repo), returns a
+    /// result with `skipped_reason` set and zeroed counts so the caller can
+    /// distinguish "clean diff" from "gate didn't run".
+    fn compute_breaking_change(&self, base_ref: &str) -> BreakingChangeResult {
+        let source_schemas = self.load_source_schemas();
+
+        let config = CompilerConfig {
+            models_dir: self.models_dir.clone(),
+            contracts_dir: None,
+            source_schemas: source_schemas.clone(),
+            source_column_info: std::collections::HashMap::new(),
+            ..Default::default()
+        };
+        let head_compile = match compile::compile(&config) {
+            Ok(r) => r,
+            Err(e) => {
+                return BreakingChangeResult {
+                    skipped_reason: Some(format!("HEAD compile failed: {e}")),
+                    ..Default::default()
+                };
+            }
+        };
+
+        let base_compile =
+            match commands::extract_base_compile(base_ref, &self.models_dir, source_schemas) {
+                Ok(r) => r,
+                Err(reason) => {
+                    return BreakingChangeResult {
+                        skipped_reason: Some(format!("base ref '{base_ref}': {reason}")),
+                        ..Default::default()
+                    };
+                }
+            };
+
+        let base_ir = commands::project_ir_from_compile(&base_compile);
+        let head_ir = commands::project_ir_from_compile(&head_compile);
+        let findings = rocky_core::breaking_change::diff_project_ir(&base_ir, &head_ir);
+
+        let breaking_count = findings.iter().filter(|f| f.is_breaking()).count();
+        let lite = findings.iter().map(breaking_finding_lite).collect();
+        BreakingChangeResult {
+            has_breaking: breaking_count > 0,
+            breaking_count,
+            findings: lite,
+            skipped_reason: None,
+        }
     }
 
     // -------------------------- MUST tools ---------------------------------
@@ -426,6 +498,69 @@ impl RockyMcpServer {
             models: to_entries(model_schemas),
             sources: to_entries(source_tables),
         }))
+    }
+
+    #[tool(
+        description = "Classify the semantic breaking changes between the working-tree models \
+         and the models at a base git ref (default HEAD). Reuses the exact compile + typed-IR \
+         classifier that `rocky review` and the branch-promote gate run. Self-check blast radius \
+         BEFORE propose. Returns {has_breaking, breaking_count, findings:[{change, severity, \
+         model, column?, message}]}. When the gate can't run (non-git project, or either side \
+         fails to compile), `skipped_reason` is set and the counts are zero."
+    )]
+    async fn breaking_change(
+        &self,
+        params: Parameters<BreakingChangeArgs>,
+    ) -> Result<Json<BreakingChangeResult>, String> {
+        let base = params.0.base;
+        Ok(Json(self.compute_breaking_change(&base)))
+    }
+
+    #[tool(
+        description = "List the downstream models that depend on a given model (the reverse of \
+         `lineage`). For each dependent, returns the focal model's columns it reads via \
+         `via_columns`. Use to gauge the blast radius of changing a model before editing it."
+    )]
+    async fn dependents(
+        &self,
+        params: Parameters<DependentsArgs>,
+    ) -> Result<Json<DependentsResult>, String> {
+        let model = params.0.model;
+        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
+
+        // Assert the focal model exists in the semantic graph — same
+        // not-found contract as `lineage_output`.
+        let schema = result
+            .semantic_graph
+            .model_schema(&model)
+            .ok_or_else(|| format!("model '{model}' not found"))?;
+
+        // Downstream model names come straight from the model schema; the
+        // per-dependent `via_columns` are the focal model's columns that feed
+        // each dependent, collected from the column-level edge set (the
+        // reverse direction of the `lineage` edge filter).
+        let mut dependents: Vec<DependentEntry> = schema
+            .downstream
+            .iter()
+            .map(|dep| {
+                let mut via_columns: Vec<String> = result
+                    .semantic_graph
+                    .edges
+                    .iter()
+                    .filter(|e| *e.source.model == *model && *e.target.model == **dep)
+                    .map(|e| e.source.column.to_string())
+                    .collect();
+                via_columns.sort();
+                via_columns.dedup();
+                DependentEntry {
+                    model: dep.clone(),
+                    via_columns,
+                }
+            })
+            .collect();
+        dependents.sort_by(|a, b| a.model.cmp(&b.model));
+
+        Ok(Json(DependentsResult { model, dependents }))
     }
 
     // ------------------------- SHOULD tools --------------------------------
@@ -829,6 +964,50 @@ fn edge_lite(e: &rocky_cli::output::LineageEdgeRecord) -> LineageEdgeLite {
     }
 }
 
+/// Project a `BreakingFinding` into the lite, schemars-1.x shape.
+///
+/// `change` is the snake_case `kind` discriminant of the tagged
+/// [`rocky_core::breaking_change::BreakingChange`] enum (e.g.
+/// `"column_dropped"`); `model` and the optional `column` are pulled from the
+/// variant; `message` is the debug rendering of the change, matching the
+/// human-readable line `rocky review` emits.
+fn breaking_finding_lite(f: &rocky_core::breaking_change::BreakingFinding) -> BreakingFindingLite {
+    use rocky_core::breaking_change::BreakingSeverity;
+    let severity = match f.severity {
+        BreakingSeverity::Breaking => "breaking",
+        BreakingSeverity::Warning => "warning",
+        BreakingSeverity::Info => "info",
+    }
+    .to_string();
+
+    // The enum is `#[serde(tag = "kind", rename_all = "snake_case")]`, so the
+    // serialized object carries the discriminant under `kind` and the variant
+    // fields (incl. `model` and, where present, `column`) at the top level.
+    let value = serde_json::to_value(&f.change).unwrap_or_default();
+    let change = value
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let model = value
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let column = value
+        .get("column")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    BreakingFindingLite {
+        change,
+        severity,
+        model,
+        column,
+        message: format!("{:?}", f.change),
+    }
+}
+
 /// Render one query cell as a display string, truncating long values.
 fn render_cell(v: serde_json::Value) -> String {
     let s = match v {
@@ -921,5 +1100,39 @@ mod tests {
         let server = RockyMcpServer::new(PathBuf::from("/tmp/proj/rocky.toml"));
         assert_eq!(server.models_dir, PathBuf::from("/tmp/proj/models"));
         assert_eq!(server.root, PathBuf::from("/tmp/proj"));
+    }
+
+    #[test]
+    fn breaking_finding_lite_projects_column_scoped_change() {
+        use rocky_core::breaking_change::{BreakingChange, BreakingFinding, BreakingSeverity};
+        let finding = BreakingFinding {
+            change: BreakingChange::ColumnDropped {
+                model: "c.s.orders".to_string(),
+                column: "legacy_flag".to_string(),
+                data_type: "String".to_string(),
+            },
+            severity: BreakingSeverity::Breaking,
+        };
+        let lite = breaking_finding_lite(&finding);
+        assert_eq!(lite.change, "column_dropped");
+        assert_eq!(lite.severity, "breaking");
+        assert_eq!(lite.model, "c.s.orders");
+        assert_eq!(lite.column.as_deref(), Some("legacy_flag"));
+        assert!(lite.message.contains("ColumnDropped"));
+    }
+
+    #[test]
+    fn breaking_finding_lite_omits_column_for_model_scoped_change() {
+        use rocky_core::breaking_change::{BreakingChange, BreakingFinding, BreakingSeverity};
+        let finding = BreakingFinding {
+            change: BreakingChange::ModelRemoved {
+                model: "c.s.orders".to_string(),
+            },
+            severity: BreakingSeverity::Breaking,
+        };
+        let lite = breaking_finding_lite(&finding);
+        assert_eq!(lite.change, "model_removed");
+        assert_eq!(lite.model, "c.s.orders");
+        assert_eq!(lite.column, None);
     }
 }

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -78,7 +78,9 @@ async fn tools_list_returns_expected_set() {
     assert_eq!(
         names,
         vec![
+            "breaking_change",
             "compile",
+            "dependents",
             "inspect_schema",
             "lineage",
             "list",
@@ -299,6 +301,70 @@ async fn sample_rows_returns_capped_rows_on_duckdb() {
     let rows = sc["rows"].as_array().unwrap();
     assert!(!rows.is_empty(), "sampled at least one row");
     assert!(rows.len() <= 50, "capped at 50 rows");
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn breaking_change_skips_gate_outside_git_repo() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    // No `git init` — `extract_base_compile` cannot resolve the base ref, so
+    // the gate is skipped and the wire contract reports why.
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let result = client
+        .call_tool(CallToolRequestParams::new("breaking_change"))
+        .await
+        .expect("breaking_change call");
+
+    let sc = result.structured_content.expect("structured content");
+    let obj = sc.as_object().unwrap();
+    assert_eq!(obj["has_breaking"], serde_json::json!(false));
+    assert_eq!(obj["breaking_count"], serde_json::json!(0));
+    assert!(
+        obj.get("skipped_reason").and_then(|v| v.as_str()).is_some(),
+        "non-git project must surface a skipped_reason, got: {obj:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn dependents_returns_downstream_consumers() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    // Add a second model that selects from `orders`, making it a dependent.
+    std::fs::write(
+        dir.path().join("models").join("order_ids.sql"),
+        "SELECT id FROM orders\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("models").join("order_ids.toml"),
+        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"order_ids\"\n",
+    )
+    .unwrap();
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("dependents").with_arguments(args))
+        .await
+        .expect("dependents call");
+
+    let sc = result.structured_content.expect("structured content");
+    assert_eq!(sc["model"], serde_json::json!("orders"));
+    let deps = sc["dependents"].as_array().unwrap();
+    assert!(
+        deps.iter()
+            .any(|d| d["model"] == serde_json::json!("order_ids")),
+        "order_ids depends on orders; got {deps:?}"
+    );
 
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## What

Two new read-only verification tools on the Rocky MCP server, following the existing stateless `#[tool]` pattern (compile fresh per call, return a trimmed schemars-1.x lite struct in `Json<T>`):

- **`breaking_change`** — input `{ base?: String (default "HEAD") }`. Compiles the working-tree models and the models at `base`, runs the semantic breaking-change classifier, and returns `{ has_breaking, breaking_count, findings: [{ change, severity, model, column?, message }] }`. Reuses the exact compile + classify path `rocky review` runs: `rocky_compiler::compile` for HEAD, `ci_diff::extract_base_compile` for the base ref, `project_ir_from_compile` on both, then `rocky_core::breaking_change::diff_project_ir`.

- **`dependents`** — input `{ model: String }`. The reverse of the existing `lineage` tool: from the compiled semantic graph, returns the downstream models that consume the focal model and, for each, the focal model's columns it reads via `via_columns`.

## Why

`breaking_change` lets an AI agent self-check the blast radius of a model edit *before* it calls `propose`, using the same typed-IR classifier that gates human review — not a text diff. `dependents` answers "what breaks if I touch this model" directly off the semantic graph.

## Notes

- `skipped_reason` is additive vs the documented shape. When the gate can't run (project isn't a git repo, base ref missing, or either side fails to compile) the tool returns zeroed counts plus `skipped_reason`, so a caller can distinguish a clean diff from a gate that didn't run. It's omitted on the happy path.
- `breaking_change` inherits the cwd-relative git behavior of `extract_base_compile` (it shells out to `git` from the process cwd), matching how `rocky review` itself resolves the base ref. Works when the MCP server's cwd is the project root, the typical IDE-spawned case.

## rocky-cli visibility

Widened `extract_base_compile` and `project_ir_from_compile` from `pub(crate)` to `pub` in `commands/ci_diff.rs`, and added them to the existing `pub use ci_diff::{...}` re-export in `commands/mod.rs`. Two-line change; no new public module.

## Tests

- `tests/roundtrip.rs`: `tools/list` includes both new tools; `dependents` resolves a seeded downstream consumer; `breaking_change` reports the documented shape with `skipped_reason` set outside a git repo.
- Two `breaking_finding_lite` projection unit tests (column-scoped + model-scoped findings).
- `cargo test -p rocky-mcp`: 6 unit + 11 roundtrip pass. `cargo test -p rocky-cli`: all pass. `cargo fmt --all -- --check` clean; scoped clippy on `rocky-mcp`/`rocky-cli` clean. No codegen (rocky mcp emits no JSON-schema CLI output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)