### PR TITLE
fix(vscode): re-fit lineage graph on resize + first Playwright E2E test

### DIFF
--- a/editors/vscode/recording/.gitignore
+++ b/editors/vscode/recording/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 out/
 .run/
+e2e/test-results/
+test-results/
+playwright-report/

--- a/editors/vscode/recording/README.md
+++ b/editors/vscode/recording/README.md
@@ -23,6 +23,23 @@ loads the built `dist/extension.js` from `--extensionDevelopmentPath`, not `src/
 so without a rebuild it would record stale code. `rocky` must be on `$PATH` (the
 launched VS Code inherits it, so the LSP connects automatically).
 
+## E2E tests
+
+The same launch infrastructure backs Playwright **end-to-end tests** — for the
+things the in-process `@vscode/test-electron` suite can't reach, chiefly webview
+DOM. These reach into the out-of-process webview iframe and assert real
+behavior (DOM, not pixels).
+
+```bash
+npm run test:e2e        # editors/vscode/recording/, runs e2e/*.spec.mjs
+```
+
+`e2e/lineage.spec.mjs` opens the lineage webview, asserts the graph rendered,
+and verifies it re-fits when the viewport widens. Tests build the extension
+bundle first (global-setup) and launch without video. Keep this layer thin —
+reserve it for webview/UI behavior; unit (vitest) and in-process integration
+(`@vscode/test-electron`) cover the rest more cheaply.
+
 ## Requirements
 
 - `ffmpeg` and `gifski` (`brew install ffmpeg gifski`) — gifski is preferred.

--- a/editors/vscode/recording/e2e/global-setup.mjs
+++ b/editors/vscode/recording/e2e/global-setup.mjs
@@ -1,0 +1,13 @@
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+
+// Build the extension bundle once before the suite runs. VS Code loads the
+// built dist/extension.js from --extensionDevelopmentPath, not src/, so without
+// this the tests would run against stale code (same trap as the recorder).
+export default function globalSetup() {
+  const vscodeDir = path.resolve(import.meta.dirname, "../..");
+  for (const script of ["bundle:webview", "bundle"]) {
+    const r = spawnSync("npm", ["run", script], { cwd: vscodeDir, stdio: "inherit" });
+    if (r.status !== 0) throw new Error(`extension build failed at \`npm run ${script}\``);
+  }
+}

--- a/editors/vscode/recording/e2e/lineage.spec.mjs
+++ b/editors/vscode/recording/e2e/lineage.spec.mjs
@@ -1,0 +1,76 @@
+// E2E: the lineage webview. This is the kind of coverage the in-process
+// @vscode/test-electron suite can't provide — it reaches into the webview's
+// out-of-process iframe DOM to assert the graph actually rendered, and that it
+// re-fits when the viewport widens (the ResizeObserver fix in
+// src/commands/lineage.ts). DOM-based, not pixel-based: correct and immune to
+// the recording-time compositor quirk.
+
+import { test as base, expect } from "@playwright/test";
+import * as path from "node:path";
+import { launchVSCode } from "../lib/vscode.mjs";
+import { makeDriver } from "../lib/driver.mjs";
+
+const VSCODE_DIR = path.resolve(import.meta.dirname, "..", "..");
+const REPO = path.resolve(VSCODE_DIR, "..", "..");
+const WORKSPACE = path.join(REPO, "examples/playground/pocs/06-developer-experience/01-lineage-column-level");
+
+const test = base.extend({
+  // Launch a real VS Code with the extension loaded; tear down after each test.
+  vscode: async ({}, use, testInfo) => {
+    const { app, win, cleanup } = await launchVSCode({
+      vscodeDir: VSCODE_DIR,
+      workspace: WORKSPACE,
+      size: { width: 1280, height: 800 },
+      recordDir: path.join(testInfo.outputDir, "vscode"),
+      video: false,
+    });
+    await use({ app, win });
+    await app.close();
+    cleanup?.();
+  },
+});
+
+// The lineage graph lives in an out-of-process webview iframe; find it by content.
+async function lineageFrame(win) {
+  for (const f of win.frames()) {
+    if (await f.locator("#graph-svg").count().catch(() => 0)) return f;
+  }
+  return null;
+}
+
+function scaleOf(transform) {
+  const m = /scale\(([0-9.]+)\)/.exec(transform ?? "");
+  return m ? parseFloat(m[1]) : null;
+}
+
+test("lineage webview renders nodes and re-fits when the viewport widens", async ({ vscode }) => {
+  const { win } = vscode;
+  const d = makeDriver(win);
+
+  // Settle, close the auto-opened chat panel, open a model, show its lineage.
+  await d.pause(4000);
+  await d.key("Meta+Alt+B");
+  await d.pause(500);
+  await d.openFile("fct_revenue.rocky");
+  await d.pause(1500);
+  await d.command("Rocky: Show Model Lineage");
+  await d.pause(4000);
+
+  const frame = await lineageFrame(win);
+  expect(frame, "lineage webview iframe should be present").toBeTruthy();
+
+  const graphGroup = frame.locator("#graph-svg > g");
+  const splitNodes = await frame.locator(".node").count();
+  expect(splitNodes, "graph should render at least one node").toBeGreaterThan(0);
+
+  const splitScale = scaleOf(await graphGroup.getAttribute("transform"));
+  expect(splitScale, "graph should have a fit transform").toBeGreaterThan(0);
+
+  // Widen the canvas — the ResizeObserver should re-fit to a larger scale.
+  await d.command("View: Toggle Maximize Editor Group");
+  await d.pause(2500);
+
+  expect(await frame.locator(".node").count(), "graph must not be lost on resize").toBe(splitNodes);
+  const maxScale = scaleOf(await graphGroup.getAttribute("transform"));
+  expect(maxScale, "graph should re-fit to a larger scale in the wider viewport").toBeGreaterThan(splitScale);
+});

