### PR TITLE
feat(vscode): register `rocky mcp` as an MCP server for agent mode

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Rocky MCP server registered for agent mode** — the extension now registers `rocky mcp` as a Model Context Protocol server (one per workspace folder that has a `rocky.toml`), so the editor's agent mode can drive Rocky through the engine's typed read-only tools (`compile`, `lineage`, `inspect_schema`, `sample_rows`, `breaking_change`, `catalog`, `history`, `metrics`, `optimize`, and more). The tool surface is defined once in the Rust server, so the editor's AI stays in lockstep with whatever the installed `rocky` binary exposes — no tool definitions are duplicated in the extension. Honours `rocky.server.path` for the binary and refreshes when workspace folders or `rocky.toml` files change. The `@rocky` chat participant keeps its four single-shot slash commands; this adds the full typed toolset to agent mode. Degrades to a no-op on editor builds that predate the MCP definition-provider API (VS Code 1.101+).
+
 ## [1.28.0] — 2026-05-25
 
 A wave of new panels and views surfacing the engine's trust + AI features directly in the editor — eight new commands (50 → 58).

--- a/editors/vscode/CLAUDE.md
+++ b/editors/vscode/CLAUDE.md
@@ -24,6 +24,7 @@ The extension is an LSP client. All language intelligence (diagnostics, completi
 src/
 ├── extension.ts          # activate/deactivate — wires LSP client + command registry
 ├── lspClient.ts          # LSP client lifecycle (start/stop/restart)
+├── mcpServer.ts          # Registers `rocky mcp` as an MCP server for agent mode (per rocky.toml root)
 ├── rockyCli.ts           # Subprocess helpers (execFile + progress wrappers)
 ├── config.ts             # Workspace + settings access
 ├── output.ts             # Shared output channel

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -824,6 +824,12 @@
         ]
       }
     ],
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "rocky-data.rocky-mcp",
+        "label": "Rocky"
+      }
+    ],
     "keybindings": [
       {
         "command": "rocky.commandPalette",

--- a/editors/vscode/src/__tests__/mcpServer.test.ts
+++ b/editors/vscode/src/__tests__/mcpServer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// vscode mock — must precede the import that touches vscode. buildRockyMcpSpecs
+// is pure (path only), but mcpServer.ts + its config.ts import reference the
+// vscode module at load time, so a minimal stub is enough to resolve them.
+// ---------------------------------------------------------------------------
+
+vi.mock("vscode", () => ({
+  workspace: { workspaceFolders: undefined },
+  lm: {},
+  window: {},
+}));
+
+import { buildRockyMcpSpecs } from "../mcpServer";
+
+describe("buildRockyMcpSpecs", () => {
+  it("returns no specs when there are no Rocky project roots", () => {
+    expect(buildRockyMcpSpecs("rocky", [])).toEqual([]);
+  });
+
+  it("launches `rocky mcp --config <root>/rocky.toml` for a single root", () => {
+    const specs = buildRockyMcpSpecs("rocky", ["/work/proj"]);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]).toEqual({
+      label: "Rocky",
+      command: "rocky",
+      args: ["mcp", "--config", "/work/proj/rocky.toml"],
+      cwd: "/work/proj",
+    });
+  });
+
+  it("honours a custom binary path from rocky.server.path", () => {
+    const specs = buildRockyMcpSpecs("/opt/bin/rocky", ["/work/proj"]);
+    expect(specs[0].command).toBe("/opt/bin/rocky");
+    expect(specs[0].args).toEqual(["mcp", "--config", "/work/proj/rocky.toml"]);
+  });
+
+  it("disambiguates labels by folder name across multiple roots", () => {
+    const specs = buildRockyMcpSpecs("rocky", ["/work/a", "/work/b"]);
+    expect(specs.map((s) => s.label)).toEqual(["Rocky (a)", "Rocky (b)"]);
+    // Each still targets its own config + cwd.
+    expect(specs[0].args).toEqual(["mcp", "--config", "/work/a/rocky.toml"]);
+    expect(specs[1].cwd).toBe("/work/b");
+  });
+});

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { setExtensionUri } from "./extensionState";
 import { registerFoldingProvider } from "./foldingProvider";
 import { registerFormattingProvider } from "./formattingProvider";
 import { startLspClient, stopLspClient } from "./lspClient";
