### PR TITLE
fix(vscode): load ReactFlow's stylesheet in the Inspector (Lineage canvas)

### DIFF
--- a/editors/vscode/webview-ui/panels/inspector/main.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/main.tsx
@@ -1,4 +1,9 @@
 import "../../styles/tailwind.generated.css";
+// ReactFlow's base stylesheet for the Lineage tab's canvas (node/edge layout,
+// MiniMap, Controls). base.css themes it via the --xy-* vars; without this the
+// MiniMap renders as an unstyled black box mis-placed at the top-left (regressed
+// when the canvas moved into this panel in the lineage/inspector consolidation).
+import "@xyflow/react/dist/style.css";
 // Register the TailwindPlus Elements custom elements eagerly (at entry-eval,
 // before React mounts) so the command palette's <el-dialog> is defined when the
 // Inspector reffs it. The /react wrappers would otherwise lazy-import this.
@@ -7,9 +12,8 @@ import { lazy } from "react";
 import { createRoot } from "react-dom/client";
 import { AppShell } from "../../runtime/AppShell";
 
-// Lazy so the panel body lands in a code-split chunk. The Inspector has no
-// ReactFlow dependency, so it shares the React/runtime chunk with the devtools
-// panel while pulling none of ReactFlow's weight.
+// Lazy so the panel body lands in a code-split chunk. The Inspector pulls in
+// ReactFlow for the Lineage tab's canvas.
 const InspectorApp = lazy(() =>
   import("./InspectorApp").then((m) => ({ default: m.InspectorApp })),
 );


### PR DESCRIPTION
## Lineage canvas rendered unstyled in 1.30.0

The Inspector's Lineage tab is a ReactFlow canvas, but `@xyflow/react/dist/style.css` was imported only by the devtools panel — never by the inspector panel. The import was dropped when the canvas moved into this panel during the lineage/inspector consolidation (#726) and first shipped broken in **vscode-v1.30.0**.

Without that CSS the **MiniMap and Controls render unstyled** (a black box mis-placed at the top-left) and **edges are unstyled**; custom nodes still positioned via inline transforms, so it looked half-alive rather than obviously broken.

**Fix:** import the stylesheet in the inspector entry (after Tailwind, so ReactFlow's `.react-flow__*` rules win over the base button/border reset). `inspector.css` now bundles the ReactFlow classes (12.6kb → 28.1kb).

### Verified (recorded + frame-audited)
- **Lineage canvas** — nodes + edges render (`raw_orders ──○── good_mart`), **MiniMap styled bottom-right**, **Controls bottom-left**, black box gone.
- **Overview** — trust dashboard renders; cards light correctly.
- **Columns** — per-column lineage dots render, confidence-colored.
- **Tests / Preview / Profile** — render their states (two engine-side issues surfaced separately during this review).
- host + webview typecheck, eslint, 194 unit tests — all green.

→ ships as **vscode-v1.30.1** (vscode-only; engine stays 1.46.0)