### PR TITLE
chore(release): triple-cut #17 — engine 1.44.0 + dagster 1.42.0 + vscode 1.28.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.0] — 2026-05-25
+
+A wave of new panels and views surfacing the engine's trust + AI features directly in the editor — eight new commands (50 → 58).
+
+### Added
+
+- **Plan review / apply gate UI** (`rocky.reviewPlan`) — review an AI-authored plan's breaking-change report in a panel, then approve + apply from the editor.
+- **Inline row preview + live compiled-SQL panel** (`rocky.previewModel`, `rocky.showCompiledSql`) — preview a model's or CTE's output rows inline and open the live compiled SQL for the active model, with cursor-aware preview and result-grid polish.
+- **Ad-hoc SQL selection preview** — preview a highlighted SQL selection, governance-safe (masks applied).
+- **Governance compliance panel** (`rocky.compliance`) — per-model mask / grant verdicts.
+- **Execution-plan panel** (`rocky.dag`) — renders `rocky dag`.
+- **Branches view** (`rocky.refreshBranches`) — sidebar listing virtual branches.
+- **Run-trace timeline panel** (`rocky.trace`) — timeline of the latest run.
+- **Lineage-diff panel** (`rocky.lineageDiff`) — per-changed-column downstream blast radius vs a base ref.
+
+### Changed
+
+- **`src/types/generated/{ai_contract,preview_rows,review}.ts`** regenerated for the engine's new `rocky ai-contract`, `rocky preview rows`, and `rocky review` output surface.
+- Documentation counts and the VS Code API-minimum string refreshed to match the current extension surface.
+
 ## [1.27.0] — 2026-05-24
 
 Codegen-companion release to engine `v1.43.0`. The regenerated TypeScript bindings under `src/types/generated/` and the `rocky-project` JSON schema surfaced via `jsonValidation` pick up the engine's new config and output surface. No new commands, settings, or LSP features.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.44.0] — 2026-05-25
+
+The AI-drivable surface lands end-to-end. `rocky mcp` exposes the engine's read-only tools over the Model Context Protocol so an agent can drive Rocky directly, a `build_model` prompt scripts the authoring loop, and AI-authored plans are gated behind `rocky review` before any `rocky apply`. Also ships `rocky ai-contract`, `rocky preview rows`, and a governance-safe ad-hoc SQL preview.
+
+### Added
+
+- **`rocky mcp`: read-only MCP server** — exposes the engine over the Model Context Protocol so an AI agent can drive Rocky through read-only tools (`compile`, `plan_preview`, `lineage`, `test`, `list`, `inspect_schema`, `sample_rows`, `profile_column`, `propose`, plus `breaking_change` and `dependents` for impact analysis). No tool mutates the warehouse or engine state: `sample_rows` / `profile_column` issue DuckDB-only `SELECT`s and return `{unavailable: true}` on any non-DuckDB adapter, and `propose` writes an `ai_authored` plan to `.rocky/plans/` that still requires `rocky review <plan-id> --approve` + `rocky apply <plan-id>` to materialize. Identifiers are validated through `rocky_sql::validation` before composing refs — no raw-input SQL injection.
+- **`build_model` MCP prompt** — a server prompt that scripts the model-authoring loop (inspect → sample → profile → write SQL → compile → plan_preview → propose), stopping at the human review gate and carrying the reconcile discipline (check the data, not just the schema). Bumps the workspace MSRV to 1.88 (the rmcp 1.7 tree requires it).
+- **`rocky ai-contract`: AI-drafted data contracts from observed data** — samples a model and infers a starter data contract (column types, nullability, observed ranges) the author can refine, rather than hand-writing one from scratch. Codegen cascade propagated to the dagster + VS Code bindings.
+- **`rocky preview rows`: inline model / CTE row preview** — previews the output rows of a model or a named CTE, governance-aware (declared masks applied). Backs the VS Code inline-preview panel.
+- **AI-authored-plan review gate (`rocky review`)** — adds a `PlanKind::AiAuthored` discriminator; a bare `rocky apply` refuses to execute an AI-authored plan until a human runs `rocky review <plan-id> --approve`, which records a sign-off marker after reporting the semantic breaking-change delta against a base ref so the approval is informed.
+- **Ad-hoc SQL selection preview (governance-safe)** — previews the result of an ad-hoc SQL selection with governance masks applied, without registering a model.
+
+### Changed
+
+- **`rocky-cli`: typed-output cores extracted from command handlers** — JSON-output construction for `compile` / `plan_preview` / `lineage` / `test` / `list*` is factored into reusable `*_output` core functions so the MCP server and the CLI share one code path. No output-schema change.
+
 ### Fixed
