### PR TITLE
feat(engine/rocky-mcp): read-only catalog/history/metrics/optimize tools

### DIFF
--- a/editors/vscode/recording/.gitignore
+++ b/editors/vscode/recording/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 out/
 .run/
+e2e/test-results/
+test-results/
+playwright-report/

--- a/editors/vscode/recording/README.md
+++ b/editors/vscode/recording/README.md
@@ -23,6 +23,23 @@ loads the built `dist/extension.js` from `--extensionDevelopmentPath`, not `src/
 so without a rebuild it would record stale code. `rocky` must be on `$PATH` (the
 launched VS Code inherits it, so the LSP connects automatically).
 
+## E2E tests
+
+The same launch infrastructure backs Playwright **end-to-end tests** — for the
+things the in-process `@vscode/test-electron` suite can't reach, chiefly webview
+DOM. These reach into the out-of-process webview iframe and assert real
+behavior (DOM, not pixels).
+
+```bash
+npm run test:e2e        # editors/vscode/recording/, runs e2e/*.spec.mjs
+```
+
+`e2e/lineage.spec.mjs` opens the lineage webview, asserts the graph rendered,
+and verifies it re-fits when the viewport widens. Tests build the extension
+bundle first (global-setup) and launch without video. Keep this layer thin —
+reserve it for webview/UI behavior; unit (vitest) and in-process integration
+(`@vscode/test-electron`) cover the rest more cheaply.
+
 ## Requirements
 
 - `ffmpeg` and `gifski` (`brew install ffmpeg gifski`) — gifski is preferred.

--- a/editors/vscode/recording/e2e/global-setup.mjs
+++ b/editors/vscode/recording/e2e/global-setup.mjs
@@ -1,0 +1,13 @@
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+
+// Build the extension bundle once before the suite runs. VS Code loads the
+// built dist/extension.js from --extensionDevelopmentPath, not src/, so without
+// this the tests would run against stale code (same trap as the recorder).
+export default function globalSetup() {
+  const vscodeDir = path.resolve(import.meta.dirname, "../..");
+  for (const script of ["bundle:webview", "bundle"]) {
+    const r = spawnSync("npm", ["run", script], { cwd: vscodeDir, stdio: "inherit" });
+    if (r.status !== 0) throw new Error(`extension build failed at \`npm run ${script}\``);
+  }
+}

--- a/editors/vscode/recording/e2e/lineage.spec.mjs
+++ b/editors/vscode/recording/e2e/lineage.spec.mjs
@@ -1,0 +1,76 @@
+// E2E: the lineage webview. This is the kind of coverage the in-process
+// @vscode/test-electron suite can't provide — it reaches into the webview's
+// out-of-process iframe DOM to assert the graph actually rendered, and that it
+// re-fits when the viewport widens (the ResizeObserver fix in
+// src/commands/lineage.ts). DOM-based, not pixel-based: correct and immune to
+// the recording-time compositor quirk.
+
+import { test as base, expect } from "@playwright/test";
+import * as path from "node:path";
+import { launchVSCode } from "../lib/vscode.mjs";
+import { makeDriver } from "../lib/driver.mjs";
+
+const VSCODE_DIR = path.resolve(import.meta.dirname, "..", "..");
+const REPO = path.resolve(VSCODE_DIR, "..", "..");
+const WORKSPACE = path.join(REPO, "examples/playground/pocs/06-developer-experience/01-lineage-column-level");
+
+const test = base.extend({
+  // Launch a real VS Code with the extension loaded; tear down after each test.
+  vscode: async ({}, use, testInfo) => {
+    const { app, win, cleanup } = await launchVSCode({
+      vscodeDir: VSCODE_DIR,
+      workspace: WORKSPACE,
+      size: { width: 1280, height: 800 },
+      recordDir: path.join(testInfo.outputDir, "vscode"),
+      video: false,
+    });
+    await use({ app, win });
+    await app.close();
+    cleanup?.();
+  },
+});
+
+// The lineage graph lives in an out-of-process webview iframe; find it by content.
+async function lineageFrame(win) {
+  for (const f of win.frames()) {
+    if (await f.locator("#graph-svg").count().catch(() => 0)) return f;
+  }
+  return null;
+}
+
+function scaleOf(transform) {
+  const m = /scale\(([0-9.]+)\)/.exec(transform ?? "");
+  return m ? parseFloat(m[1]) : null;
+}
+
+test("lineage webview renders nodes and re-fits when the viewport widens", async ({ vscode }) => {
+  const { win } = vscode;
+  const d = makeDriver(win);
+
+  // Settle, close the auto-opened chat panel, open a model, show its lineage.
+  await d.pause(4000);
+  await d.key("Meta+Alt+B");
+  await d.pause(500);
+  await d.openFile("fct_revenue.rocky");
+  await d.pause(1500);
+  await d.command("Rocky: Show Model Lineage");
+  await d.pause(4000);
+
+  const frame = await lineageFrame(win);
+  expect(frame, "lineage webview iframe should be present").toBeTruthy();
+
+  const graphGroup = frame.locator("#graph-svg > g");
+  const splitNodes = await frame.locator(".node").count();
+  expect(splitNodes, "graph should render at least one node").toBeGreaterThan(0);
+
+  const splitScale = scaleOf(await graphGroup.getAttribute("transform"));
+  expect(splitScale, "graph should have a fit transform").toBeGreaterThan(0);
+
+  // Widen the canvas — the ResizeObserver should re-fit to a larger scale.
+  await d.command("View: Toggle Maximize Editor Group");
+  await d.pause(2500);
+
+  expect(await frame.locator(".node").count(), "graph must not be lost on resize").toBe(splitNodes);
+  const maxScale = scaleOf(await graphGroup.getAttribute("transform"));
+  expect(maxScale, "graph should re-fit to a larger scale in the wider viewport").toBeGreaterThan(splitScale);
+});

--- a/editors/vscode/recording/e2e/playwright.config.mjs
+++ b/editors/vscode/recording/e2e/playwright.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+// E2E tests drive a real VS Code Electron instance (reusing the launch helper
+// in ../lib/vscode.mjs) and assert against the live extension — including
+// webview DOM, which the in-process @vscode/test-electron suite can't reach.
+// Serial + single worker: each test launches its own VS Code, and the shared
+// /tmp user-data dirs + extension build don't parallelize cleanly.
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/*.spec.mjs",
+  globalSetup: "./global-setup.mjs",
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: "list",
+});

--- a/editors/vscode/recording/lib/vscode.mjs
+++ b/editors/vscode/recording/lib/vscode.mjs
@@ -42,8 +42,9 @@ function shortUserDataDir() {
  * @param {{width:number,height:number}} o.size  recording + window size
  * @param {string} o.recordDir   dir to drop the .webm + per-run scratch in
  * @param {object} [o.settings]  per-scenario settings overrides
+ * @param {boolean} [o.video]    record a .webm (true for recording; false for E2E tests)
  */
