### PR TITLE
fix(engine): resolve clippy --all-targets failures surfaced by clippy 1.95

### DIFF
--- a/engine/crates/rocky-adapter-sdk/src/throttle.rs
+++ b/engine/crates/rocky-adapter-sdk/src/throttle.rs
@@ -67,7 +67,7 @@ impl AdaptiveThrottle {
     /// - Above half of max concurrency: increase by 1 (congestion avoidance, careful probing)
     pub fn on_success(&self) {
         let count = self.inner.success_count.fetch_add(1, Ordering::Relaxed) + 1;
-        if count % self.inner.increase_interval == 0 {
+        if count.is_multiple_of(self.inner.increase_interval) {
             let _ = self
                 .inner
                 .current

--- a/engine/crates/rocky-ai/src/sync.rs
+++ b/engine/crates/rocky-ai/src/sync.rs
@@ -140,24 +140,23 @@ pub fn detect_schema_changes(
 
         // Detect type changes
         for col in current_cols {
-            if let Some(prev_col) = prev_cols.iter().find(|p| p.name == col.name) {
-                if prev_col.data_type != col.data_type
-                    && col.data_type != rocky_compiler::types::RockyType::Unknown
-                    && prev_col.data_type != rocky_compiler::types::RockyType::Unknown
-                {
-                    changes.push(SchemaChange {
-                        model: model_name.clone(),
-                        change_type: SchemaChangeType::ColumnTypeChanged {
-                            name: col.name.clone(),
-                            old_type: format!("{:?}", prev_col.data_type),
-                            new_type: format!("{:?}", col.data_type),
-                        },
-                        details: format!(
-                            "Column '{}' type changed from {:?} to {:?} in '{}'",
-                            col.name, prev_col.data_type, col.data_type, model_name
-                        ),
-                    });
-                }
+            if let Some(prev_col) = prev_cols.iter().find(|p| p.name == col.name)
+                && prev_col.data_type != col.data_type
+                && col.data_type != rocky_compiler::types::RockyType::Unknown
+                && prev_col.data_type != rocky_compiler::types::RockyType::Unknown
+            {
+                changes.push(SchemaChange {
+                    model: model_name.clone(),
+                    change_type: SchemaChangeType::ColumnTypeChanged {
+                        name: col.name.clone(),
+                        old_type: format!("{:?}", prev_col.data_type),
+                        new_type: format!("{:?}", col.data_type),
+                    },
+                    details: format!(
+                        "Column '{}' type changed from {:?} to {:?} in '{}'",
+                        col.name, prev_col.data_type, col.data_type, model_name
+                    ),
+                });
             }
         }
     }

--- a/engine/crates/rocky-airbyte/src/adapter.rs
+++ b/engine/crates/rocky-airbyte/src/adapter.rs
@@ -88,10 +88,10 @@ fn matches_prefix(conn: &Connection, prefix: &str) -> bool {
         return true;
     }
 
-    if let Some(ns) = &conn.namespace_format {
-        if ns.starts_with(prefix) {
-            return true;
-        }
+    if let Some(ns) = &conn.namespace_format
+        && ns.starts_with(prefix)
+    {
+        return true;
     }
 
     // Fall back to connection name for connections without namespace_format.

--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -498,21 +498,21 @@ impl WarehouseAdapter for BigQueryAdapter {
         // sync path, so the `is_none()` check is currently always true
         // when a job ran — but keeping it defensive against future
         // codepaths that might pre-populate the field.
-        if response.statistics.is_none() {
-            if let Some(ref job_ref) = response.job_reference {
-                match self.fetch_job_statistics(job_ref).await {
-                    Ok(stats) => response.statistics = Some(stats),
-                    Err(e) => {
-                        // Best-effort: fall back to top-level
-                        // `total_bytes_processed`. Logged so a future
-                        // "cost numbers look low" debug session has the
-                        // failure reason recorded.
-                        debug!(
-                            job_id = %job_ref.job_id,
-                            error = %e,
-                            "jobs.get failed; falling back to totalBytesProcessed",
-                        );
-                    }
+        if response.statistics.is_none()
+            && let Some(ref job_ref) = response.job_reference
+        {
+            match self.fetch_job_statistics(job_ref).await {
+                Ok(stats) => response.statistics = Some(stats),
+                Err(e) => {
+                    // Best-effort: fall back to top-level
+                    // `total_bytes_processed`. Logged so a future
+                    // "cost numbers look low" debug session has the
+                    // failure reason recorded.
+                    debug!(
+                        job_id = %job_ref.job_id,
+                        error = %e,
+                        "jobs.get failed; falling back to totalBytesProcessed",
+                    );
                 }
             }
         }

--- a/engine/crates/rocky-cache/src/tiered.rs
+++ b/engine/crates/rocky-cache/src/tiered.rs
@@ -136,10 +136,10 @@ impl<K: Eq + Hash + Clone + Send, V: Clone + Send> TieredCache<K, V> {
         let value = fetch().await?;
 
         // 4. Populate Valkey
-        if let Some(ref valkey) = self.valkey {
-            if let Err(e) = valkey.set(valkey_key, &value, None).await {
-                tracing::warn!("tiered cache: valkey set failed: {e}");
-            }
+        if let Some(ref valkey) = self.valkey
+            && let Err(e) = valkey.set(valkey_key, &value, None).await
+        {
+            tracing::warn!("tiered cache: valkey set failed: {e}");
         }
 
         // 5. Populate memory
@@ -160,10 +160,10 @@ impl<K: Eq + Hash + Clone + Send, V: Clone + Send> TieredCache<K, V> {
             mem.remove(key);
         }
 
-        if let Some(ref valkey) = self.valkey {
-            if let Err(e) = valkey.delete(valkey_key).await {
-                tracing::warn!("tiered cache: valkey delete failed during invalidate: {e}");
-            }
+        if let Some(ref valkey) = self.valkey
+            && let Err(e) = valkey.delete(valkey_key).await
+        {
+            tracing::warn!("tiered cache: valkey delete failed during invalidate: {e}");
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -660,14 +660,14 @@ fn summarize_source_state_drift(
         ));
     }
     for (id, p_conn) in &persisted_map {
-        if let Some(l_conn) = live_map.get(id) {
-            if p_conn != l_conn {
-                lines.push(format!(
-                    "  connector '{id}' changed (tables: {} -> {}; schema/type may also differ)",
-                    p_conn.tables.len(),
-                    l_conn.tables.len(),
-                ));
-            }
+        if let Some(l_conn) = live_map.get(id)
+            && p_conn != l_conn
+        {
+            lines.push(format!(
+                "  connector '{id}' changed (tables: {} -> {}; schema/type may also differ)",
+                p_conn.tables.len(),
+                l_conn.tables.len(),
+            ));
         }
     }
     lines.join("\n")

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -421,10 +421,10 @@ fn collect_model_files(root: &Path, dir: &Path, out: &mut Vec<(String, PathBuf)>
         let path = entry.path();
         if file_type.is_dir() {
             collect_model_files(root, &path, out);
-        } else if file_type.is_file() {
-            if let Ok(rel) = path.strip_prefix(root) {
-                out.push((rel.to_string_lossy().replace('\\', "/"), path));
-            }
+        } else if file_type.is_file()
+            && let Ok(rel) = path.strip_prefix(root)
+        {
+            out.push((rel.to_string_lossy().replace('\\', "/"), path));
         }
     }
 }
@@ -1025,10 +1025,10 @@ async fn discover_replication_branch_targets(
             Ok(p) => p,
             Err(_) => continue,
         };
-        if let Some((ref filter_key, ref filter_value)) = parsed_filter {
-            if !matches_filter(conn, &parsed, filter_key, filter_value) {
-                continue;
-            }
+        if let Some((ref filter_key, ref filter_value)) = parsed_filter
+            && !matches_filter(conn, &parsed, filter_key, filter_value)
+        {
+            continue;
         }
         let target_sep = pipeline
             .target
@@ -1130,10 +1130,10 @@ fn discover_transformation_branch_targets(
     ))?;
     if let Ok(entries) = std::fs::read_dir(&models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all_models.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
+            {
+                all_models.extend(sub);
             }
         }
     }
@@ -1652,14 +1652,14 @@ pub async fn run_branch_promote_from_plan(
     let promote_plan: PromotePlan = serde_json::from_value(plan.payload.clone())
         .context("failed to deserialize promote plan payload")?;
 
-    if let Some(n) = name {
-        if n != promote_plan.branch_name {
-            anyhow::bail!(
-                "branch name '{n}' does not match plan's branch name '{}'. \
+    if let Some(n) = name
+        && n != promote_plan.branch_name
+    {
+        anyhow::bail!(
+            "branch name '{n}' does not match plan's branch name '{}'. \
                  Omit the positional arg or pass the correct name.",
-                promote_plan.branch_name
-            );
-        }
+            promote_plan.branch_name
+        );
     }
 
     let actor = approver_identity().unwrap_or_else(|_| crate::output::ApproverIdentity {

--- a/engine/crates/rocky-cli/src/commands/ci_diff.rs
+++ b/engine/crates/rocky-cli/src/commands/ci_diff.rs
@@ -273,10 +273,11 @@ pub(crate) fn extract_base_compile(
         let show_output = Command::new("git")
             .args(["show", &format!("{base_ref}:{file_path}")])
             .output();
-        if let Ok(o) = show_output {
-            if o.status.success() && std::fs::write(&dest, &o.stdout).is_ok() {
-                wrote_any = true;
-            }
+        if let Ok(o) = show_output
+            && o.status.success()
+            && std::fs::write(&dest, &o.stdout).is_ok()
+        {
+            wrote_any = true;
         }
     }
     if !wrote_any {

--- a/engine/crates/rocky-cli/src/commands/compare.rs
+++ b/engine/crates/rocky-cli/src/commands/compare.rs
@@ -73,10 +73,10 @@ pub async fn compare(
             Err(_) => continue,
         };
 
-        if let Some((ref filter_key, ref filter_value)) = parsed_filter {
-            if !matches_filter(conn, &parsed, filter_key, filter_value) {
-                continue;
-            }
+        if let Some((ref filter_key, ref filter_value)) = parsed_filter
+            && !matches_filter(conn, &parsed, filter_key, filter_value)
+        {
+            continue;
         }
 
         let target_sep = pipeline

--- a/engine/crates/rocky-cli/src/commands/compile.rs
+++ b/engine/crates/rocky-cli/src/commands/compile.rs
@@ -195,10 +195,10 @@ fn compile_inner(
 
         let mut expanded = HashMap::new();
         for model in &result.project.models {
-            if let Some(filter) = model_filter {
-                if model.config.name != filter {
-                    continue;
-                }
+            if let Some(filter) = model_filter
+                && model.config.name != filter
+            {
+                continue;
             }
             let sql = expand_macros(&model.sql, &macro_defs)?;
             expanded.insert(model.config.name.clone(), sql);

--- a/engine/crates/rocky-cli/src/commands/compliance.rs
+++ b/engine/crates/rocky-cli/src/commands/compliance.rs
@@ -210,10 +210,10 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
 
     if let Ok(entries) = std::fs::read_dir(models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
+            {
+                all.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -327,10 +327,10 @@ pub(super) fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
 
     if let Ok(entries) = std::fs::read_dir(models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
+            {
+                all.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -199,10 +199,10 @@ pub async fn doctor(
                     ));
                 }
                 // Check schema pattern is parseable (replication pipelines only)
-                if let Some(repl) = pipeline.as_replication() {
-                    if let Err(e) = repl.schema_pattern() {
-                        issues.push(format!("pipeline '{name}': invalid schema pattern: {e}"));
-                    }
+                if let Some(repl) = pipeline.as_replication()
+                    && let Err(e) = repl.schema_pattern()
+                {
+                    issues.push(format!("pipeline '{name}': invalid schema pattern: {e}"));
                 }
             }
             let pipeline_count = cfg.pipelines.len();

--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -170,10 +170,10 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
 
     if let Ok(entries) = std::fs::read_dir(models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = models::load_models_from_dir(&entry.path()) {
-                    all.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = models::load_models_from_dir(&entry.path())
+            {
+                all.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -268,10 +268,10 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<rocky_core::models::Model>> 
 
     if let Ok(entries) = std::fs::read_dir(models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
+            {
+                all.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/metrics.rs
+++ b/engine/crates/rocky-cli/src/commands/metrics.rs
@@ -167,10 +167,10 @@ pub fn run_metrics(
                 let mut rates: Vec<_> = latest.metrics.null_rates.iter().collect();
                 rates.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
                 for (col, rate) in &rates {
-                    if let Some(filter_col) = column {
-                        if col.as_str() != filter_col {
-                            continue;
-                        }
+                    if let Some(filter_col) = column
+                        && col.as_str() != filter_col
+                    {
+                        continue;
                     }
                     println!("    {col}: {:.2}%", *rate * 100.0);
                 }

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -167,10 +167,10 @@ fn load_dag_from_models(models_dir: Option<&Path>) -> Vec<DagNode> {
     // Also check one level of subdirectories (same pattern as estimate.rs).
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = models::load_models_from_dir(&entry.path()) {
-                    all_models.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = models::load_models_from_dir(&entry.path())
+            {
+                all_models.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -99,10 +99,10 @@ pub async fn plan(
             Err(_) => continue,
         };
 
-        if let Some((ref filter_key, ref filter_value)) = parsed_filter {
-            if !matches_filter(conn, &parsed, filter_key, filter_value) {
-                continue;
-            }
+        if let Some((ref filter_key, ref filter_value)) = parsed_filter
+            && !matches_filter(conn, &parsed, filter_key, filter_value)
+        {
+            continue;
         }
 
         let target_sep = pipeline
@@ -122,34 +122,33 @@ pub async fn plan(
         };
 
         // Catalog creation — only when governance enables it and the dialect supports catalogs.
-        if pipeline.target.governance.auto_create_catalogs {
-            if let Some(create_cat) = dialect.create_catalog_sql(&target_catalog) {
-                let sql = create_cat.map_err(|e| anyhow::anyhow!("create_catalog: {e}"))?;
-                output.statements.push(PlannedStatement {
-                    purpose: "create_catalog".into(),
-                    target: target_catalog.clone(),
-                    sql,
-                });
-            }
+        if pipeline.target.governance.auto_create_catalogs
+            && let Some(create_cat) = dialect.create_catalog_sql(&target_catalog)
+        {
+            let sql = create_cat.map_err(|e| anyhow::anyhow!("create_catalog: {e}"))?;
+            output.statements.push(PlannedStatement {
+                purpose: "create_catalog".into(),
+                target: target_catalog.clone(),
+                sql,
+            });
         }
 
         // Schema creation — only when governance enables it.
-        if pipeline.target.governance.auto_create_schemas {
-            if let Some(create_sch) =
+        if pipeline.target.governance.auto_create_schemas
+            && let Some(create_sch) =
                 dialect.create_schema_sql(&effective_target_catalog, &target_schema)
-            {
-                let sql = create_sch.map_err(|e| anyhow::anyhow!("create_schema: {e}"))?;
-                let target_label = if effective_target_catalog.is_empty() {
-                    target_schema.clone()
-                } else {
-                    format!("{effective_target_catalog}.{target_schema}")
-                };
-                output.statements.push(PlannedStatement {
-                    purpose: "create_schema".into(),
-                    target: target_label,
-                    sql,
-                });
-            }
+        {
+            let sql = create_sch.map_err(|e| anyhow::anyhow!("create_schema: {e}"))?;
+            let target_label = if effective_target_catalog.is_empty() {
+                target_schema.clone()
+            } else {
+                format!("{effective_target_catalog}.{target_schema}")
+            };
+            output.statements.push(PlannedStatement {
+                purpose: "create_schema".into(),
+                target: target_label,
+                sql,
+            });
         }
 
         // Per-table copy SQL
@@ -569,10 +568,10 @@ pub fn plan_preview_output(
 
     for model_ir in &project_ir.models {
         let model_name = model_ir.name.as_ref();
-        if let Some(f) = filter {
-            if model_name != f {
-                continue;
-            }
+        if let Some(f) = filter
+            && model_name != f
+        {
+            continue;
         }
 
         let target_label = if model_ir.target.catalog.is_empty() {

--- a/engine/crates/rocky-cli/src/commands/preview_rows.rs
+++ b/engine/crates/rocky-cli/src/commands/preview_rows.rs
@@ -212,10 +212,10 @@ pub async fn run_preview_rows(
     let masks = rocky_cfg.resolve_mask_for_env(None);
     let mut masked: BTreeMap<String, MaskStrategy> = BTreeMap::new();
     for (col, tag) in &m.config.classification {
-        if let Some(&strat) = masks.get(tag) {
-            if strat != MaskStrategy::None {
-                masked.insert(col.clone(), strat);
-            }
+        if let Some(&strat) = masks.get(tag)
+            && strat != MaskStrategy::None
+        {
+            masked.insert(col.clone(), strat);
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/replay.rs
+++ b/engine/crates/rocky-cli/src/commands/replay.rs
@@ -84,10 +84,10 @@ pub fn run_replay(
         .map(to_model)
         .collect();
 
-    if let Some(name) = model_filter {
-        if models.is_empty() {
-            anyhow::bail!("run '{}' did not execute model '{name}'", record.run_id);
-        }
+    if let Some(name) = model_filter
+        && models.is_empty()
+    {
+        anyhow::bail!("run '{}' did not execute model '{name}'", record.run_id);
     }
 
     if json {

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1274,11 +1274,10 @@ pub async fn run(
                 Err(_) => continue,
             };
 
-            if let Some((ref filter_key, ref filter_value)) = parsed_filter {
-                if !matches_filter(conn, &parsed, filter_key, filter_value) {
+            if let Some((ref filter_key, ref filter_value)) = parsed_filter
+                && !matches_filter(conn, &parsed, filter_key, filter_value) {
                     continue;
                 }
-            }
 
             let components = parsed_to_json_map(&parsed);
             let target_catalog = parsed.resolve_template(target_catalog_template, target_sep);
@@ -1345,13 +1344,12 @@ pub async fn run(
                 // explicit desired state that replaces any overlap by
                 // id. The FR-009 validator above has already rejected
                 // the dangerous shape (`Some(empty)` without opt-in).
-                if let Some(ov) = governance_override {
-                    if let Some(ids) = ov.workspace_ids.as_ref() {
+                if let Some(ov) = governance_override
+                    && let Some(ids) = ov.workspace_ids.as_ref() {
                         for b in ids {
                             binding_map.insert(b.id, b.clone());
                         }
                     }
-                }
                 let all_bindings: Vec<rocky_core::config::WorkspaceBindingConfig> = {
                     let mut v: Vec<_> = binding_map.into_values().collect();
                     v.sort_by_key(|b| b.id);
@@ -1404,8 +1402,8 @@ pub async fn run(
                         current_ids.get(&binding.id),
                         Some(current_kind) if current_kind == desired_kind
                     );
-                    if needs_apply {
-                        if let Err(e) = governance_adapter
+                    if needs_apply
+                        && let Err(e) = governance_adapter
                             .bind_workspace(&target_catalog, binding.id, desired_kind)
                             .await
                         {
@@ -1417,13 +1415,12 @@ pub async fn run(
                                 "workspace binding failed"
                             );
                         }
-                    }
                 }
 
                 // Remove bindings that exist on the catalog but aren't desired.
                 for &cur_id in current_ids.keys() {
-                    if !desired_ids.contains(&cur_id) {
-                        if let Err(e) = governance_adapter
+                    if !desired_ids.contains(&cur_id)
+                        && let Err(e) = governance_adapter
                             .remove_workspace_binding(&target_catalog, cur_id)
                             .await
                         {
@@ -1434,18 +1431,16 @@ pub async fn run(
                                 "remove workspace binding failed"
                             );
                         }
-                    }
                 }
 
                 let should_isolate = governance.isolation.as_ref().is_some_and(|i| i.enabled);
-                if should_isolate {
-                    if let Err(e) = governance_adapter
+                if should_isolate
+                    && let Err(e) = governance_adapter
                         .set_isolation(&target_catalog, true)
                         .await
                     {
                         warn!(catalog = target_catalog, error = %e, "catalog isolation failed");
                     }
-                }
 
                 // Merge catalog grants: config defaults + per-run override
                 let mut all_grants = governance.grants.clone();
@@ -2304,12 +2299,11 @@ pub async fn run(
                 // Signal the adaptive throttle: rate limits reduce concurrency,
                 // other errors are treated as successes (they're permanent
                 // failures, not a signal to slow down).
-                if let Some(t) = &throttle {
-                    if is_rate_limit_error(&msg) {
+                if let Some(t) = &throttle
+                    && is_rate_limit_error(&msg) {
                         t.on_rate_limit();
                         adjust_semaphore(t, &semaphore, &mut semaphore_capacity);
                     }
-                }
 
                 warn!(error = msg, "table processing failed");
                 rocky_observe::metrics::METRICS.inc_tables_failed();
@@ -2920,8 +2914,8 @@ pub async fn run(
     }
 
     // Anomaly detection
-    if row_count_enabled {
-        if let Some(ref store) = state_store {
+    if row_count_enabled
+        && let Some(ref store) = state_store {
             for (target_key, _) in &batch_asset_keys {
                 let tgt_count = target_counts
                     .iter()
@@ -2967,7 +2961,6 @@ pub async fn run(
                 }
             }
         }
-    }
 
     // Process freshness results
     if let Some(ref freshness_cfg) = pipeline.checks.freshness {
@@ -3174,8 +3167,8 @@ pub async fn run(
                     // governance adapter; best-effort — failure warns
                     // but does not abort the run, matching the
                     // classification/masking contract above.
-                    if let Some(retention) = model.config.retention {
-                        if let Err(e) = governance_adapter
+                    if let Some(retention) = model.config.retention
+                        && let Err(e) = governance_adapter
                             .apply_retention_policy(&table_ref, &retention)
                             .await
                         {
@@ -3186,7 +3179,6 @@ pub async fn run(
                                 "apply retention policy failed"
                             );
                         }
-                    }
                 }
             }
 
@@ -3853,10 +3845,10 @@ pub(crate) async fn execute_models(
     for layer in &compile_result.project.layers {
         for model_name in layer {
             // When a model name filter is active, skip models that don't match.
-            if let Some(target) = model_name_filter {
-                if model_name != target {
-                    continue;
-                }
+            if let Some(target) = model_name_filter
+                && model_name != target
+            {
+                continue;
             }
 
             let Some(model) = compile_result.project.model(model_name) else {
@@ -4015,17 +4007,17 @@ pub(crate) async fn execute_models(
                 )
                 .await
                 .with_context(|| format!("model '{model_name}' failed"));
-                if let Err(ref e) = time_interval_res {
-                    if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
-                        let _ = reg
-                            .fire(&HookContext::model_error(
-                                run_id,
-                                pipe,
-                                model_name,
-                                &format!("{e:#}"),
-                            ))
-                            .await;
-                    }
+                if let Err(ref e) = time_interval_res
+                    && let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name)
+                {
+                    let _ = reg
+                        .fire(&HookContext::model_error(
+                            run_id,
+                            pipe,
+                            model_name,
+                            &format!("{e:#}"),
+                        ))
+                        .await;
                 }
                 time_interval_res?;
                 if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
@@ -5561,11 +5553,11 @@ async fn process_completed_result(
             }
 
             // Signal the adaptive throttle
-            if let Some(t) = &throttle {
-                if is_rate_limit_error(&msg) {
-                    t.on_rate_limit();
-                    adjust_semaphore(t, semaphore, semaphore_capacity);
-                }
+            if let Some(t) = &throttle
+                && is_rate_limit_error(&msg)
+            {
+                t.on_rate_limit();
+                adjust_semaphore(t, semaphore, semaphore_capacity);
             }
 
             warn!(error = msg, "table processing failed");

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -309,19 +309,20 @@ fn event_path_is_relevant(
 ) -> bool {
     // rocky.toml exact match (+ its temporary editor backups don't match
     // the filename, so are ignored automatically).
-    if let Some(name) = path.file_name() {
-        if path.parent() == Some(config_dir) && name == config_filename {
-            return true;
-        }
+    if let Some(name) = path.file_name()
+        && path.parent() == Some(config_dir)
+        && name == config_filename
+    {
+        return true;
     }
 
     // Skip dotfiles (vim swap files like `.foo.swp`, `.DS_Store`, etc.)
     // and the embedded redb state store, which lives next to models on
     // some layouts.
-    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-        if name.starts_with('.') || name.ends_with(".redb") || name.ends_with(".redb-lock") {
-            return false;
-        }
+    if let Some(name) = path.file_name().and_then(|n| n.to_str())
+        && (name.starts_with('.') || name.ends_with(".redb") || name.ends_with(".redb-lock"))
+    {
+        return false;
     }
 
     // Match transformation-relevant suffixes. `.toml` is included so

--- a/engine/crates/rocky-cli/src/commands/shell.rs
+++ b/engine/crates/rocky-cli/src/commands/shell.rs
@@ -72,12 +72,12 @@ fn resolve_shell_adapter(
     pipeline_name: Option<&str>,
 ) -> Result<(String, Arc<dyn WarehouseAdapter>)> {
     // Try pipeline-based resolution first
-    if pipeline_name.is_some() || config.pipelines.len() == 1 {
-        if let Ok((_, pipeline)) = registry::resolve_pipeline(config, pipeline_name) {
-            let adapter_ref = pipeline_target_adapter(pipeline);
-            let adapter = registry.warehouse_adapter(&adapter_ref)?;
-            return Ok((adapter_ref, adapter));
-        }
+    if (pipeline_name.is_some() || config.pipelines.len() == 1)
+        && let Ok((_, pipeline)) = registry::resolve_pipeline(config, pipeline_name)
+    {
+        let adapter_ref = pipeline_target_adapter(pipeline);
+        let adapter = registry.warehouse_adapter(&adapter_ref)?;
+        return Ok((adapter_ref, adapter));
     }
 
     // Fallback: use the only warehouse adapter

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -108,10 +108,10 @@ fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
 
     if let Ok(entries) = std::fs::read_dir(models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = models::load_models_from_dir(&entry.path()) {
-                    all.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = models::load_models_from_dir(&entry.path())
+            {
+                all.extend(sub);
             }
         }
     }

--- a/engine/crates/rocky-cli/src/commands/test_adapter.rs
+++ b/engine/crates/rocky-cli/src/commands/test_adapter.rs
@@ -102,11 +102,10 @@ pub async fn run_test_adapter_builtin(
     // process-adapter conformance path. This makes `--adapter` the single
     // user-facing surface for both shipped adapters and installed process
     // adapters — same flag, same convention as `cargo` subcommands.
-    if !BUILTIN_ADAPTERS.contains(&adapter_name) {
-        if let Some(command) = resolve_adapter_command(adapter_name) {
-            return run_test_adapter(&command.display().to_string(), config_path, json_output)
-                .await;
-        }
+    if !BUILTIN_ADAPTERS.contains(&adapter_name)
+        && let Some(command) = resolve_adapter_command(adapter_name)
+    {
+        return run_test_adapter(&command.display().to_string(), config_path, json_output).await;
     }
 
     // For built-in adapters, we construct a manifest from the adapter name

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -506,20 +506,20 @@ fn validate_replication_pipeline(
             field: Some(format!("pipeline.{name}.target.adapter")),
         });
     }
-    if let Some(ref disc) = pipeline.source.discovery {
-        if !cfg.adapters.contains_key(&disc.adapter) {
-            ok = false;
-            msgs.push(ValidateMessage {
-                severity: "error".into(),
-                code: "V024".into(),
-                message: format!(
-                    "pipeline.{name}: discovery adapter '{}' not found in [adapter]",
-                    disc.adapter
-                ),
-                file: None,
-                field: Some(format!("pipeline.{name}.source.discovery.adapter")),
-            });
-        }
+    if let Some(ref disc) = pipeline.source.discovery
+        && !cfg.adapters.contains_key(&disc.adapter)
+    {
+        ok = false;
+        msgs.push(ValidateMessage {
+            severity: "error".into(),
+            code: "V024".into(),
+            message: format!(
+                "pipeline.{name}: discovery adapter '{}' not found in [adapter]",
+                disc.adapter
+            ),
+            file: None,
+            field: Some(format!("pipeline.{name}.source.discovery.adapter")),
+        });
     }
 
     msgs.push(ValidateMessage {
@@ -868,10 +868,10 @@ fn lint_config(
                 if pipeline.source.adapter == *adapter_name {
                     ref_count += 1;
                 }
-                if let Some(ref disc) = pipeline.source.discovery {
-                    if disc.adapter == *adapter_name {
-                        ref_count += 1;
-                    }
+                if let Some(ref disc) = pipeline.source.discovery
+                    && disc.adapter == *adapter_name
+                {
+                    ref_count += 1;
                 }
             }
         }

--- a/engine/crates/rocky-cli/src/commands/validate_migration.rs
+++ b/engine/crates/rocky-cli/src/commands/validate_migration.rs
@@ -232,10 +232,10 @@ fn collect_rocky_model_names(dir: &Path) -> std::collections::HashSet<String> {
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "sql") {
-                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                    names.insert(stem.to_string());
-                }
+            if path.extension().is_some_and(|ext| ext == "sql")
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            {
+                names.insert(stem.to_string());
             }
             // Recurse into subdirectories
             if path.is_dir() {

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -598,10 +598,10 @@ pub fn classify_anyhow_error(err: &anyhow::Error) -> FailureKind {
         if let Some(kind) = classify_cause(cause) {
             return kind;
         }
-        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>() {
-            if let Some(kind) = classify_cause(adapter_err.inner()) {
-                return kind;
-            }
+        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>()
+            && let Some(kind) = classify_cause(adapter_err.inner())
+        {
+            return kind;
         }
     }
     FailureKind::Unknown
@@ -621,10 +621,10 @@ pub fn classify_anyhow_error_with_cooldown(err: &anyhow::Error) -> (FailureKind,
         if let Some(pair) = classify_cause_with_cooldown(cause) {
             return pair;
         }
-        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>() {
-            if let Some(pair) = classify_cause_with_cooldown(adapter_err.inner()) {
-                return pair;
-            }
+        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>()
+            && let Some(pair) = classify_cause_with_cooldown(adapter_err.inner())
+        {
+            return pair;
         }
     }
     (FailureKind::Unknown, None)

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -163,15 +163,15 @@ pub(crate) fn resolve_transformation_managed_tables(
         "project root '{}' could not be resolved",
         project_root.display()
     ))?;
-    if let Ok(canonical_models) = models_dir.canonicalize() {
-        if !canonical_models.starts_with(&canonical_root) {
-            bail!(
-                "models directory '{}' resolves outside the project root '{}'. \
+    if let Ok(canonical_models) = models_dir.canonicalize()
+        && !canonical_models.starts_with(&canonical_root)
+    {
+        bail!(
+            "models directory '{}' resolves outside the project root '{}'. \
                  Refusing to load — adjust `models = \"...\"` in rocky.toml.",
-                canonical_models.display(),
-                canonical_root.display(),
-            );
-        }
+            canonical_models.display(),
+            canonical_root.display(),
+        );
     }
 
     // Load models the same way `rocky list models` does: top-level +
@@ -183,10 +183,10 @@ pub(crate) fn resolve_transformation_managed_tables(
 
     if let Ok(entries) = std::fs::read_dir(&models_dir) {
         for entry in entries.flatten() {
-            if entry.path().is_dir() {
-                if let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path()) {
-                    all_models.extend(sub);
-                }
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
+            {
+                all_models.extend(sub);
             }
         }
     }
@@ -218,10 +218,10 @@ pub(crate) fn managed_catalog_set(managed: &HashSet<String>) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut out: Vec<String> = Vec::new();
     for full in managed {
-        if let Some((catalog, _rest)) = full.split_once('.') {
-            if seen.insert(catalog.to_string()) {
-                out.push(catalog.to_string());
-            }
+        if let Some((catalog, _rest)) = full.split_once('.')
+            && seen.insert(catalog.to_string())
+        {
+            out.push(catalog.to_string());
         }
     }
     out.sort();

--- a/engine/crates/rocky-compiler/src/cache.rs
+++ b/engine/crates/rocky-compiler/src/cache.rs
@@ -55,10 +55,10 @@ impl CompileCache {
     pub fn load(path: &Path) -> Self {
         match std::fs::read_to_string(path) {
             Ok(content) => {
-                if let Ok(cache) = serde_json::from_str::<CompileCache>(&content) {
-                    if cache.version == Self::VERSION {
-                        return cache;
-                    }
+                if let Ok(cache) = serde_json::from_str::<CompileCache>(&content)
+                    && cache.version == Self::VERSION
+                {
+                    return cache;
                 }
                 // Version mismatch or corrupt — start fresh
                 Self::new()

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -368,10 +368,10 @@ pub fn compile_incremental(
     // set differs from the previous graph's must be re-typechecked —
     // the scope it reads from has changed.
     for (name, schema) in &semantic_graph.models {
-        if let Some(prev_schema) = previous.semantic_graph.models.get(name) {
-            if schema.upstream != prev_schema.upstream {
-                affected.insert(name.clone());
-            }
+        if let Some(prev_schema) = previous.semantic_graph.models.get(name)
+            && schema.upstream != prev_schema.upstream
+        {
+            affected.insert(name.clone());
         }
     }
 
@@ -555,13 +555,13 @@ pub fn default_type_mapper(warehouse_type: &str) -> RockyType {
                 .and_then(|s| s.strip_suffix(')'))
             {
                 let parts: Vec<&str> = params.split(',').collect();
-                if parts.len() == 2 {
-                    if let (Ok(p), Ok(s)) = (parts[0].trim().parse(), parts[1].trim().parse()) {
-                        return RockyType::Decimal {
-                            precision: p,
-                            scale: s,
-                        };
-                    }
+                if parts.len() == 2
+                    && let (Ok(p), Ok(s)) = (parts[0].trim().parse(), parts[1].trim().parse())
+                {
+                    return RockyType::Decimal {
+                        precision: p,
+                        scale: s,
+                    };
                 }
             }
             RockyType::Decimal {

--- a/engine/crates/rocky-compiler/src/contracts.rs
+++ b/engine/crates/rocky-compiler/src/contracts.rs
@@ -70,14 +70,14 @@ pub fn load_contracts(dir: &Path) -> Result<HashMap<String, CompilerContract>, S
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
 
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            if let Some(model_name) = name.strip_suffix(".contract.toml") {
-                let content = std::fs::read_to_string(&path)
-                    .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-                let contract: CompilerContract = toml::from_str(&content)
-                    .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
-                contracts.insert(model_name.to_string(), contract);
-            }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && let Some(model_name) = name.strip_suffix(".contract.toml")
+        {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+            let contract: CompilerContract = toml::from_str(&content)
+                .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+            contracts.insert(model_name.to_string(), contract);
         }
     }
 
@@ -149,17 +149,18 @@ pub fn validate_contract(
                 }
 
                 // Nullability check
-                if let Some(nullable) = contract_col.nullable {
-                    if !nullable && col.nullable {
-                        diagnostics.push(Diagnostic::error(
-                            E012,
-                            model_name,
-                            format!(
-                                "column '{}' must be non-nullable per contract, but is nullable",
-                                contract_col.name
-                            ),
-                        ));
-                    }
+                if let Some(nullable) = contract_col.nullable
+                    && !nullable
+                    && col.nullable
+                {
+                    diagnostics.push(Diagnostic::error(
+                        E012,
+                        model_name,
+                        format!(
+                            "column '{}' must be non-nullable per contract, but is nullable",
+                            contract_col.name
+                        ),
+                    ));
                 }
             }
             None => {

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -352,9 +352,10 @@ pub fn apply_dbt_unit_tests(manifest: &DbtManifest, result: &mut ImportResult) {
     for ut in manifest.unit_tests.values() {
         result.unit_tests_found += 1;
 
-        if let Some(format) = ut.expect.format.as_deref() {
-            if !is_dict_format(format) {
-                result.warnings.push(ImportWarning {
+        if let Some(format) = ut.expect.format.as_deref()
+            && !is_dict_format(format)
+        {
+            result.warnings.push(ImportWarning {
                     model: ut.model.clone(),
                     category: WarningCategory::UnsupportedUnitTestFormat,
                     message: format!(
@@ -365,9 +366,8 @@ pub fn apply_dbt_unit_tests(manifest: &DbtManifest, result: &mut ImportResult) {
                         "convert the expected rows to inline `format: dict` in the dbt unit_test, or hand-port to a Rocky [[test]] block".to_string(),
                     ),
                 });
-                result.unit_tests_skipped += 1;
-                continue;
-            }
+            result.unit_tests_skipped += 1;
+            continue;
         }
 
         // dbt's per-given format defaults to `dict` (inline rows). Skip
@@ -456,10 +456,10 @@ pub(crate) fn strip_ref_wrapper(input: &str) -> String {
             return bare;
         }
     }
-    if let Some(inner) = strip_call(trimmed, "source") {
-        if let Some((src, tbl)) = split_source_args(inner) {
-            return format!("{src}.{tbl}");
-        }
+    if let Some(inner) = strip_call(trimmed, "source")
+        && let Some((src, tbl)) = split_source_args(inner)
+    {
+        return format!("{src}.{tbl}");
     }
     trimmed
         .trim_matches(|c: char| c == '\'' || c == '"')
@@ -500,10 +500,10 @@ fn attach_intent(result: &mut ImportResult, model_name: &str, description: Optio
     let Some(desc) = description else {
         return;
     };
-    if let Some(imported) = result.imported.iter_mut().find(|m| m.name == model_name) {
-        if imported.config.intent.is_none() {
-            imported.config.intent = Some(desc.to_string());
-        }
+    if let Some(imported) = result.imported.iter_mut().find(|m| m.name == model_name)
+        && imported.config.intent.is_none()
+    {
+        imported.config.intent = Some(desc.to_string());
     }
 }
 
@@ -1218,12 +1218,12 @@ fn import_single_model(
 
     // If is_incremental() was detected and config didn't already set incremental,
     // override the strategy
-    if let Some(ref incr) = incr_result {
-        if matches!(strategy, StrategyConfig::FullRefresh) {
-            strategy = StrategyConfig::Incremental {
-                timestamp_column: incr.timestamp_column.clone(),
-            };
-        }
+    if let Some(ref incr) = incr_result
+        && matches!(strategy, StrategyConfig::FullRefresh)
+    {
+        strategy = StrategyConfig::Incremental {
+            timestamp_column: incr.timestamp_column.clone(),
+        };
     }
 
     // Apply project config inheritance

--- a/engine/crates/rocky-compiler/src/import/emit.rs
+++ b/engine/crates/rocky-compiler/src/import/emit.rs
@@ -111,13 +111,10 @@ pub fn emit_repo(inputs: &EmitInputs<'_>) -> Result<EmissionResult, String> {
     // warnings (Wave 2) so we don't false-flag models that hit warnings
     // for unrelated reasons (dropped tags, hooks, on_schema_change).
     for w in &inputs.import.structured_warnings {
-        if let super::dbt::ImportDbtStructuredWarning::UnsupportedMaterialization {
-            model, ..
-        } = w
+        if let super::dbt::ImportDbtStructuredWarning::UnsupportedMaterialization { model, .. } = w
+            && !unknown_materializations.contains(model)
         {
-            if !unknown_materializations.contains(model) {
-                unknown_materializations.push(model.clone());
-            }
+            unknown_materializations.push(model.clone());
         }
     }
 

--- a/engine/crates/rocky-compiler/src/typecheck.rs
+++ b/engine/crates/rocky-compiler/src/typecheck.rs
@@ -1057,11 +1057,11 @@ fn collect_refs_from_query(
         }
 
         // Collect from ORDER BY
-        if let Some(ref order_by) = query.order_by {
-            if let ast::OrderByKind::Expressions(ref exprs) = order_by.kind {
-                for order in exprs {
-                    collect_refs_from_expr(&order.expr, file_path, ref_map);
-                }
+        if let Some(ref order_by) = query.order_by
+            && let ast::OrderByKind::Expressions(ref exprs) = order_by.kind
+        {
+            for order in exprs {
+                collect_refs_from_expr(&order.expr, file_path, ref_map);
             }
         }
     }
@@ -2683,14 +2683,14 @@ mod tests {
         let sql = format!("SELECT {expr_str}");
         let dialect = rocky_sql::dialect::DatabricksDialect;
         let stmts = Parser::parse_sql(&dialect, &sql).unwrap();
-        if let Statement::Query(q) = &stmts[0] {
-            if let SetExpr::Select(s) = q.body.as_ref() {
-                if let SelectItem::UnnamedExpr(e) = &s.projection[0] {
-                    return e.clone();
-                }
-                if let SelectItem::ExprWithAlias { expr, .. } = &s.projection[0] {
-                    return expr.clone();
-                }
+        if let Statement::Query(q) = &stmts[0]
+            && let SetExpr::Select(s) = q.body.as_ref()
+        {
+            if let SelectItem::UnnamedExpr(e) = &s.projection[0] {
+                return e.clone();
+            }
+            if let SelectItem::ExprWithAlias { expr, .. } = &s.projection[0] {
+                return expr.clone();
             }
         }
         panic!("failed to parse expression: {expr_str}");

--- a/engine/crates/rocky-core/src/breaking_change.rs
+++ b/engine/crates/rocky-core/src/breaking_change.rs
@@ -366,18 +366,18 @@ fn diff_columns(
 
     // Reorder detection — only on columns that exist on both sides.
     for (name, (old_idx, _)) in &old_by_name {
-        if let Some((new_idx, _)) = new_by_name.get(name) {
-            if old_idx != new_idx {
-                findings.push(BreakingFinding {
-                    change: BreakingChange::ColumnReordered {
-                        model: model.to_string(),
-                        column: (*name).to_string(),
-                        old_index: *old_idx,
-                        new_index: *new_idx,
-                    },
-                    severity: BreakingSeverity::Warning,
-                });
-            }
+        if let Some((new_idx, _)) = new_by_name.get(name)
+            && old_idx != new_idx
+        {
+            findings.push(BreakingFinding {
+                change: BreakingChange::ColumnReordered {
+                    model: model.to_string(),
+                    column: (*name).to_string(),
+                    old_index: *old_idx,
+                    new_index: *new_idx,
+                },
+                severity: BreakingSeverity::Warning,
+            });
         }
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2066,11 +2066,11 @@ impl RockyConfig {
         }
 
         // Pass 2: if env matches a nested override table, overlay.
-        if let Some(env_name) = env {
-            if let Some(MaskEntry::EnvOverride(overrides)) = self.mask.get(env_name) {
-                for (k, v) in overrides {
-                    out.insert(k.clone(), *v);
-                }
+        if let Some(env_name) = env
+            && let Some(MaskEntry::EnvOverride(overrides)) = self.mask.get(env_name)
+        {
+            for (k, v) in overrides {
+                out.insert(k.clone(), *v);
             }
         }
 
@@ -4124,28 +4124,25 @@ pub fn validate_adapter_kinds(config: &RockyConfig) -> Vec<ConfigError> {
 
         // Skip missing / unknown-type references — those are reported by
         // `rocky validate` (V022 / V017) or by the registry at runtime.
-        if let Some(source_cfg) = config.adapters.get(&replication.source.adapter) {
-            if capability_for(&source_cfg.adapter_type).is_some()
-                && !adapter_role_active(source_cfg, AdapterKind::Data)
-            {
-                errors.push(ConfigError::PipelineSourceAdapterNotData {
-                    pipeline: pipeline_name.clone(),
-                    adapter: replication.source.adapter.clone(),
-                });
-            }
+        if let Some(source_cfg) = config.adapters.get(&replication.source.adapter)
+            && capability_for(&source_cfg.adapter_type).is_some()
+            && !adapter_role_active(source_cfg, AdapterKind::Data)
+        {
+            errors.push(ConfigError::PipelineSourceAdapterNotData {
+                pipeline: pipeline_name.clone(),
+                adapter: replication.source.adapter.clone(),
+            });
         }
 
-        if let Some(discovery) = &replication.source.discovery {
-            if let Some(disc_cfg) = config.adapters.get(&discovery.adapter) {
-                if capability_for(&disc_cfg.adapter_type).is_some()
-                    && !adapter_role_active(disc_cfg, AdapterKind::Discovery)
-                {
-                    errors.push(ConfigError::PipelineDiscoveryAdapterNotDiscovery {
-                        pipeline: pipeline_name.clone(),
-                        adapter: discovery.adapter.clone(),
-                    });
-                }
-            }
+        if let Some(discovery) = &replication.source.discovery
+            && let Some(disc_cfg) = config.adapters.get(&discovery.adapter)
+            && capability_for(&disc_cfg.adapter_type).is_some()
+            && !adapter_role_active(disc_cfg, AdapterKind::Discovery)
+        {
+            errors.push(ConfigError::PipelineDiscoveryAdapterNotDiscovery {
+                pipeline: pipeline_name.clone(),
+                adapter: discovery.adapter.clone(),
+            });
         }
     }
 
@@ -4539,23 +4536,23 @@ pub fn check_config_deprecations(toml_str: &str) -> Result<Vec<DeprecationWarnin
 fn normalize_toml_shorthands(value: &mut toml::Value) {
     if let Some(table) = value.as_table_mut() {
         // Handle bare [adapter] → [adapter.default]
-        if let Some(adapter_val) = table.get("adapter") {
-            if is_bare_adapter(adapter_val) {
-                let adapter = table.remove("adapter").expect("key was just found above");
-                let mut wrapper = toml::map::Map::new();
-                wrapper.insert("default".to_string(), adapter);
-                table.insert("adapter".to_string(), toml::Value::Table(wrapper));
-            }
+        if let Some(adapter_val) = table.get("adapter")
+            && is_bare_adapter(adapter_val)
+        {
+            let adapter = table.remove("adapter").expect("key was just found above");
+            let mut wrapper = toml::map::Map::new();
+            wrapper.insert("default".to_string(), adapter);
+            table.insert("adapter".to_string(), toml::Value::Table(wrapper));
         }
 
         // Handle bare [pipeline] → [pipeline.default]
-        if let Some(pipeline_val) = table.get("pipeline") {
-            if is_bare_pipeline(pipeline_val) {
-                let pipeline = table.remove("pipeline").expect("key was just found above");
-                let mut wrapper = toml::map::Map::new();
-                wrapper.insert("default".to_string(), pipeline);
-                table.insert("pipeline".to_string(), toml::Value::Table(wrapper));
-            }
+        if let Some(pipeline_val) = table.get("pipeline")
+            && is_bare_pipeline(pipeline_val)
+        {
+            let pipeline = table.remove("pipeline").expect("key was just found above");
+            let mut wrapper = toml::map::Map::new();
+            wrapper.insert("default".to_string(), pipeline);
+            table.insert("pipeline".to_string(), toml::Value::Table(wrapper));
         }
     }
 }

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -253,22 +253,22 @@ pub fn validate_cross_engine_config(
 ) -> Result<(), CrossEngineError> {
     // 1. Validate per-model adapter overrides reference existing adapters.
     for model in models {
-        if let Some(ref adapter_name) = model.config.adapter {
-            if !config.adapters.contains_key(adapter_name) {
-                // Find which pipeline this model belongs to (best effort).
-                let pipeline_name = model
-                    .file_path
-                    .split('/')
-                    .find(|seg| config.pipelines.contains_key(*seg))
-                    .unwrap_or("unknown")
-                    .to_owned();
+        if let Some(ref adapter_name) = model.config.adapter
+            && !config.adapters.contains_key(adapter_name)
+        {
+            // Find which pipeline this model belongs to (best effort).
+            let pipeline_name = model
+                .file_path
+                .split('/')
+                .find(|seg| config.pipelines.contains_key(*seg))
+                .unwrap_or("unknown")
+                .to_owned();
 
-                return Err(CrossEngineError::UnknownModelAdapter {
-                    model: model.config.name.clone(),
-                    pipeline: pipeline_name,
-                    adapter: adapter_name.clone(),
-                });
-            }
+            return Err(CrossEngineError::UnknownModelAdapter {
+                model: model.config.name.clone(),
+                pipeline: pipeline_name,
+                adapter: adapter_name.clone(),
+            });
         }
     }
 
@@ -446,15 +446,15 @@ fn find_cross_warehouse_edges(config: &RockyConfig) -> Vec<CrossWarehouseEdge> {
                 .get(downstream_source_name)
                 .map(|a| a.adapter_type.as_str());
 
-            if let (Some(up), Some(down)) = (upstream_type, downstream_type) {
-                if up != down {
-                    edges.push(CrossWarehouseEdge {
-                        source_pipeline: dep_name.clone(),
-                        target_pipeline: name.clone(),
-                        upstream_adapter_type: up.to_owned(),
-                        downstream_adapter_type: down.to_owned(),
-                    });
-                }
+            if let (Some(up), Some(down)) = (upstream_type, downstream_type)
+                && up != down
+            {
+                edges.push(CrossWarehouseEdge {
+                    source_pipeline: dep_name.clone(),
+                    target_pipeline: name.clone(),
+                    upstream_adapter_type: up.to_owned(),
+                    downstream_adapter_type: down.to_owned(),
+                });
             }
         }
     }

--- a/engine/crates/rocky-core/src/idempotency.rs
+++ b/engine/crates/rocky-core/src/idempotency.rs
@@ -810,10 +810,10 @@ async fn object_store_sweep_expired(
             Ok(p) => p,
             Err(_) => continue,
         };
-        if parsed.expires_at < now {
-            if let Ok(()) = provider.delete(&rel_path).await {
-                removed += 1;
-            }
+        if parsed.expires_at < now
+            && let Ok(()) = provider.delete(&rel_path).await
+        {
+            removed += 1;
         }
     }
     Ok(removed)

--- a/engine/crates/rocky-core/src/lakehouse.rs
+++ b/engine/crates/rocky-core/src/lakehouse.rs
@@ -97,12 +97,12 @@ fn validate_options(options: &LakehouseOptions) -> Result<(), LakehouseError> {
             )));
         }
     }
-    if let Some(comment) = &options.comment {
-        if comment.contains('\'') || comment.contains("--") || comment.contains(';') {
-            return Err(LakehouseError::InvalidOption(format!(
-                "comment contains unsafe characters: '{comment}'"
-            )));
-        }
+    if let Some(comment) = &options.comment
+        && (comment.contains('\'') || comment.contains("--") || comment.contains(';'))
+    {
+        return Err(LakehouseError::InvalidOption(format!(
+            "comment contains unsafe characters: '{comment}'"
+        )));
     }
     Ok(())
 }

--- a/engine/crates/rocky-core/src/sql_gen.rs
+++ b/engine/crates/rocky-core/src/sql_gen.rs
@@ -276,24 +276,24 @@ pub fn generate_transformation_sql_with_warehouse(
     // `generate_transformation_initial_ddl` when missing (Merge today;
     // Incremental / DeleteInsert / Microbatch wired in as their live smoke
     // tests land). Here we handle FullRefresh which always does CTAS.
-    if let Some(ref format) = model_ir.format {
-        if matches!(
+    if let Some(ref format) = model_ir.format
+        && matches!(
             model_ir.materialization,
             MaterializationStrategy::FullRefresh
-        ) {
-            let opts = model_ir
-                .format_options
-                .as_ref()
-                .cloned()
-                .unwrap_or_default();
-            return Ok(lakehouse::generate_lakehouse_ddl(
-                format,
-                &target,
-                &model_ir.sql,
-                &opts,
-                dialect,
-            )?);
-        }
+        )
+    {
+        let opts = model_ir
+            .format_options
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        return Ok(lakehouse::generate_lakehouse_ddl(
+            format,
+            &target,
+            &model_ir.sql,
+            &opts,
+            dialect,
+        )?);
     }
 
     match &model_ir.materialization {

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -870,16 +870,15 @@ pub fn validate(dag: &UnifiedDag) -> Vec<UnifiedDagError> {
         }
 
         // 4. Test nodes must not have outgoing DataDependency edges.
-        if edge.edge_type == EdgeType::DataDependency {
-            if let Some(from_node) = node_map.get(edge.from.0.as_str()) {
-                if from_node.kind == NodeKind::Test {
-                    errors.push(UnifiedDagError::InvalidEdge {
-                        from: edge.from.0.clone(),
-                        to: edge.to.0.clone(),
-                        reason: "test nodes cannot have outgoing data dependencies".into(),
-                    });
-                }
-            }
+        if edge.edge_type == EdgeType::DataDependency
+            && let Some(from_node) = node_map.get(edge.from.0.as_str())
+            && from_node.kind == NodeKind::Test
+        {
+            errors.push(UnifiedDagError::InvalidEdge {
+                from: edge.from.0.clone(),
+                to: edge.to.0.clone(),
+                reason: "test nodes cannot have outgoing data dependencies".into(),
+            });
         }
     }
 

--- a/engine/crates/rocky-core/tests/project_schema.rs
+++ b/engine/crates/rocky-core/tests/project_schema.rs
@@ -77,29 +77,29 @@ fn extract_adapter_blocks(
 
     // Unnamed `[adapter]` with a `type` key is the canonical shape —
     // auto-wraps as `adapter.default`.
-    if let Some(v) = table.get("adapter") {
-        if let Some(t) = v.as_table() {
-            if t.contains_key("type") {
-                // Flat shape: promote to adapter.default.
-                out.push(("adapter.default".to_owned(), serialize_toml(v)?));
-            } else {
-                // Nested shape: every sub-table is a named adapter.
-                for (name, inner) in t {
-                    if inner.is_table() {
-                        out.push((format!("adapter.{name}"), serialize_toml(inner)?));
-                    }
+    if let Some(v) = table.get("adapter")
+        && let Some(t) = v.as_table()
+    {
+        if t.contains_key("type") {
+            // Flat shape: promote to adapter.default.
+            out.push(("adapter.default".to_owned(), serialize_toml(v)?));
+        } else {
+            // Nested shape: every sub-table is a named adapter.
+            for (name, inner) in t {
+                if inner.is_table() {
+                    out.push((format!("adapter.{name}"), serialize_toml(inner)?));
                 }
             }
         }
     }
 
     // The `adapters` alias lives only as a nested table.
-    if let Some(v) = table.get("adapters") {
-        if let Some(t) = v.as_table() {
-            for (name, inner) in t {
-                if inner.is_table() {
-                    out.push((format!("adapters.{name}"), serialize_toml(inner)?));
-                }
+    if let Some(v) = table.get("adapters")
+        && let Some(t) = v.as_table()
+    {
+        for (name, inner) in t {
+            if inner.is_table() {
+                out.push((format!("adapters.{name}"), serialize_toml(inner)?));
             }
         }
     }

--- a/engine/crates/rocky-lang/src/fmt.rs
+++ b/engine/crates/rocky-lang/src/fmt.rs
@@ -25,10 +25,10 @@ const PIPELINE_KEYWORDS: &[&str] = &[
 /// word boundary (whitespace, `{`, end-of-string, etc.).
 fn is_pipeline_keyword(trimmed: &str) -> bool {
     for &kw in PIPELINE_KEYWORDS {
-        if let Some(rest) = trimmed.strip_prefix(kw) {
-            if rest.is_empty() || !rest.as_bytes()[0].is_ascii_alphanumeric() {
-                return true;
-            }
+        if let Some(rest) = trimmed.strip_prefix(kw)
+            && (rest.is_empty() || !rest.as_bytes()[0].is_ascii_alphanumeric())
+        {
+            return true;
         }
     }
     false

--- a/engine/crates/rocky-lang/src/parser.rs
+++ b/engine/crates/rocky-lang/src/parser.rs
@@ -271,12 +271,12 @@ impl Parser {
             "cross" => Some(JoinType::Cross),
             _ => None,
         };
-        if let Some(jt) = modifier {
-            if self.tokens.get(self.pos + 1).map(|(t, _)| t) == Some(&Token::Join) {
-                self.advance(); // consume the modifier ident
-                self.advance(); // consume the `join` keyword
-                return Some(jt);
-            }
+        if let Some(jt) = modifier
+            && self.tokens.get(self.pos + 1).map(|(t, _)| t) == Some(&Token::Join)
+        {
+            self.advance(); // consume the modifier ident
+            self.advance(); // consume the `join` keyword
+            return Some(jt);
         }
 
         None

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -597,10 +597,10 @@ impl RockyMcpServer {
 
         // If a model filter was given, assert it exists so we don't write a
         // plan that applies to nothing.
-        if let Some(model) = params.0.model.as_deref() {
-            if !models.iter().any(|m| m == model) {
-                return Err(format!("model '{model}' not found in project"));
-            }
+        if let Some(model) = params.0.model.as_deref()
+            && !models.iter().any(|m| m == model)
+        {
+            return Err(format!("model '{model}' not found in project"));
         }
 
         let run_plan = build_ai_run_plan(params.0.model.clone(), &result);

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -835,10 +835,9 @@ impl RockyLsp {
         };
         if let Some((cached_hash, cached_tokens)) =
             self.semantic_tokens_cache.read().await.get(uri_str)
+            && *cached_hash == sql_hash
         {
-            if *cached_hash == sql_hash {
-                return cached_tokens.clone();
-            }
+            return cached_tokens.clone();
         }
 
         let model_names: std::collections::HashSet<&str> = result
@@ -989,13 +988,13 @@ async fn seed_salsa_source(
 #[tower_lsp::async_trait]
 impl LanguageServer for RockyLsp {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        if let Some(root) = params.root_uri {
-            if let Ok(path) = root.to_file_path() {
-                let models_path = path.join("models");
-                if models_path.exists() {
-                    *self.models_dir.write().await = Some(models_path.display().to_string());
-                    info!(path = %models_path.display(), "LSP found models directory");
-                }
+        if let Some(root) = params.root_uri
+            && let Ok(path) = root.to_file_path()
+        {
+            let models_path = path.join("models");
+            if models_path.exists() {
+                *self.models_dir.write().await = Some(models_path.display().to_string());
+                info!(path = %models_path.display(), "LSP found models directory");
             }
         }
 
@@ -1205,15 +1204,14 @@ impl LanguageServer for RockyLsp {
         // was never received for this URI (e.g. tests that drive
         // `did_change` directly), the helper falls back to
         // `read_source` so the input still gets seeded.
-        if let Some(text) = new_text {
-            if let Err(err) =
+        if let Some(text) = new_text
+            && let Err(err) =
                 seed_salsa_source(&self.salsa_db, &self.salsa_sources, &uri, &text).await
-            {
-                tracing::debug!(
-                    uri = %uri_string,
-                    "did_change: salsa update skipped ({err})",
-                );
-            }
+        {
+            tracing::debug!(
+                uri = %uri_string,
+                "did_change: salsa update skipped ({err})",
+            );
         }
 
         if !self.recompile_pending.swap(true, Ordering::SeqCst) {
@@ -1376,16 +1374,16 @@ impl LanguageServer for RockyLsp {
             }
             CompletionContext::ColumnReference(ref model_name) => {
                 let mut items = Vec::new();
-                if let Some(result) = compile_result {
-                    if let Some(schema) = result.semantic_graph.model_schema(model_name) {
-                        for col in &schema.columns {
-                            items.push(CompletionItem {
-                                label: col.name.clone(),
-                                kind: Some(CompletionItemKind::FIELD),
-                                detail: Some(format!("column from {model_name}")),
-                                ..Default::default()
-                            });
-                        }
+                if let Some(result) = compile_result
+                    && let Some(schema) = result.semantic_graph.model_schema(model_name)
+                {
+                    for col in &schema.columns {
+                        items.push(CompletionItem {
+                            label: col.name.clone(),
+                            kind: Some(CompletionItemKind::FIELD),
+                            detail: Some(format!("column from {model_name}")),
+                            ..Default::default()
+                        });
                     }
                 }
                 items
@@ -1461,101 +1459,99 @@ impl LanguageServer for RockyLsp {
             let models_dir = self.models_dir.read().await;
             if let Some(ref dir) = *models_dir {
                 let macros_dir = std::path::PathBuf::from(dir).join("../macros");
-                if macros_dir.is_dir() {
-                    if let Ok(macro_defs) = rocky_core::macros::load_macros_from_dir(&macros_dir) {
-                        if let Some(m) = macro_defs.iter().find(|m| m.name == macro_name) {
-                            return Ok(Some(Hover {
-                                contents: HoverContents::Markup(MarkupContent {
-                                    kind: MarkupKind::Markdown,
-                                    value: m.hover_markdown(),
-                                }),
-                                range: None,
-                            }));
-                        }
-                    }
+                if macros_dir.is_dir()
+                    && let Ok(macro_defs) = rocky_core::macros::load_macros_from_dir(&macros_dir)
+                    && let Some(m) = macro_defs.iter().find(|m| m.name == macro_name)
+                {
+                    return Ok(Some(Hover {
+                        contents: HoverContents::Markup(MarkupContent {
+                            kind: MarkupKind::Markdown,
+                            value: m.hover_markdown(),
+                        }),
+                        range: None,
+                    }));
                 }
             }
         }
 
         // Check if hovering on a model name (could be a referenced model, not the current file's model)
-        if let Some(ref w) = word {
-            if let Some(hover_model) = result.project.model(w) {
-                let hover_name = &hover_model.config.name;
-                let schema = result.semantic_graph.model_schema(hover_name);
-                let typed_cols = result.type_check.typed_models.get(hover_name);
+        if let Some(ref w) = word
+            && let Some(hover_model) = result.project.model(w)
+        {
+            let hover_name = &hover_model.config.name;
+            let schema = result.semantic_graph.model_schema(hover_name);
+            let typed_cols = result.type_check.typed_models.get(hover_name);
 
-                let mut info_lines = vec![format!("**Model:** `{hover_name}`")];
+            let mut info_lines = vec![format!("**Model:** `{hover_name}`")];
 
-                // Show intent if available
-                if let Some(schema) = schema {
-                    if let Some(ref intent) = schema.intent {
-                        info_lines.push(String::new());
-                        info_lines.push(format!("> {intent}"));
-                    }
-
-                    info_lines.push(format!(
-                        "\n**Upstream:** {}",
-                        if schema.upstream.is_empty() {
-                            "none (leaf)".to_string()
-                        } else {
-                            schema.upstream.join(", ")
-                        }
-                    ));
-                    if !schema.downstream.is_empty() {
-                        info_lines
-                            .push(format!("**Downstream:** {}", schema.downstream.join(", ")));
-                    }
+            // Show intent if available
+            if let Some(schema) = schema {
+                if let Some(ref intent) = schema.intent {
+                    info_lines.push(String::new());
+                    info_lines.push(format!("> {intent}"));
                 }
 
-                // Show DAG-propagated cost hint if available.
-                if let Some(cost_est) = compute_model_cost_hint(result, hover_name) {
-                    info_lines.push(String::new());
-                    if cost_est.estimated_compute_cost_usd > 0.0 {
-                        info_lines.push(format!(
-                            "**Est. cost:** ${:.6} ({} rows, {} bytes) — confidence: {}",
-                            cost_est.estimated_compute_cost_usd,
-                            format_number(cost_est.estimated_rows),
-                            format_bytes(cost_est.estimated_bytes),
-                            match cost_est.confidence {
-                                rocky_core::cost::Confidence::High => "high",
-                                rocky_core::cost::Confidence::Medium => "medium",
-                                rocky_core::cost::Confidence::Low => "low",
-                            },
-                        ));
+                info_lines.push(format!(
+                    "\n**Upstream:** {}",
+                    if schema.upstream.is_empty() {
+                        "none (leaf)".to_string()
                     } else {
-                        info_lines.push(format!(
-                            "**Est. rows:** {} ({} bytes) — confidence: {}",
-                            format_number(cost_est.estimated_rows),
-                            format_bytes(cost_est.estimated_bytes),
-                            match cost_est.confidence {
-                                rocky_core::cost::Confidence::High => "high",
-                                rocky_core::cost::Confidence::Medium => "medium",
-                                rocky_core::cost::Confidence::Low => "low",
-                            },
-                        ));
+                        schema.upstream.join(", ")
                     }
+                ));
+                if !schema.downstream.is_empty() {
+                    info_lines.push(format!("**Downstream:** {}", schema.downstream.join(", ")));
                 }
-
-                if let Some(cols) = typed_cols {
-                    info_lines.push(String::new());
-                    info_lines.push("**Columns:**".to_string());
-                    for col in cols {
-                        let nullable = if col.nullable { "?" } else { "" };
-                        info_lines.push(format!(
-                            "- `{}`: `{:?}{}`",
-                            col.name, col.data_type, nullable
-                        ));
-                    }
-                }
-
-                return Ok(Some(Hover {
-                    contents: HoverContents::Markup(MarkupContent {
-                        kind: MarkupKind::Markdown,
-                        value: info_lines.join("\n"),
-                    }),
-                    range: None,
-                }));
             }
+
+            // Show DAG-propagated cost hint if available.
+            if let Some(cost_est) = compute_model_cost_hint(result, hover_name) {
+                info_lines.push(String::new());
+                if cost_est.estimated_compute_cost_usd > 0.0 {
+                    info_lines.push(format!(
+                        "**Est. cost:** ${:.6} ({} rows, {} bytes) — confidence: {}",
+                        cost_est.estimated_compute_cost_usd,
+                        format_number(cost_est.estimated_rows),
+                        format_bytes(cost_est.estimated_bytes),
+                        match cost_est.confidence {
+                            rocky_core::cost::Confidence::High => "high",
+                            rocky_core::cost::Confidence::Medium => "medium",
+                            rocky_core::cost::Confidence::Low => "low",
+                        },
+                    ));
+                } else {
+                    info_lines.push(format!(
+                        "**Est. rows:** {} ({} bytes) — confidence: {}",
+                        format_number(cost_est.estimated_rows),
+                        format_bytes(cost_est.estimated_bytes),
+                        match cost_est.confidence {
+                            rocky_core::cost::Confidence::High => "high",
+                            rocky_core::cost::Confidence::Medium => "medium",
+                            rocky_core::cost::Confidence::Low => "low",
+                        },
+                    ));
+                }
+            }
+
+            if let Some(cols) = typed_cols {
+                info_lines.push(String::new());
+                info_lines.push("**Columns:**".to_string());
+                for col in cols {
+                    let nullable = if col.nullable { "?" } else { "" };
+                    info_lines.push(format!(
+                        "- `{}`: `{:?}{}`",
+                        col.name, col.data_type, nullable
+                    ));
+                }
+            }
+
+            return Ok(Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: info_lines.join("\n"),
+                }),
+                range: None,
+            }));
         }
 
         // Check if hovering on a column name
@@ -1565,40 +1561,40 @@ impl LanguageServer for RockyLsp {
                 let model_name = &model.config.name;
 
                 // Look for the column in the current model's typed columns
-                if let Some(typed_cols) = result.type_check.typed_models.get(model_name) {
-                    if let Some(col) = typed_cols.iter().find(|c| c.name == *w) {
-                        let value =
-                            build_column_hover_markdown(col, model_name, &result.semantic_graph);
+                if let Some(typed_cols) = result.type_check.typed_models.get(model_name)
+                    && let Some(col) = typed_cols.iter().find(|c| c.name == *w)
+                {
+                    let value =
+                        build_column_hover_markdown(col, model_name, &result.semantic_graph);
 
-                        return Ok(Some(Hover {
-                            contents: HoverContents::Markup(MarkupContent {
-                                kind: MarkupKind::Markdown,
-                                value,
-                            }),
-                            range: None,
-                        }));
-                    }
+                    return Ok(Some(Hover {
+                        contents: HoverContents::Markup(MarkupContent {
+                            kind: MarkupKind::Markdown,
+                            value,
+                        }),
+                        range: None,
+                    }));
                 }
 
                 // Also check upstream model columns (for qualified refs like model.col)
                 if let Some(schema) = result.semantic_graph.model_schema(model_name) {
                     for upstream_name in &schema.upstream {
-                        if let Some(up_cols) = result.type_check.typed_models.get(upstream_name) {
-                            if let Some(col) = up_cols.iter().find(|c| c.name == *w) {
-                                let value = build_column_hover_markdown(
-                                    col,
-                                    upstream_name,
-                                    &result.semantic_graph,
-                                );
+                        if let Some(up_cols) = result.type_check.typed_models.get(upstream_name)
+                            && let Some(col) = up_cols.iter().find(|c| c.name == *w)
+                        {
+                            let value = build_column_hover_markdown(
+                                col,
+                                upstream_name,
+                                &result.semantic_graph,
+                            );
 
-                                return Ok(Some(Hover {
-                                    contents: HoverContents::Markup(MarkupContent {
-                                        kind: MarkupKind::Markdown,
-                                        value,
-                                    }),
-                                    range: None,
-                                }));
-                            }
+                            return Ok(Some(Hover {
+                                contents: HoverContents::Markup(MarkupContent {
+                                    kind: MarkupKind::Markdown,
+                                    value,
+                                }),
+                                range: None,
+                            }));
                         }
                     }
                 }
@@ -1689,22 +1685,20 @@ impl LanguageServer for RockyLsp {
             // 3. Fallback: if the column exists in an upstream model, go there
             if let Some(schema) = result.semantic_graph.model_schema(model_name) {
                 for upstream_name in &schema.upstream {
-                    if let Some(up_cols) = result.type_check.typed_models.get(upstream_name) {
-                        if up_cols.iter().any(|c| c.name == word) {
-                            if let Some(upstream_model) = result.project.model(upstream_name) {
-                                let target_path = std::path::Path::new(&upstream_model.file_path);
-                                if let Ok(target_uri) = Url::from_file_path(target_path) {
-                                    let col_line =
-                                        find_column_line_in_sql(&upstream_model.sql, &word);
-                                    return Ok(Some(GotoDefinitionResponse::Scalar(Location {
-                                        uri: target_uri,
-                                        range: Range::new(
-                                            Position::new(col_line, 0),
-                                            Position::new(col_line, 0),
-                                        ),
-                                    })));
-                                }
-                            }
+                    if let Some(up_cols) = result.type_check.typed_models.get(upstream_name)
+                        && up_cols.iter().any(|c| c.name == word)
+                        && let Some(upstream_model) = result.project.model(upstream_name)
+                    {
+                        let target_path = std::path::Path::new(&upstream_model.file_path);
+                        if let Ok(target_uri) = Url::from_file_path(target_path) {
+                            let col_line = find_column_line_in_sql(&upstream_model.sql, &word);
+                            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                                uri: target_uri,
+                                range: Range::new(
+                                    Position::new(col_line, 0),
+                                    Position::new(col_line, 0),
+                                ),
+                            })));
                         }
                     }
                 }
@@ -1885,25 +1879,25 @@ impl LanguageServer for RockyLsp {
         let mut children = Vec::new();
 
         // Add intent as first child if present
-        if let Some(schema) = result.semantic_graph.model_schema(model_name) {
-            if let Some(ref intent) = schema.intent {
-                let display = if intent.len() > 80 {
-                    format!("{}...", &intent[..77])
-                } else {
-                    intent.clone()
-                };
-                #[allow(deprecated)]
-                children.push(DocumentSymbol {
-                    name: "intent".to_string(),
-                    detail: Some(display),
-                    kind: SymbolKind::STRING,
-                    tags: None,
-                    deprecated: None,
-                    range: Range::new(Position::new(0, 0), Position::new(0, 0)),
-                    selection_range: Range::new(Position::new(0, 0), Position::new(0, 0)),
-                    children: None,
-                });
-            }
+        if let Some(schema) = result.semantic_graph.model_schema(model_name)
+            && let Some(ref intent) = schema.intent
+        {
+            let display = if intent.len() > 80 {
+                format!("{}...", &intent[..77])
+            } else {
+                intent.clone()
+            };
+            #[allow(deprecated)]
+            children.push(DocumentSymbol {
+                name: "intent".to_string(),
+                detail: Some(display),
+                kind: SymbolKind::STRING,
+                tags: None,
+                deprecated: None,
+                range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                selection_range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+                children: None,
+            });
         }
 
         // Add column symbols
@@ -2279,15 +2273,15 @@ impl LanguageServer for RockyLsp {
                 }
                 _ => {
                     // For any diagnostic with a suggestion, offer it
-                    if let Some(compiler_diag) = find_compiler_diagnostic(result, diag) {
-                        if let Some(suggestion) = &compiler_diag.suggestion {
-                            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                                title: suggestion.clone(),
-                                kind: Some(CodeActionKind::QUICKFIX),
-                                diagnostics: Some(vec![diag.clone()]),
-                                ..Default::default()
-                            }));
-                        }
+                    if let Some(compiler_diag) = find_compiler_diagnostic(result, diag)
+                        && let Some(suggestion) = &compiler_diag.suggestion
+                    {
+                        actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                            title: suggestion.clone(),
+                            kind: Some(CodeActionKind::QUICKFIX),
+                            diagnostics: Some(vec![diag.clone()]),
+                            ..Default::default()
+                        }));
                     }
                 }
             }
@@ -2602,13 +2596,13 @@ fn get_completion_context(text: &str, line: usize, col: usize) -> CompletionCont
     let upper = text_before.to_uppercase();
     let tokens: Vec<&str> = upper.split_whitespace().collect();
 
-    if let Some(last) = tokens.last() {
-        if matches!(
+    if let Some(last) = tokens.last()
+        && matches!(
             *last,
             "FROM" | "JOIN" | "INNER" | "LEFT" | "RIGHT" | "CROSS" | "FULL"
-        ) {
-            return CompletionContext::ModelReference;
-        }
+        )
+    {
+        return CompletionContext::ModelReference;
     }
 
     if tokens.len() >= 2 {
@@ -2646,16 +2640,16 @@ fn extract_cte_info(sql: &str) -> Vec<CteInfo> {
     };
     let mut ctes = Vec::new();
     for stmt in &stmts {
-        if let Statement::Query(query) = stmt {
-            if let Some(with) = &query.with {
-                for cte in &with.cte_tables {
-                    let ident = &cte.alias.name;
-                    ctes.push(CteInfo {
-                        name: ident.value.clone(),
-                        line: ident.span.start.line as usize,
-                        col: ident.span.start.column as usize,
-                    });
-                }
+        if let Statement::Query(query) = stmt
+            && let Some(with) = &query.with
+        {
+            for cte in &with.cte_tables {
+                let ident = &cte.alias.name;
+                ctes.push(CteInfo {
+                    name: ident.value.clone(),
+                    line: ident.span.start.line as usize,
+                    col: ident.span.start.column as usize,
+                });
             }
         }
     }
@@ -3928,18 +3922,17 @@ fn collect_tokens_from_table_factor(
 ) {
     if let ast::TableFactor::Table { name, .. } = factor {
         let table_name = name.to_string();
-        if model_names.contains(table_name.as_str()) {
-            if let Some(first_part) = name.0.first() {
-                if let Some(first_ident) = first_part.as_ident() {
-                    let line = first_ident.span.start.line as u32;
-                    let col = first_ident.span.start.column as u32;
-                    // sqlparser uses 1-indexed line/column; LSP expects 0-indexed.
-                    // Only emit a token for the leading identifier so the range
-                    // can't extend past the line if the qualified name wraps.
-                    let len = first_ident.value.len() as u32;
-                    tokens.push((line.saturating_sub(1), col.saturating_sub(1), len, 0)); // NAMESPACE
-                }
-            }
+        if model_names.contains(table_name.as_str())
+            && let Some(first_part) = name.0.first()
+            && let Some(first_ident) = first_part.as_ident()
+        {
+            let line = first_ident.span.start.line as u32;
+            let col = first_ident.span.start.column as u32;
+            // sqlparser uses 1-indexed line/column; LSP expects 0-indexed.
+            // Only emit a token for the leading identifier so the range
+            // can't extend past the line if the qualified name wraps.
+            let len = first_ident.value.len() as u32;
+            tokens.push((line.saturating_sub(1), col.saturating_sub(1), len, 0)); // NAMESPACE
         }
     }
 }
@@ -3969,18 +3962,17 @@ fn collect_tokens_from_expr(
         }
         ast::Expr::Function(f) => {
             let func_name = f.name.to_string().to_uppercase();
-            if func_names.contains(func_name.as_str()) {
-                if let Some(first_part) = f.name.0.first() {
-                    if let Some(first_ident) = first_part.as_ident() {
-                        let line = first_ident.span.start.line as u32;
-                        let col = first_ident.span.start.column as u32;
-                        // Emit only the first ident's length to keep the range
-                        // single-line and within the line bounds.
-                        let len = first_ident.value.len() as u32;
-                        if line > 0 && col > 0 {
-                            tokens.push((line - 1, col - 1, len, 2)); // FUNCTION
-                        }
-                    }
+            if func_names.contains(func_name.as_str())
+                && let Some(first_part) = f.name.0.first()
+                && let Some(first_ident) = first_part.as_ident()
+            {
+                let line = first_ident.span.start.line as u32;
+                let col = first_ident.span.start.column as u32;
+                // Emit only the first ident's length to keep the range
+                // single-line and within the line bounds.
+                let len = first_ident.value.len() as u32;
+                if line > 0 && col > 0 {
+                    tokens.push((line - 1, col - 1, len, 2)); // FUNCTION
                 }
             }
             if let ast::FunctionArguments::List(arg_list) = &f.args {
@@ -4063,28 +4055,28 @@ fn extract_rocky_pipeline_steps(text: &str) -> Vec<RockyPipelineStep> {
             continue;
         }
         for &kw in ROCKY_STEP_KEYWORDS {
-            if let Some(rest) = trimmed.strip_prefix(kw) {
-                if rest.is_empty() || !rest.as_bytes()[0].is_ascii_alphanumeric() {
-                    // Capture the rest of the line (after keyword) as detail
-                    let detail = rest.trim();
-                    let detail = if detail.is_empty() {
-                        None
+            if let Some(rest) = trimmed.strip_prefix(kw)
+                && (rest.is_empty() || !rest.as_bytes()[0].is_ascii_alphanumeric())
+            {
+                // Capture the rest of the line (after keyword) as detail
+                let detail = rest.trim();
+                let detail = if detail.is_empty() {
+                    None
+                } else {
+                    // Truncate long details
+                    let d = detail.trim_end_matches('{').trim();
+                    if d.len() > 60 {
+                        Some(format!("{}...", &d[..57]))
                     } else {
-                        // Truncate long details
-                        let d = detail.trim_end_matches('{').trim();
-                        if d.len() > 60 {
-                            Some(format!("{}...", &d[..57]))
-                        } else {
-                            Some(d.to_string())
-                        }
-                    };
-                    steps.push(RockyPipelineStep {
-                        keyword: kw.to_string(),
-                        detail,
-                        line: i,
-                    });
-                    break;
-                }
+                        Some(d.to_string())
+                    }
+                };
+                steps.push(RockyPipelineStep {
+                    keyword: kw.to_string(),
+                    detail,
+                    line: i,
+                });
+                break;
             }
         }
     }
@@ -4117,17 +4109,17 @@ fn compute_rocky_folding_ranges(text: &str) -> Vec<FoldingRange> {
             match ch {
                 '{' => brace_stack.push(i as u32),
                 '}' => {
-                    if let Some(start) = brace_stack.pop() {
-                        if (i as u32) > start {
-                            ranges.push(FoldingRange {
-                                start_line: start,
-                                start_character: None,
-                                end_line: i as u32,
-                                end_character: None,
-                                kind: Some(FoldingRangeKind::Region),
-                                collapsed_text: None,
-                            });
-                        }
+                    if let Some(start) = brace_stack.pop()
+                        && (i as u32) > start
+                    {
+                        ranges.push(FoldingRange {
+                            start_line: start,
+                            start_character: None,
+                            end_line: i as u32,
+                            end_character: None,
+                            kind: Some(FoldingRangeKind::Region),
+                            collapsed_text: None,
+                        });
                     }
                 }
                 _ => {}
@@ -4155,19 +4147,18 @@ fn compute_sql_folding_ranges(text: &str) -> Vec<FoldingRange> {
         for token in upper.split_whitespace() {
             if token == "CASE" || token.starts_with("CASE,") || token.ends_with(",CASE") {
                 case_stack.push(i as u32);
-            } else if token == "END" || token == "END," || token == "END)" {
-                if let Some(start) = case_stack.pop() {
-                    if (i as u32) > start {
-                        ranges.push(FoldingRange {
-                            start_line: start,
-                            start_character: None,
-                            end_line: i as u32,
-                            end_character: None,
-                            kind: Some(FoldingRangeKind::Region),
-                            collapsed_text: None,
-                        });
-                    }
-                }
+            } else if (token == "END" || token == "END," || token == "END)")
+                && let Some(start) = case_stack.pop()
+                && (i as u32) > start
+            {
+                ranges.push(FoldingRange {
+                    start_line: start,
+                    start_character: None,
+                    end_line: i as u32,
+                    end_character: None,
+                    kind: Some(FoldingRangeKind::Region),
+                    collapsed_text: None,
+                });
             }
         }
     }
@@ -4196,17 +4187,17 @@ fn compute_sql_folding_ranges(text: &str) -> Vec<FoldingRange> {
                     ')' => {
                         paren_depth -= 1;
                         if paren_depth == 0 {
-                            if let Some(start) = cte_start.take() {
-                                if (i as u32) > start {
-                                    ranges.push(FoldingRange {
-                                        start_line: start,
-                                        start_character: None,
-                                        end_line: i as u32,
-                                        end_character: None,
-                                        kind: Some(FoldingRangeKind::Region),
-                                        collapsed_text: None,
-                                    });
-                                }
+                            if let Some(start) = cte_start.take()
+                                && (i as u32) > start
+                            {
+                                ranges.push(FoldingRange {
+                                    start_line: start,
+                                    start_character: None,
+                                    end_line: i as u32,
+                                    end_character: None,
+                                    kind: Some(FoldingRangeKind::Region),
+                                    collapsed_text: None,
+                                });
                             }
                             // Check if the next non-blank line starts a new CTE
                             // (has comma + name + AS pattern).
@@ -4240,19 +4231,19 @@ fn compute_sql_folding_ranges(text: &str) -> Vec<FoldingRange> {
         if block_start.is_none() && line.contains("/*") {
             block_start = Some(i as u32);
         }
-        if block_start.is_some() && line.contains("*/") {
-            if let Some(start) = block_start.take() {
-                if (i as u32) > start {
-                    ranges.push(FoldingRange {
-                        start_line: start,
-                        start_character: None,
-                        end_line: i as u32,
-                        end_character: None,
-                        kind: Some(FoldingRangeKind::Comment),
-                        collapsed_text: None,
-                    });
-                }
-            }
+        if block_start.is_some()
+            && line.contains("*/")
+            && let Some(start) = block_start.take()
+            && (i as u32) > start
+        {
+            ranges.push(FoldingRange {
+                start_line: start,
+                start_character: None,
+                end_line: i as u32,
+                end_character: None,
+                kind: Some(FoldingRangeKind::Comment),
+                collapsed_text: None,
+            });
         }
     }
 

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -223,19 +223,18 @@ impl Auth {
         // Key-pair auth: this branch only constructs the AuthInner; JWT
         // minting + fingerprint computation + 59-minute token caching all
         // happen in `get_token` (see lines 277-354).
-        if let Some(key_path) = config.private_key_path.filter(|p| !p.is_empty()) {
-            if let Some(ref username) = config.username {
-                if !username.is_empty() {
-                    return Ok(Auth {
-                        inner: AuthInner::KeyPair {
-                            account: config.account,
-                            username: username.clone(),
-                            private_key_path: key_path,
-                            cached_token: Arc::new(RwLock::new(None)),
-                        },
-                    });
-                }
-            }
+        if let Some(key_path) = config.private_key_path.filter(|p| !p.is_empty())
+            && let Some(ref username) = config.username
+            && !username.is_empty()
+        {
+            return Ok(Auth {
+                inner: AuthInner::KeyPair {
+                    account: config.account,
+                    username: username.clone(),
+                    private_key_path: key_path,
+                    cached_token: Arc::new(RwLock::new(None)),
+                },
+            });
         }
 
         // Password auth

--- a/engine/crates/rocky-snowflake/src/governance.rs
+++ b/engine/crates/rocky-snowflake/src/governance.rs
@@ -395,10 +395,10 @@ fn parse_snowflake_retention_rows(rows: &[Vec<serde_json::Value>]) -> Option<u32
         // Accept both string and numeric JSON forms: Snowflake's SQL REST
         // API has historically sent parameter values as strings, but the
         // type is not guaranteed across versions / mock shapes.
-        if let Some(s) = raw.as_str() {
-            if let Ok(days) = s.trim().parse::<u32>() {
-                return Some(days);
-            }
+        if let Some(s) = raw.as_str()
+            && let Ok(days) = s.trim().parse::<u32>()
+        {
+            return Some(days);
         }
         if let Some(n) = raw.as_u64() {
             return u32::try_from(n).ok();

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -258,13 +258,11 @@ fn extract_expr_lineage(
                         if let sqlparser::ast::FunctionArg::Unnamed(
                             sqlparser::ast::FunctionArgExpr::Expr(inner_expr),
                         ) = arg
-                        {
-                            if let Some(mut lineage) =
+                            && let Some(mut lineage) =
                                 extract_expr_lineage(inner_expr, alias_map, source_tables)
-                            {
-                                lineage.transform = TransformKind::Aggregation(func_name.clone());
-                                return Some(lineage);
-                            }
+                        {
+                            lineage.transform = TransformKind::Aggregation(func_name.clone());
+                            return Some(lineage);
                         }
                     }
                     None

--- a/engine/crates/rocky-sql/src/parser.rs
+++ b/engine/crates/rocky-sql/src/parser.rs
@@ -150,19 +150,19 @@ fn parse_sqlparser_location(
         if let Some(comma) = tail.find(", Column ") {
             let line_str = &tail[..comma];
             let col_str = tail[comma + 9..].trim_end_matches(|c: char| !c.is_ascii_digit());
-            if let (Ok(line), Ok(col)) = (line_str.parse::<usize>(), col_str.parse::<usize>()) {
-                if let Some(offset) = line_col_to_offset(source, line, col) {
-                    // Span length: highlight up to end of the token or line.
-                    let rest = &source[offset..];
-                    let len = rest
-                        .find(|c: char| c.is_whitespace())
-                        .unwrap_or(rest.len())
-                        .max(1);
-                    return (
-                        Some(miette::SourceSpan::new(offset.into(), len)),
-                        Some("Check SQL syntax near this position".to_string()),
-                    );
-                }
+            if let (Ok(line), Ok(col)) = (line_str.parse::<usize>(), col_str.parse::<usize>())
+                && let Some(offset) = line_col_to_offset(source, line, col)
+            {
+                // Span length: highlight up to end of the token or line.
+                let rest = &source[offset..];
+                let len = rest
+                    .find(|c: char| c.is_whitespace())
+                    .unwrap_or(rest.len())
+                    .max(1);
+                return (
+                    Some(miette::SourceSpan::new(offset.into(), len)),
+                    Some("Check SQL syntax near this position".to_string()),
+                );
             }
         }
     }

--- a/engine/crates/rocky-trino/src/connector.rs
+++ b/engine/crates/rocky-trino/src/connector.rs
@@ -360,10 +360,10 @@ impl TrinoClient {
 
         let mut attempt = 0_usize;
         loop {
-            if let Some(cols) = current.columns.take() {
-                if columns.is_empty() {
-                    columns = cols.into_iter().map(TrinoColumnMeta::from_wire).collect();
-                }
+            if let Some(cols) = current.columns.take()
+                && columns.is_empty()
+            {
+                columns = cols.into_iter().map(TrinoColumnMeta::from_wire).collect();
             }
             if let Some(data) = current.data.take() {
                 rows.extend(data);

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2950,13 +2950,12 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // SIGINT: map `commands::Interrupted` to the conventional shell exit
     // code (128 + SIGINT). Only `rocky run` currently emits this; other
     // commands fall through to the default exit-1-on-error below.
-    if let Err(ref err) = result {
-        if err
+    if let Err(ref err) = result
+        && err
             .downcast_ref::<rocky_cli::commands::Interrupted>()
             .is_some()
-        {
-            std::process::exit(130);
-        }
+    {
+        std::process::exit(130);
     }
 
     // Partial-success: map `commands::PartialFailure` to exit code 2.
@@ -2966,27 +2965,24 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // results rather than treating the whole run as a hard failure.
     // Total failure (no tables copied) keeps exit code 1 — that branch
     // doesn't produce the partial-success sentinel.
-    if let Err(ref err) = result {
-        if err
+    if let Err(ref err) = result
+        && err
             .downcast_ref::<rocky_cli::commands::PartialFailure>()
             .is_some()
-        {
-            std::process::exit(2);
-        }
+    {
+        std::process::exit(2);
     }
 
     // In text mode, try to upgrade config errors to rich miette diagnostics
     // with source spans and suggestions. JSON mode returns structured errors
     // unchanged for orchestrators (e.g., Dagster).
-    if let Err(ref err) = result {
-        if !json {
-            if let Some(diagnostic) =
-                rocky_cli::error_reporter::try_upgrade_config_error(err, &config_path)
-            {
-                eprintln!("{:?}", miette::Report::new(diagnostic));
-                std::process::exit(1);
-            }
-        }
+    if let Err(ref err) = result
+        && !json
+        && let Some(diagnostic) =
+            rocky_cli::error_reporter::try_upgrade_config_error(err, &config_path)
+    {
+        eprintln!("{:?}", miette::Report::new(diagnostic));
+        std::process::exit(1);
     }
 
     result


### PR DESCRIPTION
## What

`main`'s engine-CI **Clippy** job (`cargo clippy --all-targets -- -D warnings`) is red, blocking every open PR. The workspace MSRV bump to 1.88 (#679) moved CI onto clippy 1.95, which promoted/extended two lints to warn-by-default. These are **pre-existing patterns newly flagged by clippy ≥1.95 — not a code regression.**

CI reports per-crate and stops at the first failure, so its log only named `rocky-sql`, `rocky-lang`, `rocky-adapter-sdk`. Fixing those unmasked the same `collapsible_if` lint downstream in `rocky-core`, `rocky-cli`, `rocky-compiler`, `rocky-server`, and several adapter crates. This PR fixes **every** occurrence so `cargo clippy --all-targets -- -D warnings` is clean across the whole workspace.

## Lints fixed

- **`clippy::collapsible_if`** — nested `if { if … }` / `if let { if let … }` blocks collapsed into edition-2024 let-chains (`if A && let B { … }`). Short-circuit-equivalent, behavior-preserving. Spans `rocky-sql`, `rocky-lang`, `rocky-cache`, `rocky-core`, `rocky-cli`, `rocky-compiler`, `rocky-server`, `rocky-snowflake`, `rocky-bigquery`, `rocky-trino`, `rocky-airbyte`, `rocky-ai`, `rocky-mcp`, and the `rocky` binary.
- **`clippy::manual_is_multiple_of`** — `crates/rocky-adapter-sdk/src/throttle.rs`: `count % interval == 0` → `count.is_multiple_of(interval)` (`is_multiple_of` is stable since 1.87; workspace MSRV is 1.88).

No `#[allow]` suppressions were added — all are real fixes.

## Verification (local, clippy 1.95.0)

- `cargo clippy --all-targets -- -D warnings` — clean (exit 0)
- `cargo build` — succeeds
- `cargo fmt --all -- --check` — clean
- Tests pass for every touched crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)