+import { registerRockyMcpProvider } from "./mcpServer";
 import { disposeOutputChannel } from "./output";
 import { registerRunDecorations } from "./runDecorations";
 import { registerTaskProvider } from "./taskProvider";
@@ -21,6 +22,7 @@ export function activate(context: vscode.ExtensionContext): void {
   startLspClient(context);
   registerCommands(context);
   registerChatParticipant(context);
+  registerRockyMcpProvider(context);
   registerTestExplorer(context);
   registerDeclarativeTestProvider(context);
   registerCodeLensProvider(context);

--- a/editors/vscode/src/mcpServer.ts
+++ b/editors/vscode/src/mcpServer.ts
@@ -1,0 +1,119 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { getConfig } from "./config";
+
+// ---------------------------------------------------------------------------
+// Rocky MCP server registration
+//
+// Registers `rocky mcp` as a Model Context Protocol stdio server so VS Code's
+// agent mode can drive Rocky through the engine's typed read-only tools
+// (compile, lineage, inspect_schema, sample_rows, breaking_change, catalog,
+// history, metrics, optimize, …). The tool surface is defined once, in the
+// Rust server — the extension only points the editor at the binary, so the
+// editor's AI stays in lockstep with whatever the installed `rocky` exposes.
+//
+// This complements the `@rocky` chat participant (which keeps its four
+// single-shot slash commands): agent mode gets the full typed toolset.
+// ---------------------------------------------------------------------------
+
+/** The contribution id; must match `contributes.mcpServerDefinitionProviders` in package.json. */
+const PROVIDER_ID = "rocky-data.rocky-mcp";
+
+/** A vscode-free description of one `rocky mcp` stdio server to launch. */
+export interface RockyMcpServerSpec {
+  /** Human-readable server name shown in the editor's MCP UI. */
+  label: string;
+  /** The `rocky` binary to launch. */
+  command: string;
+  /** Arguments: `mcp --config <abs rocky.toml>`. */
+  args: string[];
+  /** Working directory — the project root, so relative paths in rocky.toml resolve. */
+  cwd: string;
+}
+
+/**
+ * Build a launch spec for every project root that has a `rocky.toml`. Pure (no
+ * vscode runtime) so the launch contract is unit-testable. When more than one
+ * root is present the label is disambiguated by folder name.
+ */
+export function buildRockyMcpSpecs(
+  serverPath: string,
+  roots: string[],
+): RockyMcpServerSpec[] {
+  const disambiguate = roots.length > 1;
+  return roots.map((root) => ({
+    label: disambiguate ? `Rocky (${path.basename(root)})` : "Rocky",
+    command: serverPath,
+    args: ["mcp", "--config", path.join(root, "rocky.toml")],
+    cwd: root,
+  }));
+}
+
+/** Workspace folders whose root holds a `rocky.toml`. */
+function findRockyProjectRoots(): string[] {
+  const roots: string[] = [];
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const root = folder.uri.fsPath;
+    if (fs.existsSync(path.join(root, "rocky.toml"))) roots.push(root);
+  }
+  return roots;
+}
+
+/**
+ * Register the Rocky MCP server-definition provider so the editor's agent mode
+ * discovers `rocky mcp` for every Rocky project in the workspace.
+ *
+ * The MCP definition-provider API is finalized in VS Code 1.101+; a host (or a
+ * test harness) that predates it won't expose the entry point, so we guard and
+ * degrade to a no-op rather than throw on activation.
+ */
+export function registerRockyMcpProvider(context: vscode.ExtensionContext): void {
+  const lm = vscode.lm as typeof vscode.lm & {
+    registerMcpServerDefinitionProvider?: (
+      id: string,
+      provider: vscode.McpServerDefinitionProvider,
+    ) => vscode.Disposable;
+  };
+  if (typeof lm.registerMcpServerDefinitionProvider !== "function") return;
+
+  // `context.extension` is normally present, but optional-chain it so a
+  // startup race or stubbed host can't throw on the activation path.
+  const version =
+    (context.extension?.packageJSON as { version?: string } | undefined)
+      ?.version ?? "0.0.0";
+
+  // Re-discover when the workspace folders change or a rocky.toml appears /
+  // disappears — keeps the editor's server list current without a reload.
+  const didChange = new vscode.EventEmitter<void>();
+  context.subscriptions.push(didChange);
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders(() => didChange.fire()),
+  );
+  const watcher = vscode.workspace.createFileSystemWatcher("**/rocky.toml");
+  watcher.onDidCreate(() => didChange.fire());
+  watcher.onDidDelete(() => didChange.fire());
+  context.subscriptions.push(watcher);
+
+  const provider: vscode.McpServerDefinitionProvider = {
+    onDidChangeMcpServerDefinitions: didChange.event,
+    provideMcpServerDefinitions() {
+      const { serverPath } = getConfig();
+      return buildRockyMcpSpecs(serverPath, findRockyProjectRoots()).map((s) => {
+        const def = new vscode.McpStdioServerDefinition(
+          s.label,
+          s.command,
+          s.args,
+          {},
+          version,
+        );
+        def.cwd = vscode.Uri.file(s.cwd);
+        return def;
+      });
+    },
+  };
+
+  context.subscriptions.push(
+    lm.registerMcpServerDefinitionProvider(PROVIDER_ID, provider),
+  );
+}


