### PR TITLE
test(engine/rocky-snowflake): drop bisection schemas before unwrapping diff result

### DIFF
--- a/engine/crates/rocky-snowflake/tests/bisection_live.rs
+++ b/engine/crates/rocky-snowflake/tests/bisection_live.rs
@@ -184,13 +184,14 @@ async fn live_noop_diff_examines_root_chunks_only() {
         pk_hi: 10_000,
     };
 
-    let result = bisection_diff(&adapter, &adapter, &target, &config)
-        .await
-        .expect("noop bisection on Snowflake should succeed");
+    let result = bisection_diff(&adapter, &adapter, &target, &config).await;
 
+    // Drop the schemas BEFORE unwrapping the result, so a failed diff doesn't
+    // leak the seeded schemas (capture-before-cleanup, as clone_live does).
     drop_schema(&adapter, &database, &base_schema).await;
     drop_schema(&adapter, &database, &branch_schema).await;
 
+    let result = result.expect("noop bisection on Snowflake should succeed");
     assert_eq!(result.rows_added, 0);
     assert_eq!(result.rows_removed, 0);
     assert_eq!(result.rows_changed, 0);
@@ -247,13 +248,14 @@ async fn live_finds_planted_change() {
         pk_hi: 10_000,
     };
 
-    let result = bisection_diff(&adapter, &adapter, &target, &config)
-        .await
-        .expect("planted-change bisection on Snowflake should succeed");
+    let result = bisection_diff(&adapter, &adapter, &target, &config).await;
 
+    // Drop the schemas BEFORE unwrapping the result, so a failed diff doesn't
+    // leak the seeded schemas (capture-before-cleanup, as clone_live does).
     drop_schema(&adapter, &database, &base_schema).await;
     drop_schema(&adapter, &database, &branch_schema).await;
 
+    let result = result.expect("planted-change bisection on Snowflake should succeed");
     assert_eq!(result.rows_added, 0);
     assert_eq!(result.rows_removed, 0);
     assert_eq!(result.rows_changed, 1, "exactly one row should differ");


### PR DESCRIPTION
## What

Both `bisection_live` tests called `bisection_diff(...).await.expect(...)` **inline, before** the `drop_schema` calls. A failed diff therefore panicked and leaked the two seeded schemas into the sandbox. Now the result is captured, the schemas are dropped, then the result is unwrapped — the capture-before-cleanup pattern `clone_live` already uses.

## Scope (deliberately small)

This closes bisection's one clear **in-test failure-path** leak. It does **not** claim to fully prevent accumulation:

- **Process interruption** (Ctrl-C on the 10k-row seed, a CI timeout-kill, `panic=abort`) doesn't unwind, so no in-test cleanup — `catch_unwind` or `Drop` — would run. That's the dominant leak vector for slow `#[ignore]` tests, and it's unaddressable from inside the test.
- The residual setup-`.expect()` holes (`create_schema`/`seed_table`) are **suite-wide** — present in every live test including the recently-added ones — so they're left as-is rather than special-casing three files.

The only thing that fully prevents accumulation is a best-effort **startup sweep** (drop stale test-prefixed schemas at run start), which survives a kill — but that's a glob over shared state and a separate decision, so it's not bundled here.

Verified: `fmt` + `clippy --all-targets --all-features` clean; both `bisection_live` tests pass against the live sandbox.