### PR TITLE
fix(engine): load .rocky DSL models in all model-listing commands

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`.rocky` DSL models are no longer invisible to non-run commands.** `validate`, `list`, `dag`, `optimize`, `compliance`, `preview`, `estimate`, `docs`, and branch scoping loaded models through a `.sql`-only path, so a project with `.rocky` DSL models had them silently dropped — most visibly, `rocky validate` reported a false `DAG error: unknown dependency` when a `.rocky` model sat between two `.sql` models in a transformation DAG. All these commands now load `.sql` and `.rocky` models through one shared loader.
+
 ## [1.46.3] — 2026-05-28
 
 ### Changed

--- a/engine/crates/rocky-cli/src/commands/branch.rs
+++ b/engine/crates/rocky-cli/src/commands/branch.rs
@@ -1122,21 +1122,9 @@ fn discover_transformation_branch_targets(
     }
 
     // Load the same way `rocky list models` does: top-level files plus
-    // immediate subdirectories. Keeps behavior consistent with the rest of
-    // the transformation surface (run, plan, list).
-    let mut all_models = rocky_core::models::load_models_from_dir(&models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-    if let Ok(entries) = std::fs::read_dir(&models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
-            {
-                all_models.extend(sub);
-            }
-        }
-    }
+    // immediate subdirectories (incl. `.rocky` DSL). Keeps behavior consistent
+    // with the rest of the transformation surface (run, plan, list).
+    let all_models = crate::models_loader::load_project_models(&models_dir)?;
 
     let shadow_cfg = ShadowConfig {
         suffix: "_rocky_shadow".to_string(),

--- a/engine/crates/rocky-cli/src/commands/compliance.rs
+++ b/engine/crates/rocky-cli/src/commands/compliance.rs
@@ -202,21 +202,10 @@ fn strategy_wire_name(s: MaskStrategy) -> &'static str {
     s.as_str()
 }
 
-/// Recursive model loader — mirrors `dag.rs::load_all_models` (one level
-/// of subdirectories).
+/// Recursive model loader (top level + one level of subdirectories,
+/// including `.rocky` DSL files).
 fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
-    let mut all = rocky_core::models::load_models_from_dir(models_dir)
-        .with_context(|| format!("failed to load models from {}", models_dir.display()))?;
-
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
-            {
-                all.extend(sub);
-            }
-        }
-    }
+    let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(all)
 }

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -314,26 +314,10 @@ fn build_column_lineage_from_models(
     Ok(edges)
 }
 
-/// Load models from a directory and its immediate subdirectories.
-///
-/// Duplicated from `list.rs` — both commands need the same recursive
-/// model loading. A shared helper would be ideal but this keeps the
-/// diff contained for now.
+/// Load models from a directory and its immediate subdirectories
+/// (including `.rocky` DSL files), sorted by name.
 pub(super) fn load_all_models(models_dir: &Path) -> Result<Vec<Model>> {
-    let mut all = rocky_core::models::load_models_from_dir(models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
-            {
-                all.extend(sub);
-            }
-        }
-    }
+    let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(all)
 }

--- a/engine/crates/rocky-cli/src/commands/docs.rs
+++ b/engine/crates/rocky-cli/src/commands/docs.rs
@@ -28,11 +28,8 @@ pub fn run_docs(
         config_path.display()
     ))?;
 
-    // Discover models.
-    let models = rocky_core::models::load_models_from_dir(models_dir).context(format!(
-        "failed to discover models in {}",
-        models_dir.display()
-    ))?;
+    // Discover models (top level + subdirs, including `.rocky` DSL files).
+    let models = crate::models_loader::load_project_models(models_dir)?;
 
     let models_count = models.len();
 

--- a/engine/crates/rocky-cli/src/commands/estimate.rs
+++ b/engine/crates/rocky-cli/src/commands/estimate.rs
@@ -161,22 +161,10 @@ async fn run_explain(
     })
 }
 
-/// Load all models from a directory including one level of subdirectories.
+/// Load all models from a directory including one level of subdirectories
+/// (including `.rocky` DSL files).
 fn load_all_models(models_dir: &Path) -> Result<Vec<models::Model>> {
-    let mut all = models::load_models_from_dir(models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = models::load_models_from_dir(&entry.path())
-            {
-                all.extend(sub);
-            }
-        }
-    }
+    let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(all)
 }

