### PR TITLE
test(engine/rocky-snowflake): live coverage for governance, full-refresh drift, dynamic tables

### DIFF
--- a/engine/crates/rocky-snowflake/tests/drift_full_refresh_live.rs
+++ b/engine/crates/rocky-snowflake/tests/drift_full_refresh_live.rs
@@ -1,0 +1,266 @@
+//! Live Snowflake conformance tests for the non-widening drift paths.
+//!
+//! `#[ignore]`-gated; needs a real Snowflake account (same `SNOWFLAKE_*` env
+//! vars as the other live tests). Complements `drift_widening_live.rs`, which
+//! covers the safe-widening → `AlterColumnTypes` path. Here we pin:
+//!
+//! 1. **Unsafe narrowing → `DropAndRecreate`.** `NUMBER(38,0) → NUMBER(10,0)`
+//!    and `VARCHAR(1000) → VARCHAR(100)` are NOT safe widenings, so
+//!    `detect_drift` must return `DropAndRecreate` (an in-place `ALTER` would
+//!    lose data or be rejected). The generated `DROP TABLE` SQL is then
+//!    executed and the table recreated at the narrowed schema, so the
+//!    full-refresh cycle is validated end-to-end against Snowflake.
+//! 2. **Added column → `Ignore` action + populated `added_columns`.** A column
+//!    present in the source but not the target is surfaced in `added_columns`
+//!    (the action stays `Ignore` because no existing column's type drifted),
+//!    and the `generate_add_column_sql` `ALTER TABLE ... ADD COLUMN` Rocky
+//!    emits is accepted by Snowflake.
+//!
+//! A wiremock test can't catch a misclassification that ships warehouse-
+//! rejected SQL — the `feedback_sql_dialect_live_execute_tests` discipline.
+//!
+//! Schemas use the `hc_drift_*` prefix per Hugo's Snowflake convention; the
+//! per-run microsecond suffix isolates parallel runs.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::drift::{detect_drift, generate_add_column_sql, generate_drop_table_sql};
+use rocky_core::traits::WarehouseAdapter;
+use rocky_ir::{ColumnInfo, DriftAction, TableRef};
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::dialect::SnowflakeSqlDialect;
+
+fn adapter_from_env() -> Option<(SnowflakeWarehouseAdapter, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    let connector = SnowflakeConnector::new(config, auth);
+    Some((SnowflakeWarehouseAdapter::new(connector), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &SnowflakeWarehouseAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+/// Unsafe narrowing must classify as `DropAndRecreate`, and the generated drop
+/// + recreate cycle must execute against Snowflake.
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_unsafe_narrowing_is_drop_and_recreate() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+    let schema = format!("hc_drift_narrow_{}", schema_suffix());
+    let table = "narrowing_target";
+
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+    // Start WIDE.
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"{table}\" \
+             (\"id\" NUMBER(38,0), \"name\" VARCHAR(1000))"
+        ),
+    )
+    .await;
+
+    let table_ref = TableRef {
+        catalog: database.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+    let current_columns = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table");
+
+    // Desired = NARROWER types. Narrowing is not a safe widening.
+    let desired_columns = vec![
+        ColumnInfo {
+            name: "id".to_string(),
+            data_type: "NUMBER(10,0)".to_string(),
+            nullable: true,
+        },
+        ColumnInfo {
+            name: "name".to_string(),
+            data_type: "VARCHAR(100)".to_string(),
+            nullable: true,
+        },
+    ];
+
+    let dialect = SnowflakeSqlDialect;
+    let result = detect_drift(&table_ref, &desired_columns, &current_columns, &dialect);
+    println!(
+        "detect_drift(narrowing) -> action={:?} drifted={:?}",
+        result.action, result.drifted_columns
+    );
+
+    // Apply the full-refresh cycle: generated DROP, then recreate at the new
+    // (narrow) schema. Plain CREATE (no OR REPLACE) makes the DROP's success
+    // load-bearing — if the drop silently failed, this CREATE errors.
+    let drop_sql = generate_drop_table_sql(&table_ref, &dialect).expect("generate_drop_table_sql");
+    println!("emitting: {drop_sql}");
+    exec(&adapter, &drop_sql).await;
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"{table}\" \
+             (\"id\" NUMBER(10,0), \"name\" VARCHAR(100))"
+        ),
+    )
+    .await;
+    let recreated = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table after recreate");
+
+    // Cleanup before assertions.
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    assert_eq!(
+        result.action,
+        DriftAction::DropAndRecreate,
+        "narrowing NUMBER(38,0)->NUMBER(10,0) and VARCHAR(1000)->VARCHAR(100) must be \
+         DropAndRecreate, not an in-place ALTER. Drifted: {:?}",
+        result.drifted_columns
+    );
+    let id_new = recreated
+        .iter()
+        .find(|c| c.name == "id")
+        .map(|c| c.data_type.as_str());
+    let name_new = recreated
+        .iter()
+        .find(|c| c.name == "name")
+        .map(|c| c.data_type.as_str());
+    assert_eq!(id_new, Some("NUMBER(10,0)"), "recreated id type");
+    assert_eq!(name_new, Some("VARCHAR(100)"), "recreated name type");
+}
+
+/// An added column surfaces in `added_columns` (action `Ignore`), and the
+/// generated `ALTER TABLE ... ADD COLUMN` is accepted by Snowflake.
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_added_column_is_ignore_and_add_column_applies() {
+    let Some((adapter, database)) = adapter_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+    let schema = format!("hc_drift_add_{}", schema_suffix());
+    let table = "add_column_target";
+
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!("CREATE TABLE \"{database}\".\"{schema}\".\"{table}\" (\"id\" NUMBER(38,0))"),
+    )
+    .await;
+
+    let table_ref = TableRef {
+        catalog: database.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+    let current_columns = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table");
+
+    // Desired = the existing columns verbatim (so no type drift) + one new
+    // nullable column. Reusing the described types guarantees the only
+    // difference is the addition.
+    let mut desired_columns = current_columns.clone();
+    desired_columns.push(ColumnInfo {
+        name: "region".to_string(),
+        data_type: "VARCHAR(50)".to_string(),
+        nullable: true,
+    });
+
+    let dialect = SnowflakeSqlDialect;
+    let result = detect_drift(&table_ref, &desired_columns, &current_columns, &dialect);
+    println!(
+        "detect_drift(added) -> action={:?} added={:?}",
+        result.action, result.added_columns
+    );
+
+    let add_sql = generate_add_column_sql(&table_ref, &result.added_columns, &dialect)
+        .expect("add column sql");
+    for stmt in &add_sql {
+        println!("emitting: {stmt}");
+        exec(&adapter, stmt).await;
+    }
+    let after = adapter
+        .describe_table(&table_ref)
+        .await
+        .expect("describe_table after add");
+
+    // Cleanup before assertions.
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    assert_eq!(
+        result.action,
+        DriftAction::Ignore,
+        "a pure column addition (no type drift on existing columns) classifies as Ignore; \
+         adds are applied via added_columns, not the action"
+    );
+    assert!(
+        result.added_columns.iter().any(|c| c.name == "region"),
+        "the new column must be surfaced in added_columns; got {:?}",
+        result.added_columns
+    );
+    assert!(
+        after.iter().any(|c| c.name.eq_ignore_ascii_case("region")),
+        "ADD COLUMN must have applied; describe should show the new column. Got {after:?}"
+    );
+}

