### PR TITLE
docs: editorial cleanup of the Dagster integration section

### DIFF
--- a/docs/src/content/docs/dagster/automation.md
+++ b/docs/src/content/docs/dagster/automation.md
@@ -13,7 +13,7 @@ through Dagster docs.
 
 ## `rocky_eager_automation()`
 
-Returns `dg.AutomationCondition.eager()` — the modern 1.12+ replacement for
+Returns `dg.AutomationCondition.eager()`, the modern 1.12+ replacement for
 the deprecated `AutoMaterializePolicy.eager()`. The asset materializes
 whenever any upstream dependency updates, waiting for all upstream deps to
 finish first.
@@ -43,7 +43,7 @@ defs = dg.Definitions(assets=eager_specs, resources={"rocky": rocky})
 
 ## `rocky_cron_automation(cron_schedule, timezone="UTC")`
 
-Returns `dg.AutomationCondition.on_cron(cron_schedule, timezone)` — fires on
+Returns `dg.AutomationCondition.on_cron(cron_schedule, timezone)`, which fires on
 the cron schedule, but only after upstream dependencies have updated since
 the previous tick.
 
@@ -61,7 +61,7 @@ spec = dg.AssetSpec(
 
 ## Why dedicated helpers?
 
-The helpers are intentionally tiny — they exist to:
+The helpers are intentionally tiny; they exist to:
 
 1. **Document the canonical mapping** in one place, so users don't need to
    know which Dagster condition variant is canonical for Rocky-managed assets.
@@ -78,7 +78,7 @@ The helpers are intentionally tiny — they exist to:
 |---|---|
 | `rocky_source_sensor` | You want to react to specific Fivetran sync events with custom polling logic. |
 | `build_rocky_schedule` | You want fixed time-based execution regardless of upstream state. |
-| `rocky_eager_automation` | You want Dagster to auto-materialize whenever upstreams update — least imperative, most declarative. |
+| `rocky_eager_automation` | You want Dagster to auto-materialize whenever upstreams update; least imperative, most declarative. |
 | `rocky_cron_automation` | You want scheduled execution gated on upstream freshness. |
 
 The four can coexist on the same asset graph. Dagster will deduplicate

--- a/docs/src/content/docs/dagster/branch-deployments.md
+++ b/docs/src/content/docs/dagster/branch-deployments.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 When a pull request opens against a Dagster+ project, the platform spins
-up a *branch deployment* — an isolated code location that mirrors
+up a *branch deployment*: an isolated code location that mirrors
 production but writes to a separate dev environment. The canonical
 Rocky-side response is to **shadow-run** every materialization against a
 sandboxed schema instead of production tables, so PR diffs are visible
@@ -14,11 +14,11 @@ side-by-side without touching production data.
 
 `dagster-rocky` ships three small primitives to make this trivial:
 
-- **`is_branch_deployment()`** — boolean check for the standard Dagster+
+- **`is_branch_deployment()`:** boolean check for the standard Dagster+
   env vars.
-- **`branch_deployment_info()`** — structured snapshot of the deployment
+- **`branch_deployment_info()`:** structured snapshot of the deployment
   context (deployment name, PR number, Git SHA).
-- **`branch_deploy_shadow_suffix()`** — derives a stable Rocky shadow
+- **`branch_deploy_shadow_suffix()`:** derives a stable Rocky shadow
   suffix suitable for `rocky plan --shadow --shadow-suffix <value>` + `rocky apply <plan-id>`
   (the single-step `rocky run --shadow --shadow-suffix <value>` alias does the same in one invocation).
 
@@ -60,7 +60,7 @@ The helpers read these env vars (set automatically by Dagster+):
 | `DAGSTER_CLOUD_PULL_REQUEST_ID` | Originating PR number, when known |
 | `DAGSTER_CLOUD_GIT_SHA` | Build commit SHA |
 
-The PR number and Git SHA are optional — branch deployments created via
+The PR number and Git SHA are optional; branch deployments created via
 the Dagster+ API (rather than from a PR) won't have them.
 
 ## Shadow suffix derivation
@@ -81,7 +81,7 @@ rejects most punctuation, so this keeps the suffix usable as part of a
 table name.
 
 The function returns `None` outside branch deployments so callers can
-unconditionally pass the result through to `rocky.run()` — the resource
+unconditionally pass the result through to `rocky.run()`; the resource
 accepts `shadow_suffix: str | None`, and passing `None` is a no-op:
 
 ```python

--- a/docs/src/content/docs/dagster/checks.md
+++ b/docs/src/content/docs/dagster/checks.md
@@ -37,7 +37,7 @@ Handles every Rocky check type, both pipeline-level and model-level:
 **Model-level assertions (DQX parity):**
 `not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`, `composite`, `not_in_future`, `older_than_n_days`. Each carries a `severity` (`error` / `warning`) and an optional `filter` predicate; row-level assertions also surface `quarantined = true/false` when `[quarantine]` is configured on the pipeline.
 
-Severity maps to Dagster's `AssetCheckSeverity` (`ERROR` / `WARN`). Warnings never fail the asset check, even when the underlying assertion returned `passed = false`. All check metadata — SQL fingerprint, failing row count, quarantine state, filter used — is propagated to the Dagster event for full observability.
+Severity maps to Dagster's `AssetCheckSeverity` (`ERROR` / `WARN`). Warnings never fail the asset check, even when the underlying assertion returned `passed = false`. All check metadata (SQL fingerprint, failing row count, quarantine state, filter used) is propagated to the Dagster event for full observability.
 
 ## Example
 

--- a/docs/src/content/docs/dagster/component.md
+++ b/docs/src/content/docs/dagster/component.md
@@ -28,7 +28,7 @@ attributes:
 
 ## Opt-in surfaces
 
-Five fields toggle additional behaviour on top of the basic discover/compile cache. All default to off — existing components see no behaviour change unless you flip them on.
+Five fields toggle additional behaviour on top of the basic discover/compile cache. All default to off; existing components see no behaviour change unless you flip them on.
 
 | Field | Since | YAML | What it does |
 |---|---|---|---|
@@ -36,7 +36,7 @@ Five fields toggle additional behaviour on top of the basic discover/compile cac
 | `surface_retention_status` | 1.13.0 | yes | Calls `rocky retention-status` once per materialization batch and emits one `AssetObservation` per model row, keyed by model. |
 | `discover_on_missing_state` | 1.14.0 | yes | If the local state file is absent at code-server load, `build_defs` runs `write_state_to_path()` synchronously instead of returning an empty `Definitions`. Skipped under `dg dev` (which relies on the CLI workflow) and only applies when state management is local-filesystem. |
 | `surface_column_lineage` | 1.14.0 | yes | At code-server load, walks `models_dir/*.toml` (skipping `_*.toml` and `*.contract.toml`), calls `rocky lineage` per model, and merges the resulting `dagster.TableColumnLineage` into each matching `AssetSpec`'s `metadata["dagster/column_lineage"]`. |
-| `post_state_write_hook` | 1.14.0 | **no — Python only** | Callable invoked with the state-file path immediately after every successful `write_state_to_path()`. Typical use: push the freshly-written state to a durable store (S3, Valkey) so the next ephemeral pod boots with the cache pre-warmed. |
+| `post_state_write_hook` | 1.14.0 | **no, Python only** | Callable invoked with the state-file path immediately after every successful `write_state_to_path()`. Typical use: push the freshly-written state to a durable store (S3, Valkey) so the next ephemeral pod boots with the cache pre-warmed. |
 
 ```yaml
 type: dagster_rocky.RockyComponent
@@ -50,7 +50,7 @@ attributes:
   discover_on_missing_state: true
 ```
 
-`post_state_write_hook` cannot be set from YAML — arbitrary Python callables are not YAML-resolvable, and a non-null YAML value raises `ResolutionException` at component load. Set it programmatically in a subclass instead:
+`post_state_write_hook` cannot be set from YAML; arbitrary Python callables are not YAML-resolvable, and a non-null YAML value raises `ResolutionException` at component load. Set it programmatically in a subclass instead:
 
 ```python
 from pathlib import Path
@@ -79,7 +79,7 @@ By default, the component stores its state on the local filesystem. This is conf
 
 ## DAG mode
 
-When `dag_mode: true` is set, the component calls `rocky dag` to build a fully connected asset graph where every pipeline stage — source, load, transformation, seed, quality, snapshot — becomes a Dagster asset with resolved upstream dependencies. This replaces the separate `discover` + `surface_derived_models` paths with a single unified DAG.
+When `dag_mode: true` is set, the component calls `rocky dag` to build a fully connected asset graph where every pipeline stage (source, load, transformation, seed, quality, snapshot) becomes a Dagster asset with resolved upstream dependencies. This replaces the separate `discover` + `surface_derived_models` paths with a single unified DAG.
 
 ```yaml
 type: dagster_rocky.RockyComponent

--- a/docs/src/content/docs/dagster/contracts.md
+++ b/docs/src/content/docs/dagster/contracts.md
@@ -67,9 +67,9 @@ After deployment, every model with a contract file shows up to three new
 contract checks in the asset detail page (depending on which rule kinds
 are declared in the contract):
 
-- `contract_required_columns` — passes when no E010 diagnostics
-- `contract_protected_columns` — passes when no E013 diagnostics
-- `contract_column_constraints` — passes when no E011/E012/W010 diagnostics
+- `contract_required_columns`: passes when no E010 diagnostics
+- `contract_protected_columns`: passes when no E013 diagnostics
+- `contract_column_constraints`: passes when no E011/E012/W010 diagnostics
 
 ## Diagnostic code mapping
 
@@ -88,8 +88,8 @@ When a check fails, the `AssetCheckResult` includes:
 
 - `passed=False`
 - `severity=ERROR` (or `WARN` if every failing diagnostic is W010)
-- `rocky/violation_count` — number of contract violations for this check
-- `rocky/violation_<i>` — text of each violation in the form `[<code>] <message>`
+- `rocky/violation_count`: number of contract violations for this check
+- `rocky/violation_<i>`: text of each violation in the form `[<code>] <message>`
 
 ## Standalone helpers
 
@@ -129,7 +129,7 @@ results = list(
 Pre-declaring `AssetCheckSpec` instances at load time means the Dagster
 UI shows contract slots **before any compile or run**. Users see at a
 glance which models have contracts and which contract kinds are
-expected — even on a fresh deployment.
+expected, even on a fresh deployment.
 
 The alternative (emitting check results without pre-declared specs)
 would be hidden until the first materialization completes, which
@@ -137,7 +137,7 @@ defeats the purpose of contracts as a documentation surface.
 
 ## When does the wiring fire?
 
-`RockyComponent` matches contracts to assets by **table name** — a
+`RockyComponent` matches contracts to assets by **table name**: a
 contract file `orders.contract.toml` attaches to any asset whose key
 ends with `orders`. Today this means:
 
@@ -149,16 +149,16 @@ ends with `orders`. Today this means:
 
 This is a known limitation: dagster-rocky's RockyComponent surfaces
 source replication tables but not derived models. The contract wiring
-is correct for both cases — it just doesn't have many derived-model
+is correct for both cases; it just doesn't have many derived-model
 assets to attach to today.
 
 ## Defensive parsing
 
 `discover_contract_rules` is defensive against:
 
-- **Missing directory** — returns empty dict, no error.
-- **Empty contract files** — silently skipped (no specs declared).
-- **Malformed TOML** — raises `ContractParseError` with the offending
+- **Missing directory:** returns empty dict, no error.
+- **Empty contract files:** silently skipped (no specs declared).
+- **Malformed TOML:** raises `ContractParseError` with the offending
   file path in the message, so users can find and fix the file.
 
 This means you can pass `contracts_dir="contracts"` unconditionally

--- a/docs/src/content/docs/dagster/derived-models.md
+++ b/docs/src/content/docs/dagster/derived-models.md
@@ -7,8 +7,8 @@ sidebar:
 
 `dagster-rocky` historically only surfaced source-replication tables
 (one `AssetSpec` per discovered Fivetran/connector table). Derived models
-— the `*.sql` / `*.rocky` files Rocky compiles from your `models/`
-directory — were invisible to the asset graph. The
+(the `*.sql` / `*.rocky` files Rocky compiles from your `models/`
+directory) were invisible to the asset graph. The
 **`surface_derived_models`** flag on `RockyComponent` closes that gap:
 every entry in `compile.models_detail` becomes its own Dagster asset,
 grouped by partitioning shape so each multi-asset has a single
@@ -33,10 +33,10 @@ defs = dg.Definitions(
 
 When loaded, the code location now exposes:
 
-- **Source-replication assets** (one per discovered table) — the
+- **Source-replication assets** (one per discovered table): the
   existing behavior.
-- **Derived-model assets** (one per compiled model in `models_detail`)
-  — new in 0.4.
+- **Derived-model assets** (one per compiled model in `models_detail`),
+  new in 0.4.
 
 Each derived-model asset gets:
 
@@ -46,18 +46,18 @@ Each derived-model asset gets:
   `get_model_group_name`). Models in the same target schema share a
   group, which usually corresponds to a logical layer (`raw` /
   `staging` / `marts`).
-- **Tags** — `rocky/strategy`, `rocky/target_catalog`,
+- **Tags:** `rocky/strategy`, `rocky/target_catalog`,
   `rocky/target_schema`, `rocky/model_name`.
-- **Kinds** — `{"rocky", "model"}` for UI badges.
-- **Freshness policy** — from `model.freshness` (`[freshness]
+- **Kinds:** `{"rocky", "model"}` for UI badges.
+- **Freshness policy:** from `model.freshness` (`[freshness]
   max_lag_seconds` in the model's TOML frontmatter).
-- **Partitions definition** — from the model's `time_interval` strategy
+- **Partitions definition:** from the model's `time_interval` strategy
   via `partitions_def_for_model_detail`. `None` for `full_refresh` /
   `incremental` / `merge`.
-- **Optimize metadata** — when `surface_optimize_metadata=True`, the
+- **Optimize metadata:** when `surface_optimize_metadata=True`, the
   `rocky optimize` recommendations for matching models are merged into
   `AssetSpec.metadata`.
-- **Inter-model deps** — `model.depends_on` entries are resolved to
+- **Inter-model deps:** `model.depends_on` entries are resolved to
   `AssetKey` references against the other models, so cross-model
   lineage arrows render in the asset graph.
 
@@ -79,11 +79,11 @@ models/
 After loading, the code location has **three** derived-model
 multi-assets:
 
-- `rocky_models_daily` — contains `fct_daily_orders`, with a
+- `rocky_models_daily`: contains `fct_daily_orders`, with a
   `DailyPartitionsDefinition`.
-- `rocky_models_hourly` — contains `fct_hourly_metrics`, with an
+- `rocky_models_hourly`: contains `fct_hourly_metrics`, with an
   `HourlyPartitionsDefinition`.
-- `rocky_models_unpartitioned` — contains `dim_customers` and
+- `rocky_models_unpartitioned`: contains `dim_customers` and
   `dim_products`, no partition definition.
 
 Each multi-asset's name is derived from the partition shape so they
@@ -118,7 +118,7 @@ With `dag_mode=True` on `RockyComponent`, derived-model multi-assets use
 the DAG, and each model runs independently.
 
 This is the recommended approach for new projects. See
-[RockyComponent — DAG mode](/dagster/component/#dag-mode) for setup.
+[RockyComponent DAG mode](/dagster/component/#dag-mode) for setup.
 
 ## Legacy: `surface_derived_models` with `can_subset=False`
 

--- a/docs/src/content/docs/dagster/freshness.md
+++ b/docs/src/content/docs/dagster/freshness.md
@@ -129,13 +129,13 @@ policies = per_model_freshness_policies(compile_result)
 
 `dagster-rocky` uses Dagster 1.12+'s
 [`FreshnessPolicy.time_window(fail_window=...)`](https://docs.dagster.io/api/dagster/assets#dagster.FreshnessPolicy.time_window)
-constructor — **not** the legacy `FreshnessPolicy(maximum_lag_minutes=...)`
+constructor, **not** the legacy `FreshnessPolicy(maximum_lag_minutes=...)`
 which is deprecated.
 
 This means:
 
 - Comparisons in tests need
-  `policy.fail_window.to_timedelta().total_seconds()` — Dagster wraps the
+  `policy.fail_window.to_timedelta().total_seconds()`; Dagster wraps the
   `timedelta` in a `SerializableTimeDelta` that doesn't compare-equal to a
   plain `timedelta`.
 - The check shows up under "Freshness" in the asset detail page with the

--- a/docs/src/content/docs/dagster/health.md
+++ b/docs/src/content/docs/dagster/health.md
@@ -5,7 +5,7 @@ sidebar:
   order: 15
 ---
 
-`dagster-rocky` ships `rocky_healthcheck()` — a wrapper around
+`dagster-rocky` ships `rocky_healthcheck()`, a wrapper around
 `rocky doctor` suitable for Dagster+ code-location startup probes, custom
 asset checks, and custom ops.
 
@@ -84,7 +84,7 @@ location as unhealthy and routes traffic away from it.
 ## Why a wrapper, not a method on `RockyResource`?
 
 `rocky_healthcheck` lives outside `RockyResource` because the resource is a
-frozen Pydantic model — extending it with new methods on every iteration
+frozen Pydantic model; extending it with new methods on every iteration
 churns the resource module. The standalone wrapper pattern keeps health
 probes decoupled from the core resource shape and can be promoted to a
 method later if it stabilizes.

--- a/docs/src/content/docs/dagster/introduction.md
+++ b/docs/src/content/docs/dagster/introduction.md
@@ -5,13 +5,13 @@ sidebar:
   order: 1
 ---
 
-`dagster-rocky` bridges Rocky's Rust binary with Dagster orchestration. Rocky is the **trust plane** — typed compiler, compile-time contracts, column-level lineage, schema drift detection, branches + replay, per-model cost. Dagster is the orchestrator — scheduling, retries, alerts, the asset-centric UI. The guarantees Rocky enforces at compile time surface as native Dagster events (asset checks, materializations, metadata) so the asset graph reflects the same trust contract.
+`dagster-rocky` bridges Rocky's Rust binary with Dagster orchestration. Rocky is the **trust plane**: typed compiler, compile-time contracts, column-level lineage, schema drift detection, branches + replay, per-model cost. Dagster is the orchestrator: scheduling, retries, alerts, the asset-centric UI. The guarantees Rocky enforces at compile time surface as native Dagster events (asset checks, materializations, metadata) so the asset graph reflects the same trust contract.
 
 ## Quick start
 
-Two ways to wire Rocky into Dagster. Start with the component — it auto-discovers your tables.
+Two ways to wire Rocky into Dagster. Start with the component; it auto-discovers your tables.
 
-**Option A — component** (`defs.yaml`):
+**Option A: component** (`defs.yaml`):
 
 ```yaml
 type: dagster_rocky.RockyComponent
@@ -21,7 +21,7 @@ attributes:
   models_dir: models
 ```
 
-**Option B — resource + asset**:
+**Option B: resource + asset**:
 
 ```python
 import dagster as dg
@@ -71,12 +71,12 @@ Rocky handles the SQL transformation layer: DAG resolution, incremental logic, S
 
 `RockyResource` exposes one Python method per Rocky CLI command. The full set includes:
 
-- **Core Pipeline** — `discover`, `plan`, `run`, `run_model`, `run_streaming`, `run_pipes`, `state`, `resume_run`
-- **DAG** — `dag` (full unified DAG with enriched metadata)
-- **Modeling** — `compile`, `lineage`, `test`, `ci`
-- **AI** — `ai`, `ai_sync`, `ai_explain`, `ai_test`
-- **Observability** — `history`, `metrics`, `optimize`
-- **Diagnostics** — `doctor`, `validate_migration`, `test_adapter`
-- **Hooks** — `hooks_list`, `hooks_test`
+- **Core Pipeline:** `discover`, `plan`, `run`, `run_model`, `run_streaming`, `run_pipes`, `state`, `resume_run`
+- **DAG:** `dag` (full unified DAG with enriched metadata)
+- **Modeling:** `compile`, `lineage`, `test`, `ci`
+- **AI:** `ai`, `ai_sync`, `ai_explain`, `ai_test`
+- **Observability:** `history`, `metrics`, `optimize`
+- **Diagnostics:** `doctor`, `validate_migration`, `test_adapter`
+- **Hooks:** `hooks_list`, `hooks_test`
 
 See the [RockyResource](/dagster/resource/) page for full method signatures and details.

--- a/docs/src/content/docs/dagster/observability.md
+++ b/docs/src/content/docs/dagster/observability.md
@@ -1,5 +1,5 @@
 ---
-title: Observability — Drift, Anomalies, Optimize
+title: "Observability: Drift, Anomalies, Optimize"
 description: Surface Rocky's drift, anomaly, and optimization signals as native Dagster events
 sidebar:
   order: 12
@@ -13,7 +13,7 @@ warnings to first-class Dagster primitives:
 - **Optimization recommendations** → `AssetSpec.metadata` (load-time)
 - **Plan artifact trail** → `.rocky/plans/<plan-id>.json` per materialization
 
-Drift and anomaly emission is **automatic** when using `RockyComponent` —
+Drift and anomaly emission is **automatic** when using `RockyComponent`;
 nothing to wire up. Standalone helpers are also exported for users with
 hand-rolled multi_assets.
 
@@ -25,11 +25,11 @@ chains `rocky plan` + `rocky apply <plan-id>` under the hood (as of
 `.rocky/plans/<plan-id>.json` before the apply phase runs. That file is
 the audit record of *exactly what Rocky tried to apply*: the materialization
 list, governance plan, drift actions, and (for compact / archive plans)
-the typed IR that the apply path regenerates SQL from — see
+the typed IR that the apply path regenerates SQL from; see
 [Plan store v1 to v2 migration guide](/concepts/plan-store-v1-to-v2/).
 
 For `run_pipes`, the plan id is also attached as `extras={"plan_id":
-plan_id}` so Dagster surfaces it as run metadata in the run viewer — one
+plan_id}` so Dagster surfaces it as run metadata in the run viewer; one
 click from a failed materialization back to the plan that produced it.
 
 Replication-only projects (no `models/` directory) fall back to the
@@ -51,7 +51,7 @@ metadata describing the action taken:
 | `rocky/drift_tables_drifted` | int | Total tables that drifted this run |
 
 Why `AssetObservation` and not `AssetCheckResult`? Drift is a *change*, not a
-pass/fail — observation is the right primitive. It shows up on the asset
+pass/fail; observation is the right primitive. It shows up on the asset
 timeline as a discrete event without affecting check status.
 
 ## Anomalies as `AssetCheckResult` (severity WARN)
@@ -71,7 +71,7 @@ The check spec is **pre-declared** at load time, so the Dagster UI shows the
 anomalies, a placeholder check result is emitted automatically.
 
 Severity is `WARN` (not `ERROR`) because Rocky's anomaly detection is a
-heuristic — a row-count deviation may be legitimate business behavior.
+heuristic; a row-count deviation may be legitimate business behavior.
 Callers who want to treat anomalies as hard failures can post-process the
 check evaluation events.
 

--- a/docs/src/content/docs/dagster/partitions.md
+++ b/docs/src/content/docs/dagster/partitions.md
@@ -7,7 +7,7 @@ sidebar:
 
 Rocky's `time_interval` materialization strategy declares a model is
 partitioned by a time column with a fixed granularity (`hour`, `day`, `month`,
-or `year`). `dagster-rocky` ships `partitions.py` — a translation layer
+or `year`). `dagster-rocky` ships `partitions.py`, a translation layer
 that converts these strategies into Dagster's
 [`PartitionsDefinition`](https://docs.dagster.io/api/dagster/partitions#dagster.PartitionsDefinition)
 variants.
@@ -15,7 +15,7 @@ variants.
 These are **standalone helpers** today. The `RockyComponent`-side wiring
 (group splitting by partitioning shape, threading partition keys through
 `rocky plan --partition` + `rocky apply`) is a follow-up that depends on
-derived-model surfacing — currently the component emits source-replication
+derived-model surfacing; currently the component emits source-replication
 tables only, none of which use `time_interval`.
 
 ## Strategy mapping

--- a/docs/src/content/docs/dagster/pipes.md
+++ b/docs/src/content/docs/dagster/pipes.md
@@ -5,7 +5,7 @@ sidebar:
   order: 20
 ---
 
-`dagster-rocky` ships **`RockyResource.run_streaming()`** — a
+`dagster-rocky` ships **`RockyResource.run_streaming()`**, a
 Pipes-style alternative to `RockyResource.run()` that spawns the binary
 via `subprocess.Popen`, forwards rocky's stderr (where the engine's
 Rust `tracing` layer writes `info!()` / `warn!()` macros) to
@@ -44,7 +44,7 @@ When materialized, the Dagster run viewer shows lines like:
 [INFO] rocky: INFO run complete in 18000ms
 ```
 
-— each line forwarded as the engine emits it, not at the end.
+Each line is forwarded as the engine emits it, not at the end.
 
 ## API parity with `run()`
 
@@ -70,7 +70,7 @@ from a `@op`). All the partition selection flags from the
 ## Automatic wiring in `RockyComponent`
 
 When you use `RockyComponent`, the component already calls
-`run_streaming` by default — every multi-asset materialization gets
+`run_streaming` by default; every multi-asset materialization gets
 live log streaming for free. No configuration needed:
 
 ```python
@@ -97,7 +97,7 @@ viewer as the materialization runs.
 | Subprocess timeout | Kills the process, joins the reader thread, raises `dg.Failure` with the configured timeout in the message and the stderr tail |
 
 The `stderr_tail` metadata on failures captures the actual progress
-lines the engine emitted before crashing — much more useful for
+lines the engine emitted before crashing, much more useful for
 debugging than a bare exit code.
 
 ## How it works under the hood
@@ -143,7 +143,7 @@ debugging than a bare exit code.
 | Needs Dagster context | no | yes | yes |
 | Engine Pipes support required | no | no | yes (shipped in v0.4) |
 
-### `run()` — buffered (non-Dagster callers)
+### `run()`: buffered (non-Dagster callers)
 
 ```python
 result = rocky.run(filter="tenant=acme")
@@ -152,7 +152,7 @@ result = rocky.run(filter="tenant=acme")
 For scripts, tests, notebooks, or any code that just wants the typed
 result without a Dagster context. Buffered via `subprocess.run`.
 
-### `run_streaming()` — Pipes-style (live progress, batch result)
+### `run_streaming()`: Pipes-style (live progress, batch result)
 
 ```python
 @dg.asset
@@ -164,9 +164,9 @@ def my_asset(context, rocky: RockyResource):
 Spawns rocky via `subprocess.Popen`, forwards stderr line-by-line to
 `context.log.info` for live progress, parses the final stdout JSON into
 a `RunResult` after the subprocess exits. Doesn't depend on Pipes
-message emission — works against any rocky binary.
+message emission; works against any rocky binary.
 
-### `run_pipes()` — full Dagster Pipes (structured events)
+### `run_pipes()`: full Dagster Pipes (structured events)
 
 ```python
 @dg.asset
@@ -186,11 +186,11 @@ artifact that produced it.
 The rocky engine (v0.4+) detects the Pipes env vars and emits structured
 Pipes messages on the messages channel:
 
-* `report_asset_materialization` per copied table — appears as a
+* `report_asset_materialization` per copied table: appears as a
   `MaterializationEvent` in the run viewer with structured metadata
   (strategy, duration_ms, rows_copied, target_table_full_name,
   sql_hash, partition_key)
-* `report_asset_check` per Rocky check — appears as
+* `report_asset_check` per Rocky check: appears as
   `AssetCheckEvaluation` in the run viewer
 * `log` events for run start, completion, and drift actions
 
@@ -221,7 +221,7 @@ Dagster Pipes protocol module at
    - `report_asset_check` per `output.check_results` entry
    - `log` at WARN level per `output.drift.actions_taken` entry
    - `closed` at run end
-4. When env vars are not set, the entire path is a no-op — zero
+4. When env vars are not set, the entire path is a no-op; zero
    overhead for non-Dagster callers.
 
 The current engine emission is **batch at end of run** (events emit
@@ -233,7 +233,7 @@ wire-protocol or consumer changes.
 
 ## RockyComponent default
 
-`RockyComponent` users get `run_streaming` automatically — no decision
+`RockyComponent` users get `run_streaming` automatically; no decision
 needed. To get full Pipes integration with structured events, switch
 to a hand-rolled `@dg.asset` that calls `rocky.run_pipes()` directly.
 A future RockyComponent flag (`pipes_mode=True`) can flip the default

--- a/docs/src/content/docs/dagster/scaffold.md
+++ b/docs/src/content/docs/dagster/scaffold.md
@@ -7,10 +7,10 @@ sidebar:
 
 `dagster-rocky` ships two ways to bootstrap a new project:
 
-1. **`dg scaffold defs dagster_rocky.RockyComponent <name>`** — uses Dagster's
+1. **`dg scaffold defs dagster_rocky.RockyComponent <name>`**: uses Dagster's
    built-in scaffolder via the registered entry point. Writes a bare
    `defs.yaml`.
-2. **`init_rocky_project(target_dir)`** — Python helper that writes a complete
+2. **`init_rocky_project(target_dir)`**: Python helper that writes a complete
    skeleton with `defs.yaml`, `rocky.toml`, `models/`, and a `README.md`.
 
 ## `dg scaffold` (canonical)
@@ -59,7 +59,7 @@ Dagster assets immediately.
 
 ## Overwrite protection
 
-`init_rocky_project` refuses to overwrite existing files by default — pass
+`init_rocky_project` refuses to overwrite existing files by default; pass
 `overwrite=True` to force:
 
 ```python

--- a/docs/src/content/docs/dagster/schedules.md
+++ b/docs/src/content/docs/dagster/schedules.md
@@ -61,16 +61,16 @@ Every schedule built via `build_rocky_schedule` automatically adds a
 history view by Rocky-driven schedules.
 
 User-supplied tags merge on top of the namespace tag, so a user explicitly
-setting `rocky/schedule=<other>` wins. This is intentional — advanced users may
+setting `rocky/schedule=<other>` wins. This is intentional; advanced users may
 want different schedule-tag values for grouping.
 
 ## Pairing with sensors
 
 Schedules and sensors complement each other:
 
-- **Schedules** fire at fixed times regardless of upstream state — useful for
+- **Schedules** fire at fixed times regardless of upstream state, useful for
   reports that should run every morning.
-- **Sensors** fire when upstream state changes — useful for pipelines that
+- **Sensors** fire when upstream state changes, useful for pipelines that
   should kick off as soon as Fivetran completes a sync.
 
 Both can target the same asset selection. Dagster will deduplicate

--- a/docs/src/content/docs/dagster/sensors.md
+++ b/docs/src/content/docs/dagster/sensors.md
@@ -5,7 +5,7 @@ sidebar:
   order: 10
 ---
 
-`dagster-rocky` ships `rocky_source_sensor()` — a factory that builds a
+`dagster-rocky` ships `rocky_source_sensor()`, a factory that builds a
 Dagster [`SensorDefinition`](https://docs.dagster.io/api/dagster/sensors#dagster.SensorDefinition)
 that polls `rocky discover` and emits a `RunRequest` for any source whose
 upstream connector has produced new data since the previous tick.
@@ -49,15 +49,15 @@ The sensor:
 2. Compares each source's `last_sync_at` timestamp to a per-source cursor.
 3. Emits a `RunRequest` for any source whose latest sync is newer than the cursor.
 4. Advances the cursor for the sources it processed.
-5. Logs a warning naming any ids the engine reported in `failed_sources`, and **does not** advance their cursor — so the next tick re-evaluates them.
+5. Logs a warning naming any ids the engine reported in `failed_sources`, and **does not** advance their cursor, so the next tick re-evaluates them.
 
 ## Transient discover failures
 
-Source adapters can partially fail — a Fivetran 5xx or rate-limit window on a single connector, an Iceberg `list_tables` error on one namespace. From engine `1.17.4` onward, `rocky discover` surfaces these as `failed_sources` rather than silently dropping the connector from the output.
+Source adapters can partially fail: a Fivetran 5xx or rate-limit window on a single connector, an Iceberg `list_tables` error on one namespace. From engine `1.17.4` onward, `rocky discover` surfaces these as `failed_sources` rather than silently dropping the connector from the output.
 
 The sensor relies on this signal to avoid the asset-graph-shrinkage failure mode where a transient adapter error looks indistinguishable from "removed upstream" to a diff-based reconciler. By skipping cursor advance for failed ids, the sensor guarantees that a flapping connector keeps reappearing for evaluation until it either succeeds (cursor advances normally) or is genuinely removed upstream (drops out of both `sources` and `failed_sources`).
 
-Healthy sources in the same tick still produce `RunRequest`s — partial failure does not block the run.
+Healthy sources in the same tick still produce `RunRequest`s; partial failure does not block the run.
 
 Requires engine `≥ 1.17.4`. Older engines omit the field; the sensor treats absence as "no failures reported".
 
@@ -108,7 +108,7 @@ correctly.
 Every `RunRequest` is tagged with:
 
 - `rocky/source_id` (per_source) or `rocky/group` (per_group)
-- `rocky/sync_at` — the ISO timestamp that triggered the run
+- `rocky/sync_at`: the ISO timestamp that triggered the run
 
 These show up in the Dagster run history view so you can audit which Fivetran
 sync triggered which materialization.
@@ -117,8 +117,8 @@ sync triggered which materialization.
 
 `rocky_resource` accepts either form:
 
-- **String key** (default `"rocky"`) — Dagster resolves the resource from `context.resources` at evaluation time. Per-deployment overrides apply, mock substitution via `dg.build_sensor_context(resources={...})` works without wrapping, and the resource doesn't need to exist before the sensor is built.
-- **`RockyResource` instance** — the legacy form, closure-captured at sensor-build time. Still supported indefinitely so existing call sites don't break, but the keyed form is recommended for new code.
+- **String key** (default `"rocky"`): Dagster resolves the resource from `context.resources` at evaluation time. Per-deployment overrides apply, mock substitution via `dg.build_sensor_context(resources={...})` works without wrapping, and the resource doesn't need to exist before the sensor is built.
+- **`RockyResource` instance**: the legacy form, closure-captured at sensor-build time. Still supported indefinitely so existing call sites don't break, but the keyed form is recommended for new code.
 
 ```python
 # String-key form (recommended) — resolves "rocky" from context.resources
@@ -133,7 +133,7 @@ sensor = rocky_source_sensor(rocky_resource=rocky, target=...)
 
 ## Backlog cap
 
-Pass `backlog_cap=BacklogCap(...)` to suppress emits when too many in-flight Dagster runs already share a tag value. Useful when a hung downstream amplifies into a runaway queue — without back-pressure, a stuck run can pile up dozens of fresh `RunRequest`s tagged for the same client/tenant before anyone notices.
+Pass `backlog_cap=BacklogCap(...)` to suppress emits when too many in-flight Dagster runs already share a tag value. Useful when a hung downstream amplifies into a runaway queue; without back-pressure, a stuck run can pile up dozens of fresh `RunRequest`s tagged for the same client/tenant before anyone notices.
 
 ```python
 from dagster_rocky import BacklogCap, rocky_source_sensor
@@ -147,9 +147,9 @@ sensor = rocky_source_sensor(
 )
 ```
 
-Before each emit, the sensor counts in-flight runs matching `tag_key=<value>` in the non-terminal statuses (`QUEUED`, `NOT_STARTED`, `STARTING`, `STARTED` by default — override via `BacklogCap.statuses`). If the count is at or above `max_in_flight`, the `RunRequest` is suppressed.
+Before each emit, the sensor counts in-flight runs matching `tag_key=<value>` in the non-terminal statuses (`QUEUED`, `NOT_STARTED`, `STARTING`, `STARTED` by default; override via `BacklogCap.statuses`). If the count is at or above `max_in_flight`, the `RunRequest` is suppressed.
 
-**The cursor still advances on suppression** — the in-flight run picks up the latest data via Rocky's per-source state. Freezing the cursor would compound the failure: the next tick would re-detect the same sync, retry the same suppressed emit, and never recover until the queue drains below cap.
+**The cursor still advances on suppression**: the in-flight run picks up the latest data via Rocky's per-source state. Freezing the cursor would compound the failure: the next tick would re-detect the same sync, retry the same suppressed emit, and never recover until the queue drains below cap.
 
 `BacklogCap` is opt-in. Default behavior (no cap) is unchanged.
 
@@ -193,8 +193,8 @@ Hook contract:
 
 ## Defaults
 
-- `minimum_interval_seconds=300` — 5-minute polling
-- `default_status=DefaultSensorStatus.STOPPED` — sensor ships disabled, users opt in
+- `minimum_interval_seconds=300`: 5-minute polling
+- `default_status=DefaultSensorStatus.STOPPED`: sensor ships disabled, users opt in
   via the Dagster UI
 
 ## Custom translators

--- a/docs/src/content/docs/dagster/types.md
+++ b/docs/src/content/docs/dagster/types.md
@@ -8,7 +8,7 @@ sidebar:
 All data returned by `RockyResource` methods is parsed into Pydantic v2 models. These models provide type safety, validation, and IDE autocompletion.
 
 :::tip[Source of truth]
-Most types are generated from the engine's JSON schemas via `just codegen` — see [JSON Output](/reference/json-output/) for the pipeline. The hand-written aliases in `dagster_rocky.types` (documented below) re-export the generated classes with Python-flavored names. If a field is missing from this page, consult the generated module (`dagster_rocky.types_generated`) as the canonical definition.
+Most types are generated from the engine's JSON schemas via `just codegen`; see [JSON Output](/reference/json-output/) for the pipeline. The hand-written aliases in `dagster_rocky.types` (documented below) re-export the generated classes with Python-flavored names. If a field is missing from this page, consult the generated module (`dagster_rocky.types_generated`) as the canonical definition.
 :::
 
 ## Discover types


### PR DESCRIPTION
Fourth and final prose pass, covering the whole Dagster integration section. Prose only; no behavior or structural changes.

All 16 pages (`introduction`, `sensors`, `derived-models`, `pipes`, `contracts`, `branch-deployments`, `observability`, `component`, `automation`, `schedules`, `scaffold`, `freshness`, `partitions`, `health`, `types`, `checks`) now read as plain prose: em-dash-as-punctuation removed, `**Symbol** —` definition labels turned into colon labels, long sentences split. Em-dashes inside Python/TOML code-block comments are intentionally left intact, and the docs site builds clean.

This completes the site-wide prose sweep. The body of the docs now matches the writing bar set in the earlier passes.

## Still deferred (separate pass, your call)
- The `pipes.md` engine-internals block (`T2`, commit SHA `ef08cae`, the `pipes.rs` crate path) and other internal labels: the jargon scrub.
- The Tier 0 positioning items (homepage "trust plane" lead, `dbt` → `dbt Core` in comparison tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)