### PR TITLE
fix(engine): address security & data-integrity audit findings

### DIFF
--- a/engine/crates/rocky-ai/src/generate.rs
+++ b/engine/crates/rocky-ai/src/generate.rs
@@ -148,6 +148,24 @@ pub fn extract_code(content: &str) -> String {
     trimmed.to_string()
 }
 
+/// Validate an LLM-proposed model source through the same parse + typecheck
+/// path used to compile-verify freshly generated models.
+///
+/// `format` is `"rocky"` or `"sql"`. When `context` is `Some`, the proposal is
+/// typechecked inside the full project graph (upstream schemas visible);
+/// otherwise it is validated in isolation. Returns the merged error
+/// diagnostics on failure.
+///
+/// This is the public entry point callers use to gate writing an unvalidated
+/// proposal to disk (e.g. `rocky ai-sync --apply`).
+pub fn validate_proposed_source(
+    source: &str,
+    format: &str,
+    context: Option<&ValidationContext<'_>>,
+) -> Result<(), String> {
+    validate_generated_code(source, format, context).map(|_name| ())
+}
+
 /// Validate generated code. When `context` is `Some`, typechecks against the
 /// full project (upstream typed schemas visible); otherwise isolates the
 /// generated model (legacy behavior, used in unit tests).
@@ -314,6 +332,26 @@ mod tests {
     fn test_validate_invalid_rocky() {
         let result = validate_generated_code("this is not valid rocky", "rocky", None);
         assert!(result.is_err());
+    }
+
+    // M3: the public gate `ai-sync --apply` uses before writing a proposal.
+
+    #[test]
+    fn validate_proposed_source_rejects_unparseable_sql() {
+        // Garbage that is not a valid SQL statement must be rejected so it is
+        // never written to a model file.
+        let result = validate_proposed_source("this is not sql at all ;;;", "sql", None);
+        assert!(result.is_err(), "unparseable SQL must be rejected");
+    }
+
+    #[test]
+    fn validate_proposed_source_rejects_empty() {
+        assert!(validate_proposed_source("", "sql", None).is_err());
+    }
+
+    #[test]
+    fn validate_proposed_source_accepts_valid_sql() {
+        assert!(validate_proposed_source("SELECT id FROM orders", "sql", None).is_ok());
     }
 
     /// Build an upstream `Model` by hand. Used in project-aware validation tests.

--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -19,6 +19,19 @@ use crate::output::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const ANTHROPIC_API_KEY_VAR: &str = "ANTHROPIC_API_KEY";
 
+/// Pick the validation format for a model from its source file path: `.rocky`
+/// files are Rocky DSL, everything else (notably `.sql`) is raw SQL.
+fn proposed_source_format(file_path: &str) -> &'static str {
+    if std::path::Path::new(file_path)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("rocky"))
+    {
+        "rocky"
+    } else {
+        "sql"
+    }
+}
+
 /// Create an LLM client from environment + project config.
 ///
 /// Reads `[ai] max_tokens` from `rocky.toml` when the config loads cleanly;
