### PR TITLE
feat(vscode): Inspector Overview → model trust dashboard

### DIFF
--- a/editors/vscode/webview-ui/panels/inspector/components.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/components.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { ColumnTestStatus } from "./viewModel";
 
 const STATUS_COLOR: Record<Exclude<ColumnTestStatus, "none">, string> = {
@@ -5,6 +6,67 @@ const STATUS_COLOR: Record<Exclude<ColumnTestStatus, "none">, string> = {
   warn: "var(--vscode-testing-iconQueued)",
   fail: "var(--vscode-testing-iconFailed)",
 };
+
+/** Trust-signal tone → a theme chart colour, used as the card's accent. */
+export type Tone = "ok" | "warn" | "risk" | "muted" | "pending";
+
+const TONE_COLOR: Record<Tone, string> = {
+  ok: "var(--vscode-charts-green)",
+  warn: "var(--vscode-charts-yellow)",
+  risk: "var(--vscode-charts-red)",
+  muted: "var(--vscode-descriptionForeground)",
+  pending: "var(--vscode-descriptionForeground)",
+};
+
+/**
+ * A trust-plane status card for the Overview dashboard: a label, a value, an
+ * optional sub-line, and a tone accent (left border + label dot). `hero` gives
+ * the value extra weight for the headline signals (cost, blast radius). `title`
+ * carries an explain-on-hover tooltip. Themed to `--vscode-*`.
+ */
+export function StatusCard({
+  label,
+  value,
+  tone = "muted",
+  sub,
+  hero = false,
+  title,
+}: {
+  label: string;
+  value: ReactNode;
+  tone?: Tone;
+  sub?: ReactNode;
+  hero?: boolean;
+  title?: string;
+}) {
+  return (
+    <div
+      title={title}
+      className="rounded-md border border-vscode-border bg-vscode-widget-bg p-3"
+      style={{ borderLeft: `3px solid ${TONE_COLOR[tone]}` }}
+    >
+      <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-vscode-desc">
+        <span
+          aria-hidden
+          className="inline-block h-1.5 w-1.5 rounded-full"
+          style={{ backgroundColor: TONE_COLOR[tone] }}
+        />
+        {label}
+      </div>
+      <div
+        className={
+          "mt-1 break-words font-semibold text-vscode-fg " +
+          (hero ? "text-2xl leading-tight" : "text-sm")
+        }
+      >
+        {value}
+      </div>
+      {sub != null && sub !== "" && (
+        <div className="mt-0.5 text-xs text-vscode-desc">{sub}</div>
+      )}
+    </div>
+  );
+}
 
 /** A small theme-aware test-status pill (or an em dash when untested). */
 export function StatusBadge({ status }: { status: ColumnTestStatus }) {

--- a/editors/vscode/webview-ui/panels/inspector/tabs/OverviewTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/OverviewTab.tsx
@@ -1,18 +1,62 @@
+import { useEffect, useState } from "react";
 import type { InspectorModelData } from "../../../../src/webviews/inspector/contract";
-import { contractLabel, costLabel, freshnessLabel } from "../viewModel";
+import type {
+  BreakingData,
+  DriftData,
+  GovernanceData,
+  ReplayData,
+} from "../../../../src/webviews/lineage/contract";
+import { getRpc } from "../../../runtime/rpcClient";
+import { StatusCard } from "../components";
+import {
+  contractLabel,
+  costLabel,
+  formatCount,
+  freshnessLabel,
+} from "../viewModel";
 
-function Field({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded border border-vscode-border p-3">
-      <div className="text-[11px] uppercase tracking-wide text-vscode-desc">
-        {label}
-      </div>
-      <div className="mt-1 break-words text-sm text-vscode-fg">{value}</div>
-    </div>
-  );
-}
-
+/**
+ * Overview = the model trust dashboard. Headline cost + blast-radius, then a
+ * grid of the trust-plane signals dbt has no engine for — contract, freshness,
+ * drift, governance, last run — fetched once the tab opens (project-wide, then
+ * sliced to this model). Each card degrades to a muted state when its source
+ * has no data yet (no runs, no base ref, no classified columns).
+ */
 export function OverviewTab({ data }: { data: InspectorModelData }) {
+  const [drift, setDrift] = useState<DriftData | null>(null);
+  const [gov, setGov] = useState<GovernanceData | null>(null);
+  const [breaking, setBreaking] = useState<BreakingData | null>(null);
+  const [replay, setReplay] = useState<ReplayData | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const req = <T,>(method: string, set: (v: T) => void): void => {
+      void getRpc()
+        .request<T>(method)
+        .then((v) => active && set(v))
+        .catch(() => {});
+    };
+    req<DriftData>("drift", setDrift);
+    req<GovernanceData>("governance", setGov);
+    req<BreakingData>("breaking", setBreaking);
+    req<ReplayData>("replay", setReplay);
+    return () => {
+      active = false;
+    };
+  }, [data.modelName]);
+
+  const govModel = gov?.models.find((m) => m.model === data.modelName);
+  const lastRun = replay?.models.find((m) => m.model === data.modelName);
+  const breakingFinding = breaking?.findings.find(
+    (f) => f.model === data.modelName,
+  );
+  const driftAction = drift?.actions.find(
+    (a) =>
+      a.table === data.modelName ||
+      a.table === data.fqn ||
+      a.table.endsWith(`.${data.modelName}`),
+  );
+
   return (
     <div className="flex flex-col gap-4">
       {data.intent ? (
@@ -22,22 +66,125 @@ export function OverviewTab({ data }: { data: InspectorModelData }) {
           No description in the model sidecar.
         </p>
       )}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-        <Field label="Kind" value={data.kind} />
-        <Field label="Materialization" value={data.materialization ?? "—"} />
-        <Field label="Contract" value={contractLabel(data.contractSource)} />
-        <Field
-          label="Freshness"
-          value={freshnessLabel(data.freshness) ?? "Not declared"}
+
+      {/* Headline signals — the differentiators dbt can't show. */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatusCard
+          hero
+          label="Estimated cost"
+          title="Compile-time cost estimate (directional, not a warehouse EXPLAIN)."
+          value={costLabel(data.costHint) ?? "—"}
+          tone={data.costHint ? "warn" : "muted"}
+          sub="per run"
         />
-        <Field label="Est. cost" value={costLabel(data.costHint) ?? "—"} />
-        <Field
+        <StatusCard
+          hero
+          label="Blast radius"
+          title="Models downstream of this one — what could break if you change it."
+          value={`${data.downstreamModels.length} downstream`}
+          tone={
+            breakingFinding
+              ? "risk"
+              : data.downstreamModels.length > 0
+                ? "warn"
+                : "ok"
+          }
+          sub={
+            breakingFinding
+              ? `breaking · ${breakingFinding.severity}`
+              : `${data.upstreamModels.length} upstream`
+          }
+        />
+      </div>
+
+      {/* Trust-plane status grid. */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <StatusCard
+          label="Contract"
+          title="Whether this model has a data contract (auto-inferred or explicit)."
+          value={contractLabel(data.contractSource)}
+          tone={data.contractSource ? "ok" : "muted"}
+        />
+        <StatusCard
+          label="Freshness"
+          title="Declared freshness SLA for this model."
+          value={freshnessLabel(data.freshness) ?? "Not declared"}
+          tone={data.freshness ? "ok" : "muted"}
+        />
+        <StatusCard
+          label="Drift"
+          title="Schema drift Rocky reconciled on the last run."
+          value={driftAction ? driftAction.action : drift ? "None" : "…"}
+          tone={
+            driftAction
+              ? driftAction.action.toUpperCase().includes("REFRESH")
+                ? "risk"
+                : "warn"
+              : drift
+                ? "ok"
+                : "pending"
+          }
+          sub={driftAction?.reason}
+        />
+        <StatusCard
+          label="Governance"
+          title="Classified (PII/sensitive) columns, and any left unmasked."
+          value={
+            govModel
+              ? `${govModel.classifiedColumns} classified`
+              : gov
+                ? "None"
+                : "…"
+          }
+          tone={
+            govModel?.unmaskedColumns
+              ? "risk"
+              : govModel?.classifiedColumns
+                ? "ok"
+                : gov
+                  ? "muted"
+                  : "pending"
+          }
+          sub={
+            govModel?.unmaskedColumns
+              ? `${govModel.unmaskedColumns} unmasked`
+              : undefined
+          }
+        />
+        <StatusCard
+          label="Last run"
+          title="The most recent run's status and row count for this model."
+          value={lastRun ? lastRun.status : replay ? "Never run" : "…"}
+          tone={
+            lastRun
+              ? lastRun.status.toLowerCase() === "success"
+                ? "ok"
+                : "warn"
+              : replay
+                ? "muted"
+                : "pending"
+          }
+          sub={
+            lastRun?.rows != null
+              ? `${formatCount(lastRun.rows)} rows`
+              : undefined
+          }
+        />
+        <StatusCard
+          label="Materialization"
+          value={data.materialization ?? "—"}
+          tone="muted"
+        />
+        <StatusCard
+          label="Columns"
+          value={String(data.columns.length)}
+          tone="muted"
+        />
+        <StatusCard
           label="Last materialized"
           value={data.lastMaterializedAt ?? "Never"}
+          tone={data.lastMaterializedAt ? "ok" : "muted"}
         />
-        <Field label="Columns" value={String(data.columns.length)} />
-        <Field label="Upstream" value={String(data.upstreamModels.length)} />
-        <Field label="Downstream" value={String(data.downstreamModels.length)} />
       </div>
     </div>
   );


### PR DESCRIPTION
**Phase 1 of the Inspector overhaul** — make the Inspector modern *and* surface the signals dbt has no engine for.

The **Overview** tab becomes a **model trust dashboard**:
- **Hero stats** — Estimated cost and **blast radius** (downstream count + breaking severity), given visual weight.
- **Trust-plane status grid** — Contract · Freshness · **Drift** · **Governance** (classified/unmasked) · **Last run** · Materialization · Columns · Last materialized. Color-coded by tone (ok/warn/risk/muted).
- The drift/governance/breaking/last-run signals are fetched on open (the existing overlay RPCs) and sliced to the focused model; each **degrades to a muted state** when its source has no data (no runs, no base ref, no classified columns).

New shared **`StatusCard`** (tone accent + dot, hero variant, explain-on-hover title), themed `--vscode-*` — a "balanced" look: native cards that belong in the editor, with the differentiators given weight.

Note: on an un-run / un-governed project the trust cards read "None"/"Never" (as in any demo POC); on a real project they light green/amber/red. The README demo GIFs will be refreshed against richer data once more of the overhaul lands (Columns / Tests / Preview / Profile polish to follow).

## Testing
Host + webview typecheck, eslint, 194 unit tests, production bundle — all green. Recorded the Inspector live; the dashboard renders and the trust signals populate from the overlay RPCs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
