### PR TITLE
feat(vscode): Inspector empty states + a Blast radius popover

### DIFF
--- a/editors/vscode/recording/scenarios/inspector-blast-radius.mjs
+++ b/editors/vscode/recording/scenarios/inspector-blast-radius.mjs
@@ -1,0 +1,30 @@
+// Blast-radius popover: open an upstream model in the Inspector and click the
+// "N downstream" value on the Blast radius card to reveal exactly which models a
+// change would hit. The DAG is raw_orders → stg_orders → fct_revenue, so opening
+// raw_orders gives 2 downstream. The popover renders in the browser top layer
+// (el-popover), so it floats over the panel rather than clipping at its edge.
+
+export default {
+  name: "inspector-blast-radius",
+  description: "Click Blast radius to reveal which downstream models a change would hit.",
+  workspace: "examples/playground/pocs/06-developer-experience/01-lineage-column-level",
+  size: { width: 1280, height: 800 },
+  fps: 15,
+  gifWidth: 1000,
+  quality: 65,
+
+  async run(d) {
+    await d.openFile("raw_orders.sql");
+    await d.pause(600);
+
+    await d.command("Rocky: Open in Inspector");
+    await d.pause(1500);
+    await d.command("View: Toggle Maximized Panel");
+    await d.pause(3000); // catalog + compile fan-in; Overview is the default tab
+
+    // The Blast radius value is a button named "2 downstream" — click it to open
+    // the top-layer popover listing the downstream models.
+    await d.clickInWebview("text=Overview", "downstream");
+    await d.pause(2800);
+  },
+};

--- a/editors/vscode/webview-ui/panels/inspector/components.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/components.tsx
@@ -103,6 +103,37 @@ export function TableSkeleton({ rows = 5 }: { rows?: number }) {
   );
 }
 
