### PR TITLE
docs(playground): promote BigQuery native-queries POC to a recorded live demo

### DIFF
--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/README.md
@@ -1,18 +1,21 @@
-# 05-bigquery-native-queries — BigQuery Adapter
+# 05-bigquery-native-queries — BigQuery Adapter (live demo)
 
 > **Category:** 07-adapters
-> **Credentials:** GCP Service Account JSON or ADC (`GOOGLE_APPLICATION_CREDENTIALS` or `BIGQUERY_TOKEN`). Optional — the compile smoke runs without them.
-> **Runtime:** seconds (compile smoke) or ~3–5 minutes (full live tour) against the EU sandbox
+> **Status:** Live demo. The full BigQuery surface tour runs against a real GCP project; a credential-free compile smoke is the no-creds fallback.
+> **Credentials:** GCP Service Account JSON or ADC (`GOOGLE_APPLICATION_CREDENTIALS` or `BIGQUERY_TOKEN`) for the live tour. The compile smoke runs without them.
+> **Runtime:** seconds (compile smoke) or ~3–5 minutes (full live tour) against an EU-region GCP project
 > **Rocky features:** BigQuery adapter, backtick quoting, region-qualified `INFORMATION_SCHEMA`, time-interval DML transactions, MERGE bootstrap, drift evolution (add / type-change / safe-widen), cost cross-check
 
 ## What it shows
 
-Rocky's BigQuery adapter end-to-end against a real GCP project. The top-level `./run.sh` operates in two modes:
+Rocky's BigQuery adapter end-to-end against a real GCP project. This is a **live demo**: six independent drivers under `live/` materialize against BigQuery and assert the resulting warehouse state, covering every BigQuery-specific surface Rocky exercises in production. A credential-free compile smoke is the no-creds fallback.
+
+The top-level `./run.sh` operates in two modes:
 
 1. **Compile smoke** (always). Type-checks the BigQuery model frontmatter against the current `rocky` binary. Runs without credentials, so the credential-free POC sweep (`scripts/run-all-duckdb.sh`) covers it.
-2. **Live demo** (when BigQuery credentials are present). Materializes a full-refresh transformation against the sandbox, captures the `rocky run` receipt to `expected/run.json`, and queries the target table back to prove the row landed.
+2. **Live demo** (when BigQuery credentials are present). Materializes a full-refresh transformation against the project, captures the `rocky run` receipt to `expected/run.json`, and queries the target table back to prove the row landed.
 
-Six independent live drivers under `live/` cover every BigQuery-specific surface Rocky exercises in production. The top-level script runs the full-refresh demo as the primary receipt; the others are runnable individually.
+The full-refresh run is the primary receipt the top-level script captures; the other five drivers are runnable individually for the complete surface tour. The live tour is run by a maintainer with GCP credentials; the compile smoke is what everyone else (and CI) runs. **To record the live demo, follow [`RECORDING.md`](./RECORDING.md).**
 
 ## Why it's distinctive
 
