### PR TITLE
feat(vscode): enrich the Inspector Columns, Tests, Preview, and Profile tabs

### DIFF
--- a/editors/vscode/webview-ui/panels/inspector/tabs/ColumnsTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/ColumnsTab.tsx
@@ -1,8 +1,14 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type {
   InspectorModelData,
   InspectorTestsData,
+  ModelParam,
 } from "../../../../src/webviews/inspector/contract";
+import type {
+  ProfileColumnStats,
+  ProfileOutput,
+} from "../../../../src/types/generated/profile";
+import { getRpc } from "../../../runtime/rpcClient";
 import { StatusBadge } from "../components";
 import {
   statusRank,
@@ -29,6 +35,19 @@ function sortButton(active: boolean, enabled = true): string {
   );
 }
 
+/** Column-lineage confidence → a chart colour for the source dot. */
+const CONFIDENCE_COLOR: Record<string, string> = {
+  High: "var(--vscode-charts-green)",
+  Medium: "var(--vscode-charts-yellow)",
+  Low: "var(--vscode-charts-red)",
+};
+
+interface ColumnSource {
+  source: string;
+  transform: string;
+  confidence: string;
+}
+
 export function ColumnsTab({
   data,
   tests,
@@ -37,6 +56,46 @@ export function ColumnsTab({
   tests: InspectorTestsData | null;
 }) {
   const [sort, setSort] = useState<SortMode>("az");
+  const [profile, setProfile] = useState<Map<string, ProfileColumnStats> | null>(
+    null,
+  );
+
+  // Profile this model's columns (distinct / null-rate) inline — the same
+  // DuckDB aggregate the Profile tab uses. DuckDB-only; degrades to "—".
+  useEffect(() => {
+    let active = true;
+    void getRpc()
+      .request<ProfileOutput>("profile", {
+        model: data.modelName,
+      } satisfies ModelParam)
+      .then((p) => {
+        if (!active) return;
+        setProfile(
+          p.unavailable ? new Map() : new Map(p.columns.map((c) => [c.name, c])),
+        );
+      })
+      .catch(() => active && setProfile(new Map()));
+    return () => {
+      active = false;
+    };
+  }, [data.modelName]);
+
+  // Per-column upstream lineage (confidence + transform + source), from the
+  // catalog's column edges into this model.
+  const lineageByColumn = useMemo(() => {
+    const m = new Map<string, ColumnSource[]>();
+    for (const e of data.columnEdges) {
+      if (e.target_model !== data.modelName) continue;
+      const arr = m.get(e.target_column) ?? [];
+      arr.push({
+        source: `${e.source_model}.${e.source_column}`,
+        transform: e.transform,
+        confidence: e.confidence,
+      });
+      m.set(e.target_column, arr);
+    }
+    return m;
+  }, [data.columnEdges, data.modelName]);
 
   const statusByColumn = useMemo<Map<string, ColumnTestStatus>>(
     () => (tests ? testStatusByColumn(tests.results) : new Map()),
@@ -58,6 +117,8 @@ export function ColumnsTab({
     }
     return cols;
   }, [data.columns, sort, hasTests, statusByColumn]);
+
+  const numCell = "border-b border-vscode-border py-1 pr-4 text-right tabular-nums text-vscode-desc";
 
   return (
     <div>
@@ -93,7 +154,16 @@ export function ColumnsTab({
               Type
             </th>
             <th className="border-b border-vscode-border py-1 pr-4 font-medium">
-              Nullability
+              Null
+            </th>
+            <th className="border-b border-vscode-border py-1 pr-4 font-medium">
+              Lineage
+            </th>
+            <th className="border-b border-vscode-border py-1 pr-4 text-right font-medium">
+              Distinct
+            </th>
+            <th className="border-b border-vscode-border py-1 pr-4 text-right font-medium">
+              Null %
             </th>
             <th className="border-b border-vscode-border py-1 font-medium">
               Tests
@@ -101,22 +171,59 @@ export function ColumnsTab({
           </tr>
         </thead>
         <tbody>
-          {columns.map((col) => (
-            <tr key={col.name}>
-              <td className="border-b border-vscode-border py-1 pr-4 font-mono text-vscode-fg">
-                {col.name}
-              </td>
-              <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
-                {col.data_type ?? "—"}
-              </td>
-              <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
-                {nullability(col.nullable)}
-              </td>
-              <td className="border-b border-vscode-border py-1">
-                <StatusBadge status={statusByColumn.get(col.name) ?? "none"} />
-              </td>
-            </tr>
-          ))}
+          {columns.map((col) => {
+            const edges = lineageByColumn.get(col.name) ?? [];
+            const primary = edges[0];
+            const stats = profile?.get(col.name);
+            return (
+              <tr key={col.name}>
+                <td className="border-b border-vscode-border py-1 pr-4 font-mono text-vscode-fg">
+                  {col.name}
+                </td>
+                <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
+                  {col.data_type ?? "—"}
+                </td>
+                <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
+                  {nullability(col.nullable)}
+                </td>
+                <td className="border-b border-vscode-border py-1 pr-4">
+                  {primary ? (
+                    <span
+                      className="inline-flex items-center gap-1.5 text-vscode-desc"
+                      title={edges
+                        .map(
+                          (e) =>
+                            `← ${e.source} · ${e.transform} · ${e.confidence} confidence`,
+                        )
+                        .join("\n")}
+                    >
+                      <span
+                        aria-hidden
+                        className="inline-block h-1.5 w-1.5 rounded-full"
+                        style={{
+                          backgroundColor:
+                            CONFIDENCE_COLOR[primary.confidence] ??
+                            "var(--vscode-descriptionForeground)",
+                        }}
+                      />
+                      {primary.transform}
+                    </span>
+                  ) : (
+                    <span className="text-vscode-desc">—</span>
+                  )}
+                </td>
+                <td className={numCell}>
+                  {stats ? stats.distinct : profile ? "—" : "…"}
+                </td>
+                <td className={numCell}>
+                  {stats ? `${Math.round(stats.null_rate * 100)}%` : profile ? "—" : "…"}
+                </td>
+                <td className="border-b border-vscode-border py-1">
+                  <StatusBadge status={statusByColumn.get(col.name) ?? "none"} />
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       {!tests && (

--- a/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
@@ -49,15 +49,31 @@ export function PreviewTab({
           </thead>
           <tbody>
             {rows.rows.map((row, i) => (
-              <tr key={i}>
-                {row.map((cell, j) => (
-                  <td
-                    key={j}
-                    className="whitespace-pre border-b border-vscode-border px-2 py-1 text-vscode-fg"
-                  >
-                    {coerce(cell)}
-                  </td>
-                ))}
+              <tr
+                key={i}
+                style={
+                  i % 2 ? { backgroundColor: "rgba(127,127,127,0.05)" } : undefined
+                }
+              >
+                {row.map((cell, j) => {
+                  const isNull = cell === null || cell === undefined;
+                  return (
+                    <td
+                      key={j}
+                      className={`whitespace-pre border-b border-vscode-border px-2 py-1 text-vscode-fg ${
+                        typeof cell === "number" ? "text-right tabular-nums" : ""
+                      }`}
+                    >
+                      {isNull ? (
+                        <span className="italic text-vscode-desc opacity-60">
+                          NULL
+                        </span>
+                      ) : (
+                        coerce(cell)
+                      )}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>

--- a/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
@@ -1,5 +1,36 @@
 import type { ProfileOutput } from "../../../../src/types/generated/profile";
 
+/** Null-rate as a colored bar — green clean, amber some, red mostly-null. */
+function NullBar({ rate }: { rate: number }) {
+  const pct = rate * 100;
+  const tone =
+    rate === 0
+      ? "var(--vscode-charts-green)"
+      : rate > 0.5
+        ? "var(--vscode-charts-red)"
+        : "var(--vscode-charts-yellow)";
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span
+        className="relative inline-block h-1.5 w-14 shrink-0 rounded-full"
+        style={{ backgroundColor: "rgba(127,127,127,0.25)" }}
+      >
+        <span
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{
+            width: `${pct}%`,
+            minWidth: rate > 0 ? "0.25rem" : 0,
+            backgroundColor: tone,
+          }}
+        />
+      </span>
+      <span className="tabular-nums text-vscode-desc">{pct.toFixed(1)}%</span>
+    </span>
+  );
+}
+
+const num = "border-b border-vscode-border py-1 pr-4 text-right tabular-nums";
+
 export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
   if (!profile) {
     return (
@@ -20,17 +51,28 @@ export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
   return (
     <table className="w-full border-collapse text-sm">
       <thead>
-        <tr className="text-left text-vscode-desc">
-          {["Column", "Type", "Rows", "Nulls", "Distinct", "Min", "Max"].map(
-            (h) => (
-              <th
-                key={h}
-                className="border-b border-vscode-border py-1 pr-4 font-medium"
-              >
-                {h}
-              </th>
-            ),
-          )}
+        <tr className="text-vscode-desc">
+          <th className="border-b border-vscode-border py-1 pr-4 text-left font-medium">
+            Column
+          </th>
+          <th className="border-b border-vscode-border py-1 pr-4 text-left font-medium">
+            Type
+          </th>
+          <th className="border-b border-vscode-border py-1 pr-4 text-right font-medium">
+            Rows
+          </th>
+          <th className="border-b border-vscode-border py-1 pr-4 text-left font-medium">
+            Null rate
+          </th>
+          <th className="border-b border-vscode-border py-1 pr-4 text-right font-medium">
+            Distinct
+          </th>
+          <th className="border-b border-vscode-border py-1 pr-4 text-left font-medium">
+            Min
+          </th>
+          <th className="border-b border-vscode-border py-1 text-left font-medium">
+            Max
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -42,14 +84,26 @@ export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
             <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
               {col.type}
             </td>
-            <td className="border-b border-vscode-border py-1 pr-4 text-vscode-fg">
+            <td className={`${num} text-vscode-fg`}>
               {col.rows.toLocaleString()}
             </td>
-            <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
-              {col.nulls} ({(col.null_rate * 100).toFixed(1)}%)
+            <td
+              className="border-b border-vscode-border py-1 pr-4"
+              title={`${col.nulls.toLocaleString()} null${col.nulls === 1 ? "" : "s"}`}
+            >
+              <NullBar rate={col.null_rate} />
             </td>
-            <td className="border-b border-vscode-border py-1 pr-4 text-vscode-fg">
+            <td className={`${num} text-vscode-fg`}>
               {col.distinct.toLocaleString()}
+              {col.distinct === col.rows && col.rows > 0 && (
+                <span
+                  className="ml-1.5 align-middle text-[10px] uppercase tracking-wide"
+                  style={{ color: "var(--vscode-charts-blue)" }}
+                  title="Every value is distinct — a candidate key"
+                >
+                  unique
+                </span>
+              )}
             </td>
             <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
               {col.min ?? "—"}

--- a/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
@@ -1,8 +1,39 @@
+import { useMemo } from "react";
 import type { InspectorTestsData } from "../../../../src/webviews/inspector/contract";
 import { StatusBadge } from "../components";
-import { toStatus } from "../viewModel";
+import { statusRank, toStatus } from "../viewModel";
+
+const SUMMARY = [
+  { key: "fail", label: "failed", color: "var(--vscode-testing-iconFailed)" },
+  { key: "warn", label: "warning", color: "var(--vscode-testing-iconQueued)" },
+  { key: "pass", label: "passed", color: "var(--vscode-testing-iconPassed)" },
+] as const;
 
 export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
+  const rows = useMemo(
+    () =>
+      (tests?.results ?? []).map((r) => ({
+        r,
+        status: toStatus(r.status, r.severity),
+      })),
+    [tests],
+  );
+  // Failed first, then by column — surface what needs attention.
+  const sorted = useMemo(
+    () =>
+      [...rows].sort(
+        (a, b) =>
+          statusRank(b.status) - statusRank(a.status) ||
+          (a.r.column ?? "").localeCompare(b.r.column ?? ""),
+      ),
+    [rows],
+  );
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { pass: 0, warn: 0, fail: 0 };
+    for (const { status } of rows) if (status in c) c[status] += 1;
+    return c;
+  }, [rows]);
+
   if (!tests) {
     return <p className="text-vscode-desc">Running tests…</p>;
   }
@@ -19,42 +50,61 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
       <p className="text-vscode-desc">No declarative tests for this model.</p>
     );
   }
+
   return (
-    <table className="w-full border-collapse text-sm">
-      <thead>
-        <tr className="text-left text-vscode-desc">
-          <th className="border-b border-vscode-border py-1 pr-4 font-medium">
-            Test
-          </th>
-          <th className="border-b border-vscode-border py-1 pr-4 font-medium">
-            Column
-          </th>
-          <th className="border-b border-vscode-border py-1 pr-4 font-medium">
-            Status
-          </th>
-          <th className="border-b border-vscode-border py-1 font-medium">
-            Detail
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {tests.results.map((result, i) => (
-          <tr key={i}>
-            <td className="border-b border-vscode-border py-1 pr-4 font-mono text-vscode-fg">
-              {result.test_type}
-            </td>
-            <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
-              {result.column ?? "—"}
-            </td>
-            <td className="border-b border-vscode-border py-1 pr-4">
-              <StatusBadge status={toStatus(result.status, result.severity)} />
-            </td>
-            <td className="border-b border-vscode-border py-1 text-vscode-desc">
-              {result.detail ?? ""}
-            </td>
-          </tr>
+    <div>
+      <div className="mb-3 flex flex-wrap items-center gap-3 text-xs text-vscode-desc">
+        {SUMMARY.filter((s) => counts[s.key] > 0).map((s) => (
+          <span key={s.key} className="inline-flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: s.color }}
+            />
+            {counts[s.key]} {s.label}
+          </span>
         ))}
-      </tbody>
-    </table>
+        <span className="flex-1" />
+        <span>
+          {rows.length} test{rows.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="text-left text-vscode-desc">
+            <th className="border-b border-vscode-border py-1 pr-4 font-medium">
+              Test
+            </th>
+            <th className="border-b border-vscode-border py-1 pr-4 font-medium">
+              Column
+            </th>
+            <th className="border-b border-vscode-border py-1 pr-4 font-medium">
+              Status
+            </th>
+            <th className="border-b border-vscode-border py-1 font-medium">
+              Detail
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(({ r, status }, i) => (
+            <tr key={i}>
+              <td className="border-b border-vscode-border py-1 pr-4 font-mono text-vscode-fg">
+                {r.test_type}
+              </td>
+              <td className="border-b border-vscode-border py-1 pr-4 text-vscode-desc">
+                {r.column ?? "—"}
+              </td>
+              <td className="border-b border-vscode-border py-1 pr-4">
+                <StatusBadge status={status} />
+              </td>
+              <td className="border-b border-vscode-border py-1 text-vscode-desc">
+                {r.detail ?? ""}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Inspector — tab surfaces

Polishes every Inspector tab on top of the new trust dashboard, so each surfaces what dbt's catalog can't.

**Columns** — where each column's data comes from and what it looks like:
- Upstream column lineage — a confidence-colored dot (green/amber/red) plus the transform, full source chain on hover, from the catalog's column edges.
- Inline profiling — distinct count and null-rate %, from `rocky profile` (DuckDB; degrades to `—` where profiling isn't available).
- Sort by name or by test status.

**Tests** — a pass / warning / failed summary header with colored counts and a total; the table sorts failed-first so what needs attention is at the top.

**Profile** — a colored null-rate bar (green clean → amber → red), a `unique` flag on candidate keys (distinct = rows), and right-aligned numeric columns.

**Preview** — zebra rows, muted `NULL` cells (distinct from empty strings), and right-aligned numbers.

Verified: host + webview typecheck, eslint, 194 unit tests green.