### PR TITLE
docs(vscode): point dev docs at the demo-recording harness

### DIFF
--- a/editors/vscode/AGENTS.md
+++ b/editors/vscode/AGENTS.md
@@ -65,6 +65,7 @@ themes/
 └── rocky-semantic.json   # Semantic token colors
 icons/
 └── rocky-icon.svg        # File icon
+recording/                # Playwright-driven demo-GIF recorder (see recording/README.md)
 ```
 
 ## Coding Standards
@@ -87,7 +88,12 @@ npm run lint              # ESLint
 npm run package           # Build .vsix
 ```
 
-## Extension Commands (25)
+Demo GIFs are recorded with `just record-demo <scenario>` from the monorepo root
+(Playwright drives a real VS Code; output in `recording/out/`). See `recording/README.md`.
+
+## Extension Commands (58)
+
+Selected commands below — see `CLAUDE.md` for the full table.
 
 | Command | What It Does |
 |---------|-------------|

--- a/editors/vscode/DEVELOPMENT.md
+++ b/editors/vscode/DEVELOPMENT.md
@@ -73,6 +73,7 @@ editors/vscode/                  # path inside the rocky-data/rocky monorepo
 │   └── rocky-semantic.json       # Semantic token colors for LSP tokens
 ├── icons/
 │   └── rocky-icon.svg            # File icon for .rocky files
+├── recording/                    # Playwright-driven demo-GIF recorder (see recording/README.md)
 ├── .vscode/
 │   └── launch.json               # F5 debug configuration
 ├── language-configuration.json   # Editor behavior (comments, brackets, folding)
@@ -161,6 +162,9 @@ npm run package
 
 # Install the .vsix locally
 code --install-extension rocky-0.2.0.vsix
+
+# Record a demo GIF (Playwright drives a real VS Code; output in recording/out/)
+just record-demo quickstart        # from the monorepo root; see recording/README.md
 ```
 
 ## Development Workflow


### PR DESCRIPTION
Follow-up to #688. The recording harness landed with its own README and a pointer in `editors/vscode/CLAUDE.md`, but the other two dev-facing docs weren't updated. This closes that gap.

- `DEVELOPMENT.md` and `AGENTS.md`: add a `recording/` entry to the Project Structure tree and a `just record-demo` entry to Common Commands.
- `AGENTS.md`: correct the stale `Extension Commands (25)` heading to `(58)` (matching CLAUDE.md) and note the table is a selected subset.

Scope is deliberately just the extension's dev docs. The public README embeds CLI/terminal demo GIFs and the `/docs` site is user-facing — the recording harness is internal dev tooling, so neither is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)