### PR TITLE
fix(vscode): harden binary-path scope and doctor webview command URIs

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -76,6 +76,7 @@
         "rocky.server.path": {
           "type": "string",
           "default": "rocky",
+          "scope": "machine",
           "description": "Path to the Rocky binary"
         },
         "rocky.server.extraArgs": {
@@ -84,6 +85,7 @@
             "type": "string"
           },
           "default": [],
+          "scope": "machine",
           "description": "Extra arguments to pass to rocky lsp"
         },
         "rocky.inlayHints.enabled": {

--- a/editors/vscode/src/webviews/doctor.ts
+++ b/editors/vscode/src/webviews/doctor.ts
@@ -12,7 +12,15 @@ export function showDoctorResult(result: DoctorResult): void {
     "rockyDoctor",
     "Rocky Doctor",
     vscode.ViewColumn.Beside,
-    { enableScripts: true, retainContextWhenHidden: true, enableCommandUris: true },
+    {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+      // Allow only the exact command: URIs this webview's HTML links to, so a
+      // future templating bug can't smuggle in an arbitrary command. Every
+      // command: anchor here resolves to workbench.action.openSettings (the
+      // ?"…" query is the settings filter, not a separate command).
+      enableCommandUris: ["workbench.action.openSettings"],
+    },
   );
 
   panel.webview.html = renderDoctorHtml(panel.webview, result);
@@ -124,9 +132,10 @@ function badgeFor(status: string | undefined): string {
 /**
  * Returns inline `command:` anchor tags for a failed check.
  *
- * Uses VS Code `command:` URIs — these work because `enableCommandUris: true`
- * is set on the webview. All links are hardcoded to commands that are always
- * registered; no user-supplied data is interpolated into the href.
+ * Uses VS Code `command:` URIs — these work because
+ * `workbench.action.openSettings` is on the webview's `enableCommandUris`
+ * allowlist. All links are hardcoded to that command; no user-supplied data is
+ * interpolated into the href.
  */
 function buildCheckActionLinks(checkName: string): string {
   // Always offer "Open settings" for any failed check.


### PR DESCRIPTION
Two hardening fixes for the VS Code extension.

## M4 — scope `rocky.server.path` / `rocky.server.extraArgs` to `machine`

Both settings declared no `scope`, so they defaulted to `window`, meaning a workspace `.vscode/settings.json` could override them. The resolved `rocky.server.path` is spawned by the LSP client, the MCP provider, the inline code-lens, and the task provider. Once a user grants Workspace Trust (a routine action), a hostile repository could repoint that path at a repo-supplied binary and get it executed.

Marking both keys `"scope": "machine"` makes them user/machine-only — workspace settings can no longer set them — which closes the override vector. `machine-overridable` would not suffice, since it still permits a workspace override.

## L7 — allowlist the doctor webview's command URIs

The doctor webview used `enableCommandUris: true`, which permits *any* `command:` URI embedded in webview HTML to execute. Every `command:` anchor the doctor HTML actually renders resolves to a single command (`workbench.action.openSettings`; the `?"…"` portion is the settings filter, not a separate command), so the option is narrowed to an explicit one-element allowlist.

The webview's Re-run / Open Settings buttons use `postMessage` and are gated by a separate allowlist, so they are unaffected.

## Verification

- `npm run compile` — 0 errors
- `npm run lint` — clean
- `npm run test:unit` — 194/194 passing (the full `npm test` Electron integration suite was not run headless)