### PR TITLE
docs: reframe rocky run as a first-class single-step alias (not legacy/deprecated)

### DIFF
--- a/docs/src/content/docs/advanced/failure-modes.md
+++ b/docs/src/content/docs/advanced/failure-modes.md
@@ -139,7 +139,7 @@ The dispatched adapter classifies its own failures:
 **Recovery playbook.**
 
 1. Run `rocky doctor --output json` first. The `adapters[]` block tells you which adapter Rocky thinks should work and which it currently can't reach. Treat doctor as a credentials / connectivity smoke test.
-2. For **transient** failures (entries with `failure_kind: "transient"` or `"connection-failed"` on `errors[*]`), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the legacy `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
+2. For **transient** failures (entries with `failure_kind: "transient"` or `"connection-failed"` on `errors[*]`), use `rocky plan --resume-latest && rocky apply <plan-id>` (or the single-step `rocky run --resume-latest` alias) to pick up where the failed run left off rather than restarting from scratch.
 3. For **auth** failures, walk the adapter's auth chain (e.g. Snowflake: OAuth → JWT → password) and verify the env-vars / config in `rocky.toml`. The [authentication guide](../../features/authentication) has the per-adapter checklist.
 4. For **quota** failures, check the warehouse-side quota dashboard. Rocky's adaptive concurrency (Databricks AIMD throttle) automatically backs off, but a hard quota reset is a warehouse-side action.
 5. For **statement timeouts**, increase `timeout_secs` on the adapter, or — better — re-evaluate whether the model's materialization strategy is right (a multi-hour `FullRefresh` is often a missed `Merge` or `Incremental` opportunity; `rocky optimize` will surface the recommendation).
@@ -238,7 +238,7 @@ The dispatched adapter classifies its own failures:
 - [Per-table error containment](./per-table-error-containment) — how the run path isolates failures at the table boundary and how to consume the `failure_kind` discriminator
 - [Troubleshooting](./troubleshooting) — symptom-first lookup ("I got error X")
 - [`rocky doctor`](../../reference/cli#doctor) — aggregate health check across config, state, adapters, pipelines
-- [`rocky plan --resume-latest`](../../reference/cli#run) — resume a failed run from its checkpoint (canonical form; the legacy `rocky run --resume-latest` alias is still accepted)
+- [`rocky plan --resume-latest`](../../reference/cli#run) — resume a failed run from its checkpoint (canonical, auditable form; the single-step `rocky run --resume-latest` alias does the same in one invocation)
 - [Schema drift](../../features/schema-drift) — graduated drift handling deep dive
 - [Data quality checks](../../features/data-quality-checks) — inline check authoring + result shape
 - [Governance guide](../../guides/governance) — permissions, classification, masking, retention

--- a/docs/src/content/docs/concepts/bronze-layer.md
+++ b/docs/src/content/docs/concepts/bronze-layer.md
@@ -19,7 +19,7 @@ rocky discover  →  rocky plan  →  rocky apply
 
 1. **Discover** — Finds what schemas and tables are available for processing. For `fivetran` adapters, calls the Fivetran REST API to list connectors and enabled tables. For `duckdb` adapters, queries `information_schema`. For `manual` adapters, reads inline schema/table definitions. Discovery is metadata-only — it identifies what exists, it does not extract data.
 2. **Plan** — Parses source schema names, resolves target catalogs/schemas, generates SQL statements. Records a deterministic plan keyed by `plan_id`.
-3. **Apply** — Executes the plan by id: creates catalogs/schemas, copies data, runs quality checks, updates watermarks. The legacy `rocky run` alias collapses plan + apply into a single invocation and still works.
+3. **Apply** — Executes the plan by id: creates catalogs/schemas, copies data, runs quality checks, updates watermarks. The `rocky run` alias collapses plan + apply into a single invocation, for local iteration and automation.
 
 ## Schema pattern parsing
 

--- a/docs/src/content/docs/concepts/incremental.md
+++ b/docs/src/content/docs/concepts/incremental.md
@@ -158,7 +158,7 @@ lookback = 3
 
 ### CLI flags
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. Every partition-selection flag below is accepted on both `rocky plan` and the legacy `rocky run` alias; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`).
+> Note: the canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`. Every partition-selection flag below is accepted on both `rocky plan` and the `rocky run` single-step alias, which fuses plan + apply into one invocation for local iteration and automation.
 
 ```bash
 rocky plan --partition 2026-04-01 && rocky apply <plan-id>          # Process one partition

