### PR TITLE
chore(vscode): refresh demo recordings + e2e for the React canvas/Inspector

### DIFF
--- a/editors/vscode/recording/e2e/lineage.spec.mjs
+++ b/editors/vscode/recording/e2e/lineage.spec.mjs
@@ -1,9 +1,13 @@
-// E2E: the lineage webview. This is the kind of coverage the in-process
+// E2E: the lineage canvas webview. This is the kind of coverage the in-process
 // @vscode/test-electron suite can't provide — it reaches into the webview's
-// out-of-process iframe DOM to assert the graph actually rendered, and that it
-// re-fits when the viewport widens (the ResizeObserver fix in
-// src/commands/lineage.ts). DOM-based, not pixel-based: correct and immune to
+// out-of-process iframe DOM to assert the ReactFlow graph actually rendered and
+// survives a viewport resize. DOM-based, not pixel-based: correct and immune to
 // the recording-time compositor quirk.
+//
+// (The panel is now a ReactFlow canvas — `.react-flow__node` — replacing the
+// old dagre/d3 `#graph-svg` renderer. ReactFlow keeps the graph on container
+// resize rather than re-fitting the transform, so we assert survival, not a
+// scale change.)
 
 import { test as base, expect } from "@playwright/test";
 import * as path from "node:path";
@@ -30,49 +34,41 @@ const test = base.extend({
   },
 });
 
