### PR TITLE
docs: tighten READMEs and make the dbt comparison accurate and fair

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,13 @@
 
 **Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.**
 
-Not a warehouse. Not a table format. Not a query engine. The trust plane for your data — a typed compiler, named branches, deterministic replay, column-level lineage, compile-time contracts, and per-model cost — running over your existing Databricks / Snowflake / BigQuery / DuckDB. Apache 2.0.
+It is a typed compiler that runs over your existing Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data: named branches, deterministic replay, column-level lineage, compile-time contracts, and per-model cost. Storage and compute stay where they are, and Rocky works on the SQL you already have. The `.rocky` DSL is there when you want it. Apache 2.0.
 
-Rocky exists because the disasters that cost data teams real money — silent schema drift wrecking a revenue dashboard, a column rename quietly poisoning 47 downstream models, an auditor asking who touched `fct_revenue.amount` and when, a cost spike that no one can attribute to a model — all share a common shape. They're problems the warehouse can't see and the templating engine on top of it was never asked to. Rocky owns the graph between your code and the warehouse so those problems become compile errors, blocked PRs, and verifiable artifacts instead of pages and post-mortems.
-
-It's built for the team running production-critical multi-tenant pipelines on Databricks today, on Snowflake or BigQuery tomorrow, who can't tolerate another silent failure. Storage and compute stay where they are. **Rocky works on the SQL you already have** — the `.rocky` DSL is an acceleration when you want it, not a gate.
+The failures that cost data teams the most are invisible to the warehouse and out of scope for the templating layer above it: schema drift, column-rename blast radius, dialect divergence, cost spikes nobody can attribute. Rocky turns them into compile errors and blocked PRs.
 
 <p align="center">
   <img src="docs/public/demo-quickstart.gif" alt="Rocky quickstart — create a project, compile, and run 3 models in under 15s" width="900" />
 </p>
-
-## The disasters Rocky prevents
-
-| Disaster | What dbt does | What Rocky does |
-|---|---|---|
-| Upstream changes a column type | Silent — fails downstream, hours later | `E013` at compile, blocks the PR |
-| Required column dropped from a contract | No contract concept | `E010` at compile, blocks the PR |
-| Column rename with unknown blast radius | `dbt docs` post-hoc, table-level (dbt Cloud Enterprise has column lineage in their UI, also post-hoc, not PR-blocking) | `rocky lineage-diff` at PR time, column-level, downstream consumers listed, blocks the merge |
-| `SELECT *` pulls a new column you didn't expect | Silent | `P002` warning, downstream consumers named |
-| Snowflake-only function written for a Databricks project | Runs in dev, fails in prod | `P001` dialect-portability lint at compile |
-| Run cost doubles, no one knows which model | Manual warehouse spelunking | `RunOutput.cost_summary` per model, every run |
-| Auditor asks: who changed `fct_revenue.amount`, when, and why? | Git blame + screenshots | `rocky replay <run_id>` — content-addressed record of the exact code and the output it produced |
-| Sev-2 at 3 AM, half the pipeline already ran | Re-run everything | `rocky run --resume-latest` — checkpoint, three-state circuit breaker, skip what succeeded |
-
-Each row is a real failure mode, with a Rocky command that turns it into a non-event. The same primitives — typed compiler, content-addressed state, column-level lineage, per-model cost — back every row.
-
-**Already on dbt?** `rocky import-dbt` converts a vanilla dbt project to Rocky in one command. The "What dbt does" column above is dbt Core's behavior. **dbt Fusion** — dbt Labs' Rust rewrite of dbt Core (public beta) — catches some compile-time issues that dbt Core misses, but doesn't ship named branches, content-addressed deterministic replay, per-model cost attribution as a first-class column, dialect-portability lint across warehouses, or declarative governance + masking outside dbt platform's paid tiers. Those stay Rocky's surface, Apache 2.0.
 
 ## Try it in 60 seconds
 
