### PR TITLE
feat(engine/rocky-mcp): live-warehouse data grounding + suggest_freshness_block tool

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4187,6 +4187,7 @@ dependencies = [
  "arrow",
  "chrono",
  "rmcp",
+ "rocky-ai",
  "rocky-cli",
  "rocky-compiler",
  "rocky-core",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4184,6 +4184,7 @@ name = "rocky-mcp"
 version = "1.47.1"
 dependencies = [
  "anyhow",
+ "arrow",
  "chrono",
  "rmcp",
  "rocky-cli",

--- a/engine/crates/rocky-ai/src/client.rs
+++ b/engine/crates/rocky-ai/src/client.rs
@@ -14,6 +14,12 @@ use thiserror::Error;
 /// `[ai] max_tokens` in `rocky.toml`.
 pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 
+/// Environment variable that holds the Anthropic API key. Both the LSP's AI
+/// code-action arms and the MCP `suggest_freshness_block` tool gate on it;
+/// keeping the name in one place keeps their behaviour aligned with
+/// `rocky ai`.
+pub const AI_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
+
 /// AI provider configuration.
 ///
 /// `api_key` is wrapped in [`RedactedString`] so accidental `?config` /

--- a/engine/crates/rocky-ai/src/prompt.rs
+++ b/engine/crates/rocky-ai/src/prompt.rs
@@ -105,6 +105,44 @@ pub fn build_system_prompt(
     prompt
 }
 
+/// Build the LLM prompt for a W005 freshness-coverage fix.
+///
+/// The system half encodes the role + output-format constraint; the user half
+/// supplies the per-call context (model name, candidate temporal columns,
+/// current sidecar). Splitting this way keeps the system portion stable across
+/// calls for prompt caching. Returns `(system, user)`.
+///
+/// Shared by the LSP's `[freshness]` code-action arm and the MCP
+/// `suggest_freshness_block` tool so the two never drift.
+pub fn build_freshness_fix_prompt(
+    model_name: &str,
+    temporal_columns: &[String],
+    sidecar_text: &str,
+) -> (String, String) {
+    let system = "You are an expert Rocky data-pipeline reviewer. Your task is to \
+                 propose a TOML `[freshness]` block for a model's sidecar `.toml` so \
+                 the model declares a time-to-live after which it is considered \
+                 stale. Set `expected_lag_seconds` to a sensible TTL for the model \
+                 (e.g. 3600 for hourly data, 86400 for daily). Set `time_column` to \
+                 the most appropriate timestamp/date column from the supplied \
+                 candidates. Output ONLY the new TOML block inside a single ```toml \
+                 fenced block — no commentary, no explanation, no diff. The block \
+                 must start with `[freshness]` on its own line."
+        .to_string();
+
+    let candidates = temporal_columns.join(", ");
+    let user = format!(
+        "Model: `{model_name}`\n\
+         Candidate temporal columns: {candidates}\n\n\
+         Current sidecar `.toml`:\n```toml\n{sidecar_text}\n```\n\n\
+         Emit a `[freshness]` block with `expected_lag_seconds` and a \
+         `time_column` chosen from the candidates. Do not duplicate or modify \
+         any existing block."
+    );
+
+    (system, user)
+}
+
 /// Render a column list as a compact one-liner: `id: INT64, amount: DECIMAL(10,2)`.
 fn render_columns(cols: &[TypedColumn]) -> String {
     cols.iter()
@@ -189,5 +227,24 @@ mod tests {
         let prompt = build_system_prompt(&[], &[], "rocky");
         assert!(!prompt.contains("# Existing Models"));
         assert!(!prompt.contains("# Available Source Tables"));
+    }
+
+    #[test]
+    fn test_build_freshness_fix_prompt_threads_context() {
+        let (system, user) = build_freshness_fix_prompt(
+            "daily_revenue",
+            &["created_at".to_string(), "updated_at".to_string()],
+            "name = \"daily_revenue\"\n",
+        );
+        // System half: the role + output-format constraint.
+        assert!(system.contains("[freshness]"));
+        assert!(system.contains("expected_lag_seconds"));
+        assert!(system.contains("time_column"));
+        assert!(system.contains("```toml"));
+        // User half: the per-call context (model + candidates + sidecar).
+        assert!(user.contains("daily_revenue"));
+        assert!(user.contains("created_at"));
+        assert!(user.contains("updated_at"));
+        assert!(user.contains("name = \"daily_revenue\""));
     }
 }

--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -201,6 +201,13 @@ impl SqlDialect for BigQueryDialect {
         "CURRENT_TIMESTAMP()"
     }
 
+    fn string_type_name(&self) -> &'static str {
+        // BigQuery has no `VARCHAR` type; the variable-length string type is
+        // `STRING`. The trait default `"VARCHAR"` would make `CAST(... AS
+        // VARCHAR)` a query error on BigQuery.
+        "STRING"
+    }
+
     fn quote_identifier(&self, name: &str) -> String {
         // BigQuery uses backticks for identifiers; double quotes denote
         // STRING literals. The default `"name"` quoting from the trait
@@ -472,6 +479,13 @@ mod tests {
             d.drop_table_sql("`p`.`d`.`t`"),
             "DROP TABLE IF EXISTS `p`.`d`.`t`"
         );
+    }
+
+    #[test]
+    fn string_type_name_is_bigquery_string_not_varchar() {
+        // BigQuery has no VARCHAR; the variable-length string type is STRING.
+        let d = BigQueryDialect;
+        assert_eq!(d.string_type_name(), "STRING");
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -895,6 +895,17 @@ pub trait SqlDialect: Send + Sync {
         "CURRENT_TIMESTAMP"
     }
 
+    /// The dialect's variable-length string type name, for an explicit
+    /// `CAST(... AS <type>)`. Used by the data-grounding tools to coerce a
+    /// column to text for min/max display and value listing.
+    ///
+    /// Default: `"VARCHAR"` — accepted by DuckDB, Snowflake, Databricks, and
+    /// Trino. BigQuery overrides to `"STRING"` because `VARCHAR` is not a
+    /// BigQuery type and the cast is rejected.
+    fn string_type_name(&self) -> &'static str {
+        "VARCHAR"
+    }
+
     /// Build a NULL-safe inequality predicate: `lhs` differs from `rhs`,
     /// treating two NULLs as equal and a single NULL as a real difference.
     /// Used by SCD2 change detection on the watermark / check columns —

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -24,6 +24,9 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
+# `fetch_arrow_batch` returns a workspace `arrow 58` `RecordBatch`; the
+# data-grounding tools convert it to the JSON row shape via `arrow::util::display`.
+arrow = { workspace = true }
 # rmcp's `#[tool]` macro generates code that references `schemars` (1.x) by
 # path, so the param structs need it as a direct dependency. This is the
 # 1.x major; the rest of the workspace pins 0.8 via [workspace.dependencies].

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -17,6 +17,10 @@ rocky-cli = { path = "../rocky-cli" }
 rocky-core = { path = "../rocky-core" }
 rocky-sql = { path = "../rocky-sql" }
 rocky-compiler = { path = "../rocky-compiler" }
+# Direct dependency for the suggest_freshness_block tool: the hoisted
+# freshness-prompt builder, the LLM client, and extract_code. No cycle —
+# rocky-ai depends only on compiler/core/ir/lang/sql.
+rocky-ai = { path = "../rocky-ai" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -34,6 +38,7 @@ schemars = "1"
 
 [dev-dependencies]
 rocky-duckdb = { path = "../rocky-duckdb" }
+rocky-ai = { path = "../rocky-ai" }
 tempfile = "3"
 serde_json = { workspace = true }
 # The scripted round-trip test drives the stdio server in-process with an rmcp

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -187,12 +187,14 @@ pub struct InspectSchemaResult {
 
 /// `sample_rows` result — a capped sample of real rows.
 ///
-/// On a non-DuckDB adapter, `unavailable` is `true`, `reason` explains why,
-/// and the data fields are empty. (A single concrete schema is required:
-/// rmcp's output-schema derivation rejects an untyped union.)
+/// `unavailable` / `reason` are reserved for the case where the tool could not
+/// run (e.g. the target adapter has no live credentials); the data fields are
+/// then empty. (A single concrete schema is required: rmcp's output-schema
+/// derivation rejects an untyped union.)
 #[derive(Debug, Default, Serialize, JsonSchema)]
 pub struct SampleRowsResult {
-    /// `true` when the tool could not run (e.g. non-DuckDB adapter).
+    /// `true` when the tool could not run (reserved for future degradation
+    /// paths; the fields below carry the sample when `false`).
     #[serde(default, skip_serializing_if = "is_false")]
     pub unavailable: bool,
     /// Why the tool is unavailable, when `unavailable` is `true`.
@@ -209,10 +211,12 @@ pub struct SampleRowsResult {
 
 /// `profile_column` result — one-pass aggregate stats for a column.
 ///
-/// On a non-DuckDB adapter, `unavailable` is `true` and `reason` explains why.
+/// `unavailable` / `reason` are reserved for the case where the tool could not
+/// run (e.g. the target adapter has no live credentials).
 #[derive(Debug, Default, Serialize, JsonSchema)]
 pub struct ProfileColumnResult {
-    /// `true` when the tool could not run (e.g. non-DuckDB adapter).
+    /// `true` when the tool could not run (reserved for future degradation
+    /// paths).
     #[serde(default, skip_serializing_if = "is_false")]
     pub unavailable: bool,
     /// Why the tool is unavailable, when `unavailable` is `true`.

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -491,3 +491,21 @@ pub struct OptimizeResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
+
+/// `suggest_freshness_block` result — an LLM-drafted `[freshness]` TOML block
+/// for a model with temporal columns (the W005 fix).
+///
+/// `freshness_block` is the ready-to-paste TOML when drafting succeeds;
+/// `message` explains why no block was produced (the API key is unset, or the
+/// model returned no fenced block) so the caller can distinguish a real draft
+/// from a graceful no-op rather than seeing an error.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct SuggestFreshnessBlockResult {
+    /// The drafted `[freshness]` TOML block, when one was produced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness_block: Option<String>,
+    /// Why no block was produced (key unset / no fenced block), when
+    /// `freshness_block` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -160,6 +160,19 @@ pub struct OptimizeArgs {
     pub model: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SuggestFreshnessBlockArgs {
+    /// The model the `[freshness]` block is for (used in the prompt context).
+    pub model: String,
+    /// Candidate temporal columns (timestamp/date) the block's `time_column`
+    /// may be chosen from — typically the model's date/timestamp columns.
+    pub temporal_columns: Vec<String>,
+    /// The model's current sidecar `.toml` text, so the draft does not
+    /// duplicate or conflict with an existing block. Optional.
+    #[serde(default)]
+    pub current_sidecar: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
 // MCP prompt arguments are string-typed on the wire; `Serialize` is part of
@@ -797,6 +810,72 @@ impl RockyMcpServer {
         Ok(Json(OptimizeResult {
             recommendations,
             message: out.message,
+        }))
+    }
+
+    #[tool(
+        description = "Draft a `[freshness]` TOML block for a model with temporal columns (the \
+         W005 fix): an LLM picks a sensible `expected_lag_seconds` TTL and a `time_column` from \
+         the supplied candidates. Returns the ready-to-paste block directly (NOT a TextEdit); the \
+         caller appends it to the model's sidecar. Requires ANTHROPIC_API_KEY in the server \
+         environment — without it, `freshness_block` is null and `message` explains why."
+    )]
+    async fn suggest_freshness_block(
+        &self,
+        params: Parameters<SuggestFreshnessBlockArgs>,
+    ) -> Result<Json<SuggestFreshnessBlockResult>, String> {
+        let args = params.0;
+
+        // Gate on the API key the same way the LSP's freshness arm does;
+        // degrade to a null block + message rather than erroring.
+        let api_key = match std::env::var(rocky_ai::client::AI_API_KEY_ENV) {
+            Ok(v) if !v.is_empty() => v,
+            _ => {
+                return Ok(Json(SuggestFreshnessBlockResult {
+                    freshness_block: None,
+                    message: Some(format!(
+                        "{} not set in the server environment",
+                        rocky_ai::client::AI_API_KEY_ENV
+                    )),
+                }));
+            }
+        };
+
+        let sidecar_text = args.current_sidecar.unwrap_or_default();
+        let (system_prompt, user_prompt) = rocky_ai::prompt::build_freshness_fix_prompt(
+            &args.model,
+            &args.temporal_columns,
+            &sidecar_text,
+        );
+
+        // Mirror the LSP's AiConfig: anthropic / sonnet / TOML / single attempt.
+        let ai_config = rocky_ai::client::AiConfig {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            api_key: rocky_core::redacted::RedactedString::new(api_key),
+            default_format: "toml".to_string(),
+            max_attempts: 1,
+            max_tokens: rocky_ai::client::DEFAULT_MAX_TOKENS,
+        };
+        let client = rocky_ai::client::LlmClient::new(ai_config)
+            .map_err(|e| format!("AI client init failed: {e}"))?;
+        let response = client
+            .generate(&system_prompt, &user_prompt, None)
+            .await
+            .map_err(|e| format!("AI request failed: {e}"))?;
+
+        let extracted = rocky_ai::generate::extract_code(&response.content);
+        let snippet = extracted.trim();
+        if snippet.is_empty() {
+            return Ok(Json(SuggestFreshnessBlockResult {
+                freshness_block: None,
+                message: Some("AI response did not contain a TOML code block".to_string()),
+            }));
+        }
+
+        Ok(Json(SuggestFreshnessBlockResult {
+            freshness_block: Some(snippet.to_string()),
+            message: None,
         }))
     }
 

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -554,11 +554,12 @@ impl RockyMcpServer {
             Err(e) => return Err(format!("{e:#}")),
         };
 
-        // On DuckDB, surface the physical warehouse tables so an agent can
-        // ground a raw source the project never declared — and at cold start,
-        // before any model exists. Skip a table that is a model's target or is
-        // already reported as a compile-derived source.
-        if let Ok(Some(adapter)) = self.duckdb_warehouse() {
+        // Surface the physical warehouse tables so an agent can ground a raw
+        // source the project never declared — and at cold start, before any
+        // model exists. Skip a table that is a model's target or is already
+        // reported as a compile-derived source. Best-effort across warehouses:
+        // the discovery query degrades to an empty list on any error.
+        if let Ok(Some(adapter)) = self.warehouse_adapter() {
             let seen: std::collections::HashSet<String> =
                 sources.iter().map(|s| s.name.clone()).collect();
             for entry in discover_source_tables(adapter.as_ref()).await {
@@ -803,10 +804,10 @@ impl RockyMcpServer {
 
     #[tool(
         description = "Sample real rows from a model's target table OR a qualified `schema.table` \
-         source reference (DuckDB only). Look at literal values, units, and null patterns the \
-         schema can't tell you. Omit `percent` to get the first rows (the right default for small \
-         tables); set 1–100 for a random-percentage sample. Capped at 50 rows / 16 KB; long cells \
-         truncated. Returns {unavailable:true} on non-DuckDB adapters."
+         source reference. Look at literal values, units, and null patterns the schema can't tell \
+         you. Omit `percent` to get the first rows (the right default for small tables); set 1–100 \
+         for a random-percentage sample. Capped at 50 rows / 16 KB; long cells truncated. Requires \
+         live warehouse credentials in the target adapter (rocky.toml)."
     )]
     async fn sample_rows(
         &self,
@@ -814,17 +815,10 @@ impl RockyMcpServer {
     ) -> Result<Json<SampleRowsResult>, String> {
         let args = params.0;
 
-        let prepared = match self.prepare_table_query(&args.model).await {
-            Ok(PreparedTable::Ready(p)) => p,
-            Ok(PreparedTable::Unavailable(reason)) => {
-                return Ok(Json(SampleRowsResult {
-                    unavailable: true,
-                    reason: Some(reason),
-                    ..Default::default()
-                }));
-            }
-            Err(e) => return Err(format!("{e:#}")),
-        };
+        let prepared = self
+            .prepare_table_query(&args.model)
+            .await
+            .map_err(|e| format!("{e:#}"))?;
 
         // Build: SELECT * FROM <ref> [tablesample] LIMIT n. The ref is built
         // only from validated identifiers; never `format!`'d from raw input.
@@ -841,9 +835,7 @@ impl RockyMcpServer {
             prepared.table_ref, sample, SAMPLE_MAX_ROWS
         );
 
-        let qr = prepared
-            .adapter
-            .execute_query(&sql)
+        let qr = query_grounding(prepared.adapter.as_ref(), &sql)
             .await
             .map_err(|e| format!("sample query failed: {e}"))?;
 
@@ -872,10 +864,10 @@ impl RockyMcpServer {
 
     #[tool(
         description = "Profile one column of a model's target table OR a qualified `schema.table` \
-         source (DuckDB only): row count, nulls, null rate, distinct count, min, max — and, for a \
+         source: row count, nulls, null rate, distinct count, min, max — and, for a \
          low-cardinality column (≤25 distinct), the distinct values with their counts \
          (`top_values`), which surfaces exact literals (e.g. a status string) that min/max hide. \
-         Returns {unavailable:true} on non-DuckDB adapters."
+         Requires live warehouse credentials in the target adapter (rocky.toml)."
     )]
     async fn profile_column(
         &self,
@@ -883,31 +875,26 @@ impl RockyMcpServer {
     ) -> Result<Json<ProfileColumnResult>, String> {
         let args = params.0;
 
-        let prepared = match self.prepare_table_query(&args.model).await {
-            Ok(PreparedTable::Ready(p)) => p,
-            Ok(PreparedTable::Unavailable(reason)) => {
-                return Ok(Json(ProfileColumnResult {
-                    unavailable: true,
-                    reason: Some(reason),
-                    ..Default::default()
-                }));
-            }
-            Err(e) => return Err(format!("{e:#}")),
-        };
+        let prepared = self
+            .prepare_table_query(&args.model)
+            .await
+            .map_err(|e| format!("{e:#}"))?;
 
         let col = rocky_sql::validation::validate_identifier(&args.column)
             .map_err(|e| format!("invalid column identifier: {e}"))?;
 
+        // Cast to the dialect's string type — `VARCHAR` everywhere except
+        // BigQuery, where it is `STRING` (BigQuery rejects `CAST(... AS VARCHAR)`).
+        let string_type = prepared.adapter.dialect().string_type_name();
         let sql = format!(
             "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n, \
-             CAST(MIN({col}) AS VARCHAR) AS min_v, CAST(MAX({col}) AS VARCHAR) AS max_v \
+             CAST(MIN({col}) AS {string_type}) AS min_v, \
+             CAST(MAX({col}) AS {string_type}) AS max_v \
              FROM {}",
             prepared.table_ref
         );
 
-        let qr = prepared
-            .adapter
-            .execute_query(&sql)
+        let qr = query_grounding(prepared.adapter.as_ref(), &sql)
             .await
             .map_err(|e| format!("profile query failed: {e}"))?;
         let row = qr
@@ -945,11 +932,11 @@ impl RockyMcpServer {
         // when the cardinality makes it cheap.
         let top_values = if distinct > 0 && distinct <= PROFILE_TOP_VALUES_MAX as u64 {
             let q = format!(
-                "SELECT CAST({col} AS VARCHAR) AS v, COUNT(*) AS c FROM {} \
+                "SELECT CAST({col} AS {string_type}) AS v, COUNT(*) AS c FROM {} \
                  GROUP BY {col} ORDER BY c DESC, v LIMIT {}",
                 prepared.table_ref, PROFILE_TOP_VALUES_MAX
             );
-            match prepared.adapter.execute_query(&q).await {
+            match query_grounding(prepared.adapter.as_ref(), &q).await {
                 Ok(r) => r
                     .rows
                     .into_iter()
@@ -1017,44 +1004,36 @@ impl RockyMcpServer {
         Ok(Json(ProposeResult { plan_id, models }))
     }
 
-    /// Resolve a model's target table into a runnable, validated table ref +
-    /// the warehouse adapter — but only on DuckDB. Other adapters return the
-    /// typed "unavailable" result so the grounding tools degrade cleanly.
-    /// The project's target warehouse adapter, but only when it is DuckDB — the
-    /// data-grounding tools (`sample_rows`, `profile_column`, and
-    /// `inspect_schema`'s source discovery) are DuckDB-only in this release.
-    /// Returns `Ok(None)` on any other adapter so callers degrade cleanly.
-    fn duckdb_warehouse(
+    /// Resolve the project's target warehouse adapter from `rocky.toml`.
+    ///
+    /// Returns the configured target adapter for the resolved pipeline — any
+    /// warehouse (DuckDB, Snowflake, BigQuery, Databricks, Trino). The data
+    /// grounding tools (`sample_rows`, `profile_column`, and `inspect_schema`'s
+    /// source discovery) reach the live warehouse through it. Kept as
+    /// `Result<Option<...>>` so `inspect_schema`'s `if let Ok(Some(_))`
+    /// graceful-degradation path survives a resolution failure.
+    fn warehouse_adapter(
         &self,
     ) -> anyhow::Result<Option<std::sync::Arc<dyn rocky_core::traits::WarehouseAdapter>>> {
         let cfg = rocky_core::config::load_rocky_config(&self.config_path)?;
         let registry = commands_adapter_registry(&cfg)?;
         let (_, pipeline) = rocky_cli::registry::resolve_pipeline(&cfg, None)?;
         let target_adapter = pipeline.target_adapter().to_string();
-        let adapter_type = registry
-            .adapter_config(&target_adapter)
-            .map(|a| a.adapter_type.clone())
-            .unwrap_or_default();
-        if adapter_type != "duckdb" {
-            return Ok(None);
-        }
         Ok(Some(registry.warehouse_adapter(&target_adapter)?))
     }
 
     /// Resolve a grounding-tool target into a runnable, validated table ref plus
-    /// the warehouse adapter — DuckDB only.
+    /// the warehouse adapter.
     ///
     /// The target is either a **compiled model name** (resolved to its target
     /// table, which requires the models to compile) or a **qualified
     /// `schema.table` / `catalog.schema.table` source reference** (any dotted
     /// name — resolved directly with no compile, so it reaches raw sources the
     /// project never declared and works at cold start, before any model exists).
-    async fn prepare_table_query(&self, target: &str) -> anyhow::Result<PreparedTable> {
-        let Some(adapter) = self.duckdb_warehouse()? else {
-            return Ok(PreparedTable::Unavailable(
-                "sample_rows/profile_column are DuckDB-only in this release".to_string(),
-            ));
-        };
+    async fn prepare_table_query(&self, target: &str) -> anyhow::Result<Prepared> {
+        let adapter = self
+            .warehouse_adapter()?
+            .ok_or_else(|| anyhow::anyhow!("could not resolve the target warehouse adapter"))?;
 
         let table_ref = if target.contains('.') {
             // Qualified raw reference — validate each segment and use it as-is.
@@ -1074,8 +1053,9 @@ impl RockyMcpServer {
             parts.join(".")
         } else {
             // Bare name — resolve the model's target coordinates by compiling
-            // the models dir. DuckDB has no catalog level, so we emit a two-part
-            // `schema.table` name.
+            // the models dir. Emit `catalog.schema.table` when the target
+            // carries a catalog (Snowflake/BigQuery/Databricks); DuckDB has no
+            // catalog level so it stays a two-part `schema.table` name.
             let result = self.compile_full()?;
             let model = result
                 .project
@@ -1084,18 +1064,10 @@ impl RockyMcpServer {
                 .find(|m| m.config.name == target)
                 .ok_or_else(|| anyhow::anyhow!("model '{target}' not found in project"))?;
             let t = &model.config.target;
-            let schema = rocky_sql::validation::validate_identifier(&t.schema)
-                .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
-            let table = rocky_sql::validation::validate_identifier(&t.table)
-                .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
-            if !t.catalog.is_empty() {
-                rocky_sql::validation::validate_identifier(&t.catalog)
-                    .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
-            }
-            format!("{schema}.{table}")
+            qualify_table_ref(&t.catalog, &t.schema, &t.table)?
         };
 
-        Ok(PreparedTable::Ready(Prepared { adapter, table_ref }))
+        Ok(Prepared { adapter, table_ref })
     }
 }
 
@@ -1193,7 +1165,7 @@ impl ServerHandler for RockyMcpServer {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// A validated, DuckDB-runnable table reference plus the adapter to run it on.
+/// A validated, runnable table reference plus the warehouse adapter to run it on.
 struct Prepared {
     adapter: std::sync::Arc<dyn rocky_core::traits::WarehouseAdapter>,
     table_ref: String,
@@ -1205,11 +1177,88 @@ impl Prepared {
     }
 }
 
-/// Either a runnable table query or the reason a non-DuckDB adapter makes the
-/// data-grounding tool unavailable.
-enum PreparedTable {
-    Ready(Prepared),
-    Unavailable(String),
+/// Build a validated, dialect-agnostic table reference from a model's target
+/// coordinates. Emits `catalog.schema.table` when a catalog is set
+/// (Snowflake/BigQuery/Databricks), or `schema.table` otherwise (DuckDB has no
+/// catalog level). Each segment is validated as a SQL identifier.
+fn qualify_table_ref(catalog: &str, schema: &str, table: &str) -> anyhow::Result<String> {
+    let schema = rocky_sql::validation::validate_identifier(schema)
+        .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
+    let table = rocky_sql::validation::validate_identifier(table)
+        .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
+    if catalog.is_empty() {
+        Ok(format!("{schema}.{table}"))
+    } else {
+        let catalog = rocky_sql::validation::validate_identifier(catalog)
+            .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
+        Ok(format!("{catalog}.{schema}.{table}"))
+    }
+}
+
+/// Run a grounding query, preferring the columnar Arrow path and falling back
+/// to the row-based JSON path.
+///
+/// `fetch_arrow_batch` is implemented on DuckDB / BigQuery / Databricks / Trino;
+/// Snowflake inherits the trait default that errors before running any SQL, so
+/// it always falls back to [`WarehouseAdapter::execute_query`]. A genuine SQL
+/// error on an Arrow-capable adapter re-surfaces with its real message via the
+/// `execute_query` arm — nothing is swallowed, just one extra round-trip on a
+/// real failure. The inner conversion `Err` (an unformattable Arrow type) also
+/// falls back rather than hard-erroring.
+async fn query_grounding(
+    adapter: &dyn rocky_core::traits::WarehouseAdapter,
+    sql: &str,
+) -> rocky_core::traits::AdapterResult<rocky_core::traits::QueryResult> {
+    if let Ok(batch) = adapter.fetch_arrow_batch(sql).await
+        && let Ok(qr) = record_batch_to_query_result(&batch)
+    {
+        return Ok(qr);
+    }
+    adapter.execute_query(sql).await
+}
+
+/// Convert an Arrow [`RecordBatch`](arrow::record_batch::RecordBatch) into the
+/// row-based [`QueryResult`](rocky_core::traits::QueryResult) the grounding
+/// tools consume.
+///
+/// Each cell renders to text via `arrow`'s `ArrayFormatter`, EXCEPT SQL NULL:
+/// the default `FormatOptions` renders NULL as the empty string, which would be
+/// indistinguishable from an empty value, so NULL is emitted as
+/// `serde_json::Value::Null` explicitly (checked via `Array::is_null`). All
+/// other cells become `Value::String`, matching the JSON path's effective shape
+/// for the grounding tools (which render every cell to a display string and
+/// parse aggregates back out of strings).
+fn record_batch_to_query_result(
+    batch: &arrow::record_batch::RecordBatch,
+) -> Result<rocky_core::traits::QueryResult, arrow::error::ArrowError> {
+    use arrow::util::display::{ArrayFormatter, FormatOptions};
+
+    let schema = batch.schema();
+    let columns: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    let options = FormatOptions::default();
+    // One formatter per column, built once, then indexed per row.
+    let formatters: Vec<ArrayFormatter> = batch
+        .columns()
+        .iter()
+        .map(|col| ArrayFormatter::try_new(col.as_ref(), &options))
+        .collect::<Result<_, _>>()?;
+
+    let mut rows: Vec<Vec<serde_json::Value>> = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let mut cells: Vec<serde_json::Value> = Vec::with_capacity(batch.num_columns());
+        for (col_idx, fmt) in formatters.iter().enumerate() {
+            let cell = if batch.column(col_idx).is_null(row) {
+                serde_json::Value::Null
+            } else {
+                serde_json::Value::String(fmt.value(row).to_string())
+            };
+            cells.push(cell);
+        }
+        rows.push(cells);
+    }
+
+    Ok(rocky_core::traits::QueryResult { columns, rows })
 }
 
 /// Build the `AdapterRegistry` from the loaded config. Thin wrapper so the
@@ -1522,6 +1571,59 @@ mod tests {
         assert_eq!(lite.model, "c.s.orders");
         assert_eq!(lite.column.as_deref(), Some("legacy_flag"));
         assert!(lite.message.contains("ColumnDropped"));
+    }
+
+    #[test]
+    fn qualify_table_ref_emits_catalog_when_present() {
+        // Catalog set (Snowflake/BigQuery/Databricks) → three-part name.
+        assert_eq!(
+            qualify_table_ref("analytics", "raw", "orders").unwrap(),
+            "analytics.raw.orders"
+        );
+        // No catalog (DuckDB) → two-part name.
+        assert_eq!(
+            qualify_table_ref("", "raw", "orders").unwrap(),
+            "raw.orders"
+        );
+    }
+
+    #[test]
+    fn qualify_table_ref_rejects_bad_identifier() {
+        assert!(qualify_table_ref("", "raw", "orders; DROP TABLE x").is_err());
+        assert!(qualify_table_ref("a.b", "raw", "orders").is_err());
+    }
+
+    #[test]
+    fn record_batch_to_query_result_renders_null_as_json_null() {
+        use std::sync::Arc;
+
+        use arrow::array::{Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+
+        // A 2-row batch where row 1 is NULL in both columns. The default
+        // `FormatOptions` renders NULL as "", so the converter MUST emit
+        // `Value::Null` for those cells (checked via `is_null`), not "".
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("n", DataType::Int64, true),
+            Field::new("s", DataType::Utf8, true),
+        ]));
+        let ints = Int64Array::from(vec![Some(42), None]);
+        let strs = StringArray::from(vec![Some("hello"), None]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ints), Arc::new(strs)]).unwrap();
+
+        let qr = record_batch_to_query_result(&batch).unwrap();
+        assert_eq!(qr.columns, vec!["n".to_string(), "s".to_string()]);
+        assert_eq!(qr.rows.len(), 2);
+        // Row 0: non-null cells render to strings.
+        assert_eq!(qr.rows[0][0], serde_json::Value::String("42".to_string()));
+        assert_eq!(
+            qr.rows[0][1],
+            serde_json::Value::String("hello".to_string())
+        );
+        // Row 1: SQL NULL → JSON null, NOT the empty string.
+        assert_eq!(qr.rows[1][0], serde_json::Value::Null);
+        assert_eq!(qr.rows[1][1], serde_json::Value::Null);
     }
 
     #[test]

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -92,6 +92,7 @@ async fn tools_list_returns_expected_set() {
             "profile_column",
             "propose",
             "sample_rows",
+            "suggest_freshness_block",
             "test",
         ]
     );
@@ -849,6 +850,52 @@ async fn inspect_schema_discovers_raw_sources_and_tolerates_cold_start() {
         cols.iter()
             .any(|c| c["name"] == serde_json::json!("status")),
         "discovered source carries its columns; got {cols:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn suggest_freshness_block_returns_null_without_api_key() {
+    // Without ANTHROPIC_API_KEY the tool degrades gracefully: a null block
+    // plus an explanatory message, never an error and never a network call.
+    // SAFETY: `#[tokio::test]` runs on a current-thread runtime, so the
+    // spawned server task shares this single thread; nothing else reads the
+    // env concurrently.
+    unsafe {
+        std::env::remove_var(rocky_ai::client::AI_API_KEY_ENV);
+    }
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let args = serde_json::json!({
+        "model": "orders",
+        "temporal_columns": ["created_at", "updated_at"],
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("suggest_freshness_block").with_arguments(args))
+        .await
+        .expect("suggest_freshness_block call");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "missing key is a graceful no-op, not an error"
+    );
+    let sc = result.structured_content.expect("structured content");
+    assert!(
+        sc.get("freshness_block").is_none() || sc["freshness_block"].is_null(),
+        "no block without a key; got {sc:?}"
+    );
+    let message = sc["message"].as_str().expect("explanatory message");
+    assert!(
+        message.contains(rocky_ai::client::AI_API_KEY_ENV),
+        "message should name the missing env var; got `{message}`"
     );
 
     client.cancel().await.unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -34,7 +34,7 @@ separator = "__"
 components = ["source"]
 
 [pipeline.p.target]
-catalog_template = "main"
+catalog_template = "warehouse"
 schema_template = "out"
 "#,
             db_path.display()
@@ -48,7 +48,7 @@ schema_template = "out"
     .unwrap();
     std::fs::write(
         dir.join("models").join("orders.toml"),
-        "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"orders\"\n",
+        "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"out\"\ntable = \"orders\"\n",
     )
     .unwrap();
 }
@@ -186,88 +186,14 @@ async fn propose_writes_ai_authored_plan() {
     client.cancel().await.unwrap();
 }
 
-/// Write a project whose target adapter is Snowflake (not DuckDB) so the
-/// grounding tools must report `unavailable` without touching a warehouse.
-fn write_snowflake_project(dir: &Path) {
-    std::fs::create_dir_all(dir.join("models")).unwrap();
-    std::fs::write(
-        dir.join("rocky.toml"),
-        r#"[adapter]
-type = "snowflake"
-account = "acct"
-username = "u"
-password = "p"
-warehouse = "wh"
-database = "db"
-
-[pipeline.p]
-type = "transformation"
-target = { adapter = "default" }
-"#,
-    )
-    .unwrap();
-    std::fs::write(dir.join("models").join("orders.sql"), "SELECT 1 AS id\n").unwrap();
-    std::fs::write(
-        dir.join("models").join("orders.toml"),
-        "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"db\"\nschema = \"out\"\ntable = \"orders\"\n",
-    )
-    .unwrap();
-}
-
-#[tokio::test]
-async fn sample_rows_unavailable_on_non_duckdb_adapter() {
-    let dir = TempDir::new().unwrap();
-    write_snowflake_project(dir.path());
-    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
-
-    let client = connect(server).await;
-    let args = serde_json::json!({ "model": "orders" })
-        .as_object()
-        .unwrap()
-        .clone();
-    let result = client
-        .call_tool(CallToolRequestParams::new("sample_rows").with_arguments(args))
-        .await
-        .expect("sample_rows call");
-    let sc = result.structured_content.expect("structured content");
-    assert_eq!(sc["unavailable"], serde_json::json!(true));
-    assert!(
-        sc["reason"].as_str().unwrap().contains("DuckDB-only"),
-        "reason should explain the DuckDB-only limitation"
-    );
-    // Data fields must be empty on the unavailable path.
-    assert!(sc["columns"].as_array().unwrap().is_empty());
-    assert!(sc["rows"].as_array().unwrap().is_empty());
-
-    client.cancel().await.unwrap();
-}
-
-#[tokio::test]
-async fn profile_column_unavailable_on_non_duckdb_adapter() {
-    let dir = TempDir::new().unwrap();
-    write_snowflake_project(dir.path());
-    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
-
-    let client = connect(server).await;
-    let args = serde_json::json!({ "model": "orders", "column": "id" })
-        .as_object()
-        .unwrap()
-        .clone();
-    let result = client
-        .call_tool(CallToolRequestParams::new("profile_column").with_arguments(args))
-        .await
-        .expect("profile_column call");
-    let sc = result.structured_content.expect("structured content");
-    assert_eq!(sc["unavailable"], serde_json::json!(true));
-    assert!(sc["reason"].as_str().unwrap().contains("DuckDB-only"));
-
-    client.cancel().await.unwrap();
-}
-
 #[tokio::test]
 async fn sample_rows_returns_capped_rows_on_duckdb() {
     let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("sample.duckdb");
+    // The model declares `catalog = "warehouse"`; the bare-model ref the tool
+    // builds is the runner.s three-part `warehouse.out.orders`. On DuckDB the
+    // catalog name is the file stem, so the file must be `warehouse.duckdb`.
+    // (DuckDB reserves `main`, renaming a `main.duckdb` catalog to `main_db`.)
+    let db_path = dir.path().join("warehouse.duckdb");
     write_project(dir.path(), &db_path);
 
     // Pre-materialize the model's target table so sample_rows has data to read.
@@ -346,7 +272,7 @@ async fn dependents_returns_downstream_consumers() {
     .unwrap();
     std::fs::write(
         dir.path().join("models").join("order_ids.toml"),
-        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"order_ids\"\n",
+        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"out\"\ntable = \"order_ids\"\n",
     )
     .unwrap();
 
@@ -539,7 +465,7 @@ async fn catalog_returns_project_assets() {
     .unwrap();
     std::fs::write(
         dir.path().join("models").join("order_ids.toml"),
-        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"main\"\nschema = \"out\"\ntable = \"order_ids\"\n",
+        "name = \"order_ids\"\n\n[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"warehouse\"\nschema = \"out\"\ntable = \"order_ids\"\n",
     )
     .unwrap();
     let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
@@ -751,7 +677,7 @@ separator = "__"
 components = ["source"]
 
 [pipeline.p.target]
-catalog_template = "main"
+catalog_template = "warehouse"
 schema_template = "out"
 "#,
             db_path.display()
@@ -782,7 +708,9 @@ async fn sample_rows_default_returns_rows_on_small_table() {
     // Regression: the old default (10% bernoulli) returned ~0 rows on a tiny
     // table. With no `percent`, sample_rows now returns the first rows.
     let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("small.duckdb");
+    // File stem must equal the model.s declared catalog (`warehouse`) so the
+    // runner-shaped three-part ref `warehouse.out.orders` resolves on DuckDB.
+    let db_path = dir.path().join("warehouse.duckdb");
     write_project(dir.path(), &db_path);
     materialize_orders(
         &db_path,
@@ -817,7 +745,9 @@ async fn sample_rows_default_returns_rows_on_small_table() {
 #[tokio::test]
 async fn profile_column_lists_top_values_for_low_cardinality() {
     let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("profile.duckdb");
+    // File stem must equal the model.s declared catalog (`warehouse`) so the
+    // runner-shaped three-part ref `warehouse.out.orders` resolves on DuckDB.
+    let db_path = dir.path().join("warehouse.duckdb");
     write_project(dir.path(), &db_path);
     materialize_orders(
         &db_path,

--- a/engine/crates/rocky-server/src/lsp.rs
+++ b/engine/crates/rocky-server/src/lsp.rs
@@ -3053,10 +3053,10 @@ const AI_FRESHNESS_FIX_KIND: &str = "rocky.ai-freshness-fix.v1";
 /// `code_action` can hook the AI fix.
 const E028: &str = "E028";
 
-/// Environment variable that gates every AI fallback arm. Only env-var-based;
-/// the LSP server doesn't currently surface a richer credentials channel
-/// and matching `rocky ai`'s behaviour keeps the rules predictable.
-const AI_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
+// Environment variable that gates every AI fallback arm. Shared with the MCP
+// `suggest_freshness_block` tool via `rocky_ai::client::AI_API_KEY_ENV` so the
+// two stay aligned; matching `rocky ai`'s behaviour keeps the rules predictable.
+use rocky_ai::client::AI_API_KEY_ENV;
 
 /// Serializable payload threaded from [`code_action`] into
 /// [`code_action_resolve`] via the LSP `CodeAction.data` field.
@@ -3605,8 +3605,11 @@ async fn resolve_ai_freshness_action(data: &AiFreshnessActionData) -> AiResolveO
         }
     };
 
-    let (system_prompt, user_prompt) =
-        build_freshness_fix_prompt(&data.model_name, &data.temporal_columns, &data.sidecar_text);
+    let (system_prompt, user_prompt) = rocky_ai::prompt::build_freshness_fix_prompt(
+        &data.model_name,
+        &data.temporal_columns,
+        &data.sidecar_text,
+    );
 
     let ai_config = rocky_ai::client::AiConfig {
         provider: "anthropic".to_string(),
@@ -3649,40 +3652,6 @@ async fn resolve_ai_freshness_action(data: &AiFreshnessActionData) -> AiResolveO
         range: Range::new(append_position, append_position),
         new_text,
     })
-}
-
-/// Build the LLM prompt for a W005 freshness-coverage fix. The system
-/// half encodes the role + output-format constraint; the user half
-/// supplies the per-call context (model name, candidate temporal
-/// columns, current sidecar). Splitting this way keeps the system
-/// portion stable across resolves for prompt caching.
-fn build_freshness_fix_prompt(
-    model_name: &str,
-    temporal_columns: &[String],
-    sidecar_text: &str,
-) -> (String, String) {
-    let system = "You are an expert Rocky data-pipeline reviewer. Your task is to \
-                 propose a TOML `[freshness]` block for a model's sidecar `.toml` so \
-                 the model declares a time-to-live after which it is considered \
-                 stale. Set `expected_lag_seconds` to a sensible TTL for the model \
-                 (e.g. 3600 for hourly data, 86400 for daily). Set `time_column` to \
-                 the most appropriate timestamp/date column from the supplied \
-                 candidates. Output ONLY the new TOML block inside a single ```toml \
-                 fenced block — no commentary, no explanation, no diff. The block \
-                 must start with `[freshness]` on its own line."
-        .to_string();
-
-    let candidates = temporal_columns.join(", ");
-    let user = format!(
-        "Model: `{model_name}`\n\
-         Candidate temporal columns: {candidates}\n\n\
-         Current sidecar `.toml`:\n```toml\n{sidecar_text}\n```\n\n\
-         Emit a `[freshness]` block with `expected_lag_seconds` and a \
-         `time_column` chosen from the candidates. Do not duplicate or modify \
-         any existing block."
-    );
-
-    (system, user)
 }
 
 // ── AI fallback for `.rocky` DSL parse errors (E028) ───────────────────────


### PR DESCRIPTION
## Summary

Two changes to the Rocky MCP server (`rocky mcp`):

**D1 — live-warehouse data grounding.** `sample_rows`, `profile_column`, and `inspect_schema`'s raw-source discovery were gated to DuckDB. They now reach any configured target warehouse (Snowflake, BigQuery, Databricks, Trino) through the resolved adapter — the same path `rocky preview-rows` already uses. The grounding queries prefer the columnar Arrow path (`fetch_arrow_batch`) and fall back to row-based `execute_query` on any error, so Snowflake (no Arrow impl) transparently uses JSON and a genuine SQL error re-surfaces with its real message via the fallback arm.

Correctness fixes that ride along:
- **Catalog qualification.** A bare-model target now resolves to `catalog.schema.table` when a catalog is set (it previously dropped the catalog, which could ground a *different* table than the runner materializes in a multi-catalog project). This matches exactly what the runner's `format_table_ref` produces.
- **Dialect-correct string cast.** `profile_column`'s `MIN`/`MAX`/`top_values` cast through a new defaulted `SqlDialect::string_type_name()` (`"VARCHAR"`), overridden to `"STRING"` on BigQuery — BigQuery rejects `CAST(... AS VARCHAR)`.
- **NULL handling in the Arrow converter.** Arrow's default `FormatOptions` renders SQL NULL as the empty string, so the `RecordBatch` → row converter checks `is_null` and emits JSON `null` explicitly; every other cell becomes a string. This keeps downstream NULL rendering and aggregate parsing correct.
- Removes the now-dead `PreparedTable::Unavailable` path; the result types keep their `unavailable`/`reason` fields for forward compatibility.

**D2 — `suggest_freshness_block` tool.** A new MCP tool that drafts a `[freshness]` TOML block for a model with temporal columns (the W005 fix, previously only reachable via the LSP code action). It builds the prompt, calls the LLM (anthropic / `claude-sonnet-4-6` / toml / single attempt), extracts the fenced block, and returns the ready-to-paste TOML directly. When `ANTHROPIC_API_KEY` is unset (or the model returns no fenced block), it returns a null block plus an explanatory message rather than erroring. The freshness-prompt builder is hoisted from the LSP into `rocky-ai` (`pub fn build_freshness_fix_prompt`) and the API-key env-var name into `rocky-ai` (`pub const AI_API_KEY_ENV`) so the LSP and MCP share one source of truth; the LSP now calls the hoisted fn (no behaviour change).

## Notes

- The MCP result types are schemars-1.x consumed by `rmcp` at runtime, so this does **not** go through the `just codegen` Pydantic/TypeScript cascade.
- **Known limitation:** `inspect_schema`'s raw-source discovery runs a DuckDB-shaped `information_schema.columns` query. With the gate removed it now executes on other warehouses too. On Snowflake/Databricks it may return noisy current-database/catalog rows; on BigQuery the bare query errors (INFORMATION_SCHEMA must be dataset- or region-qualified) and degrades to an empty list — cosmetic, not incorrect. Generalizing cross-warehouse `information_schema` is a follow-up.

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test -p rocky-mcp -p rocky-ai -p rocky-server -p rocky-core -p rocky-bigquery` all pass. New no-creds tests cover: the Arrow converter rendering SQL NULL as JSON null, `qualify_table_ref` emitting `catalog.schema.table` vs `schema.table`, the BigQuery `STRING` cast, the hoisted prompt builder, and `suggest_freshness_block` returning a null block + message with no key set. The DuckDB round-trip grounding tests now exercise the runner-shaped three-part catalog reference end-to-end.

Live non-DuckDB grounding cannot be exercised in CI (no warehouse credentials) — see the checklist below.

## Live-verify checklist

Run `rocky mcp` against each sandbox:

- [ ] **Snowflake:** `sample_rows` + `profile_column` on a test table return real rows + stats (via `execute_query` JSON — Snowflake has no Arrow impl, so the fallback arm is exercised). `top_values` populated for a low-cardinality column.
- [ ] **BigQuery:** `sample_rows` returns rows via the Arrow path; `profile_column` runs and `min`/`max`/`top_values` populate — confirm the string cast emits `STRING`, not `VARCHAR`, and that NULL cells render correctly (JSON null, not empty string).
- [ ] **Databricks:** `sample_rows` + `profile_column` return real rows + stats via the Arrow path; `dialect_tablesample` honored when `percent` is set.
- [ ] **Catalog-qualified targets:** a bare-model `sample_rows`/`profile_column` on a Snowflake/BigQuery/Databricks model resolves to `catalog.schema.table` (not just `schema.table`).
- [ ] **inspect_schema raw-source discovery on non-DuckDB:** known limitation — the `information_schema.columns` discovery query is DuckDB-shaped; on Snowflake/Databricks it may return noisy current-database rows and on BigQuery it errors then degrades to empty (cosmetic, not incorrect). Compiled-model schemas still show.
- [ ] **suggest_freshness_block** (with `ANTHROPIC_API_KEY` set): returns a valid `[freshness]` block (`expected_lag_seconds` + a `time_column` from the supplied candidates) for a model with temporal columns; returns `freshness_block: null` + a message when the key is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
