### PR TITLE
chore(release): engine 1.46.4 + vscode 1.31.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.0] — 2026-05-29
+
 ### Added
 
 - **The Inspector follows the active editor.** When the Inspector panel is open and you switch to a model file (`.rocky`, or `.sql` under `models/`), it retargets to that model automatically — no need to re-run "Open in Inspector". Gated to when the panel is visible (never steals focus), debounced against rapid tab-switching, and ignores non-model files. The explicit triggers (Open-in-Inspector, lineage-canvas node click) still work.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.30.3",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.30.3",
+      "version": "1.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.30.3",
+  "version": "1.31.0",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.4] — 2026-05-29
+
 ### Fixed
 
 - **`.rocky` DSL models are no longer invisible to non-run commands.** `validate`, `list`, `dag`, `optimize`, `compliance`, `preview`, `estimate`, `docs`, and branch scoping loaded models through a `.sql`-only path, so a project with `.rocky` DSL models had them silently dropped — most visibly, `rocky validate` reported a false `DAG error: unknown dependency` when a `.rocky` model sat between two `.sql` models in a transformation DAG. All these commands now load `.sql` and `.rocky` models through one shared loader.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "redis",
  "serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "async-trait",
  "serde",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "logos",
  "miette",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "miette",
  "regex",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.46.3"
+version = "1.46.4"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.46.3"
+version = "1.46.4"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.46.3"
+version = "1.46.4"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.46.3"
+version = "1.46.4"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.46.3"
+version = "1.46.4"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.46.3"
+version = "1.46.4"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.46.3"
+version = "1.46.4"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.46.3"
+version = "1.46.4"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.46.3"
+version = "1.46.4"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.46.3"
+version = "1.46.4"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.46.3"
+version = "1.46.4"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.46.3"
+version = "1.46.4"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.46.3"
+version = "1.46.4"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.46.3"
+version = "1.46.4"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.46.3"
+version = "1.46.4"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.46.3"
+version = "1.46.4"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.46.3"
+version = "1.46.4"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.46.3"
+version = "1.46.4"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.46.3"
+version = "1.46.4"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.46.3"
+version = "1.46.4"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.46.3"
+version = "1.46.4"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Double-cut release. dagster has no unreleased work.

## engine 1.46.4

### Fixed
- `.rocky` DSL models are no longer invisible to non-run commands (`validate`, `list`, `dag`, `optimize`, `compliance`, `preview`, `estimate`, `docs`, branch scoping) — they share one loader with `.sql` models now, so a `.rocky` model between two `.sql` models no longer triggers a false `DAG error: unknown dependency`.
- Columns with no source (aliased `COUNT(*)`, literals, computed expressions) are kept in a model's schema instead of being dropped, so they appear in `rocky profile`, the Inspector Columns tab, and column lineage.

## vscode 1.31.0

### Added
- The Inspector follows the active editor — switching to a model file retargets it automatically (visible-only, debounced, ignores non-model files).

### Removed
- The Inspector's Cmd+K model-search palette, its header "Search models" button, and the Cmd+K shortcut — superseded by editor auto-follow, lineage node-click, and "Open in Inspector".

## Notes
- Verified under Rust 1.96: `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `just codegen` produces no binding drift (no output-struct changes).
- Tags `engine-v1.46.4` + `vscode-v1.31.0` to be pushed on the squashed merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)