@@ -338,6 +351,23 @@ pub async fn run_ai_sync(
         if apply {
             for proposal in &proposals {
                 if let Some(model) = result.project.model(&proposal.model) {
+                    // Validate the LLM-proposed source through the same
+                    // parse + typecheck path used to compile-verify generated
+                    // models BEFORE writing it. An unvalidated proposal that
+                    // does not parse or typecheck must never land on disk.
+                    let format = proposed_source_format(&model.file_path);
+                    if let Err(diagnostics) = rocky_ai::generate::validate_proposed_source(
+                        &proposal.proposed_source,
+                        format,
+                        None,
+                    ) {
+                        anyhow::bail!(
+                            "refusing to apply proposal for model '{}': the proposed source \
+                             does not compile.\n{}",
+                            proposal.model,
+                            diagnostics
+                        );
+                    }
                     std::fs::write(&model.file_path, &proposal.proposed_source)?;
                     println!("Updated: {}", model.file_path);
                 }
@@ -503,4 +533,41 @@ pub async fn run_ai_test(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposed_source_format_detects_rocky_and_sql() {
+        assert_eq!(proposed_source_format("models/orders.rocky"), "rocky");
+        assert_eq!(proposed_source_format("models/orders.ROCKY"), "rocky");
+        assert_eq!(proposed_source_format("models/orders.sql"), "sql");
+        assert_eq!(proposed_source_format("models/orders"), "sql");
+    }
+
+    /// `ai-sync --apply` must validate a proposal before writing. An
+    /// unparseable proposal is rejected and the on-disk file is left untouched.
+    #[test]
+    fn unvalidated_proposal_is_not_written_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_path = dir.path().join("orders.sql");
+        let original = "SELECT id FROM orders";
+        std::fs::write(&model_path, original).unwrap();
+
+        let bad_proposal = "this is not sql at all ;;;";
+        let format = proposed_source_format(model_path.to_str().unwrap());
+
+        // Mirror the apply gate: validate first, only write on success.
+        let validation = rocky_ai::generate::validate_proposed_source(bad_proposal, format, None);
+        assert!(validation.is_err(), "bad proposal must fail validation");
+
+        // The gate bails before writing — confirm the file is unchanged.
+        let on_disk = std::fs::read_to_string(&model_path).unwrap();
+        assert_eq!(
+            on_disk, original,
+            "an invalid proposal must not overwrite the model file"
+        );
+    }
 }

--- a/engine/crates/rocky-cli/src/commands/ai_contract.rs
+++ b/engine/crates/rocky-cli/src/commands/ai_contract.rs
@@ -301,23 +301,40 @@ fn str_cell(v: Option<&serde_json::Value>) -> Option<String> {
     }
 }
 
-/// Profile one column: a single aggregate query for count/nulls/distinct/min/max,
-/// plus a bounded domain query when the distinct count is low. SQL is built
-/// from the already-validated `table_ref` and a freshly-validated column
-/// identifier — never from raw input.
+/// Profile one column.
+///
+/// By default this issues only aggregate **statistics** queries
+/// (count / non-null / distinct count) — no raw cell values leave the machine.
+/// When `with_data` is `true` the caller has opted into sending observed cell
+/// values to the LLM, so it additionally captures `MIN`/`MAX` and (for
+/// low-cardinality columns) the observed domain values.
+///
+/// SQL is built from the already-validated `table_ref` and a freshly-validated
+/// column identifier — never from raw input.
 pub(crate) async fn profile_column(
     adapter: &dyn WarehouseAdapter,
     table_ref: &str,
     typed_col: &TypedColumn,
+    with_data: bool,
 ) -> Result<ColumnProfile> {
     let col = rocky_sql::validation::validate_identifier(&typed_col.name)
         .map_err(|e| anyhow::anyhow!("invalid column identifier: {e}"))?;
 
-    let agg_sql = format!(
-        "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n, \
-         CAST(MIN({col}) AS VARCHAR) AS min_v, CAST(MAX({col}) AS VARCHAR) AS max_v \
-         FROM {table_ref}"
-    );
+    // Aggregate STATISTICS only — counts, not row values. These are computed
+    // on every path. MIN/MAX (which are real cell values) are only selected
+    // when the caller opted into `--with-data`.
+    let agg_sql = if with_data {
+        format!(
+            "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n, \
+             CAST(MIN({col}) AS VARCHAR) AS min_v, CAST(MAX({col}) AS VARCHAR) AS max_v \
+             FROM {table_ref}"
+        )
+    } else {
+        format!(
+            "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n \
+             FROM {table_ref}"
+        )
+    };
     let qr = adapter.execute_query(&agg_sql).await.map_err(|e| {
         anyhow::anyhow!("profile query failed for column '{}': {e}", typed_col.name)
     })?;
@@ -334,11 +351,15 @@ pub(crate) async fn profile_column(
     } else {
         nulls as f64 / total as f64
     };
-    let min = str_cell(row.get(3));
-    let max = str_cell(row.get(4));
+    let (min, max) = if with_data {
+        (str_cell(row.get(3)), str_cell(row.get(4)))
+    } else {
+        (None, None)
+    };
 
-    // For low-cardinality columns, fetch the observed domain as evidence.
-    let observed_values = if distinct > 0 && distinct <= LOW_CARDINALITY_CAP {
+    // For low-cardinality columns, fetch the observed domain as evidence —
+    // only when `--with-data` opted into shipping raw cell values.
+    let observed_values = if with_data && distinct > 0 && distinct <= LOW_CARDINALITY_CAP {
         let domain_sql = format!(
             "SELECT DISTINCT CAST({col} AS VARCHAR) AS v FROM {table_ref} \
              WHERE {col} IS NOT NULL ORDER BY v LIMIT {DOMAIN_FETCH_LIMIT}"
@@ -373,6 +394,7 @@ pub async fn run_ai_contract(
     models_dir: &str,
     model_name: &str,
     save: bool,
+    with_data: bool,
     output_json: bool,
     cache_ttl_override: Option<u64>,
 ) -> Result<()> {
@@ -409,13 +431,45 @@ pub async fn run_ai_contract(
         }
     };
 
+    // Egress notice: `rocky ai-contract` sends an LLM prompt to
+    // api.anthropic.com. By default that prompt carries only aggregate
+    // STATISTICS (row/null/distinct counts) — no raw cell values. `--with-data`
+    // opts into additionally sending observed MIN/MAX and low-cardinality
+    // domain samples, which ARE real cell values; name that explicitly on
+    // stderr so it's never silent.
+    if with_data {
+        eprintln!(
+            "ai-contract: --with-data enabled — will send observed min/max and \
+             low-cardinality domain samples for {} column(s) of model '{}' to \
+             api.anthropic.com (alongside schema + aggregate statistics).",
+            inferred_schema.len(),
+            model_name,
+        );
+    } else {
+        eprintln!(
+            "ai-contract: sending schema + aggregate statistics (row/null/distinct \
+             counts) for {} column(s) of model '{}' to api.anthropic.com. No raw \
+             cell values are sent. Pass --with-data to also include observed \
+             min/max and domain samples.",
+            inferred_schema.len(),
+            model_name,
+        );
+    }
+
     // Profile each column of the model's inferred schema. The profile reads
     // the full target table (no sampling): a sampled `null_rate` of 0 would
     // not justify proposing `nullable = false`, so soundness requires the
-    // exact count.
+    // exact count. By default only aggregate statistics are computed; raw cell
+    // values (min/max/domain) are gated behind `--with-data`.
     let mut profiles = Vec::with_capacity(inferred_schema.len());
     for col in &inferred_schema {
-        let p = profile_column(prepared.adapter.as_ref(), &prepared.table_ref, col).await?;
+        let p = profile_column(
+            prepared.adapter.as_ref(),
+            &prepared.table_ref,
+            col,
+            with_data,
+        )
+        .await?;
         profiles.push(p);
     }
 
@@ -553,6 +607,192 @@ adapter = "warehouse"
         assert!(duckdb_only_refusal(&resolved.adapter_type).is_none());
     }
 
+    // ── Egress safety: no raw cell values without --with-data (H2) ────────
+
+    use std::sync::Mutex;
+
+    use rocky_compiler::types::RockyType;
+    use rocky_core::traits::{
+        AdapterError, AdapterResult, QueryResult, SqlDialect, WarehouseAdapter,
+    };
+    use rocky_ir::{ColumnInfo, TableRef};
+
+    /// A `WarehouseAdapter` that records every SQL string passed to
+    /// `execute_query` and replies with a fixed three-column count row. Only
+    /// `execute_query` is exercised by `profile_column`; the other trait
+    /// methods are never called on this path and panic if they are.
+    struct RecordingAdapter {
+        queries: Mutex<Vec<String>>,
+    }
+
+    impl RecordingAdapter {
+        fn new() -> Self {
+            Self {
+                queries: Mutex::new(Vec::new()),
+            }
+        }
+        fn recorded(&self) -> Vec<String> {
+            self.queries.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WarehouseAdapter for RecordingAdapter {
+        fn dialect(&self) -> &dyn SqlDialect {
+            unimplemented!("profile_column never calls dialect()")
+        }
+        async fn execute_statement(&self, _sql: &str) -> AdapterResult<()> {
+            unimplemented!("profile_column never calls execute_statement()")
+        }
+        async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
+            self.queries.lock().unwrap().push(sql.to_string());
+            // n=100, non_null=100, distinct=3 — distinct is low enough that the
+            // with-data path WOULD fire the domain query, so the no-data path's
+            // absence of it is meaningful.
+            Ok(QueryResult {
+                columns: vec!["n".into(), "non_null".into(), "distinct_n".into()],
+                rows: vec![vec![
+                    serde_json::json!(100),
+                    serde_json::json!(100),
+                    serde_json::json!(3),
+                ]],
+            })
+        }
+        async fn describe_table(&self, _table: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
+            Err(AdapterError::msg("not used"))
+        }
+    }
+
+    fn col(name: &str) -> TypedColumn {
+        TypedColumn {
+            name: name.to_string(),
+            data_type: RockyType::String,
+            nullable: true,
+        }
+    }
+
+    /// Without `--with-data`, `profile_column` must issue ONLY the statistics
+    /// aggregate — no `MIN`/`MAX`, no `DISTINCT ... LIMIT` domain query — and
+    /// the resulting profile must carry no cell values.
+    #[tokio::test]
+    async fn profile_column_without_data_sends_no_values() {
+        let adapter = RecordingAdapter::new();
+        let profile = profile_column(&adapter, "main.orders", &col("status"), false)
+            .await
+            .expect("profile should succeed");
+
+        let queries = adapter.recorded();
+        assert_eq!(queries.len(), 1, "exactly one statistics query expected");
+        let q = &queries[0];
+        assert!(
+            !q.contains("MIN(") && !q.contains("MAX("),
+            "no-data path must not select MIN/MAX: {q}"
+        );
+        assert!(
+            !q.to_uppercase().contains("DISTINCT CAST"),
+            "no-data path must not issue the domain-values query: {q}"
+        );
+        assert!(
+            q.contains("COUNT(DISTINCT"),
+            "distinct COUNT is a statistic and is fine: {q}"
+        );
+
+        assert!(profile.observed_values.is_empty(), "no domain values");
+        assert!(profile.min.is_none(), "no min value");
+        assert!(profile.max.is_none(), "no max value");
+        assert_eq!(profile.rows, 100);
+        assert_eq!(profile.distinct, 3);
+
+        // And the assembled prompt evidence carries no value lines.
+        let table = TableProfile {
+            model: "orders".to_string(),
+            columns: vec![profile],
+        };
+        let evidence = rocky_ai::contract::render_profile_evidence(&table);
+        assert!(
+            !evidence.contains("min="),
+            "prompt must omit min: {evidence}"
+        );
+        assert!(
+            !evidence.contains("max="),
+            "prompt must omit max: {evidence}"
+        );
+        assert!(
+            !evidence.contains("observed_domain="),
+            "prompt must omit observed domain: {evidence}"
+        );
+    }
+
+    /// With `--with-data`, the domain query fires for a low-cardinality column
+    /// (sanity that the opt-in still works).
+    #[tokio::test]
+    async fn profile_column_with_data_issues_value_queries() {
+        // A custom adapter that answers both the agg (5 cols) and domain query.
+        struct WithDataAdapter {
+            queries: Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl WarehouseAdapter for WithDataAdapter {
+            fn dialect(&self) -> &dyn SqlDialect {
+                unimplemented!()
+            }
+            async fn execute_statement(&self, _sql: &str) -> AdapterResult<()> {
+                unimplemented!()
+            }
+            async fn execute_query(&self, sql: &str) -> AdapterResult<QueryResult> {
+                self.queries.lock().unwrap().push(sql.to_string());
+                if sql.to_uppercase().contains("DISTINCT CAST") {
+                    Ok(QueryResult {
+                        columns: vec!["v".into()],
+                        rows: vec![vec![serde_json::json!("active")]],
+                    })
+                } else {
+                    Ok(QueryResult {
+                        columns: vec![
+                            "n".into(),
+                            "non_null".into(),
+                            "distinct_n".into(),
+                            "min_v".into(),
+                            "max_v".into(),
+                        ],
+                        rows: vec![vec![
+                            serde_json::json!(10),
+                            serde_json::json!(10),
+                            serde_json::json!(2),
+                            serde_json::json!("active"),
+                            serde_json::json!("inactive"),
+                        ]],
+                    })
+                }
+            }
+            async fn describe_table(&self, _t: &TableRef) -> AdapterResult<Vec<ColumnInfo>> {
+                Err(AdapterError::msg("not used"))
+            }
+        }
+
+        let adapter = WithDataAdapter {
+            queries: Mutex::new(Vec::new()),
+        };
+        let profile = profile_column(&adapter, "main.orders", &col("status"), true)
+            .await
+            .expect("profile should succeed");
+
+        assert_eq!(profile.min.as_deref(), Some("active"));
+        assert_eq!(profile.max.as_deref(), Some("inactive"));
+        assert_eq!(profile.observed_values, vec!["active".to_string()]);
+        let recorded = adapter.queries.lock().unwrap().clone();
+        assert!(
+            recorded.iter().any(|q| q.contains("MIN(")),
+            "with-data path must select MIN/MAX"
+        );
+        assert!(
+            recorded
+                .iter()
+                .any(|q| q.to_uppercase().contains("DISTINCT CAST")),
+            "with-data path must issue the domain query"
+        );
+    }
+
     /// Live end-to-end: profiles a real DuckDB table and drafts a
     /// compile-verified contract. Gated on `ANTHROPIC_API_KEY` + `#[ignore]`
     /// per the repo convention for LLM commands. Run with:
@@ -632,9 +872,10 @@ type = "full_refresh"
             &state_path,
             models_dir.to_str().unwrap(),
             "orders",
-            true,
-            true,
-            None,
+            true, // save
+            true, // with_data (exercise the values-included path)
+            true, // output_json
+            None, // cache_ttl
         )
         .await;
         assert!(result.is_ok(), "ai-contract failed: {result:?}");

--- a/engine/crates/rocky-cli/src/commands/profile.rs
+++ b/engine/crates/rocky-cli/src/commands/profile.rs
@@ -131,7 +131,10 @@ pub async fn build_profile_output(
         // caller gets whatever overlap exists, plus `fell_back_from` to
         // signal "this is a source preview." On the target path we keep
         // strict behaviour: any per-column error is a real problem.
-        let result = profile_column(prepared.adapter.as_ref(), &prepared.table_ref, col).await;
+        // `rocky profile` prints min/max/distinct to the user locally — no LLM
+        // egress — so it always wants the full per-column values.
+        let result =
+            profile_column(prepared.adapter.as_ref(), &prepared.table_ref, col, true).await;
         match result {
             Ok(p) => columns.push(ProfileColumnStats {
                 // Prefer the observed warehouse type; fall back to the
@@ -249,7 +252,7 @@ mod tests {
             data_type: RockyType::String,
             nullable: true,
         };
-        let profile = profile_column(adapter.as_ref(), "main.orders", &status_col)
+        let profile = profile_column(adapter.as_ref(), "main.orders", &status_col, true)
             .await
             .expect("profile_column should succeed on duckdb");
         assert_eq!(profile.rows, 3);
@@ -263,7 +266,7 @@ mod tests {
             data_type: RockyType::Int64,
             nullable: true,
         };
-        let id_profile = profile_column(adapter.as_ref(), "main.orders", &id_col)
+        let id_profile = profile_column(adapter.as_ref(), "main.orders", &id_col, true)
             .await
             .unwrap();
         assert_eq!(id_profile.rows, 3);

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4792,8 +4792,10 @@ fn resolve_merge_update_columns(
 }
 
 /// `MAX(<timestamp_column>) FROM <target>` — the post-execute watermark for the
-/// replication path. Mirrors [`query_source_max_timestamp`] but reads the
-/// **target** table, so the recorded value reflects exactly what was loaded.
+/// replication path. Reads the **target** table so the recorded value reflects
+/// exactly what was loaded (closing the source-side TOCTOU described on
+/// [`resolve_new_watermark`]). Returns `None` on NULL / empty / failure so the
+/// caller can keep the prior watermark.
 async fn query_target_max_timestamp(
     warehouse: &dyn WarehouseAdapter,
     dialect: &dyn rocky_core::traits::SqlDialect,
@@ -7063,19 +7065,18 @@ merge_keys = ["id"]
         }
     }
 
-    /// End-to-end test for `query_source_max_timestamp` against an
+    /// End-to-end test for `query_target_max_timestamp` against an
     /// in-memory DuckDB.
     ///
-    /// Seeds a source table with three rows at known timestamps, asks the
-    /// helper to query `MAX(ts) FROM source`, and asserts the returned
-    /// `DateTime<Utc>` matches the max seed value. This is the
-    /// discriminating check the SqlDialect-level tests don't cover —
-    /// the runner reads the warehouse result row, parses the timestamp
-    /// shape DuckDB returns, and we want to find out at unit-test time
-    /// (not at the first live run) if those assumptions ever shift.
+    /// Seeds a table with three rows at known timestamps, asks the helper to
+    /// query `MAX(ts)`, and asserts the returned `DateTime<Utc>` matches the
+    /// max seed value. This is the discriminating check the SqlDialect-level
+    /// tests don't cover — the runner reads the warehouse result row, parses
+    /// the timestamp shape DuckDB returns, and we want to find out at
+    /// unit-test time (not at the first live run) if those assumptions shift.
     #[cfg(feature = "duckdb")]
     #[tokio::test]
-    async fn query_source_max_timestamp_returns_max_of_seeded_source() {
+    async fn query_target_max_timestamp_returns_max_of_seeded_table() {
         use chrono::TimeZone;
         use rocky_core::traits::{SqlDialect, WarehouseAdapter};
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
@@ -7129,11 +7130,11 @@ merge_keys = ["id"]
         );
     }
 
-    /// `query_source_max_timestamp` returns `None` for an empty source so
-    /// `process_table` can fall back to `Utc::now()` without panicking.
+    /// `query_target_max_timestamp` returns `None` for an empty table so
+    /// `resolve_new_watermark` keeps the prior watermark rather than advancing.
     #[cfg(feature = "duckdb")]
     #[tokio::test]
-    async fn query_source_max_timestamp_returns_none_for_empty_source() {
+    async fn query_target_max_timestamp_returns_none_for_empty_table() {
         use rocky_core::traits::{SqlDialect, WarehouseAdapter};
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
         use rocky_duckdb::dialect::DuckDbSqlDialect;
@@ -7391,7 +7392,7 @@ merge_keys = ["id"]
     /// parameter (the runner reads it from `rocky.toml`).
     #[cfg(feature = "duckdb")]
     #[tokio::test]
-    async fn query_source_max_timestamp_rejects_unsafe_timestamp_column() {
+    async fn query_target_max_timestamp_rejects_unsafe_timestamp_column() {
         use rocky_core::traits::{SqlDialect, WarehouseAdapter};
         use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
         use rocky_duckdb::dialect::DuckDbSqlDialect;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4660,12 +4660,15 @@ fn accumulate_bytes(acc: Option<u64>, next: Option<u64>) -> Option<u64> {
 ///   note in PR body about tightening unknown strategy values).
 ///
 /// Note: the watermark-filter clause (`WHERE ts > TIMESTAMP '<prior>'`, where
-/// `<prior>` is the previous run's `MAX(ts) FROM source`) lives in
+/// `<prior>` is the previous run's recorded watermark) lives in
 /// `sql_gen::generate_select_sql` and applies for `Incremental` only; `merge`
-/// upserts the entire source via the dialect-specific `MERGE INTO`. The
-/// runner re-queries `MAX(ts) FROM source` after each tick (via
-/// [`query_source_max_timestamp`]) regardless of strategy, recording the
-/// new value via `DeferredWatermark`.
+/// upserts the entire source via the dialect-specific `MERGE INTO`. After each
+/// incremental/microbatch tick the runner records `MAX(ts) FROM target` (via
+/// [`query_target_max_timestamp`] / [`resolve_new_watermark`]) — the max among
+/// the rows actually loaded — into `DeferredWatermark`. Reading the target
+/// rather than re-querying the source closes a TOCTOU where a row appended to
+/// source after the INSERT's snapshot would otherwise advance the watermark
+/// past a row that was never loaded.
 ///
 /// Convenience wrapper used by unit tests — applies no per-table
 /// override. Production code paths go through
@@ -4788,40 +4791,30 @@ fn resolve_merge_update_columns(
     }
 }
 
-/// Queries `SELECT MAX({timestamp_column}) FROM source` and parses the
-/// returned value into a `DateTime<Utc>`.
-///
-/// Returns `None` on any failure path (network error, malformed result,
-/// NULL / empty source, unparseable timestamp). Callers fall back to a
-/// wall-clock `Utc::now()` when the value is unavailable — same shape as
-/// the batch freshness check at the top of this file. Identifier validation
-/// is delegated to the dialect's `format_table_ref` and to the centralised
-/// `validate_identifier` check on the column name.
-///
-/// Used by `process_table` to record the source-side watermark after a
-/// successful replication tick — the value the next run will use to bound
-/// the WHERE clause via `SqlDialect::watermark_where`.
-async fn query_source_max_timestamp(
+/// `MAX(<timestamp_column>) FROM <target>` — the post-execute watermark for the
+/// replication path. Mirrors [`query_source_max_timestamp`] but reads the
+/// **target** table, so the recorded value reflects exactly what was loaded.
+async fn query_target_max_timestamp(
     warehouse: &dyn WarehouseAdapter,
     dialect: &dyn rocky_core::traits::SqlDialect,
-    source: &TableRef,
+    target: &TableRef,
     timestamp_column: &str,
 ) -> Option<chrono::DateTime<Utc>> {
     if rocky_sql::validation::validate_identifier(timestamp_column).is_err() {
         return None;
     }
-    let source_ref = dialect
-        .format_table_ref(&source.catalog, &source.schema, &source.table)
+    let target_ref = dialect
+        .format_table_ref(&target.catalog, &target.schema, &target.table)
         .ok()?;
-    let sql = format!("SELECT MAX({timestamp_column}) FROM {source_ref}");
+    let sql = format!("SELECT MAX({timestamp_column}) FROM {target_ref}");
 
     let result = match warehouse.execute_query(&sql).await {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(
-                table = source.full_name(),
+                table = target.full_name(),
                 error = %e,
-                "source-side MAX(ts) query failed — falling back to wall-clock"
+                "target-side MAX(ts) query failed — keeping prior watermark"
             );
             return None;
         }
@@ -4830,8 +4823,6 @@ async fn query_source_max_timestamp(
     result.rows.first().and_then(|r| r.first()).and_then(|v| {
         v.as_str().and_then(|s| {
             s.parse::<chrono::DateTime<Utc>>().ok().or_else(|| {
-                // Some warehouses (Snowflake REST, DuckDB) return naive
-                // timestamps without an offset; treat as UTC.
                 chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
                     .or_else(|_| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
                     .ok()
@@ -4841,22 +4832,40 @@ async fn query_source_max_timestamp(
     })
 }
 
-/// Resolve the source-side watermark to persist after copying `source_table`.
+/// Resolve the watermark to persist after copying into `target_table`.
 ///
-/// Incremental and microbatch strategies advance the watermark to
-/// `MAX(source.{timestamp_column})` — **including the bootstrap full-refresh
-/// run** (the first run, or a drift drop-and-recreate). The next incremental
-/// tick filters `WHERE {ts} > watermark`, so the bootstrap must record the real
-/// data max: a wall-clock `now` is later than every existing row and would
-/// silently drop the next delta. Other strategies never consult state-store
-/// watermarks, so they record `now` without the extra round-trip. Falls back to
-/// `now` when the source is empty / NULL / unparseable.
+/// # The TOCTOU this fixes (M2)
+///
+/// The incremental INSERT filters `WHERE source.{ts} > prior_watermark` against
+/// the source's snapshot, then a separate later query recorded the new
+/// watermark. If that later query read `MAX(ts) FROM source`, any row appended
+/// to source *between* the INSERT's snapshot and the MAX query would advance the
+/// watermark past rows the INSERT never loaded — a permanent skip on the next
+/// strict-`>` run.
+///
+/// On the replication path the timestamp column is identity-mapped source →
+/// target (a `SELECT *` / `ColumnSelection::All` passthrough copy, with all
+/// transformation strategies rejected upstream), so reading `MAX(ts) FROM
+/// target` records exactly the max timestamp among the rows that were actually
+/// loaded — no loss, and no spurious reprocessing of source rows that weren't.
+///
+/// # Empty-target handling
+///
+/// `MAX` over an empty / freshly-truncated target returns NULL. On the
+/// incremental path `now` is NEVER a safe watermark — it is later than every
+/// real row and would skip any source row written after this run's snapshot.
+/// So a NULL / unparseable / failed target MAX falls back to the **prior
+/// watermark** (unchanged). When there is no prior watermark either (a true
+/// first run that loaded nothing), it falls back to the epoch sentinel
+/// (`1970-01-01`), which is "no progress" — the next run re-scans the whole
+/// source rather than advancing past unloaded rows.
 async fn resolve_new_watermark(
     strategy: &MaterializationStrategy,
     warehouse: &dyn WarehouseAdapter,
     dialect: &dyn rocky_core::traits::SqlDialect,
-    source_table: &TableRef,
+    target_table: &TableRef,
     timestamp_column: &str,
+    prior_watermark: Option<chrono::DateTime<Utc>>,
     now: chrono::DateTime<Utc>,
 ) -> chrono::DateTime<Utc> {
     let advances_watermark = matches!(
@@ -4864,12 +4873,24 @@ async fn resolve_new_watermark(
         MaterializationStrategy::Incremental { .. } | MaterializationStrategy::Microbatch { .. }
     );
     if advances_watermark {
-        query_source_max_timestamp(warehouse, dialect, source_table, timestamp_column)
-            .await
-            .unwrap_or(now)
+        // Record what was actually loaded (MAX over the target). On an empty
+        // target / NULL / failure, keep the prior watermark — never `now`,
+        // which would skip rows written to source after this run's snapshot.
+        // With no prior either, fall back to the epoch sentinel = no progress.
+        match query_target_max_timestamp(warehouse, dialect, target_table, timestamp_column).await {
+            Some(target_max) => target_max,
+            None => prior_watermark.unwrap_or_else(epoch_watermark_sentinel),
+        }
     } else {
         now
     }
+}
+
+/// The "no progress" watermark sentinel (`1970-01-01T00:00:00Z`). Recorded when
+/// an incremental run loaded nothing and has no prior watermark, so the next
+/// run re-scans the whole source rather than advancing past unloaded rows.
+fn epoch_watermark_sentinel() -> chrono::DateTime<Utc> {
+    chrono::DateTime::<Utc>::from_timestamp(0, 0).unwrap_or_else(Utc::now)
 }
 
 /// Processes a single table: drift detection + replication.
@@ -5072,7 +5093,7 @@ async fn process_table(
     // Effective timestamp column after per-table override. Mirrors the same
     // override > pipeline-default precedence used inside
     // `build_replication_strategy_with_override` so the strategy's WHERE
-    // clause and the post-execute `query_source_max_timestamp` call below
+    // clause and the post-execute `query_target_max_timestamp` call below
     // both operate on the same column — if an override changes the column,
     // the recorded watermark stays aligned with the next run's filter.
     let effective_timestamp_column = task
@@ -5310,17 +5331,22 @@ async fn process_table(
         None
     };
 
-    // Record the source-side watermark this run advanced to. Incremental and
-    // microbatch strategies advance to MAX(source.ts) even on a bootstrap
-    // full-refresh run, so the next incremental tick filters off the real data
-    // max rather than a wall-clock value that would exclude every existing row
-    // (see `resolve_new_watermark`).
+    // Record the watermark this run advanced to. Incremental and microbatch
+    // strategies record `MAX(target.ts)` — exactly the max timestamp among the
+    // rows actually loaded into the target. Reading the TARGET (not re-querying
+    // the source) closes a TOCTOU: a row appended to source after the INSERT's
+    // snapshot but before the watermark capture would otherwise advance the
+    // watermark past a row that was never loaded, permanently skipping it on
+    // the next strict-`>` run. On the replication path the ts column is an
+    // identity-mapped passthrough, so target-MAX is in the same value space as
+    // source-MAX for the loaded rows. See `resolve_new_watermark`.
     let new_watermark = resolve_new_watermark(
         &strategy,
         warehouse,
         dialect,
-        &source_table,
+        &target_table,
         &effective_timestamp_column,
+        prior_watermark,
         now,
     )
     .await;
@@ -7087,7 +7113,7 @@ merge_keys = ["id"]
             table: "events".into(),
         };
 
-        let watermark = super::query_source_max_timestamp(
+        let watermark = super::query_target_max_timestamp(
             &adapter as &dyn WarehouseAdapter,
             &dialect as &dyn SqlDialect,
             &source,
@@ -7132,7 +7158,7 @@ merge_keys = ["id"]
             table: "empty_events".into(),
         };
 
-        let watermark = super::query_source_max_timestamp(
+        let watermark = super::query_target_max_timestamp(
             &adapter as &dyn WarehouseAdapter,
             &dialect as &dyn SqlDialect,
             &source,
@@ -7200,6 +7226,7 @@ merge_keys = ["id"]
             &dialect as &dyn SqlDialect,
             &source,
             "_fivetran_synced",
+            None,
             now,
         )
         .await;
@@ -7207,7 +7234,7 @@ merge_keys = ["id"]
         let data_max = chrono::Utc.with_ymd_and_hms(2026, 3, 3, 12, 0, 0).unwrap();
         assert_eq!(
             watermark, data_max,
-            "incremental bootstrap must record MAX(source.ts), not wall-clock now"
+            "incremental bootstrap must record MAX(target.ts), not wall-clock now"
         );
         assert!(
             watermark < now,
@@ -7225,12 +7252,137 @@ merge_keys = ["id"]
             &dialect as &dyn SqlDialect,
             &source,
             "_fivetran_synced",
+            None,
             now,
         )
         .await;
         assert_eq!(
             mb_watermark, data_max,
-            "microbatch must also record MAX(source.ts), not wall-clock now"
+            "microbatch must also record MAX(target.ts), not wall-clock now"
+        );
+    }
+
+    /// M2 regression: a row appended to SOURCE between the incremental INSERT's
+    /// snapshot and the watermark capture must NOT be skipped on the next run.
+    ///
+    /// Recording `MAX(target.ts)` (what was loaded) instead of a later
+    /// `MAX(source.ts)` closes the TOCTOU. This drives the actual SQL the
+    /// runner emits (the dialect's `watermark_where` filter + INSERT) against
+    /// in-memory DuckDB across two consecutive incremental runs and asserts no
+    /// row loss.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn incremental_no_row_loss_on_source_append_between_insert_and_watermark() {
+        use chrono::TimeZone;
+        use rocky_core::traits::{SqlDialect, WarehouseAdapter};
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+        use rocky_ir::{MaterializationStrategy, TableRef};
+
+        let adapter = DuckDbWarehouseAdapter::in_memory().unwrap();
+        for ddl in [
+            "CREATE SCHEMA src",
+            "CREATE SCHEMA tgt",
+            "CREATE TABLE src.events (id INTEGER, ts TIMESTAMP)",
+            "CREATE TABLE tgt.events (id INTEGER, ts TIMESTAMP)",
+            // Initial source rows, all in the past.
+            "INSERT INTO src.events VALUES (1, TIMESTAMP '2026-03-01 10:00:00'), \
+             (2, TIMESTAMP '2026-03-02 10:00:00')",
+        ] {
+            adapter.execute_statement(ddl).await.unwrap();
+        }
+
+        let dialect = DuckDbSqlDialect;
+        let strategy = MaterializationStrategy::Incremental {
+            timestamp_column: "ts".to_string(),
+        };
+        let target = TableRef {
+            catalog: String::new(),
+            schema: "tgt".into(),
+            table: "events".into(),
+        };
+        let now = chrono::Utc::now();
+
+        // ── Run 1 ────────────────────────────────────────────────────────
+        // INSERT INTO target SELECT * FROM source WHERE ts > epoch.
+        let where1 = dialect.watermark_where("ts", None).unwrap();
+        adapter
+            .execute_statement(&format!(
+                "INSERT INTO tgt.events SELECT * FROM src.events {where1}"
+            ))
+            .await
+            .unwrap();
+
+        // *** The TOCTOU window ***: a row lands in SOURCE with a timestamp
+        // later than the rows the INSERT above selected, but it was NOT part of
+        // run 1's snapshot. A source-MAX watermark would jump to 03-03 and the
+        // next `ts > 03-03` filter would skip this row forever.
+        adapter
+            .execute_statement("INSERT INTO src.events VALUES (3, TIMESTAMP '2026-03-03 10:00:00')")
+            .await
+            .unwrap();
+
+        // Capture the watermark the way the runner does — from the TARGET.
+        let wm1 = super::resolve_new_watermark(
+            &strategy,
+            &adapter as &dyn WarehouseAdapter,
+            &dialect as &dyn SqlDialect,
+            &target,
+            "ts",
+            None,
+            now,
+        )
+        .await;
+        // It must reflect only what was loaded (max = 03-02), NOT the appended
+        // source row (03-03).
+        let loaded_max = chrono::Utc.with_ymd_and_hms(2026, 3, 2, 10, 0, 0).unwrap();
+        assert_eq!(
+            wm1, loaded_max,
+            "watermark must be MAX(target.ts), not the post-snapshot source append"
+        );
+
+        // ── Run 2 ────────────────────────────────────────────────────────
+        // Filter `ts > wm1`. Because wm1 = 03-02 (not 03-03), the appended row
+        // (id=3, 03-03) IS picked up — no loss.
+        let where2 = dialect.watermark_where("ts", Some(&wm1)).unwrap();
+        adapter
+            .execute_statement(&format!(
+                "INSERT INTO tgt.events SELECT * FROM src.events {where2}"
+            ))
+            .await
+            .unwrap();
+
+        // Assert the target now has all three source rows, exactly once each.
+        let count = adapter
+            .execute_query("SELECT COUNT(*) FROM tgt.events")
+            .await
+            .unwrap();
+        let n = count.rows[0][0].as_u64().or_else(|| {
+            count.rows[0][0]
+                .as_str()
+                .and_then(|s| s.parse::<u64>().ok())
+        });
+        assert_eq!(
+            n,
+            Some(3),
+            "all three source rows must be loaded exactly once — no loss, no dup"
+        );
+        let ids = adapter
+            .execute_query("SELECT id FROM tgt.events ORDER BY id")
+            .await
+            .unwrap();
+        let got: Vec<i64> = ids
+            .rows
+            .iter()
+            .filter_map(|r| {
+                r[0].as_i64()
+                    .or_else(|| r[0].as_str().and_then(|s| s.parse().ok()))
+            })
+            .collect();
+        assert_eq!(
+            got,
+            vec![1, 2, 3],
+            "the appended row (id=3) must not be skipped"
         );
     }
 
@@ -7253,7 +7405,7 @@ merge_keys = ["id"]
             table: "events".into(),
         };
 
-        let watermark = super::query_source_max_timestamp(
+        let watermark = super::query_target_max_timestamp(
             &adapter as &dyn WarehouseAdapter,
             &dialect as &dyn SqlDialect,
             &source,

--- a/engine/crates/rocky-cli/src/plan_store.rs
+++ b/engine/crates/rocky-cli/src/plan_store.rs
@@ -273,6 +273,27 @@ pub fn read_plan(root: &Path, plan_id: &str) -> Result<PersistedPlan> {
     let plan: PersistedPlan = serde_json::from_slice(&bytes)
         .with_context(|| format!("plan file at {} is not valid JSON", path.display()))?;
 
+    // Integrity check: the plan_id is the blake3 digest of `{kind, payload}`.
+    // Recompute it from the bytes we just parsed and reject the plan if it does
+    // not match the requested id (and the stored id). This binds the applied
+    // bytes to the reviewed plan id — a plan whose payload was tampered with or
+    // truncated-but-still-parseable after it was written (and reviewed) no
+    // longer matches its filename / stored id, so apply refuses it.
+    let recomputed = compute_plan_id(&plan.kind, &plan.payload);
+    if recomputed != plan_id || recomputed != plan.plan_id {
+        bail!(
+            "plan '{}' failed its integrity check: the payload hashes to '{}', \
+             which does not match the requested id '{}' (stored id '{}'). \
+             The plan file at {} may have been modified after it was written — \
+             re-generate the plan and (if AI-authored) re-review it before applying.",
+            plan_id,
+            recomputed,
+            plan_id,
+            plan.plan_id,
+            path.display()
+        );
+    }
+
     Ok(plan)
 }
 
@@ -305,6 +326,43 @@ mod tests {
         assert_eq!(plan.kind, PlanKind::Compact);
         assert_eq!(plan.payload["model"], json!("mydb.myschema.orders"));
         assert_eq!(plan.payload["statement_count"], json!(2));
+        Ok(())
+    }
+
+    /// L3: a persisted plan whose payload is mutated after write (so it no
+    /// longer hashes to its filename / stored id) must be rejected by
+    /// `read_plan`, not silently applied.
+    #[test]
+    fn tampered_payload_is_rejected() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let payload = DummyPayload {
+            model: "cat.sc.tbl",
+            statement_count: 2,
+        };
+        let plan_id = write_plan(dir.path(), PlanKind::Compact, &payload)?;
+
+        // It reads cleanly before tampering.
+        assert!(read_plan(dir.path(), &plan_id).is_ok());
+
+        // Mutate the payload on disk while leaving the JSON valid and the
+        // filename + stored plan_id unchanged — exactly the post-review
+        // tamper the integrity check must catch.
+        let path = dir
+            .path()
+            .join(".rocky")
+            .join("plans")
+            .join(format!("{plan_id}.json"));
+        let raw = std::fs::read_to_string(&path)?;
+        let mut record: serde_json::Value = serde_json::from_str(&raw)?;
+        record["payload"]["statement_count"] = json!(999);
+        std::fs::write(&path, serde_json::to_vec_pretty(&record)?)?;
+
+        let err = read_plan(dir.path(), &plan_id).expect_err("a tampered plan must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("integrity check"),
+            "expected an integrity-check error, got: {msg}"
+        );
         Ok(())
     }
 
@@ -592,12 +650,16 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let plans_dir = dir.path().join(".rocky").join("plans");
         std::fs::create_dir_all(&plans_dir)?;
-        let plan_id = "a".repeat(64);
+        // Use a hash-consistent plan_id for the payload so the integrity check
+        // passes — this test exercises the `format_version` default, not a
+        // tamper case. (Pre-integrity-check this used a fabricated all-`a` id.)
+        let payload = serde_json::json!({"dummy": true});
+        let plan_id = compute_plan_id(&PlanKind::Compact, &payload);
         let legacy_json = serde_json::json!({
             "plan_id": plan_id,
             "kind": "compact",
             "created_at": "2026-05-15T12:34:56Z",
-            "payload": {"dummy": true}
+            "payload": payload
         });
         std::fs::write(
             plans_dir.join(format!("{plan_id}.json")),

--- a/engine/crates/rocky-compiler/src/import/dbt.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt.rs
@@ -993,6 +993,63 @@ fn collect_unresolvable_macros(sql: &str, model_name: &str, result: &mut ImportR
 // Import from raw SQL files (regex path)
 // ---------------------------------------------------------------------------
 
+/// Join an untrusted relative model path under `base`, rejecting any path that
+/// would escape the project root.
+///
+/// `dbt_project.yml`'s `model-paths` is third-party input. A path that is
+/// absolute or contains a `..` (`ParentDir`) component could steer the import
+/// into reading files outside the project. This rejects those syntactically
+/// (no filesystem access required), and — when the joined path exists —
+/// canonicalizes it and asserts it stays within the canonicalized `base`,
+/// catching symlink-based escapes too. A not-yet-existing joined path that
+/// passed the syntactic check is allowed through (the caller already tolerates
+/// missing model dirs).
+fn safe_join_under(base: &Path, rel: &Path) -> Result<std::path::PathBuf, String> {
+    use std::path::Component;
+
+    if rel.is_absolute() {
+        return Err(format!(
+            "model path '{}' is absolute — model paths must be relative to the dbt project",
+            rel.display()
+        ));
+    }
+    if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(format!(
+            "model path '{}' contains a '..' component — model paths may not escape the dbt project",
+            rel.display()
+        ));
+    }
+
+    let joined = base.join(rel);
+
+    // Defense in depth: if the path exists, canonicalize and confirm
+    // containment (catches symlink escapes the syntactic check can't see).
+    if joined.exists() {
+        let canon_base = base.canonicalize().map_err(|e| {
+            format!(
+                "failed to canonicalize project root {}: {e}",
+                base.display()
+            )
+        })?;
+        let canon_joined = joined.canonicalize().map_err(|e| {
+            format!(
+                "failed to canonicalize model path {}: {e}",
+                joined.display()
+            )
+        })?;
+        if !canon_joined.starts_with(&canon_base) {
+            return Err(format!(
+                "model path '{}' resolves to {}, outside the dbt project at {}",
+                rel.display(),
+                canon_joined.display(),
+                canon_base.display()
+            ));
+        }
+    }
+
+    Ok(joined)
+}
+
 /// Import a dbt project directory.
 ///
 /// Scans `dbt_project/models/` for `.sql` files, extracts Jinja refs/sources,
@@ -1018,9 +1075,18 @@ pub fn import_dbt_project(
         }
     };
 
-    // Determine model paths
+    // Determine model paths. Model paths come from an untrusted
+    // `dbt_project.yml`; reject any that escape the project root (absolute or
+    // containing a `..` component) so an import can't be steered into reading
+    // files outside `dbt_dir`.
     let model_dirs: Vec<std::path::PathBuf> = match &project_config {
-        Some(cfg) => cfg.model_paths.iter().map(|p| dbt_dir.join(p)).collect(),
+        Some(cfg) => {
+            let mut dirs = Vec::with_capacity(cfg.model_paths.len());
+            for p in &cfg.model_paths {
+                dirs.push(safe_join_under(dbt_dir, p)?);
+            }
+            dirs
+        }
         None => vec![dbt_dir.join("models")],
     };
 
@@ -1083,6 +1149,7 @@ pub fn import_dbt_project(
                 &project_config,
                 &source_map,
                 &mut result,
+                0,
             )?;
         }
     }
@@ -1116,7 +1183,17 @@ fn visit_dbt_models(
     project_config: &Option<DbtProjectConfig>,
     source_map: &HashMap<(String, String), dbt_sources::RockySourceMapping>,
     result: &mut ImportResult,
+    depth: usize,
 ) -> Result<(), String> {
+    if depth > super::MAX_IMPORT_RECURSION_DEPTH {
+        return Err(format!(
+            "model directory tree exceeds the maximum import depth of {} at {} — \
+             refusing to recurse further (possible symlink cycle)",
+            super::MAX_IMPORT_RECURSION_DEPTH,
+            dir.display()
+        ));
+    }
+
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("failed to read {}: {e}", dir.display()))?;
 
@@ -1124,7 +1201,7 @@ fn visit_dbt_models(
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
 
-        if path.is_dir() {
+        if super::is_traversable_subdir(&entry) {
             visit_dbt_models(
                 &path,
                 models_root,
@@ -1132,6 +1209,7 @@ fn visit_dbt_models(
                 project_config,
                 source_map,
                 result,
+                depth + 1,
             )?;
         } else if path.extension().is_some_and(|ext| ext == "sql") {
             let name = path
@@ -2761,5 +2839,85 @@ FROM {{ ref('stg_events') }}
         assert_eq!(result.unit_tests_skipped, 0);
         let imported = result.imported.iter().find(|m| m.name == "m").unwrap();
         assert_eq!(imported.unit_tests.len(), 1);
+    }
+
+    // --- L1: model-path traversal rejection ---
+
+    #[test]
+    fn safe_join_rejects_parent_dir_component() {
+        let base = std::path::Path::new("/tmp/project");
+        let err = safe_join_under(base, std::path::Path::new("../../etc"))
+            .expect_err("a `..` path must be rejected");
+        assert!(err.contains(".."), "error should mention the escape: {err}");
+    }
+
+    #[test]
+    fn safe_join_rejects_absolute_path() {
+        let base = std::path::Path::new("/tmp/project");
+        let err = safe_join_under(base, std::path::Path::new("/etc/passwd"))
+            .expect_err("an absolute path must be rejected");
+        assert!(err.contains("absolute"), "error should explain: {err}");
+    }
+
+    #[test]
+    fn safe_join_allows_normal_relative_path() {
+        let base = std::path::Path::new("/tmp/project");
+        let joined = safe_join_under(base, std::path::Path::new("models"))
+            .expect("a normal relative path is allowed");
+        assert_eq!(joined, std::path::Path::new("/tmp/project/models"));
+    }
+
+    /// A `dbt_project.yml` declaring a traversal `model-paths` must be rejected
+    /// by the full import entry point, not silently read.
+    #[test]
+    fn import_rejects_traversal_model_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("dbt_project.yml"),
+            "name: evil\nmodel-paths: [\"../../etc\"]\n",
+        )
+        .unwrap();
+        let target = TargetConfig {
+            catalog: "cat".into(),
+            schema: "sch".into(),
+            table: String::new(),
+        };
+        let err = match import_dbt_project(dir.path(), &target) {
+            Err(e) => e,
+            Ok(_) => panic!("traversal model path must abort the import"),
+        };
+        assert!(
+            err.contains("..") || err.contains("escape"),
+            "expected a traversal-rejection error, got: {err}"
+        );
+    }
+
+    // --- M1: symlink-cycle recursion guard ---
+
+    /// A directory symlink cycle (`loop -> ..`) inside the models tree must not
+    /// drive the importer into unbounded recursion — the symlink is skipped
+    /// (and the depth cap is a backstop), so the import terminates.
+    #[cfg(unix)]
+    #[test]
+    fn import_terminates_on_directory_symlink_cycle() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::write(models.join("ok.sql"), "SELECT 1 AS x").unwrap();
+        // models/loop -> models (a cycle back into the tree being walked).
+        std::os::unix::fs::symlink(&models, models.join("loop")).unwrap();
+
+        let target = TargetConfig {
+            catalog: "cat".into(),
+            schema: "sch".into(),
+            table: String::new(),
+        };
+        // The key assertion is that this RETURNS (no stack overflow / hang).
+        let result =
+            import_dbt_project(dir.path(), &target).expect("import should terminate cleanly");
+        assert!(
+            result.imported.iter().any(|m| m.name == "ok"),
+            "the real model should still be imported"
+        );
     }
 }

--- a/engine/crates/rocky-compiler/src/import/dbt_sources.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_sources.rs
@@ -254,11 +254,24 @@ pub fn scan_sources_in_dir(dir: &Path) -> Result<Vec<DbtSource>, String> {
         return Ok(all_sources);
     }
 
-    scan_sources_recursive(dir, &mut all_sources)?;
+    scan_sources_recursive(dir, &mut all_sources, 0)?;
     Ok(all_sources)
 }
 
-fn scan_sources_recursive(dir: &Path, sources: &mut Vec<DbtSource>) -> Result<(), String> {
+fn scan_sources_recursive(
+    dir: &Path,
+    sources: &mut Vec<DbtSource>,
+    depth: usize,
+) -> Result<(), String> {
+    if depth > super::MAX_IMPORT_RECURSION_DEPTH {
+        return Err(format!(
+            "sources directory tree exceeds the maximum import depth of {} at {} — \
+             refusing to recurse further (possible symlink cycle)",
+            super::MAX_IMPORT_RECURSION_DEPTH,
+            dir.display()
+        ));
+    }
+
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("failed to read {}: {e}", dir.display()))?;
 
@@ -266,8 +279,8 @@ fn scan_sources_recursive(dir: &Path, sources: &mut Vec<DbtSource>) -> Result<()
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
 
-        if path.is_dir() {
-            scan_sources_recursive(&path, sources)?;
+        if super::is_traversable_subdir(&entry) {
+            scan_sources_recursive(&path, sources, depth + 1)?;
         } else if is_yaml_file(&path) {
             match parse_sources(&path) {
                 Ok(found) => sources.extend(found),

--- a/engine/crates/rocky-compiler/src/import/dbt_tests.rs
+++ b/engine/crates/rocky-compiler/src/import/dbt_tests.rs
@@ -105,14 +105,24 @@ pub fn parse_model_yamls(models_dir: &Path) -> Result<HashMap<String, DbtModelYa
         return Ok(models);
     }
 
-    scan_models_recursive(models_dir, &mut models)?;
+    scan_models_recursive(models_dir, &mut models, 0)?;
     Ok(models)
 }
 
 fn scan_models_recursive(
     dir: &Path,
     models: &mut HashMap<String, DbtModelYaml>,
+    depth: usize,
 ) -> Result<(), String> {
+    if depth > super::MAX_IMPORT_RECURSION_DEPTH {
+        return Err(format!(
+            "model YAML tree exceeds the maximum import depth of {} at {} — \
+             refusing to recurse further (possible symlink cycle)",
+            super::MAX_IMPORT_RECURSION_DEPTH,
+            dir.display()
+        ));
+    }
+
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("failed to read {}: {e}", dir.display()))?;
 
@@ -120,8 +130,8 @@ fn scan_models_recursive(
         let entry = entry.map_err(|e| e.to_string())?;
         let path = entry.path();
 
-        if path.is_dir() {
-            scan_models_recursive(&path, models)?;
+        if super::is_traversable_subdir(&entry) {
+            scan_models_recursive(&path, models, depth + 1)?;
         } else if is_yaml_file(&path) {
             match parse_model_yaml_file(&path) {
                 Ok(parsed) => {

--- a/engine/crates/rocky-compiler/src/import/mod.rs
+++ b/engine/crates/rocky-compiler/src/import/mod.rs
@@ -9,3 +9,26 @@ pub mod dbt_sources;
 pub mod dbt_tests;
 pub mod emit;
 pub mod report;
+
+/// Maximum directory-recursion depth for any importer tree walk.
+///
+/// `rocky import-dbt` ingests an untrusted third-party project, so the walkers
+/// must not be able to recurse unboundedly. Combined with the symlink skip in
+/// [`is_traversable_subdir`] this bounds a maliciously-deep or symlink-cyclic
+/// tree. A real dbt project nests only a handful of levels; this cap is far
+/// above any legitimate layout.
+pub(crate) const MAX_IMPORT_RECURSION_DEPTH: usize = 64;
+
+/// True when `entry` is a directory the importer should descend into.
+///
+/// Uses [`std::fs::DirEntry::file_type`], which (unlike `Path::is_dir`) does
+/// **not** follow symlinks, then explicitly rejects symlinks. This prevents a
+/// directory symlink cycle (e.g. `models/loop -> ..`) from driving an importer
+/// walk into unbounded recursion / stack overflow. On any I/O error reading
+/// the file type the entry is treated as non-traversable.
+pub(crate) fn is_traversable_subdir(entry: &std::fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(ft) => ft.is_dir() && !ft.is_symlink(),
+        Err(_) => false,
+    }
+}

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -56,6 +56,12 @@ pub enum ProjectError {
     #[error("no models found in {path}")]
     NoModels { path: String },
 
+    #[error(
+        "duplicate model name '{name}': two or more models share this name. \
+         Model names must be unique within a project — rename one."
+    )]
+    DuplicateModel { name: String },
+
     #[error("failed to parse .rocky file '{path}': {reason}")]
     RockyParse { path: String, reason: String },
 
@@ -117,6 +123,19 @@ impl Project {
     /// Useful when models come from sources other than a directory
     /// (e.g., DSL lowering, dbt import).
     pub fn from_models(models: Vec<Model>) -> Result<Self, ProjectError> {
+        // Reject duplicate model names up front. `model()` is first-wins and
+        // `resolve` collapses names into a HashSet, so a second model with the
+        // same name would silently shadow the first — a real source of "my edit
+        // had no effect" confusion. Fail loudly instead.
+        let mut seen = std::collections::HashSet::with_capacity(models.len());
+        for m in &models {
+            if !seen.insert(m.config.name.as_str()) {
+                return Err(ProjectError::DuplicateModel {
+                    name: m.config.name.clone(),
+                });
+            }
+        }
+
         let (dag_nodes, lineage_cache, resolve_diagnostics) =
             resolve::resolve_dependencies(&models)?;
         let execution_order = dag::topological_sort(&dag_nodes)?;
@@ -506,6 +525,20 @@ mod tests {
             sql: sql.to_string(),
             file_path: format!("models/{name}.sql"),
             contract_path: None,
+        }
+    }
+
+    #[test]
+    fn duplicate_model_name_is_rejected() {
+        let models = vec![
+            make_model("orders", "SELECT 1 AS id"),
+            make_model("orders", "SELECT 2 AS id"),
+        ];
+        let err =
+            Project::from_models(models).expect_err("two models sharing a name must be rejected");
+        match err {
+            ProjectError::DuplicateModel { name } => assert_eq!(name, "orders"),
+            other => panic!("expected DuplicateModel, got {other:?}"),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -543,6 +543,8 @@ pub struct StateConfig {
     /// GCS key prefix (default: "rocky/state/")
     pub gcs_prefix: Option<String>,
     /// Valkey/Redis URL for state persistence
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message.
     pub valkey_url: Option<String>,
     /// Valkey key prefix (default: "rocky:state:")
     pub valkey_prefix: Option<String>,
@@ -1683,6 +1685,11 @@ impl ModelBudgetConfig {
 /// (schemas section).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValkeyCacheConfig {
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message. (Not
+    // wrapped in RedactedString because the cache client consumes it as a
+    // plain connection URL — threading RedactedString through that
+    // construction is invasive; this comment is the guard instead.)
     pub valkey_url: String,
 }
 
@@ -2552,6 +2559,8 @@ pub struct FivetranCacheConfig {
 
     /// Connection URL for `backend = "valkey"` or `backend = "tiered"`
     /// (primary layer). Standard `redis://` (plain) or `rediss://` (TLS).
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valkey_url: Option<String>,
 
@@ -2687,6 +2696,8 @@ pub struct FivetranRatelimitConfig {
 
     /// Connection URL for `backend = "valkey"`. Standard `redis://`
     /// (plain) or `rediss://` (TLS).
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valkey_url: Option<String>,
 
@@ -2780,6 +2791,8 @@ pub struct FivetranStampedeConfig {
 
     /// Connection URL for `backend = "valkey"`. Standard `redis://`
     /// (plain) or `rediss://` (TLS).
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valkey_url: Option<String>,
 
@@ -2883,6 +2896,8 @@ pub struct FivetranCircuitBreakerConfig {
 
     /// Connection URL for `backend = "valkey"`. Standard `redis://`
     /// (plain) or `rediss://` (TLS).
+    // SECURITY: may embed credentials (`redis://:password@host`). Never log
+    // this value; redact it if it ever reaches an error/trace message.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valkey_url: Option<String>,
 

--- a/engine/crates/rocky-core/src/object_store.rs
+++ b/engine/crates/rocky-core/src/object_store.rs
@@ -269,13 +269,45 @@ impl ObjectStoreProvider {
     }
 
     /// Download an object from the store to a local file.
+    ///
+    /// The bytes are written to a uniquely-named temp file in the **same
+    /// directory** as `local_path` and then atomically `rename`d into place
+    /// (POSIX rename is atomic within a filesystem). This guarantees readers
+    /// never observe a half-written `state.redb`: they see either the old file
+    /// or the complete new one, never a truncated mix. Writing in place would
+    /// leave a corrupt redb if the process died mid-write.
     pub async fn download_file(
         &self,
         relative_path: &str,
         local_path: &Path,
     ) -> ObjectStoreResult<()> {
         let bytes = self.get(relative_path).await?;
-        tokio::fs::write(local_path, &bytes).await?;
+
+        let parent = local_path.parent().unwrap_or_else(|| Path::new("."));
+        let file_name = local_path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "state".to_string());
+        // Same-directory temp name so the rename stays on one filesystem (a
+        // cross-device rename is not atomic and would error). The pid + a
+        // nanosecond timestamp keep concurrent downloads from colliding.
+        let unique = format!(
+            "{}.{}.{}.tmp",
+            file_name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let tmp_path = parent.join(unique);
+
+        tokio::fs::write(&tmp_path, &bytes).await?;
+        // Atomic publish. On failure, best-effort clean up the temp file.
+        if let Err(e) = tokio::fs::rename(&tmp_path, local_path).await {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(e.into());
+        }
         Ok(())
     }
 
@@ -406,6 +438,41 @@ mod tests {
         provider.download_file("copy", out.path()).await.unwrap();
         let back = std::fs::read(out.path()).unwrap();
         assert_eq!(back, b"file-data");
+    }
+
+    /// `download_file` must atomically replace an existing file with the
+    /// correct content and leave no temp file behind in the directory.
+    #[tokio::test]
+    async fn test_download_overwrites_atomically_no_temp_left() {
+        let provider = ObjectStoreProvider::in_memory();
+        provider
+            .put("state", Bytes::from_static(b"new-state-bytes"))
+            .await
+            .unwrap();
+
+        let target_dir = tempfile::tempdir().unwrap();
+        let target = target_dir.path().join("state.redb");
+        // Pre-existing (stale) content that must be fully replaced.
+        std::fs::write(&target, b"old-stale-content").unwrap();
+
+        provider.download_file("state", &target).await.unwrap();
+
+        let back = std::fs::read(&target).unwrap();
+        assert_eq!(
+            back, b"new-state-bytes",
+            "content must be the downloaded bytes"
+        );
+
+        // The same-directory temp file must have been renamed away, not left.
+        let leftover: Vec<_> = std::fs::read_dir(target_dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "no .tmp file should remain after an atomic download"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-databricks/src/auth.rs
+++ b/engine/crates/rocky-databricks/src/auth.rs
@@ -77,12 +77,25 @@ async fn read_fresh_token(cache: &RwLock<Option<CachedToken>>) -> Option<String>
         .map(|ct| ct.access_token.expose().to_string())
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct OAuthTokenResponse {
     access_token: String,
     #[allow(dead_code)]
     token_type: String,
     expires_in: u64,
+}
+
+// Custom `Debug` that masks the bearer token. The derive would print
+// `access_token` verbatim, so a future `tracing`/`{:?}` of this response would
+// leak the secret into logs. Nothing currently relies on the derived `Debug`.
+impl std::fmt::Debug for OAuthTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthTokenResponse")
+            .field("access_token", &"***")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
 }
 
 /// Configuration for Databricks auth, typically from env vars or config.

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -407,6 +407,68 @@ impl UniformWriter {
     }
 }
 
+/// True if a `_delta_log` commit body (JSONL) contains an `add` action whose
+/// `path` equals `add_file_path`.
+///
+/// Pure parsing — no I/O — so it is unit-testable. Each Delta commit line is a
+/// single-key object; we only inspect `add` actions and compare their `path`
+/// field against the content-addressed path the writer is about to commit.
+pub(super) fn commit_jsonl_contains_add_path(body: &[u8], add_file_path: &str) -> Result<bool> {
+    let text = std::str::from_utf8(body)
+        .map_err(|e| UniformWriterError::DeltaLog(format!("non-utf8 _delta_log: {e}")))?;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| UniformWriterError::DeltaLog(format!("scan add path: {e}")))?;
+        let Some(add) = value.get("add") else {
+            continue;
+        };
+        if add.get("path").and_then(|v| v.as_str()) == Some(add_file_path) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Scan every `_delta_log/<20-digit>.json` commit for an `add` action that
+/// already references `add_file_path`, returning the commit version that did.
+///
+/// Used by the cond-put retry loop: on a 412 the writer must distinguish a
+/// genuine version race (some *other* commit grabbed the version it wanted →
+/// retry at a higher version) from a competing writer that landed *this exact
+/// content-addressed file* (→ do not add it a second time; return the existing
+/// commit). Scans newest → oldest and returns the first match.
+pub(super) async fn find_commit_with_add_path<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+    add_file_path: &str,
+) -> Result<Option<u64>> {
+    use futures::TryStreamExt;
+    let log_prefix = Path::from(format!("{prefix}/_delta_log"));
+    let mut versions: Vec<(u64, Path)> = Vec::new();
+    let mut stream = store.list(Some(&log_prefix));
+    while let Some(meta) = stream.try_next().await? {
+        let key = meta.location.to_string();
+        if let Some((_, last)) = key.rsplit_once('/')
+            && let Some(stem) = last.strip_suffix(".json")
+            && stem.len() == 20
+            && let Ok(v) = stem.parse::<u64>()
+        {
+            versions.push((v, meta.location));
+        }
+    }
+    versions.sort_by_key(|(v, _)| std::cmp::Reverse(*v));
+    for (version, path) in versions {
+        let body = store.get(&path).await?.bytes().await?;
+        if commit_jsonl_contains_add_path(&body, add_file_path)? {
+            return Ok(Some(version));
+        }
+    }
+    Ok(None)
+}
+
 /// Scan `_delta_log/` for the highest `<20-digit>.json` and return that + 1.
 pub(super) async fn next_commit_version<S: ObjectStore + ?Sized>(
     store: &S,
@@ -438,6 +500,38 @@ mod tests {
         include_bytes!("../../tests/fixtures/exp09_rowtracking_bootstrap.json");
     const EXP11_PARTITIONED_BOOTSTRAP: &[u8] =
         include_bytes!("../../tests/fixtures/exp11_partitioned_bootstrap.json");
+
+    #[test]
+    fn commit_jsonl_contains_add_path_matches_only_the_add_path() {
+        // A realistic two-line commit: a commitInfo and an add action.
+        let body = br#"{"commitInfo":{"timestamp":1700000000000}}
+{"add":{"path":"data/abc123.parquet","size":42,"dataChange":true}}"#;
+
+        // The exact content-addressed path is found.
+        assert!(
+            commit_jsonl_contains_add_path(body, "data/abc123.parquet").unwrap(),
+            "the committed add path must be detected"
+        );
+        // A different path is not.
+        assert!(
+            !commit_jsonl_contains_add_path(body, "data/other.parquet").unwrap(),
+            "a non-matching path must not match"
+        );
+    }
+
+    #[test]
+    fn commit_jsonl_contains_add_path_ignores_remove_and_blank_lines() {
+        // A `remove` action referencing the same path must NOT count as a live
+        // add, and blank lines are skipped.
+        let body = br#"
+{"remove":{"path":"data/abc123.parquet","dataChange":true}}
+{"metaData":{"id":"x"}}
+"#;
+        assert!(
+            !commit_jsonl_contains_add_path(body, "data/abc123.parquet").unwrap(),
+            "a remove action must not be treated as a live add"
+        );
+    }
 
     #[test]
     fn exp04_basic_uniform_parses() {

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -345,6 +345,31 @@ impl UniformWriter {
                     });
                 }
                 Err(object_store::Error::AlreadyExists { .. }) => {
+                    // Distinguish a genuine version race from a competing writer
+                    // that already landed this exact content-addressed file. If
+                    // an existing `add` action references our `add_file_path`, a
+                    // concurrent identical write won — return its commit version
+                    // rather than adding the same file a second time at a higher
+                    // version (which would double-count rows/bytes).
+                    if let Some(existing_version) =
+                        discover::find_commit_with_add_path(&*self.store, &prefix, &add_file_path)
+                            .await?
+                    {
+                        tracing::info!(
+                            add_file_path = %add_file_path,
+                            existing_version,
+                            "cond-put 412: identical content-addressed file already \
+                             committed by a concurrent writer; returning existing commit"
+                        );
+                        return Ok(WriteResult {
+                            file_path: parquet_path.to_string(),
+                            blake3_hash: hash,
+                            commit_version: existing_version,
+                            num_records: batch.num_rows(),
+                            size_bytes: file_size,
+                        });
+                    }
+
                     let observed = discover::next_commit_version(&*self.store, &prefix).await?;
                     state.next_commit_version = observed.max(target_version.saturating_add(1));
                     // The cond-put loser may also be racing on the

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -735,10 +735,10 @@ impl RockyLsp {
     /// Get the word at a cursor position in document text.
     fn word_at_position(text: &str, line: u32, col: u32) -> Option<String> {
         let target_line = text.lines().nth(line as usize)?;
-        let col = col as usize;
-        if col > target_line.len() {
-            return None;
-        }
+        // `col` is a UTF-16 code-unit offset (LSP `Position.character`); convert
+        // it to a byte offset before slicing or we panic on any multibyte char
+        // before the cursor.
+        let col = utf16_to_byte_offset(target_line, col as usize);
 
         let start = target_line[..col]
             .rfind(|c: char| !c.is_alphanumeric() && c != '_')
@@ -763,10 +763,9 @@ impl RockyLsp {
     /// or immediately after the `@` prefix of a macro invocation.
     fn macro_at_position(text: &str, line: u32, col: u32) -> Option<String> {
         let target_line = text.lines().nth(line as usize)?;
-        let col = col as usize;
-        if col > target_line.len() {
-            return None;
-        }
+        // `col` is a UTF-16 code-unit offset; convert to a byte offset before
+        // slicing (panics otherwise on a multibyte char before the cursor).
+        let col = utf16_to_byte_offset(target_line, col as usize);
 
         // Walk left from cursor to find the identifier start.
         let start = target_line[..col]
@@ -1882,8 +1881,10 @@ impl LanguageServer for RockyLsp {
         if let Some(schema) = result.semantic_graph.model_schema(model_name)
             && let Some(ref intent) = schema.intent
         {
-            let display = if intent.len() > 80 {
-                format!("{}...", &intent[..77])
+            // Truncate by characters, not bytes: `&intent[..77]` panics if a
+            // multibyte char straddles byte 77.
+            let display = if intent.chars().count() > 80 {
+                format!("{}...", intent.chars().take(77).collect::<String>())
             } else {
                 intent.clone()
             };
@@ -2015,12 +2016,10 @@ impl LanguageServer for RockyLsp {
         }
 
         let line = lines[pos.line as usize];
-        let col = pos.character as usize;
-        let before = if col <= line.len() {
-            &line[..col]
-        } else {
-            line
-        };
+        // `pos.character` is a UTF-16 code-unit offset; convert to a byte
+        // offset before slicing or a multibyte char before the cursor panics.
+        let col = utf16_to_byte_offset(line, pos.character as usize);
+        let before = &line[..col];
 
         // Walk backward to find the enclosing function call
         let mut paren_depth = 0i32;
@@ -2568,11 +2567,10 @@ fn get_completion_context(text: &str, line: usize, col: usize) -> CompletionCont
     }
 
     let current_line = lines[line];
-    let before_cursor = if col <= current_line.len() {
-        &current_line[..col]
-    } else {
-        current_line
-    };
+    // `col` is a UTF-16 code-unit offset (LSP `Position.character`); convert to
+    // a byte offset before slicing or a multibyte char before the cursor panics.
+    let byte_col = utf16_to_byte_offset(current_line, col);
+    let before_cursor = &current_line[..byte_col];
 
     let trimmed = before_cursor.trim();
 
@@ -3850,6 +3848,33 @@ fn lsp_range_from_parse_error(err: &rocky_lang::ParseError, source: &str) -> (Ra
         .unwrap_or_else(|| Position::new(0, 0));
     let end = Position::new(position.line, position.character.saturating_add(1));
     (Range::new(position, end), message)
+}
+
+/// Convert an LSP UTF-16 character offset within a single line into a Rust
+/// byte offset.
+///
+/// LSP `Position.character` is a count of UTF-16 code units, not bytes. Using
+/// it directly to slice a `&str` panics the moment a multibyte character
+/// (e.g. `é`, an emoji) sits before the cursor, because the offset lands
+/// inside a UTF-8 code point. This walks `char_indices`, accumulating each
+/// character's `len_utf16()` until the requested UTF-16 count is reached, and
+/// returns the byte index of the boundary. The result is always a valid char
+/// boundary and is clamped to `line.len()` when the offset runs past the end
+/// of the line (e.g. a column past the last character).
+fn utf16_to_byte_offset(line: &str, utf16_character: usize) -> usize {
+    if utf16_character == 0 {
+        return 0;
+    }
+    let mut utf16_count = 0usize;
+    for (byte_idx, ch) in line.char_indices() {
+        if utf16_count >= utf16_character {
+            return byte_idx;
+        }
+        utf16_count += ch.len_utf16();
+    }
+    // The offset reached or exceeded the end of the line — clamp to the end,
+    // which is always a valid char boundary.
+    line.len()
 }
 
 /// Convert a byte offset into an LSP `(line, character)` `Position` by
@@ -5886,5 +5911,62 @@ mod tests {
             salsa_sources.read().await.is_empty(),
             "failed seed must not populate the URI → SourceFile map",
         );
+    }
+
+    // ── UTF-16 offset handling (H1: multibyte-char panic regression) ──────
+
+    #[test]
+    fn utf16_to_byte_offset_handles_multibyte() {
+        // `é` is 2 UTF-8 bytes but 1 UTF-16 code unit; `🦀` is 4 UTF-8 bytes
+        // and 2 UTF-16 code units (a surrogate pair).
+        // Bytes:  c a f  é   ' ' 🦀     ' ' x
+        // byte:   0 1 2  3,4  5  6,7,8,9 10  11
+        // utf16:  0 1 2  3    4  5,6     7   8
+        let line = "café 🦀 x";
+        // c=1 a=1 f=1 (utf16) → byte 3 is just before 'é'.
+        assert_eq!(utf16_to_byte_offset(line, 3), 3);
+        // After 'é' (utf16 idx 4) we're at the space → byte 5 (é is 2 bytes).
+        assert_eq!(utf16_to_byte_offset(line, 4), 5);
+        // 🦀 spans utf16 units 5..7 (surrogate pair); idx 7 is the space → byte 10.
+        assert_eq!(utf16_to_byte_offset(line, 7), 10);
+        // Past the end clamps to the byte length (never panics).
+        assert_eq!(utf16_to_byte_offset(line, 999), line.len());
+        assert_eq!(utf16_to_byte_offset(line, 0), 0);
+    }
+
+    /// A cursor placed *after* a multibyte character on a comment line used to
+    /// panic because `col` (a UTF-16 offset) was sliced as a byte index. The
+    /// word-extraction path must now return cleanly.
+    #[test]
+    fn word_at_position_after_multibyte_does_not_panic() {
+        // "-- café customer_id" — cursor on `customer_id`.
+        let text = "-- café customer_id";
+        // UTF-16 column of the first char of `customer_id`:
+        // "-- café " is 8 chars / 8 UTF-16 units (é is 1 unit) → place cursor
+        // a few units into the identifier.
+        let utf16_col = "-- café cust".chars().map(char::len_utf16).sum::<usize>() as u32;
+        let word = RockyLsp::word_at_position(text, 0, utf16_col);
+        assert_eq!(word.as_deref(), Some("customer_id"));
+    }
+
+    /// Hover over the word containing a multibyte char itself must not panic.
+    #[test]
+    fn word_at_position_on_multibyte_word() {
+        let text = "from café_table";
+        // Cursor inside `café_table` (after the é).
+        let utf16_col = "from café".chars().map(char::len_utf16).sum::<usize>() as u32;
+        let word = RockyLsp::word_at_position(text, 0, utf16_col);
+        assert_eq!(word.as_deref(), Some("café_table"));
+    }
+
+    /// `macro_at_position` walks bytes around the cursor; a multibyte prefix
+    /// must not panic the byte-slice.
+    #[test]
+    fn macro_at_position_after_multibyte_does_not_panic() {
+        let text = "-- café @my_macro(x)";
+        let utf16_col = "-- café @my_ma".chars().map(char::len_utf16).sum::<usize>() as u32;
+        // Should detect the macro name without panicking.
+        let m = RockyLsp::macro_at_position(text, 0, utf16_col);
+        assert_eq!(m.as_deref(), Some("my_macro"));
     }
 }

--- a/engine/crates/rocky-snowflake/src/auth.rs
+++ b/engine/crates/rocky-snowflake/src/auth.rs
@@ -187,11 +187,25 @@ struct LoginResponse {
     success: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct LoginData {
     token: Option<String>,
     #[serde(rename = "validityInSeconds")]
     validity_in_seconds: Option<u64>,
+}
+
+// Custom `Debug` that masks the session token. The derive would print `token`
+// verbatim, so a future `{:?}` of a `LoginResponse` (which still derives
+// `Debug` and embeds this) would leak the secret. The masking lives here so
+// the embedding type stays safe too. Nothing currently relies on the derived
+// `Debug`.
+impl std::fmt::Debug for LoginData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoginData")
+            .field("token", &self.token.as_ref().map(|_| "***"))
+            .field("validity_in_seconds", &self.validity_in_seconds)
+            .finish()
+    }
 }
 
 impl Auth {

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -877,6 +877,12 @@ enum Command {
         /// directory (default: print to stdout)
         #[arg(long)]
         save: bool,
+        /// Include observed cell VALUES (min/max + low-cardinality domain
+        /// samples) in the prompt sent to Anthropic. Off by default — only
+        /// schema and aggregate statistics (row/null/distinct counts) leave
+        /// the machine. Opt in when sending sample values is acceptable.
+        #[arg(long)]
+        with_data: bool,
         /// Models directory (compiled to obtain the model's inferred schema,
         /// and the destination directory when `--save` is passed)
         #[arg(long, default_value = "models")]
@@ -2486,6 +2492,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
         Command::AiContract {
             model,
             save,
+            with_data,
             models,
         } => {
             rocky_cli::commands::run_ai_contract(
@@ -2494,6 +2501,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 &models,
                 &model,
                 save,
+                with_data,
                 json,
                 cli.cache_ttl,
             )


### PR DESCRIPTION
Addresses a batch of security and data-integrity findings from an engine audit. Each finding is its own commit with a focused test.

## Findings

- **H1 — LSP panic on non-ASCII lines (rocky-server).** `Position.character` is a UTF-16 code-unit offset, but `word_at_position` / `macro_at_position` / `signature_help` / `get_completion_context` used it directly as a Rust byte index, so any multibyte char before the cursor (an accented letter, an emoji) panicked the language server. Added a `utf16_to_byte_offset` helper (walks `char_indices` accumulating `len_utf16`, clamped to a char boundary) and used it at every site; the document-symbol intent preview now truncates by chars. *Tested:* unit tests drive the word/macro path at a cursor after `café`/🦀 and assert clean extraction (previously panicked).

- **H2 — `ai-contract` sent real cell values to a third party by default (rocky-cli).** `rocky ai-contract` shipped observed per-column MIN/MAX and low-cardinality domain samples to api.anthropic.com with no notice and no opt-out. Now the default is statistics-only: profiling issues only aggregate COUNT queries (row/non-null/distinct — not row values), so the profile carries no min/max/domain and the LLM prompt has no value lines. A new `--with-data` flag opts into sending values (the prior behavior). Either way an egress notice is printed to stderr naming exactly what leaves the machine. **Rationale:** a trust-positioned data tool should not ship row values to a third party by default; `--with-data` makes that explicit and is intentionally flippable. `rocky profile` (local display, no egress) is unchanged. No `*Output` struct changed, so no codegen. *Tested:* without `--with-data`, `profile_column` issues no MIN/MAX or DISTINCT-domain SQL, the profile has empty values, and the assembled prompt contains no value lines.

- **M1 — dbt importer symlink-cycle unbounded recursion (rocky-compiler).** The three import tree walkers recursed on `path.is_dir()` (follows symlinks) with no visited-set or depth cap, so a directory symlink cycle (`models/loop -> ..`) overflowed the stack. They now descend only via a helper using `DirEntry::file_type` (does not follow symlinks) that rejects symlinks, plus a recursion-depth cap as a backstop. `rocky import-dbt` ingests an untrusted third-party project. *Tested:* a temp tree with a directory symlink cycle terminates cleanly and still imports the real model.

- **L1 — dbt `model-paths` path traversal (rocky-compiler).** `model-paths` from `dbt_project.yml` was joined onto the project dir unsanitized, so `["../../etc"]` (or an absolute path) read outside the project. Model paths are now rejected if absolute or containing a `..` component, and canonicalized-and-contained when the joined path exists (catching symlink escapes). *Tested:* a `dbt_project.yml` with a traversal `model-paths` is rejected.

- **M3 — `ai-sync --apply` wrote unvalidated LLM output to a model file (rocky-cli / rocky-ai).** The apply path wrote the proposed source straight to disk with no validation, so a proposal that doesn't parse/typecheck could clobber a working model. It now validates through the same parse + typecheck path used to compile-verify generated models (new public `validate_proposed_source`, format picked from the file extension) and bails with the diagnostics instead of writing on failure. *Tested:* an unparseable proposal is rejected and the on-disk file is left unchanged.

- **L2 — content-addressed Iceberg writer double-add under concurrent identical writes (rocky-iceberg).** The cond-put retry loop treated every 412 as a version race and re-added the file at a higher version. When two writers produced byte-identical Parquet (same hash → same path) and raced, the loser double-counted the already-committed file. On a 412 the writer now scans the live `_delta_log` for an existing `add` referencing this content-addressed path; if found, it returns that commit version instead of re-adding. Genuine version races (path not yet committed) still retry. *Tested:* a unit test on the pure add-path-presence helper (matches the add path, ignores remove/blank lines).

- **L3 — apply-time plan integrity was presence-only (rocky-cli).** The review/apply gate only checked that the plan file (and review marker) existed; it never verified the bytes still matched the reviewed plan id. `read_plan` now recomputes the blake3 plan id from the parsed `{kind, payload}` and rejects the plan if it does not match the requested/stored id, binding the applied bytes to the reviewed id. *Tested:* a plan whose payload is mutated after write (hash ≠ id) is rejected; untampered plans still round-trip (existing round-trip + real compact/archive apply tests stay green).

- **L4 — state download overwrote `state.redb` non-atomically (rocky-core).** `download_file` overwrote the local path in place, so a crash mid-write left a corrupt redb. It now writes to a uniquely-named temp file in the same directory and atomically renames into place. *Tested:* a round-trip overwrite test asserts correct content and no leftover temp file.

- **L6 — duplicate model name silently shadowed (rocky-compiler).** `model()` is first-wins and resolution collapses names into a set, so a second model with an existing name silently shadowed the first. `from_models` now detects duplicate names and returns a new `ProjectError::DuplicateModel`. *Tested:* two models sharing a name return the error.

- **Hardening — secret-bearing types (rocky-databricks / rocky-snowflake / rocky-core).** Replaced the bare `#[derive(Debug)]` on the Databricks `OAuthTokenResponse` and Snowflake `LoginData` token structs with a custom `Debug` that masks the token (nothing relied on the derive). Added `// SECURITY:` comments on `valkey_url` (a connection URL that can embed `redis://:password@host`); it's consumed by the cache client as a plain URL, so threading `RedactedString` through that construction was deemed too invasive for this PR.

## ⚠ Needs careful review: M2 — watermark TOCTOU → silent row loss

The incremental replication INSERT filters `WHERE source.ts > prior_watermark` against the source's snapshot, then a separate later `SELECT MAX(ts) FROM source` recorded the new watermark. A row written to source between the INSERT's snapshot and that MAX query advanced the watermark past rows the INSERT never loaded — a permanent skip on the next strict-`>` run (silent row loss).

**Investigation conclusion — Case 1 (replication-only, identity-mapped).** The watermark recording is reached only from `process_table`, which is the replication pipeline. That path is a `SELECT *` / `ColumnSelection::All` passthrough copy and explicitly bails on every transformation strategy (`time_interval`, `ephemeral`, `content_addressed`); transformation models use partition state with `watermark: None` and never reach this code. So the timestamp column is identity-mapped source → target, and `MAX(ts) FROM target` is in the same value space as the loaded rows.

**Fix.** After an incremental/microbatch tick, record `MAX(ts) FROM target` — exactly the max among the rows actually loaded — so a row appended to source after the snapshot simply isn't in the target yet and is picked up next run. The empty-target trap is handled explicitly: `MAX` over an empty target is NULL, which must **not** advance to a wall-clock `now` (that would reintroduce the bug); it falls back to the prior watermark, or to the epoch sentinel (no progress, full re-scan) when there's no prior either. Merge and the non-advancing strategies are unchanged.

*Tested:* an in-memory DuckDB execute test runs two consecutive incremental ticks with a source row appended inside the TOCTOU window and asserts all rows load exactly once — no loss, no dup.

## Verification

Run from `engine/` (with `CARGO_BUILD_JOBS=4`):
- `cargo build` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo fmt --check` — pass
- `cargo test` for rocky-server, rocky-cli (`--features duckdb`), rocky-compiler, rocky-ai, rocky-iceberg, rocky-core (incl. `--test e2e`) — pass
