### PR TITLE
fix(engine): keep source-less columns in a model's schema

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`.rocky` DSL models are no longer invisible to non-run commands.** `validate`, `list`, `dag`, `optimize`, `compliance`, `preview`, `estimate`, `docs`, and branch scoping loaded models through a `.sql`-only path, so a project with `.rocky` DSL models had them silently dropped — most visibly, `rocky validate` reported a false `DAG error: unknown dependency` when a `.rocky` model sat between two `.sql` models in a transformation DAG. All these commands now load `.sql` and `.rocky` models through one shared loader.
+- **Columns with no source no longer vanish from a model's schema.** A named projection with no column-level lineage — an aliased `COUNT(*)`, a literal, a computed expression like `total_revenue / order_count AS avg_order_value` — was dropped from the model's column set, so it never appeared in `rocky profile`, the Inspector Columns tab, or column lineage. These are now kept as source-less columns (present in the schema, with no upstream edge).
 
 ## [1.46.3] — 2026-05-28
 

--- a/engine/crates/rocky-sql/src/lineage.rs
+++ b/engine/crates/rocky-sql/src/lineage.rs
@@ -161,6 +161,18 @@ fn build_alias_map(tables: &[TableReference]) -> HashMap<String, String> {
     map
 }
 
+/// A model output column with no column-level lineage to any source — an
+/// aliased `COUNT(*)`, a literal, a computed expression. It belongs in the
+/// model's column set but has no upstream edge.
+fn source_less_column(target: &str) -> ColumnLineage {
+    ColumnLineage {
+        source_table: None,
+        source_column: String::new(),
+        target_column: target.to_string(),
+        transform: TransformKind::Expression,
+    }
+}
+
 fn extract_select_columns(
     projection: &[SelectItem],
     alias_map: &HashMap<String, String>,
@@ -181,21 +193,41 @@ fn extract_select_columns(
                 if let Some(lineage) = extract_expr_lineage(expr, alias_map, source_tables) {
                     columns.push(lineage);
                 }
+                // An unnamed expression with no traceable source (e.g. a bare
+                // `COUNT(*)` or a literal) has no portable output name, so we
+                // can't emit a column entry for it. Aliased forms below are the
+                // ones that matter — and models alias their aggregates.
             }
             SelectItem::ExprWithAlias { expr, alias } => {
-                if let Some(mut lineage) = extract_expr_lineage(expr, alias_map, source_tables) {
-                    lineage.target_column = alias.value.clone();
-                    columns.push(lineage);
+                match extract_expr_lineage(expr, alias_map, source_tables) {
+                    Some(mut lineage) => {
+                        lineage.target_column = alias.value.clone();
+                        columns.push(lineage);
+                    }
+                    // A named projection with no upstream column — `COUNT(*)`,
+                    // a literal, a multi-column expression — is still a real
+                    // output column. Emit a source-less entry so it's not
+                    // dropped from the model's schema (the column set drives
+                    // `rocky profile` / the Inspector Columns tab and the
+                    // typed schema); it simply has no column-level lineage edge.
+                    None => columns.push(source_less_column(&alias.value)),
                 }
             }
             // Spark SQL `SELECT expr AS (a, b, c)` — multi-alias binding.
             // Emit one lineage entry per alias, cloning the upstream lineage.
             SelectItem::ExprWithAliases { expr, aliases } => {
-                if let Some(base) = extract_expr_lineage(expr, alias_map, source_tables) {
-                    for alias in aliases {
-                        let mut lineage = base.clone();
-                        lineage.target_column = alias.value.clone();
-                        columns.push(lineage);
+                match extract_expr_lineage(expr, alias_map, source_tables) {
+                    Some(base) => {
+                        for alias in aliases {
+                            let mut lineage = base.clone();
+                            lineage.target_column = alias.value.clone();
+                            columns.push(lineage);
+                        }
+                    }
+                    None => {
+                        for alias in aliases {
+                            columns.push(source_less_column(&alias.value));
+                        }
                     }
                 }
             }
@@ -415,5 +447,35 @@ mod tests {
             result.columns[0].transform,
             TransformKind::Aggregation("SUM".to_string())
         );
+    }
+
+    /// Named projections with no traceable source (an aliased `COUNT(*)`, a
+    /// computed multi-source expression) must still appear as output columns —
+    /// with no source, so they carry no lineage edge but aren't dropped from
+    /// the model's schema. (Regression: `COUNT(*) AS order_count` was silently
+    /// omitted, so it vanished from `rocky profile` / the Inspector Columns.)
+    #[test]
+    fn source_less_named_projections_are_kept() {
+        let result = extract_lineage(
+            "SELECT customer_id, COUNT(*) AS order_count, \
+             total_revenue / order_count AS avg_order_value \
+             FROM cat.sch.customer_orders GROUP BY customer_id",
+        )
+        .unwrap();
+        let by_name: std::collections::HashMap<_, _> = result
+            .columns
+            .iter()
+            .map(|c| (c.target_column.as_str(), c))
+            .collect();
+        // COUNT(*) and the division expression both lack a source column, but
+        // are present in the column set.
+        let order_count = by_name.get("order_count").expect("order_count kept");
+        assert_eq!(order_count.source_table, None);
+        let avg = by_name
+            .get("avg_order_value")
+            .expect("avg_order_value kept");
+        assert_eq!(avg.source_table, None);
+        // The sourced column still resolves normally.
+        assert!(by_name.contains_key("customer_id"));
     }
 }

--- a/integrations/dagster/tests/fixtures_generated/lineage.json
+++ b/integrations/dagster/tests/fixtures_generated/lineage.json
@@ -13,6 +13,9 @@
       "name": "order_count"
     },
     {
+      "name": "avg_order_value"
+    },
+    {
       "name": "first_order"
     }
   ],