@@ -55,27 +36,27 @@ cd my-first-project
 rocky compile && rocky test && rocky run
 ```
 
-No credentials needed — the playground runs end-to-end on local DuckDB.
+No credentials needed; the playground runs end-to-end on local DuckDB.
 
 ## Who Rocky is for
 
-Rocky is built first for **data platform engineers running production-critical, multi-tenant pipelines on Databricks** — the team that's hit dbt's ceiling, where silent failures cost real money, and where Dagster is already the orchestrator. That's the launch wedge, and that's where Rocky is most battle-tested.
+Rocky is built first for **data platform engineers running production-critical, multi-tenant pipelines on Databricks**, where silent failures cost real money and Dagster is already the orchestrator. That is the launch wedge, and where Rocky is most battle-tested.
 
-The next ring out: **Snowflake and BigQuery shops** currently evaluating SQLMesh, who want correctness moved to the compiler (not the planner) and prefer SQL by default over Python-first ergonomics. Adapters are Beta today; see [Where Rocky is today](#where-rocky-is-today) below.
+The next ring out: **Snowflake and BigQuery shops** evaluating SQLMesh, who want correctness in the compiler rather than the planner and prefer SQL by default. Adapters are Beta today; see [Where Rocky is today](#where-rocky-is-today) below.
 
 ## See it in action
 
-Each demo below is a self-contained POC in [`examples/playground/pocs/`](examples/playground/) — `cd` in, run `./run.sh`, reproduce locally.
+Each demo below is a self-contained POC in [`examples/playground/pocs/`](examples/playground/): `cd` in, run `./run.sh`, and reproduce it locally.
 
 ### Detects schema drift the moment it happens
 
-A source column type changes upstream. On the next run, Rocky diffs source vs. target, drops the target, and recreates it. No silent data corruption, no dbt-style quiet divergence.
+A source column type changes upstream. On the next run, Rocky diffs source against target, drops the target, and recreates it. No silent data corruption.
 
 <p align="center">
   <img src="docs/public/demo-drift-recover.gif" alt="rocky run detects source type change and recreates the target" width="900" />
 </p>
 
-[POC — `02-performance/06-schema-drift-recover`](examples/playground/pocs/02-performance/06-schema-drift-recover/)
+[POC: `02-performance/06-schema-drift-recover`](examples/playground/pocs/02-performance/06-schema-drift-recover/)
 
 ### Enforces data contracts at compile time
 
@@ -85,7 +66,7 @@ Missing required columns, protected columns being removed, or unsafe type change
   <img src="docs/public/demo-data-contracts.gif" alt="rocky compile flags E010 and E013 contract violations on broken_metrics" width="900" />
 </p>
 
-[POC — `01-quality/01-data-contracts-strict`](examples/playground/pocs/01-quality/01-data-contracts-strict/)
+[POC: `01-quality/01-data-contracts-strict`](examples/playground/pocs/01-quality/01-data-contracts-strict/)
 
 ### Named branches for risk-free experiments
 
@@ -95,7 +76,7 @@ Create a branch, run against it in an isolated schema, inspect, then drop or pro
   <img src="docs/public/demo-branches-replay.gif" alt="rocky branch create, run on branch, and trace column lineage downstream" width="900" />
 </p>
 
-[POC — `00-foundations/06-branches-replay-lineage`](examples/playground/pocs/00-foundations/06-branches-replay-lineage/)
+[POC: `00-foundations/06-branches-replay-lineage`](examples/playground/pocs/00-foundations/06-branches-replay-lineage/)
 
 ### Column-level lineage, not table-level
 
@@ -105,67 +86,84 @@ Trace a single column from a downstream fact back through its aggregations, all 
   <img src="docs/public/demo-column-lineage.gif" alt="rocky lineage --column traces fct_revenue.total back to seeds.orders.amount" width="900" />
 </p>
 
-[POC — `06-developer-experience/01-lineage-column-level`](examples/playground/pocs/06-developer-experience/01-lineage-column-level/)
+[POC: `06-developer-experience/01-lineage-column-level`](examples/playground/pocs/06-developer-experience/01-lineage-column-level/)
 
 ### AI model generation with a compile-validate loop
 
-Describe what you want in plain English. Rocky generates a Rocky DSL model, compiles it, and retries on parse failure — the `Attempts: 2` line shows the loop catching a first-pass error invisibly.
+Describe what you want in plain English. Rocky generates a Rocky DSL model, compiles it, and retries on parse failure. The `Attempts: 2` line shows the loop catching a first-pass error.
 
 <p align="center">
   <img src="docs/public/demo-ai-model-generation.gif" alt="rocky ai generates a .rocky model from natural language intent, Attempts: 2" width="900" />
 </p>
 
-[POC — `03-ai/01-model-generation`](examples/playground/pocs/03-ai/01-model-generation/)
+[POC: `03-ai/01-model-generation`](examples/playground/pocs/03-ai/01-model-generation/)
 
 ### PR-time blast-radius with `rocky lineage-diff`
 
-Compare two git refs and get a per-changed-column readout of downstream consumers — pre-rendered Markdown drops straight into a GitHub PR comment. CODEOWNERS-style review tooling can't reach this granularity without a compiled engine.
+Compare two git refs and get a per-changed-column readout of downstream consumers; the pre-rendered Markdown drops straight into a GitHub PR comment. CODEOWNERS-style review tooling can't reach this granularity without a compiled engine.
 
 <p align="center">
   <img src="docs/public/demo-lineage-diff.gif" alt="rocky lineage-diff main lists added and removed columns across two models with downstream consumers per change" width="900" />
 </p>
 
-[POC — `06-developer-experience/11-lineage-diff`](examples/playground/pocs/06-developer-experience/11-lineage-diff/)
+[POC: `06-developer-experience/11-lineage-diff`](examples/playground/pocs/06-developer-experience/11-lineage-diff/)
 
 ### Classify columns, mask by environment, gate CI
 
-Tag PII columns in the model sidecar; bind tags to mask strategies in `[mask]` / `[mask.<env>]`. `rocky compliance --env prod --fail-on exception` exits 1 the moment a classified column has no resolved strategy — a one-line CI gate against accidentally-unmasked data.
+Tag PII columns in the model sidecar, and bind tags to mask strategies in `[mask]` / `[mask.<env>]`. `rocky compliance --env prod --fail-on exception` exits 1 the moment a classified column has no resolved strategy: a one-line CI gate against accidentally unmasked data.
 
 <p align="center">
   <img src="docs/public/demo-classification-masking.gif" alt="rocky compliance rolls up classification tags to mask strategies; --fail-on exception exits 1, gating CI on unmasked PII" width="900" />
 </p>
 
-[POC — `04-governance/05-classification-masking-compliance`](examples/playground/pocs/04-governance/05-classification-masking-compliance/)
+[POC: `04-governance/05-classification-masking-compliance`](examples/playground/pocs/04-governance/05-classification-masking-compliance/)
 
 ### Incremental loads with persistent watermark state
 
-`strategy = "incremental"` plus a `timestamp_column` is all it takes. Rocky writes the high-water mark to the embedded state store; subsequent runs only `INSERT … WHERE timestamp > watermark`. Append 25 rows after a 500-row load — run 2 still finishes in 0.2s.
+`strategy = "incremental"` plus a `timestamp_column` is all it takes. Rocky writes the high-water mark to the embedded state store, and subsequent runs only `INSERT … WHERE timestamp > watermark`. Append 25 rows after a 500-row load, and run 2 still finishes in 0.2s.
 
 <p align="center">
   <img src="docs/public/demo-incremental-watermark.gif" alt="rocky run with incremental strategy: run 1 copies 500 rows; appended 25 rows; run 2 only copies the delta in 0.2s" width="900" />
 </p>
 
-[POC — `02-performance/01-incremental-watermark`](examples/playground/pocs/02-performance/01-incremental-watermark/)
+[POC: `02-performance/01-incremental-watermark`](examples/playground/pocs/02-performance/01-incremental-watermark/)
 
 ## Where Rocky is today
 
-The trust primitives — compiler, branches, replay, lineage, contracts, cost attribution — are production-grade on Databricks. We're explicit about the rest:
+The trust primitives (compiler, branches, replay, lineage, contracts, cost attribution) are production-grade on Databricks. The rest is in progress:
 
-- **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta — connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
-- **AI is a growing surface, not a finished product.** The compile-validate loop (generate → type-check → auto-fix → land) is real and shipped; the broader story (mass refactor across the DAG, auto-migration from a column type change, schema-aware assertion generation) is on the roadmap, not the changelog.
-- **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm — shipped end-to-end (Wave 2). First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
+- **Databricks is the production target for 2026.** Snowflake, BigQuery, and Trino adapters are Beta: connection, execution, and the core run loop work, but conformance coverage is still growing. If your enterprise warehouse is Snowflake or BigQuery and you need it production-grade today, talk to us.
+- **AI is a growing surface, not a finished product.** The compile-validate loop (generate, type-check, auto-fix, then land) is shipped. The broader story (mass refactor across the DAG, auto-migration from a column-type change, schema-aware assertion generation) is on the roadmap.
+- **Iceberg.** REST-catalog source discovery is Beta. Content-addressed writes round-trip as Iceberg through Delta UniForm, shipped end-to-end. First-class Iceberg-native writes without the Delta intermediate are on the 2026 roadmap.
 - **No built-in semantic layer.** Rocky's typed IR is the right home for one. Today, integrate with Cube, the dbt Semantic Layer, or your existing metric store.
-- **Orchestration: Dagster is first-class.** A `rocky serve` standalone path exists; native Airflow / Prefect integrations are not yet shipped — they're called from the CLI like any other binary.
+- **Orchestration: Dagster is first-class.** A `rocky serve` standalone path exists; native Airflow and Prefect integrations are not yet shipped, so they're called from the CLI like any other binary.
 
-If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions) — the roadmap is shaped by where production pipelines are actually getting hurt.
+If those gaps are blockers for your team, [open a discussion](https://github.com/rocky-data/rocky/discussions). The roadmap is shaped by where production pipelines are actually getting hurt.
+
+## How it compares to dbt Core
+
+| Disaster | What dbt Core does | What Rocky does |
+|---|---|---|
+| Upstream changes a column type | Silent; surfaces as a downstream failure later | `E013` at compile, blocks the PR |
+| Required column dropped from a contract | Caught at build time via `contract: enforced` | `E010` at compile, blocks the PR |
+| Column rename with unknown blast radius | `dbt docs` is post-hoc and table-level; dbt Cloud Enterprise adds column lineage in the UI, also post-hoc and not PR-blocking | `rocky lineage-diff` at PR time, column-level, downstream consumers listed, blocks the merge |
+| `SELECT *` pulls a new column you didn't expect | Silent | `P002` warning, downstream consumers named |
+| Snowflake-only function written for a Databricks project | No dialect-portability lint; runs in dev, fails in prod | `P001` dialect-portability lint at compile |
+| Run cost doubles, no one knows which model | No per-model cost attribution; reconstruct it from warehouse query history | `RunOutput.cost_summary` per model, every run |
+| Auditor asks: who changed `fct_revenue.amount`, when, and why? | Run history in dbt Cloud, but no content-addressed record of code and output | `rocky replay <run_id>`: a content-addressed record of the exact code and the output it produced |
+| Sev-2 at 3 AM, half the pipeline already ran | `dbt retry` resumes from the failed model; no within-run checkpoint or circuit breaker | `rocky run --resume-latest`: checkpoint, three-state circuit breaker, skip what succeeded |
+
+Each row is a real failure mode and a Rocky command that turns it into a non-event. The same primitives back every row: typed compiler, content-addressed state, column-level lineage, per-model cost.
+
+dbt Core defined this category, and `rocky import-dbt` converts a vanilla dbt project to Rocky in one command. dbt Fusion (dbt Labs' Rust rewrite of dbt Core, in public beta) closes part of the compile-time gap by type-checking SQL, though it still templates with Jinja. Neither open-source engine ships named branches, content-addressed replay, per-model cost as a first-class column, cross-warehouse dialect lint, or declarative RBAC and masking. Some governance features live in dbt's paid platform; Rocky's are open source under Apache 2.0.
 
 ## Subprojects
 
 | Path | Artifact | Language | Description |
 |---|---|---|---|
-| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine — 23-crate Cargo workspace |
+| [`engine/`](engine/) | `rocky` CLI binary | Rust | Core SQL transformation engine, 23-crate Cargo workspace |
 | [`integrations/dagster/`](integrations/dagster/) | `dagster-rocky` PyPI wheel | Python | Dagster resource and component wrapping the Rocky CLI |
-| [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension — LSP client + commands for AI features |
+| [`editors/vscode/`](editors/vscode/) | Rocky VSIX | TypeScript | VS Code extension; LSP client + commands for AI features |
 | [`examples/playground/`](examples/playground/) | (config only) | TOML / SQL | Self-contained DuckDB sample pipeline used for smoke tests and benchmarks |
 
 Each subproject has its own README with detailed usage. The [`engine/README.md`](engine/README.md) is the canonical product reference for the Rocky CLI.
@@ -196,7 +194,7 @@ just test        # runs all test suites
 just lint        # cargo clippy/fmt + ruff + eslint
 ```
 
