### PR TITLE
fix(engine/rocky-snowflake): enable TRANSACTION_ABORT_ON_ERROR via ALTER SESSION, not a SQL-API parameter

### DIFF
--- a/engine/crates/rocky-snowflake/src/connector.rs
+++ b/engine/crates/rocky-snowflake/src/connector.rs
@@ -433,26 +433,38 @@ impl SnowflakeConnector {
         // transactional unit. Single-statement calls keep the parameters
         // map empty so the body is byte-identical to the pre-Bug-1 payload.
         //
-        // For multi-statement scripts we also set `TRANSACTION_ABORT_ON_ERROR
+        // For multi-statement scripts we also need `TRANSACTION_ABORT_ON_ERROR
         // = TRUE`. Without it, a failed DML rolls back only its own changes
         // and leaves the transaction open — subsequent statements (including
         // the trailing `COMMIT`) are skipped, and the in-flight transaction
         // only rolls back implicitly when the REST session ends. That
-        // session-close cleanup is incidental, not contractual: setting
-        // `ABORT_ON_ERROR` makes Snowflake roll back the entire transaction
-        // at the moment of error, which is what `insert_overwrite_partition`
-        // semantically requires.
-        let statement_count = count_statements(sql);
+        // session-close cleanup is incidental, not contractual: abort-on-error
+        // makes Snowflake roll back the entire transaction at the moment of
+        // error, which is what `insert_overwrite_partition` semantically
+        // requires.
+        //
+        // It CANNOT be passed in `parameters`, though: the SQL API rejects
+        // `TRANSACTION_ABORT_ON_ERROR` there with HTTP 400 / code `391917`
+        // ("not allowed or invalid for SQL API"). Instead we prepend an
+        // `ALTER SESSION SET` statement to the script — it runs in the same
+        // session immediately before the `BEGIN`, so the abort-on-error
+        // behavior applies to the transaction that follows. The statement
+        // count is recomputed on the wrapped SQL so `MULTI_STATEMENT_COUNT`
+        // stays correct. Single-statement calls keep the body byte-identical
+        // to the pre-Bug-1 payload (empty parameters, original SQL).
+        let mut statement_sql = sql.to_string();
+        let mut statement_count = count_statements(sql);
         let mut parameters = std::collections::BTreeMap::new();
         if statement_count > 1 {
+            statement_sql = format!("ALTER SESSION SET TRANSACTION_ABORT_ON_ERROR = TRUE;\n{sql}");
+            statement_count = count_statements(&statement_sql);
             parameters.insert(
                 "MULTI_STATEMENT_COUNT".to_string(),
                 statement_count.to_string(),
             );
-            parameters.insert("TRANSACTION_ABORT_ON_ERROR".to_string(), "TRUE".to_string());
         }
         let body = SubmitRequest {
-            statement: sql.to_string(),
+            statement: statement_sql,
             warehouse: self.config.warehouse.clone(),
             database: self.config.database.clone(),
             schema: self.config.schema.clone(),

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -223,13 +223,14 @@ impl SqlDialect for SnowflakeSqlDialect {
         // `MULTI_STATEMENT_COUNT` in `parameters` so Snowflake accepts the
         // multi-statement body and runs them in one session.
         //
-        // The connector ALSO sets `TRANSACTION_ABORT_ON_ERROR = TRUE` for
-        // multi-statement bodies. Without that parameter, a failed DML in
-        // a Snowflake transaction rolls back only its own changes and leaves
+        // The connector ALSO enables `TRANSACTION_ABORT_ON_ERROR` for
+        // multi-statement bodies (by prepending `ALTER SESSION SET ...` — the
+        // SQL API rejects it as a request parameter). Without it, a failed DML
+        // in a Snowflake transaction rolls back only its own changes and leaves
         // the transaction open — subsequent statements (including the
         // trailing `COMMIT`) are skipped, and the in-flight transaction only
         // unwinds implicitly when the REST session ends. That session-close
-        // cleanup is incidental, not contractual: `ABORT_ON_ERROR` makes
+        // cleanup is incidental, not contractual: abort-on-error makes
         // Snowflake roll back the whole transaction at error-time, which
         // is what partition-replace semantically requires. Mirrors BigQuery's
         // single-script `BEGIN TRANSACTION; ...; COMMIT TRANSACTION` form.

--- a/engine/crates/rocky-snowflake/tests/insert_overwrite_partition_live.rs
+++ b/engine/crates/rocky-snowflake/tests/insert_overwrite_partition_live.rs
@@ -24,12 +24,19 @@
 //! `DELETE` autocommits, and the trailing `COMMIT`/`ROLLBACK` is a no-op.
 //!
 //! The dialect now returns a single semicolon-joined script, and the
-//! connector sets `MULTI_STATEMENT_COUNT` so Snowflake parses and runs all
-//! four statements as one transactional unit. This test plants a SQL-level
-//! failure between DELETE and INSERT (the INSERT projects a type-mismatched
-//! literal into a numeric column) and asserts that the partition's
-//! pre-existing rows are still present after the failure — proving the
-//! DELETE was rolled back rather than autocommitted.
+//! connector sets `MULTI_STATEMENT_COUNT` (plus a prepended `ALTER SESSION SET
+//! TRANSACTION_ABORT_ON_ERROR = TRUE`) so Snowflake parses and runs all the
+//! statements as one transactional unit that aborts on error. The happy-path
+//! test (`commits_on_success`) is the load-bearing proof: a replaced target
+//! partition with the untouched sibling can only result from DELETE + INSERT +
+//! COMMIT all running in one transaction. The partial-failure test plants a
+//! SQL-level error at the INSERT (a type-mismatched literal into a numeric
+//! column) and asserts the partition's pre-existing rows survive — i.e.
+//! partition integrity is preserved on failure. (Row counts are read in
+//! separate sessions, which see only committed data, so they confirm
+//! integrity without distinguishing error-time rollback from a never-committed
+//! transaction; the assertion that the error is the *planted* one guards
+//! against false-passing on a pre-execution API rejection.)
 //!
 //! Schemas use the `hc_iop_*` prefix per Hugo's Databricks/Snowflake
 //! convention; the per-run microsecond suffix isolates parallel runs.
@@ -146,9 +153,10 @@ async fn count_rows_in_partition(
 /// Builds the four-statement script via the dialect (the production code path)
 /// but substitutes the INSERT's SELECT with a SQL-level failure that fires
 /// AFTER the DELETE would have committed under the old non-transactional
-/// implementation. Asserts the pre-existing partition rows survive — proving
-/// Snowflake auto-rolled back the DELETE because the script ran in one
-/// session with `MULTI_STATEMENT_COUNT=4`.
+/// implementation. Asserts the pre-existing partition rows survive AND that the
+/// failure is the planted numeric error (not a pre-execution API rejection) —
+/// i.e. the script ran as one aborting transaction and partition integrity was
+/// preserved on failure.
 #[tokio::test]
 #[ignore]
 async fn live_insert_overwrite_partition_rolls_back_on_partial_failure() {
@@ -196,9 +204,20 @@ async fn live_insert_overwrite_partition_rolls_back_on_partial_failure() {
 
     drop_schema(&adapter, &database, &schema).await;
 
+    let err = exec_result.expect_err("script with malformed INSERT should fail end-to-end, got Ok");
+    // The failure must be the planted numeric type-conversion error raised at
+    // the INSERT — proof the script actually executed through DELETE to INSERT
+    // in one session. A pre-execution API rejection (e.g. a forbidden session
+    // parameter, HTTP 400 / code 391917) ALSO satisfies `is_err()` and leaves
+    // the partition untouched, so a bare `is_err()` here false-passes when the
+    // request never runs at all. Match on the planted literal / Snowflake's
+    // numeric-conversion message so this can only pass when execution genuinely
+    // reached the INSERT.
+    let err_text = format!("{err:?}");
     assert!(
-        exec_result.is_err(),
-        "script with malformed INSERT should fail end-to-end, got Ok"
+        err_text.contains("not_a_number") || err_text.contains("Numeric value"),
+        "expected the planted numeric type-conversion failure at the INSERT, but got a \
+         different error — did the request bounce before executing? {err_text}"
     );
     assert_eq!(
         target_partition_count,


### PR DESCRIPTION
## Problem

`insert_overwrite_partition` on Snowflake emits a single semicolon-joined `BEGIN; DELETE; INSERT; COMMIT` script and runs it as one multi-statement request. To make the transaction abort and roll back on a mid-script error, the connector set `TRANSACTION_ABORT_ON_ERROR = TRUE` in the `/api/v2/statements` request `parameters` map.

Snowflake's SQL API **forbids** that parameter and rejects the request with `HTTP 400` / code `391917` (`'TRANSACTION_ABORT_ON_ERROR' is not allowed or invalid for SQL API`). Every multi-statement transaction therefore 400'd before executing — the Snowflake `insert_overwrite_partition` path did not work against the live API.

## Fix

Stop sending it as a request parameter. For multi-statement scripts, prepend an `ALTER SESSION SET TRANSACTION_ABORT_ON_ERROR = TRUE;` statement to the script — it runs in the same session immediately before `BEGIN`, so the abort-on-error behaviour applies to the transaction that follows — and recompute `MULTI_STATEMENT_COUNT` on the wrapped SQL. Single-statement calls keep the request body byte-identical.

## Test hardening

The `rolls_back_on_partial_failure` live test was **false-passing** on this bug: it asserts `is_err()` and that the target partition still holds its seeded rows, both of which hold trivially when the request is rejected before any statement runs. It now also asserts the failure is the *planted* numeric type-conversion error, which can only happen if execution actually reached the `INSERT`.

A wiremock unit test can't catch the original bug — the mock doesn't enforce Snowflake's parameter allowlist.

## Verification

Live-verified against a Snowflake sandbox — all `rocky-snowflake` `#[ignore]` live tests pass:

| Test file | Result |
|---|---|
| `insert_overwrite_partition_live` | 2/2 (incl. `commits_on_success`) |
| `replication_merge_live` | 2/2 |
| `drift_widening_live` | 1/1 |
| `clone_live` | 2/2 |
| `bisection_live` | 2/2 |

Plus `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean.

`commits_on_success` is the load-bearing positive proof: a replaced target partition alongside an untouched sibling can only result from `DELETE` + `INSERT` + `COMMIT` all running in one transaction. The partial-failure test reads row counts in separate sessions (which see only committed data), so it confirms partition integrity is preserved on failure without independently demonstrating the error-time rollback mechanism.
