### PR TITLE
chore(release): engine 1.46.3 + vscode 1.30.3

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.30.3] — 2026-05-28
+
 ### Changed
 
 - **Inspector Cmd+K model search is richer and keyboard-navigable.** Each result is now a two-line row — a color-coded kind tile (matching the lineage canvas), the model name, and its fully-qualified target — with a leading search icon and a keyboard-hint footer. The keyboard-selected row now highlights correctly (it keyed off `:focus`, which the command palette never sets — it marks the active row with `aria-selected`).

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.30.2",
+      "version": "1.30.3",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.3] — 2026-05-28
+
 ### Changed
 
 - **`rocky playground` now scaffolds a runnable transformation pipeline.** The quickstart project's models materialize via `rocky run` into the database's default schema (`playground.main`), so `rocky run` → `rocky preview rows` / `rocky profile` (and the VS Code Inspector) work end-to-end on a fresh scaffold. Previously the scaffold was a replication pipeline whose models only ran under `rocky test`.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "redis",
  "serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "blake3",
  "chrono",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "logos",
  "miette",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "miette",
  "regex",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.46.2"
+version = "1.46.3"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.46.2"
+version = "1.46.3"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.46.2"
+version = "1.46.3"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.46.2"
+version = "1.46.3"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.46.2"
+version = "1.46.3"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.46.2"
+version = "1.46.3"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.46.2"
+version = "1.46.3"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.46.2"
+version = "1.46.3"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.46.2"
+version = "1.46.3"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.46.2"
+version = "1.46.3"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.46.2"
+version = "1.46.3"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.46.2"
+version = "1.46.3"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.46.2"
+version = "1.46.3"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.46.2"
+version = "1.46.3"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.46.2"
+version = "1.46.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.46.2"
+version = "1.46.3"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.46.2"
+version = "1.46.3"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.46.2"
+version = "1.46.3"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.46.2"
+version = "1.46.3"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.46.2"
+version = "1.46.3"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.46.2"
+version = "1.46.3"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Double-cut release of the unreleased work on main. dagster has no unreleased changes (stays 1.42.0).

### engine 1.46.2 → 1.46.3
- `rocky playground` scaffolds a runnable transformation pipeline (models materialize via `rocky run` into `playground.main`; profile/preview/Inspector work on a fresh scaffold). (#741)
- `rocky preview rows` gives accurate guidance on replication pipelines instead of unconditionally advising `rocky run`. (#741)

### vscode 1.30.2 → 1.30.3
- Inspector Cmd+K model search: richer two-line rows (kind tile + name + FQN), search icon, keyboard-hint footer, and a fixed `aria-selected` keyboard highlight. (#742)

### This PR
- Bumps all 25 engine crate versions + `Cargo.lock`, and `editors/vscode/package.json` + `package-lock.json`.
- Moves each `[Unreleased]` CHANGELOG section under its dated version.

After merge: tag the merged commit `engine-v1.46.3` and `vscode-v1.30.3`, push both. `engine-v1.46.3` should be marked Latest if the publish order flips it.