### PR TITLE
fix(engine/rocky-cli): make the playground quickstart work first-try and stop doctor/run/output from crying wolf

### DIFF
--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -230,27 +230,23 @@ pub async fn doctor(
         let start = Instant::now();
         if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
             let backend = &cfg.state.backend;
-            let has_remote = *backend != rocky_core::config::StateBackend::Local;
             let details = if verbose {
                 vec![("backend".into(), backend.to_string())]
             } else {
                 Vec::new()
             };
+            // A `local` state backend is the healthy default for a single-node
+            // project (it mirrors the `state_rw` check, which already treats
+            // local as Healthy — no remote probe needed). `Warning` is
+            // reserved for a misconfigured remote backend, surfaced by the
+            // `state_rw` RW probe below.
             checks.push(HealthCheck {
                 name: "state_sync".into(),
-                status: if has_remote {
-                    HealthStatus::Healthy
-                } else {
-                    HealthStatus::Warning
-                },
+                status: HealthStatus::Healthy,
                 message: format!("State backend: {backend}"),
                 duration_ms: start.elapsed().as_millis() as u64,
                 details,
             });
-            if !has_remote {
-                suggestions
-                    .push("Consider using 'tiered' state backend for distributed execution".into());
-            }
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/playground.rs
+++ b/engine/crates/rocky-cli/src/commands/playground.rs
@@ -61,6 +61,15 @@ pub fn run_playground_with_template(target_dir: &str, template_name: &str) -> Re
         Template::Showcase => write_showcase(dir)?,
     }
 