--- a/docs/src/content/docs/concepts/preview-internals.md
+++ b/docs/src/content/docs/concepts/preview-internals.md
@@ -17,7 +17,7 @@ sidebar:
 
 3. **Compute the copy set.** Every working-DAG model not in the prune set is a copy candidate: it's logically identical to its counterpart on `--base`, so re-running it would produce the same bytes. For each copy-set model, Rocky issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` against the configured adapter — the portable copy substrate, with per-adapter overrides described below.
 
-4. **Run the prune set.** Rocky calls the existing branch run path ([`rocky plan --branch <name>`](/reference/commands/core-pipeline/#rocky-run) + `rocky apply <plan-id>`, with the legacy `rocky run --branch <name>` alias still accepted) with a model selector limited to the prune set. The branch is registered via [`rocky branch create`](/reference/commands/core-pipeline/#rocky-branch); the run writes into the branch's `schema_prefix`.
+4. **Run the prune set.** Rocky calls the existing branch run path ([`rocky plan --branch <name>`](/reference/commands/core-pipeline/#rocky-run) + `rocky apply <plan-id>`, with the single-step `rocky run --branch <name>` alias doing the same in one invocation) with a model selector limited to the prune set. The branch is registered via [`rocky branch create`](/reference/commands/core-pipeline/#rocky-branch); the run writes into the branch's `schema_prefix`.
 
 The final output ([`PreviewCreateOutput`](#output-shapes)) records `prune_set`, `copy_set`, and `skipped_set` so the decision is auditable from the JSON alone.
 

--- a/docs/src/content/docs/concepts/schema-patterns.md
+++ b/docs/src/content/docs/concepts/schema-patterns.md
@@ -200,7 +200,7 @@ schema_template = "{department}__{system}"
 
 ## Filtering by parsed component
 
-Once your sources are parsed into components, you can scope `rocky plan` and `rocky compare` (and the legacy `rocky run` alias) to a subset via the `--filter` flag. The filter key is one of the component names you declared above (or the reserved `id`), and the value is matched against the parsed value — with containment semantics for multi-valued (`...`) components:
+Once your sources are parsed into components, you can scope `rocky plan` and `rocky compare` (and the `rocky run` alias) to a subset via the `--filter` flag. The filter key is one of the component names you declared above (or the reserved `id`), and the value is matched against the parsed value — with containment semantics for multi-valued (`...`) components:
 
 ```sh
 # Plan everything for tenant "acme" (then `rocky apply <plan-id>` to execute)

--- a/docs/src/content/docs/dagster/branch-deployments.md
+++ b/docs/src/content/docs/dagster/branch-deployments.md
@@ -20,7 +20,7 @@ side-by-side without touching production data.
   context (deployment name, PR number, Git SHA).
 - **`branch_deploy_shadow_suffix()`** — derives a stable Rocky shadow
   suffix suitable for `rocky plan --shadow --shadow-suffix <value>` + `rocky apply <plan-id>`
-  (the legacy `rocky run --shadow --shadow-suffix <value>` alias is still accepted).
+  (the single-step `rocky run --shadow --shadow-suffix <value>` alias does the same in one invocation).
 
 ## Quickstart
 

--- a/docs/src/content/docs/features/time-interval.md
+++ b/docs/src/content/docs/features/time-interval.md
@@ -108,7 +108,7 @@ is rejected even though `chrono` would parse it.
 
 ## CLI flags
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; it emits a one-line `[deprecated]` notice to stderr that can be silenced with `ROCKY_SUPPRESS_DEPRECATION=1`. Every partition-selection flag below is accepted on both `rocky plan` and `rocky run`.
+> Note: the canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`. The `rocky run` single-step alias fuses plan + apply into one invocation for local iteration and automation. Every partition-selection flag below is accepted on both `rocky plan` and `rocky run`.
 
 `rocky run` accepts seven new flags for selecting and modifying which
 partitions to compute. The selection flags are mutually exclusive (`clap`

--- a/docs/src/content/docs/guides/governance.md
+++ b/docs/src/content/docs/guides/governance.md
@@ -714,7 +714,7 @@ Each `RunRecord` carries:
 | `session_source` | Auto-detected: `Cli` / `Dagster` / `Lsp` / `HttpApi`. |
 | `git_commit` | Resolved at run start from the current repo. |
 | `git_branch` | Resolved at run start from the current repo. |
-| `idempotency_key` | Echoed from `rocky plan --idempotency-key <KEY>` (or the legacy `rocky run --idempotency-key` alias) when passed. |
+| `idempotency_key` | Echoed from `rocky plan --idempotency-key <KEY>` (or the single-step `rocky run --idempotency-key` alias) when passed. |
 | `target_catalog` | The catalog(s) the run wrote to. |
 | `hostname` | The host that executed the run. |
 | `rocky_version` | The CLI version that produced the record. |

--- a/docs/src/content/docs/guides/preview-a-pr.md
+++ b/docs/src/content/docs/guides/preview-a-pr.md
@@ -35,7 +35,7 @@ What this does:
 3. Computes the **copy set** — every working-DAG model not in the prune set.
 4. Registers a branch in the state store (mirrors `rocky branch create`).
 5. Issues `CREATE TABLE <branch_schema>.<model> AS SELECT * FROM <base_schema>.<model>` for each copy-set model.
-6. Calls `rocky plan --branch <name>` followed by `rocky apply <plan-id>` (or the legacy `rocky run --branch <name>` alias) with a model selector limited to the prune set.
+6. Calls `rocky plan --branch <name>` followed by `rocky apply <plan-id>` (or the single-step `rocky run --branch <name>` alias) with a model selector limited to the prune set.
 
 The output is a `PreviewCreateOutput` JSON document:
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -7,7 +7,7 @@ sidebar:
 
 Rocky provides a single binary with subcommands for the full pipeline lifecycle. Commands are organized into categories:
 
-- **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `apply`, `state`, `branch` (legacy alias: `run`)
+- **Core Pipeline**: `init`, `validate`, `discover`, `plan`, `apply`, `state`, `branch` (single-step alias: `run`)
 - **Modeling**: `compile`, `lineage`, `lineage-diff`, `test`, `ci`, `ci-diff`, `preview`
 - **Data**: `seed`, `snapshot`, `docs`
 - **AI**: `ai`, `ai-sync`, `ai-explain`, `ai-test`
@@ -193,7 +193,7 @@ rocky plan --filter <key=value> [--pipeline NAME]
 
 ### `rocky run`
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; it emits a one-line `[deprecated]` notice to stderr that can be silenced with `ROCKY_SUPPRESS_DEPRECATION=1`.
+> Note: the canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`. The `rocky run` single-step alias fuses plan + apply into one invocation for local iteration and automation.
 
 Executes the full pipeline end-to-end.
 
@@ -423,7 +423,7 @@ data_type = "DATE"
 
 ### `rocky compare`
 
-Compare shadow tables against production tables. Used after `rocky plan --shadow` + `rocky apply <plan-id>` (or the legacy `rocky run --shadow` alias) to validate results before promoting shadow data to production.
+Compare shadow tables against production tables. Used after `rocky plan --shadow` + `rocky apply <plan-id>` (or the single-step `rocky run --shadow` alias) to validate results before promoting shadow data to production.
 
 ```bash
 rocky compare --filter <key=value> [flags]

--- a/docs/src/content/docs/reference/commands/administration.md
+++ b/docs/src/content/docs/reference/commands/administration.md
@@ -112,7 +112,7 @@ run_20260401_080015      | 2026-04-01T08:00:15Z  | 52.1s     | 19     | 1      |
 
 ### Audit trail
 
-`--audit` (added in v1.16.0) expands each run record with an eight-field governance trail captured by every `rocky apply` (and the legacy `rocky run` alias) against redb schema v6. Default output omits these fields for byte-stability with pre-v1.16 consumers.
+`--audit` (added in v1.16.0) expands each run record with an eight-field governance trail captured by every `rocky apply` (and the `rocky run` alias) against redb schema v6. Default output omits these fields for byte-stability with pre-v1.16 consumers.
 
 | Field | Description |
 |-------|-------------|

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -286,7 +286,7 @@ rocky plan --filter client=acme --pipeline shopify_us
 
 ## `rocky run`
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; it emits a one-line `[deprecated]` notice to stderr that can be silenced with `ROCKY_SUPPRESS_DEPRECATION=1`.
+> Note: the canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`. The `rocky run` single-step alias fuses plan + apply into one invocation for local iteration and automation.
 
 Execute the full pipeline end-to-end: discover sources, detect schema drift, create catalogs/schemas, copy data, apply governance, and run quality checks.
 
@@ -468,7 +468,7 @@ acme_warehouse.staging__eu_central__stripe.charges    | 2026-03-29T22:15:00Z    
 
 ## `rocky branch`
 
-Manage named virtual branches. A branch is the persistent, named analogue of `--shadow` mode: it records a `schema_prefix` in the state store and, when `rocky plan --branch <name>` + `rocky apply <plan-id>` is invoked (or the legacy `rocky run --branch <name>` alias), every model target has the prefix applied. Schema-prefix branches work uniformly across every adapter today; warehouse-native clones (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`) are a follow-up.
+Manage named virtual branches. A branch is the persistent, named analogue of `--shadow` mode: it records a `schema_prefix` in the state store and, when `rocky plan --branch <name>` + `rocky apply <plan-id>` is invoked (or the single-step `rocky run --branch <name>` alias), every model target has the prefix applied. Schema-prefix branches work uniformly across every adapter today; warehouse-native clones (Delta `SHALLOW CLONE`, Snowflake zero-copy `CLONE`) are a follow-up.
 
 ```bash
 rocky branch create <name> [--description <text>]

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -636,7 +636,7 @@ Terminal outcomes surface as structured `outcome` fields on `state.upload` / `st
 
 ### `[state.idempotency]`
 
-Tuning knobs for `rocky plan --idempotency-key <KEY>` dedup (also accepted on the legacy `rocky run --idempotency-key` alias). All fields are optional with the shown defaults; the block is a no-op on runs that don't pass `--idempotency-key`. Unknown fields are rejected.
+Tuning knobs for `rocky plan --idempotency-key <KEY>` dedup (also accepted on the `rocky run --idempotency-key` alias). All fields are optional with the shown defaults; the block is a no-op on runs that don't pass `--idempotency-key`. Unknown fields are rejected.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|

--- a/docs/src/content/docs/reference/filters.md
+++ b/docs/src/content/docs/reference/filters.md
@@ -126,7 +126,7 @@ key         = "id" | <component name from schema_pattern>
 value       = any non-empty string
 ```
 
-The filter flag is mandatory for `plan` and `compare` (and the legacy `run` alias) — these commands require explicit scoping so a typo like `--filter tenat=acme` surfaces as "0 sources matched", not as "oh, I ran everything by accident".
+The filter flag is mandatory for `plan` and `compare` (and the `run` alias) — these commands require explicit scoping so a typo like `--filter tenat=acme` surfaces as "0 sources matched", not as "oh, I ran everything by accident".
 
 ## What's NOT supported today
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -104,7 +104,7 @@ Consumers diffing successive discover snapshots **must** treat ids that appear i
 
 ### `rocky run`
 
-> Note: as of engine v1.33, the canonical form is `rocky plan` followed by `rocky apply <plan-id>`. `rocky run` continues to work and is now an alias; the JSON output shape below is the same on both `apply` and `run` (the `command` field reflects which verb was invoked). Suppress the alias's stderr deprecation notice with `ROCKY_SUPPRESS_DEPRECATION=1`.
+> Note: the canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`. The `rocky run` single-step alias fuses plan + apply into one invocation for local iteration and automation; the JSON output shape below is the same on both `apply` and `run` (the `command` field reflects which verb was invoked).
 
 Returns a complete summary of the pipeline execution.
 
@@ -394,7 +394,7 @@ Aggregate health checks across config, state, adapters, and pipelines.
 
 ### Drift (inline within `rocky apply`)
 
-There is no standalone `rocky drift` CLI command today — drift detection runs inline during `rocky apply` (or the legacy `rocky run` alias) and surfaces through the top-level `drift` field of the run JSON output (already shown under [`rocky run`](#rocky-run) above).
+There is no standalone `rocky drift` CLI command today — drift detection runs inline during `rocky apply` (or the `rocky run` alias) and surfaces through the top-level `drift` field of the run JSON output (already shown under [`rocky run`](#rocky-run) above).
 
 **Field reference for `drift`:**
 

--- a/docs/src/content/docs/reference/model-format.md
+++ b/docs/src/content/docs/reference/model-format.md
@@ -508,7 +508,7 @@ schema = "warehouse"
 table = "fct_daily_events"
 ```
 
-**CLI flags** for time-interval models. As of engine v1.33 every flag below is accepted on both `rocky plan` and the legacy `rocky run` alias; `rocky run` continues to work and emits a one-line `[deprecated]` notice to stderr (silence with `ROCKY_SUPPRESS_DEPRECATION=1`). The canonical form is `rocky plan` followed by `rocky apply <plan-id>`.
+**CLI flags** for time-interval models. Every flag below is accepted on both `rocky plan` and the `rocky run` single-step alias, which fuses plan + apply into one invocation for local iteration and automation. The canonical, auditable form is `rocky plan` followed by `rocky apply <plan-id>`.
 
 ```bash
 # Process a specific partition


### PR DESCRIPTION
Completes the `run` vs `plan`/`apply` documentation consistency pass across the rest of the docs corpus. The onboarding pages (quickstart, playground guide, splash) were corrected separately; this sweeps the remaining 16 reference/concept/guide pages.

`rocky run` is a first-class single-step alias that fuses `plan` + `apply` for local iteration and automation; `rocky plan` → `rocky apply <plan-id>` remains the canonical, auditable two-step for production and PR gating. The docs previously framed `run` as a "legacy alias," and two pages stated as fact that `rocky run` emits a `[deprecated]` notice to stderr.

Changes (prose only, +21/−21, no structural/anchor changes):
- Reframe "legacy `rocky run` alias" → neutral "`rocky run` single-step alias" across the corpus.
- Remove the now-incorrect claims that `rocky run` emits a `[deprecated]` notice (it no longer warns). Found and fixed six such claims total (two flagged plus four more carrying the identical wording).
- Preserve all accurate substance: plan/apply as the canonical/auditable path, flag tables, behavior notes.
- Intentionally **kept**: the `rocky branch promote` deprecation + `ROCKY_SUPPRESS_DEPRECATION` notes (that bare form skips breaking-change gates and remains deprecated).