-`just` is optional — you can also build each subproject directly. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
+`just` is optional; you can also build each subproject directly. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for per-subproject build commands.
 
 ## Releases
 
@@ -210,11 +208,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md#releases) for the full release flow.
 
 ## Documentation
 
-Full documentation: **[rocky-data.dev](https://rocky-data.dev)** — concepts, guides, CLI reference, Dagster integration, adapter SDK.
+Full documentation lives at **[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, Dagster integration, and the adapter SDK.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, please read the cross-project change guidance — schema and DSL changes must update consumers atomically.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). Before opening a PR, please read the cross-project change guidance: schema and DSL changes must update consumers atomically.
 
 ## Sponsoring
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -7,7 +7,7 @@
 
 # Rocky VS Code Extension
 
-Editor support for [Rocky](https://github.com/rocky-data/rocky) — the typed graph between your code and your warehouse. Real LSP (not Jinja-aware text completion), interactive column-level lineage, compile-time diagnostics inline, and AI model generation gated through the compiler.
+Editor support for [Rocky](https://github.com/rocky-data/rocky), the typed graph between your code and your warehouse: a real LSP backed by the Rocky compiler, interactive column-level lineage, inline compile-time diagnostics, and AI model generation gated through the compiler.
 
 ## In action
 
@@ -19,7 +19,7 @@ Editor support for [Rocky](https://github.com/rocky-data/rocky) — the typed gr
 
 <p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-lineage.gif" alt="The lineage canvas focused on a model's neighborhood, with a cost overlay drawn on the graph" width="820" /></p>
 
-**Inspect any model.** The Inspector's Overview is a model trust dashboard — cost, blast radius, drift, governance, and freshness in one place. Here a PII-classified model flags a column left unmasked, and the Columns tab traces each column's upstream lineage.
+**Inspect any model.** The Inspector's Overview is a model trust dashboard: cost, blast radius, drift, governance, and freshness in one place. Here a PII-classified model flags a column left unmasked, and the Columns tab traces each column's upstream lineage.
 
 <p align="center"><img src="https://raw.githubusercontent.com/rocky-data/rocky/main/editors/vscode/media/demo-inspector.gif" alt="The Rocky Inspector's Overview as a model trust dashboard, its Governance card flagging two classified columns with one left unmasked" width="820" /></p>
 
@@ -33,17 +33,17 @@ Editor support for [Rocky](https://github.com/rocky-data/rocky) — the typed gr
 
 ## Features
 
-**Editor intelligence** — diagnostics, hover, go-to-definition, find references, rename, code actions, signature help, document symbols, and inlay hints for inferred column types.
+**Editor intelligence**: diagnostics, hover, go-to-definition, find references, rename, code actions, signature help, document symbols, and inlay hints for inferred column types.
 
-**Syntax** — `.rocky` TextMate grammar + semantic tokens, plus code snippets for every DSL construct (`from`, `where`, `group`, `derive`, `select`, `join`, `sort`, `match`, `window`).
+**Syntax**: `.rocky` TextMate grammar + semantic tokens, plus code snippets for every DSL construct (`from`, `where`, `group`, `derive`, `select`, `join`, `sort`, `match`, `window`).
 
-**Activity bar sidebar** — Get Started, Extension Info, Models, Runs, Sources, and Help panels. Workspaces without a `rocky.toml` show orientation and one-click actions for Initialize Project, Try Playground, and Open Documentation instead of CLI errors.
+**Activity bar sidebar**: Get Started, Extension Info, Models, Runs, Sources, and Help panels. Workspaces without a `rocky.toml` show orientation and one-click actions for Initialize Project, Try Playground, and Open Documentation instead of CLI errors.
 
-**Lineage view** — `Rocky: Show Model Lineage` renders the column-level DAG as an interactive graph.
+**Lineage view**: `Rocky: Show Model Lineage` renders the column-level DAG as an interactive graph.
 
-**AI generate** — `Rocky: Generate Model from Intent` creates a model from a natural language description using the Rocky AI intent layer.
+**AI generate**: `Rocky: Generate Model from Intent` creates a model from a natural language description using the Rocky AI intent layer.
 
-**Status bar** — LSP server status and live error count.
+**Status bar**: LSP server status and live error count.
 
 ## Requirements
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,10 +1,10 @@
 # Rocky
 
-**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.** A typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data — named branches, deterministic replay, column-level lineage, compile-time contracts, per-model cost attribution. The trust plane for your data; a single static Rust binary; storage and compute stay where they are.
+**Rocky is the typed graph between your code and whichever warehouse, table format, or query engine you've chosen.** It is a typed compiler that sits above Databricks, Snowflake, BigQuery, or DuckDB and owns the graph between your code and your data: named branches, deterministic replay, column-level lineage, compile-time contracts, and per-model cost attribution. It ships as a single static Rust binary, and storage and compute stay where they are.
 
-**Rocky is not a warehouse, not a table format, not a query engine, not a templating layer.** It's a real compiler with type inference, diagnostic codes, and an IDE — so the failures that quietly cost data teams the most (silent schema drift, column rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs, not pages and post-mortems.
+**Rocky is a real compiler** with type inference, diagnostic codes, and an IDE, not a warehouse, table format, query engine, or templating layer. The failures that quietly cost data teams the most (silent schema drift, column-rename blast radius, dialect divergence, cost spikes nobody can attribute) become compile errors and blocked PRs.
 
-No Jinja. No manifest. No parse step.
+There is no Jinja, no manifest, and no separate parse step.
 
 ## Why Rocky exists
 
@@ -15,16 +15,16 @@ The expensive failures in modern data platforms aren't slow queries. They're tru
 - A `SELECT *` pulls a new column nobody designed for; a downstream join silently double-counts.
 - A Snowflake-only function lands in a Databricks-targeted project and only fails in prod.
 - Warehouse spend doubles in a month and nobody can attribute which model caused it.
-- An auditor asks who changed `fct_revenue.amount`, when, and why — and the answer involves `git blame` and screenshots.
+- An auditor asks who changed `fct_revenue.amount`, when, and why, and the answer involves `git blame` and screenshots.
 
-dbt Core, by design, is a templating engine — it can't catch any of these at compile time. dbt Fusion (dbt Labs' Rust rewrite of dbt Core, in public beta since 2025-05-28) catches some compile-time issues but still uses Jinja templating (`dbt-jinja` is a Rust port of mini-jinja), and doesn't ship named branches, content-addressed deterministic replay, per-model cost attribution, dialect-portability lint across warehouses, or declarative governance + masking outside dbt platform paid tiers. SQLMesh moved correctness to the planner. Rocky owns the trust dimensions all of them leave open — each failure above maps to a Rocky diagnostic code, a CI gate, or a content-addressed replay artifact.
+dbt Core is a templating engine with no compile-time type checker. Contracts and tests catch some of these, but only at build time, after the SQL runs. dbt Fusion, dbt Labs' Rust rewrite of dbt Core (in public beta), adds real SQL type-checking and catches a class of errors dbt Core cannot, though it still templates with Jinja. Neither open-source engine ships named branches, content-addressed replay, per-model cost attribution, cross-warehouse dialect lint, or declarative RBAC and masking; some governance features live in dbt's paid platform. SQLMesh takes a different route and moves correctness into the planner. Rocky covers the trust dimensions these leave open: each failure above maps to a diagnostic code, a CI gate, or a content-addressed replay artifact.
 
 ## Scope on the ELT spectrum
 
 | Stage | Rocky | Notes |
 |---|---|---|
 | Extract (SaaS sources) | — | Use Fivetran, Airbyte, Stitch, or warehouse-native CDC |
-| Extract (files) | ✅ | `rocky load` — CSV / Parquet / JSONL from a directory |
+| Extract (files) | ✅ | `rocky load`: CSV / Parquet / JSONL from a directory |
 | Load (bronze replication) | ✅ | Config-driven replication pipelines |
 | Transform | ✅ | Compiled SQL models |
 | Quality | ✅ | Inline assertions during `rocky run` |
@@ -32,13 +32,13 @@ dbt Core, by design, is a templating engine — it can't catch any of these at c
 
 ## The seven trust dimensions
 
-1. **SQL as a typed, compiled language.** Real type inference, real diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`), real LSP. Not text macros, not runtime checks — a compiler. This is the moat.
-2. **Compile-time column-level lineage.** Rocky knows the lineage of every column before a row is written. Block a PR when a downstream contract breaks. `rocky lineage-diff main` per-changed-column at PR time.
-3. **Branches + deterministic replay.** `rocky branch create`, `rocky run --branch`, `rocky replay <run_id>` — branches are isolated schemas, replays are content-addressed artifacts. Inputs + code → outputs is a pure function, recorded.
-4. **Per-model cost attribution.** Cost is a column on every run record — not a dashboard you have to opt into. `[budget]` blocks fail the run; `budget_breach` fires the hook; `rocky preview cost` projects spend at PR time.
-5. **AI gated through the compiler.** Every AI suggestion goes through type-check before it lands. The `Attempts: 2` retry loop on `rocky ai` is the signature: generate → type-check → auto-fix → land.
-6. **Dialect-divergence lint.** Cross-warehouse teams write SQL once; `P001` catches Snowflake-only constructs in a Databricks project at compile time. Useful the day you start a migration; essential the day you finish one.
-7. **Declarative governance.** RBAC as code with GRANT/REVOKE diffing, Unity Catalog tags, workspace isolation, masking strategies bound to classification tags. Compliance becomes a CI check, not a quarterly fire drill.
+1. **SQL as a typed, compiled language.** Real type inference, diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`), and a real LSP, not text macros or runtime checks.
+2. **Compile-time column-level lineage.** Rocky knows every column's lineage before a row is written, so `rocky lineage-diff main` can block a PR when a downstream contract breaks.
+3. **Branches and deterministic replay.** `rocky branch create`, `rocky run --branch`, and `rocky replay <run_id>`: branches are isolated schemas, and replays are content-addressed, so the same inputs and code reproduce the same recorded output.
+4. **Per-model cost attribution.** Cost is a column on every run record. `[budget]` blocks fail the run, `budget_breach` fires a hook, and `rocky preview cost` projects spend at PR time.
+5. **AI gated through the compiler.** Every AI suggestion is type-checked before it lands. The `Attempts: 2` retry on `rocky ai` is the loop: generate, type-check, auto-fix, then land.
+6. **Dialect-divergence lint.** Cross-warehouse teams write SQL once, and `P001` catches Snowflake-only constructs in a Databricks project at compile time.
+7. **Declarative governance.** RBAC as code with GRANT/REVOKE diffing, Unity Catalog tags, workspace isolation, and masking strategies bound to classification tags, so compliance becomes a CI check.
 
 ## Quick start
 
@@ -62,7 +62,7 @@ The playground is self-contained: sample models, contracts, and a DuckDB backend
 | **Cost** | Per-model cost attribution on every run, `[budget]` blocks, `budget_breach` hook event |
 | **Observability** | `rocky trace` Gantt output, OpenTelemetry OTLP export, structured JSON events |
 | **Portability** | Dialect-divergence lint across Databricks / Snowflake / BigQuery / DuckDB |
-| **DSL** | Pipeline-oriented `.rocky` syntax — optional, models stay plain SQL by default |
+| **DSL** | Pipeline-oriented `.rocky` syntax; optional, models stay plain SQL by default |
 | **AI** | Intent metadata, schema-sync, intent extraction, test generation |
 | **IDE** | VS Code extension, full LSP (completion, hover, go-to-def, rename, code actions, inlay hints) |
 | **Quality** | Pipeline-level checks + 13 declarative assertions with severity, filters, and row quarantine |
@@ -105,7 +105,7 @@ Full reference: [CLI commands](https://rocky-data.dev/reference/cli/).
 | Warehouse | DuckDB | Local / Testing | Embedded execution for development and CI |
 | Warehouse | Trino | Beta | REST `/v1/statement` polling client; Basic + JWT auth; Docker conformance harness behind the `trino-conformance` feature |
 
-Build a custom adapter in Rust or any language: [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/) — walks through a ClickHouse-shaped skeleton, the trait surface, auth, testing, and distribution. Concepts overview: [Adapter SDK](https://rocky-data.dev/concepts/adapters/).
+Build a custom adapter in Rust or any language with the [Adapter SDK guide](https://rocky-data.dev/guides/adapter-sdk/), which walks through a ClickHouse-shaped skeleton, the trait surface, auth, testing, and distribution. Concepts overview: [Adapter SDK](https://rocky-data.dev/concepts/adapters/).
 
 ## Installation
 
@@ -131,7 +131,7 @@ cargo build --release
 
 ## Documentation
 
-**[rocky-data.dev](https://rocky-data.dev)** — concepts, guides, CLI reference, Dagster integration, adapter SDK.
+**[rocky-data.dev](https://rocky-data.dev)**: concepts, guides, CLI reference, Dagster integration, and the adapter SDK.
 
 ## License
 

--- a/integrations/dagster/README.md
+++ b/integrations/dagster/README.md
@@ -1,10 +1,10 @@
 # dagster-rocky
 
-Dagster integration for [Rocky](https://github.com/rocky-data/rocky) — the typed graph between your code and your warehouse.
+Dagster integration for [Rocky](https://github.com/rocky-data/rocky), the typed graph between your code and your warehouse.
 
 `dagster-rocky` wraps the `rocky` CLI as a Dagster `ConfigurableResource` and exposes Rocky-managed
 tables as materializable Dagster assets. Compile-time contracts, column-level lineage, schema-drift
-detection, quality check results, and per-model cost surface as native Dagster events — so the
+detection, quality check results, and per-model cost surface as native Dagster events, so the
 guarantees Rocky enforces at compile time appear directly in the Dagster asset graph.
 
 ## Install
@@ -78,14 +78,14 @@ def acme_orders(rocky: RockyResource) -> dg.MaterializeResult:
 
 ## Documentation
 
-* **[Dagster Integration docs](https://rocky-data.dev/dagster/introduction/)** — resource, component, translator, schedules, sensors, pipes, and more
-* **[DEVELOPMENT.md](./DEVELOPMENT.md)** — local setup, architecture, testing
-* **[CHANGELOG.md](./CHANGELOG.md)** — release notes
+* **[Dagster Integration docs](https://rocky-data.dev/dagster/introduction/)**: resource, component, translator, schedules, sensors, pipes, and more
+* **[DEVELOPMENT.md](./DEVELOPMENT.md)**: local setup, architecture, testing
+* **[CHANGELOG.md](./CHANGELOG.md)**: release notes
 
 ## Related projects
 
-* **[Rocky](https://github.com/rocky-data/rocky)** — the Rust SQL transformation engine
-* **[Rocky VS Code extension](https://github.com/rocky-data/rocky/tree/main/editors/vscode)** — VS Code extension with LSP and AI features
+* **[Rocky](https://github.com/rocky-data/rocky)**: the Rust SQL transformation engine
+* **[Rocky VS Code extension](https://github.com/rocky-data/rocky/tree/main/editors/vscode)**: VS Code extension with LSP and AI features
 
 ## License
 


### PR DESCRIPTION
## What

A cleanup pass across the four READMEs (root, engine, dagster, vscode), focused on density, the dbt comparison, and prose voice. Docs only — no code, schema, or binding changes.

## dbt comparison

The root README's comparison table is reworked for accuracy and moved below the demos into a "How it compares to dbt Core" section, so it no longer opens the page.

- Corrected cells that misstated current dbt behavior:
  - dbt Core has model contracts (since 1.5), so a "required column dropped from a contract" is caught at build time via `contract: enforced`, not unsupported.
  - `dbt retry` (since 1.6) resumes from the failed model; the honest distinction is Rocky's within-run checkpoint and circuit breaker, not resume-vs-none.
- Replaced editorializing cells with neutral, architectural distinctions (timing, scope, granularity).
- Renamed the middle column to "What dbt Core does", and separated the Fusion OSS engine (type-checks SQL, still Jinja) from dbt's paid platform.
- Added that dbt Core defined this category, and removed the internal jabs.

## Density and voice

- Collapsed the repeating root intro paragraphs and tightened the engine README's trust-dimension list.
- Reduced em-dash overuse (39 → 1 in the root README) and removed triple-rhythm and balanced-antithesis flourishes so the prose reads more plainly.
