### PR TITLE
docs(dagster): add StateHealthResult usage example

### DIFF
--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -932,6 +932,25 @@ class StateHealthResult(BaseModel):
     * :attr:`probe_error` — human-readable failure message from the same
       check when :attr:`probe_outcome` is ``"timeout"`` or ``"error"``.
       ``None`` on success and when the probe wasn't requested.
+
+    Example:
+
+        Inspect a snapshot to log or tag per-tick state-backend health.
+        ``probe_outcome`` is ``None`` on the cheap path; with
+        ``probe_write=True`` it is one of ``"ok"`` / ``"timeout"`` /
+        ``"error"``. Tag a run with the outcome::
+
+            from dagster_rocky import StateHealthResult, state_health
+
+            snapshot: StateHealthResult = state_health(rocky, probe_write=True)
+            tags = {
+                "rocky/state_backend": snapshot.backend,
+                "rocky/last_run_status": snapshot.last_run_status or "unknown",
+            }
+            if snapshot.probe_outcome == "ok":
+                tags["rocky/state_rw_ms"] = str(snapshot.probe_duration_ms)
+            elif snapshot.probe_outcome in ("timeout", "error"):
+                tags["rocky/state_rw_error"] = snapshot.probe_error or "unknown"
     """
 
     backend: StateBackendKind


### PR DESCRIPTION
Completes the `dagster_rocky.health` docstring examples started in #696.

#696 added `Example` sections to `HealthcheckResult`, `rocky_healthcheck`, and `state_health`. This adds the remaining one — a usage example on `StateHealthResult` showing how to read a snapshot and tag a run with the per-tick state-backend health, including the `probe_write=True` path.

Written in the bare-`::` literal-block style the surrounding docstrings use (matching `schedules.py` and the examples merged in #696). Picks up the `StateHealthResult` example originally drafted in #557, which #696 + this PR supersede.

ruff format + lint clean; `test_types` and `test_state_health` pass.