--- a/engine/crates/rocky-snowflake/tests/governance_live.rs
+++ b/engine/crates/rocky-snowflake/tests/governance_live.rs
@@ -1,0 +1,139 @@
+//! Live Snowflake governance tests: the grant lifecycle (apply → show → revoke).
+//!
+//! `#[ignore]`-gated; needs a real Snowflake account (same `SNOWFLAKE_*` env
+//! vars as the other live tests). The connected role must be able to create a
+//! schema in `SNOWFLAKE_TEST_DATABASE` and grant privileges on it.
+//!
+//! **What this pins.** `SnowflakeGovernanceAdapter` generates `GRANT` /
+//! `SHOW GRANTS` / `REVOKE` SQL that Snowflake actually accepts, and the
+//! `SHOW GRANTS` parser round-trips an applied grant. A wiremock test can't
+//! validate the SQL against Snowflake's privilege model — that `USAGE` is a
+//! schema-valid privilege, that the role name must be double-quoted, or that
+//! the `SHOW GRANTS` column layout matches what `get_grants` indexes into.
+//!
+//! Schemas use the `hc_gov_*` prefix per Hugo's Snowflake convention; the
+//! per-run microsecond suffix isolates parallel runs.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::GovernanceAdapter;
+use rocky_ir::{Grant, GrantTarget, Permission};
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::governance::SnowflakeGovernanceAdapter;
+
+fn connector_from_env() -> Option<(SnowflakeConnector, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    Some((SnowflakeConnector::new(config, auth), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+/// Whether a grant list holds a USAGE-class grant to the PUBLIC role.
+///
+/// Snowflake collapses both `UseCatalog` and `UseSchema` to the `USAGE`
+/// privilege, and the `SHOW GRANTS` parser maps `"USAGE"` back to
+/// `Permission::UseCatalog`, so an applied `UseSchema` reads back as
+/// `UseCatalog`. Accept either to stay robust to that documented collapse.
+fn has_public_usage(grants: &[Grant]) -> bool {
+    grants.iter().any(|g| {
+        g.principal.eq_ignore_ascii_case("PUBLIC")
+            && matches!(g.permission, Permission::UseCatalog | Permission::UseSchema)
+    })
+}
+
+/// `apply_grants` → `get_grants` → `revoke_grants` round-trips against live
+/// Snowflake.
+///
+/// Grants `USAGE` on a freshly created schema to the built-in PUBLIC role,
+/// confirms `SHOW GRANTS` surfaces it, then revokes and confirms it is gone.
+/// Filtering on the PUBLIC grantee keeps the assertion independent of the
+/// owner-role grants `SHOW GRANTS` also returns.
+#[tokio::test]
+#[ignore]
+async fn live_grant_apply_show_revoke_roundtrip() {
+    let Some((connector, database)) = connector_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+    let suffix = schema_suffix();
+    let schema = format!("hc_gov_{suffix}");
+
+    // Create the schema UNQUOTED, matching the dialect's `create_schema_sql`
+    // (and `format_grant_target`/`format_show_grants_sql`) — the governance
+    // adapter interpolates schema identifiers unquoted, relying on Snowflake's
+    // uppercase folding. A quoted (case-sensitive lowercase) schema here would
+    // not be found by the unquoted GRANT/SHOW GRANTS that follow.
+    connector
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {database}.{schema}"))
+        .await
+        .expect("create schema");
+
+    let gov = SnowflakeGovernanceAdapter::from_ref(&connector);
+    let target = GrantTarget::Schema {
+        catalog: database.clone(),
+        schema: schema.clone(),
+    };
+    let grant = Grant {
+        principal: "PUBLIC".to_string(),
+        permission: Permission::UseSchema,
+        target: target.clone(),
+    };
+
+    let applied = gov.apply_grants(std::slice::from_ref(&grant)).await;
+    let after_apply = gov.get_grants(&target).await;
+    let revoked = gov.revoke_grants(std::slice::from_ref(&grant)).await;
+    let after_revoke = gov.get_grants(&target).await;
+
+    // Drop before asserting so a failed assertion leaves no orphan schema.
+    let _ = connector
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {database}.{schema} CASCADE"
+        ))
+        .await;
+
+    applied.expect("apply_grants should be accepted by Snowflake");
+    revoked.expect("revoke_grants should be accepted by Snowflake");
+
+    let after_apply = after_apply.expect("get_grants after apply");
+    assert!(
+        has_public_usage(&after_apply),
+        "USAGE grant to PUBLIC must appear in SHOW GRANTS after apply; got {after_apply:?}"
+    );
+
+    let after_revoke = after_revoke.expect("get_grants after revoke");
+    assert!(
+        !has_public_usage(&after_revoke),
+        "USAGE grant to PUBLIC must be gone after revoke; got {after_revoke:?}"
+    );
+}

--- a/engine/crates/rocky-snowflake/tests/materialization_ddl_live.rs
+++ b/engine/crates/rocky-snowflake/tests/materialization_ddl_live.rs
@@ -1,0 +1,225 @@
+//! Live Snowflake conformance tests for the proprietary materialization DDL:
+//! `DYNAMIC TABLE` and `MATERIALIZED VIEW`.
+//!
+//! `#[ignore]`-gated; needs a real Snowflake account (same `SNOWFLAKE_*` env
+//! vars as the other live tests). These DDL forms are Snowflake-specific —
+//! `CREATE DYNAMIC TABLE ... TARGET_LAG = ... WAREHOUSE = ...` and
+//! `CREATE MATERIALIZED VIEW` — with syntax and feature constraints a wiremock
+//! test can't validate. This pins that the DDL `SnowflakeSqlDialect` emits is
+//! actually accepted by Snowflake and produces a queryable object.
+//!
+//! `MATERIALIZED VIEW` requires Snowflake Enterprise Edition; on a Standard
+//! account the CREATE fails with an "unsupported feature" error. That sub-test
+//! treats the edition error as a skip (the DDL syntax can't be exercised on
+//! that edition) rather than a failure. Dynamic tables are GA on Standard.
+//!
+//! Schemas use the `hc_mat_*` prefix per Hugo's Snowflake convention; the
+//! per-run microsecond suffix isolates parallel runs.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::dialect::SnowflakeSqlDialect;
+
+/// Returns `(adapter, database, warehouse)` — the warehouse is needed for the
+/// dynamic-table DDL.
+fn adapter_from_env() -> Option<(SnowflakeWarehouseAdapter, String, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse: warehouse.clone(),
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    let connector = SnowflakeConnector::new(config, auth);
+    Some((
+        SnowflakeWarehouseAdapter::new(connector),
+        database,
+        warehouse,
+    ))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &SnowflakeWarehouseAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+/// Seeds a 3-row source table and returns its fully-qualified quoted ref.
+async fn seed_source(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) -> String {
+    let source = format!("\"{database}\".\"{schema}\".\"src\"");
+    exec(
+        adapter,
+        &format!("CREATE OR REPLACE TABLE {source} (\"id\" NUMBER(10,0), \"val\" VARCHAR(50))"),
+    )
+    .await;
+    exec(
+        adapter,
+        &format!("INSERT INTO {source} (\"id\", \"val\") VALUES (1, 'a'), (2, 'b'), (3, 'c')"),
+    )
+    .await;
+    source
+}
+
+async fn count_rows(adapter: &SnowflakeWarehouseAdapter, table_ref: &str) -> Option<i64> {
+    let result = adapter
+        .execute_query(&format!("SELECT COUNT(*) AS \"n\" FROM {table_ref}"))
+        .await
+        .ok()?;
+    let cell = result.rows.first()?.first()?.clone();
+    cell.as_i64()
+        .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
+}
+
+/// `CREATE DYNAMIC TABLE ... TARGET_LAG ... WAREHOUSE ... AS <select>` is
+/// accepted by Snowflake and the table refreshes to the source's rows.
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_dynamic_table_ddl_creates_and_refreshes() {
+    let Some((adapter, database, warehouse)) = adapter_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+    let schema = format!("hc_mat_dt_{}", schema_suffix());
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+    let source = seed_source(&adapter, &database, &schema).await;
+
+    let dialect = SnowflakeSqlDialect;
+    let dt_ref = format!("\"{database}\".\"{schema}\".\"dt_orders\"");
+    let select_sql = format!("SELECT \"id\", \"val\" FROM {source}");
+    let ddl = dialect
+        .dynamic_table_ddl(&dt_ref, &select_sql, "1 minute", &warehouse)
+        .expect("dynamic_table_ddl");
+    println!("emitting: {ddl}");
+
+    let create_result = adapter.execute_statement(&ddl).await;
+
+    // A freshly created dynamic table refreshes asynchronously; poll briefly
+    // for the initial refresh to reflect the 3 source rows.
+    let mut observed = None;
+    if create_result.is_ok() {
+        for _ in 0..15 {
+            if let Some(n) = count_rows(&adapter, &dt_ref).await {
+                observed = Some(n);
+                if n == 3 {
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    create_result.expect("CREATE DYNAMIC TABLE should be accepted by Snowflake");
+    assert_eq!(
+        observed,
+        Some(3),
+        "dynamic table should refresh to the 3 source rows; observed {observed:?}"
+    );
+}
+
+/// `CREATE MATERIALIZED VIEW ... AS <select>` is accepted by Snowflake (when
+/// the account edition supports MVs) and serves the source's rows.
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_materialized_view_ddl_creates_and_serves() {
+    let Some((adapter, database, _warehouse)) = adapter_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+    let schema = format!("hc_mat_mv_{}", schema_suffix());
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+    let source = seed_source(&adapter, &database, &schema).await;
+
+    let dialect = SnowflakeSqlDialect;
+    let mv_ref = format!("\"{database}\".\"{schema}\".\"mv_orders\"");
+    // Single-table projection with no joins/aggregates — within Snowflake's MV
+    // restrictions.
+    let select_sql = format!("SELECT \"id\", \"val\" FROM {source}");
+    let ddl = dialect
+        .materialized_view_ddl(&mv_ref, &select_sql)
+        .expect("materialized_view_ddl");
+    println!("emitting: {ddl}");
+
+    let create_result = adapter.execute_statement(&ddl).await;
+
+    // MVs are an Enterprise-edition feature; on Standard the CREATE is rejected
+    // with an unsupported-feature error. Treat that as a skip, not a failure.
+    if let Err(e) = &create_result {
+        let msg = format!("{e:?}");
+        if msg.contains("Unsupported feature")
+            || msg.to_lowercase().contains("materialized view")
+            || msg.contains("Enterprise")
+        {
+            eprintln!("MATERIALIZED VIEW unsupported on this account edition; skipping: {msg}");
+            let _ = adapter
+                .execute_statement(&format!(
+                    "DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"
+                ))
+                .await;
+            return;
+        }
+    }
+
+    let served = if create_result.is_ok() {
+        count_rows(&adapter, &mv_ref).await
+    } else {
+        None
+    };
+
+    exec(
+        &adapter,
+        &format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\" CASCADE"),
+    )
+    .await;
+
+    create_result.expect("CREATE MATERIALIZED VIEW should be accepted (non-edition errors)");
+    assert_eq!(
+        served,
+        Some(3),
+        "materialized view should serve the 3 source rows; got {served:?}"
+    );
+}


### PR DESCRIPTION
## What

Three `#[ignore]` live conformance tests against a real Snowflake account, expanding coverage beyond the existing clone / insert-overwrite / bisection / widening / merge suite onto surfaces that only a live run can validate (the `feedback_sql_dialect_live_execute_tests` discipline — a wiremock mock can't enforce Snowflake's SQL contract).

| Test file | Surface |
|---|---|
| `governance_live` | `apply_grants` → `get_grants` → `revoke_grants` round-trip |
| `drift_full_refresh_live` | unsafe narrowing → `DropAndRecreate`; added column → `Ignore` + `added_columns` |
| `materialization_ddl_live` | `CREATE DYNAMIC TABLE`; `CREATE MATERIALIZED VIEW` |

## Notes from the live runs

- **Governance:** the grant lifecycle round-trips correctly. Documented in the test: the governance adapter interpolates schema/database identifiers **unquoted** (relying on Snowflake's uppercase folding), consistent with the dialect's `create_schema_sql` — so the test creates its schema unquoted to match.
- **Drift:** unsafe narrowing (`NUMBER(38,0)→NUMBER(10,0)`, `VARCHAR(1000)→VARCHAR(100)`) correctly classifies as `DropAndRecreate`; the generated `DROP TABLE` is executed and the table recreated at the narrowed schema. An added column surfaces in `added_columns` (action stays `Ignore`) and the generated `ALTER TABLE ... ADD COLUMN` is accepted.
- **Materialization:** `CREATE DYNAMIC TABLE … TARGET_LAG … WAREHOUSE …` is accepted and refreshes to the source rows. `MATERIALIZED VIEW` is Enterprise-edition only; on a Standard account the CREATE returns `Unsupported feature 'MATERIALIZED VIEWS'`, which the test treats as a skip (the DDL syntax can't be exercised on that edition) rather than a failure.

No adapter bugs found in these three paths. All four tests pass against the live sandbox; `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean.

These tests don't run in CI (no creds) — they're gated behind `#[ignore]` and `SNOWFLAKE_*` env vars, run on demand.
