### PR TITLE
chore(deps): bump opentelemetry stack + tracing-opentelemetry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2447,7 +2447,7 @@ dependencies = [
  "cc",
  "flate2",
  "pkg-config",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tar",
@@ -2854,7 +2854,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pemfile",
  "serde",
@@ -2892,9 +2892,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2906,22 +2906,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2929,18 +2929,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2951,15 +2951,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
  "tokio",
@@ -3675,6 +3676,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,7 +3823,7 @@ name = "rocky-ai"
 version = "1.45.0"
 dependencies = [
  "indexmap",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-compiler",
  "rocky-core",
  "rocky-ir",
@@ -3814,7 +3846,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-core",
  "serde",
  "serde_json",
@@ -3837,7 +3869,7 @@ dependencies = [
  "googleapis-tonic-google-cloud-bigquery-storage-v1",
  "jsonwebtoken",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-adapter-sdk",
  "rocky-core",
  "rocky-ir",
@@ -3977,7 +4009,7 @@ dependencies = [
  "redb",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-duckdb",
  "rocky-ir",
  "rocky-sql",
@@ -4004,7 +4036,7 @@ dependencies = [
  "chrono",
  "futures",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-adapter-sdk",
  "rocky-catalog-core",
  "rocky-core",
@@ -4071,7 +4103,7 @@ dependencies = [
  "object_store",
  "percent-encoding",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-core",
  "rocky-observe",
  "schemars 0.8.22",
@@ -4099,7 +4131,7 @@ dependencies = [
  "object_store",
  "parquet",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-catalog-core",
  "rocky-core",
  "rocky-databricks",
@@ -4192,7 +4224,7 @@ dependencies = [
  "chrono",
  "indexmap",
  "notify",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-ai",
  "rocky-compiler",
  "rocky-core",
@@ -4221,7 +4253,7 @@ dependencies = [
  "base64",
  "chrono",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-adapter-sdk",
  "rocky-core",
  "rocky-ir",
@@ -4261,7 +4293,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "reqwest",
+ "reqwest 0.12.28",
  "rocky-adapter-sdk",
  "rocky-core",
  "rocky-ir",
@@ -5315,6 +5347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5462,9 +5505,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -194,11 +194,11 @@ uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 # OpenTelemetry (feature-gated in rocky-observe).
 # `tracing-opentelemetry` major versions track `opentelemetry` minor
-# versions: 0.32 pairs with opentelemetry 0.31 — pin the pair together.
-opentelemetry = "0.31"
-opentelemetry_sdk = "0.31"
-opentelemetry-otlp = "0.31"
-tracing-opentelemetry = "0.32"
+# versions: 0.33 pairs with opentelemetry 0.32 — pin the pair together.
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+opentelemetry-otlp = "0.32"
+tracing-opentelemetry = "0.33"
 
 # gRPC stack — used by `rocky-bigquery`'s Storage Read API impl of
 # `WarehouseAdapter::fetch_arrow_batch`. `tonic` 0.14 + `prost` 0.14

--- a/engine/crates/rocky-observe/src/tracing_setup.rs
+++ b/engine/crates/rocky-observe/src/tracing_setup.rs
@@ -271,10 +271,10 @@ pub fn extract_remote_context() -> Option<opentelemetry::Context> {
 
     let mut carrier = HashMap::new();
     carrier.insert("traceparent".to_string(), traceparent);
-    if let Ok(tracestate) = std::env::var("TRACESTATE") {
-        if !tracestate.is_empty() {
-            carrier.insert("tracestate".to_string(), tracestate);
-        }
+    if let Ok(tracestate) = std::env::var("TRACESTATE")
+        && !tracestate.is_empty()
+    {
+        carrier.insert("tracestate".to_string(), tracestate);
     }
 
     let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();


### PR DESCRIPTION
## What

Bumps the whole OpenTelemetry stack together so the types resolve to a single major version. Supersedes Dependabot #703.

Dependabot #703 wanted `tracing-opentelemetry` 0.32 → 0.33 in isolation, but that single bump fails to compile: `tracing-opentelemetry 0.33` requires `opentelemetry` 0.32 while the rest of the stack was pinned at 0.31. Two `opentelemetry` majors land in the graph and the shared types (`KeyValue`, `trace::Status`, etc.) collide. The fix is to move the whole stack together.

## Version set

| Crate | Before | After |
|---|---|---|
| `opentelemetry` | 0.31 | **0.32** |
| `opentelemetry_sdk` | 0.31 | **0.32** |
| `opentelemetry-otlp` | 0.31 | **0.32** |
| `opentelemetry-http` (transitive) | 0.31 | **0.32** |
| `opentelemetry-proto` (transitive) | 0.31 | **0.32** |
| `tracing-opentelemetry` | 0.32 | **0.33** |

Pinned at the workspace level in `engine/Cargo.toml`; lockfile updated via `cargo update -p` for each crate (resolver locked to "latest Rust 1.88 compatible", so MSRV 1.88 is unaffected).

## Code changes

No OpenTelemetry API adaptation was needed. The 0.32 breaking changes (`SpanBuilder` field removals, `SamplingDecision`/`SamplingResult` relocation to `opentelemetry_sdk::trace`, OTLP `ExportConfig`/`with_export_config()` removal, `SpanExporter::shutdown`/`force_flush` now `&self`) do not touch any of Rocky's call sites — the exporter/tracer builders already use the recommended `WithExportConfig` + `with_endpoint()` path, and the in-memory test exporters already implement `async fn export(&self, …)`.

One drive-by clippy fix in `rocky-observe`'s `tracing_setup::extract_remote_context` collapses a nested `if let` into a let-chain. This lives on the `otel`-feature-gated path and is surfaced by `cargo clippy --all-features`; CI's clippy job runs without `--all-features`, so this code was never linted there before.

## Verification

All run with `--all-features` so the `otel`-gated code path actually compiles:

- `cargo build --workspace --all-features` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check` ✅
- `cargo test --workspace --all-features` ✅ (incl. the otel span/status/event tests in `rocky-observe`)
- `cargo test -p rocky-cli --features duckdb` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)