### PR TITLE
fix(engine/rocky-mcp): correct BigQuery and Databricks dialects in live data grounding

### DIFF
--- a/engine/crates/rocky-bigquery/src/dialect.rs
+++ b/engine/crates/rocky-bigquery/src/dialect.rs
@@ -208,6 +208,32 @@ impl SqlDialect for BigQueryDialect {
         "STRING"
     }
 
+    fn ground_table_ref(&self, parts: &[&str]) -> AdapterResult<String> {
+        // BigQuery refs are `project.dataset.table`. The project (catalog)
+        // segment allows hyphens — every real GCP project ID has them — so it
+        // gets the hyphen-allowing `validate_gcp_project_id` rule while the
+        // dataset + table stay on the strict SQL-identifier rule. Each segment
+        // is backtick-quoted: a hyphenated ref like
+        // `bigquery-public-data.samples.shakespeare` parses as subtraction
+        // unless quoted, and double quotes denote STRING literals in BigQuery.
+        match parts {
+            [project, dataset, table] => {
+                validation::validate_gcp_project_id(project).map_err(AdapterError::new)?;
+                validation::validate_identifier(dataset).map_err(AdapterError::new)?;
+                validation::validate_identifier(table).map_err(AdapterError::new)?;
+                Ok(format!("`{project}`.`{dataset}`.`{table}`"))
+            }
+            [dataset, table] => {
+                validation::validate_identifier(dataset).map_err(AdapterError::new)?;
+                validation::validate_identifier(table).map_err(AdapterError::new)?;
+                Ok(format!("`{dataset}`.`{table}`"))
+            }
+            _ => Err(AdapterError::msg(
+                "table reference must be `dataset.table` or `project.dataset.table`",
+            )),
+        }
+    }
+
     fn quote_identifier(&self, name: &str) -> String {
         // BigQuery uses backticks for identifiers; double quotes denote
         // STRING literals. The default `"name"` quoting from the trait
@@ -486,6 +512,54 @@ mod tests {
         // BigQuery has no VARCHAR; the variable-length string type is STRING.
         let d = BigQueryDialect;
         assert_eq!(d.string_type_name(), "STRING");
+    }
+
+    #[test]
+    fn ground_table_ref_backtick_quotes_hyphenated_project() {
+        // Every real GCP project ID carries hyphens. The grounding ref builder
+        // must accept the hyphenated project segment (via the project-id rule)
+        // and backtick-quote the ref so `project.dataset.table` doesn't parse
+        // as subtraction.
+        let d = BigQueryDialect;
+        assert_eq!(
+            d.ground_table_ref(&["bigquery-public-data", "samples", "shakespeare"])
+                .unwrap(),
+            "`bigquery-public-data`.`samples`.`shakespeare`"
+        );
+        assert_eq!(
+            d.ground_table_ref(&["my-proj-123", "ds", "tbl"]).unwrap(),
+            "`my-proj-123`.`ds`.`tbl`"
+        );
+    }
+
+    #[test]
+    fn ground_table_ref_two_part_is_backtick_quoted() {
+        // Dataset-qualified ref (no project) — both segments stay on the strict
+        // identifier rule but are still backtick-quoted.
+        let d = BigQueryDialect;
+        assert_eq!(
+            d.ground_table_ref(&["samples", "shakespeare"]).unwrap(),
+            "`samples`.`shakespeare`"
+        );
+    }
+
+    #[test]
+    fn ground_table_ref_rejects_injection_and_bad_arity() {
+        let d = BigQueryDialect;
+        // Injection in any segment is rejected.
+        assert!(
+            d.ground_table_ref(&["bigquery-public-data", "samples", "a; DROP TABLE x"])
+                .is_err()
+        );
+        // The strict project-id rule still rejects a hyphen in the dataset /
+        // table segments (only the project segment allows hyphens).
+        assert!(
+            d.ground_table_ref(&["proj-ok-123", "bad-dataset", "tbl"])
+                .is_err()
+        );
+        // Out-of-range arity.
+        assert!(d.ground_table_ref(&["a", "b", "c", "d"]).is_err());
+        assert!(d.ground_table_ref(&["just_one"]).is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -906,6 +906,40 @@ pub trait SqlDialect: Send + Sync {
         "VARCHAR"
     }
 
+    /// Build a validated, dialect-correct table reference for the
+    /// data-grounding tools from an already-split list of name segments.
+    ///
+    /// `parts` is 2 (`schema.table`) or 3 (`catalog.schema.table`)
+    /// segments. The result is interpolated directly into
+    /// `SELECT * FROM <ref> ...`, so it must be both injection-safe
+    /// (every segment validated) and syntactically correct for the
+    /// dialect.
+    ///
+    /// Default: validate each segment with the strict SQL-identifier rule
+    /// and join with dots, unquoted. This matches the behavior the
+    /// grounding path has always had on DuckDB, Snowflake, and Databricks
+    /// — unquoted, so Snowflake folds the segments to its default
+    /// uppercase casing rather than locking in a case-sensitive quoted
+    /// name. BigQuery overrides this because its project (catalog) segment
+    /// allows hyphens (which the strict rule rejects) and a hyphenated ref
+    /// parses as subtraction unless backtick-quoted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `parts` is not 2 or 3 segments, or if any
+    /// segment fails identifier validation.
+    fn ground_table_ref(&self, parts: &[&str]) -> AdapterResult<String> {
+        if !(2..=3).contains(&parts.len()) {
+            return Err(AdapterError::msg(
+                "table reference must be `schema.table` or `catalog.schema.table`",
+            ));
+        }
+        for part in parts {
+            rocky_sql::validation::validate_identifier(part).map_err(AdapterError::new)?;
+        }
+        Ok(parts.join("."))
+    }
+
     /// Build a NULL-safe inequality predicate: `lhs` differs from `rhs`,
     /// treating two NULLs as equal and a single NULL as a real difference.
     /// Used by SCD2 change detection on the watermark / check columns —

--- a/engine/crates/rocky-databricks/src/dialect.rs
+++ b/engine/crates/rocky-databricks/src/dialect.rs
@@ -188,6 +188,15 @@ impl SqlDialect for DatabricksSqlDialect {
         format!("`{name}`")
     }
 
+    fn string_type_name(&self) -> &'static str {
+        // Spark SQL (Databricks) rejects a bare `VARCHAR` in `CAST(... AS
+        // VARCHAR)` with `[DATATYPE_MISSING_SIZE] DataType "VARCHAR" requires
+        // a length parameter`. The unbounded variable-length text type is
+        // `STRING`, so the data-grounding cast must target that instead of the
+        // trait default `"VARCHAR"`.
+        "STRING"
+    }
+
     fn materialized_view_ddl(&self, target: &str, select_sql: &str) -> AdapterResult<String> {
         // Unity Catalog managed materialized views — refresh schedule is
         // configured server-side via `ALTER MATERIALIZED VIEW … SET
@@ -247,6 +256,15 @@ mod tests {
     fn test_format_table_ref_rejects_bad_identifier() {
         let d = dialect();
         assert!(d.format_table_ref("bad; DROP", "sch", "tbl").is_err());
+    }
+
+    #[test]
+    fn string_type_name_is_spark_string_not_varchar() {
+        // Spark SQL rejects a bare `CAST(... AS VARCHAR)` (DATATYPE_MISSING_SIZE);
+        // the unbounded text type is STRING. The data-grounding profile cast
+        // depends on this override.
+        let d = dialect();
+        assert_eq!(d.string_type_name(), "STRING");
     }
 
     #[test]

--- a/engine/crates/rocky-duckdb/src/dialect.rs
+++ b/engine/crates/rocky-duckdb/src/dialect.rs
@@ -274,6 +274,14 @@ mod tests {
     }
 
     #[test]
+    fn string_type_name_is_varchar() {
+        // DuckDB accepts `CAST(... AS VARCHAR)`, so the data-grounding cast
+        // uses the trait default.
+        let d = dialect();
+        assert_eq!(d.string_type_name(), "VARCHAR");
+    }
+
+    #[test]
     fn test_create_table_as() {
         let d = dialect();
         let sql = d.create_table_as("sch.tbl", "SELECT * FROM src");

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1114,22 +1114,17 @@ impl RockyMcpServer {
             .warehouse_adapter()?
             .ok_or_else(|| anyhow::anyhow!("could not resolve the target warehouse adapter"))?;
 
+        let dialect = adapter.dialect();
         let table_ref = if target.contains('.') {
-            // Qualified raw reference — validate each segment and use it as-is.
-            // No compile required: this is how an agent grounds a source before
-            // (or without) authoring any model.
+            // Qualified raw reference — validate each segment and quote it
+            // dialect-correctly. No compile required: this is how an agent
+            // grounds a source before (or without) authoring any model. The
+            // dialect decides validation + quoting (e.g. BigQuery allows a
+            // hyphenated project segment and backtick-quotes the ref).
             let parts: Vec<&str> = target.split('.').collect();
-            if !(2..=3).contains(&parts.len()) {
-                return Err(anyhow::anyhow!(
-                    "table reference '{target}' must be `schema.table` or \
-                     `catalog.schema.table`"
-                ));
-            }
-            for part in &parts {
-                rocky_sql::validation::validate_identifier(part)
-                    .map_err(|e| anyhow::anyhow!("invalid identifier '{part}': {e}"))?;
-            }
-            parts.join(".")
+            dialect
+                .ground_table_ref(&parts)
+                .map_err(|e| anyhow::anyhow!("invalid table reference '{target}': {e}"))?
         } else {
             // Bare name — resolve the model's target coordinates by compiling
             // the models dir. Emit `catalog.schema.table` when the target
@@ -1143,7 +1138,14 @@ impl RockyMcpServer {
                 .find(|m| m.config.name == target)
                 .ok_or_else(|| anyhow::anyhow!("model '{target}' not found in project"))?;
             let t = &model.config.target;
-            qualify_table_ref(&t.catalog, &t.schema, &t.table)?
+            let parts: Vec<&str> = if t.catalog.is_empty() {
+                vec![&t.schema, &t.table]
+            } else {
+                vec![&t.catalog, &t.schema, &t.table]
+            };
+            dialect
+                .ground_table_ref(&parts)
+                .map_err(|e| anyhow::anyhow!("invalid model target reference: {e}"))?
         };
 
         Ok(Prepared { adapter, table_ref })
@@ -1253,24 +1255,6 @@ struct Prepared {
 impl Prepared {
     fn dialect_tablesample(&self, percent: u32) -> Option<String> {
         self.adapter.dialect().tablesample_clause(percent)
-    }
-}
-
-/// Build a validated, dialect-agnostic table reference from a model's target
-/// coordinates. Emits `catalog.schema.table` when a catalog is set
-/// (Snowflake/BigQuery/Databricks), or `schema.table` otherwise (DuckDB has no
-/// catalog level). Each segment is validated as a SQL identifier.
-fn qualify_table_ref(catalog: &str, schema: &str, table: &str) -> anyhow::Result<String> {
-    let schema = rocky_sql::validation::validate_identifier(schema)
-        .map_err(|e| anyhow::anyhow!("invalid schema identifier: {e}"))?;
-    let table = rocky_sql::validation::validate_identifier(table)
-        .map_err(|e| anyhow::anyhow!("invalid table identifier: {e}"))?;
-    if catalog.is_empty() {
-        Ok(format!("{schema}.{table}"))
-    } else {
-        let catalog = rocky_sql::validation::validate_identifier(catalog)
-            .map_err(|e| anyhow::anyhow!("invalid catalog identifier: {e}"))?;
-        Ok(format!("{catalog}.{schema}.{table}"))
     }
 }
 
@@ -1653,23 +1637,40 @@ mod tests {
     }
 
     #[test]
-    fn qualify_table_ref_emits_catalog_when_present() {
-        // Catalog set (Snowflake/BigQuery/Databricks) → three-part name.
+    fn ground_table_ref_default_emits_unquoted_segments() {
+        use rocky_core::traits::SqlDialect;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+        // The grounding path routes a parsed table ref through the target
+        // dialect's `ground_table_ref`. The default (DuckDB/Snowflake/
+        // Databricks) joins validated segments unquoted — Snowflake relies on
+        // this to fold to its default uppercase casing rather than locking in
+        // a case-sensitive quoted name.
+        let d = DuckDbSqlDialect;
+        // Three-part name (catalog.schema.table).
         assert_eq!(
-            qualify_table_ref("analytics", "raw", "orders").unwrap(),
+            d.ground_table_ref(&["analytics", "raw", "orders"]).unwrap(),
             "analytics.raw.orders"
         );
-        // No catalog (DuckDB) → two-part name.
+        // Two-part name (schema.table).
         assert_eq!(
-            qualify_table_ref("", "raw", "orders").unwrap(),
+            d.ground_table_ref(&["raw", "orders"]).unwrap(),
             "raw.orders"
         );
     }
 
     #[test]
-    fn qualify_table_ref_rejects_bad_identifier() {
-        assert!(qualify_table_ref("", "raw", "orders; DROP TABLE x").is_err());
-        assert!(qualify_table_ref("a.b", "raw", "orders").is_err());
+    fn ground_table_ref_default_rejects_bad_identifier_and_arity() {
+        use rocky_core::traits::SqlDialect;
+        use rocky_duckdb::dialect::DuckDbSqlDialect;
+        let d = DuckDbSqlDialect;
+        // Injection in any segment is rejected.
+        assert!(
+            d.ground_table_ref(&["raw", "orders; DROP TABLE x"])
+                .is_err()
+        );
+        // A four-part ref (or a single bare name) is out of range.
+        assert!(d.ground_table_ref(&["a", "b", "c", "d"]).is_err());
+        assert!(d.ground_table_ref(&["orders"]).is_err());
     }
 
     #[test]

--- a/engine/crates/rocky-snowflake/src/dialect.rs
+++ b/engine/crates/rocky-snowflake/src/dialect.rs
@@ -448,6 +448,38 @@ mod tests {
     }
 
     #[test]
+    fn string_type_name_is_varchar() {
+        // Snowflake accepts `CAST(... AS VARCHAR)`, so the data-grounding cast
+        // uses the trait default rather than overriding to STRING.
+        let d = dialect();
+        assert_eq!(d.string_type_name(), "VARCHAR");
+    }
+
+    #[test]
+    fn ground_table_ref_stays_unquoted() {
+        // Critical regression guard: the grounding ref must stay UNQUOTED on
+        // Snowflake even though `format_table_ref` double-quotes. Snowflake
+        // folds unquoted identifiers to its default uppercase casing, so an
+        // unquoted lowercase input still resolves a default-uppercase object;
+        // double-quoting would lock in a case-sensitive lowercase name that
+        // would not match. The MCP grounding path was live-verified against
+        // Snowflake on the unquoted form.
+        let d = dialect();
+        assert_eq!(
+            d.ground_table_ref(&["mydb", "public", "users"]).unwrap(),
+            "mydb.public.users"
+        );
+        assert_eq!(
+            d.ground_table_ref(&["public", "users"]).unwrap(),
+            "public.users"
+        );
+        assert!(
+            d.ground_table_ref(&["public", "users; DROP TABLE x"])
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_format_table_ref_two_part() {
         let d = dialect();
         assert_eq!(


### PR DESCRIPTION
Live grounding (#775) shipped with two dialect-specific bugs that compile-time and unit tests didn't catch — both found by live verification against sandbox warehouses.

**BigQuery — grounding was fully broken.** BigQuery project IDs contain hyphens, but the grounding catalog/project segment was validated with the strict `[a-zA-Z0-9_]+` identifier rule (and the reference wasn't quoted), so every `project.dataset.table` reference was rejected as an invalid identifier. Grounding now resolves the reference through a dialect-aware `SqlDialect::ground_table_ref`: BigQuery validates the project segment with the hyphen-allowing GCP project-id rule and backtick-quotes each segment; the other dialects keep their existing unquoted behavior.

**Databricks — `profile_column` was broken.** The profile cast used bare `VARCHAR`, which Spark SQL rejects (`DATATYPE_MISSING_SIZE`). `string_type_name()` now returns `STRING` for Databricks, matching the existing BigQuery override. (`sample_rows` was unaffected.)

Adds unit tests for hyphenated-project backtick-quoting, injection rejection, two-part refs, and the per-dialect string casts.

**Live-verified** against the Snowflake / BigQuery / Databricks sandboxes: `sample_rows` and `profile_column` now return real rows + stats on all three (Snowflake via JSON fallback, BigQuery/Databricks via Arrow); Snowflake unaffected.