-export async function launchVSCode({ vscodeDir, workspace, size, recordDir, settings = {} }) {
+export async function launchVSCode({ vscodeDir, workspace, size, recordDir, settings = {}, video = true }) {
   const executablePath = await downloadAndUnzipVSCode({
     version: VSCODE_VERSION,
     cachePath: path.join(vscodeDir, ".vscode-test"),
@@ -74,7 +75,7 @@ export async function launchVSCode({ vscodeDir, workspace, size, recordDir, sett
       "--disable-gpu-sandbox",
       workspace,
     ],
-    recordVideo: { dir: recordDir, size },
+    ...(video ? { recordVideo: { dir: recordDir, size } } : {}),
     timeout: 60_000,
   });
 

--- a/editors/vscode/recording/package-lock.json
+++ b/editors/vscode/recording/package-lock.json
@@ -8,8 +8,25 @@
       "name": "rocky-vscode-recording",
       "version": "0.0.0",
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vscode/test-electron": "^2.5.2",
         "playwright": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@vscode/test-electron": {

--- a/editors/vscode/recording/package.json
+++ b/editors/vscode/recording/package.json
@@ -5,9 +5,11 @@
   "description": "Automated demo-GIF recording for the Rocky VS Code extension (Playwright drives a real VS Code Electron instance).",
   "type": "module",
   "scripts": {
-    "record": "node record.mjs"
+    "record": "node record.mjs",
+    "test:e2e": "playwright test --config e2e/playwright.config.mjs"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vscode/test-electron": "^2.5.2",
     "playwright": "^1.60.0"
   }

--- a/editors/vscode/recording/scenarios/lineage.mjs
+++ b/editors/vscode/recording/scenarios/lineage.mjs
@@ -1,12 +1,6 @@
 // Lineage: open a model and render its lineage as an interactive DAG webview
 // (rocky lineage -> DOT -> SVG via viz.js). Exercises the harness's ability to
 // capture a webview panel, not just the editor. Deterministic, offline.
-//
-// TODO: graph-fit-in-narrow-canvas needs more work. The webview opens in a
-// split, leaving the SVG canvas cramped (~39% zoom). Maximizing the editor
-// group reloads the webview, and a post-reload programmatic fit ('f' hotkey)
-// doesn't reliably refit the SVG. This is content-polish, not a harness
-// blocker — the panel, controls, and node counts all capture correctly.
 
 export default {
   name: "lineage",
@@ -25,5 +19,11 @@ export default {
     // Show Model Lineage opens a webview panel for the active model.
     await d.command("Rocky: Show Model Lineage");
     await d.pause(4500); // CLI lineage call + DOT->SVG render
+
+    // NOTE: kept on the split view on purpose. The graph now re-fits on resize
+    // (ResizeObserver fix in src/commands/lineage.ts, covered by e2e/lineage.spec.mjs),
+    // but the maximized SVG doesn't reliably repaint under the recording-time
+    // compositor, so the wider view records blank. The fit fix is real (verified
+    // via the webview DOM in the e2e test); this is a recording artifact only.
   },
 };

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -1244,12 +1244,18 @@ function renderLineageHtml(
 
   const graphGroup = d3.select(svgEl).append('g');
 
+  // Set once the user pans/zooms by hand (d3 tags those events with a
+  // sourceEvent; programmatic fitToView/reset calls have none). Used to decide
+  // whether an automatic re-fit on resize would clobber a deliberate view.
+  let userZoomed = false;
+
   const zoom = d3.zoom()
     .scaleExtent([0.1, 8])
     .on('zoom', (event) => {
       graphGroup.attr('transform', event.transform);
       document.getElementById('zoom-reset').textContent =
         Math.round(event.transform.k * 100) + '%';
+      if (event.sourceEvent) userZoomed = true;
       persistState({
         scale: event.transform.k,
         panX: event.transform.x,
@@ -1848,6 +1854,27 @@ function renderLineageHtml(
       e.preventDefault();
     }
   });
+
+  // Re-fit when the viewport resizes (maximizing the editor group, dragging the
+  // split wider, etc.). The transform is otherwise computed once at render and
+  // never recomputed, so the graph stays stranded at its old scale/position in
+  // the resized canvas. Debounced; skipped once the user has zoomed/panned by
+  // hand so we don't yank a deliberate view out from under them.
+  const viewportEl = document.getElementById('viewport');
+  if (typeof ResizeObserver !== 'undefined' && viewportEl) {
+    let resizeTimer;
+    let lastW = viewportEl.clientWidth;
+    let lastH = viewportEl.clientHeight;
+    new ResizeObserver(() => {
+      const w = viewportEl.clientWidth;
+      const h = viewportEl.clientHeight;
+      if (w === lastW && h === lastH) return;
+      lastW = w;
+      lastH = h;
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => { if (!userZoomed) fitToView(); }, 120);
+    }).observe(viewportEl);
+  }
 
   // ── Export SVG ───────────────────────────────────────────────────────────────
   // The live SVG references VS Code CSS variables (e.g. --vscode-foreground)

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`rocky mcp`: read-only `catalog` / `history` / `metrics` / `optimize` tools** — four more tools on the MCP server, all offline (no warehouse connection, no credentials) and built on the engine's existing command cores. `catalog` returns the project-wide asset inventory in one call: every model and source with its typed columns and upstream/downstream model lists (the token-heavy column-edge set is dropped — agents use `lineage` for the column-level trace, `inspect_schema` for typed columns alone, `dependents` for one model's consumers). `history` reads the run ledger — the recent project runs, or a single model's executions (duration, rows, status, `sql_hash`) when `model` is set. `metrics` returns a model's quality snapshots (row count, freshness lag, per-column null rates) plus derived freshness / null-rate alerts. `optimize` returns the cost model's materialization recommendations (current vs recommended strategy, projected monthly savings, reasoning) computed from run history and the on-disk DAG. The tools ground an agent's proposals in the typed graph and operational reality before it reaches `propose`; none of them mutate the warehouse or engine state.
+
+### Changed
+
+- **`rocky-cli`: more typed-output cores extracted for reuse** — `history` / `metrics` / `optimize` now build their JSON output through reusable `history_runs_output` / `model_history_output` / `metrics_output` / `optimize_output` functions (the `run_*` handlers call the core, then print), and `compute_catalog_output` is widened to `pub`, so the MCP server and the CLI share one code path. No output-schema change.
+
 ## [1.44.0] — 2026-05-25
 
 The AI-drivable surface lands end-to-end. `rocky mcp` exposes the engine's read-only tools over the Model Context Protocol so an agent can drive Rocky directly, a `build_model` prompt scripts the authoring loop, and AI-authored plans are gated behind `rocky review` before any `rocky apply`. Also ships `rocky ai-contract`, `rocky preview rows`, and a governance-safe ad-hoc SQL preview.

--- a/engine/crates/rocky-cli/src/commands/catalog.rs
+++ b/engine/crates/rocky-cli/src/commands/catalog.rs
@@ -159,7 +159,7 @@ pub async fn run_catalog(
 /// SemanticGraph for assets + edges, then enriches with state-store
 /// run history (`last_run_id` / `last_materialized_at`) when the
 /// state store is available.
-pub(crate) fn compute_catalog_output(
+pub fn compute_catalog_output(
     config_path: &Path,
     state_path: &Path,
     models_dir: &Path,

--- a/engine/crates/rocky-cli/src/commands/history.rs
+++ b/engine/crates/rocky-cli/src/commands/history.rs
@@ -87,6 +87,108 @@ fn record_to_history(run: &RunRecord, audit: bool) -> RunHistoryRecord {
     }
 }
 
+/// Parse a `--since` filter string (RFC 3339 or `YYYY-MM-DD`) into a UTC
+/// timestamp. Shared by the run-level and model-level cores.
+fn parse_since(since: Option<&str>) -> Result<Option<DateTime<Utc>>> {
+    since
+        .map(|s| {
+            s.parse::<DateTime<Utc>>()
+                .or_else(|_| {
+                    // Try parsing as date-only (YYYY-MM-DD)
+                    chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                        .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc())
+                })
+                .map_err(|e| anyhow::anyhow!("invalid --since date: {e}"))
+        })
+        .transpose()
+}
+
+/// Build the project-level run-history output from the state store (the
+/// model-unscoped `rocky history`). Pure compute — no printing — so other
+/// surfaces (the MCP `history` tool) can reuse it.
+pub fn history_runs_output(
+    state_path: &Path,
+    since: Option<&str>,
+    audit: bool,
+) -> Result<HistoryOutput> {
+    let store = StateStore::open_read_only(state_path)?;
+    let since_ts = parse_since(since)?;
+
+    let runs = store.list_runs(50)?;
+    let filtered: Vec<_> = if let Some(ts) = since_ts {
+        runs.into_iter().filter(|r| r.started_at >= ts).collect()
+    } else {
+        runs
+    };
+    let runs: Vec<RunHistoryRecord> = filtered
+        .iter()
+        .map(|r| record_to_history(r, audit))
+        .collect();
+    Ok(HistoryOutput {
+        version: VERSION.to_string(),
+        command: "history".to_string(),
+        count: runs.len(),
+        runs,
+    })
+}
+
+/// Build the model-scoped run-history output from the state store (the
+/// `rocky history --model <name>` path), augmenting with [`RollingStats`]
+/// when `rolling_stats` is set. Pure compute — no printing.
+pub fn model_history_output(
+    state_path: &Path,
+    model_name: &str,
+    since: Option<&str>,
+    rolling_stats: bool,
+    window: usize,
+) -> Result<ModelHistoryOutput> {
+    let store = StateStore::open_read_only(state_path)?;
+    let since_ts = parse_since(since)?;
+
+    // Fetch a wide enough pool so that rolling stats can find `window`
+    // successful executions even when recent history includes failures.
+    let fetch_limit = if rolling_stats {
+        window.saturating_mul(5).max(100)
+    } else {
+        50
+    };
+    let executions = store.get_model_history(model_name, fetch_limit)?;
+
+    let filtered: Vec<_> = if let Some(ts) = since_ts {
+        executions
+            .into_iter()
+            .filter(|e| e.started_at >= ts)
+            .collect()
+    } else {
+        executions
+    };
+
+    let stats: Option<RollingStats> = if rolling_stats {
+        Some(compute_rolling_stats(&filtered, window))
+    } else {
+        None
+    };
+
+    let executions: Vec<ModelExecutionRecord> = filtered
+        .iter()
+        .map(|e| ModelExecutionRecord {
+            started_at: e.started_at,
+            duration_ms: e.duration_ms,
+            rows_affected: e.rows_affected,
+            status: format!("{:?}", e.status),
+            sql_hash: e.sql_hash.clone(),
+        })
+        .collect();
+    Ok(ModelHistoryOutput {
+        version: VERSION.to_string(),
+        command: "history".to_string(),
+        model: model_name.to_string(),
+        count: executions.len(),
+        executions,
+        rolling_stats: stats,
+    })
+}
+
 /// Execute `rocky history`.
 ///
 /// When `audit` is true, both the JSON output (the eight new optional
@@ -107,65 +209,9 @@ pub fn run_history(
     window: usize,
     output_json: bool,
 ) -> Result<()> {
-    let store = StateStore::open_read_only(state_path)?;
-
-    let since_ts: Option<DateTime<Utc>> = since
-        .map(|s| {
-            s.parse::<DateTime<Utc>>()
-                .or_else(|_| {
-                    // Try parsing as date-only (YYYY-MM-DD)
-                    chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
-                        .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc())
-                })
-                .map_err(|e| anyhow::anyhow!("invalid --since date: {e}"))
-        })
-        .transpose()?;
-
     if let Some(model_name) = model_filter {
-        // Fetch a wide enough pool so that rolling stats can find `window`
-        // successful executions even when recent history includes failures.
-        let fetch_limit = if rolling_stats {
-            window.saturating_mul(5).max(100)
-        } else {
-            50
-        };
-        let executions = store.get_model_history(model_name, fetch_limit)?;
-
-        let filtered: Vec<_> = if let Some(ts) = since_ts {
-            executions
-                .into_iter()
-                .filter(|e| e.started_at >= ts)
-                .collect()
-        } else {
-            executions
-        };
-
-        // Compute rolling stats before consuming `filtered`.
-        let stats: Option<RollingStats> = if rolling_stats {
-            Some(compute_rolling_stats(&filtered, window))
-        } else {
-            None
-        };
-
+        let output = model_history_output(state_path, model_name, since, rolling_stats, window)?;
         if output_json {
-            let executions: Vec<ModelExecutionRecord> = filtered
-                .iter()
-                .map(|e| ModelExecutionRecord {
-                    started_at: e.started_at,
-                    duration_ms: e.duration_ms,
-                    rows_affected: e.rows_affected,
-                    status: format!("{:?}", e.status),
-                    sql_hash: e.sql_hash.clone(),
-                })
-                .collect();
-            let output = ModelHistoryOutput {
-                version: VERSION.to_string(),
-                command: "history".to_string(),
-                model: model_name.to_string(),
-                count: executions.len(),
-                executions,
-                rolling_stats: stats,
-            };
             print_json(&output)?;
         } else {
             println!("History for model: {model_name}");
@@ -175,7 +221,7 @@ pub fn run_history(
             );
             println!("{}", "-".repeat(72));
 
-            for exec in &filtered {
+            for exec in &output.executions {
                 println!(
                     "{:<24} {:<10} {:<12} {:<14} {:<10}",
                     exec.started_at.format("%Y-%m-%d %H:%M:%S"),
@@ -187,29 +233,11 @@ pub fn run_history(
                     &exec.sql_hash[..exec.sql_hash.len().min(8)],
                 );
             }
-            println!("\nTotal executions: {}", filtered.len());
+            println!("\nTotal executions: {}", output.executions.len());
         }
     } else {
-        // Show all runs
-        let runs = store.list_runs(50)?;
-
-        let filtered: Vec<_> = if let Some(ts) = since_ts {
-            runs.into_iter().filter(|r| r.started_at >= ts).collect()
-        } else {
-            runs
-        };
-
+        let output = history_runs_output(state_path, since, audit)?;
         if output_json {
-            let runs: Vec<RunHistoryRecord> = filtered
-                .iter()
-                .map(|r| record_to_history(r, audit))
-                .collect();
-            let output = HistoryOutput {
-                version: VERSION.to_string(),
-                command: "history".to_string(),
-                count: runs.len(),
-                runs,
-            };
             print_json(&output)?;
         } else {
             println!(
@@ -218,21 +246,30 @@ pub fn run_history(
             );
             println!("{}", "-".repeat(66));
 
-            for run in &filtered {
-                let status = format!("{:?}", run.status);
-                let trigger = format!("{:?}", run.trigger);
+            for run in &output.runs {
                 println!(
                     "{:<12} {:<24} {:<10} {:<8} {:<10}",
                     &run.run_id[..run.run_id.len().min(11)],
                     run.started_at.format("%Y-%m-%d %H:%M:%S"),
-                    status,
-                    run.models_executed.len(),
-                    trigger,
+                    run.status,
+                    run.models_executed,
+                    run.trigger,
                 );
             }
-            println!("\nTotal runs: {}", filtered.len());
+            println!("\nTotal runs: {}", output.runs.len());
 
             if audit {
+                // Re-read the raw records for the governance table — the typed
+                // output drops the audit-trail source fields when `audit` is
+                // false, and the text table wants the full `RunRecord`.
+                let store = StateStore::open_read_only(state_path)?;
+                let since_ts = parse_since(since)?;
+                let runs = store.list_runs(50)?;
+                let filtered: Vec<_> = if let Some(ts) = since_ts {
+                    runs.into_iter().filter(|r| r.started_at >= ts).collect()
+                } else {
+                    runs
+                };
                 print_audit_table(&filtered);
             }
         }

--- a/engine/crates/rocky-cli/src/commands/metrics.rs
+++ b/engine/crates/rocky-cli/src/commands/metrics.rs
@@ -13,38 +13,36 @@ use crate::output::{
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Execute `rocky metrics`.
-pub fn run_metrics(
+/// Build the quality-metrics output from the state store. Pure compute — no
+/// printing — so other surfaces (the MCP `metrics` tool) can reuse it.
+///
+/// `trend` pulls up to 20 snapshots (vs the single latest); `column` adds a
+/// per-run trend for one column; `alerts` derives freshness / null-rate
+/// alerts. An absent metric history yields an output with `message` set and
+/// empty snapshots.
+pub fn metrics_output(
     state_path: &Path,
     model_name: &str,
     trend: bool,
     column: Option<&str>,
     alerts: bool,
-    output_json: bool,
-) -> Result<()> {
+) -> Result<MetricsOutput> {
     let store = StateStore::open_read_only(state_path)?;
 
     let snapshots = store.get_quality_trend(model_name, if trend { 20 } else { 1 })?;
 
     if snapshots.is_empty() {
-        if output_json {
-            let output = MetricsOutput {
-                version: VERSION.to_string(),
-                command: "metrics".to_string(),
-                model: model_name.to_string(),
-                snapshots: vec![],
-                count: 0,
-                alerts: vec![],
-                column: None,
-                column_trend: vec![],
-                message: Some("no quality metrics available".to_string()),
-            };
-            print_json(&output)?;
-        } else {
-            println!("No quality metrics available for model: {model_name}");
-            println!("Run `rocky run` with checks enabled to collect metrics.");
-        }
-        return Ok(());
+        return Ok(MetricsOutput {
+            version: VERSION.to_string(),
+            command: "metrics".to_string(),
+            model: model_name.to_string(),
+            snapshots: vec![],
+            count: 0,
+            alerts: vec![],
+            column: None,
+            column_trend: vec![],
+            message: Some("no quality metrics available".to_string()),
+        });
     }
 
     // Build alerts if requested
@@ -87,107 +85,129 @@ pub fn run_metrics(
         Vec::new()
     };
 
-    if output_json {
-        let typed_snapshots: Vec<MetricsSnapshotEntry> = snapshots
+    let typed_snapshots: Vec<MetricsSnapshotEntry> = snapshots
+        .iter()
+        .map(|s| MetricsSnapshotEntry {
+            run_id: s.run_id.clone(),
+            timestamp: s.timestamp,
+            row_count: s.metrics.row_count,
+            freshness_lag_seconds: s.metrics.freshness_lag_seconds,
+            null_rates: s
+                .metrics
+                .null_rates
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect::<IndexMap<_, _>>(),
+        })
+        .collect();
+
+    let column_trend: Vec<ColumnTrendPoint> = if let Some(col_name) = column {
+        snapshots
             .iter()
-            .map(|s| MetricsSnapshotEntry {
+            .map(|s| ColumnTrendPoint {
                 run_id: s.run_id.clone(),
                 timestamp: s.timestamp,
+                null_rate: s.metrics.null_rates.get(col_name).copied(),
                 row_count: s.metrics.row_count,
-                freshness_lag_seconds: s.metrics.freshness_lag_seconds,
-                null_rates: s
-                    .metrics
-                    .null_rates
-                    .iter()
-                    .map(|(k, v)| (k.clone(), *v))
-                    .collect::<IndexMap<_, _>>(),
             })
-            .collect();
-
-        let column_trend: Vec<ColumnTrendPoint> = if let Some(col_name) = column {
-            snapshots
-                .iter()
-                .map(|s| ColumnTrendPoint {
-                    run_id: s.run_id.clone(),
-                    timestamp: s.timestamp,
-                    null_rate: s.metrics.null_rates.get(col_name).copied(),
-                    row_count: s.metrics.row_count,
-                })
-                .collect()
-        } else {
-            vec![]
-        };
-
-        let output = MetricsOutput {
-            version: VERSION.to_string(),
-            command: "metrics".to_string(),
-            model: model_name.to_string(),
-            count: typed_snapshots.len(),
-            snapshots: typed_snapshots,
-            alerts: alert_entries.clone(),
-            column: column.map(std::string::ToString::to_string),
-            column_trend,
-            message: None,
-        };
-        print_json(&output)?;
+            .collect()
     } else {
-        println!("Quality metrics for model: {model_name}");
-        println!();
+        vec![]
+    };
 
-        if trend {
+    Ok(MetricsOutput {
+        version: VERSION.to_string(),
+        command: "metrics".to_string(),
+        model: model_name.to_string(),
+        count: typed_snapshots.len(),
+        snapshots: typed_snapshots,
+        alerts: alert_entries,
+        column: column.map(std::string::ToString::to_string),
+        column_trend,
+        message: None,
+    })
+}
+
+/// Execute `rocky metrics`.
+pub fn run_metrics(
+    state_path: &Path,
+    model_name: &str,
+    trend: bool,
+    column: Option<&str>,
+    alerts: bool,
+    output_json: bool,
+) -> Result<()> {
+    let output = metrics_output(state_path, model_name, trend, column, alerts)?;
+
+    if output_json {
+        print_json(&output)?;
+        return Ok(());
+    }
+
+    if output.message.is_some() {
+        println!("No quality metrics available for model: {model_name}");
+        println!("Run `rocky run` with checks enabled to collect metrics.");
+        return Ok(());
+    }
+
+    let snapshots = &output.snapshots;
+    let alert_entries = &output.alerts;
+
+    println!("Quality metrics for model: {model_name}");
+    println!();
+
+    if trend {
+        println!(
+            "{:<24} {:<12} {:<10} {:<14}",
+            "TIMESTAMP", "ROW COUNT", "RUN ID", "FRESHNESS"
+        );
+        println!("{}", "-".repeat(62));
+
+        for snapshot in snapshots {
+            let freshness = snapshot
+                .freshness_lag_seconds
+                .map(|s| format!("{s}s"))
+                .unwrap_or_else(|| "-".to_string());
             println!(
                 "{:<24} {:<12} {:<10} {:<14}",
-                "TIMESTAMP", "ROW COUNT", "RUN ID", "FRESHNESS"
+                snapshot.timestamp.format("%Y-%m-%d %H:%M:%S"),
+                snapshot.row_count,
+                &snapshot.run_id[..snapshot.run_id.len().min(9)],
+                freshness,
             );
-            println!("{}", "-".repeat(62));
-
-            for snapshot in &snapshots {
-                let freshness = snapshot
-                    .metrics
-                    .freshness_lag_seconds
-                    .map(|s| format!("{s}s"))
-                    .unwrap_or_else(|| "-".to_string());
-                println!(
-                    "{:<24} {:<12} {:<10} {:<14}",
-                    snapshot.timestamp.format("%Y-%m-%d %H:%M:%S"),
-                    snapshot.metrics.row_count,
-                    &snapshot.run_id[..snapshot.run_id.len().min(9)],
-                    freshness,
-                );
-            }
-        } else if let Some(latest) = snapshots.first() {
-            println!("Latest snapshot (run: {}):", latest.run_id);
-            println!("  Row count: {}", latest.metrics.row_count);
-            if let Some(lag) = latest.metrics.freshness_lag_seconds {
-                println!("  Freshness lag: {lag}s");
-            }
-
-            if !latest.metrics.null_rates.is_empty() {
-                println!("  Null rates:");
-                let mut rates: Vec<_> = latest.metrics.null_rates.iter().collect();
-                rates.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
-                for (col, rate) in &rates {
-                    if let Some(filter_col) = column
-                        && col.as_str() != filter_col
-                    {
-                        continue;
-                    }
-                    println!("    {col}: {:.2}%", *rate * 100.0);
-                }
-            }
+        }
+    } else if let Some(latest) = snapshots.first() {
+        println!("Latest snapshot (run: {}):", latest.run_id);
+        println!("  Row count: {}", latest.row_count);
+        if let Some(lag) = latest.freshness_lag_seconds {
+            println!("  Freshness lag: {lag}s");
         }
 
-        if alerts && !alert_entries.is_empty() {
-            println!();
-            println!("ALERTS:");
-            for alert in &alert_entries {
-                let sev_marker = match alert.severity.as_str() {
-                    "critical" => "[CRITICAL]",
-                    "warning" => "[WARNING]",
-                    _ => "[INFO]",
-                };
-                println!("  {sev_marker} {}", alert.message);
+        if !latest.null_rates.is_empty() {
+            println!("  Null rates:");
+            let mut rates: Vec<_> = latest.null_rates.iter().collect();
+            rates.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap_or(std::cmp::Ordering::Equal));
+            for (col, rate) in &rates {
+                if let Some(filter_col) = column
+                    && col.as_str() != filter_col
+                {
+                    continue;
+                }
+                println!("    {col}: {:.2}%", *rate * 100.0);
             }
+        }
+    }
+
+    if alerts && !alert_entries.is_empty() {
+        println!();
+        println!("ALERTS:");
+        for alert in alert_entries {
+            let sev_marker = match alert.severity.as_str() {
+                "critical" => "[CRITICAL]",
+                "warning" => "[WARNING]",
+                _ => "[INFO]",
+            };
+            println!("  {sev_marker} {}", alert.message);
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -78,7 +78,9 @@ pub use branch::{
     run_branch_approve, run_branch_compare, run_branch_create, run_branch_delete, run_branch_list,
     run_branch_promote, run_branch_promote_from_plan, run_branch_show,
 };
-pub use catalog::{CatalogFormat, default_out_dir as catalog_default_out_dir, run_catalog};
+pub use catalog::{
+    CatalogFormat, compute_catalog_output, default_out_dir as catalog_default_out_dir, run_catalog,
+};
 #[cfg(feature = "duckdb")]
 pub use ci::run_ci;
 pub use ci_diff::{extract_base_compile, project_ir_from_compile, run_ci_diff};
@@ -95,7 +97,7 @@ pub use doctor::doctor;
 pub use estimate::run_estimate;
 pub use export_schemas::export_schemas;
 pub use fmt::run_fmt;
-pub use history::run_history;
+pub use history::{history_runs_output, model_history_output, run_history};
 pub use hooks::{run_hooks_list, run_hooks_test};
 pub use import_dbt::run_import_dbt;
 pub use init::init;
@@ -108,8 +110,8 @@ pub use list::{
 };
 pub use load::run_load;
 pub use lsp::run_lsp;
-pub use metrics::run_metrics;
-pub use optimize::run_optimize;
+pub use metrics::{metrics_output, run_metrics};
+pub use optimize::{optimize_output, run_optimize};
 pub use plan::{PlanRunOptions, plan, plan_preview_output, plan_promote};
 pub use playground::{run_playground, run_playground_with_template};
 pub use preview::{

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -12,13 +12,14 @@ use rocky_ir::dag::DagNode;
 
 use crate::output::{OptimizeOutput, OptimizeRecommendation, print_json};
 
-/// Execute `rocky optimize`.
-pub fn run_optimize(
+/// Build the optimize output from run history + the on-disk DAG. Pure
+/// compute — no printing — so other surfaces (the MCP `optimize` tool) can
+/// reuse it. Returns [`OptimizeOutput::empty`] when there is no run history.
+pub fn optimize_output(
     state_path: &Path,
     models_dir: Option<&Path>,
     model_filter: Option<&str>,
-    output_json: bool,
-) -> Result<()> {
+) -> Result<OptimizeOutput> {
     let store = StateStore::open_read_only(state_path)?;
     let config = CostConfig::default();
 
@@ -26,12 +27,7 @@ pub fn run_optimize(
     let runs = store.list_runs(100)?;
 
     if runs.is_empty() {
-        if output_json {
-            print_json(&OptimizeOutput::empty("no run history available"))?;
-        } else {
-            println!("No run history available. Run `rocky run` first to collect execution data.");
-        }
-        return Ok(());
+        return Ok(OptimizeOutput::empty("no run history available"));
     }
 
     // Build DAG from model definitions on disk (if models_dir is available).
@@ -99,52 +95,70 @@ pub fn run_optimize(
         recommendations.push(recommend_strategy(&stats, &config));
     }
 
+    let typed_recs: Vec<OptimizeRecommendation> = recommendations
+        .iter()
+        .map(|r| OptimizeRecommendation {
+            model_name: r.model_name.clone(),
+            current_strategy: r.current_strategy.clone(),
+            recommended_strategy: r.recommended_strategy.clone(),
+            estimated_monthly_savings: r.estimated_monthly_savings,
+            reasoning: r.reasoning.clone(),
+            compute_cost_per_run: r.compute_cost_per_run,
+            storage_cost_per_month: r.storage_cost_per_month,
+            downstream_references: r.downstream_references as u64,
+        })
+        .collect();
+    Ok(OptimizeOutput::new(typed_recs))
+}
+
+/// Execute `rocky optimize`.
+pub fn run_optimize(
+    state_path: &Path,
+    models_dir: Option<&Path>,
+    model_filter: Option<&str>,
+    output_json: bool,
+) -> Result<()> {
+    let output = optimize_output(state_path, models_dir, model_filter)?;
+
     if output_json {
-        let typed_recs: Vec<OptimizeRecommendation> = recommendations
-            .iter()
-            .map(|r| OptimizeRecommendation {
-                model_name: r.model_name.clone(),
-                current_strategy: r.current_strategy.clone(),
-                recommended_strategy: r.recommended_strategy.clone(),
-                estimated_monthly_savings: r.estimated_monthly_savings,
-                reasoning: r.reasoning.clone(),
-                compute_cost_per_run: r.compute_cost_per_run,
-                storage_cost_per_month: r.storage_cost_per_month,
-                downstream_references: r.downstream_references as u64,
-            })
-            .collect();
-        let output = OptimizeOutput::new(typed_recs);
         print_json(&output)?;
-    } else {
-        println!(
-            "{:<30} {:<12} {:<14} {:<12} {:<10}",
-            "MODEL", "CURRENT", "RECOMMENDED", "SAVINGS/MO", "REASONING"
-        );
-        println!("{}", "-".repeat(90));
+        return Ok(());
+    }
 
-        for rec in &recommendations {
-            println!(
-                "{:<30} {:<12} {:<14} ${:<11.4} {}",
-                truncate(&rec.model_name, 29),
-                rec.current_strategy,
-                rec.recommended_strategy,
-                rec.estimated_monthly_savings,
-                truncate(&rec.reasoning, 40),
-            );
-        }
+    if output.recommendations.is_empty() && output.message.is_some() {
+        println!("No run history available. Run `rocky run` first to collect execution data.");
+        return Ok(());
+    }
 
-        let total_savings: f64 = recommendations
-            .iter()
-            .map(|r| r.estimated_monthly_savings)
-            .sum();
-        println!();
-        println!("Total estimated monthly savings: ${total_savings:.2}");
-        println!("Models analyzed: {}", recommendations.len());
-        println!();
+    println!(
+        "{:<30} {:<12} {:<14} {:<12} {:<10}",
+        "MODEL", "CURRENT", "RECOMMENDED", "SAVINGS/MO", "REASONING"
+    );
+    println!("{}", "-".repeat(90));
+
+    for rec in &output.recommendations {
         println!(
-            "Tip: Run `rocky compile --output json` for inferred incrementality hints on full_refresh models."
+            "{:<30} {:<12} {:<14} ${:<11.4} {}",
+            truncate(&rec.model_name, 29),
+            rec.current_strategy,
+            rec.recommended_strategy,
+            rec.estimated_monthly_savings,
+            truncate(&rec.reasoning, 40),
         );
     }
+
+    let total_savings: f64 = output
+        .recommendations
+        .iter()
+        .map(|r| r.estimated_monthly_savings)
+        .sum();
+    println!();
+    println!("Total estimated monthly savings: ${total_savings:.2}");
+    println!("Models analyzed: {}", output.recommendations.len());
+    println!();
+    println!(
+        "Tip: Run `rocky compile --output json` for inferred incrementality hints on full_refresh models."
+    );
 
     Ok(())
 }

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -303,3 +303,170 @@ pub struct ProposeResult {
     /// The models this plan would materialize.
     pub models: Vec<String>,
 }
+
+/// One column on a `catalog` asset.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CatalogColumnLite {
+    pub name: String,
+    /// Declared or inferred type, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<String>,
+    /// Whether the column accepts nulls, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+}
+
+/// One asset (model or source) in a `catalog` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CatalogAssetLite {
+    /// Fully-qualified target (`catalog.schema.table`) when resolvable,
+    /// otherwise the model name.
+    pub fqn: String,
+    /// Model / source name as it appears in lineage edges.
+    pub model_name: String,
+    /// `"model"`, `"source"`, `"view"`, or `"materialized_view"`.
+    pub kind: String,
+    pub columns: Vec<CatalogColumnLite>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub upstream_models: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub downstream_models: Vec<String>,
+    /// Natural-language description from the model's sidecar, when set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+}
+
+/// `catalog` result — the project-wide asset inventory in one call: every
+/// model and source with its typed columns and the upstream/downstream model
+/// lists. Column-level edges are intentionally dropped (token-heavy); use
+/// `lineage` for the column-level trace of one model and `inspect_schema` for
+/// typed columns alone.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CatalogResult {
+    /// Pipeline the catalog was built for (first in declaration order).
+    pub project_name: String,
+    pub assets: Vec<CatalogAssetLite>,
+    pub asset_count: usize,
+    pub column_count: usize,
+    pub edge_count: usize,
+}
+
+/// One project run in a model-unscoped `history` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RunHistoryLite {
+    pub run_id: String,
+    /// RFC 3339 start timestamp.
+    pub started_at: String,
+    /// `"Success"`, `"Failed"`, `"Partial"`, etc.
+    pub status: String,
+    /// `"Manual"`, `"Scheduled"`, etc.
+    pub trigger: String,
+    /// Number of models executed in the run.
+    pub models_executed: usize,
+    pub duration_ms: u64,
+}
+
+/// One model execution in a model-scoped `history` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ModelExecutionLite {
+    /// RFC 3339 start timestamp.
+    pub started_at: String,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rows_affected: Option<u64>,
+    pub status: String,
+    /// Hash of the executed SQL — distinguishes a re-run from a changed model.
+    pub sql_hash: String,
+}
+
+/// `history` result — recent runs from the state store. When `model` is set the
+/// query is model-scoped and `executions` is populated; otherwise `runs` holds
+/// the project-level run summary. Both empty means no recorded history.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct HistoryResult {
+    /// Set when the query was scoped to a single model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Recent project runs (model-unscoped query).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub runs: Vec<RunHistoryLite>,
+    /// Per-model executions, newest first (model-scoped query).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub executions: Vec<ModelExecutionLite>,
+}
+
+/// One column's null rate in a `metrics` snapshot.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ColumnNullRateLite {
+    pub column: String,
+    /// Fraction of rows that were null (0.0–1.0).
+    pub null_rate: f64,
+}
+
+/// One quality snapshot in a `metrics` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MetricsSnapshotLite {
+    pub run_id: String,
+    /// RFC 3339 snapshot timestamp.
+    pub timestamp: String,
+    pub row_count: u64,
+    /// Seconds since the data was last fresh, when tracked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness_lag_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub null_rates: Vec<ColumnNullRateLite>,
+}
+
+/// One quality alert in a `metrics` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MetricsAlertLite {
+    /// `"freshness"` or `"null_rate"`.
+    pub kind: String,
+    /// `"warning"` or `"critical"`.
+    pub severity: String,
+    pub message: String,
+    /// Affected column, for column-scoped alerts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+}
+
+/// `metrics` result — quality snapshots (row count, freshness, per-column null
+/// rates) plus derived alerts for a model. `message` is set instead of
+/// snapshots when the model has no recorded quality metrics yet.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct MetricsResult {
+    pub model: String,
+    pub snapshots: Vec<MetricsSnapshotLite>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub alerts: Vec<MetricsAlertLite>,
+    /// Why there are no snapshots, when the model has no metrics yet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// One materialization-strategy recommendation in an `optimize` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct OptimizeRecommendationLite {
+    pub model_name: String,
+    /// Current strategy assumed by the cost model.
+    pub current_strategy: String,
+    /// Strategy the cost model recommends.
+    pub recommended_strategy: String,
+    /// Projected monthly savings (USD) from switching.
+    pub estimated_monthly_savings: f64,
+    /// Why the strategy is recommended.
+    pub reasoning: String,
+    /// How many models depend on this one (weights the recommendation).
+    pub downstream_references: u64,
+}
+
+/// `optimize` result — cost-model-driven materialization recommendations,
+/// derived from run history + the on-disk DAG. `message` is set instead of
+/// recommendations when there is no run history to analyse.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct OptimizeResult {
+    pub recommendations: Vec<OptimizeRecommendationLite>,
+    /// Why there are no recommendations, when run history is absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -126,6 +126,34 @@ pub struct DependentsArgs {
     pub model: String,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CatalogArgs {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct HistoryArgs {
+    /// When set, return that model's execution history instead of the
+    /// project-level run summary.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct MetricsArgs {
+    /// The model whose quality metrics to read.
+    pub model: String,
+    /// When set, also return a per-run trend for this single column.
+    #[serde(default)]
+    pub column: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct OptimizeArgs {
+    /// Substring filter on model name. When unset, analyses every model with
+    /// run history.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
 // MCP prompt arguments are string-typed on the wire; `Serialize` is part of
@@ -563,6 +591,170 @@ impl RockyMcpServer {
         Ok(Json(DependentsResult { model, dependents }))
     }
 
+    #[tool(
+        description = "Return the project-wide asset catalog in one call: every model and source \
+         with its typed columns and upstream/downstream model lists. Use to orient on the whole \
+         project at once. For the column-level edge trace of a single model use `lineage`; for \
+         typed columns alone use `inspect_schema`; for one model's consumers use `dependents`."
+    )]
+    async fn catalog(
+        &self,
+        _params: Parameters<CatalogArgs>,
+    ) -> Result<Json<CatalogResult>, String> {
+        let output = commands::compute_catalog_output(
+            &self.config_path,
+            &self.state_path(),
+            &self.models_dir,
+            None,
+        )
+        .map_err(|e| format!("{e:#}"))?;
+        Ok(Json(catalog_result(output)))
+    }
+
+    #[tool(
+        description = "Read run history from the state store. Without `model`, returns the recent \
+         project-level runs (id, status, trigger, duration). With `model`, returns that model's \
+         executions (duration, rows, status, sql_hash) newest-first. Grounds proposals in \
+         operational reality — is this model flaky, slow, recently changed? Empty when nothing has \
+         been run yet."
+    )]
+    async fn history(
+        &self,
+        params: Parameters<HistoryArgs>,
+    ) -> Result<Json<HistoryResult>, String> {
+        let state_path = self.state_path();
+        match params.0.model {
+            Some(model) => {
+                let out = commands::model_history_output(&state_path, &model, None, false, 20)
+                    .map_err(|e| format!("{e:#}"))?;
+                let executions = out
+                    .executions
+                    .into_iter()
+                    .map(|e| ModelExecutionLite {
+                        started_at: e.started_at.to_rfc3339(),
+                        duration_ms: e.duration_ms,
+                        rows_affected: e.rows_affected,
+                        status: e.status,
+                        sql_hash: e.sql_hash,
+                    })
+                    .collect();
+                Ok(Json(HistoryResult {
+                    model: Some(out.model),
+                    runs: vec![],
+                    executions,
+                }))
+            }
+            None => {
+                let out = commands::history_runs_output(&state_path, None, false)
+                    .map_err(|e| format!("{e:#}"))?;
+                let runs = out
+                    .runs
+                    .into_iter()
+                    .map(|r| RunHistoryLite {
+                        run_id: r.run_id,
+                        started_at: r.started_at.to_rfc3339(),
+                        status: r.status,
+                        trigger: r.trigger,
+                        models_executed: r.models_executed,
+                        duration_ms: r.duration_ms,
+                    })
+                    .collect();
+                Ok(Json(HistoryResult {
+                    model: None,
+                    runs,
+                    executions: vec![],
+                }))
+            }
+        }
+    }
+
+    #[tool(
+        description = "Read a model's quality-metric snapshots from the state store: row count, \
+         freshness lag, and per-column null rates over recent runs, plus derived freshness / \
+         null-rate alerts. Pass `column` to also get that column's per-run trend. `message` is set \
+         (and snapshots empty) when the model has no recorded metrics yet."
+    )]
+    async fn metrics(
+        &self,
+        params: Parameters<MetricsArgs>,
+    ) -> Result<Json<MetricsResult>, String> {
+        let args = params.0;
+        let out = commands::metrics_output(
+            &self.state_path(),
+            &args.model,
+            true,
+            args.column.as_deref(),
+            true,
+        )
+        .map_err(|e| format!("{e:#}"))?;
+
+        let snapshots = out
+            .snapshots
+            .into_iter()
+            .map(|s| MetricsSnapshotLite {
+                run_id: s.run_id,
+                timestamp: s.timestamp.to_rfc3339(),
+                row_count: s.row_count,
+                freshness_lag_seconds: s.freshness_lag_seconds,
+                null_rates: s
+                    .null_rates
+                    .into_iter()
+                    .map(|(column, null_rate)| ColumnNullRateLite { column, null_rate })
+                    .collect(),
+            })
+            .collect();
+        let alerts = out
+            .alerts
+            .into_iter()
+            .map(|a| MetricsAlertLite {
+                kind: a.kind,
+                severity: a.severity,
+                message: a.message,
+                column: a.column,
+            })
+            .collect();
+        Ok(Json(MetricsResult {
+            model: out.model,
+            snapshots,
+            alerts,
+            message: out.message,
+        }))
+    }
+
+    #[tool(
+        description = "Cost-model materialization recommendations from run history + the on-disk \
+         DAG: for each model, the current vs recommended strategy, projected monthly savings, and \
+         the reasoning. Use to reason about materialization with Rocky's cost model rather than \
+         guessing. `message` is set (and recommendations empty) when there's no run history yet."
+    )]
+    async fn optimize(
+        &self,
+        params: Parameters<OptimizeArgs>,
+    ) -> Result<Json<OptimizeResult>, String> {
+        let out = commands::optimize_output(
+            &self.state_path(),
+            Some(&self.models_dir),
+            params.0.model.as_deref(),
+        )
+        .map_err(|e| format!("{e:#}"))?;
+        let recommendations = out
+            .recommendations
+            .into_iter()
+            .map(|r| OptimizeRecommendationLite {
+                model_name: r.model_name,
+                current_strategy: r.current_strategy,
+                recommended_strategy: r.recommended_strategy,
+                estimated_monthly_savings: r.estimated_monthly_savings,
+                reasoning: r.reasoning,
+                downstream_references: r.downstream_references,
+            })
+            .collect();
+        Ok(Json(OptimizeResult {
+            recommendations,
+            message: out.message,
+        }))
+    }
+
     // ------------------------- SHOULD tools --------------------------------
 
     #[tool(
@@ -950,6 +1142,52 @@ fn project_compile_result(output: &rocky_cli::output::CompileOutput) -> CompileR
         warning_count,
         model_count: output.models,
         diagnostics,
+    }
+}
+
+/// Project a `CatalogOutput` into the lite [`CatalogResult`], dropping the
+/// (token-heavy) column-level edge set in favour of the per-asset
+/// upstream/downstream model lists plus the aggregate counts. Agents that
+/// need the edge trace use the `lineage` tool.
+fn catalog_result(output: rocky_cli::output::CatalogOutput) -> CatalogResult {
+    use rocky_cli::output::AssetKind;
+    let assets = output
+        .assets
+        .into_iter()
+        .map(|a| {
+            let kind = match a.kind {
+                AssetKind::Source => "source",
+                AssetKind::Model => "model",
+                AssetKind::View => "view",
+                AssetKind::MaterializedView => "materialized_view",
+            }
+            .to_string();
+            let columns = a
+                .columns
+                .into_iter()
+                .map(|c| CatalogColumnLite {
+                    name: c.name,
+                    data_type: c.data_type,
+                    nullable: c.nullable,
+                })
+                .collect();
+            CatalogAssetLite {
+                fqn: a.fqn,
+                model_name: a.model_name,
+                kind,
+                columns,
+                upstream_models: a.upstream_models,
+                downstream_models: a.downstream_models,
+                intent: a.intent,
+            }
+        })
+        .collect();
+    CatalogResult {
+        project_name: output.project_name,
+        assets,
+        asset_count: output.stats.asset_count,
+        column_count: output.stats.column_count,
+        edge_count: output.stats.edge_count,
     }
 }
 

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -79,11 +79,15 @@ async fn tools_list_returns_expected_set() {
         names,
         vec![
             "breaking_change",
+            "catalog",
             "compile",
             "dependents",
+            "history",
             "inspect_schema",
             "lineage",
             "list",
+            "metrics",
+            "optimize",
             "plan_preview",
             "profile_column",
             "propose",
@@ -456,6 +460,269 @@ async fn prompt_get_build_model_returns_authoring_loop() {
     assert!(
         haystack.to_lowercase().contains("reconcile"),
         "build_model must emphasize the reconcile discipline"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// Seed one successful run (recording an `orders` execution) plus one quality
+/// snapshot into the state store the server will resolve for `models_dir`. The
+/// `StateStore` handle is dropped before the caller starts the server so the
+/// read-only opens inside the tools don't contend on the redb lock.
+fn seed_run_history(models_dir: &Path) {
+    use rocky_core::state::{
+        ModelExecution, QualityMetrics, QualitySnapshot, RunRecord, RunStatus, RunTrigger,
+        SessionSource, StateStore,
+    };
+
+    let state_path = rocky_core::state::resolve_state_path(None, models_dir).path;
+    let store = StateStore::open(&state_path).expect("open state store");
+    let now = chrono::Utc::now();
+
+    let run = RunRecord {
+        run_id: "run-seed-001".to_string(),
+        started_at: now,
+        finished_at: now + chrono::Duration::seconds(2),
+        status: RunStatus::Success,
+        models_executed: vec![ModelExecution {
+            model_name: "orders".to_string(),
+            started_at: now,
+            finished_at: now + chrono::Duration::seconds(2),
+            duration_ms: 2000,
+            rows_affected: Some(42),
+            status: "success".to_string(),
+            sql_hash: "abc123def456".to_string(),
+            bytes_scanned: None,
+            bytes_written: Some(1024),
+        }],
+        trigger: RunTrigger::Manual,
+        config_hash: "cfg".to_string(),
+        triggering_identity: None,
+        session_source: SessionSource::Cli,
+        git_commit: None,
+        git_branch: None,
+        idempotency_key: None,
+        target_catalog: None,
+        hostname: "test-host".to_string(),
+        rocky_version: "0.0.0-test".to_string(),
+    };
+    store.record_run(&run).expect("record run");
+
+    let mut null_rates = std::collections::HashMap::new();
+    // 0.6 > the 0.5 critical threshold → exercises the alert projection.
+    null_rates.insert("status".to_string(), 0.6);
+    store
+        .record_quality(&QualitySnapshot {
+            timestamp: now,
+            run_id: "run-seed-001".to_string(),
+            model_name: "orders".to_string(),
+            metrics: QualityMetrics {
+                row_count: 42,
+                null_rates,
+                freshness_lag_seconds: Some(120),
+            },
+        })
+        .expect("record quality");
+}
+
+#[tokio::test]
+async fn catalog_returns_project_assets() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    // Add a model that selects `id FROM orders` so it has real column lineage
+    // (a literal-only leaf has no produced edges, hence no tracked columns).
+    // This exercises the column projection, not just the asset inventory.
+    std::fs::write(
+        dir.path().join("models").join("order_ids.sql"),
+        "SELECT id FROM orders\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("models").join("order_ids.toml"),
+        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"order_ids\"\n",
+    )
+    .unwrap();
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let result = client
+        .call_tool(CallToolRequestParams::new("catalog"))
+        .await
+        .expect("catalog call");
+
+    let sc = result.structured_content.expect("structured content");
+    assert!(sc["asset_count"].as_u64().unwrap() >= 2);
+    assert!(sc.as_object().unwrap().contains_key("column_count"));
+    let assets = sc["assets"].as_array().unwrap();
+
+    let orders = assets
+        .iter()
+        .find(|a| a["model_name"] == serde_json::json!("orders"))
+        .expect("orders asset present");
+    // `kind` is snake_cased at the projection boundary (the underlying
+    // `AssetKind` serializes PascalCase).
+    assert_eq!(orders["kind"], serde_json::json!("model"));
+
+    // `order_ids` selects from `orders`, so its `id` column has tracked
+    // lineage and must surface through the column projection.
+    let order_ids = assets
+        .iter()
+        .find(|a| a["model_name"] == serde_json::json!("order_ids"))
+        .expect("order_ids asset present");
+    let cols = order_ids["columns"].as_array().unwrap();
+    assert!(
+        cols.iter().any(|c| c["name"] == serde_json::json!("id")),
+        "order_ids should carry its `id` column; got {cols:?}"
+    );
+
+    // The token-heavy column edge set is intentionally not part of the lite
+    // catalog — agents reach for `lineage` instead.
+    assert!(!sc.as_object().unwrap().contains_key("edges"));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn history_reports_runs_and_model_executions() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    seed_run_history(&dir.path().join("models"));
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // Project-level: recent runs, no `model` arg.
+    let runs = client
+        .call_tool(CallToolRequestParams::new("history"))
+        .await
+        .expect("history call")
+        .structured_content
+        .expect("structured content");
+    let run_list = runs["runs"].as_array().unwrap();
+    assert_eq!(run_list.len(), 1);
+    assert_eq!(run_list[0]["run_id"], serde_json::json!("run-seed-001"));
+    assert_eq!(run_list[0]["status"], serde_json::json!("Success"));
+    assert_eq!(run_list[0]["models_executed"], serde_json::json!(1));
+
+    // Model-scoped: executions for `orders`.
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let model_hist = client
+        .call_tool(CallToolRequestParams::new("history").with_arguments(args))
+        .await
+        .expect("history --model call")
+        .structured_content
+        .expect("structured content");
+    assert_eq!(model_hist["model"], serde_json::json!("orders"));
+    let execs = model_hist["executions"].as_array().unwrap();
+    assert_eq!(execs.len(), 1);
+    assert_eq!(execs[0]["rows_affected"], serde_json::json!(42));
+    assert_eq!(execs[0]["sql_hash"], serde_json::json!("abc123def456"));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn history_is_empty_without_runs() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let sc = client
+        .call_tool(CallToolRequestParams::new("history"))
+        .await
+        .expect("history call")
+        .structured_content
+        .expect("structured content");
+    // No runs recorded → `runs` omitted (skip_serializing_if empty), no panic.
+    assert!(sc.get("runs").is_none() || sc["runs"].as_array().unwrap().is_empty());
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn metrics_returns_seeded_snapshot_and_alert() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    seed_run_history(&dir.path().join("models"));
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let sc = client
+        .call_tool(CallToolRequestParams::new("metrics").with_arguments(args))
+        .await
+        .expect("metrics call")
+        .structured_content
+        .expect("structured content");
+
+    assert_eq!(sc["model"], serde_json::json!("orders"));
+    let snapshots = sc["snapshots"].as_array().unwrap();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0]["row_count"], serde_json::json!(42));
+    let null_rates = snapshots[0]["null_rates"].as_array().unwrap();
+    assert_eq!(null_rates[0]["column"], serde_json::json!("status"));
+    // The 0.6 null rate trips the critical null_rate alert.
+    let alerts = sc["alerts"].as_array().unwrap();
+    assert!(
+        alerts
+            .iter()
+            .any(|a| a["kind"] == serde_json::json!("null_rate")),
+        "0.6 null rate should raise a null_rate alert; got {alerts:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn optimize_recommends_from_seeded_history() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    seed_run_history(&dir.path().join("models"));
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let sc = client
+        .call_tool(CallToolRequestParams::new("optimize"))
+        .await
+        .expect("optimize call")
+        .structured_content
+        .expect("structured content");
+
+    let recs = sc["recommendations"].as_array().unwrap();
+    assert!(
+        recs.iter()
+            .any(|r| r["model_name"] == serde_json::json!("orders")),
+        "optimize should analyse the seeded orders model; got {recs:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn optimize_reports_message_without_history() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+
+    let client = connect(server).await;
+    let sc = client
+        .call_tool(CallToolRequestParams::new("optimize"))
+        .await
+        .expect("optimize call")
+        .structured_content
+        .expect("structured content");
+
+    assert!(sc["recommendations"].as_array().unwrap().is_empty());
+    assert!(
+        sc["message"].as_str().unwrap().contains("no run history"),
+        "empty optimize must explain why"
     );
 
     client.cancel().await.unwrap();


### PR DESCRIPTION
Adds four offline, read-only tools to the `rocky mcp` server, extending the existing read-only surface (`compile`, `lineage`, `inspect_schema`, `breaking_change`, `dependents`, …). All four are creds-free and built on the engine's existing command cores — none connect to a warehouse or mutate state.

## New tools

| Tool | Returns |
|---|---|
| `catalog` | Project-wide asset inventory in one call — every model and source with its typed columns and upstream/downstream model lists. The token-heavy column-edge set is intentionally dropped; agents use `lineage` for the column trace, `inspect_schema` for typed columns alone, `dependents` for one model's consumers. |
| `history` | The run ledger — recent project runs, or a single model's executions (duration, rows, status, `sql_hash`) when `model` is set. |
| `metrics` | A model's quality snapshots (row count, freshness lag, per-column null rates) plus derived freshness / null-rate alerts. |
| `optimize` | Cost-model materialization recommendations (current vs recommended strategy, projected monthly savings, reasoning) computed from run history and the on-disk DAG. |

These ground an agent's reasoning in the typed graph and operational reality before it reaches `propose`.

## Implementation

- Follows the established stateless `#[tool]` pattern: reuse a rocky-cli `*_output` core, project into a trimmed schemars-1.x lite struct returned in `Json<T>`.
- Extracts reusable typed-output cores so the MCP server and the CLI share one code path: `history_runs_output` / `model_history_output` (history), `metrics_output` (metrics), `optimize_output` (optimize); the `run_*` handlers now call the core, then print. `compute_catalog_output` is widened `pub(crate)` → `pub`.
- No `*Output` struct changed, so no codegen drift.

## Tests

`tests/roundtrip.rs` extended: `tools/list` includes the four new tools; `catalog` returns the asset inventory plus a tracked column projection (via an `order_ids` model with real lineage); `history` / `metrics` / `optimize` reflect a seeded state store and report their empty paths.

`cargo test -p rocky-mcp` + `-p rocky-cli` green; `cargo clippy --all-targets` clean; `cargo fmt --check` clean.

## Scope note

The warehouse-gated `estimate_cost` tool (EXPLAIN-based cost) is deliberately not in this PR — it needs the DuckDB-only / `unavailable` envelope used by `sample_rows` / `profile_column`, which is structurally different from these offline tools, and ships as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)