### PR TITLE
fix(dagster): guard non-dict plan JSON to avoid uncaught AttributeError

### DIFF
--- a/integrations/dagster/src/dagster_rocky/resource.py
+++ b/integrations/dagster/src/dagster_rocky/resource.py
@@ -1887,6 +1887,12 @@ class RockyResource(dg.ConfigurableResource):
             # the caller will hit when it parses the apply output —
             # giving up here would mask the actual JSON shape problem.
             return None
+        if not isinstance(payload, dict):
+            # Valid JSON that is not an object (``null``, ``[]``, ``5``).
+            # Route into the same ``plan_id is None`` -> ``dg.Failure``
+            # path the caller already raises, instead of crashing on
+            # ``.get`` with an uncaught AttributeError.
+            return None
         plan_id = payload.get("plan_id")
         if not isinstance(plan_id, str):
             return None

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -1246,9 +1246,15 @@ def parse_rocky_output(json_str: str) -> RockyOutput:
     """Parse a Rocky JSON output payload, auto-detecting the command type.
 
     Raises:
-        ValueError: If the ``command`` field is missing or unrecognized.
+        ValueError: If the payload is not a JSON object, or the
+            ``command`` field is missing or unrecognized.
     """
     data = json.loads(json_str)
+    if not isinstance(data, dict):
+        # Valid JSON that is not an object (``null``, ``[]``, ``5``) would
+        # otherwise crash on ``.get`` with an uncaught AttributeError —
+        # honour the documented ValueError contract instead.
+        raise ValueError(f"Rocky output is not a JSON object: {data!r}")
     command = data.get("command", "")
 
     # Lineage and history have multiple shapes that share the same command name.

--- a/integrations/dagster/tests/test_resource.py
+++ b/integrations/dagster/tests/test_resource.py
@@ -1883,6 +1883,11 @@ def test_extract_plan_id_returns_none_for_malformed_payload():
     assert RockyResource._extract_plan_id(json.dumps({"plan_id": None})) is None
     assert RockyResource._extract_plan_id(json.dumps({"plan_id": 42})) is None
     assert RockyResource._extract_plan_id(json.dumps({"plan_id": "abc"})) == "abc"
+    # Valid JSON that is not an object must return None (not raise
+    # AttributeError on ``.get``) so the caller's clean dg.Failure fires.
+    assert RockyResource._extract_plan_id("null") is None
+    assert RockyResource._extract_plan_id("[]") is None
+    assert RockyResource._extract_plan_id("5") is None
 
 
 def test_build_plan_args_mirrors_build_run_args_flag_surface():

--- a/integrations/dagster/tests/test_types.py
+++ b/integrations/dagster/tests/test_types.py
@@ -664,6 +664,14 @@ def test_parse_missing_command_key():
         parse_rocky_output('{"version": "0.1.0"}')
 
 
+@pytest.mark.parametrize("payload", ["null", "[]", "5"])
+def test_parse_non_dict_json_raises_value_error(payload: str):
+    """Valid JSON that is not an object must raise the documented
+    ValueError, not crash on ``.get`` with an uncaught AttributeError."""
+    with pytest.raises(ValueError, match="not a JSON object"):
+        parse_rocky_output(payload)
+
+
 def test_parse_drift_result(drift_json: str):
     result = DriftDetectResult.model_validate_json(drift_json)
     assert result.command == "drift"


### PR DESCRIPTION
## Problem

Two JSON-parsing paths in `dagster_rocky` did `json.loads(...)` then `.get(...)`, catching only `json.JSONDecodeError`. Valid-but-non-object JSON (`null`, `[]`, `5`) parses successfully, so the subsequent `.get(...)` raised an uncaught `AttributeError` — bypassing the clean error the very next block was written to surface:

- `resource.py::_extract_plan_id` — called unguarded from `_apply_plan` and `run_pipes`. The `AttributeError` short-circuited the `plan_id is None -> dg.Failure` upgrade-hint that operators rely on.
- `types.py::parse_rocky_output` — the `AttributeError` violated the docstring's documented `ValueError` contract.

## Fix

- `_extract_plan_id`: after `json.loads`, return `None` for non-dict payloads so the caller's existing `plan_id is None -> dg.Failure` path handles it cleanly.
- `parse_rocky_output`: raise `ValueError` for non-dict payloads before dispatch, honoring the documented contract (its own distinct message, so the existing "Unknown Rocky command" assertions stay precise).

Single-line guards at each site; no call sites changed and no unrelated refactors.

## Tests

- `test_extract_plan_id_returns_none_for_malformed_payload` extended with `null` / `[]` / `5` -> `None`.
- New parametrized `test_parse_non_dict_json_raises_value_error` feeds `null` / `[]` / `5` and asserts `ValueError` (not `AttributeError`).

## Gates

- `ruff format --check` — pass
- `ruff check` — pass
- `pytest` — 567 passed