### PR TITLE
fix: profile source-fallback + per-model test results (engine 1.46.1, vscode 1.30.2)

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.2] — 2026-05-28
+
+### Fixed
+
+- **Inspector Profile tab shows data again.** The tab was blank whenever a model's target table wasn't materialized. It now renders the column profile the engine returns, and when the engine profiled the upstream source instead of the model's own (not-yet-materialized) target, a banner names the source so the numbers aren't mistaken for the model's output. Requires engine 1.46.1.
+- **Inspector Tests tab reflects passing models.** A model that passes `rocky test` but declares no `[[tests]]` showed only an empty "No declarative tests" state. The tab now shows a "Model executes" pass/fail banner from the engine's per-model test results, above the declarative-test list. Requires engine 1.46.1.
+
 ## [1.30.1] — 2026-05-28
 
 ### Fixed

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/editors/vscode/src/commands/inspector.ts
+++ b/editors/vscode/src/commands/inspector.ts
@@ -112,29 +112,53 @@ async function loadModelData(model: string): Promise<InspectorModelData> {
 }
 
 /**
- * Run declarative tests and scope the results to `model`. Invoked lazily (the
- * Tests tab) because it executes SQL.
+ * Load tests for `model`, scoped to one model. Invoked lazily (the Tests tab)
+ * because it executes SQL. Two engine calls:
  *
- * `rocky test` currently runs the whole project — its `model_filter` is an
- * unimplemented TODO in `commands/test.rs` — so we run the full declarative
- * suite and filter client-side. Switch to a per-model invocation once the
- * engine scopes test execution.
+ * 1. `rocky test --declarative` — the `[[tests]]` assertions from sidecars.
+ *    Still project-wide on the wire, so we filter client-side.
+ * 2. `rocky test --model <model>` — the DuckDB model-execution check. The
+ *    engine now scopes this to one model and itemizes passes (not just
+ *    failures), so a model with no declarative assertions still reports
+ *    green here instead of leaving the tab empty.
  */
 async function loadTests(model: string): Promise<InspectorTestsData> {
+  let results: InspectorTestsData["results"] = [];
+  let modelExecution: InspectorTestsData["modelExecution"];
+  let unavailable: string | undefined;
+
   try {
-    const out = await runRockyJson<TestOutput>([
+    const declarative = await runRockyJson<TestOutput>([
       "test",
       "--declarative",
       "--output",
       "json",
     ]);
-    const results = (out.declarative?.results ?? []).filter(
+    results = (declarative.declarative?.results ?? []).filter(
       (r) => r.model === model,
     );
-    return { results };
   } catch (err) {
-    return { results: [], unavailable: errMessage(err) };
+    unavailable = errMessage(err);
   }
+
+  try {
+    const execution = await runRockyJson<TestOutput>([
+      "test",
+      "--model",
+      model,
+      "--output",
+      "json",
+    ]);
+    modelExecution = (execution.model_results ?? []).find(
+      (r) => r.model === model,
+    );
+  } catch (err) {
+    // Keep any declarative results we got; only report unavailable when both
+    // calls failed (nothing to show).
+    if (results.length === 0) unavailable = unavailable ?? errMessage(err);
+  }
+
+  return { results, modelExecution, unavailable };
 }
 
 /**

--- a/editors/vscode/src/types/generated/profile.ts
+++ b/editors/vscode/src/types/generated/profile.ts
@@ -9,6 +9,8 @@
  * JSON output for `rocky profile <model> [--column <col>]`.
  *
  * A per-column data profile (row / null / distinct counts, min / max, and the low-cardinality domain) for a model's target table, computed by a single aggregate query per column. DuckDB-only this release; a non-DuckDB target reports `unavailable` with an empty `columns` list rather than erroring.
+ *
+ * When the model's declared target isn't materialized (the agentic authoring loop pre-`rocky run`, or a replication-pipeline POC that doesn't run the transformation models), profile falls back to the model's first resolvable source table. The fallback is labelled via `profiled_table` (the table actually queried) and `fell_back_from` (the missing target), so consumers can surface "source preview, not model output" in the UI.
  */
 export interface ProfileOutput {
   /**
@@ -16,7 +18,15 @@ export interface ProfileOutput {
    */
   columns: ProfileColumnStats[];
   command: string;
+  /**
+   * When set, profile fell back to a source because the model's declared target wasn't materialized; carries the declared-target FQN that was missing. `None` when the declared target was profiled directly.
+   */
+  fell_back_from?: string | null;
   model: string;
+  /**
+   * Fully-qualified table actually profiled (e.g. `staging.raw_orders` or `raw__orders.orders`). When `fell_back_from` is set, this differs from the model's declared target. Omitted when `unavailable` is set.
+   */
+  profiled_table?: string | null;
   /**
    * Set when profiling could not run (e.g. a non-DuckDB target this release).
    */

--- a/editors/vscode/src/types/generated/test.ts
+++ b/editors/vscode/src/types/generated/test.ts
@@ -16,6 +16,10 @@ export interface TestOutput {
   declarative?: DeclarativeTestSummary | null;
   failed: number;
   failures: TestFailure[];
+  /**
+   * Per-model outcomes for the (DuckDB-backed) model-execution test — passes too, not just failures. Lets the VS Code Inspector Tests tab and the dagster integration render "good_mart: pass" without inferring it from `total - failures`. Empty when only declarative tests ran. Filtered to `--model` when that flag is set.
+   */
+  model_results?: ModelTestResult[];
   passed: number;
   total: number;
   version: string;
@@ -77,5 +81,19 @@ export interface DeclarativeTestResult {
 export interface TestFailure {
   error: string;
   name: string;
+  [k: string]: unknown;
+}
+/**
+ * One per-model outcome from the local model-execution test.
+ *
+ * `status` is `"pass"` or `"fail"`. `error` is set only when `status = "fail"`. Mirrors `rocky_engine::test_runner::ModelTestResult` with the status flattened to a string so consumers (Pydantic, TypeScript) get a stable, JSON-Schema-friendly shape.
+ */
+export interface ModelTestResult {
+  error?: string | null;
+  model: string;
+  /**
+   * `"pass"` or `"fail"`.
+   */
+  status: string;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/webviews/inspector/contract.ts
+++ b/editors/vscode/src/webviews/inspector/contract.ts
@@ -5,7 +5,7 @@
  */
 import type { CatalogColumn, CatalogEdge } from "../../types/generated/catalog";
 import type { CostHint, ModelFreshnessConfig } from "../../types/generated/compile";
-import type { DeclarativeTestResult } from "../../types/generated/test";
+import type { DeclarativeTestResult, ModelTestResult } from "../../types/generated/test";
 import type { PreviewRowsOutput } from "../../types/generated/preview_rows";
 
 /**
@@ -36,9 +36,17 @@ export interface InspectorModelData {
   costHint: CostHint | null;
 }
 
-/** Declarative test results scoped to one model (lazy "Tests" tab). */
+/** Test results scoped to one model (lazy "Tests" tab). */
 export interface InspectorTestsData {
+  /** Declarative `[[tests]]` assertions from the model's sidecar. */
   results: DeclarativeTestResult[];
+  /**
+   * Model-execution check: does the model compile and materialize against a
+   * local DuckDB. Present even when the model declares no `[[tests]]`, so a
+   * model that has no assertions but passes `rocky test` still shows green
+   * instead of an empty state.
+   */
+  modelExecution?: ModelTestResult;
   /** Set when tests could not run (e.g. CLI error); `results` is then empty. */
   unavailable?: string;
 }

--- a/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/ProfileTab.tsx
@@ -48,8 +48,24 @@ export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
   if (profile.columns.length === 0) {
     return <EmptyState title="No columns to profile" />;
   }
+  // Source-fallback: the model's target isn't materialized, so these stats
+  // come from the upstream source (`profiled_table`), not the model output.
+  // Label it so the numbers aren't mistaken for the materialized model.
+  const fallback =
+    profile.fell_back_from != null ? (
+      <p className="mb-3 rounded border border-vscode-border px-3 py-2 text-xs text-vscode-desc">
+        Showing source{" "}
+        <span className="font-mono text-vscode-fg">{profile.profiled_table}</span> —
+        the model target{" "}
+        <span className="font-mono text-vscode-fg">{profile.fell_back_from}</span> isn't
+        materialized yet. Run <span className="font-mono">rocky run</span> to profile the
+        model's own output.
+      </p>
+    ) : null;
   return (
-    <table className="w-full border-collapse text-sm">
+    <div>
+      {fallback}
+      <table className="w-full border-collapse text-sm">
       <thead>
         <tr className="text-vscode-desc">
           <th className="border-b border-vscode-border py-1 pr-4 text-left font-medium">
@@ -114,6 +130,7 @@ export function ProfileTab({ profile }: { profile: ProfileOutput | null }) {
           </tr>
         ))}
       </tbody>
-    </table>
+      </table>
+    </div>
   );
 }

--- a/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/tabs/TestsTab.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import type { InspectorTestsData } from "../../../../src/webviews/inspector/contract";
+import type { DeclarativeTestResult } from "../../../../src/types/generated/test";
 import { EmptyState, StatusBadge, TableSkeleton } from "../components";
-import { statusRank, toStatus } from "../viewModel";
+import { type ColumnTestStatus, statusRank, toStatus } from "../viewModel";
 
 const SUMMARY = [
   { key: "fail", label: "failed", color: "var(--vscode-testing-iconFailed)" },
@@ -34,6 +35,13 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
     return c;
   }, [rows]);
 
+  // The model-execution check (does the model compile + materialize via
+  // DuckDB) is surfaced as a banner above the declarative assertions, so a
+  // model that passes `rocky test` but declares no `[[tests]]` still shows
+  // green instead of an empty state.
+  const exec = tests?.modelExecution;
+  const execStatus = exec ? toStatus(exec.status, "error") : "none";
+
   if (!tests) {
     return <TableSkeleton rows={4} />;
   }
@@ -42,15 +50,51 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
       <EmptyState tone="error" title="Tests unavailable" hint={tests.unavailable} />
     );
   }
-  if (tests.results.length === 0) {
+  if (tests.results.length === 0 && !exec) {
     return (
       <EmptyState
-        title="No declarative tests"
-        hint="This model declares no tests in its contract."
+        title="No tests"
+        hint="This model declares no tests, and its execution status is unavailable."
       />
     );
   }
 
+  return (
+    <div>
+      {exec && (
+        <div className="mb-3 flex items-center gap-2 rounded border border-vscode-border px-3 py-2 text-sm">
+          <StatusBadge status={execStatus} />
+          <span className="text-vscode-fg">Model executes</span>
+          <span className="text-vscode-desc">
+            {exec.status === "pass"
+              ? "compiles and materializes against local DuckDB"
+              : (exec.error ?? "execution failed")}
+          </span>
+        </div>
+      )}
+      {tests.results.length === 0 ? (
+        <EmptyState
+          title="No declarative tests"
+          hint="This model declares no [[tests]] in its contract."
+        />
+      ) : (
+        <DeclarativeTests sorted={sorted} counts={counts} rowCount={rows.length} />
+      )}
+    </div>
+  );
+}
+
+/** The declarative `[[tests]]` assertions table. Split out so the Model
+ *  execution banner can render above it without nesting the table logic. */
+function DeclarativeTests({
+  sorted,
+  counts,
+  rowCount,
+}: {
+  sorted: { r: DeclarativeTestResult; status: ColumnTestStatus }[];
+  counts: Record<string, number>;
+  rowCount: number;
+}) {
   return (
     <div>
       <div className="mb-3 flex flex-wrap items-center gap-3 text-xs text-vscode-desc">
@@ -66,7 +110,7 @@ export function TestsTab({ tests }: { tests: InspectorTestsData | null }) {
         ))}
         <span className="flex-1" />
         <span>
-          {rows.length} test{rows.length === 1 ? "" : "s"}
+          {rowCount} test{rowCount === 1 ? "" : "s"}
         </span>
       </div>
       <table className="w-full border-collapse text-sm">

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.1] — 2026-05-28
+
+### Fixed
+
+- **`rocky profile <model>` no longer fails when the model isn't materialized.** Profile queried the model's declared target table directly, so profiling a model whose target doesn't exist yet — an unmaterialized transformation, or a replication pipeline that never runs its transformation models — failed with a raw catalog error. Profile now probes the declared target and, when it's missing, falls back to the model's first resolvable source table, recording the substitution in `ProfileOutput.profiled_table` and `fell_back_from`. With no source to fall back to it returns a clear "run `rocky run` first" message instead of the catalog error. This powers the VS Code Inspector's Profile tab and inline column profiling. (`rocky ai-contract` keeps refusing an unmaterialized target, since a contract drafted from source data would be misleading.)
+- **`rocky test --model <name>` now scopes the run to one model.** The flag was accepted but ignored, so it reported every model. It now filters the reported results to the named model; the model's upstream dependencies still execute so its SQL resolves.
+
+### Added
+
+- **`rocky test` reports per-model results.** `TestOutput` gains `model_results`, one entry per model with a `pass` / `fail` status, so passes are surfaced individually instead of inferred from `total` minus the failure list. The VS Code Inspector's Tests tab uses this to show that a model passes even when it declares no `[[tests]]`.
+
 ## [1.46.0] — 2026-05-27
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "redis",
  "serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4083,6 +4083,7 @@ dependencies = [
  "rocky-sql",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -4090,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4121,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4146,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -4159,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "logos",
  "miette",
