### PR TITLE
feat(vscode): automated demo-GIF recording harness

### DIFF
--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -114,6 +114,10 @@ code --install-extension rocky-*.vsix
 
 # Debug
 # Press F5 in VS Code → launches Extension Development Host
+
+# Demo GIFs
+# recording/ — Playwright drives a real VS Code to auto-record extension demos.
+# `just record-demo <scenario>` (see recording/README.md for the gotchas).
 ```
 
 ## Extension Commands (58)

--- a/editors/vscode/recording/.gitignore
+++ b/editors/vscode/recording/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+.run/

--- a/editors/vscode/recording/README.md
+++ b/editors/vscode/recording/README.md
@@ -1,0 +1,77 @@
+# Demo GIF recording
+
+Automated demo-GIF recording for the Rocky VS Code extension. Playwright drives
+a **real VS Code Electron instance** with the extension loaded from source, runs
+a scripted scenario, records video, and converts it to a GIF.
+
+This records the *extension UI* (editor, LSP, command palette, webviews). The
+CLI/terminal demos in the repo-root `docs/` are a separate thing.
+
+## Usage
+
+```bash
+cd editors/vscode/recording
+npm install
+npm run record quickstart        # -> out/quickstart.gif
+# or from the repo root:
+just record-demo quickstart
+just publish-demo quickstart      # copy to editors/vscode/media/demo-quickstart.gif
+```
+
+The recorder **rebuilds the extension bundle first** (`npm run bundle`): VS Code
+loads the built `dist/extension.js` from `--extensionDevelopmentPath`, not `src/`,
+so without a rebuild it would record stale code. `rocky` must be on `$PATH` (the
+launched VS Code inherits it, so the LSP connects automatically).
+
+## Requirements
+
+- `ffmpeg` and `gifski` (`brew install ffmpeg gifski`) — gifski is preferred.
+  Without gifski it falls back to an ffmpeg palette pipeline, plus a
+  `gifsicle --lossy` pass if `gifsicle` is installed.
+- VS Code is downloaded on first run via `@vscode/test-electron` (reuses the
+  `../.vscode-test` cache the test suite already populates).
+
+## Adding a scenario
+
+Drop a `scenarios/<name>.mjs` exporting a default object:
+
+```js
+export default {
+  name: "myscenario",
+  description: "One line shown while recording.",
+  workspace: "examples/playground",   // relative to repo root
+  size: { width: 1280, height: 800 }, // capture (and forced window) size
+  fps: 15,
+  gifWidth: 1000,                      // output width; quality is the size lever
+  quality: 65,                         // gifski 1-100 — the main size/quality knob
+  async run(d) {
+    await d.openFile("customer_orders.rocky");
+    await d.pause(3000);
+    await d.palette("Rocky: ");        // open palette filtered; add {run:true} to execute
+    await d.pause(3000);
+    await d.escape();
+  },
+};
+```
+
+The driver (`lib/driver.mjs`) is deliberately **keyboard-only** — Playwright's
+Electron video has no visible mouse cursor, so click flows look broken. Available
+actions: `openFile`, `palette`, `command`, `key`, `type`, `escape`, `pause`.
+
+Boot + preamble are auto-trimmed (recording starts at launch; everything before
+`run()` is cut). Per-run scratch (the `.webm`) is kept in `.run/` for debugging.
+
+## Gotchas (learned the hard way)
+
+- **macOS unix-socket cap.** VS Code's single-instance IPC socket lives inside
+  `--user-data-dir`, and macOS caps socket paths at ~104 chars. A long
+  user-data-dir → instant death with `connect ENOTSOCK .../<v>-main.sock`. The
+  harness puts it under `/tmp/rkv-<id>`.
+- **gifski halves resolution by default** (assumes 2× HiDPI input). The
+  converter passes `--width` explicitly so output matches the captured frames.
+- **gifsicle doesn't help gifski output.** gifski already emits a tightly
+  optimized GIF; `gifski --quality` is the real size lever. gifsicle is only
+  used on the ffmpeg fallback path.
+- **Fresh profile auto-opens the chat panel.** The runner closes the secondary
+  side bar (⌘⌥B) in the preamble; injected settings suppress the git-repo
+  notification, telemetry, and minimap.

--- a/editors/vscode/recording/lib/convert.mjs
+++ b/editors/vscode/recording/lib/convert.mjs
@@ -1,0 +1,66 @@
+// webm -> gif. Prefers gifski (smaller files, nicer color) fed PNG frames
+// extracted by ffmpeg; falls back to a pure-ffmpeg palettegen pipeline if
+// gifski isn't installed.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+function run(cmd, args) {
+  const r = spawnSync(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+  if (r.status !== 0) {
+    throw new Error(`${cmd} failed (${r.status}): ${r.stderr?.toString() || r.error?.message}`);
+  }
+  return r;
+}
+
+function has(cmd) {
+  return spawnSync("which", [cmd], { stdio: "ignore" }).status === 0;
+}
+
+/**
+ * @param {object} o
+ * @param {string} o.webm       source video
+ * @param {string} o.out        output .gif path
+ * @param {number} [o.fps]
+ * @param {number} [o.width]    output width in px (height auto)
+ * @param {number} [o.quality]  gifski quality 1-100
+ * @param {number} [o.trimStart] seconds to cut from the start (drops boot/preamble)
+ * @param {number} [o.duration]  cap output to this many seconds
+ */
+export function toGif({ webm, out, fps = 15, width = 1000, quality = 65, trimStart = 0, duration }) {
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  const trim = [];
+  if (trimStart > 0) trim.push("-ss", String(trimStart));
+  if (duration) trim.push("-t", String(duration));
+  const vf = `fps=${fps},scale=${width}:-1:flags=lanczos`;
+
+  if (has("gifski")) {
+    const framesDir = fs.mkdtempSync(path.join(os.tmpdir(), "rkv-frames-"));
+    try {
+      run("ffmpeg", ["-y", "-loglevel", "error", ...trim, "-i", webm, "-vf", vf, path.join(framesDir, "f%05d.png")]);
+      const frames = fs
+        .readdirSync(framesDir)
+        .filter((f) => f.endsWith(".png"))
+        .sort()
+        .map((f) => path.join(framesDir, f));
+      if (frames.length === 0) throw new Error("no frames extracted from " + webm);
+      // gifski halves the resolution by default (assumes 2x HiDPI input), so
+      // pass --width explicitly to match the frames we already scaled.
+      run("gifski", ["--width", String(width), "--quality", String(quality), "--fps", String(fps), "-o", out, ...frames]);
+    } finally {
+      fs.rmSync(framesDir, { recursive: true, force: true });
+    }
+  } else {
+    // Fallback when gifski isn't installed. ffmpeg's palette pipeline produces
+    // larger files for screen content, so here a gifsicle --lossy pass (if
+    // present) earns its keep — unlike on gifski output, where it does little.
+    const palette = out + ".palette.png";
+    run("ffmpeg", ["-y", "-loglevel", "error", ...trim, "-i", webm, "-vf", `${vf},palettegen=stats_mode=diff`, palette]);
+    run("ffmpeg", ["-y", "-loglevel", "error", ...trim, "-i", webm, "-i", palette, "-lavfi", `${vf}[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3`, out]);
+    fs.rmSync(palette, { force: true });
+    if (has("gifsicle")) run("gifsicle", ["--lossy=100", "--colors=128", "-O3", out, "-o", out]);
+  }
+  return out;
+}

--- a/editors/vscode/recording/lib/driver.mjs
+++ b/editors/vscode/recording/lib/driver.mjs
@@ -1,0 +1,47 @@
+// A tiny keyboard-only action vocabulary for scenarios. Keyboard-driven on
+// purpose: Playwright's Electron video has no visible mouse cursor, so
+// click-based flows look like things happen by magic. Everything here drives
+// VS Code the way a keyboard user would — command palette, quick open, typing.
+
+export function makeDriver(win) {
+  const pause = (ms) => win.waitForTimeout(ms);
+
+  // Open the command palette (pre-filled with ">"), type a filter, optionally
+  // run the top match. Leave `run` false to just *show* the filtered list.
+  async function palette(query, { run = false, settle = 700 } = {}) {
+    await win.keyboard.press("Meta+Shift+P");
+    await pause(settle);
+    if (query) await win.keyboard.type(query, { delay: 55 });
+    await pause(settle);
+    if (run) {
+      await win.keyboard.press("Enter");
+      await pause(settle);
+    }
+  }
+
+  // Run a VS Code command by its title (e.g. "Rocky: Compile Models").
+  async function command(title, opts = {}) {
+    await palette(title, { run: true, ...opts });
+  }
+
+  // Quick-open a file by (fuzzy) name.
+  async function openFile(name, { settle = 700 } = {}) {
+    await win.keyboard.press("Meta+P");
+    await pause(settle);
+    await win.keyboard.type(name, { delay: 45 });
+    await pause(settle + 400);
+    await win.keyboard.press("Enter");
+    await pause(settle);
+  }
+
+  return {
+    win,
+    pause,
+    key: (combo) => win.keyboard.press(combo),
+    type: (text, delay = 60) => win.keyboard.type(text, { delay }),
+    escape: () => win.keyboard.press("Escape"),
+    palette,
+    command,
+    openFile,
+  };
+}

--- a/editors/vscode/recording/lib/vscode.mjs
+++ b/editors/vscode/recording/lib/vscode.mjs
@@ -1,0 +1,105 @@
+// Launch a real VS Code Electron instance with the Rocky extension loaded
+// from source, driven by Playwright and recording to a .webm.
+//
+// See ../README.md for the why behind each arg. The one non-obvious thing:
+// --user-data-dir MUST be short (macOS caps unix-socket paths at ~104 chars
+// and VS Code's single-instance IPC socket lives inside it).
+
+import { downloadAndUnzipVSCode } from "@vscode/test-electron";
+import { _electron as electron } from "playwright";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import * as os from "node:os";
+
+// Keep in sync with src/test/runTest.ts — the extension is built against this.
+export const VSCODE_VERSION = process.env.VSCODE_TEST_VERSION ?? "1.120.0";
+
+// Settings injected into the throwaway profile so demos look clean and
+// deterministic (no telemetry prompts, no git/notification chrome, no minimap).
+const DEFAULT_SETTINGS = {
+  "workbench.startupEditor": "none",
+  "window.commandCenter": false,
+  "workbench.layoutControl.enabled": false,
+  "editor.minimap.enabled": false,
+  "breadcrumbs.enabled": false,
+  "git.openRepositoryInParentFolders": "never",
+  "telemetry.telemetryLevel": "off",
+  "update.mode": "none",
+  "workbench.tips.enabled": false,
+  "editor.fontSize": 14,
+};
+
+function shortUserDataDir() {
+  const id = Math.random().toString(36).slice(2, 8);
+  const base = process.platform === "darwin" ? "/tmp" : os.tmpdir();
+  return path.join(base, `rkv-${id}`);
+}
+
+/**
+ * @param {object} o
+ * @param {string} o.vscodeDir   absolute path to editors/vscode
+ * @param {string} o.workspace   absolute path to the folder to open
+ * @param {{width:number,height:number}} o.size  recording + window size
+ * @param {string} o.recordDir   dir to drop the .webm + per-run scratch in
+ * @param {object} [o.settings]  per-scenario settings overrides
+ */
+export async function launchVSCode({ vscodeDir, workspace, size, recordDir, settings = {} }) {
+  const executablePath = await downloadAndUnzipVSCode({
+    version: VSCODE_VERSION,
+    cachePath: path.join(vscodeDir, ".vscode-test"),
+  });
+
+  const userDataDir = shortUserDataDir();
+  const userDir = path.join(userDataDir, "User");
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(userDir, "settings.json"),
+    JSON.stringify({ ...DEFAULT_SETTINGS, ...settings }, null, 2),
+  );
+
+  const extDir = path.join(recordDir, "extensions");
+  fs.mkdirSync(extDir, { recursive: true });
+
+  const app = await electron.launch({
+    executablePath,
+    args: [
+      `--extensionDevelopmentPath=${vscodeDir}`,
+      `--user-data-dir=${userDataDir}`,
+      `--extensions-dir=${extDir}`,
+      "--disable-workspace-trust",
+      "--skip-welcome",
+      "--skip-release-notes",
+      "--disable-updates",
+      "--disable-telemetry",
+      "--disable-gpu-sandbox",
+      workspace,
+    ],
+    recordVideo: { dir: recordDir, size },
+    timeout: 60_000,
+  });
+
+  const win = await app.firstWindow({ timeout: 60_000 });
+  await win.waitForLoadState("domcontentloaded");
+  const windowReadyAt = Date.now();
+
+  // Force the real OS window to exactly the recording size so the captured
+  // frame is 1:1 instead of scaled/letterboxed.
+  try {
+    const bw = await app.browserWindow(win);
+    await bw.evaluate((w, s) => {
+      w.setBounds({ x: 0, y: 0, width: s.width, height: s.height });
+      if (typeof w.setMenuBarVisibility === "function") w.setMenuBarVisibility(false);
+    }, size);
+  } catch (e) {
+    console.warn("could not resize window:", e.message);
+  }
+
+  return {
+    app,
+    win,
+    executablePath,
+    userDataDir,
+    windowReadyAt,
+    cleanup: () => fs.rmSync(userDataDir, { recursive: true, force: true }),
+  };
+}

--- a/editors/vscode/recording/package-lock.json
+++ b/editors/vscode/recording/package-lock.json
@@ -1,0 +1,529 @@
+{
+  "name": "rocky-vscode-recording",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rocky-vscode-recording",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@vscode/test-electron": "^2.5.2",
+        "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
+      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/editors/vscode/recording/package.json
+++ b/editors/vscode/recording/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rocky-vscode-recording",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Automated demo-GIF recording for the Rocky VS Code extension (Playwright drives a real VS Code Electron instance).",
+  "type": "module",
+  "scripts": {
+    "record": "node record.mjs"
+  },
+  "devDependencies": {
+    "@vscode/test-electron": "^2.5.2",
+    "playwright": "^1.60.0"
+  }
+}

--- a/editors/vscode/recording/record.mjs
+++ b/editors/vscode/recording/record.mjs
@@ -1,0 +1,101 @@
+// Record a demo GIF of the Rocky VS Code extension.
+//
+//   node record.mjs <scenario>        # e.g. quickstart
+//
+// Output lands in out/<scenario>.gif. Per-run scratch (webm, extension dir)
+// stays in .run/ for debugging; the throwaway VS Code profile is cleaned up.
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { spawnSync } from "node:child_process";
+import { launchVSCode } from "./lib/vscode.mjs";
+import { makeDriver } from "./lib/driver.mjs";
+import { toGif } from "./lib/convert.mjs";
+
+const HERE = import.meta.dirname;
+const VSCODE_DIR = path.resolve(HERE, ".."); // editors/vscode
+const REPO = path.resolve(HERE, "../../.."); // rocky-data
+
+// VS Code loads the extension's built `main` (dist/extension.js) from
+// --extensionDevelopmentPath; it does NOT compile from src/. So rebuild the
+// bundle (+ webviews) first, or we'd record stale code.
+function buildExtension() {
+  console.log("⚙ building extension bundle…");
+  for (const script of ["bundle:webview", "bundle"]) {
+    const r = spawnSync("npm", ["run", script], { cwd: VSCODE_DIR, stdio: "inherit" });
+    if (r.status !== 0) {
+      console.error(`extension build failed at \`npm run ${script}\``);
+      process.exit(1);
+    }
+  }
+}
+
+const name = process.argv[2];
+if (!name) {
+  console.error("usage: node record.mjs <scenario>");
+  console.error("scenarios:", fs.readdirSync(path.join(HERE, "scenarios")).map((f) => f.replace(/\.mjs$/, "")).join(", "));
+  process.exit(1);
+}
+
+const scenarioPath = path.join(HERE, "scenarios", `${name}.mjs`);
+if (!fs.existsSync(scenarioPath)) {
+  console.error(`no such scenario: ${scenarioPath}`);
+  process.exit(1);
+}
+const scenario = (await import(scenarioPath)).default;
+
+const size = scenario.size ?? { width: 1280, height: 800 };
+const workspace = path.resolve(REPO, scenario.workspace ?? "examples/playground");
+const runDir = path.join(HERE, ".run", `${name}-${Date.now()}`);
+
+console.log(`▶ recording "${name}" — ${scenario.description ?? ""}`);
+buildExtension();
+const { app, win, windowReadyAt, cleanup } = await launchVSCode({
+  vscodeDir: VSCODE_DIR,
+  workspace,
+  size,
+  recordDir: runDir,
+  settings: scenario.settings,
+});
+const d = makeDriver(win);
+
+// Preamble: let the workbench + LSP settle, then close the secondary side bar
+// (the chat panel auto-opens in a fresh profile) for a clean canvas.
+await d.pause(scenario.settle ?? 4000);
+if (scenario.closeAuxBar !== false) {
+  await d.key("Meta+Alt+B");
+  await d.pause(600);
+}
+
+const scenarioStart = Date.now();
+let failed;
+try {
+  await scenario.run(d);
+} catch (e) {
+  failed = e;
+} finally {
+  const video = win.video();
+  await app.close();
+  const webm = await video.path();
+
+  // Auto-trim the boot + preamble: everything before the scenario started.
+  const autoTrim = Math.max(0, (scenarioStart - windowReadyAt) / 1000 - 0.3);
+  const out = path.join(HERE, "out", `${name}.gif`);
+  toGif({
+    webm,
+    out,
+    fps: scenario.fps ?? 15,
+    width: scenario.gifWidth ?? 1000,
+    quality: scenario.quality ?? 65,
+    trimStart: scenario.trimStart ?? autoTrim,
+    duration: scenario.duration,
+  });
+  cleanup?.();
+  console.log(`✔ GIF: ${out} (${(fs.statSync(out).size / 1024).toFixed(0)} KB)`);
+  console.log(`  webm kept at: ${webm}`);
+}
+
+if (failed) {
+  console.error("scenario threw (GIF still written up to the failure):", failed);
+  process.exit(1);
+}

