### PR TITLE
feat(vscode): show loading skeletons in the Inspector data tabs

### DIFF
--- a/editors/vscode/webview-ui/panels/inspector/components.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/components.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import type { ColumnTestStatus } from "./viewModel";
 
 const STATUS_COLOR: Record<Exclude<ColumnTestStatus, "none">, string> = {
@@ -64,6 +64,41 @@ export function StatusCard({
       {sub != null && sub !== "" && (
         <div className="mt-0.5 text-xs text-vscode-desc">{sub}</div>
       )}
+    </div>
+  );
+}
+
+/** A shimmer placeholder block — width/height via `className` or `style`. */
+export function Skeleton({
+  className = "",
+  style,
+}: {
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={`animate-pulse rounded ${className}`}
+      style={{ backgroundColor: "rgba(127,127,127,0.18)", ...style }}
+    />
+  );
+}
+
+/** A loading placeholder shaped like a table, shown while a tab's data loads. */
+export function TableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-2.5" aria-hidden>
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex items-center gap-3">
+          <Skeleton className="h-3.5 shrink-0" style={{ width: "9rem" }} />
+          <Skeleton
+            className="h-3.5 flex-1"
+            style={{ maxWidth: `${55 + ((r * 17) % 35)}%` }}
+          />
+          <Skeleton className="h-3.5 shrink-0" style={{ width: "3.5rem" }} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
@@ -1,4 +1,5 @@
 import type { InspectorPreviewData } from "../../../../src/webviews/inspector/contract";
+import { TableSkeleton } from "../components";
 
 /** Coerce a JSON cell value to a display string (mirrors the query-results grid). */
 function coerce(value: unknown): string {
@@ -13,7 +14,7 @@ export function PreviewTab({
   preview: InspectorPreviewData | null;
 }) {
   if (!preview) {
-    return <p className="text-vscode-desc">Loading preview…</p>;
+    return <TableSkeleton rows={6} />;
   }
   if (preview.unavailable || !preview.preview) {
     return (

--- a/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
@@ -1,4 +1,5 @@
 import type { ProfileOutput } from "../../../../src/types/generated/profile";
+import { TableSkeleton } from "../components";
 
 /** Null-rate as a colored bar — green clean, amber some, red mostly-null. */
 function NullBar({ rate }: { rate: number }) {
@@ -33,9 +34,7 @@ const num = "border-b border-vscode-border py-1 pr-4 text-right tabular-nums";
 
 export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
   if (!profile) {
-    return (
-      <p className="text-vscode-desc">Profiling… (one query per column)</p>
-    );
+    return <TableSkeleton rows={5} />;
   }
   if (profile.unavailable) {
     return (

--- a/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { InspectorTestsData } from "../../../../src/webviews/inspector/contract";
-import { StatusBadge } from "../components";
+import { StatusBadge, TableSkeleton } from "../components";
 import { statusRank, toStatus } from "../viewModel";
 
 const SUMMARY = [
@@ -35,7 +35,7 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
   }, [rows]);
 
   if (!tests) {
-    return <p className="text-vscode-desc">Running tests…</p>;
+    return <TableSkeleton rows={4} />;
   }
   if (tests.unavailable) {
     return (


### PR DESCRIPTION
## Inspector — loading skeletons

The Tests, Profile, and Preview tabs showed a bare "Loading…" line while their data fetched. They now render an animated table-shaped skeleton, so an on-demand tab load reads as a placeholder rather than a blank wait.

Adds a reusable `Skeleton` + `TableSkeleton` to the shared Inspector components.

Verified: host + webview typecheck, eslint, 194 unit tests, and a bundle (confirmed the `animate-pulse` keyframes emit with Tailwind preflight off).