+/**
+ * A centered, consistent empty / unavailable state. `tone="error"` flags an
+ * unavailable surface (a failed fetch); the default reads as "nothing here yet."
+ */
+export function EmptyState({
+  title,
+  hint,
+  tone = "muted",
+}: {
+  title: string;
+  hint?: ReactNode;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1 py-10 text-center">
+      <p
+        className={
+          tone === "error"
+            ? "text-sm font-semibold text-vscode-error"
+            : "text-sm text-vscode-fg"
+        }
+      >
+        {title}
+      </p>
+      {hint != null && hint !== "" && (
+        <p className="max-w-xs text-xs text-vscode-desc">{hint}</p>
+      )}
+    </div>
+  );
+}
+
 /** A small theme-aware test-status pill (or an em dash when untested). */
 export function StatusBadge({ status }: { status: ColumnTestStatus }) {
   if (status === "none") return <span className="text-vscode-desc">—</span>;

--- a/editors/vscode/webview-ui/panels/inspector/tabs/OverviewTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/OverviewTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ElPopover } from "@tailwindplus/elements/react";
 import type { InspectorModelData } from "../../../../src/webviews/inspector/contract";
 import type {
   BreakingData,
@@ -14,6 +15,51 @@ import {
   formatCount,
   freshnessLabel,
 } from "../viewModel";
+
+const DOWNSTREAM_POPOVER_ID = "rocky-blast-radius-downstream";
+
+/**
+ * The blast-radius value, click-to-reveal: shows the downstream count and (when
+ * non-zero) opens a popover listing exactly which models a change would hit.
+ * el-popover renders in the browser top layer, so it never clips at the panel edge.
+ */
+function BlastRadiusValue({ downstream }: { downstream: string[] }) {
+  const label = `${downstream.length} downstream`;
+  if (downstream.length === 0) return <>{label}</>;
+  // el-popover's `anchor` isn't in React's HTMLAttributes — pass it as a raw attribute.
+  const anchorAttr = { anchor: "bottom start" };
+  return (
+    <>
+      <button
+        type="button"
+        popoverTarget={DOWNSTREAM_POPOVER_ID}
+        className="text-left underline decoration-dotted underline-offset-4 hover:decoration-solid"
+      >
+        {label}
+      </button>
+      <ElPopover
+        id={DOWNSTREAM_POPOVER_ID}
+        popover="auto"
+        {...anchorAttr}
+        className="max-h-64 w-56 overflow-auto rounded-md border border-vscode-border bg-vscode-widget-bg p-1 shadow-lg [--anchor-gap:4px]"
+      >
+        <p className="px-2 py-1 text-[11px] uppercase tracking-wide text-vscode-desc">
+          Downstream models
+        </p>
+        <ul>
+          {downstream.map((m) => (
+            <li
+              key={m}
+              className="truncate rounded px-2 py-1 font-mono text-xs text-vscode-fg"
+            >
+              {m}
+            </li>
+          ))}
+        </ul>
+      </ElPopover>
+    </>
+  );
+}
 
 /**
  * Overview = the model trust dashboard. Headline cost + blast-radius, then a
@@ -81,7 +127,7 @@ export function OverviewTab({ data }: { data: InspectorModelData }) {
           hero
           label="Blast radius"
           title="Models downstream of this one — what could break if you change it."
-          value={`${data.downstreamModels.length} downstream`}
+          value={<BlastRadiusValue downstream={data.downstreamModels} />}
           tone={
             breakingFinding
               ? "risk"

--- a/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/PreviewTab.tsx
@@ -1,5 +1,5 @@
 import type { InspectorPreviewData } from "../../../../src/webviews/inspector/contract";
-import { TableSkeleton } from "../components";
+import { EmptyState, TableSkeleton } from "../components";
 
 /** Coerce a JSON cell value to a display string (mirrors the query-results grid). */
 function coerce(value: unknown): string {
@@ -18,12 +18,11 @@ export function PreviewTab({
   }
   if (preview.unavailable || !preview.preview) {
     return (
-      <div className="text-sm">
-        <p className="font-semibold text-vscode-error">Preview unavailable.</p>
-        <p className="mt-1 text-vscode-desc">
-          {preview.unavailable ?? "No rows returned."}
-        </p>
-      </div>
+      <EmptyState
+        tone="error"
+        title="Preview unavailable"
+        hint={preview.unavailable ?? "No rows returned."}
+      />
     );
   }
   const rows = preview.preview;

--- a/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
@@ -1,5 +1,5 @@
 import type { ProfileOutput } from "../../../../src/types/generated/profile";
-import { TableSkeleton } from "../components";
+import { EmptyState, TableSkeleton } from "../components";
 
 /** Null-rate as a colored bar — green clean, amber some, red mostly-null. */
 function NullBar({ rate }: { rate: number }) {
@@ -38,14 +38,15 @@ export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
   }
   if (profile.unavailable) {
     return (
-      <div className="text-sm">
-        <p className="font-semibold text-vscode-error">Profile unavailable.</p>
-        <p className="mt-1 text-vscode-desc">{profile.unavailable}</p>
-      </div>
+      <EmptyState
+        tone="error"
+        title="Profile unavailable"
+        hint={profile.unavailable}
+      />
     );
   }
   if (profile.columns.length === 0) {
-    return <p className="text-vscode-desc">No columns to profile.</p>;
+    return <EmptyState title="No columns to profile" />;
   }
   return (
     <table className="w-full border-collapse text-sm">

--- a/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { InspectorTestsData } from "../../../../src/webviews/inspector/contract";
-import { StatusBadge, TableSkeleton } from "../components";
+import { EmptyState, StatusBadge, TableSkeleton } from "../components";
 import { statusRank, toStatus } from "../viewModel";
 
 const SUMMARY = [
@@ -39,15 +39,15 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
   }
   if (tests.unavailable) {
     return (
-      <div className="text-sm">
-        <p className="font-semibold text-vscode-error">Tests unavailable.</p>
-        <p className="mt-1 text-vscode-desc">{tests.unavailable}</p>
-      </div>
+      <EmptyState tone="error" title="Tests unavailable" hint={tests.unavailable} />
     );
   }
   if (tests.results.length === 0) {
     return (
-      <p className="text-vscode-desc">No declarative tests for this model.</p>
+      <EmptyState
+        title="No declarative tests"
+        hint="This model declares no tests in its contract."
+      />
     );
   }
 


### PR DESCRIPTION
## Inspector — empty states + Blast radius popover

Two polish items on the Inspector.

**Consistent empty states** — the Tests, Profile, and Preview tabs each had ad-hoc empty / "unavailable" messages (left-aligned, inline). They now route through a shared `EmptyState` (centered, with a hint) for all five states: no tests, no columns, and the three "unavailable" fetch-failure cases.

**Blast radius popover** — the Overview's Blast radius value is now a click-to-open popover listing exactly *which* downstream models a change would hit. It uses TailwindPlus `el-popover`, rendered in the browser top layer so it floats over the panel instead of clipping at its edge.

Verified: host + webview typecheck, eslint, 194 unit tests, bundle, and a recording confirming the popover renders + anchors correctly over the card grid.