--- a/editors/vscode/recording/scenarios/lineage.mjs
+++ b/editors/vscode/recording/scenarios/lineage.mjs
@@ -1,0 +1,29 @@
+// Lineage: open a model and render its lineage as an interactive DAG webview
+// (rocky lineage -> DOT -> SVG via viz.js). Exercises the harness's ability to
+// capture a webview panel, not just the editor. Deterministic, offline.
+//
+// TODO: graph-fit-in-narrow-canvas needs more work. The webview opens in a
+// split, leaving the SVG canvas cramped (~39% zoom). Maximizing the editor
+// group reloads the webview, and a post-reload programmatic fit ('f' hotkey)
+// doesn't reliably refit the SVG. This is content-polish, not a harness
+// blocker — the panel, controls, and node counts all capture correctly.
+
+export default {
+  name: "lineage",
+  description: "Render a model's lineage DAG in the webview.",
+  // Self-contained POC: fct_revenue <- stg_orders <- raw_orders.
+  workspace: "examples/playground/pocs/06-developer-experience/01-lineage-column-level",
+  size: { width: 1280, height: 800 },
+  fps: 15,
+  gifWidth: 1000,
+  quality: 65,
+
+  async run(d) {
+    await d.openFile("fct_revenue.rocky");
+    await d.pause(2500);
+
+    // Show Model Lineage opens a webview panel for the active model.
+    await d.command("Rocky: Show Model Lineage");
+    await d.pause(4500); // CLI lineage call + DOT->SVG render
+  },
+};

