### PR TITLE
feat(engine/rocky-mcp): data-grounding tools reach raw sources + cold start

### DIFF
--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -226,6 +226,23 @@ pub struct ProfileColumnResult {
     pub min: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max: Option<String>,
+    /// For a low-cardinality column (≤25 distinct), the distinct values with
+    /// their row counts — surfaces exact literals that `min`/`max` hide (e.g.
+    /// `status` = 'COMPLETE', not 'completed'). Empty for high-cardinality
+    /// columns, and omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub top_values: Vec<ValueCount>,
+}
+
+/// One distinct value of a column and how many rows carry it — the entries of
+/// `ProfileColumnResult::top_values`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ValueCount {
+    /// The value rendered as text; omitted (JSON null) for the SQL NULL group.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// Number of rows carrying this value.
+    pub count: u64,
 }
 
 /// serde `skip_serializing_if` predicate for `bool` fields.

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -87,16 +87,22 @@ pub struct InspectSchemaArgs {}
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SampleRowsArgs {
-    /// The model whose target table to sample. Must be a compiled model.
+    /// What to sample: a compiled model name, OR a qualified `schema.table`
+    /// (or `catalog.schema.table`) reference to a raw source table. A dotted
+    /// reference resolves directly against the warehouse and needs no compiled
+    /// model, so it also works at cold start (a project with zero models yet).
     pub model: String,
-    /// Sample percentage (1–100). Defaults to 10.
+    /// Random-sample percentage (1–100). Omit to return the first rows
+    /// deterministically — the right default for small tables, where a low
+    /// percentage sample can return zero rows.
     #[serde(default)]
     pub percent: Option<u32>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ProfileColumnArgs {
-    /// The model whose target table to profile.
+    /// What to profile: a compiled model name, OR a qualified `schema.table`
+    /// (or `catalog.schema.table`) reference to a raw source table.
     pub model: String,
     /// The column to profile.
     pub column: String,
@@ -175,6 +181,9 @@ pub struct BuildModelArgs {
 const SAMPLE_MAX_ROWS: usize = 50;
 const SAMPLE_MAX_BYTES: usize = 16 * 1024;
 const CELL_MAX_CHARS: usize = 256;
+/// Max distinct values `profile_column` lists in `top_values`; above this the
+/// column is treated as high-cardinality and the value list is omitted.
+const PROFILE_TOP_VALUES_MAX: usize = 25;
 
 #[tool_router(router = tool_router)]
 impl RockyMcpServer {
@@ -505,8 +514,6 @@ impl RockyMcpServer {
         &self,
         _params: Parameters<InspectSchemaArgs>,
     ) -> Result<Json<InspectSchemaResult>, String> {
-        let result = self.compile_full().map_err(|e| format!("{e:#}"))?;
-        let (model_schemas, source_tables) = commands::build_schema_context(&result);
         let to_entries = |buckets: Vec<(String, Vec<rocky_compiler::types::TypedColumn>)>| {
             buckets
                 .into_iter()
@@ -523,10 +530,46 @@ impl RockyMcpServer {
                 })
                 .collect::<Vec<_>>()
         };
-        Ok(Json(InspectSchemaResult {
-            models: to_entries(model_schemas),
-            sources: to_entries(source_tables),
-        }))
+
+        // Compile to learn the project's models. Tolerate a models-less project
+        // (cold start) — there, the source discovery below is the whole point.
+        let (models, mut sources, model_targets) = match self.compile_full() {
+            Ok(result) => {
+                let (model_schemas, source_tables) = commands::build_schema_context(&result);
+                let targets: std::collections::HashSet<String> = result
+                    .project
+                    .models
+                    .iter()
+                    .map(|m| format!("{}.{}", m.config.target.schema, m.config.target.table))
+                    .collect();
+                (
+                    to_entries(model_schemas),
+                    to_entries(source_tables),
+                    targets,
+                )
+            }
+            Err(e) if e.to_string().contains("no models found") => {
+                (Vec::new(), Vec::new(), std::collections::HashSet::new())
+            }
+            Err(e) => return Err(format!("{e:#}")),
+        };
+
+        // On DuckDB, surface the physical warehouse tables so an agent can
+        // ground a raw source the project never declared — and at cold start,
+        // before any model exists. Skip a table that is a model's target or is
+        // already reported as a compile-derived source.
+        if let Ok(Some(adapter)) = self.duckdb_warehouse() {
+            let seen: std::collections::HashSet<String> =
+                sources.iter().map(|s| s.name.clone()).collect();
+            for entry in discover_source_tables(adapter.as_ref()).await {
+                if model_targets.contains(&entry.name) || seen.contains(&entry.name) {
+                    continue;
+                }
+                sources.push(entry);
+            }
+        }
+
+        Ok(Json(InspectSchemaResult { models, sources }))
     }
 
     #[tool(
@@ -759,16 +802,17 @@ impl RockyMcpServer {
     // ------------------------- SHOULD tools --------------------------------
 
     #[tool(
-        description = "Sample real rows from a model's target table (DuckDB only). Look at \
-         literal values, units, and null patterns the schema can't tell you. Capped at 50 rows / \
-         16 KB; long cells truncated. Returns {unavailable:true} on non-DuckDB adapters."
+        description = "Sample real rows from a model's target table OR a qualified `schema.table` \
+         source reference (DuckDB only). Look at literal values, units, and null patterns the \
+         schema can't tell you. Omit `percent` to get the first rows (the right default for small \
+         tables); set 1–100 for a random-percentage sample. Capped at 50 rows / 16 KB; long cells \
+         truncated. Returns {unavailable:true} on non-DuckDB adapters."
     )]
     async fn sample_rows(
         &self,
         params: Parameters<SampleRowsArgs>,
     ) -> Result<Json<SampleRowsResult>, String> {
         let args = params.0;
-        let percent = args.percent.unwrap_or(10).clamp(1, 100);
 
         let prepared = match self.prepare_table_query(&args.model).await {
             Ok(PreparedTable::Ready(p)) => p,
@@ -782,11 +826,14 @@ impl RockyMcpServer {
             Err(e) => return Err(format!("{e:#}")),
         };
 
-        // Build: SELECT * FROM <ref> <tablesample> LIMIT n. The table ref is
-        // built only from validated identifiers; never `format!`'d from raw
-        // input. `percent` is a clamped integer.
-        let sample = prepared
-            .dialect_tablesample(percent)
+        // Build: SELECT * FROM <ref> [tablesample] LIMIT n. The ref is built
+        // only from validated identifiers; never `format!`'d from raw input.
+        // With no `percent`, return the first rows deterministically — a low
+        // percentage sample returns ~0 rows on a small table, which is the most
+        // common grounding case. `percent`, when given, is a clamped integer.
+        let sample = args
+            .percent
+            .and_then(|p| prepared.dialect_tablesample(p.clamp(1, 100)))
             .map(|s| format!(" {s}"))
             .unwrap_or_default();
         let sql = format!(
@@ -824,9 +871,11 @@ impl RockyMcpServer {
     }
 
     #[tool(
-        description = "Profile one column of a model's target table in a single aggregate query \
-         (DuckDB only): row count, nulls, null rate, distinct count, min, max. Returns \
-         {unavailable:true} on non-DuckDB adapters."
+        description = "Profile one column of a model's target table OR a qualified `schema.table` \
+         source (DuckDB only): row count, nulls, null rate, distinct count, min, max — and, for a \
+         low-cardinality column (≤25 distinct), the distinct values with their counts \
+         (`top_values`), which surfaces exact literals (e.g. a status string) that min/max hide. \
+         Returns {unavailable:true} on non-DuckDB adapters."
     )]
     async fn profile_column(
         &self,
@@ -890,6 +939,31 @@ impl RockyMcpServer {
             }
         };
 
+        // For a low-cardinality column, surface the distinct values + their
+        // counts — what `min`/`max` alone can't reveal (e.g. that `status`
+        // holds 'COMPLETE', not 'completed'). One extra grouped query, run only
+        // when the cardinality makes it cheap.
+        let top_values = if distinct > 0 && distinct <= PROFILE_TOP_VALUES_MAX as u64 {
+            let q = format!(
+                "SELECT CAST({col} AS VARCHAR) AS v, COUNT(*) AS c FROM {} \
+                 GROUP BY {col} ORDER BY c DESC, v LIMIT {}",
+                prepared.table_ref, PROFILE_TOP_VALUES_MAX
+            );
+            match prepared.adapter.execute_query(&q).await {
+                Ok(r) => r
+                    .rows
+                    .into_iter()
+                    .map(|row| ValueCount {
+                        value: str_cell(row.first()),
+                        count: row.get(1).map(as_u64).unwrap_or(0),
+                    })
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+
         Ok(Json(ProfileColumnResult {
             unavailable: false,
             reason: None,
@@ -899,6 +973,7 @@ impl RockyMcpServer {
             distinct,
             min: str_cell(row.get(3)),
             max: str_cell(row.get(4)),
+            top_values,
         }))
     }
 
@@ -945,45 +1020,81 @@ impl RockyMcpServer {
     /// Resolve a model's target table into a runnable, validated table ref +
     /// the warehouse adapter — but only on DuckDB. Other adapters return the
     /// typed "unavailable" result so the grounding tools degrade cleanly.
-    async fn prepare_table_query(&self, model_name: &str) -> anyhow::Result<PreparedTable> {
+    /// The project's target warehouse adapter, but only when it is DuckDB — the
+    /// data-grounding tools (`sample_rows`, `profile_column`, and
+    /// `inspect_schema`'s source discovery) are DuckDB-only in this release.
+    /// Returns `Ok(None)` on any other adapter so callers degrade cleanly.
+    fn duckdb_warehouse(
+        &self,
+    ) -> anyhow::Result<Option<std::sync::Arc<dyn rocky_core::traits::WarehouseAdapter>>> {
         let cfg = rocky_core::config::load_rocky_config(&self.config_path)?;
         let registry = commands_adapter_registry(&cfg)?;
         let (_, pipeline) = rocky_cli::registry::resolve_pipeline(&cfg, None)?;
         let target_adapter = pipeline.target_adapter().to_string();
-
         let adapter_type = registry
             .adapter_config(&target_adapter)
             .map(|a| a.adapter_type.clone())
             .unwrap_or_default();
         if adapter_type != "duckdb" {
+            return Ok(None);
+        }
+        Ok(Some(registry.warehouse_adapter(&target_adapter)?))
+    }
+
+    /// Resolve a grounding-tool target into a runnable, validated table ref plus
+    /// the warehouse adapter — DuckDB only.
+    ///
+    /// The target is either a **compiled model name** (resolved to its target
+    /// table, which requires the models to compile) or a **qualified
+    /// `schema.table` / `catalog.schema.table` source reference** (any dotted
+    /// name — resolved directly with no compile, so it reaches raw sources the
+    /// project never declared and works at cold start, before any model exists).
+    async fn prepare_table_query(&self, target: &str) -> anyhow::Result<PreparedTable> {
+        let Some(adapter) = self.duckdb_warehouse()? else {
             return Ok(PreparedTable::Unavailable(
                 "sample_rows/profile_column are DuckDB-only in this release".to_string(),
             ));
-        }
+        };
 
-        // Resolve the model's target coordinates by loading the models dir.
-        let result = self.compile_full()?;
-        let model = result
-            .project
-            .models
-            .iter()
-            .find(|m| m.config.name == model_name)
-            .ok_or_else(|| anyhow::anyhow!("model '{model_name}' not found in project"))?;
-        let t = &model.config.target;
+        let table_ref = if target.contains('.') {
+            // Qualified raw reference — validate each segment and use it as-is.
+            // No compile required: this is how an agent grounds a source before
+            // (or without) authoring any model.
+            let parts: Vec<&str> = target.split('.').collect();
+            if !(2..=3).contains(&parts.len()) {
+                return Err(anyhow::anyhow!(
+                    "table reference '{target}' must be `schema.table` or \
+                     `catalog.schema.table`"
+                ));
+            }
+            for part in &parts {
+                rocky_sql::validation::validate_identifier(part)
+                    .map_err(|e| anyhow::anyhow!("invalid identifier '{part}': {e}"))?;
+            }
+            parts.join(".")
+        } else {
+            // Bare name — resolve the model's target coordinates by compiling
+            // the models dir. DuckDB has no catalog level, so we emit a two-part
+            // `schema.table` name.
+            let result = self.compile_full()?;
+            let model = result
+                .project
+                .models
+                .iter()
+                .find(|m| m.config.name == target)
+                .ok_or_else(|| anyhow::anyhow!("model '{target}' not found in project"))?;
+            let t = &model.config.target;
+            let schema = rocky_sql::validation::validate_identifier(&t.schema)
+                .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
+            let table = rocky_sql::validation::validate_identifier(&t.table)
+                .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
+            if !t.catalog.is_empty() {
+                rocky_sql::validation::validate_identifier(&t.catalog)
+                    .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
+            }
+            format!("{schema}.{table}")
+        };
 
-        // Validate every identifier before composing the ref. DuckDB has no
-        // catalog level, so we emit a two-part `schema.table` name.
-        let schema = rocky_sql::validation::validate_identifier(&t.schema)
-            .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
-        let table = rocky_sql::validation::validate_identifier(&t.table)
-            .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
-        if !t.catalog.is_empty() {
-            rocky_sql::validation::validate_identifier(&t.catalog)
-                .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
-        }
-        let table_ref = format!("{schema}.{table}");
-
-        let adapter = registry.warehouse_adapter(&target_adapter)?;
         Ok(PreparedTable::Ready(Prepared { adapter, table_ref }))
     }
 }
@@ -1245,6 +1356,59 @@ fn breaking_finding_lite(f: &rocky_core::breaking_change::BreakingFinding) -> Br
         column,
         message: format!("{:?}", f.change),
     }
+}
+
+/// Discover the physical tables in the DuckDB warehouse as schema-qualified
+/// source entries (best-effort — returns empty on any query error). Excludes
+/// the system schemas. Lets `inspect_schema` show an agent the raw sources the
+/// project never declared, including at cold start.
+async fn discover_source_tables(
+    adapter: &dyn rocky_core::traits::WarehouseAdapter,
+) -> Vec<SchemaEntry> {
+    let sql = "SELECT table_schema, table_name, column_name, data_type, is_nullable \
+               FROM information_schema.columns \
+               WHERE table_schema NOT IN ('information_schema', 'pg_catalog') \
+               ORDER BY table_schema, table_name, ordinal_position";
+    let Ok(qr) = adapter.execute_query(sql).await else {
+        return Vec::new();
+    };
+    let cell = |v: Option<&serde_json::Value>| -> String {
+        match v {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(serde_json::Value::Null) | None => String::new(),
+            Some(other) => other.to_string(),
+        }
+    };
+    // Group columns under their `schema.table`, preserving first-seen order.
+    let mut order: Vec<String> = Vec::new();
+    let mut columns: std::collections::HashMap<String, Vec<ColumnLite>> =
+        std::collections::HashMap::new();
+    for row in qr.rows {
+        let schema = cell(row.first());
+        let table = cell(row.get(1));
+        if schema.is_empty() || table.is_empty() {
+            continue;
+        }
+        let key = format!("{schema}.{table}");
+        if !columns.contains_key(&key) {
+            order.push(key.clone());
+        }
+        columns.entry(key).or_default().push(ColumnLite {
+            name: cell(row.get(2)),
+            data_type: cell(row.get(3)),
+            nullable: !cell(row.get(4)).eq_ignore_ascii_case("NO"),
+        });
+    }
+    order
+        .into_iter()
+        .map(|name| {
+            let cols = columns.remove(&name).unwrap_or_default();
+            SchemaEntry {
+                name,
+                columns: cols,
+            }
+        })
+        .collect()
 }
 
 /// Render one query cell as a display string, truncating long values.

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -727,3 +727,199 @@ async fn optimize_reports_message_without_history() {
 
     client.cancel().await.unwrap();
 }
+
+/// Like `write_project` but with zero model files — exercises the cold-start
+/// path (a project an agent has not authored any model into yet).
+fn write_empty_project(dir: &Path, db_path: &Path) {
+    std::fs::create_dir_all(dir.join("models")).unwrap();
+    std::fs::write(
+        dir.join("rocky.toml"),
+        format!(
+            r#"[adapter]
+type = "duckdb"
+path = "{}"
+
+[pipeline.p]
+strategy = "full_refresh"
+
+[pipeline.p.source.discovery]
+adapter = "default"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "main"
+schema_template = "out"
+"#,
+            db_path.display()
+        ),
+    )
+    .unwrap();
+}
+
+/// Pre-materialize `out.orders` with the given `VALUES` body on `db_path`.
+async fn materialize_orders(db_path: &Path, schema: &str, values: &str) {
+    use rocky_core::traits::WarehouseAdapter;
+    let adapter = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(db_path).unwrap();
+    adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
+        .await
+        .unwrap();
+    adapter
+        .execute_statement(&format!(
+            "CREATE OR REPLACE TABLE {schema}.orders AS \
+             SELECT * FROM (VALUES {values}) AS t(id, status)"
+        ))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn sample_rows_default_returns_rows_on_small_table() {
+    // Regression: the old default (10% bernoulli) returned ~0 rows on a tiny
+    // table. With no `percent`, sample_rows now returns the first rows.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("small.duckdb");
+    write_project(dir.path(), &db_path);
+    materialize_orders(
+        &db_path,
+        "out",
+        "(1,'COMPLETE'),(2,'COMPLETE'),(3,'PENDING')",
+    )
+    .await;
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    // No `percent` → deterministic first-rows, not a percentage sample.
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let sc = client
+        .call_tool(CallToolRequestParams::new("sample_rows").with_arguments(args))
+        .await
+        .expect("sample_rows call")
+        .structured_content
+        .expect("structured content");
+    let rows = sc["rows"].as_array().unwrap();
+    assert_eq!(
+        rows.len(),
+        3,
+        "all 3 rows returned without sampling; got {rows:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn profile_column_lists_top_values_for_low_cardinality() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("profile.duckdb");
+    write_project(dir.path(), &db_path);
+    materialize_orders(
+        &db_path,
+        "out",
+        "(1,'COMPLETE'),(2,'COMPLETE'),(3,'PENDING')",
+    )
+    .await;
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let args = serde_json::json!({ "model": "orders", "column": "status" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let sc = client
+        .call_tool(CallToolRequestParams::new("profile_column").with_arguments(args))
+        .await
+        .expect("profile_column call")
+        .structured_content
+        .expect("structured content");
+
+    assert_eq!(sc["distinct"], serde_json::json!(2));
+    let top_values = sc["top_values"]
+        .as_array()
+        .expect("top_values present for a low-cardinality column");
+    // The exact literal 'COMPLETE' is surfaced — what min/max alone cannot show.
+    let complete = top_values
+        .iter()
+        .find(|v| v["value"] == serde_json::json!("COMPLETE"))
+        .expect("COMPLETE listed in top_values");
+    assert_eq!(complete["count"], serde_json::json!(2));
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn sample_rows_reaches_raw_source_by_qualified_ref() {
+    // Source-reach: a qualified `schema.table` that is NOT a model is sampled
+    // directly, with no compile required.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("src.duckdb");
+    write_project(dir.path(), &db_path);
+    materialize_orders(&db_path, "seeds", "(1,'COMPLETE'),(2,'PENDING')").await;
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    // `seeds.orders` is a raw table, not a model — reached by its qualified name.
+    let args = serde_json::json!({ "model": "seeds.orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let sc = client
+        .call_tool(CallToolRequestParams::new("sample_rows").with_arguments(args))
+        .await
+        .expect("sample_rows call")
+        .structured_content
+        .expect("structured content");
+
+    assert_ne!(sc["unavailable"], serde_json::json!(true));
+    assert_eq!(
+        sc["columns"].as_array().unwrap().len(),
+        2,
+        "id + status from the raw source"
+    );
+    assert_eq!(sc["rows"].as_array().unwrap().len(), 2);
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn inspect_schema_discovers_raw_sources_and_tolerates_cold_start() {
+    // Cold start: a project with ZERO models must not error, and the physical
+    // raw source tables must still be discovered with their columns.
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("cold.duckdb");
+    write_empty_project(dir.path(), &db_path);
+    materialize_orders(&db_path, "seeds", "(1,'COMPLETE')").await;
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+    let sc = client
+        .call_tool(CallToolRequestParams::new("inspect_schema"))
+        .await
+        .expect("inspect_schema must not error at cold start")
+        .structured_content
+        .expect("structured content");
+
+    assert!(
+        sc["models"].as_array().unwrap().is_empty(),
+        "no models authored yet"
+    );
+    let sources = sc["sources"].as_array().unwrap();
+    let orders = sources
+        .iter()
+        .find(|s| s["name"] == serde_json::json!("seeds.orders"))
+        .expect("seeds.orders discovered as a source");
+    let cols = orders["columns"].as_array().unwrap();
+    assert!(
+        cols.iter()
+            .any(|c| c["name"] == serde_json::json!("status")),
+        "discovered source carries its columns; got {cols:?}"
+    );
+
+    client.cancel().await.unwrap();
+}

--- a/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
+++ b/examples/playground/pocs/03-ai/06-mcp-grounding/README.md
@@ -94,17 +94,23 @@ Open this directory in Claude Code (it picks up `.mcp.json`), confirm the `rocky
 
 > Build a Rocky model for total completed-order revenue in USD from the orders source.
 
+### Prerequisite: seed the warehouse
+
+The MCP grounding tools read the **warehouse**, so the source data must exist in `poc.duckdb` first. Run `./run.sh` once (it seeds `poc.duckdb` with `seeds.orders`) before the interactive demo.
+
 ### Expected agent trajectory
 
-1. **`inspect_schema`** — learns the source columns: `order_id`, `customer_id`, `status`, `amount_cents`, `ordered_at`. A column called `status` and one called `amount_cents` are all the schema offers.
-2. **`sample_rows`** — sees real rows. The `status` values are `'COMPLETE'` (uppercase), never `'completed'`. This is the step a schema-only agent skips.
-3. **`profile_column`** on `amount_cents` — sees the scale: values like 12500, 30000, 45000. Integer cents, not dollars.
+1. **`inspect_schema`** — lists `seeds.orders` under `sources` with its typed columns: `order_id`, `customer_id`, `status`, `amount_cents`, `ordered_at`. (Physical warehouse tables the project never declared as a Rocky source are discovered here too, so the agent can find what to ground against.)
+2. **`sample_rows`** on `seeds.orders` — sees real rows. The `status` values are `'COMPLETE'` (uppercase), never `'completed'`. With no `percent`, the first rows come back deterministically — the right default for a small table. This is the step a schema-only agent skips.
+3. **`profile_column`** on `seeds.orders` / `amount_cents` — sees the scale: values like 12500, 30000, 45000. Integer cents, not dollars. On `status`, the result's `top_values` lists the exact literals (`COMPLETE`, `PENDING`, `CANCELLED`) that a `min`/`max` pair would hide.
 4. **Writes the model** — `WHERE status = 'COMPLETE'`, `SUM(amount_cents) / 100.0 AS revenue_usd`. Equivalent to `revenue_correct.sql`.
 5. **`compile`** — type-checks clean. So would the naive model; compile is necessary, not sufficient.
 6. **`plan_preview`** — reads the exact SQL that would run and confirms it matches intent.
 7. **`propose`** — records an AI-authored plan and returns a `plan_id`. The agent stops here. It does not apply.
 8. **Human review** — you run `rocky review <plan-id>` to read the breaking-change report, then `rocky review <plan-id> --approve` to sign off, then `rocky apply <plan-id>` to materialize.
 9. **`rocky test --declarative`** — the `SUM(revenue_usd) = 1000` assertion reconciles green.
+
+Both grounding tools accept either a compiled model name **or** a qualified `schema.table` source reference (like `seeds.orders`), so an agent can ground a raw source before it has authored any model.
 
 ### Why a schema-only agent ships `revenue_naive`
 


### PR DESCRIPTION
## What

The Rocky MCP data-grounding tools (`sample_rows`, `profile_column`, `inspect_schema`) could only reach a compiled model's *materialized target table*. An agent therefore couldn't sample a raw source **before** authoring a model — the exact gap the `06-mcp-grounding` POC is built to demonstrate, where the documented "sample the source, see `'COMPLETE'`, then write the filter" trajectory could not actually run through MCP.

## Changes

- **Source reach + cold start.** `sample_rows` / `profile_column` now accept a qualified `schema.table` (or `catalog.schema.table`) reference, resolved directly against the warehouse with no compile. This reaches raw sources and works at cold start (a project with zero models yet).
- **`inspect_schema` source discovery.** Lists the physical DuckDB tables as `sources` (typed columns from `information_schema`), and no longer errors on a models-less project.
- **`sample_rows` default.** With no `percent`, returns the first rows deterministically instead of a 10% sample that yields ~0 rows on a small table.
- **`profile_column` `top_values`.** Adds the distinct values + counts for a low-cardinality column (≤25 distinct), surfacing exact literals (e.g. `status = 'COMPLETE'`) that `min`/`max` alone hide.
- **POC.** Updates the `06-mcp-grounding` trajectory to the now-working flow + a seed-the-warehouse prerequisite.

## Tests

4 new round-trip tests (raw-source reach, cold-start discovery, default sampling, `top_values`). `cargo test -p rocky-mcp` green (21/21); clippy `--all-targets` + fmt clean; POC `run.sh` green.

The MCP result types are not part of the CLI codegen cascade, so no `just codegen` is required.