@@ -96,6 +99,18 @@ Full BigQuery surface tour — one scenario at a time:
 ```
 
 Each driver creates its own `hc_phase*_*` dataset, runs end-to-end, and cleans up on exit.
+
+## Recording
+
+The live tour is a recorded demo. [`RECORDING.md`](./RECORDING.md) is the standalone shooting script: a seven-shot order (compile smoke → full-refresh → discover → merge → time-interval → drift → cost cross-check), each with the command, what it proves, and a caption, plus the pre-flight env vars and binary setup.
+
+The recording is recorder-agnostic on purpose — the repo's `cli-recording/` vhs tapes are local-DuckDB and no-creds, and vhs's fixed `Sleep` pacing can't track multi-minute live BigQuery jobs — so capture with asciinema, a screen recorder, or whatever you prefer. The env vars are the same as the live run:
+
+```bash
+export GCP_PROJECT_ID="<your-gcp-project-id>"          # BIGQUERY_TEST_PROJECT also accepted
+export GOOGLE_APPLICATION_CREDENTIALS="<path-to-service-account-json>"   # or BIGQUERY_TOKEN
+export BQ_LOCATION="EU"                                # optional; default EU
+```
 
 ## Expected output
 

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/RECORDING.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/RECORDING.md
@@ -1,0 +1,166 @@
+# Recording the BigQuery live demo
+
+A recorder-agnostic shooting script for the seven-shot BigQuery tour: a
+compile smoke that runs anywhere, plus six live drivers that materialize
+against a real GCP project and assert the resulting warehouse state.
+
+The script names the command, what it proves, and a one-line caption for
+each shot, in simple to payoff order. The drivers already echo `==>`
+status lines as they run, so most captions are on-screen for free.
+
+## Recorder-agnostic, on purpose
+
+The repo's other CLI demos record with [vhs](https://github.com/charmbracelet/vhs)
+tapes (`cli-recording/`), but every one of those tapes drives a local
+DuckDB pipeline with no credentials. vhs paces a recording with fixed
+`Sleep` directives, which can't track the variable, multi-minute latency
+of live BigQuery jobs. So this tour is recorder-agnostic: capture it with
+asciinema, a terminal screen recorder, or whatever you prefer. Don't try
+to force it into a `.tape`.
+
+## Pre-flight
+
+1. **Build the binary you're demoing.** Every driver calls a bare
+   `rocky` from `PATH`. Record against a freshly built binary so the demo
+   matches the current code, not a stale install:
+
+   ```bash
+   cargo build --release -p rocky --manifest-path engine/Cargo.toml
+   export PATH="$PWD/engine/target/release:$PATH"
+   rocky --version          # confirm this resolves to the build you just made
+   ```
+
+   (Any current `rocky` release also covers every surface here -- the
+   drift, cost-attribution, and discovery paths are long-shipped -- but
+   building from source removes all ambiguity about which binary ran.)
+
+2. **`bq` and `python3` on `PATH`.** The drivers seed, verify, and clean
+   up with the `bq` CLI, and assert JSON output with `python3`.
+
+   ```bash
+   bq version
+   python3 --version
+   ```
+
+3. **Credentials and project.**
+
+   ```bash
+   export GCP_PROJECT_ID="<your-gcp-project-id>"          # BIGQUERY_TEST_PROJECT also accepted
+   export GOOGLE_APPLICATION_CREDENTIALS="<path-to-service-account-json>"   # or BIGQUERY_TOKEN
+   export BQ_LOCATION="EU"                                # optional; default EU
+   ```
+
+4. **Terminal.** Size the window so a full driver's `==>` output fits
+   without wrapping (~100 cols is comfortable). A dark theme reads best on
+   playback.
+
+## Shot order
+
+Seven shots, simple to payoff. Run each from the POC directory.
+
+### 1. Compile smoke -- no credentials
+
+```bash
+rocky compile --models live/models/ --output json
+```
+
+- **Proves:** the BigQuery model frontmatter type-checks against the
+  current binary with zero credentials. This is the path the
+  credential-free POC sweep runs.
+- **Caption:** "Type-check the BigQuery models -- no warehouse, no creds."
+
+### 2. Full-refresh -- `CREATE TABLE AS`
+
+```bash
+./live/run.sh
+```
+
+- **Proves:** a `full_refresh` transformation materializes end-to-end via
+  `BigQueryDialect::create_table_as`, and the row lands in the warehouse
+  (`bq query` confirms `COUNT(*) = 1`).
+- **Caption:** "Full-refresh CTAS -- one row materialized and verified live."
+
+### 3. Discover -- region-qualified `INFORMATION_SCHEMA`
+
+```bash
+./live/discover/run.sh
+```
+
+- **Proves:** `BigQueryDiscoveryAdapter` enumerates datasets through the
+  region-scoped `INFORMATION_SCHEMA.SCHEMATA`; two prefixed datasets
+  surface as sources via the schema-pattern parser.
+- **Caption:** "Discover sources -- region-qualified INFORMATION_SCHEMA, two datasets found."
+
+### 4. Merge -- `WHEN NOT MATCHED THEN INSERT ROW`
+
+```bash
+./live/merge/run.sh
+```
+
+- **Proves:** the `merge` strategy bootstraps the target on first run,
+  then upserts across two runs (bob updated, dave inserted, alice/carol
+  untouched) using BigQuery's `WHEN NOT MATCHED THEN INSERT ROW` shape
+  with explicit `update_columns`. Asserts billed bytes at the 10 MB floor.
+- **Caption:** "MERGE upsert -- update bob, insert dave, leave the rest."
+
+### 5. Time-interval -- DML transaction script
+
+```bash
+./live/time-interval/run.sh
+```
+
+- **Proves:** the `time_interval` strategy emits
+  `BEGIN TRANSACTION; DELETE; INSERT; COMMIT TRANSACTION` as one
+  semicolon-joined script (BigQuery's REST API is stateless -- separate
+  calls are rejected). Two day partitions materialize the expected
+  aggregated row counts.
+- **Caption:** "Two partitions, one DML transaction script -- 3 orders, then 2."
+
+### 6. Drift -- four-stage schema evolution
+
+```bash
+./live/drift/run.sh
+```
+
+- **Proves:** replication-from-BigQuery with per-table drift detection
+  across four stages on the same source/target pair:
+  1. **initial** -- replicates the source, no drift.
+  2. **`add_columns`** -- source gains `region`; the target is `ALTER TABLE
+     ADD COLUMN`-ed in place (no full refresh, historical rows intact).
+  3. **`drop_and_recreate`** -- `id` changes INT64 to STRING (unsafe); the
+     target is rebuilt.
+  4. **`alter_column_types`** -- `score` widens INT64 to NUMERIC (safe); the
+     target column type is altered in place via
+     `ALTER COLUMN ... SET DATA TYPE`.
+
+  Each stage's drift action is asserted from the `rocky run` JSON, and the
+  final target schema is confirmed (`region` present, `id` is STRING,
+  `score` is NUMERIC).
+- **Caption:** "Four drift stages -- add column, rebuild on unsafe change, widen in place."
+
+### 7. Cost cross-check -- exact billed-bytes round-trip
+
+```bash
+./live/cost-cross-check/run.sh
+```
+
+- **Proves:** the strongest closer. A transformation scans a real source
+  table, and rocky's reported `bytes_scanned` matches the
+  `totalBytesBilled` BigQuery itself reports for the same job ID via
+  `bq show -j` -- exact, not an approximation.
+- **Caption:** "rocky's billed bytes == BigQuery's billed bytes, to the byte."
+
+## Notes
+
+- **Self-cleaning.** Every driver pre-creates its own `hc_phase*` dataset
+  and drops it on exit (success or failure) via a `trap`. Nothing persists
+  in the project between takes.
+- **Independent and re-runnable.** Each driver owns its `live.rocky.toml`,
+  models, and dataset, so shots run in any order and every take is a clean
+  re-run. If a take is fumbled, just run that one driver again.
+- **Runtime.** The full seven-shot tour runs in roughly 3-5 minutes;
+  individual drivers are seconds to tens of seconds each.
+- **No project ID in the repo.** The committed configs and model files
+  carry a `__GCP_PROJECT__` placeholder that each driver substitutes at
+  runtime from `GCP_PROJECT_ID`. Nothing in the recording reveals a real
+  project ID beyond what your terminal shows live.

--- a/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
+++ b/examples/playground/pocs/07-adapters/05-bigquery-native-queries/live/README.md
@@ -32,11 +32,6 @@ Each driver:
   auto-rollback). The script-as-transaction shape proves the happy
   path; rollback semantics are a separate property worth its own test.
 - MERGE without explicit `update_columns` (see finding 5).
-- Drift detection on **added** columns (see finding 7).
-- Safe type-widening drift action (`alter_column_types`) — the
-  detection branch exists in `drift::detect_drift` but the runtime at
-  `run.rs:4137` only wires `drop_and_recreate`; safe widenings fall
-  through to the next `INSERT` and may fail.
 
 ## Run
 


### PR DESCRIPTION
Promotes `examples/playground/pocs/07-adapters/05-bigquery-native-queries/` from a credential-gated POC to a recorded **live demo**. Docs only — no engine changes.

## What changed

- **New `RECORDING.md`** — a recorder-agnostic shooting script. Seven shots in simple→payoff order (compile smoke → full-refresh → discover → merge → time-interval → drift → cost cross-check), each with the command, what it proves, and a one-line caption. Includes pre-flight (env vars, `bq`/`python3` on PATH, a freshly built `rocky` binary on PATH) and the self-cleanup / independent-re-run / ~3–5 min notes. The drivers already echo `==>` captions as they run.
- **`README.md` reframe** — header/status elevated from "credential-gated POC" to "live demo"; clarifies the maintainer-run live tour (the `live/` drivers) vs the no-creds compile smoke (what everyone else and CI run); adds a Recording section pointing at `RECORDING.md`.
- **`live/README.md`** — drops two stale "not covered yet" bullets (added-column drift, and the safe type-widening `alter_column_types` action) that the in-file findings #8/#9 and the drift driver's stage 4 already document as shipped.

## Recorder-agnostic, on purpose

The repo's `cli-recording/` vhs tapes are local-DuckDB and no-creds, and vhs's fixed `Sleep` pacing can't track multi-minute live BigQuery jobs — so the narrative is recorder-agnostic (asciinema / screen capture / whatever). `cli-recording/` is untouched.

## Verification

Built the `rocky` binary in this branch (`cargo build --release -p rocky`, `rocky 1.47.1`) and ran the no-creds compile-smoke path of `run.sh` against it with credentials unset: exit 0, "live demo: SKIPPED". The live BigQuery tour is run by a maintainer with GCP credentials and is not exercised in CI.

The committed configs keep the `__GCP_PROJECT__` placeholder and `hc_` dataset prefixes — no project ID is checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)