### PR TITLE
chore(release): cut #18 — engine 1.45.0 + vscode 1.29.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.29.0] — 2026-05-26
+
+The extension registers `rocky mcp` as a Model Context Protocol server for agent mode, and model lineage moves to a full-width bottom panel.
+
 ### Added
 
 - **Rocky MCP server registered for agent mode** — the extension now registers `rocky mcp` as a Model Context Protocol server (one per workspace folder that has a `rocky.toml`), so the editor's agent mode can drive Rocky through the engine's typed read-only tools (`compile`, `lineage`, `inspect_schema`, `sample_rows`, `breaking_change`, `catalog`, `history`, `metrics`, `optimize`, and more). The tool surface is defined once in the Rust server, so the editor's AI stays in lockstep with whatever the installed `rocky` binary exposes — no tool definitions are duplicated in the extension. Honours `rocky.server.path` for the binary and refreshes when workspace folders or `rocky.toml` files change. The `@rocky` chat participant keeps its four single-shot slash commands; this adds the full typed toolset to agent mode. Degrades to a no-op on editor builds that predate the MCP definition-provider API (VS Code 1.101+).
+
+### Changed
+
+- **Model lineage opens in the bottom panel** — `Rocky: Show Model Lineage` now renders in its own full-width panel tab (bottom, alongside Terminal / Output) instead of a side editor tab, so the dependency graph gets the full horizontal width.
+
+### Fixed
+
+- **Lineage graph re-fits on resize** — the graph recomputes its fit when the view is resized (widening the panel, hiding the side bar) instead of staying stranded at its initial scale.
 
 ## [1.28.0] — 2026-05-25
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {
@@ -95,7 +95,12 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["warehouse", "lastRunAge", "driftCount", "branchState"]
+            "enum": [
+              "warehouse",
+              "lastRunAge",
+              "driftCount",
+              "branchState"
+            ]
           },
           "default": [],
           "markdownDescription": "Optional status bar segments to show after the LSP state. Each segment silently no-ops if its data is unavailable. Options: `warehouse`, `lastRunAge`, `driftCount`, `branchState`."
@@ -870,7 +875,9 @@
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"
             },
-            "completionEvents": ["onCommand:rocky.doctor"]
+            "completionEvents": [
+              "onCommand:rocky.doctor"
+            ]
           },
           {
             "id": "rocky.walkthrough.initProject",
@@ -880,7 +887,9 @@
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"
             },
-            "completionEvents": ["onCommand:rocky.init"]
+            "completionEvents": [
+              "onCommand:rocky.init"
+            ]
           },
           {
             "id": "rocky.walkthrough.compile",
@@ -890,7 +899,9 @@
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"
             },
-            "completionEvents": ["onCommand:rocky.compile"]
+            "completionEvents": [
+              "onCommand:rocky.compile"
+            ]
           },
           {
             "id": "rocky.walkthrough.lineage",
@@ -900,7 +911,9 @@
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"
             },
-            "completionEvents": ["onCommand:rocky.showLineage"]
+            "completionEvents": [
+              "onCommand:rocky.showLineage"
+            ]
           },
           {
             "id": "rocky.walkthrough.run",
@@ -910,7 +923,9 @@
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"
             },
-            "completionEvents": ["onCommand:rocky.run"]
+            "completionEvents": [
+              "onCommand:rocky.run"
+            ]
           }
         ]
       }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.45.0] — 2026-05-26
+
+Read-only MCP tools round out the agent surface, and a watermark bug that silently dropped the first incremental delta is fixed.
+
 ### Added
 
 - **`rocky mcp`: read-only `catalog` / `history` / `metrics` / `optimize` tools** — four more tools on the MCP server, all offline (no warehouse connection, no credentials) and built on the engine's existing command cores. `catalog` returns the project-wide asset inventory in one call: every model and source with its typed columns and upstream/downstream model lists (the token-heavy column-edge set is dropped — agents use `lineage` for the column-level trace, `inspect_schema` for typed columns alone, `dependents` for one model's consumers). `history` reads the run ledger — the recent project runs, or a single model's executions (duration, rows, status, `sql_hash`) when `model` is set. `metrics` returns a model's quality snapshots (row count, freshness lag, per-column null rates) plus derived freshness / null-rate alerts. `optimize` returns the cost model's materialization recommendations (current vs recommended strategy, projected monthly savings, reasoning) computed from run history and the on-disk DAG. The tools ground an agent's proposals in the typed graph and operational reality before it reaches `propose`; none of them mutate the warehouse or engine state.
@@ -14,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`rocky-cli`: more typed-output cores extracted for reuse** — `history` / `metrics` / `optimize` now build their JSON output through reusable `history_runs_output` / `model_history_output` / `metrics_output` / `optimize_output` functions (the `run_*` handlers call the core, then print), and `compute_catalog_output` is widened to `pub`, so the MCP server and the CLI share one code path. No output-schema change.
+
+### Fixed
+
+- **Incremental bootstrap no longer drops the first delta** — an incremental pipeline's bootstrap run (the first run, or after a drift drop-and-recreate) recorded the watermark as the run's wall-clock time instead of `MAX(source.<timestamp>)`. Wall-clock is later than every existing row, so the next incremental run filtered them all out and copied zero new rows. The bootstrap now records the source data max, so the next tick picks up the delta.
 
 ## [1.44.0] — 2026-05-25
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "indexmap",
  "reqwest",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "redis",
  "serde",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "logos",
  "miette",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "rocky-server",
  "tokio",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "miette",
  "regex",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.44.0"
+version = "1.45.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.44.0"
+version = "1.45.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.44.0"
+version = "1.45.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.44.0"
+version = "1.45.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.44.0"
+version = "1.45.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.44.0"
+version = "1.45.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.44.0"
+version = "1.45.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.44.0"
+version = "1.45.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.44.0"
+version = "1.45.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.44.0"
+version = "1.45.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.44.0"
+version = "1.45.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.44.0"
+version = "1.45.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.44.0"
+version = "1.45.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.44.0"
+version = "1.45.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.44.0"
+version = "1.45.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.44.0"
+version = "1.45.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.44.0"
+version = "1.45.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.44.0"
+version = "1.45.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.44.0"
+version = "1.45.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.44.0"
+version = "1.45.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.44.0"
+version = "1.45.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Consolidated release cut #18. Dagster sits out — no changes since 1.42.0.

## engine 1.44.0 → 1.45.0
- Read-only `catalog` / `history` / `metrics` / `optimize` MCP tools + typed-output core reuse (#691)
- Fix: incremental-bootstrap watermark recorded wall-clock instead of `MAX(source.ts)`, silently dropping the first delta (#708)

## vscode 1.28.0 → 1.29.0
- Registers `rocky mcp` as an MCP server for agent mode (#694)
- Model lineage moves to a full-width bottom panel (#709)
- Fix: lineage graph re-fits on resize (#690)
- (plus the demo-recording harness, hero GIFs, and Marketplace README showcase — dev/docs)

## Mechanics
- 25 engine `Cargo.toml` + `Cargo.lock` bumped to 1.45.0; `editors/vscode/package.json` + lock to 1.29.0; both CHANGELOGs updated. `cargo metadata --locked` confirms lock/manifest consistency.
- After merge: tag `engine-v1.45.0` and `vscode-v1.29.0` on the merge commit and push — the release workflows handle the GitHub Releases + Marketplace publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)