+    // Auto-seed the persistent DuckDB file for the quickstart template so the
+    // `rocky compile && rocky test && rocky run` golden path works first-try
+    // with no manual `duckdb playground.duckdb < data/seed.sql` step and no
+    // DuckDB-CLI prerequisite. The quickstart `rocky.toml` points its adapter
+    // at `playground.duckdb`; we load the seed into that exact file.
+    if template == Template::Quickstart {
+        seed_quickstart_db(dir)?;
+    }
+
     let template_label = match template {
         Template::Quickstart => "Quickstart (3 models)",
         Template::Ecommerce => "E-Commerce (11 models, incremental + merge)",
@@ -77,11 +86,38 @@ pub fn run_playground_with_template(target_dir: &str, template_name: &str) -> Re
     println!("    cd {target_dir}");
     println!("    rocky compile                           # type-check the models");
     println!("    rocky test                              # run models on an in-memory DuckDB");
-    println!("    duckdb playground.duckdb < data/seed.sql # seed the file DB");
     println!("    rocky run                               # materialize the model DAG");
     println!("    rocky preview rows --model customer_orders  # peek at materialized rows");
     println!();
 
+    Ok(())
+}
+
+/// Load `data/seed.sql` into the quickstart's persistent `playground.duckdb`
+/// file so `rocky run` has source tables to read on the very first invocation.
+///
+/// The seed is applied to `<dir>/playground.duckdb` — the exact path the
+/// scaffolded `rocky.toml` adapter points at. We open the file, execute the
+/// (already-written) seed script, then drop the connection before returning so
+/// the file isn't locked when the user's `rocky run` opens it.
+#[cfg(feature = "duckdb")]
+fn seed_quickstart_db(dir: &Path) -> Result<()> {
+    use rocky_duckdb::DuckDbConnector;
+
+    let db_path = dir.join("playground.duckdb");
+    let conn = DuckDbConnector::open(&db_path)
+        .with_context(|| format!("failed to open {}", db_path.display()))?;
+    conn.execute_statement(QUICKSTART_SEED)
+        .context("failed to seed playground.duckdb")?;
+    // `conn` drops here, releasing the file lock before the next-steps print.
+    Ok(())
+}
+
+/// No-op when the `duckdb` feature is disabled: the scaffold still writes
+/// `data/seed.sql`, and the printed next-steps tell the user to seed manually
+/// is no longer applicable for such builds (which can't run DuckDB anyway).
+#[cfg(not(feature = "duckdb"))]
+fn seed_quickstart_db(_dir: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -136,12 +172,12 @@ fn write_quickstart(dir: &Path) -> Result<()> {
 
 const QUICKSTART_SEED: &str = r#"-- Seed data for quickstart playground.
 --
--- `rocky test` auto-loads this file into an in-memory DuckDB before
--- executing models, so the playground is runnable end-to-end with no
--- manual setup.
+-- `rocky playground` auto-loads this file into the persistent
+-- `playground.duckdb` during scaffold, so `rocky run` works first-try with
+-- no manual setup. `rocky test` also auto-loads it into an in-memory DuckDB
+-- before executing models.
 --
--- For the `rocky discover/plan/run` flow you need to seed the persistent
--- file referenced by `path` in rocky.toml first:
+-- Re-seed at any time (e.g. after editing this file) with:
 --   duckdb playground.duckdb < data/seed.sql
 
 CREATE SCHEMA IF NOT EXISTS raw__orders;

--- a/engine/crates/rocky-cli/src/commands/playground_data/rocky.toml
+++ b/engine/crates/rocky-cli/src/commands/playground_data/rocky.toml
@@ -1,13 +1,14 @@
 # Rocky Playground — a runnable, inspectable DuckDB pipeline. No credentials.
 #
-# Seed the local DuckDB once, then materialize the model DAG:
-#   duckdb playground.duckdb < data/seed.sql
+# `rocky playground` already seeded the local DuckDB (data/seed.sql), so you
+# can materialize the model DAG straight away:
 #   rocky run
 #
 # `rocky test` runs the models against an in-memory DuckDB (auto-loading
-# data/seed.sql), so it needs no manual seeding. After `rocky run` you can
-# `rocky preview rows --model customer_orders`, `rocky profile customer_orders`,
-# or open a model in the VS Code Inspector to see real materialized data.
+# data/seed.sql), so it needs no manual seeding either. After `rocky run` you
+# can `rocky preview rows --model customer_orders`, `rocky profile
+# customer_orders`, or open a model in the VS Code Inspector to see real
+# materialized data. Re-seed any time with `duckdb playground.duckdb < data/seed.sql`.
 
 [adapter]
 type = "duckdb"

--- a/engine/crates/rocky-cli/src/deprecation.rs
+++ b/engine/crates/rocky-cli/src/deprecation.rs
@@ -1,37 +1,25 @@
-//! Deprecation-notice emission for CLI aliases retained during the Phase 4
-//! deprecation cycle.
+//! Deprecation-notice emission for the bare-verb `rocky branch promote
+//! <name>` alias.
 //!
-//! `rocky run` and the bare-verb form of `rocky branch promote <name>` are
-//! kept as aliases that internally chain `plan + apply` (per Phases 1–3 of
-//! the plan/apply spine, shipped in engine-v1.32.0). They emit a one-line
-//! `[deprecated]` notice to stderr on every invocation pointing at the
-//! canonical two-step flow. Removal target: a future major release.
+//! `rocky branch promote <name>` (without `--plan`) is kept as an alias that
+//! internally chains `plan + apply`. It emits a one-line `[deprecated]`
+//! notice to stderr on every invocation pointing at the canonical
+//! `rocky plan promote` + `rocky apply` flow, which runs the approval +
+//! breaking-change gates before any production data is touched. Removal
+//! target: a future major release.
+//!
+//! (`rocky run` is intentionally *not* deprecated — it stays first-class as
+//! the fused single-step plan+apply convenience for local iteration and
+//! automation, alongside the canonical auditable two-step.)
 //!
 //! Suppression: set `ROCKY_SUPPRESS_DEPRECATION=1` in the environment to
 //! silence the warning. The dagster integration sets this on every
-//! subprocess invocation so existing `RockyResource.materialize()` callers
-//! don't see noise on every run while their orchestration code still
-//! routes through the alias verbs.
+//! subprocess invocation so existing callers don't see noise on every
+//! run while their orchestration code still routes through the alias verb.
 
 use std::io::{self, Write};
 
 const SUPPRESS_ENV_VAR: &str = "ROCKY_SUPPRESS_DEPRECATION";
-
-/// Stderr message emitted by `rocky run`.
-///
-/// As of the flag-surface parity work, `rocky plan` accepts the full flag
-/// surface of `rocky run` (`--resume`, `--shadow`, `--partition`,
-/// `--idempotency-key`, `--parallel`, `--all`, `--branch`,
-/// `--governance-override`, `--dag`, `--model`, `--models`, `--from`,
-/// `--to`, `--latest`, `--missing`, `--lookback`, `--resume-latest`,
-/// `--shadow-suffix`, `--shadow-schema`). `--watch` remains on `rocky run`
-/// because its re-run-loop semantics have no plan/apply analogue.
-pub const RUN_DEPRECATION: &str = "\
-`rocky run` is deprecated — the canonical form is `rocky plan [flags]` followed by `rocky apply <plan-id>`, \
-which persists an auditable artifact at `.rocky/plans/<plan-id>.json`. \
-`rocky plan` accepts the same flag surface as `rocky run` (filter, pipeline, partition, shadow, branch, resume, idempotency-key, parallel, all, dag, governance-override, model, models, env). \
-The only exception is `--watch`, whose re-run-loop semantics are inherently runtime-only; it remains on `rocky run`. \
-Suppress this warning with ROCKY_SUPPRESS_DEPRECATION=1.";
 
 /// Stderr message emitted by bare `rocky branch promote <name>` (without `--plan`).
 pub const BRANCH_PROMOTE_DEPRECATION: &str = "\
@@ -67,16 +55,15 @@ mod tests {
     /// parallel cargo-test threads — we deliberately don't try to test
     /// `warn()` in-process for that reason.
     #[test]
-    fn warning_messages_are_one_logical_line() {
-        for msg in [RUN_DEPRECATION, BRANCH_PROMOTE_DEPRECATION] {
-            assert!(
-                !msg.contains('\n'),
-                "message must not embed newlines: {msg:?}"
-            );
-            assert!(
-                msg.contains("ROCKY_SUPPRESS_DEPRECATION=1"),
-                "suppress hint missing: {msg:?}"
-            );
-        }
+    fn warning_message_is_one_logical_line() {
+        let msg = BRANCH_PROMOTE_DEPRECATION;
+        assert!(
+            !msg.contains('\n'),
+            "message must not embed newlines: {msg:?}"
+        );
+        assert!(
+            msg.contains("ROCKY_SUPPRESS_DEPRECATION=1"),
+            "suppress hint missing: {msg:?}"
+        );
     }
 }

--- a/engine/crates/rocky-observe/src/tracing_setup.rs
+++ b/engine/crates/rocky-observe/src/tracing_setup.rs
@@ -69,7 +69,9 @@ impl TracingGuard {
 ///   dagster-rocky).
 /// - `json=false`: human-readable compact output (for local dev).
 ///
-/// Log level controlled by `RUST_LOG` env var (default `info`).
+/// Log level controlled by `RUST_LOG` env var. The default
+/// (`info,salsa=warn`) keeps Rocky's own spans at `info` while silencing the
+/// chatty salsa query-cache trace.
 ///
 /// **Hold the returned [`TracingGuard`] for the lifetime of the
 /// process** — dropping it earlier flushes and shuts down the batch
@@ -77,7 +79,12 @@ impl TracingGuard {
 /// tracer.
 #[must_use]
 pub fn init_tracing(json: bool) -> TracingGuard {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    // Default to `info` for Rocky's own spans (so `rocky trace` / replay keep
+    // capturing `pipeline.run`, `materialize.table`, ...) but silence the
+    // chatty `salsa::function::execute` query-cache trace that would otherwise
+    // dump on every bare `rocky compile`. `RUST_LOG` overrides this entirely.
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,salsa=warn"));
 
     // `Layer::boxed()` erases the layer type so the if/else branch
     // returns a uniform `BoxLayer` that still implements

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -294,7 +294,14 @@ enum Command {
         no_cache: bool,
     },
 
-    /// Generate SQL without executing (dry-run).
+    /// Generate SQL without executing (dry-run) — the deliberate, auditable
+    /// first half of the two-step rollout.
+    ///
+    /// `rocky plan` + `rocky apply <plan-id>` is the canonical path for
+    /// production and PR gating: the plan is persisted at
+    /// `.rocky/plans/<plan-id>.json` so it can be inspected and reviewed
+    /// before any data is touched. For local iteration where you just want
+    /// the pipeline to run now, the single-step `rocky run` is the sibling.
     ///
     /// With no subcommand: emits a replication-pipeline SQL dry-run plus an
     /// optional `RunPlan` blueprint (when a `models/` directory is present).
@@ -450,7 +457,13 @@ enum Command {
         env: Option<String>,
     },
 
-    /// Execute the full pipeline: discover → drift → create → copy → check
+    /// Execute the full pipeline in one step: discover → drift → create → copy → check.
+    ///
+    /// `rocky run` is the imperative single-step path — a fused plan+apply for
+    /// local development and automation where you want the pipeline to execute
+    /// now. For deliberate, auditable rollouts (production, PR gating) use the
+    /// two-step `rocky plan` + `rocky apply <plan-id>`, which persists the plan
+    /// at `.rocky/plans/<plan-id>.json` so it can be reviewed before it runs.
     Run {
         /// Filter sources by component value (e.g., --filter client=acme)
         #[arg(long, long_help = FILTER_LONG_HELP)]
@@ -2210,12 +2223,11 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     }
                 }
             } else {
-                // `rocky run` is routed through `apply::run_apply_inline_for_run`
-                // (the Phase 2 alias path). This is a thin passthrough — behaviour
-                // is unchanged. Phase 4 emits a deprecation notice; the canonical
-                // flow is `rocky plan` + `rocky apply <plan-id>`. The notice
-                // honours `ROCKY_SUPPRESS_DEPRECATION=1` (dagster sets it).
-                rocky_cli::deprecation::warn(rocky_cli::deprecation::RUN_DEPRECATION);
+                // `rocky run` is the first-class fused plan+apply convenience
+                // for local iteration and automation; it routes through
+                // `apply::run_apply_inline_for_run`. The canonical auditable
+                // two-step (`rocky plan` + `rocky apply <plan-id>`) remains
+                // available for production / PR gating.
                 //
                 // `rocky_cli::commands::run` handles SIGINT internally so it
                 // can flush watermarks + mark in-flight tables as

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -63,9 +64,14 @@ struct Cli {
     #[arg(short, long, default_value = "rocky.toml")]
     config: PathBuf,
 
-    /// Output format
-    #[arg(short, long, default_value = "json", global = true)]
-    output: OutputFormat,
+    /// Output format.
+    ///
+    /// When unset, Rocky picks a default by inspecting stdout: human-readable
+    /// `table` when stdout is an interactive terminal, `json` otherwise (so
+    /// piped consumers — Dagster, the LSP, CI — keep getting machine-readable
+    /// JSON). Pass `--output json` or `--output table` to force one explicitly.
+    #[arg(short, long, global = true)]
+    output: Option<OutputFormat>,
 
     /// State store path.
     ///
@@ -100,10 +106,28 @@ struct Cli {
     command: Command,
 }
 
-#[derive(Clone, clap::ValueEnum)]
+#[derive(Clone, clap::ValueEnum, PartialEq, Eq, Debug)]
 enum OutputFormat {
     Json,
     Table,
+}
+
+/// Resolve the effective output format from the (optional) `--output` flag.
+///
+/// Precedence: an explicit `--output json|table` always wins. When the flag is
+/// unset, default by TTY-detection — `table` for an interactive terminal,
+/// `json` otherwise. The non-TTY (pipe) fallback to `json` is load-bearing:
+/// Dagster, the LSP, and CI capture stdout as a pipe and rely on JSON.
+///
+/// Split out as a pure function so the precedence logic is unit-testable
+/// without a real terminal (`is_terminal()` itself can't be exercised in a
+/// test harness, hence the bool parameter).
+fn resolve_output(explicit: Option<OutputFormat>, is_tty: bool) -> OutputFormat {
+    match explicit {
+        Some(fmt) => fmt,
+        None if is_tty => OutputFormat::Table,
+        None => OutputFormat::Json,
+    }
 }
 
 /// Artefact family selector for `rocky catalog --format`.
@@ -1878,7 +1902,11 @@ fn main() -> Result<()> {
     reset_sigpipe();
 
     let cli = Cli::parse();
-    let json = matches!(cli.output, OutputFormat::Json);
+    // Resolve the effective output format: an explicit `--output` always wins;
+    // otherwise TTY-detect (table at a terminal, json when piped). Computed
+    // here because `json` feeds both `init_tracing` and the miette hook.
+    let output = resolve_output(cli.output.clone(), std::io::stdout().is_terminal());
+    let json = matches!(output, OutputFormat::Json);
 
     // Install the rustls crypto provider before any TLS handshake. Runs
     // after `Cli::parse()` so the `--version` / `--help` fast-exit stays
@@ -3114,6 +3142,38 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::sync::Mutex;
+
+    // -----------------------------------------------------------------------
+    // resolve_output — `--output` default resolution
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_output_explicit_json_wins_over_tty() {
+        assert_eq!(
+            resolve_output(Some(OutputFormat::Json), true),
+            OutputFormat::Json
+        );
+    }
+
+    #[test]
+    fn resolve_output_explicit_table_wins_over_pipe() {
+        assert_eq!(
+            resolve_output(Some(OutputFormat::Table), false),
+            OutputFormat::Table
+        );
+    }
+
+    #[test]
+    fn resolve_output_default_tty_is_table() {
+        assert_eq!(resolve_output(None, true), OutputFormat::Table);
+    }
+
+    /// Load-bearing: a piped (non-TTY) stdout must default to JSON so
+    /// Dagster / LSP / CI keep parsing structured output.
+    #[test]
+    fn resolve_output_default_pipe_is_json() {
+        assert_eq!(resolve_output(None, false), OutputFormat::Json);
+    }
 
     /// Serialises every env-mutating test in this module so concurrent
     /// `cargo test` threads don't race on the shared process env.

--- a/integrations/dagster/tests/fixtures_generated/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor.json
@@ -1,6 +1,6 @@
 {
   "command": "doctor",
-  "overall": "warning",
+  "overall": "healthy",
   "checks": [
     {
       "name": "config",
@@ -28,7 +28,7 @@
     },
     {
       "name": "state_sync",
-      "status": "warning",
+      "status": "healthy",
       "message": "State backend: local",
       "duration_ms": 0
     },
@@ -57,7 +57,5 @@
       "duration_ms": 0
     }
   ],
-  "suggestions": [
-    "Consider using 'tiered' state backend for distributed execution"
-  ]
+  "suggestions": []
 }

--- a/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
+++ b/integrations/dagster/tests/fixtures_generated/doctor_ci/doctor.json
@@ -1,6 +1,6 @@
 {
   "command": "doctor",
-  "overall": "warning",
+  "overall": "healthy",
   "checks": [
     {
       "name": "config",
@@ -28,7 +28,7 @@
     },
     {
       "name": "state_sync",
-      "status": "warning",
+      "status": "healthy",
       "message": "State backend: local",
       "duration_ms": 0
     },
@@ -57,7 +57,5 @@
       "duration_ms": 0
     }
   ],
-  "suggestions": [
-    "Consider using 'tiered' state backend for distributed execution"
-  ]
+  "suggestions": []
 }


### PR DESCRIPTION
Three fixes to the first-run experience so a brand-new user hits a green path instead of confusing errors and noise.

## 1. `rocky playground` works first-try — no manual seed step

`rocky playground <name>` now seeds the scaffolded `playground.duckdb` during scaffold, so the quickstart runs end-to-end immediately:

```
rocky playground demo && cd demo
rocky compile && rocky test && rocky run    # all green, zero manual setup
```

Previously `rocky run` failed with `Catalog Error: Table "raw__orders.orders" does not exist` until you ran `duckdb playground.duckdb < data/seed.sql` by hand (which also required the DuckDB CLI). The manual-seed line is gone from the printed next-steps; you can still re-seed any time with that command.

## 2. `rocky run` is a first-class single-step alias again

`rocky run` stays first-class as the fused plan+apply convenience for local iteration and automation — the per-invocation deprecation notice is removed. The canonical auditable two-step (`rocky plan` + `rocky apply <plan-id>`, which persists `.rocky/plans/<id>.json` for review) remains the path for production and PR gating. The `run` / `plan` `--help` text now reads as intent-based siblings:

- `rocky run` — imperative single step (local dev / automation)
- `rocky plan` + `rocky apply` — deliberate, auditable two-step (production / PR gating)

(The `rocky branch promote` deprecation, which has a real safety justification, is unchanged.)

## 3. `doctor`, output, and logging stop crying wolf

- **doctor:** a `local` state backend now reports Healthy (matching the sibling read/write probe) instead of a spurious Warning. A pristine playground project reports `Overall: ok`; Warning is reserved for a misconfigured remote backend.
- **`--output`:** the global flag now defaults by terminal detection — human-readable `table` at an interactive terminal, `json` when piped. Piped consumers (orchestrators, editors, CI) still get JSON, and an explicit `--output json|table` always wins.
- **logging:** a bare `rocky compile` no longer dumps internal query-cache trace lines at the user; the default log filter quiets that noise while keeping pipeline spans. `RUST_LOG` still overrides everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