+
+- **`rocky-cli`: clippy `--all-targets` failures surfaced by clippy 1.95** — the MSRV→1.88 bump moved CI to clippy 1.95, which newly flags `collapsible_if` / `manual_is_multiple_of`. Resolved across the workspace so `cargo clippy --all-targets -- -D warnings` stays green.
 
 - **`rocky-cli`: `branch promote` approvals no longer self-invalidate under the canonical state layout** — `models_fingerprint` (folded into `branch_state_hash` by the v1.43.0 model-byte approval binding) walked the `<config_dir>/models` tree but only skipped `.git` / `target` / `.DS_Store`. The canonical state path is `<models>/.rocky-state.redb` (+ its `.lock`), so the state DB lives *inside* the models tree — its mutable bytes were feeding the content hash. The result: the first state-writing command after `branch approve` (including `branch promote` itself) drifted `branch_state_hash`, so a freshly-signed approval failed its own `state_hash_mismatch` check before it could be honoured. `collect_model_files` now also skips any entry whose name starts with `.rocky-state.redb`, so state churn no longer voids approvals; a genuine model-source edit still drifts the hash (approval soundness preserved). Regression test `models_fingerprint_ignores_state_db_but_tracks_model_edits` pins both halves.
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "redis",
  "serde",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "logos",
  "miette",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "miette",
  "regex",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.43.0"
+version = "1.44.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.43.0"
+version = "1.44.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.43.0"
+version = "1.44.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.43.0"
+version = "1.44.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.43.0"
+version = "1.44.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.43.0"
+version = "1.44.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.43.0"
+version = "1.44.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.43.0"
+version = "1.44.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.43.0"
+version = "1.44.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.43.0"
+version = "1.44.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.43.0"
+version = "1.44.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.43.0"
+version = "1.44.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.43.0"
+version = "1.44.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.43.0"
+version = "1.44.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.43.0"
+version = "1.44.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.43.0"
+version = "1.44.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.43.0"
+version = "1.44.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.43.0"
+version = "1.44.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.43.0"
+version = "1.44.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.43.0"
+version = "1.44.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.42.0] — 2026-05-25
+
+Companion to engine `v1.44.0`. Codegen-driven — regenerated Pydantic bindings for the engine's new AI surface (`rocky ai-contract`, `rocky preview rows`, and the `rocky review` AI-authored-plan gate). No new resource wiring or behaviour.
+
+### Changed
+
+- **`types_generated/{ai_contract,preview_rows,review}_schema.py`** generated for the engine's new `rocky ai-contract`, `rocky preview rows`, and `rocky review` output schemas. The new models are additive, so parsing of fixtures captured before this cut stays byte-stable.
+
 ## [1.41.0] — 2026-05-24
 
 Companion to engine `v1.43.0`. The dagster side picks up the warehouse-cooldown parity work plus the regenerated Pydantic bindings for the engine's new config and compile-output surface (the `[freshness]` block and the W005 freshness-coverage diagnostic, the `AdapterConfig.extra` escape hatch). Codegen-driven — no new resource wiring or behaviour beyond the cooldown handler below.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.41.0"
+version = "1.42.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Consolidated triple-cut release. Bumps all three artifacts + changelogs; tags follow after merge on green CI.

## Engine 1.43.0 → 1.44.0
The AI-drivable surface, end-to-end:
- `rocky mcp` — read-only MCP server (compile, plan_preview, lineage, test, list, inspect_schema, sample_rows, profile_column, propose, breaking_change, dependents). No tool mutates state; `propose` writes an `ai_authored` plan gated behind `rocky review` + `rocky apply`.
- `build_model` MCP prompt scripting the authoring loop; workspace MSRV → 1.88.
- `rocky ai-contract` — AI-drafted data contracts from observed data.
- `rocky preview rows` — inline model/CTE row preview (governance-aware).
- AI-authored-plan review gate (`rocky review`) — `PlanKind::AiAuthored`; bare `rocky apply` refuses until a human signs off.
- Governance-safe ad-hoc SQL selection preview.
- Typed-output cores extracted from command handlers (CLI/MCP share one path).
- Fixed: clippy-1.95 `--all-targets`; `branch promote` approval self-invalidation under the canonical state layout.

## Dagster 1.41.0 → 1.42.0
Codegen-only companion: regenerated Pydantic bindings for `ai_contract` / `preview_rows` / `review`. Additive — pre-cut fixtures stay byte-stable.

## VS Code 1.27.0 → 1.28.0
8 new commands (50 → 58): plan review/apply gate, governance compliance, execution-plan (`rocky dag`), run-trace, branches view, lineage-diff, inline row preview + compiled-SQL, ad-hoc SQL preview. Regenerated TS bindings.

## Verification
- All 25 engine manifests + `Cargo.lock` at 1.44.0; `cargo metadata` resolves.
- No version literals in `schemas/` or generated bindings, so the bump produces no codegen drift.
- `package-lock.json` bumped in lockstep with `package.json`.

Relying on PR CI (engine-ci, vscode-ci, dagster-ci, codegen-drift) for the full build/test/lint gate before tagging.