--- a/engine/crates/rocky-cli/src/commands/list.rs
+++ b/engine/crates/rocky-cli/src/commands/list.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use crate::output::*;
 
@@ -259,22 +259,9 @@ pub fn list_sources(config_path: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
-/// Load all models from a directory (with subdirectory scan).
+/// Load all models from a directory (with subdirectory scan, incl. `.rocky`).
 fn load_all_models(models_dir: &Path) -> Result<Vec<rocky_core::models::Model>> {
-    let mut all = rocky_core::models::load_models_from_dir(models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
-            {
-                all.extend(sub);
-            }
-        }
-    }
+    let mut all = crate::models_loader::load_project_models(models_dir)?;
     all.sort_unstable_by(|a, b| a.config.name.cmp(&b.config.name));
     Ok(all)
 }

--- a/engine/crates/rocky-cli/src/commands/optimize.rs
+++ b/engine/crates/rocky-cli/src/commands/optimize.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use anyhow::Result;
 
 use rocky_core::cost::downstream_counts;
-use rocky_core::models;
 use rocky_core::optimize::{CostConfig, MaterializationCost, ModelStats, recommend_strategy};
 use rocky_core::state::StateStore;
 use rocky_ir::dag::DagNode;
@@ -173,21 +172,10 @@ fn load_dag_from_models(models_dir: Option<&Path>) -> Vec<DagNode> {
         return vec![];
     };
 
-    let mut all_models = match models::load_models_from_dir(dir) {
-        Ok(m) => m,
-        Err(_) => return vec![],
+    // Top-level + immediate subdirectories, including `.rocky` DSL files.
+    let Ok(all_models) = crate::models_loader::load_project_models(dir) else {
+        return vec![];
     };
-
-    // Also check one level of subdirectories (same pattern as estimate.rs).
-    if let Ok(entries) = std::fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = models::load_models_from_dir(&entry.path())
-            {
-                all_models.extend(sub);
-            }
-        }
-    }
 
     all_models
         .iter()

--- a/engine/crates/rocky-cli/src/commands/preview.rs
+++ b/engine/crates/rocky-cli/src/commands/preview.rs
@@ -393,8 +393,7 @@ async fn apply_bisection_to_models(
     };
     let adapter = registry.warehouse_adapter(&adapter_name)?;
 
-    let models = rocky_core::models::load_models_from_dir(models_dir)
-        .with_context(|| format!("loading models from {}", models_dir.display()))?;
+    let models = crate::models_loader::load_project_models(models_dir)?;
     let model_by_name: BTreeMap<String, &rocky_core::models::Model> =
         models.iter().map(|m| (m.config.name.clone(), m)).collect();
     let mut model_out_idx: HashMap<String, usize> = HashMap::new();
