### PR TITLE
test(dagster): assert golden field values on generated fixtures, not just type

### DIFF
--- a/integrations/dagster/tests/test_generated_fixtures.py
+++ b/integrations/dagster/tests/test_generated_fixtures.py
@@ -24,6 +24,7 @@ same regen and fails on any uncommitted diff.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -113,8 +114,6 @@ def test_generated_fixture_parses(fixture_path: Path):
     level shape variants in ``test_types.py``; this test guards against the
     *engine* shipping JSON the parser doesn't recognize.
     """
-    import json
-
     payload = fixture_path.read_text(encoding="utf-8")
     data = json.loads(payload)
 
@@ -131,3 +130,141 @@ def test_generated_fixture_parses(fixture_path: Path):
         f"{fixture_path.name}: parse_rocky_output returned {type(parsed).__name__}, "
         f"expected {expected_type.__name__}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Golden field-value assertions
+# ---------------------------------------------------------------------------
+#
+# The parametrized ``test_generated_fixture_parses`` above proves every
+# captured fixture still parses into the expected Pydantic *type* — it guards
+# JSON *shape*. But because the corpus is regenerated *from* the binary, the
+# shape check can only ever match the binary against itself: it pins nothing
+# about whether the engine emits the *correct* drift / incremental / anomaly
+# *content* for a given scenario.
+#
+# The tests below close that gap on a handful of high-signal, live-captured
+# fixtures by asserting the deterministic content values the scenario is
+# supposed to produce. Each loads its fixture by an explicit path (a wrong
+# path raises ``FileNotFoundError`` and fails loudly, rather than silently
+# skipping the assertions). They assert only seeded / logical content — never
+# wall-clock or timing fields, which the regen normalizer zeroes or replaces
+# with a sentinel (see ``scripts/_normalize_fixture.py``), so timing asserts
+# would be brittle by construction.
+#
+# Coverage note: ``governance`` / ``compliance`` / ``retention-status`` /
+# failure-mode outputs have generated Pydantic models under ``types_generated/``
+# but no live capture under ``fixtures_generated/`` (the playground POCs don't
+# exercise them), so they remain shape-only — covered by the hand-crafted
+# ``scenarios.py`` dicts in ``test_types.py``, not by a golden value here.
+
+
+def _load(rel_path: str):
+    """Load a generated fixture by its path relative to ``fixtures_generated/``."""
+    payload = (GENERATED_DIR / rel_path).read_text(encoding="utf-8")
+    parsed = parse_rocky_output(payload)
+    assert parsed is not None, f"{rel_path}: parse_rocky_output returned None"
+    return parsed
+
+
+def test_drift_after_drift_golden():
+    """The drift scenario's *drifted* run must report the one detected change.
+
+    Pins that the engine still detects the seeded ``amount`` column widening
+    (``VARCHAR`` → ``DECIMAL(10,2)``) and emits a drop-and-recreate action —
+    a regression in drift detection would flip ``tables_drifted`` to 0 or lose
+    the column-change reason.
+    """
+    parsed = _load("drift/run_after_drift.json")
+
+    assert isinstance(parsed, RunResult)
+    assert parsed.drift.tables_checked == 1
+    assert parsed.drift.tables_drifted == 1
+
+    assert len(parsed.drift.actions_taken) == 1
+    action = parsed.drift.actions_taken[0]
+    assert action.action == "drop_and_recreate"
+    assert action.table == "poc.staging__orders.orders"
+    # ASCII substrings only — the live reason contains a non-ASCII "→" arrow
+    # (→) whose exact spacing is brittle to pin literally.
+    assert "amount" in action.reason
+    assert "VARCHAR" in action.reason
+    assert "DECIMAL(10,2)" in action.reason
+
+
+def test_drift_clean_golden():
+    """The drift scenario's *clean* run is the negative control: no drift.
+
+    Without this companion to ``run_after_drift``, a bug that reported drift
+    unconditionally would still pass the drifted-run assertions above.
+    """
+    parsed = _load("drift/run_clean.json")
+
+    assert isinstance(parsed, RunResult)
+    assert parsed.drift.tables_checked == 1
+    assert parsed.drift.tables_drifted == 0
+    assert parsed.drift.actions_taken == []
+
+
+def test_incremental_strategy_progression_golden():
+    """The two-run incremental scenario must switch full_refresh → incremental.
+
+    The watermark ``last_value`` is a temporal value the regen normalizer
+    replaces with the sentinel timestamp, so it can't anchor a golden assert
+    here (it reads identically across both runs and rows_copied is null for
+    DuckDB). The materialization ``strategy`` is the *deterministic* signal
+    that the second run actually took the incremental path: run 1 does a full
+    load, run 2 loads only the delta. Break incremental detection and run 2
+    reverts to ``full_refresh`` — caught here.
+    """
+    run1 = _load("incremental/run1_initial.json")
+    run2 = _load("incremental/run2_delta.json")
+
+    assert isinstance(run1, RunResult)
+    assert isinstance(run2, RunResult)
+    assert run1.materializations[0].metadata.strategy == "full_refresh"
+    assert run2.materializations[0].metadata.strategy == "incremental"
+
+
+def test_anomaly_baseline_golden():
+    """A baseline run sees the full table and flags no anomaly."""
+    parsed = _load("anomaly/run_baseline_1.json")
+
+    assert isinstance(parsed, RunResult)
+    assert parsed.anomalies == []
+    assert parsed.metrics is not None
+    assert parsed.metrics.anomalies_detected == 0
+
+    # The row_count check sees the full seeded table on both sides.
+    check = parsed.check_results[0].checks[0]
+    assert check.name == "row_count"
+    assert check.passed is True
+    assert check.source_count == 500
+    assert check.target_count == 500
+
+
+def test_anomaly_incident_golden():
+    """The incident run must detect the seeded row-count collapse.
+
+    The events table drops from a ~376-row historical baseline to 5 rows; the
+    engine must surface exactly one anomaly with the collapsed current count.
+    A regression in baseline comparison would drop the anomaly entirely.
+    """
+    parsed = _load("anomaly/run_incident.json")
+
+    assert isinstance(parsed, RunResult)
+    assert parsed.metrics is not None
+    assert parsed.metrics.anomalies_detected == 1
+
+    assert len(parsed.anomalies) == 1
+    anomaly = parsed.anomalies[0]
+    assert anomaly.table == "poc.staging__events.events"
+    assert anomaly.current_count == 5
+    assert "row count dropped" in anomaly.reason
+
+    # The row_count check itself still passes (source == target == 5); the
+    # anomaly is a *historical* signal, distinct from the source/target match.
+    check = parsed.check_results[0].checks[0]
+    assert check.name == "row_count"
+    assert check.source_count == 5
+    assert check.target_count == 5


### PR DESCRIPTION
## What

The generated-fixture suite (`tests/test_generated_fixtures.py`) previously did `parse_rocky_output(json)` then `assert isinstance(parsed, expected_type)` for every fixture — it pinned the Pydantic **type** (JSON shape) but never a field **value**. Since the corpus is regenerated *from* the binary, that shape check can only ever match the binary against itself: it catches a backwards-incompatible JSON shape change (genuinely useful, kept) but pins nothing about whether the engine emits correct drift / incremental / anomaly **content**.

This PR adds targeted **golden field-value** assertions on five high-signal, live-captured fixtures. The existing `isinstance`/shape coverage is unchanged — the golden tests are purely additive.

## Golden assertions added

| Fixture | Pins |
|---|---|
| `drift/run_after_drift.json` | `tables_drifted == 1`; the one action is `drop_and_recreate` on the orders table; reason names the seeded `amount` column widening (`VARCHAR` → `DECIMAL(10,2)`) |
| `drift/run_clean.json` | Negative control: `tables_drifted == 0`, no actions — so a bug that reported drift unconditionally can't pass the drifted-run asserts |
| `incremental/run1_initial.json` + `run2_delta.json` | Materialization strategy switches `full_refresh` → `incremental` across the two-run scenario (the deterministic signal the delta run took the incremental path) |
| `anomaly/run_baseline_1.json` | No anomaly; `anomalies_detected == 0`; row_count check 500/500 |
| `anomaly/run_incident.json` | One anomaly; `current_count == 5`; row-count-drop reason; `anomalies_detected == 1` |

## Why these fields

- Asserts only **deterministic** seeded / logical content. Wall-clock and timing fields are deliberately avoided — the regen normalizer zeroes/sentinels them, so timing asserts would be brittle by construction. (The incremental watermark `last_value` is normalized to the sentinel and reads identically across both runs, and `rows_copied` is null on DuckDB — so the materialization `strategy` is the right deterministic anchor for the two-run scenario.)
- Each golden test loads its fixture by an **explicit path**, so a mistyped path raises `FileNotFoundError` and fails loudly rather than silently skipping the assertions.
- Verified every assertion actually fires via a one-shot mutation check (flip each expected value → confirm RED → revert).

A coverage note in the file records that governance / compliance / retention-status / failure-mode outputs have generated Pydantic models but no live capture, so they remain shape-only (covered by the hand-crafted scenario dicts in `test_types.py`).

## Verification

- `ruff format --check src/ tests/` — pass
- `ruff check src/ tests/` — pass
- `pytest` — 572 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)