### PR TITLE
fix(engine): install rustls aws-lc-rs crypto provider at startup

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **TLS no longer aborts the binary at startup** — when both rustls crypto backends are compiled into the dependency graph (`ring` via reqwest's TLS stack and `aws-lc-rs` via the JWT signer), rustls cannot determine a default provider from crate features, and the first HTTPS call (`discover`, `doctor`, any network path) panicked with *"Could not automatically determine the process-level CryptoProvider"* — aborting the process before any request was sent. The `rocky` and `rocky-lsp` binaries now install the aws-lc-rs provider as the process default at startup, before any TLS. A regression test exercises the exact panic site so it can't recur.
+
 ## [1.45.0] — 2026-05-26
 
 Read-only MCP tools round out the agent surface, and a watermark bug that silently dropped the first incremental delta is fixed.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3799,6 +3799,7 @@ dependencies = [
  "rocky-core",
  "rocky-mcp",
  "rocky-observe",
+ "rustls",
  "serde_json",
  "tempfile",
  "tokio",
@@ -4173,6 +4174,7 @@ name = "rocky-lsp"
 version = "1.45.0"
 dependencies = [
  "rocky-server",
+ "rustls",
  "tokio",
 ]
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -96,6 +96,18 @@ rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2"] }
 
+# rustls crypto provider — direct dep on the binary crates so they can
+# install a single process-level default at startup. The dependency graph
+# compiles in BOTH rustls backends: `ring` (via hyper-rustls → reqwest) and
+# `aws_lc_rs` (via jsonwebtoken + rustls). With two providers present,
+# rustls cannot auto-detect a default from crate features, so the first
+# `ClientConfig::builder()` (reqwest's discover/doctor TLS path) panics with
+# "Could not automatically determine the process-level CryptoProvider".
+# Installing aws-lc-rs explicitly resolves the ambiguity — it matches the
+# reqwest `rustls-tls` + tonic `tls-aws-lc` + jsonwebtoken `aws_lc_rs` stack
+# already in the tree.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12", "logging"] }
+
 # Async
 futures = "0.3"
 

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -17,6 +17,10 @@ rust-version.workspace = true
 [dependencies]
 rocky-server = { path = "../crates/rocky-server" }
 tokio = { workspace = true }
+# Process-level rustls crypto provider, installed at startup before any TLS.
+# The LSP's AI code-actions hit the Anthropic API over HTTPS, and the dep
+# graph compiles in both rustls backends. See the workspace manifest note.
+rustls = { workspace = true }
 
 [lints]
 workspace = true

--- a/engine/rocky-lsp/src/main.rs
+++ b/engine/rocky-lsp/src/main.rs
@@ -13,5 +13,11 @@
 
 #[tokio::main]
 async fn main() {
+    // Install the rustls crypto provider before any TLS handshake. The dep
+    // graph compiles in both `ring` and `aws_lc_rs`, so rustls cannot
+    // auto-detect a default and would panic on the first HTTPS call (the
+    // LSP's AI code-actions reach the Anthropic API). aws-lc-rs matches the
+    // workspace reqwest/tonic TLS stack. Idempotent — see the `rocky` binary.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     rocky_server::lsp::run_lsp().await;
 }

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -24,6 +24,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+# Process-level rustls crypto provider, installed at startup before any TLS.
+# See the `rustls` note in the workspace manifest.
+rustls = { workspace = true }
 
 # Used to restore the kernel-default SIGPIPE handler on startup so the
 # CLI exits cleanly when its stdout is piped into `head`, `less`, `jq | head`,

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1854,11 +1854,41 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let json = matches!(cli.output, OutputFormat::Json);
 
+    // Install the rustls crypto provider before any TLS handshake. Runs
+    // after `Cli::parse()` so the `--version` / `--help` fast-exit stays
+    // untouched, and before the runtime so every async command (discover,
+    // doctor, ...) sees the process-level default. See `install_crypto_provider`.
+    install_crypto_provider();
+
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("failed to build tokio runtime")?;
     runtime.block_on(run_async(cli, json))
+}
+
+/// Install the process-level rustls [`CryptoProvider`] before any TLS.
+///
+/// The dependency graph compiles in *both* rustls crypto backends —
+/// `ring` (via `hyper-rustls` → `reqwest`) and `aws_lc_rs` (via
+/// `jsonwebtoken` + `rustls`). With two providers present, rustls cannot
+/// determine a default from crate features, so the first
+/// `rustls::ClientConfig::builder()` — which `reqwest` calls when building
+/// the HTTPS client for `discover`, `doctor`, and every other network path
+/// — panics with *"Could not automatically determine the process-level
+/// CryptoProvider from Rustls crate features"*. Installing aws-lc-rs
+/// explicitly resolves the ambiguity; it matches the aws-lc-rs stack already
+/// in the tree (`reqwest` `rustls-tls`, `tonic` `tls-aws-lc`, `jsonwebtoken`
+/// `aws_lc_rs`).
+///
+/// Idempotent: a no-op if a provider was already installed (the `Err`
+/// returned by [`install_default`] carries the existing provider, which we
+/// intentionally discard).
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+/// [`install_default`]: rustls::crypto::CryptoProvider::install_default
+fn install_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
 /// Parse `--governance-override` from its CLI string form.
@@ -3097,6 +3127,32 @@ mod tests {
             } => idempotency_key,
             _ => panic!("expected Run subcommand"),
         }