### PR DESCRIPTION
Wires the editor onto the Rocky MCP server using VS Code's native MCP definition-provider API (finalized in 1.101+; the extension targets 1.120). For every workspace folder that has a `rocky.toml`, the extension registers an `McpStdioServerDefinition` that launches `rocky mcp --config <rocky.toml>` — so the editor's **agent mode** can drive Rocky through the engine's typed read-only tools (`compile`, `lineage`, `inspect_schema`, `sample_rows`, `breaking_change`, `catalog`, `history`, `metrics`, `optimize`, and more).

## Why this shape

The tool surface is defined once, in the Rust MCP server. The extension points the editor at the binary rather than reimplementing a tool loop in TypeScript, so the editor's AI stays in lockstep with whatever the installed `rocky` exposes — including tools added engine-side without an extension release. The `@rocky` chat participant keeps its four single-shot slash commands; this adds the full typed toolset to agent mode.

## Implementation

- `src/mcpServer.ts` — a pure `buildRockyMcpSpecs` (unit-tested) plus a thin provider that resolves the binary from `rocky.server.path`, scans workspace folders for `rocky.toml`, and fires `onDidChangeMcpServerDefinitions` when folders or `rocky.toml` files change. The API entry point is guarded so a host predating it (or a test harness) degrades to a no-op instead of throwing; the version read is optional-chained off the activation path.
- `package.json` — `contributes.mcpServerDefinitionProviders` entry (`rocky-data.rocky-mcp`).
- `extension.ts` — registered alongside the other providers.

## Tests

`src/__tests__/mcpServer.test.ts` pins the launch contract: command, `mcp --config <root>/rocky.toml`, cwd, a custom binary path, multi-root label disambiguation, and the empty case (no project). `tsc` + `eslint` + `vitest` (171 tests) green.

The Electron integration suite (`npm test`) was not run locally; the unit test covers the load-bearing launch logic, and a bad registration shape fails loudly at activation rather than silently.

No `engines.vscode` bump (1.120 already covers the API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)