@@ -4171,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4180,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4201,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4219,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4249,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4275,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "miette",
  "regex",
@@ -4288,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4311,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.46.0"
+version = "1.46.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.46.0"
+version = "1.46.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.46.0"
+version = "1.46.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.46.0"
+version = "1.46.1"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.46.0"
+version = "1.46.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.46.0"
+version = "1.46.1"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.46.0"
+version = "1.46.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/src/commands/ai_contract.rs
+++ b/engine/crates/rocky-cli/src/commands/ai_contract.rs
@@ -84,6 +84,12 @@ pub(crate) fn compile_project(
 pub(crate) struct PreparedTable {
     pub(crate) adapter: std::sync::Arc<dyn WarehouseAdapter>,
     pub(crate) table_ref: String,
+    /// Set when the model's declared target wasn't materialized and we fell
+    /// back to a source table (only when `FallbackPolicy::SourceFallback` is
+    /// requested). Carries the declared-target FQN that was missing so the
+    /// caller can surface "this is a source preview, not the model output" in
+    /// its output. `None` means we profiled the declared target directly.
+    pub(crate) fell_back_from: Option<String>,
 }
 
 /// Either a runnable table query or the reason a non-DuckDB adapter blocks
@@ -91,6 +97,20 @@ pub(crate) struct PreparedTable {
 pub(crate) enum PreparedKind {
     Ready(PreparedTable),
     Unavailable(String),
+}
+
+/// How `prepare_table_query` should react when the model's declared target is
+/// not materialized in the warehouse.
+///
+/// `Strict` (the ai-contract caller) refuses with a clear message — a contract
+/// drafted from source data would be semantically wrong for a non-passthrough
+/// model. `SourceFallback` (the `rocky profile` caller) tries the model's
+/// declared sources so the agentic authoring loop and replication-pipeline
+/// demos can still get observed data, surfacing the fallback via
+/// `PreparedTable::fell_back_from`.
+pub(crate) enum FallbackPolicy {
+    Strict,
+    SourceFallback,
 }
 
 /// The target adapter resolved from config, plus whether it's DuckDB.
@@ -134,10 +154,17 @@ fn duckdb_only_refusal(adapter_type: &str) -> Option<String> {
 /// Resolve a model's target table into a validated table ref + warehouse
 /// adapter — but only on DuckDB. Other adapters return the typed "unavailable"
 /// reason so the command refuses cleanly with a clear message.
-pub(crate) fn prepare_table_query(
+///
+/// When `policy` is [`FallbackPolicy::SourceFallback`] and the model's declared
+/// target isn't materialized, this probes the model's declared sources (or
+/// SQL-extracted FROM tables when sidecars don't declare any) and returns the
+/// first one that exists, with [`PreparedTable::fell_back_from`] set so the
+/// caller can label the result.
+pub(crate) async fn prepare_table_query(
     config_path: &Path,
     compile_result: &CompileResult,
     model_name: &str,
+    policy: FallbackPolicy,
 ) -> Result<PreparedKind> {
     let resolved = resolve_target(config_path)?;
     if let Some(reason) = duckdb_only_refusal(&resolved.adapter_type) {
@@ -164,10 +191,95 @@ pub(crate) fn prepare_table_query(
         rocky_sql::validation::validate_identifier(&t.catalog)
             .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
     }
-    let table_ref = format!("{schema}.{table}");
+    let target_ref = format!("{schema}.{table}");
 
     let adapter = registry.warehouse_adapter(&target_adapter)?;
-    Ok(PreparedKind::Ready(PreparedTable { adapter, table_ref }))
+
+    // Probe the model's declared target. We use `describe_table` rather than
+    // information_schema so the existence check goes through the adapter trait
+    // (works for any future warehouse), and is cheap even on cold tables.
+    let target_table_ref = rocky_ir::TableRef {
+        catalog: t.catalog.clone(),
+        schema: t.schema.clone(),
+        table: t.table.clone(),
+    };
+    if adapter.describe_table(&target_table_ref).await.is_ok() {
+        return Ok(PreparedKind::Ready(PreparedTable {
+            adapter,
+            table_ref: target_ref,
+            fell_back_from: None,
+        }));
+    }
+
+    // Target isn't materialized. Strict callers (ai-contract) refuse here —
+    // drafting a contract from source data would be semantically wrong.
+    match policy {
+        FallbackPolicy::Strict => Ok(PreparedKind::Unavailable(format!(
+            "model '{model_name}' target '{target_ref}' is not materialized. \
+             Run `rocky run` to materialize the model first."
+        ))),
+        FallbackPolicy::SourceFallback => {
+            match first_existing_source(adapter.as_ref(), model).await {
+                Some(source_ref) => Ok(PreparedKind::Ready(PreparedTable {
+                    adapter,
+                    table_ref: source_ref,
+                    fell_back_from: Some(target_ref),
+                })),
+                None => Ok(PreparedKind::Unavailable(format!(
+                    "model '{model_name}' has no profile-able table: target \
+                     '{target_ref}' is not materialized and no source table \
+                     could be resolved. Run `rocky run` to materialize the \
+                     model first."
+                ))),
+            }
+        }
+    }
+}
+
+/// Find the first source table for `model` that actually exists in the
+/// warehouse. Tries explicit `[[sources]]` sidecar declarations first, then
+/// falls back to FROM clauses parsed out of the model's SQL — useful when the
+/// sidecar doesn't list sources (the common shape in the playground POCs).
+/// Returns the DuckDB-style two-part `schema.table` ref, since this release
+/// is DuckDB-only.
+async fn first_existing_source(
+    adapter: &dyn WarehouseAdapter,
+    model: &rocky_core::models::Model,
+) -> Option<String> {
+    for src in &model.config.sources {
+        let r = rocky_ir::TableRef {
+            catalog: src.catalog.clone(),
+            schema: src.schema.clone(),
+            table: src.table.clone(),
+        };
+        if adapter.describe_table(&r).await.is_ok() {
+            return Some(format!("{}.{}", src.schema, src.table));
+        }
+    }
+    // SQL-extracted fallback. `referenced_tables` returns lowercased
+    // `schema.table` or three-part names; unqualified names (no dot) can't be
+    // resolved without a default schema, so we skip them.
+    let refs = rocky_sql::lineage::referenced_tables(&model.sql).ok()?;
+    for name in refs {
+        let parts: Vec<&str> = name.split('.').collect();
+        let table_ref = match parts.as_slice() {
+            [s, t] => rocky_ir::TableRef {
+                catalog: String::new(),
+                schema: (*s).to_string(),
+                table: (*t).to_string(),
+            },
+            [c, s, t] => rocky_ir::TableRef {
+                catalog: (*c).to_string(),
+                schema: (*s).to_string(),
+                table: (*t).to_string(),
+            },
+            _ => continue,
+        };
+        if adapter.describe_table(&table_ref).await.is_ok() {
+            return Some(format!("{}.{}", table_ref.schema, table_ref.table));
+        }
+    }
+    None
 }
 
 /// Read a `serde_json::Value` cell as a `u64`, tolerating string-encoded ints.
@@ -280,8 +392,17 @@ pub async fn run_ai_contract(
         })?;
 
     // Resolve the target table — refuses non-DuckDB adapters with a clear
-    // message before any LLM tokens are spent.
-    let prepared = match prepare_table_query(config_path, &compile_result, model_name)? {
+    // message before any LLM tokens are spent. `Strict` policy: refuse if the
+    // model isn't materialized rather than drafting a contract from source
+    // data (which would be semantically wrong for non-passthrough models).
+    let prepared = match prepare_table_query(
+        config_path,
+        &compile_result,
+        model_name,
+        FallbackPolicy::Strict,
+    )
+    .await?
+    {
         PreparedKind::Ready(p) => p,
         PreparedKind::Unavailable(reason) => {
             anyhow::bail!(reason);

--- a/engine/crates/rocky-cli/src/commands/profile.rs
+++ b/engine/crates/rocky-cli/src/commands/profile.rs
@@ -11,7 +11,9 @@ use anyhow::Result;
 
 use crate::output::{ProfileColumnStats, ProfileOutput, print_json};
 
-use super::ai_contract::{PreparedKind, compile_project, prepare_table_query, profile_column};
+use super::ai_contract::{
+    FallbackPolicy, PreparedKind, compile_project, prepare_table_query, profile_column,
+};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -39,13 +41,28 @@ pub async fn build_profile_output(
             )
         })?;
 
-    let prepared = match prepare_table_query(config_path, &compile_result, model_name)? {
+    // `SourceFallback`: if the model's declared target isn't materialized
+    // (agentic authoring loop pre-`rocky run`, or a replication-pipeline POC
+    // that doesn't run the transformation models), profile its first
+    // resolvable source instead so the caller still gets observed data. The
+    // fallback is labelled via `profiled_table` + `fell_back_from` so the JSON
+    // tells the truth.
+    let prepared = match prepare_table_query(
+        config_path,
+        &compile_result,
+        model_name,
+        FallbackPolicy::SourceFallback,
+    )
+    .await?
+    {
         PreparedKind::Ready(p) => p,
         PreparedKind::Unavailable(reason) => {
             return Ok(ProfileOutput {
                 version: VERSION.to_string(),
                 command: "profile".to_string(),
                 model: model_name.to_string(),
+                profiled_table: None,
+                fell_back_from: None,
                 columns: Vec::new(),
                 unavailable: Some(reason),
             });
@@ -62,26 +79,41 @@ pub async fn build_profile_output(
         anyhow::bail!("column '{name}' not found in model '{model_name}'");
     }
 
+    let fell_back = prepared.fell_back_from.is_some();
     let mut columns = Vec::with_capacity(targets.len());
     for col in targets {
-        let p = profile_column(prepared.adapter.as_ref(), &prepared.table_ref, col).await?;
-        columns.push(ProfileColumnStats {
-            name: p.name,
-            type_name: p.type_name,
-            rows: p.rows,
-            nulls: p.nulls,
-            null_rate: p.null_rate,
-            distinct: p.distinct,
-            observed_values: p.observed_values,
-            min: p.min,
-            max: p.max,
-        });
+        // On the source-fallback path, a column from the model's inferred
+        // schema may not exist on the source (the model added/renamed it).
+        // Skip such columns rather than aborting the whole profile — the
+        // caller gets whatever overlap exists, plus `fell_back_from` to
+        // signal "this is a source preview." On the target path we keep
+        // strict behaviour: any per-column error is a real problem.
+        let result = profile_column(prepared.adapter.as_ref(), &prepared.table_ref, col).await;
+        match result {
+            Ok(p) => columns.push(ProfileColumnStats {
+                name: p.name,
+                type_name: p.type_name,
+                rows: p.rows,
+                nulls: p.nulls,
+                null_rate: p.null_rate,
+                distinct: p.distinct,
+                observed_values: p.observed_values,
+                min: p.min,
+                max: p.max,
+            }),
+            Err(e) if fell_back => {
+                tracing::debug!(column = %col.name, error = %e, "skipping column in source-fallback profile");
+            }
+            Err(e) => return Err(e),
+        }
     }
 
     Ok(ProfileOutput {
         version: VERSION.to_string(),
         command: "profile".to_string(),
         model: model_name.to_string(),
+        profiled_table: Some(prepared.table_ref),
+        fell_back_from: prepared.fell_back_from,
         columns,
         unavailable: None,
     })
@@ -187,5 +219,110 @@ mod tests {
             .unwrap();
         assert_eq!(id_profile.rows, 3);
         assert_eq!(id_profile.nulls, 1);
+    }
+
+    /// Set up a temp DuckDB + rocky.toml + a `raw_orders` model whose SQL
+    /// reads `FROM raw__orders.orders`. The seed creates the source table;
+    /// the caller chooses whether to also materialize the declared target,
+    /// which exercises the source-fallback vs no-fallback paths in one
+    /// shared scaffold.
+    async fn scaffold_fallback_poc(
+        materialize_target: bool,
+    ) -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("wh.duckdb");
+        let config_path = dir.path().join("rocky.toml");
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        std::fs::write(
+            &config_path,
+            format!(
+                "[adapter.warehouse]\ntype = \"duckdb\"\npath = \"{}\"\n\n\
+                 [pipeline.t]\ntype = \"transformation\"\n\n\
+                 [pipeline.t.target]\nadapter = \"warehouse\"\n",
+                db_path.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("raw_orders.sql"),
+            "SELECT order_id, amount FROM raw__orders.orders",
+        )
+        .unwrap();
+        std::fs::write(
+            models_dir.join("raw_orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n\
+             [target]\ncatalog = \"wh\"\nschema = \"staging\"\n",
+        )
+        .unwrap();
+
+        let cfg = rocky_core::config::load_rocky_config(&config_path).unwrap();
+        let registry = crate::registry::AdapterRegistry::from_config(&cfg).unwrap();
+        let adapter = registry.warehouse_adapter("warehouse").unwrap();
+        for stmt in [
+            "CREATE SCHEMA IF NOT EXISTS raw__orders",
+            "CREATE TABLE raw__orders.orders (order_id BIGINT, amount DOUBLE)",
+            "INSERT INTO raw__orders.orders VALUES (1, 10.0), (2, 20.0), (3, 30.0)",
+        ] {
+            adapter.execute_statement(stmt).await.unwrap();
+        }
+        if materialize_target {
+            for stmt in [
+                "CREATE SCHEMA IF NOT EXISTS staging",
+                "CREATE TABLE staging.raw_orders AS \
+                 SELECT order_id, amount FROM raw__orders.orders",
+            ] {
+                adapter.execute_statement(stmt).await.unwrap();
+            }
+        }
+        (dir, config_path, models_dir)
+    }
+
+    /// Target table absent + a source table exists → profile falls back to
+    /// the source and labels the fallback. The agentic authoring loop and
+    /// replication-pipeline demos rely on this branch.
+    #[tokio::test]
+    async fn falls_back_to_source_when_target_missing() {
+        let (_tmp, config_path, models_dir) = scaffold_fallback_poc(false).await;
+        let state_path = config_path.parent().unwrap().join(".rocky_state");
+        let output = build_profile_output(
+            &config_path,
+            &state_path,
+            models_dir.to_str().unwrap(),
+            "raw_orders",
+            None,
+            None,
+        )
+        .await
+        .expect("profile should succeed via source fallback");
+        assert_eq!(output.profiled_table.as_deref(), Some("raw__orders.orders"));
+        assert_eq!(output.fell_back_from.as_deref(), Some("staging.raw_orders"));
+        assert_eq!(output.unavailable, None);
+        // Both source columns exist on the model → both should profile.
+        let names: Vec<_> = output.columns.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"order_id"));
+        assert!(names.contains(&"amount"));
+        assert_eq!(output.columns[0].rows, 3);
+    }
+
+    /// Target table materialized → profile uses it directly, no fallback.
+    /// Guards against accidentally falling back when the model is healthy.
+    #[tokio::test]
+    async fn no_fallback_when_target_materialized() {
+        let (_tmp, config_path, models_dir) = scaffold_fallback_poc(true).await;
+        let state_path = config_path.parent().unwrap().join(".rocky_state");
+        let output = build_profile_output(
+            &config_path,
+            &state_path,
+            models_dir.to_str().unwrap(),
+            "raw_orders",
+            None,
+            None,
+        )
+        .await
+        .expect("profile should succeed against the materialized target");
+        assert_eq!(output.profiled_table.as_deref(), Some("staging.raw_orders"));
+        assert_eq!(output.fell_back_from, None);
+        assert_eq!(output.columns[0].rows, 3);
     }
 }

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -11,9 +11,28 @@ use rocky_core::tests::{TestSeverity, TestType, generate_test_sql_with_dialect};
 use rocky_core::traits::WarehouseAdapter;
 
 use crate::output::{
-    DeclarativeTestResult, DeclarativeTestSummary, TestFailure, TestOutput, print_json,
+    DeclarativeTestResult, DeclarativeTestSummary, ModelTestResult, TestFailure, TestOutput,
+    print_json,
 };
 use crate::registry::{self, AdapterRegistry};
+
+/// Map the engine test runner's `ModelTestResult` to the JsonSchema-derived
+/// output shape. Centralized so `test_output` + `run_test` agree.
+fn to_output_results(
+    results: &[rocky_engine::test_runner::ModelTestResult],
+) -> Vec<ModelTestResult> {
+    results
+        .iter()
+        .map(|r| ModelTestResult {
+            model: r.model.clone(),
+            status: match r.status {
+                rocky_engine::test_runner::ModelTestStatus::Pass => "pass".to_string(),
+                rocky_engine::test_runner::ModelTestStatus::Fail => "fail".to_string(),
+            },
+            error: r.error.clone(),
+        })
+        .collect()
+}
 
 /// Side-effect-free core of `rocky test` (DuckDB-based local tests): run the
 /// tests and assemble the typed [`TestOutput`] without printing.
@@ -22,8 +41,12 @@ use crate::registry::{self, AdapterRegistry};
 /// (`rocky-mcp`) obtains the struct directly.
 // Reusable typed-output core for the in-process MCP server. `run_test`
 // re-runs the test runner so it can also render text.
-pub fn test_output(models_dir: &Path, contracts_dir: Option<&Path>) -> Result<TestOutput> {
-    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir)?;
+pub fn test_output(
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    model_filter: Option<&str>,
+) -> Result<TestOutput> {
+    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter)?;
     let failures: Vec<TestFailure> = result
         .failures
         .iter()
@@ -32,7 +55,8 @@ pub fn test_output(models_dir: &Path, contracts_dir: Option<&Path>) -> Result<Te
             error: error.clone(),
         })
         .collect();
-    Ok(TestOutput::new(result.total, result.passed, failures))
+    let model_results = to_output_results(&result.model_results);
+    Ok(TestOutput::new(result.total, result.passed, failures).with_model_results(model_results))
 }
 
 /// Execute `rocky test` (DuckDB-based local tests).
@@ -42,7 +66,7 @@ pub fn run_test(
     model_filter: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
-    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir)?;
+    let result = rocky_engine::test_runner::run_tests(models_dir, contracts_dir, model_filter)?;
 
     if output_json {
         let failures: Vec<TestFailure> = result
@@ -53,10 +77,16 @@ pub fn run_test(
                 error: error.clone(),
             })
             .collect();
-        let output = TestOutput::new(result.total, result.passed, failures);
+        let model_results = to_output_results(&result.model_results);
+        let output = TestOutput::new(result.total, result.passed, failures)
+            .with_model_results(model_results);
         print_json(&output)?;
     } else {
-        println!("Testing {} models...", result.total);
+        let scope = match model_filter {
+            Some(m) => format!(" (model={m})"),
+            None => String::new(),
+        };
+        println!("Testing {} models{scope}...", result.total);
         println!();
 
         for d in &result.diagnostics {
@@ -85,8 +115,6 @@ pub fn run_test(
             result.failures.len()
         );
     }
-
-    let _ = model_filter; // TODO: filter to single model
 
     if !result.failures.is_empty() {
         anyhow::bail!("test failures detected");

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1215,6 +1215,13 @@ pub struct TestOutput {
     pub passed: usize,
     pub failed: usize,
     pub failures: Vec<TestFailure>,
+    /// Per-model outcomes for the (DuckDB-backed) model-execution test —
+    /// passes too, not just failures. Lets the VS Code Inspector Tests tab
+    /// and the dagster integration render "good_mart: pass" without
+    /// inferring it from `total - failures`. Empty when only declarative
+    /// tests ran. Filtered to `--model` when that flag is set.
+    #[serde(default)]
+    pub model_results: Vec<ModelTestResult>,
     /// Results from declarative `[[tests]]` in model sidecars.
     /// Present only when `--declarative` is used.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1228,6 +1235,21 @@ pub struct TestOutput {
 pub struct TestFailure {
     pub name: String,
     pub error: String,
+}
+
+/// One per-model outcome from the local model-execution test.
+///
+/// `status` is `"pass"` or `"fail"`. `error` is set only when `status =
+/// "fail"`. Mirrors `rocky_engine::test_runner::ModelTestResult` with the
+/// status flattened to a string so consumers (Pydantic, TypeScript) get a
+/// stable, JSON-Schema-friendly shape.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ModelTestResult {
+    pub model: String,
+    /// `"pass"` or `"fail"`.
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Summary of declarative test execution (from `[[tests]]` in model sidecars).
@@ -1273,8 +1295,16 @@ impl TestOutput {
             passed,
             failed: failures.len(),
             failures,
+            model_results: Vec::new(),
             declarative: None,
         }
+    }
+
+    /// Attach per-model results from the engine test runner. Returns `self`
+    /// so callers can chain it onto `new(...)`.
+    pub fn with_model_results(mut self, results: Vec<ModelTestResult>) -> Self {
+        self.model_results = results;
+        self
     }
 }
 
@@ -1825,11 +1855,28 @@ pub struct AiContractColumnProfile {
 /// low-cardinality domain) for a model's target table, computed by a single
 /// aggregate query per column. DuckDB-only this release; a non-DuckDB target
 /// reports `unavailable` with an empty `columns` list rather than erroring.
+///
+/// When the model's declared target isn't materialized (the agentic authoring
+/// loop pre-`rocky run`, or a replication-pipeline POC that doesn't run the
+/// transformation models), profile falls back to the model's first resolvable
+/// source table. The fallback is labelled via `profiled_table` (the table
+/// actually queried) and `fell_back_from` (the missing target), so consumers
+/// can surface "source preview, not model output" in the UI.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ProfileOutput {
     pub version: String,
     pub command: String,
     pub model: String,
+    /// Fully-qualified table actually profiled (e.g. `staging.raw_orders` or
+    /// `raw__orders.orders`). When `fell_back_from` is set, this differs from
+    /// the model's declared target. Omitted when `unavailable` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profiled_table: Option<String>,
+    /// When set, profile fell back to a source because the model's declared
+    /// target wasn't materialized; carries the declared-target FQN that was
+    /// missing. `None` when the declared target was profiled directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fell_back_from: Option<String>,
     /// One entry per profiled column.
     pub columns: Vec<ProfileColumnStats>,
     /// Set when profiling could not run (e.g. a non-DuckDB target this release).

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.46.0"
+version = "1.46.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.46.0"
+version = "1.46.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.46.0"
+version = "1.46.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true
@@ -22,6 +22,9 @@ chrono = { workspace = true }
 [features]
 default = ["duckdb"]
 duckdb = ["dep:rocky-duckdb"]
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-engine/src/ci.rs
+++ b/engine/crates/rocky-engine/src/ci.rs
@@ -56,7 +56,7 @@ pub fn run_ci(models_dir: &Path, contracts_dir: Option<&Path>) -> anyhow::Result
 
     // Step 1: Compile
     info!("step 1: compile");
-    let test_result = crate::test_runner::run_tests(models_dir, contracts_dir)?;
+    let test_result = crate::test_runner::run_tests(models_dir, contracts_dir, None)?;
 
     let compile_ok = !test_result
         .diagnostics

--- a/engine/crates/rocky-engine/src/test_runner.rs
+++ b/engine/crates/rocky-engine/src/test_runner.rs
@@ -10,15 +10,38 @@ use rocky_compiler::compile::CompilerConfig;
 use rocky_duckdb::DuckDbConnector;
 use tracing::info;
 
+/// Per-model outcome of a local test run.
+///
+/// Surfaces passes alongside failures so consumers (the VS Code Inspector
+/// Tests tab, the dagster integration) can render "good_mart: pass" instead
+/// of inferring it from `total - failures`. `error` is populated only for
+/// `status = "fail"`.
+#[derive(Debug, Clone)]
+pub struct ModelTestResult {
+    pub model: String,
+    pub status: ModelTestStatus,
+    pub error: Option<String>,
+}
+
+/// Outcome of executing one model locally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelTestStatus {
+    Pass,
+    Fail,
+}
+
 /// Result of a test run.
 #[derive(Debug)]
 pub struct TestResult {
-    /// Total models tested.
+    /// Total models tested (post-filter).
     pub total: usize,
-    /// Models that passed all checks.
+    /// Models that passed all checks (post-filter).
     pub passed: usize,
-    /// Models that failed (name, reason).
+    /// Models that failed (name, reason) (post-filter).
     pub failures: Vec<(String, String)>,
+    /// Per-model outcomes (post-filter). Includes passes — the only way to
+    /// surface "good_mart: pass" without inferring from total - failures.
+    pub model_results: Vec<ModelTestResult>,
     /// Compilation diagnostics.
     pub diagnostics: Vec<rocky_compiler::diagnostic::Diagnostic>,
 }
@@ -26,10 +49,15 @@ pub struct TestResult {
 /// Run tests on a project.
 ///
 /// 1. Compile models
-/// 2. Execute each model locally via DuckDB
+/// 2. Execute each model locally via DuckDB (dependencies always run, even
+///    when `model_filter` is set, so the filtered model's SQL can resolve)
 /// 3. Validate output against contracts (if present)
-/// 4. Report results
-pub fn run_tests(models_dir: &Path, contracts_dir: Option<&Path>) -> anyhow::Result<TestResult> {
+/// 4. Report results (filtered to `model_filter` when set)
+pub fn run_tests(
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    model_filter: Option<&str>,
+) -> anyhow::Result<TestResult> {
     let config = CompilerConfig {
         models_dir: models_dir.to_path_buf(),
         contracts_dir: contracts_dir.map(std::path::Path::to_path_buf),
@@ -41,21 +69,28 @@ pub fn run_tests(models_dir: &Path, contracts_dir: Option<&Path>) -> anyhow::Res
     let compile_result = rocky_compiler::compile::compile(&config)?;
 
     let mut result = TestResult {
-        total: compile_result.project.model_count(),
+        total: 0,
         passed: 0,
         failures: Vec::new(),
+        model_results: Vec::new(),
         diagnostics: compile_result.diagnostics.clone(),
     };
 
     // Check for compilation errors
     if compile_result.has_errors {
         for d in &compile_result.diagnostics {
-            if d.is_error() {
+            if d.is_error() && include_model(model_filter, &d.model) {
                 result
                     .failures
                     .push((d.model.clone(), d.message.to_string()));
+                result.model_results.push(ModelTestResult {
+                    model: d.model.clone(),
+                    status: ModelTestStatus::Fail,
+                    error: Some(d.message.to_string()),
+                });
             }
         }
+        result.total = result.model_results.len();
         return Ok(result);
     }
 
@@ -74,23 +109,135 @@ pub fn run_tests(models_dir: &Path, contracts_dir: Option<&Path>) -> anyhow::Res
                     "seed".to_string(),
                     format!("failed to load data/seed.sql: {e}"),
                 ));
+                result.model_results.push(ModelTestResult {
+                    model: "seed".to_string(),
+                    status: ModelTestStatus::Fail,
+                    error: Some(format!("failed to load data/seed.sql: {e}")),
+                });
+                result.total = result.model_results.len();
                 return Ok(result);
             }
             info!(path = %seed_path.display(), "loaded seed data");
         }
     }
 
+    // Always execute every model so a filtered model's upstream dependencies
+    // resolve. The filter is applied below when assembling the reported
+    // results, so passes/failures match the requested scope.
     let exec_result = crate::executor::execute_locally(&compile_result, &db);
 
-    result.passed = exec_result.succeeded.len();
-    result.failures.extend(exec_result.failed);
+    for name in &exec_result.succeeded {
+        if include_model(model_filter, name) {
+            result.model_results.push(ModelTestResult {
+                model: name.clone(),
+                status: ModelTestStatus::Pass,
+                error: None,
+            });
+        }
+    }
+    for (name, err) in &exec_result.failed {
+        if include_model(model_filter, name) {
+            result.failures.push((name.clone(), err.clone()));
+            result.model_results.push(ModelTestResult {
+                model: name.clone(),
+                status: ModelTestStatus::Fail,
+                error: Some(err.clone()),
+            });
+        }
+    }
+    result.total = result.model_results.len();
+    result.passed = result
+        .model_results
+        .iter()
+        .filter(|m| m.status == ModelTestStatus::Pass)
+        .count();
 
     info!(
         total = result.total,
         passed = result.passed,
         failed = result.failures.len(),
+        filter = model_filter.unwrap_or("<none>"),
         "test run complete"
     );
 
     Ok(result)
+}
+
+/// Filter helper: include a model when there's no filter, or when the filter
+/// matches the model name exactly. Centralized so callers can't accidentally
+/// substring-match.
+fn include_model(filter: Option<&str>, model: &str) -> bool {
+    match filter {
+        None => true,
+        Some(target) => target == model,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Set up a temp project with two SQL models (`raw_orders`, `good_mart`)
+    /// where `good_mart` reads from `raw_orders`. Returns the temp dir guard
+    /// so the caller can drop it.
+    fn scaffold_two_model_project() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        std::fs::write(
+            models.join("raw_orders.sql"),
+            "SELECT 1 AS id, 'a' AS status",
+        )
+        .unwrap();
+        std::fs::write(
+            models.join("raw_orders.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog=\"wh\"\nschema=\"main\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            models.join("good_mart.sql"),
+            "SELECT id, status FROM raw_orders",
+        )
+        .unwrap();
+        std::fs::write(
+            models.join("good_mart.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog=\"wh\"\nschema=\"main\"\n",
+        )
+        .unwrap();
+        (dir, models)
+    }
+
+    /// Unfiltered run reports every model — passes too, not just failures —
+    /// so the Inspector Tests tab can render "raw_orders: pass" without
+    /// inferring it from `total - failures`.
+    #[test]
+    fn full_run_itemizes_passes() {
+        let (_tmp, models) = scaffold_two_model_project();
+        let result = run_tests(&models, None, None).unwrap();
+        assert_eq!(result.total, 2);
+        assert_eq!(result.passed, 2);
+        assert!(result.failures.is_empty());
+        let names: Vec<_> = result
+            .model_results
+            .iter()
+            .map(|m| (m.model.as_str(), m.status))
+            .collect();
+        assert!(names.contains(&("raw_orders", ModelTestStatus::Pass)));
+        assert!(names.contains(&("good_mart", ModelTestStatus::Pass)));
+    }
+
+    /// `--model good_mart` filters the reported results to one model. The
+    /// upstream `raw_orders` still executes (so good_mart's SQL resolves)
+    /// but doesn't appear in `model_results`. Closes the TODO that had
+    /// `rocky test --model X` silently testing every model.
+    #[test]
+    fn model_filter_scopes_results_to_one_model() {
+        let (_tmp, models) = scaffold_two_model_project();
+        let result = run_tests(&models, None, Some("good_mart")).unwrap();
+        assert_eq!(result.total, 1);
+        assert_eq!(result.passed, 1);
+        assert_eq!(result.model_results.len(), 1);
+        assert_eq!(result.model_results[0].model, "good_mart");
+        assert_eq!(result.model_results[0].status, ModelTestStatus::Pass);
+    }
 }

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.46.0"
+version = "1.46.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.46.0"
+version = "1.46.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.46.0"
+version = "1.46.1"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.46.0"
+version = "1.46.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -410,7 +410,8 @@ impl RockyMcpServer {
          return pass/fail counts plus per-failure detail. Use after writing or changing a model."
     )]
     async fn test(&self) -> Result<Json<TestResult>, String> {
-        let output = commands::test_output(&self.models_dir, None).map_err(|e| format!("{e:#}"))?;
+        let output =
+            commands::test_output(&self.models_dir, None, None).map_err(|e| format!("{e:#}"))?;
         let failures = output
             .failures
             .into_iter()

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.46.0"
+version = "1.46.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.46.0"
+version = "1.46.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.46.0"
+version = "1.46.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.46.0"
+version = "1.46.1"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.46.0"
+version = "1.46.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.46.0"
+version = "1.46.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/src/dagster_rocky/types_generated/profile_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/profile_schema.py
@@ -33,6 +33,8 @@ class ProfileOutput(BaseModel):
     JSON output for `rocky profile <model> [--column <col>]`.
 
     A per-column data profile (row / null / distinct counts, min / max, and the low-cardinality domain) for a model's target table, computed by a single aggregate query per column. DuckDB-only this release; a non-DuckDB target reports `unavailable` with an empty `columns` list rather than erroring.
+
+    When the model's declared target isn't materialized (the agentic authoring loop pre-`rocky run`, or a replication-pipeline POC that doesn't run the transformation models), profile falls back to the model's first resolvable source table. The fallback is labelled via `profiled_table` (the table actually queried) and `fell_back_from` (the missing target), so consumers can surface "source preview, not model output" in the UI.
     """
 
     columns: list[ProfileColumnStats]
@@ -40,7 +42,15 @@ class ProfileOutput(BaseModel):
     One entry per profiled column.
     """
     command: str
+    fell_back_from: str | None = None
+    """
+    When set, profile fell back to a source because the model's declared target wasn't materialized; carries the declared-target FQN that was missing. `None` when the declared target was profiled directly.
+    """
     model: str
+    profiled_table: str | None = None
+    """
+    Fully-qualified table actually profiled (e.g. `staging.raw_orders` or `raw__orders.orders`). When `fell_back_from` is set, this differs from the model's declared target. Omitted when `unavailable` is set.
+    """
     unavailable: str | None = None
     """
     Set when profiling could not run (e.g. a non-DuckDB target this release).

--- a/integrations/dagster/src/dagster_rocky/types_generated/test_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/test_schema.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, conint
+from pydantic import BaseModel, Field, conint
 
 
 class DeclarativeTestResult(BaseModel):
@@ -58,6 +58,21 @@ class DeclarativeTestSummary(BaseModel):
     warned: conint(ge=0)
 
 
+class ModelTestResult(BaseModel):
+    """
+    One per-model outcome from the local model-execution test.
+
+    `status` is `"pass"` or `"fail"`. `error` is set only when `status = "fail"`. Mirrors `rocky_engine::test_runner::ModelTestResult` with the status flattened to a string so consumers (Pydantic, TypeScript) get a stable, JSON-Schema-friendly shape.
+    """
+
+    error: str | None = None
+    model: str
+    status: str
+    """
+    `"pass"` or `"fail"`.
+    """
+
+
 class TestFailure(BaseModel):
     """
     One failed test, mirroring the (name, error) tuple in `rocky_engine::test_runner::TestResult::failures` but with named fields because schemars/JSON Schema can't represent positional tuples cleanly.
@@ -79,6 +94,10 @@ class TestOutput(BaseModel):
     """
     failed: conint(ge=0)
     failures: list[TestFailure]
+    model_results: list[ModelTestResult] | None = Field([], validate_default=True)
+    """
+    Per-model outcomes for the (DuckDB-backed) model-execution test — passes too, not just failures. Lets the VS Code Inspector Tests tab and the dagster integration render "good_mart: pass" without inferring it from `total - failures`. Empty when only declarative tests ran. Filtered to `--model` when that flag is set.
+    """
     passed: conint(ge=0)
     total: conint(ge=0)
     version: str

--- a/integrations/dagster/tests/fixtures_generated/lineage/test.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage/test.json
@@ -4,5 +4,19 @@
   "total": 3,
   "passed": 3,
   "failed": 0,
-  "failures": []
+  "failures": [],
+  "model_results": [
+    {
+      "model": "raw_orders",
+      "status": "pass"
+    },
+    {
+      "model": "stg_orders",
+      "status": "pass"
+    },
+    {
+      "model": "fct_revenue",
+      "status": "pass"
+    }
+  ]
 }

--- a/integrations/dagster/tests/fixtures_generated/test.json
+++ b/integrations/dagster/tests/fixtures_generated/test.json
@@ -4,5 +4,19 @@
   "total": 3,
   "passed": 3,
   "failed": 0,
-  "failures": []
+  "failures": [],
+  "model_results": [
+    {
+      "model": "raw_orders",
+      "status": "pass"
+    },
+    {
+      "model": "customer_orders",
+      "status": "pass"
+    },
+    {
+      "model": "revenue_summary",
+      "status": "pass"
+    }
+  ]
 }

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -62,7 +62,7 @@
       "type": "object"
     }
   },
-  "description": "JSON output for `rocky profile <model> [--column <col>]`.\n\nA per-column data profile (row / null / distinct counts, min / max, and the low-cardinality domain) for a model's target table, computed by a single aggregate query per column. DuckDB-only this release; a non-DuckDB target reports `unavailable` with an empty `columns` list rather than erroring.",
+  "description": "JSON output for `rocky profile <model> [--column <col>]`.\n\nA per-column data profile (row / null / distinct counts, min / max, and the low-cardinality domain) for a model's target table, computed by a single aggregate query per column. DuckDB-only this release; a non-DuckDB target reports `unavailable` with an empty `columns` list rather than erroring.\n\nWhen the model's declared target isn't materialized (the agentic authoring loop pre-`rocky run`, or a replication-pipeline POC that doesn't run the transformation models), profile falls back to the model's first resolvable source table. The fallback is labelled via `profiled_table` (the table actually queried) and `fell_back_from` (the missing target), so consumers can surface \"source preview, not model output\" in the UI.",
   "properties": {
     "columns": {
       "description": "One entry per profiled column.",
@@ -74,8 +74,22 @@
     "command": {
       "type": "string"
     },
+    "fell_back_from": {
+      "description": "When set, profile fell back to a source because the model's declared target wasn't materialized; carries the declared-target FQN that was missing. `None` when the declared target was profiled directly.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "model": {
       "type": "string"
+    },
+    "profiled_table": {
+      "description": "Fully-qualified table actually profiled (e.g. `staging.raw_orders` or `raw__orders.orders`). When `fell_back_from` is set, this differs from the model's declared target. Omitted when `unavailable` is set.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "unavailable": {
       "description": "Set when profiling could not run (e.g. a non-DuckDB target this release).",

--- a/schemas/test.schema.json
+++ b/schemas/test.schema.json
@@ -98,6 +98,29 @@
       ],
       "type": "object"
     },
+    "ModelTestResult": {
+      "description": "One per-model outcome from the local model-execution test.\n\n`status` is `\"pass\"` or `\"fail\"`. `error` is set only when `status = \"fail\"`. Mirrors `rocky_engine::test_runner::ModelTestResult` with the status flattened to a string so consumers (Pydantic, TypeScript) get a stable, JSON-Schema-friendly shape.",
+      "properties": {
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": "string"
+        },
+        "status": {
+          "description": "`\"pass\"` or `\"fail\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "model",
+        "status"
+      ],
+      "type": "object"
+    },
     "TestFailure": {
       "description": "One failed test, mirroring the (name, error) tuple in `rocky_engine::test_runner::TestResult::failures` but with named fields because schemars/JSON Schema can't represent positional tuples cleanly.",
       "properties": {
@@ -139,6 +162,14 @@
     "failures": {
       "items": {
         "$ref": "#/definitions/TestFailure"
+      },
+      "type": "array"
+    },
+    "model_results": {
+      "default": [],
+      "description": "Per-model outcomes for the (DuckDB-backed) model-execution test — passes too, not just failures. Lets the VS Code Inspector Tests tab and the dagster integration render \"good_mart: pass\" without inferring it from `total - failures`. Empty when only declarative tests ran. Filtered to `--model` when that flag is set.",
+      "items": {
+        "$ref": "#/definitions/ModelTestResult"
       },
       "type": "array"
     },


### PR DESCRIPTION
Two post-release fixes from the Inspector-overhaul review, plus the matching release bumps (engine `1.46.0 → 1.46.1`, vscode `1.30.1 → 1.30.2`). dagster is excluded — only its generated bindings + fixtures change, no source.

## Bug 1 — Profile tab / inline column profiling were dead

`rocky profile <model>` failed with a raw `Table "<schema>.<model>" does not exist` catalog error.

The cause was **not** the table-ref construction (that's correct — a transformation model materialises to its literal `target.{catalog,schema,table}`, and profiling a transformation pipeline already worked). The model simply wasn't materialised: the demo POCs are **replication** pipelines, which replicate sources to `staging__<source>` and never build the transformation models in `models/`.

**Fix:** profile probes the declared target and, when it's missing, falls back to the model's first resolvable source table — useful both for these POCs and for the agentic authoring loop (profiling before a run). The substitution is reported in `ProfileOutput.profiled_table` / `fell_back_from`, so the JSON (and the Inspector) can label it "source preview, not model output." With no source to fall back to, it returns a clear "run `rocky run` first" message. `rocky ai-contract` keeps the stricter behaviour: it refuses an unmaterialised target rather than drafting a contract from source data.

## Bug 2 — Tests tab showed "No declarative tests" even when tests pass

The tab only rendered declarative `[[tests]]`; a model's passing "tests" were per-model execution checks the engine reported only as aggregate counts.

**Fix:**
- `TestOutput` now itemises `model_results` (one `pass`/`fail` per model) instead of only listing failures.
- `rocky test --model <name>` now actually filters to that model (its dependencies still execute so the model resolves) — closing a long-standing TODO where the flag was accepted but ignored.
- The Inspector Tests tab shows a **Model executes** pass/fail banner; the Profile tab shows the source-fallback banner.

## Verification

- New unit tests: profile source-fallback + no-fallback-when-materialised; test `--model` filter + per-model passes. Full workspace `cargo test`, clippy `--all-targets`, fmt all green.
- `just codegen` + `just regen-fixtures` regenerated; no drift.
- Inspector audited frame-by-frame against the built binary: Tests, Profile, Columns, and Overview all render correctly.

## Known follow-up (not in this PR)

`ProfileColumnStats.type` reports `Unknown` for raw-SQL models — a pre-existing type-inference gap in `profile_column`, unrelated to this change.

## Release

After merge, tag the merged commit twice: `engine-v1.46.1` and `vscode-v1.30.2`. engine-v1.46.1 should be marked Latest if the publish order flips it.