-// The lineage graph lives in an out-of-process webview iframe; find it by content.
-async function lineageFrame(win) {
+// The canvas lives in an out-of-process webview iframe; find it by content.
+async function canvasFrame(win) {
   for (const f of win.frames()) {
-    if (await f.locator("#graph-svg").count().catch(() => 0)) return f;
+    if (await f.locator(".react-flow__node").count().catch(() => 0)) return f;
   }
   return null;
 }
 
-function scaleOf(transform) {
-  const m = /scale\(([0-9.]+)\)/.exec(transform ?? "");
-  return m ? parseFloat(m[1]) : null;
-}
-
-test("lineage webview renders nodes and re-fits when the viewport widens", async ({ vscode }) => {
+test("lineage canvas renders nodes and survives a viewport resize", async ({ vscode }) => {
   const { win } = vscode;
   const d = makeDriver(win);
 
   // Settle, close the auto-opened chat panel, open a model, show its lineage
-  // (which now renders in the bottom panel, full width).
+  // (rendered in the bottom panel, full width).
   await d.pause(4000);
   await d.key("Meta+Alt+B");
   await d.pause(500);
   await d.openFile("fct_revenue.rocky");
   await d.pause(1500);
   await d.command("Rocky: Show Model Lineage");
-  await d.pause(4000);
+  await d.pause(5000); // catalog + compile fan-in + dagre layout + fitView
 
-  const frame = await lineageFrame(win);
-  expect(frame, "lineage webview iframe should be present").toBeTruthy();
+  const frame = await canvasFrame(win);
+  expect(frame, "lineage canvas webview iframe should be present").toBeTruthy();
 
-  const graphGroup = frame.locator("#graph-svg > g");
-  const nodeCount = await frame.locator(".node").count();
-  expect(nodeCount, "graph should render at least one node").toBeGreaterThan(0);
+  const nodeCount = await frame.locator(".react-flow__node").count();
+  expect(nodeCount, "canvas should render at least one node").toBeGreaterThan(0);
 
-  const initialScale = scaleOf(await graphGroup.getAttribute("transform"));
-  expect(initialScale, "graph should have a fit transform").toBeGreaterThan(0);
-
-  // Hide the primary side bar to widen the panel — the ResizeObserver should
-  // re-fit the graph to a larger scale.
+  // Hide the primary side bar to widen the panel — ReactFlow must keep the
+  // graph intact (the old renderer re-fit the transform; ReactFlow preserves it).
   await d.key("Meta+B");
   await d.pause(2500);
 
-  expect(await frame.locator(".node").count(), "graph must not be lost on resize").toBe(nodeCount);
-  const widerScale = scaleOf(await graphGroup.getAttribute("transform"));
-  expect(widerScale, "graph should re-fit to a larger scale in the wider panel").toBeGreaterThan(initialScale);
+  expect(
+    await frame.locator(".react-flow__node").count(),
+    "graph must survive the resize",
+  ).toBe(nodeCount);
 });

--- a/editors/vscode/recording/lib/driver.mjs
+++ b/editors/vscode/recording/lib/driver.mjs
@@ -34,6 +34,31 @@ export function makeDriver(win) {
     await pause(settle);
   }
 
+  // Reach into an out-of-process webview iframe. VS Code renders webviews in
+  // nested iframes that Playwright flattens into `win.frames()`; find ours by a
+  // DOM marker unique to that panel (a CSS selector or `text=` locator). Polls
+  // until present. NOTE: clicks have no visible cursor in the Electron video,
+  // so what the GIF shows is the *resulting* state change (badges appearing,
+  // tab content switching) — keep that in mind when scripting interactions.
+  async function webview(marker, { timeout = 10000 } = {}) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      for (const f of win.frames()) {
+        if (await f.locator(marker).count().catch(() => 0)) return f;
+      }
+      await pause(250);
+    }
+    throw new Error(`webview with marker '${marker}' not found within ${timeout}ms`);
+  }
+
+  // Click a control (by accessible name) inside the webview identified by
+  // `marker`, then settle so the state change is captured.
+  async function clickInWebview(marker, name, { settle = 900 } = {}) {
+    const frame = await webview(marker);
+    await frame.getByRole("button", { name }).first().click();
+    await pause(settle);
+  }
+
   return {
     win,
     pause,
@@ -43,5 +68,7 @@ export function makeDriver(win) {
     palette,
     command,
     openFile,
+    webview,
+    clickInWebview,
   };
 }

--- a/editors/vscode/recording/scenarios/inspector.mjs
+++ b/editors/vscode/recording/scenarios/inspector.mjs
@@ -1,0 +1,30 @@
+// Inspector: open a model in the Catalog/Inspector panel and tour its tabs.
+// The panel fans in `rocky catalog` + `rocky compile` on open. The Overview /
+// Columns / Lineage tabs are catalog-fed and always render; Tests / Preview /
+// Profile load lazily and need a materialized target (record against a POC
+// you've `rocky run` to show those, then append their tab clicks below).
+
+export default {
+  name: "inspector",
+  description: "Open a model in the Inspector and tour its tabs.",
+  workspace: "examples/playground/pocs/06-developer-experience/01-lineage-column-level",
+  size: { width: 1280, height: 800 },
+  fps: 15,
+  gifWidth: 1000,
+  quality: 65,
+
+  async run(d) {
+    await d.openFile("fct_revenue.rocky");
+    await d.pause(1800);
+
+    await d.command("Rocky: Open in Inspector");
+    await d.pause(4000); // catalog + compile fan-in
+
+    // Tour the catalog-fed tabs. "Overview" is always present, so it's the
+    // stable marker for the Inspector webview frame; each tab is a button.
+    await d.clickInWebview("text=Overview", "Columns");
+    await d.pause(2400);
+    await d.clickInWebview("text=Overview", "Lineage");
+    await d.pause(3000);
+  },
+};

--- a/editors/vscode/recording/scenarios/lineage.mjs
+++ b/editors/vscode/recording/scenarios/lineage.mjs
@@ -1,10 +1,13 @@
-// Lineage: open a model and render its lineage DAG. As of the panel migration,
-// "Show Model Lineage" renders in the bottom panel (full width) instead of a
-// side editor tab, so the graph has horizontal room. Deterministic, offline.
+// Lineage: render the project as an interactive ReactFlow canvas in the bottom
+// panel, focused on a model's neighborhood, then light up a trust-plane overlay
+// on the graph. The canvas fans in `rocky catalog` + `rocky compile`, so it
+// needs more settle time than the single-`rocky lineage` SVG renderer it
+// replaced. Interactions use the webview-reach driver (no visible cursor — the
+// GIF shows the badges appearing, not the click).
 
 export default {
   name: "lineage",
-  description: "Render a model's lineage DAG in the bottom panel.",
+  description: "Render the project lineage canvas and light up an overlay.",
   // Self-contained POC: fct_revenue <- stg_orders <- raw_orders.
   workspace: "examples/playground/pocs/06-developer-experience/01-lineage-column-level",
   size: { width: 1280, height: 800 },
@@ -14,10 +17,19 @@ export default {
 
   async run(d) {
     await d.openFile("fct_revenue.rocky");
-    await d.pause(2500);
+    await d.pause(2000);
 
-    // Show Model Lineage reveals the Lineage panel (bottom, full width).
+    // "Show Model Lineage" reveals the ReactFlow canvas (bottom panel, full
+    // width) and frames the focal model's neighborhood.
     await d.command("Rocky: Show Model Lineage");
-    await d.pause(4500); // CLI lineage call + DOT->SVG render + ResizeObserver fit
+    await d.pause(5000); // catalog + compile fan-in, dagre layout, fitView
+
+    // Toggle an overlay so the GIF shows trust-plane data on the graph. Cost
+    // rides on compile's heuristic estimate; swap for Freshness / Drift /
+    // Breaking / Last run / Governance depending on which has data for the
+    // recorded POC (Drift / Last run need a prior `rocky run`; Breaking needs a
+    // git base ref; Governance needs classified columns).
+    await d.clickInWebview(".react-flow", "Cost");
+    await d.pause(3000);
   },
 };


### PR DESCRIPTION
Refreshes the VS Code demo-recording harness for the React + ReactFlow revamp (#723), which replaced the dagre/d3 lineage renderer and left the recording scenarios and e2e test pointing at the old DOM.

## Changes

- **Driver** (`lib/driver.mjs`): adds `webview()` / `clickInWebview()` — reaches into the out-of-process webview iframe via the proven `win.frames()` + marker pattern (the same one the e2e spec uses), so scenarios can drive overlays, tabs, and menus *inside* the React panels. Clicks have no visible cursor in the Electron video (the harness is keyboard-only by design), so what the GIF shows is the resulting state change — badges appearing, tab content switching.
- **`lineage` scenario**: retimed for the canvas's `catalog` + `compile` fan-in (slower than the old single `rocky lineage` call), and toggles the Cost overlay so the graph shows trust-plane data.
- **`inspector` scenario** (new): opens the Catalog/Inspector panel and tours the Columns + Lineage tabs.
- **`e2e/lineage.spec.mjs`**: fixed for the ReactFlow canvas (`.react-flow__node`); asserts the graph survives a viewport resize, since ReactFlow preserves the viewport rather than re-fitting the transform like the old renderer did.

## Recording / validating

These run on a desktop, not in CI:

```
just record-demo lineage          # -> recording/out/lineage.gif
just record-demo inspector
just publish-demo lineage         # -> editors/vscode/media/demo-lineage.gif
cd editors/vscode/recording && npm run test:e2e
```

The scenarios are best-effort starting points: pause timings and the overlay choice may need tuning on first capture (Cost rides on compile's heuristic; Drift / Last run need a prior `rocky run`, Breaking a git base ref, Governance classified columns). The committed `media/demo-lineage.gif` still shows the old renderer and should be re-recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
