### PR TITLE
fix(vscode): fix first-use onboarding for users without the CLI

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -40,7 +40,7 @@ Editor support for [Rocky](https://github.com/rocky-data/rocky), the typed graph
 ## Requirements
 
 - **[Rocky CLI](https://github.com/rocky-data/rocky/releases?q=engine)** on your `PATH` (or set `rocky.server.path`)
-- **VS Code** 1.116.0+
+- **VS Code** 1.120.0+
 
 ## Install
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -105,25 +105,10 @@
           "default": [],
           "markdownDescription": "Optional status bar segments to show after the LSP state. Each segment silently no-ops if its data is unavailable. Options: `warehouse`, `lastRunAge`, `driftCount`, `branchState`."
         },
-        "rocky.defaultWarehouse": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Default warehouse identifier shown in status bar and command prompts. Read-only contract — consumed by future commands; changing this has no immediate effect beyond display."
-        },
-        "rocky.defaultBranch": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Default branch name for `rocky.branchApprove` / `rocky.branchPromote` prompts. Read-only contract — consumed by future commands."
-        },
         "rocky.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "Enable drift diagnostics (inline errors/warnings from `rocky compile`). Set to `false` to disable all Rocky diagnostics without uninstalling the extension."
-        },
-        "rocky.autoRunOnSave": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Automatically run the pipeline when a model file is saved. Read-only contract — consumed by future commands; has no effect in this release."
         },
         "rocky.costAnnotations.enabled": {
           "type": "boolean",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -902,12 +902,21 @@
       {
         "id": "rocky.getStartedWalkthrough",
         "title": "Get Started with Rocky",
-        "description": "Set up Rocky and run your first pipeline in five steps.",
+        "description": "Set up Rocky and run your first pipeline.",
         "steps": [
           {
             "id": "rocky.walkthrough.installCli",
             "title": "Install the Rocky CLI",
-            "description": "Rocky needs the `rocky` binary on your PATH. Run Doctor to verify your installation.\n\n[Run Health Check](command:rocky.doctor)",
+            "description": "Rocky needs the `rocky` binary on your PATH. The extension talks to it; it isn't bundled.\n\n[Install instructions](https://github.com/rocky-data/rocky#readme)\n\nmacOS / Linux:\n\n```\ncurl -fsSL https://raw.githubusercontent.com/rocky-data/rocky/main/engine/install.sh | bash\n```",
+            "media": {
+              "image": "media/rocky-readme-light.png",
+              "altText": "Rocky logo"
+            }
+          },
+          {
+            "id": "rocky.walkthrough.verifyCli",
+            "title": "Verify Your Installation",
+            "description": "Once the CLI is installed, run the health check to confirm the extension can find and talk to it.\n\n[Run Health Check](command:rocky.doctor)",
             "media": {
               "image": "media/rocky-readme-light.png",
               "altText": "Rocky logo"

--- a/editors/vscode/src/lspClient.ts
+++ b/editors/vscode/src/lspClient.ts
@@ -11,6 +11,14 @@ import {
 import { getConfig } from "./config";
 import { getOutputChannel } from "./output";
 
+/**
+ * Install instructions for the Rocky CLI. Opened from the "Install Rocky"
+ * action on the missing-binary startup toast so a Marketplace user with no CLI
+ * has a one-click path off the dead end. Points at the README quickstart (the
+ * `curl … | bash` one-liner), not the raw releases list.
+ */
+const ROCKY_INSTALL_URL = "https://github.com/rocky-data/rocky#readme";
+
 let client: LanguageClient | undefined;
 let statusBarItem: vscode.StatusBarItem;
 
@@ -436,11 +444,13 @@ function handleStartupFailure(err: Error): void {
     : `Rocky language server failed to start: ${err.message}`;
 
   const actions = isMissingBinary
-    ? ["Configure Path", "Show Logs"]
+    ? ["Install Rocky", "Configure Path", "Show Logs"]
     : ["Show Logs"];
 
   vscode.window.showErrorMessage(message, ...actions).then((choice) => {
-    if (choice === "Configure Path") {
+    if (choice === "Install Rocky") {
+      void vscode.env.openExternal(vscode.Uri.parse(ROCKY_INSTALL_URL));
+    } else if (choice === "Configure Path") {
       void vscode.commands.executeCommand(
         "workbench.action.openSettings",
         "rocky.server.path",


### PR DESCRIPTION
The extension is an LSP client that spawns `rocky lsp` and bundles no binary — it hard-depends on `rocky` being on `PATH`. Several onboarding surfaces broke down for a Marketplace user who installs the extension before the CLI. This PR fixes the first-use path.

## One-click install off the missing-binary dead end
When the language server fails to start because the binary is missing (ENOENT / "not found"), the startup toast previously offered only **Configure Path** — useless when nothing is installed yet. Added an **Install Rocky** action that opens the install instructions in the browser. **Configure Path** stays.

## Walkthrough no longer requires the missing binary to confirm install
The "Get Started" walkthrough's first step was titled "Install the Rocky CLI" but its action shelled out to `rocky doctor` — the very binary that may be absent — so the step meant to confirm the install failed identically when the install was absent. Split it into two:

1. **Install the Rocky CLI** — links to the installer and shows the one-line install command. No binary required.
2. **Verify Your Installation** — runs the health check, after the CLI is installed.

Init → Compile → Lineage → Run are unchanged.

## Removed three settings that have no effect
`rocky.autoRunOnSave`, `rocky.defaultWarehouse`, and `rocky.defaultBranch` were each documented as having no effect ("read-only contract for future commands") and are read nowhere in the extension. Removed from the settings contribution so users aren't presented dead switches.

## Corrected the README's minimum VS Code version
The README said `1.116.0+`, but `engines.vscode` (the real Marketplace install gate) is `^1.120.0`. The README understated the requirement and would mislead users on 1.116–1.119. Aligned to `1.120.0+`.

## Verification
- `npm run compile` (tsc) — clean, no type errors
- `npm run lint` (eslint) — clean
- `npm run test:unit` (vitest) — 194 passed across 23 files
- `package.json` re-parses as valid JSON; walkthrough now has 6 steps; the three settings are gone