+    }
+
+    /// Regression for the 1.45.0 startup abort: the dependency graph
+    /// compiles in BOTH rustls crypto backends (`ring` via
+    /// hyper-rustls/reqwest, `aws_lc_rs` via jsonwebtoken/rustls), so rustls
+    /// can't pick a provider from crate features and
+    /// `rustls::ClientConfig::builder()` — the exact call `reqwest` makes
+    /// when constructing its HTTPS client for `discover` / `doctor` — panics
+    /// with "Could not automatically determine the process-level
+    /// CryptoProvider". `install_crypto_provider()` installs aws-lc-rs as the
+    /// process default, so the builder resolves it instead of bailing.
+    ///
+    /// This test hits the panic site directly: delete the
+    /// `install_crypto_provider()` call below and the test panics with the
+    /// production message, which is the proof the guard works.
+    #[test]
+    fn crypto_provider_install_lets_default_tls_config_build() {
+        // Mirrors what `main()` runs before any TLS. Idempotent.
+        install_crypto_provider();
+
+        // `ClientConfig::builder()` consults the process-level default first
+        // and only falls back to the (ambiguous, panicking) crate-feature
+        // detection when none is installed. After the install it builds.
+        let _config = rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth();
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The published binary aborts (SIGABRT) on its first HTTPS call — `discover`, `doctor`, any network path — with:

```
thread 'tokio-rt-worker' panicked at rustls-0.23.40/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() ... or make sure exactly one of
the 'aws-lc-rs' and 'ring' features is enabled.
```

The dependency graph compiles in **both** rustls crypto backends:

- `ring` — via `hyper-rustls` → `reqwest` (the `rustls-tls` HTTP stack)
- `aws-lc-rs` — via `jsonwebtoken` (the BigQuery/Snowflake JWT signer) and `rustls`

With two providers present, rustls cannot determine a default from crate features, so the first `rustls::ClientConfig::builder()` — which `reqwest` calls when building its HTTPS client — panics. The process aborts **before any request is sent**, so it is not a config, credential, or environment issue, and `rocky validate` (parse-only, never opens a socket) cannot catch it.

## Fix

Install the aws-lc-rs provider as the **process-level default at startup**, before any TLS, in both binaries (`rocky` and `rocky-lsp`). aws-lc-rs matches the rest of the workspace stack (`reqwest` `rustls-tls`, `tonic` `tls-aws-lc`, `jsonwebtoken` `aws_lc_rs`). With a default installed, `ClientConfig::builder()` resolves it instead of bailing on the ambiguous crate-feature detection.

- `rocky` — installs after `Cli::parse()` (keeps `--version`/`--help` fast-exit untouched) and before the tokio runtime, so every async command sees the default.
- `rocky-lsp` — installs at the top of `main()`; the LSP's AI code-actions reach the Anthropic API over TLS.

The call is idempotent (a second install is a no-op).

## Why not remove `ring` from the tree?

Reconfiguring `hyper-rustls`/`reqwest` features to drop `ring` is a deeper, more invasive change with real risk to the TLS path — wrong tool for a hotfix. Installing the provider explicitly is rustls's own recommended resolution for this exact situation.

## Verification

- Build green; single `rustls v0.23.40` in the tree.
- Feature tree confirms the bug condition: **both** `rustls feature "aws_lc_rs"` and `rustls feature "ring"` are enabled.
- New regression test `crypto_provider_install_lets_default_tls_config_build` exercises the exact panic site. With the install **removed**, it panics with the verbatim production message (`crypto/mod.rs:249`); with the install **restored**, it passes. This unit-level guard runs in `engine-ci` and catches this class of regression faster than (and without the network of) a `doctor` smoke step.
- `cargo fmt --check`, `cargo clippy --all-targets`, full `rocky` bin test suite (10/10) all green.

This is the engine-side fix only. Cutting the patch release and re-bumping downstream consumers are follow-ups.