### PR TITLE
feat(vscode): polish the Inspector Cmd+K model-search palette

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Inspector Cmd+K model search is richer and keyboard-navigable.** Each result is now a two-line row — a color-coded kind tile (matching the lineage canvas), the model name, and its fully-qualified target — with a leading search icon and a keyboard-hint footer. The keyboard-selected row now highlights correctly (it keyed off `:focus`, which the command palette never sets — it marks the active row with `aria-selected`).
+
 ## [1.30.2] — 2026-05-28
 
 ### Fixed

--- a/editors/vscode/webview-ui/panels/inspector/InspectorApp.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/InspectorApp.tsx
@@ -165,6 +165,7 @@ export function InspectorApp() {
         id: n.id,
         label: n.label,
         fqn: n.fqn,
+        kind: n.kind,
       })),
     [lineage.graph],
   );

--- a/editors/vscode/webview-ui/panels/inspector/ModelSearch.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/ModelSearch.tsx
@@ -6,10 +6,11 @@ import {
   ElDialogBackdrop,
   ElDialogPanel,
 } from "@tailwindplus/elements/react";
+import { kindColor, kindGlyph } from "./colors";
 
 interface ModelSearchProps {
   /** Project models to search, in display order. */
-  models: { id: string; label: string; fqn: string }[];
+  models: { id: string; label: string; fqn: string; kind: string }[];
   open: boolean;
   onClose: () => void;
   /** A model was picked — re-target the Inspector to it. */
@@ -20,11 +21,14 @@ type DialogElement = HTMLElement & { show(): void; hide(): void };
 
 /**
  * Cmd+K model search — a TailwindPlus Elements command palette inside a dialog.
- * The palette filters the model buttons as you type and handles keyboard nav;
- * picking one re-targets the Inspector. Themed to `--vscode-*` like the rest of
- * the webview. Driven from React state via the el-dialog `show()`/`hide()`
- * methods (gated on the element being defined). See the `tailwind-plus-elements`
- * skill for the integration notes.
+ * The palette filters the model rows as you type (toggling each row's `hidden`)
+ * and marks the active row with `aria-selected` for keyboard nav; picking one
+ * re-targets the Inspector. Browse-then-filter: an empty query lists every
+ * model (no `el-no-results`, per the `tailwind-plus-elements` skill). The input
+ * is uncontrolled so React never re-renders the row list out from under the
+ * palette's filtering. Each row reuses the canvas's `kindColor` / `kindGlyph`
+ * so a model reads the same here as on the lineage graph. Themed to
+ * `--vscode-*`; driven from React state via the el-dialog `show()`/`hide()`.
  */
 export function ModelSearch({
   models,
@@ -78,26 +82,65 @@ export function ModelSearch({
         <ElDialogBackdrop className="fixed inset-0 bg-black/50 transition duration-150 data-[closed]:opacity-0" />
         <ElDialogPanel className="overflow-hidden rounded-lg border border-vscode-border bg-vscode-widget-bg shadow-2xl transition duration-150 data-[closed]:scale-95 data-[closed]:opacity-0">
           <ElCommandPalette>
-            <input
-              ref={inputRef}
-              placeholder="Search models…"
-              className="w-full border-b border-vscode-border bg-transparent px-4 py-3 text-sm text-vscode-fg outline-none placeholder:text-vscode-desc"
-            />
-            <ElCommandList className="block max-h-80 overflow-auto p-2">
+            {/* Search input with a leading magnifying-glass, layered via a
+                single-cell grid so the icon sits inside the input's padding. */}
+            <div className="grid grid-cols-1 border-b border-vscode-border">
+              <input
+                ref={inputRef}
+                placeholder="Search models…"
+                className="col-start-1 row-start-1 h-11 w-full bg-transparent pr-4 pl-10 text-sm text-vscode-fg outline-none placeholder:text-vscode-desc"
+              />
+              <svg
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+                className="pointer-events-none col-start-1 row-start-1 ml-3.5 size-4 self-center text-vscode-desc"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9Z"
+                />
+              </svg>
+            </div>
+            <ElCommandList className="block max-h-80 scroll-py-2 overflow-auto p-2">
               {models.map((m) => (
                 <button
                   key={m.id}
                   hidden
                   type="button"
                   onClick={() => pick(m.id)}
-                  className="flex w-full items-baseline gap-2 rounded px-3 py-1.5 text-left text-sm text-vscode-fg outline-none hover:bg-[var(--vscode-list-hoverBackground)] focus:bg-[var(--vscode-list-activeSelectionBackground)] focus:text-[var(--vscode-list-activeSelectionForeground)]"
+                  className="group flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left outline-none aria-selected:bg-[var(--vscode-list-activeSelectionBackground)]"
                 >
-                  <span className="font-mono">{m.label}</span>
-                  <span className="truncate text-xs text-vscode-desc">{m.fqn}</span>
+                  <span
+                    aria-hidden="true"
+                    className="flex size-7 flex-none items-center justify-center rounded text-[10px] font-semibold tracking-wide text-[var(--vscode-editor-background)]"
+                    style={{ backgroundColor: kindColor(m.kind) }}
+                  >
+                    {kindGlyph(m.kind)}
+                  </span>
+                  <span className="min-w-0 flex-auto">
+                    <span className="block truncate font-mono text-sm text-vscode-fg group-aria-selected:text-[var(--vscode-list-activeSelectionForeground)]">
+                      {m.label}
+                    </span>
+                    <span className="block truncate text-xs text-vscode-desc group-aria-selected:text-[var(--vscode-list-activeSelectionForeground)]">
+                      {m.fqn}
+                    </span>
+                  </span>
+                  <span className="flex-none text-[10px] tracking-wide text-vscode-desc uppercase group-aria-selected:text-[var(--vscode-list-activeSelectionForeground)]">
+                    {m.kind}
+                  </span>
                 </button>
               ))}
             </ElCommandList>
           </ElCommandPalette>
+          {/* Static keyboard-hint footer (outside the palette so it's never
+              filtered). */}
+          <div className="flex items-center justify-end gap-4 border-t border-vscode-border px-3 py-1.5 text-[10px] text-vscode-desc">
+            <span>↑↓ navigate</span>
+            <span>↵ open</span>
+            <span>esc dismiss</span>
+          </div>
         </ElDialogPanel>
       </dialog>
     </ElDialog>


### PR DESCRIPTION
The Inspector's Cmd+K model search "needed some love."

## What was wrong

- Rows were flat single-line text (`name` + `fqn`), no visual anchor.
- The keyboard-selected row was styled with `:focus` — but `el-command-palette` marks the active option with **`aria-selected`**, not focus, so arrowing through the list showed **no highlight**.

## Change (`ModelSearch.tsx` + a `kind` passthrough in `InspectorApp.tsx`)

- **Keyboard nav highlights now** — switched to `aria-selected` / `group-aria-selected` variants (built-in in Tailwind v3.4; confirmed generated).
- **Two-line rows** — a color-coded kind tile reusing the canvas's `kindColor` / `kindGlyph` (a model reads the same here as on the lineage graph), the model name, its fully-qualified target, and a kind label.
- **Leading search icon** in the input + a keyboard-hint footer.
- Kept **browse-then-filter** (empty query lists all models; no `el-no-results`) and the **uncontrolled input**, so React never re-renders the rows out from under the palette's `hidden`-based filtering — per the `tailwind-plus-elements` skill.

Themed entirely to `--vscode-*` (no hard-coded palette).

## Verification

`npm run typecheck:webview` + `lint` + `bundle` + `test:unit` (194) green. Recorded the palette against the built binary and audited frame-by-frame: open → browse-all → filter (`order`) → **ArrowDown moves the `aria-selected` highlight** across rows; tiles, two-line rows, and footer all render correctly in the workbench theme.

vscode-only; lands under `[Unreleased]`, rides the next vscode cut.