--- a/editors/vscode/recording/scenarios/quickstart.mjs
+++ b/editors/vscode/recording/scenarios/quickstart.mjs
@@ -1,0 +1,25 @@
+// Quickstart: open a Rocky model (syntax highlighting + inline CodeLens from
+// the running LSP), then reveal the Rocky command surface. No warehouse calls,
+// no webview, no mouse — fully keyboard-driven and offline.
+
+export default {
+  name: "quickstart",
+  description: "Open a Rocky model and reveal the Rocky command palette.",
+  workspace: "examples/playground",
+  size: { width: 1280, height: 800 },
+  fps: 15,
+  gifWidth: 1000,
+  quality: 65,
+
+  async run(d) {
+    // A model with Run/Compile/Test/Lineage CodeLens above it.
+    await d.openFile("customer_orders.rocky");
+    await d.pause(3000);
+
+    // Show the branded command surface.
+    await d.palette("Rocky: ");
+    await d.pause(3000);
+    await d.escape();
+    await d.pause(700);
+  },
+};

--- a/editors/vscode/src/runDecorations.ts
+++ b/editors/vscode/src/runDecorations.ts
@@ -128,7 +128,7 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
       {
         range,
         renderOptions: {
-          after: { contentText: "$(circle-outline)  no run history" },
+          after: { contentText: "○  no run history" },
         },
       },
     ]);
