### PR TITLE
feat(vscode): Inspector auto-follows the active editor

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The Inspector follows the active editor.** When the Inspector panel is open and you switch to a model file (`.rocky`, or `.sql` under `models/`), it retargets to that model automatically — no need to re-run "Open in Inspector". Gated to when the panel is visible (never steals focus), debounced against rapid tab-switching, and ignores non-model files. The explicit triggers (Open-in-Inspector, lineage-canvas node click, Cmd+K) still work.
+
 ## [1.30.3] — 2026-05-28
 
 ### Changed

--- a/editors/vscode/src/commands/inspector.ts
+++ b/editors/vscode/src/commands/inspector.ts
@@ -54,6 +54,42 @@ export function registerInspectorView(context: vscode.ExtensionContext): void {
       h.onRequest("governance", () => loadGovernance());
     },
   });
+
+  registerActiveEditorFollow(context);
+}
+
+/**
+ * Auto-follow: when the active editor switches to a model file, retarget the
+ * Inspector to that model — but only while the panel is visible (so it never
+ * steals focus or churns while hidden), debounced against rapid tab-flipping,
+ * and skipping non-model files (a stray `.ts`/`.md` shouldn't blank the panel).
+ * Explicit triggers (Open-in-Inspector, canvas node click, Cmd+K) still work;
+ * this just makes browsing model files in the editor track along.
+ */
+function registerActiveEditorFollow(context: vscode.ExtensionContext): void {
+  let lastModel: string | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const isModelFile = (doc: vscode.TextDocument): boolean =>
+    doc.languageId === "rocky" ||
+    (doc.fileName.endsWith(".sql") && /[\\/]models[\\/]/.test(doc.fileName));
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (!editor || !controller?.visible || !isModelFile(editor.document)) {
+        return;
+      }
+      const model = path
+        .basename(editor.document.fileName)
+        .replace(/\.(rocky|sql)$/i, "");
+      if (model === lastModel) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        lastModel = model;
+        controller?.push<InspectorTarget>("target", { model });
+      }, 250);
+    }),
+  );
 }
 
 /**

--- a/editors/vscode/src/webviews/host/registerPanel.ts
+++ b/editors/vscode/src/webviews/host/registerPanel.ts
@@ -46,6 +46,7 @@ export function createWebviewPanelApp(
 export class WebviewViewController {
   private host: WebviewHost | undefined;
   private readonly preResolve: Array<{ type: string; payload: unknown }> = [];
+  private isVisible = false;
 
   /** @internal Bind the live host once the view resolves; flushes buffered pushes. */
   attach(host: WebviewHost): void {
@@ -58,6 +59,20 @@ export class WebviewViewController {
   /** @internal Unbind when the view is disposed. */
   detach(): void {
     this.host = undefined;
+    this.isVisible = false;
+  }
+
+  /** @internal Track the view's visibility (panel tab shown vs hidden). */
+  setVisible(visible: boolean): void {
+    this.isVisible = visible;
+  }
+
+  /**
+   * Whether the view is currently visible (resolved and its panel tab shown).
+   * Callers use this to avoid pushing/retargeting while the panel is hidden.
+   */
+  get visible(): boolean {
+    return this.host !== undefined && this.isVisible;
   }
 
   /** Push to the view, buffering until it is resolved and ready. */
@@ -88,6 +103,8 @@ export function registerWebviewViewApp(
       // rather than being wiped by render().
       host.render({ entry: opts.entry, title: opts.title });
       controller.attach(host);
+      controller.setVisible(view.visible);
+      view.onDidChangeVisibility(() => controller.setVisible(view.visible));
       view.onDidDispose(() => {
         host.dispose();
         if (extra) extra.dispose();


### PR DESCRIPTION
You asked whether the Inspector tracks the selected model — it only retargeted on explicit triggers (Open-in-Inspector / lineage-canvas node click / Cmd+K). Now it follows the active editor.

## Change

- While the Inspector panel is **visible**, switching to a model file (`.rocky`, or `.sql` under `models/`) retargets the Inspector to that model.
- Gated to visible (`WebviewViewController` now tracks `onDidChangeVisibility`) so it never steals focus or churns while hidden; debounced (250ms) against rapid tab-flipping; skips non-model files; no-ops when already on that model.
- Explicit triggers unchanged.

## Verification

Compile + lint + unit tests (194) green. Recorded against the built binary and audited frame-by-frame: opened the Inspector on `customer_orders`, then switched the editor to `revenue_summary.sql` → Inspector header retargeted to `revenue_summary`; switched to `raw_orders.sql` → retargeted to `raw_orders`. No Open-in-Inspector in between.

vscode-only; lands under `[Unreleased]`, rides the next vscode cut. (Engine required checks won't trigger on a vscode-only PR, so merge with `--admin` once the vscode Lint/Test checks are green.)