--- a/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_backfill.json
@@ -37,7 +37,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "a8975e5a44e05fc9",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {
@@ -60,7 +60,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "6841226935681d42",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {
@@ -83,7 +83,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "43c5cc76b5aad342",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {
@@ -106,7 +106,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "ce0fd1a2df2e4b0d",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {
@@ -129,7 +129,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "d0e9a49c9722f466",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {

--- a/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_late_correction.json
@@ -37,7 +37,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "ce0fd1a2df2e4b0d",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {

--- a/integrations/dagster/tests/fixtures_generated/partition/run_single.json
+++ b/integrations/dagster/tests/fixtures_generated/partition/run_single.json
@@ -37,7 +37,7 @@
         "strategy": "time_interval",
         "target_table_full_name": ".marts.fct_daily_orders",
         "sql_hash": "ce0fd1a2df2e4b0d",
-        "column_count": 3,
+        "column_count": 4,
         "compile_time_ms": 0
       },
       "partition": {


### PR DESCRIPTION
The second of the two playground follow-ups: source-less projection columns were dropped from a model's schema.

## Problem

`extract_select_columns` only emitted a column when `extract_expr_lineage` could trace it to a source. A named projection with **no** source column — an aliased `COUNT(*)`, a literal, a computed expression like `total_revenue / order_count AS avg_order_value` — produced `None` and was dropped entirely. So the column vanished from `rocky profile`, the Inspector Columns tab, and column lineage. The reported case: the playground's `customer_orders.order_count` (a `COUNT(*)`) showed up as 3 of 4 columns.

## Fix

Emit a **source-less** `ColumnLineage` (`source_table: None`) for named projections that don't trace. The downstream already handles this shape: the semantic graph pushes a `ColumnDef` for every lineage entry and only adds an edge when a source resolves, and typecheck produces the column with no producing edge. So the column re-appears in the schema with no upstream lineage — which is correct (it genuinely has no source column).

Unnamed untraceable exprs (a bare `SELECT COUNT(*)` with no alias) are still skipped — there's no portable output name, and models alias their aggregates.

## Verification

- `rocky profile customer_orders` now lists all 4 columns (`order_count` shows `BIGINT`, the observed warehouse type).
- New `rocky-sql` regression test: an aliased `COUNT(*)` and a `/` expression are kept as source-less columns.
- Workspace `cargo test` (78 suites) + clippy + fmt green.
- Regenerated dagster fixtures for the recovered columns (`avg_order_value` in `lineage.json`; `column_count` 3→4 in the partition POC); dagster pytest (564) green. Diffs are exactly the recovered columns.

## Known follow-up (not here)

A source-less column's *inferred* type is `Unknown` (no producing edge), so the **Inspector Columns** tab may show no type for it — though `rocky profile` shows the real observed type. Refining inferred types for source-less aggregates (routing through `infer_select_types`) is a separate, optional enhancement.

Engine-only; lands under `[Unreleased]`, rides the next engine cut.