--- a/editors/vscode/recording/e2e/playwright.config.mjs
+++ b/editors/vscode/recording/e2e/playwright.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+// E2E tests drive a real VS Code Electron instance (reusing the launch helper
+// in ../lib/vscode.mjs) and assert against the live extension — including
+// webview DOM, which the in-process @vscode/test-electron suite can't reach.
+// Serial + single worker: each test launches its own VS Code, and the shared
+// /tmp user-data dirs + extension build don't parallelize cleanly.
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/*.spec.mjs",
+  globalSetup: "./global-setup.mjs",
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+});

--- a/editors/vscode/recording/lib/vscode.mjs
+++ b/editors/vscode/recording/lib/vscode.mjs
@@ -42,8 +42,9 @@ function shortUserDataDir() {
  * @param {{width:number,height:number}} o.size  recording + window size
  * @param {string} o.recordDir   dir to drop the .webm + per-run scratch in
  * @param {object} [o.settings]  per-scenario settings overrides
+ * @param {boolean} [o.video]    record a .webm (true for recording; false for E2E tests)
  */
-export async function launchVSCode({ vscodeDir, workspace, size, recordDir, settings = {} }) {
+export async function launchVSCode({ vscodeDir, workspace, size, recordDir, settings = {}, video = true }) {
   const executablePath = await downloadAndUnzipVSCode({
     version: VSCODE_VERSION,
     cachePath: path.join(vscodeDir, ".vscode-test"),
@@ -74,7 +75,7 @@ export async function launchVSCode({ vscodeDir, workspace, size, recordDir, sett
       "--disable-gpu-sandbox",
       workspace,
     ],
-    recordVideo: { dir: recordDir, size },
+    ...(video ? { recordVideo: { dir: recordDir, size } } : {}),
     timeout: 60_000,
   });
 

--- a/editors/vscode/recording/package-lock.json
+++ b/editors/vscode/recording/package-lock.json
@@ -8,8 +8,25 @@
       "name": "rocky-vscode-recording",
       "version": "0.0.0",
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vscode/test-electron": "^2.5.2",
         "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@vscode/test-electron": {

--- a/editors/vscode/recording/package.json
+++ b/editors/vscode/recording/package.json
@@ -5,9 +5,11 @@
   "description": "Automated demo-GIF recording for the Rocky VS Code extension (Playwright drives a real VS Code Electron instance).",
   "type": "module",
   "scripts": {
-    "record": "node record.mjs"
+    "record": "node record.mjs",
+    "test:e2e": "playwright test --config e2e/playwright.config.mjs"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vscode/test-electron": "^2.5.2",
     "playwright": "^1.60.0"
   }

--- a/editors/vscode/recording/scenarios/lineage.mjs
+++ b/editors/vscode/recording/scenarios/lineage.mjs
@@ -1,12 +1,6 @@
 // Lineage: open a model and render its lineage as an interactive DAG webview
 // (rocky lineage -> DOT -> SVG via viz.js). Exercises the harness's ability to
 // capture a webview panel, not just the editor. Deterministic, offline.
-//
-// TODO: graph-fit-in-narrow-canvas needs more work. The webview opens in a
-// split, leaving the SVG canvas cramped (~39% zoom). Maximizing the editor
-// group reloads the webview, and a post-reload programmatic fit ('f' hotkey)
-// doesn't reliably refit the SVG. This is content-polish, not a harness
-// blocker — the panel, controls, and node counts all capture correctly.
 
 export default {
   name: "lineage",
@@ -25,5 +19,11 @@ export default {
     // Show Model Lineage opens a webview panel for the active model.
     await d.command("Rocky: Show Model Lineage");
     await d.pause(4500); // CLI lineage call + DOT->SVG render
+
+    // NOTE: kept on the split view on purpose. The graph now re-fits on resize
+    // (ResizeObserver fix in src/commands/lineage.ts, covered by e2e/lineage.spec.mjs),
+    // but the maximized SVG doesn't reliably repaint under the recording-time
+    // compositor, so the wider view records blank. The fit fix is real (verified
+    // via the webview DOM in the e2e test); this is a recording artifact only.
   },
 };

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -1244,12 +1244,18 @@ function renderLineageHtml(
 
   const graphGroup = d3.select(svgEl).append('g');
 
+  // Set once the user pans/zooms by hand (d3 tags those events with a
+  // sourceEvent; programmatic fitToView/reset calls have none). Used to decide
+  // whether an automatic re-fit on resize would clobber a deliberate view.
+  let userZoomed = false;
+
   const zoom = d3.zoom()
     .scaleExtent([0.1, 8])
     .on('zoom', (event) => {
       graphGroup.attr('transform', event.transform);
       document.getElementById('zoom-reset').textContent =
         Math.round(event.transform.k * 100) + '%';
+      if (event.sourceEvent) userZoomed = true;
       persistState({
         scale: event.transform.k,
         panX: event.transform.x,
@@ -1848,6 +1854,27 @@ function renderLineageHtml(
       e.preventDefault();
     }
   });
+
+  // Re-fit when the viewport resizes (maximizing the editor group, dragging the
+  // split wider, etc.). The transform is otherwise computed once at render and
+  // never recomputed, so the graph stays stranded at its old scale/position in
+  // the resized canvas. Debounced; skipped once the user has zoomed/panned by
+  // hand so we don't yank a deliberate view out from under them.
+  const viewportEl = document.getElementById('viewport');
+  if (typeof ResizeObserver !== 'undefined' && viewportEl) {
+    let resizeTimer;
+    let lastW = viewportEl.clientWidth;
+    let lastH = viewportEl.clientHeight;
+    new ResizeObserver(() => {
+      const w = viewportEl.clientWidth;
+      const h = viewportEl.clientHeight;
+      if (w === lastW && h === lastH) return;
+      lastW = w;
+      lastH = h;
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => { if (!userZoomed) fitToView(); }, 120);
+    }).observe(viewportEl);
+  }
 
   // ── Export SVG ───────────────────────────────────────────────────────────────
   // The live SVG references VS Code CSS variables (e.g. --vscode-foreground)


### PR DESCRIPTION
Follow-up to #688. Investigated the lineage graph-fit issue flagged there, found a real bug, fixed it, and stood up the first Playwright E2E test to lock it in.

## The bug (real, human-facing)

The lineage webview computed its zoom/pan once at render and never recomputed it. Reaching into the webview iframe DOM made it concrete:

```
SPLIT:      nodeCount=2, viewport=186×672, transform=scale(0.389)
MAXIMIZED:  nodeCount=2, viewport=652×685, transform=scale(0.389)   ← never updated
```

The nodes were always present — not a render bug. But on resize (maximizing the editor group, dragging the split wider) the transform never recomputed, so the graph stayed stranded at its old scale in a corner of the enlarged canvas.

**Fix:** a `ResizeObserver` on the viewport that re-fits (debounced), skipped once the user has zoomed/panned by hand so a deliberate view isn't clobbered. After the fix the maximized transform recomputes to `scale(1.365)` — the graph fills the widened canvas.

## First E2E test

`recording/e2e/lineage.spec.mjs` (Playwright, reusing the harness launch helper) opens the lineage webview, asserts the graph rendered, then maximizes and verifies the scale **increases** while node count holds. This is the coverage layer the in-process `@vscode/test-electron` suite can't provide — it reaches into the out-of-process webview iframe. Asserts DOM, not pixels (correct, and immune to a recording-time compositor quirk). `npm run test:e2e`.

The intended testing shape: vitest (unit) and `@vscode/test-electron` (in-process integration) for the bulk; Playwright E2E kept thin, for webview/UI behavior only.

## Notes

- The lineage *recording* scenario stays on the split view: the maximized SVG doesn't repaint reliably under the recording compositor (a capture artifact, not a webview bug — the fix is verified via the DOM in the E2E test).
- Surfaced separately during investigation: the LSP emits an `Invalid Semantic Tokens Data` console error (`end character > getLineLength`) — an engine-side semantic-tokens desync, unrelated to lineage. Worth a separate look.
- `tsc`, eslint, and the 167 unit tests are green; the E2E test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)