### PR TITLE
chore: triple-cut release — engine 1.47.0, dagster 1.43.0, vscode 1.31.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.1] — 2026-05-30
+
+### Changed
+
+- **Refreshed the Marketplace listing demos.** Merged the separate Inspector and lineage recordings into one full Inspector tour (Overview, Columns, the lineage canvas, Tests, Preview, Profile), and re-recorded every extension demo on a consistent Default Dark Modern theme. No functional code changes — this release re-publishes the extension so the listing picks up the new recordings.
+
 ## [1.31.0] — 2026-05-29
 
 ### Added

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.47.0] — 2026-05-30
+
+### Added
+
+- **`rocky mcp` data-grounding tools reach raw sources and cold-start projects.** The MCP grounding tools now sample qualified `schema.table` sources (not just materialized models), discover an uncompiled project's schema on cold start via `inspect_schema`, default to a deterministic sample, and `profile_column` reports top values. (#752)
+
 ## [1.46.4] — 2026-05-29
 
 ### Fixed

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "redis",
  "serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "logos",
  "miette",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "miette",
  "regex",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.46.4"
+version = "1.47.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.46.4"
+version = "1.47.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.46.4"
+version = "1.47.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.46.4"
+version = "1.47.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.46.4"
+version = "1.47.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.46.4"
+version = "1.47.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.46.4"
+version = "1.47.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.46.4"
+version = "1.47.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.46.4"
+version = "1.47.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.46.4"
+version = "1.47.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.46.4"
+version = "1.47.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.46.4"
+version = "1.47.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.46.4"
+version = "1.47.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.46.4"
+version = "1.47.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.46.4"
+version = "1.47.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.46.4"
+version = "1.47.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.46.4"
+version = "1.47.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.46.4"
+version = "1.47.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.46.4"
+version = "1.47.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.46.4"
+version = "1.47.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.46.4"
+version = "1.47.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.43.0] — 2026-05-30
+
+Companion to engine `v1.47.0`. Codegen-driven — regenerated Pydantic bindings for the engine's `rocky profile` output (the new `profile_schema`) and updated `rocky test` results, plus documentation examples on the public health helpers and a dependency refresh. No new resource wiring or behaviour.
+
 ## [1.42.0] — 2026-05-25
 
 Companion to engine `v1.44.0`. Codegen-driven — regenerated Pydantic bindings for the engine's new AI surface (`rocky ai-contract`, `rocky preview rows`, and the `rocky review` AI-authored-plan gate). No new resource wiring or behaviour.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.42.0"
+version = "1.43.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.42.0"
+version = "1.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
Triple-cut release — consolidates all three artifacts' unreleased work into one PR (per the repo convention), rather than one PR per artifact.

## engine 1.46.4 → 1.47.0
Ships **#752**: `rocky-mcp` data-grounding tools now reach qualified `schema.table` sources (not just materialized models) and cold-start (uncompiled) projects via `inspect_schema`, with a deterministic sample default and `profile_column` top-values. Version bump across the 25 workspace crates + `Cargo.lock` (cargo-validated consistent).

## dagster 1.42.0 → 1.43.0
Companion to engine 1.47.0: regenerated `rocky profile` / `rocky test` Pydantic bindings, health-helper doc examples, and a dependency refresh (all already on `main`; this bump publishes them).

## vscode 1.31.0 → 1.31.1
Listing/docs-only refresh — re-publishes so the Marketplace listing picks up the consolidated Inspector demo + Dark Modern recordings from #751, and drops the now-broken `demo-lineage.gif` reference.

## After merge — tag all three + push
This is squash-merged to one commit on `main`; all three bumps live in that commit, so the three tags point at the same SHA. Each tag push triggers its `*-release.yml` (GitHub Release + external publish — engine binaries, PyPI wheel, Marketplace VSIX):

```
git fetch origin main
SHA=<merged-commit-sha>
git tag -a engine-v1.47.0  "$SHA" -m "Release engine-v1.47.0"
git tag -a dagster-v1.43.0 "$SHA" -m "Release dagster-v1.43.0"
git tag -a vscode-v1.31.1  "$SHA" -m "Release vscode-v1.31.1"
git push origin engine-v1.47.0 dagster-v1.43.0 vscode-v1.31.1
```

Coupled tag pushes can race GitHub's "latest release" flag; after the runs finish, pin engine as latest: `gh release edit engine-v1.47.0 --latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