@@ -141,7 +141,7 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
       {
         range,
         renderOptions: {
-          after: { contentText: "$(circle-outline)  no run history" },
+          after: { contentText: "○  no run history" },
         },
       },
     ]);
@@ -163,7 +163,7 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
         range,
         renderOptions: {
           after: {
-            contentText: `$(error)  FAILED  ${formatDuration(latest.duration_ms)}`,
+            contentText: `✕  FAILED  ${formatDuration(latest.duration_ms)}`,
           },
         },
       },
@@ -181,7 +181,7 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
   const decorationType = isSuccess
     ? successDecorationType
     : noHistoryDecorationType;
-  const icon = isSuccess ? "$(pass)" : "$(circle-outline)";
+  const icon = isSuccess ? "✓" : "○";
 
   editor.setDecorations(decorationType, [
     {

--- a/justfile
+++ b/justfile
@@ -184,6 +184,24 @@ release-dagster version *args:
 release-vscode version *args:
     ./scripts/release.sh vscode {{version}} {{args}}
 
+# --- Demo recording ---
+
+# Record a VS Code extension demo GIF (Playwright drives a real VS Code).
+# Output lands in editors/vscode/recording/out/<scenario>.gif. The recorder
+# rebuilds the extension bundle first (it loads dist/, not src/).
+#   just record-demo quickstart
+record-demo scenario="quickstart":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    (cd editors/vscode && npm install)
+    (cd editors/vscode/recording && npm install && npm run record {{scenario}})
+
+# Copy a recorded GIF into editors/vscode/media/ (where Marketplace-referenced
+# media lives). Embedding it still means adding an <img> to editors/vscode/README.md.
+publish-demo scenario:
+    cp editors/vscode/recording/out/{{scenario}}.gif editors/vscode/media/demo-{{scenario}}.gif
+    @echo "Published editors/vscode/media/demo-{{scenario}}.gif — now embed it in editors/vscode/README.md"
+
 # --- Convenience ---
 
 # Install the monorepo-root git hooks (.git-hooks/) as the active hooksPath.


### PR DESCRIPTION
Records demo GIFs of the VS Code extension automatically: Playwright drives a real VS Code Electron instance with the extension loaded from source, runs a scripted keyboard-only scenario, records video, and converts it to a GIF (gifski, ffmpeg fallback). Self-contained under `editors/vscode/recording/` with its own `package.json`, so it never touches the extension's lockfile or vsix.

```
just record-demo quickstart     # -> editors/vscode/recording/out/quickstart.gif
just publish-demo quickstart    # -> editors/vscode/media/demo-quickstart.gif
```

## What's here

- `record.mjs` runner — launch → preamble → scenario → record → convert, with boot/preamble auto-trimmed. Rebuilds the extension bundle first (VS Code loads `dist/`, not `src/`).
- `lib/` — Electron launch + isolated clean-UI profile, a keyboard-only action vocabulary (`openFile`, `palette`, `command`, …), and webm→GIF conversion.
- Two scenarios: `quickstart` (open a model, show the command palette) and `lineage` (open the lineage webview).
- `just record-demo` / `just publish-demo`, a harness README documenting the gotchas, and a pointer in the extension CLAUDE.md.

Output is ~450 KB at 1000×625 — committable size, readable. No GIFs are embedded in any README yet; publishing is a deliberate later step.

## Bug fix included

The run-status decorations put `$(codicon)` syntax into a decoration's `after.contentText`, which VS Code renders **literally** — codicon substitution only happens in `MarkdownString`, not decorations. So every `.rocky` file showed the raw string `$(circle-outline)  no run history` instead of an icon. Replaced with Unicode glyphs (`○ / ✓ / ✕`); the existing themed colors already convey pass/fail.

## Follow-ups (not in this PR)

- **Lineage graph fit.** The webview panel/controls/node-counts capture fine, but the DAG renders cramped in the split canvas. Maximizing to widen it reloads the webview, and a post-reload programmatic fit didn't reliably refit the SVG. Left as a `TODO` in the scenario. Worth checking whether maximizing the lineage editor group blanks the graph for human users too.
- **AI-generate and drift scenarios.** AI-generate makes live model calls (non-deterministic, needs a key) and drift needs warehouse-fixture setup — both deserve a separate change with a decision on mocking vs. env-gating vs. fixtures.

## Notes

- `ffmpeg` + `gifski` required (`brew install ffmpeg gifski`). gifski's `--quality` is the size lever.
- `tsc`, eslint, and the 167 unit tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)