### PR TITLE
chore(release): engine 1.46.0 + vscode 1.30.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.0] — 2026-05-27
+
+A ground-up rebuild of Rocky's visual surfaces in the editor: a React Flow lineage canvas, and a Rocky Inspector that turns any model into a trust dashboard — cost, blast radius, drift, governance, and freshness, read straight from the engine's typed output.
+
+### Added
+
+- **Rocky Inspector — a model trust dashboard.** Open any model in a bottom-panel Inspector whose Overview surfaces the signals that matter before you ship a change: estimated cost per run, blast radius (how many models depend on this one, with a click to see exactly which), data contract, freshness SLA, schema drift reconciled on the last run, governance (classified or PII columns, and any left unmasked), last-run status, and materialization. Each card lights green, amber, or red from the engine's typed output.
+- **Inspector tabs for every angle on a model.** Columns shows per-column upstream lineage with its confidence and transform, plus inline distinct and null-rate profiling. Profile gives per-column row, null, distinct, and min/max with a null-rate bar and a `unique` flag on candidate keys. Tests summarises pass/warn/fail and sorts failures first. Preview shows sampled rows.
+- **A React Flow lineage canvas** with drag, pan, zoom, a minimap, color-by-type or by-materialization, search, and focus/refocus. A right-click menu opens the file, refocuses, or shows upstream and downstream. Trust-plane overlays draw cost, freshness, drift, breaking-change blast radius, last run, and governance directly onto the graph.
+- **Right-click AI on a node** — explain it, draft a contract, generate tests, or build everything downstream, scoped to that model.
+- **Cmd+K model search** in the Inspector — fuzzy-find any model and retarget the Inspector to it.
+
+### Changed
+
+- **Lineage and the Inspector are now one panel.** The standalone lineage view became the Inspector's Lineage tab; clicking a node retargets every detail tab to that model.
+
 ## [1.29.0] — 2026-05-26
 
 The extension registers `rocky mcp` as a Model Context Protocol server for agent mode, and model lineage moves to a full-width bottom panel.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.0] — 2026-05-27
+
+### Added
+
+- **`rocky profile <model>`** — profile a model's columns directly: row count, null count and rate, distinct count, and min/max per column, from a single aggregate query (DuckDB today, no LLM round-trip). `--column <name>` narrows to one column; `--output json` emits `ProfileOutput`. Powers the VS Code Inspector's Profile tab and its inline column profiling.
+
 ## [1.45.1] — 2026-05-27
 
 ### Fixed

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "redis",
  "serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "logos",
  "miette",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4275,7 +4275,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "miette",
  "regex",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.45.1"
+version = "1.46.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.45.1"
+version = "1.46.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.45.1"
+version = "1.46.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.45.1"
+version = "1.46.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.45.1"
+version = "1.46.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.45.1"
+version = "1.46.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.45.1"
+version = "1.46.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.45.1"
+version = "1.46.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.45.1"
+version = "1.46.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.45.1"
+version = "1.46.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.45.1"
+version = "1.46.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.45.1"
+version = "1.46.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.45.1"
+version = "1.46.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.45.1"
+version = "1.46.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.45.1"
+version = "1.46.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.45.1"
+version = "1.46.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.45.1"
+version = "1.46.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.45.1"
+version = "1.46.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.45.1"
+version = "1.46.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.45.1"
+version = "1.46.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.45.1"
+version = "1.46.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Release: engine-v1.46.0 + vscode-v1.30.0

A consolidated double-cut. Dagster is excluded — its only unreleased work is docs + a routine deps bump, matching the previous cut.

### engine-v1.46.0
- **`rocky profile <model>`** — column profiling (rows, nulls, null rate, distinct, min/max) from a single aggregate query, no LLM round-trip. Powers the VS Code Inspector's Profile tab.
- All 25 crate versions 1.45.1 → 1.46.0, plus `Cargo.lock`.

### vscode-v1.30.0
- The React + React Flow Inspector overhaul: a model **trust dashboard** (cost, blast radius, drift, governance, freshness), four polished tabs (Columns / Tests / Profile / Preview), the lineage canvas, right-click AI, and Cmd+K model search.
- `package.json` + lock 1.29.0 → 1.30.0.

### Tagging (after merge)
Push **engine-v1.46.0 first, vscode-v1.30.0 second**. If GitHub flags the vscode release as `isLatest`, fix with `gh release edit engine-v1.46.0 --latest`.

### Deferred
Demo GIFs (the Marketplace listing) still show the pre-overhaul Inspector. Refresh is a fast-follow: the recorder has a workspace state-leak to fix first, and a governance-POC frame shows the trust dashboard lit best.