@@ -1000,7 +999,7 @@ pub async fn run_preview_cost(
     // silently degrades to an empty per-model budget map. Project-level
     // budget projection still runs.
     let model_budgets: BTreeMap<String, rocky_core::config::ModelBudgetConfig> =
-        rocky_core::models::load_models_from_dir(models_dir)
+        crate::models_loader::load_project_models(models_dir)
             .ok()
             .map(|models| {
                 models
@@ -1859,8 +1858,7 @@ async fn execute_copy_from_base(
         .unwrap_or_else(|| "unknown".to_string());
 
     // Load the model sidecars to resolve each model's source schema.
-    let models = rocky_core::models::load_models_from_dir(models_dir)
-        .with_context(|| format!("loading models from {}", models_dir.display()))?;
+    let models = crate::models_loader::load_project_models(models_dir)?;
     let model_by_name: BTreeMap<String, &rocky_core::models::Model> =
         models.iter().map(|m| (m.config.name.clone(), m)).collect();
 

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -153,7 +153,7 @@ fn validate_inner(config_path: &Path) -> Result<ValidateOutput> {
         .unwrap_or(Path::new("."))
         .join("models");
     let loaded_models = if models_dir.exists() {
-        match rocky_core::models::load_models_from_dir(&models_dir) {
+        match crate::models_loader::load_project_models(&models_dir) {
             Ok(models) => {
                 let count = models.len();
                 if count > 0 {

--- a/engine/crates/rocky-cli/src/lib.rs
+++ b/engine/crates/rocky-cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 pub mod deprecation;
 pub mod error_reporter;
+pub mod models_loader;
 pub mod otel_guard;
 pub mod output;
 pub mod pipes;

--- a/engine/crates/rocky-cli/src/models_loader.rs
+++ b/engine/crates/rocky-cli/src/models_loader.rs
@@ -1,0 +1,36 @@
+//! Shared model-directory loader for CLI commands.
+//!
+//! The canonical "load every model in the project" path: top-level dir plus
+//! one level of immediate subdirectories, including **both** `.sql` (sidecar
+//! `.toml`) and `.rocky` DSL files. Commands that need the model list (but not
+//! the resolved DAG) should use this instead of
+//! [`rocky_core::models::load_models_from_dir`], which collects only `.sql`
+//! files and therefore silently drops `.rocky` DSL models.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rocky_core::models::Model;
+
+/// Load all models under `models_dir` (top level + immediate subdirectories),
+/// including `.rocky` DSL files. Subdirectory load failures are skipped
+/// silently — same tolerance the previous per-command loops had.
+pub fn load_project_models(models_dir: &Path) -> Result<Vec<Model>> {
+    let mut all = rocky_compiler::project::load_dir_models(models_dir)
+        .map_err(|e| anyhow::anyhow!("{e}"))
+        .context(format!(
+            "failed to load models from {}",
+            models_dir.display()
+        ))?;
+
+    if let Ok(entries) = std::fs::read_dir(models_dir) {
+        for entry in entries.flatten() {
+            if entry.path().is_dir()
+                && let Ok(sub) = rocky_compiler::project::load_dir_models(&entry.path())
+            {
+                all.extend(sub);
+            }
+        }
+    }
+    Ok(all)
+}

--- a/engine/crates/rocky-cli/src/scope.rs
+++ b/engine/crates/rocky-cli/src/scope.rs
@@ -174,22 +174,9 @@ pub(crate) fn resolve_transformation_managed_tables(
         );
     }
 
-    // Load models the same way `rocky list models` does: top-level +
-    // immediate subdirectories.
-    let mut all_models = rocky_core::models::load_models_from_dir(&models_dir).context(format!(
-        "failed to load models from {}",
-        models_dir.display()
-    ))?;
-
-    if let Ok(entries) = std::fs::read_dir(&models_dir) {
-        for entry in entries.flatten() {
-            if entry.path().is_dir()
-                && let Ok(sub) = rocky_core::models::load_models_from_dir(&entry.path())
-            {
-                all_models.extend(sub);
-            }
-        }
-    }
+    // Load all models the same way `rocky list models` does: top-level +
+    // immediate subdirectories, including `.rocky` DSL files.
+    let all_models = crate::models_loader::load_project_models(&models_dir)?;
 
     let mut managed = HashSet::new();
     for model in &all_models {

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -153,6 +153,24 @@ impl Project {
     }
 }
 
+/// Load every model in a single directory — both `.sql` (with sidecar
+/// `.toml`) and `.rocky` DSL files — without resolving the DAG.
+///
+/// This is the loader CLI commands should use when they need the model list
+/// but not the dependency graph (`list`, `dag`, `validate`'s count, `docs`,
+/// `optimize`, `compliance`, `preview`, `estimate`, branch scoping, …).
+/// [`rocky_core::models::load_models_from_dir`] alone collects only `.sql`
+/// files, so any command on that path silently drops `.rocky` DSL models —
+/// this includes them. Unlike [`Project::load`] it never fails on dependency
+/// resolution (it does none), so a partial or broken DAG still yields the
+/// models that parsed.
+pub fn load_dir_models(dir: &Path) -> Result<Vec<Model>, ProjectError> {
+    let mut models = models::load_models_from_dir(dir)?;
+    let mut db = crate::salsa_compile::RockyDatabase::default();
+    models.extend(load_rocky_models_with_db(dir, &mut db)?);
+    Ok(models)
+}
+
 /// Load `.rocky` files from a directory through the salsa database.
 ///
 /// Sequential rather than rayon-parallel: salsa's `RockyDatabase` is
@@ -591,5 +609,41 @@ mod tests {
         let result = Project::from_models(models);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("circular"));
+    }
+
+    /// `load_dir_models` must pick up BOTH `.sql` (sidecar) and `.rocky` DSL
+    /// files — the gap that made `load_models_from_dir` (sql-only) silently
+    /// drop DSL models from `validate` / `list` / `dag` / etc.
+    #[test]
+    fn load_dir_models_includes_sql_and_rocky() {
+        // Loading a `.rocky` file runs the salsa-tracked `file_typecheck`,
+        // which bumps the process-global invocation counter the salsa tests
+        // assert on — hold their lock so we don't race those assertions.
+        let _guard = crate::salsa_compile::tests::TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let d = dir.path();
+        std::fs::write(d.join("stg.sql"), "SELECT 1 AS id FROM raw__x.y").unwrap();
+        std::fs::write(
+            d.join("stg.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog = \"c\"\nschema = \"s\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("agg.rocky"),
+            "from stg\ngroup id {\n    n: count()\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            d.join("agg.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n[target]\ncatalog = \"c\"\nschema = \"s\"\n",
+        )
+        .unwrap();
+
+        let models = load_dir_models(d).unwrap();
+        let names: Vec<_> = models.iter().map(|m| m.config.name.as_str()).collect();
+        assert!(names.contains(&"stg"), "sql model loaded: {names:?}");
+        assert!(names.contains(&"agg"), "rocky DSL model loaded: {names:?}");
     }
 }

--- a/engine/crates/rocky-compiler/src/salsa_compile.rs
+++ b/engine/crates/rocky-compiler/src/salsa_compile.rs
@@ -262,8 +262,10 @@ pub(crate) mod tests {
     pub(super) static TYPECHECK_INVOCATIONS: Mutex<usize> = Mutex::new(0);
 
     /// Serialize the salsa-tracked tests in this crate — they share
-    /// the process-global counter so concurrent execution would race.
-    pub(super) static TEST_LOCK: Mutex<()> = Mutex::new(());
+    /// the process-global `file_typecheck` invocation counter, so any test
+    /// that triggers a `.rocky` parse must hold this lock (incl. cross-module
+    /// callers like `project::tests`) or it races the counter assertions.
+    pub(crate) static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     pub(crate) fn reset_counter() {
         *TYPECHECK_INVOCATIONS.lock().unwrap() = 0;


### PR DESCRIPTION
Closes the first of the two follow-ups queued from the playground work: `.rocky` DSL models were invisible to most non-`run` commands.

## Problem

`rocky_core::models::load_models_from_dir` collects only `.sql` files. ~10 commands load models through it (`validate`, `list`, `dag`, `optimize`, `compliance`, `preview`, `estimate`, `docs`, branch scoping), so a project containing `.rocky` DSL models had them **silently dropped**. The sharpest symptom: `rocky validate` reported a false `V031 DAG error: unknown dependency '<model>'` when a `.rocky` model sat between two `.sql` models in a transformation DAG — the exact gap that forced the playground's `customer_orders` to ship as `.sql` instead of `.rocky`.

## Fix

- **`rocky_compiler::project::load_dir_models`** — loads `.sql` (sidecar) **and** `.rocky` from one directory, with no DAG resolution (callers here want the model list, not the graph, and it must not fail on a partial/broken DAG).
- **`rocky_cli::models_loader::load_project_models`** — shared helper (top level + immediate subdirs, `.rocky`-aware). The ~10 call sites now route through it, collapsing the duplicated load-dir + subdir-loop pattern.
- Widened `salsa_compile::tests::TEST_LOCK` to `pub(crate)` so the new loader test (which triggers the salsa-tracked `file_typecheck`) serializes with the existing global-counter salsa tests.

## Verification

- New test: `load_dir_models` returns both a `.sql` and a `.rocky` model.
- Empirically: a `.rocky` model in a transformation DAG → `rocky validate` reports valid / 3 models / dag_valid (V031 gone); `rocky list models` includes it.
- Workspace `cargo test` (78 suites) + clippy `--all-targets` + fmt green; rocky-compiler suite run 3× (counter-flake-free).

Engine-only; lands under `[Unreleased]`, rides the next engine cut. Unblocks the follow-up that restores `customer_orders.rocky` in the playground + scaffold.