### PR TITLE
chore(dagster): raise dagster floor to the CI-tested 1.13.6

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raised the minimum `dagster` version from `>=1.13.2` to `>=1.13.6` to match the version CI resolves and tests. The `RockyComponent` path relies on `dagster.components.*` APIs from preview namespaces; advertising the tested floor is more honest than an older lower bound that CI never exercises. This is a hygiene change — the previous floor was not broken (those symbols import on earlier releases), so no behaviour changes.
+
 ## [1.43.0] — 2026-05-30
 
 Companion to engine `v1.47.0`. Codegen-driven — regenerated Pydantic bindings for the engine's `rocky profile` output (the new `profile_schema`) and updated `rocky test` results, plus documentation examples on the public health helpers and a dependency refresh. No new resource wiring or behaviour.

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -19,7 +19,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
-    "dagster>=1.13.2",
+    # Floor matches the version CI actually resolves and tests (uv.lock). The
+    # RockyComponent path uses dagster.components.* APIs from preview namespaces,
+    # so we advertise a tested floor rather than an older, never-exercised one.
+    "dagster>=1.13.6",
     "pydantic>=2.0",
     "pygments>=2.20.0",
 ]

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -284,7 +284,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "dagster", specifier = ">=1.13.2" },
+    { name = "dagster", specifier = ">=1.13.6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygments", specifier = ">=2.20.0" },
 ]


### PR DESCRIPTION
Raises the minimum `dagster` from `>=1.13.2` to `>=1.13.6` in `dagster-rocky`.

**Why (hygiene, not a fix):** the lockfile resolves and CI tests `dagster 1.13.6`, so the declared `>=1.13.2` lower bound was never actually exercised. The `RockyComponent` path depends on `dagster.components.*` APIs that live in preview namespaces; advertising the floor we test is more honest than one we don't.

**Not a bug fix.** The previous floor was not broken — those symbols import on earlier releases and the full suite passes at `1.13.2`. This only tightens the advertised lower bound to the tested one; no behaviour changes.

Verified: `uv sync` + import OK on `dagster 1.13.6`, `ruff check`/`ruff format --check` clean, `pytest` 567 passed.