### PR TITLE
docs: add Examples & POC catalog page, surface the full corpus

### DIFF
--- a/docs/src/content/docs/getting-started/examples.mdx
+++ b/docs/src/content/docs/getting-started/examples.mdx
@@ -1,0 +1,78 @@
+---
+title: Examples & POC catalog
+description: A catalog of small, runnable POCs, each demonstrating one Rocky capability end-to-end.
+sidebar:
+  order: 5
+---
+
+import pocCounts from "../../../data/poc-counts.json";
+
+The playground ships **{pocCounts.total} self-contained POCs** across {pocCounts.categoryCount} categories. Each is a small project with its own `rocky.toml`, `models/`, and a single `run.sh` that takes it end-to-end. Most run on local DuckDB with no credentials, so you can read the code and run it in one step.
+
+These complement the [Quickstart](/getting-started/quickstart/) and [Playground](/guides/playground/) walkthroughs: those teach the workflow, and the POCs show one capability each, in isolation.
+
+## Run one
+
+```bash
+git clone https://github.com/rocky-data/rocky.git
+cd rocky/examples/playground
+
+# Run any POC end-to-end (DuckDB, no credentials)
+./pocs/02-performance/01-incremental-watermark/run.sh
+```
+
+## Start with these
+
+The demos from the [README](https://github.com/rocky-data/rocky#readme), each a single `run.sh`:
+
+| What it shows | POC |
+|---|---|
+| Schema drift detected and recovered on the next run | [`02-performance/06-schema-drift-recover`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/02-performance/06-schema-drift-recover) |
+| Data contracts enforced at compile time (`E010` / `E013`) | [`01-quality/01-data-contracts-strict`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/01-quality/01-data-contracts-strict) |
+| Named branches, deterministic replay, and column lineage | [`00-foundations/06-branches-replay-lineage`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/00-foundations/06-branches-replay-lineage) |
+| Column-level lineage on a branching DAG | [`06-developer-experience/01-lineage-column-level`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/01-lineage-column-level) |
+| AI model generation with the compile-verify loop | [`03-ai/01-model-generation`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/03-ai/01-model-generation) |
+| PR-time blast radius with `rocky lineage-diff` | [`06-developer-experience/11-lineage-diff`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/11-lineage-diff) |
+| Classify columns, mask by environment, gate CI | [`04-governance/05-classification-masking-compliance`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/04-governance/05-classification-masking-compliance) |
+| Incremental loads with persistent watermark state | [`02-performance/01-incremental-watermark`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/02-performance/01-incremental-watermark) |
+| One run, three views: `trace` + `cost` + `replay` | [`06-developer-experience/17-trace-replay-cost-combo`](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience/17-trace-replay-cost-combo) |
+
+## Browse by category
+
+Each link opens the category folder on GitHub, where every POC has a README that states what it shows, the exact command, and the expected output.
+
+### [Foundations](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/00-foundations) ({pocCounts.perCategory["00-foundations"]} POCs)
+
+DSL syntax, materialization basics, branches and replay, file ingest, per-tenant routing, and the plan/apply deployment workflow. Credential-free (DuckDB).
+
+### [Quality](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/01-quality) ({pocCounts.perCategory["01-quality"]} POCs)
+
+Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, the standalone quality pipeline, and freshness SLAs. Credential-free (DuckDB).
+
+### [Performance](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/02-performance) ({pocCounts.perCategory["02-performance"]} POCs)
+
+Incremental, merge, partition checksums, drift recovery, ephemeral CTEs, delete+insert, adaptive concurrency, cost and budgets, and `EXPLAIN`-based estimation. Credential-free (DuckDB).
+
+### [AI](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/03-ai) ({pocCounts.perCategory["03-ai"]} POCs)
+
+Model generation, intent extraction, schema-change sync, test generation, schema-grounded validation, and MCP data-grounding. Most need an `ANTHROPIC_API_KEY`.
+
+### [Governance](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/04-governance) ({pocCounts.perCategory["04-governance"]} POCs)
+
+Unity Catalog grants, schema patterns, workspace isolation, tagging, classification and masking, retention, and cross-team contracts. Some need a Databricks workspace; classification/masking and retention run on DuckDB.
+
+### [Orchestration](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/05-orchestration) ({pocCounts.perCategory["05-orchestration"]} POCs)
+
+Shell hooks, webhook presets, remote state, checkpoint/resume, the Valkey cache, Dagster DAG mode, the circuit breaker, and idempotency keys. DuckDB, with a few using Docker.
+
+### [Developer Experience](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/06-developer-experience) ({pocCounts.perCategory["06-developer-experience"]} POCs)
+
+Column lineage, the HTTP API, dbt import, shadow mode, CI, trace Gantt views, portability lint, PR preview and data diff, and `lineage-diff`. Credential-free (DuckDB).
+
+### [Adapters](https://github.com/rocky-data/rocky/tree/main/examples/playground/pocs/07-adapters) ({pocCounts.perCategory["07-adapters"]} POCs)
+
+Snowflake dynamic tables, Databricks materialized views, Fivetran discovery, a custom process adapter, BigQuery, a Rust-native adapter skeleton, and Trino via Docker. Most need the matching warehouse; the process-adapter and Rust-skeleton POCs are credential-free.
+
+## The full catalog
+
+The complete, always-current list with a one-line description per POC lives in [`examples/playground/README.md`](https://github.com/rocky-data/rocky/tree/main/examples/playground#readme). It also documents the [benchmark suite](https://github.com/rocky-data/rocky/tree/main/examples/playground/benchmarks) comparing Rocky against dbt Core, dbt Fusion, and PySpark.

--- a/docs/src/content/docs/guides/playground.mdx
+++ b/docs/src/content/docs/guides/playground.mdx
@@ -367,117 +367,14 @@ Exit code 0 means all checks passed. A non-zero exit code fails the CI job.
 
 ## 8. Explore the POC Catalog
 
-The playground includes a curated catalog of {pocCounts.total} POCs across {pocCounts.categoryCount} categories that showcase Rocky's distinctive capabilities. Each POC is self-contained with its own `rocky.toml`, `models/`, and `run.sh`. Most run on local DuckDB with zero credentials.
-
-### Foundations ({pocCounts.perCategory["00-foundations"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `00-playground-default` | Stock 3-model scaffold -- baseline smoke test |
-| `01-dsl-pipeline-syntax` | Every Rocky DSL operator in one file |
-| `02-null-safe-operators` | `!=` lowering to `IS DISTINCT FROM` |
-| `03-date-literals-and-match` | `@2025-01-01` date literals and `match { ... }` pattern matching |
-| `04-window-functions` | DSL window syntax with partition + sort + frame |
-| `05-generic-adapter-exercise` | Full generic-adapter trait surface against DuckDB |
-| `06-branches-replay-lineage` | Trust arc 1: branches + replay + column lineage end-to-end |
-| `07-config-layering` | Three-layer config (`rocky.toml` + `_defaults.toml` + sidecar) with `${VAR}` substitution at every layer |
-
-### Quality ({pocCounts.perCategory["01-quality"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `01-data-contracts-strict` | Every contract rule + deliberately broken diagnostics |
-| `02-inline-checks` | Built-in checks (row_count, column_match, freshness, null_rate) |
-| `03-anomaly-detection` | `rocky history` + `rocky metrics --alerts` driven by row count anomalies |
-| `04-local-test-with-duckdb` | `rocky test` with passing and failing assertions |
-| `05-snapshot-scd2` | Snapshot pipeline with SCD Type 2 history |
-| `06-quality-pipeline-standalone` | Standalone `pipeline.type = "quality"` (checks-only run) |
-
-### Performance ({pocCounts.perCategory["02-performance"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `01-incremental-watermark` | Full load on run #1, watermark-filtered INSERT on run #2 |
-| `02-merge-upsert` | Merge with `unique_key` + `update_columns` for SCD-1 |
-| `03-partition-checksum` | Partition checksum incremental catching late-arriving corrections |
-| `04-column-propagation` | Column-level lineage pruning -- skip unchanged downstream models |
-| `05-optimize-recommendations` | `rocky optimize` + `profile-storage` + `compact --dry-run` |
-| `06-schema-drift-recover` | Drift detection, auto-widening, DROP+RECREATE |
-| `07-ephemeral-cte` | `strategy = "ephemeral"` CTE inlining |
-| `08-delete-insert-partitioned` | Partitioned `delete+insert` strategy |
-| `09-adaptive-concurrency` | AIMD dynamic parallelism via the throttle module |
-| `10-cost-budgets` | Trust arc 2: per-run cost summary + `[budget]` breach |
-
-### AI ({pocCounts.perCategory["03-ai"]} POCs, `ANTHROPIC_API_KEY` required)
-
-| POC | Feature |
-|---|---|
-| `01-model-generation` | `rocky ai "intent..."` with compile-verify retry loop |
-| `02-ai-explain-bootstrap` | `rocky ai-explain --all --save` reverse-engineers intent |
-| `03-ai-sync-schema-evolution` | `rocky ai-sync` proposes downstream updates |
-| `04-ai-test-generation` | `rocky ai-test --all --save` generates SQL assertions |
-| `05-schema-grounded-validation` | Trust arc 5: AI output is compiler-gated against the schema |
-
-### Governance ({pocCounts.perCategory["04-governance"]} POCs, Databricks required)
-
-| POC | Feature |
-|---|---|
-| `01-unity-catalog-grants` | Declarative RBAC with SHOW GRANTS before/after |
-| `02-schema-patterns-multi-tenant` | Schema patterns with variadic `regions...` routing |
-| `03-workspace-isolation` | Workspace bindings + ISOLATED catalog mode |
-| `04-tagging-lifecycle` | Tags propagated via `ALTER ... SET TAGS` |
-| `05-classification-masking-compliance` | `[classification]` + `[mask]` + `rocky compliance` |
-| `06-retention-policies` | Declarative `retention = "<N>[dy]"` + `rocky retention-status --drift` |
-
-### Orchestration ({pocCounts.perCategory["05-orchestration"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `01-shell-hooks` | Lifecycle hooks with stdin-JSON context |
-| `02-webhook-slack-preset` | Webhook presets (Slack, PagerDuty, Datadog, Teams) |
-| `03-remote-state-s3` | S3 state backend via MinIO docker-compose |
-| `04-checkpoint-resume` | `rocky run --resume-latest` (or `rocky plan` + `rocky apply`) after a mid-pipeline failure |
-| `05-webhook-presets-multi` | Multiple webhook presets composed on the same run |
-| `06-valkey-distributed-cache` | Distributed cache + tiered state via Valkey/Redis |
-| `07-dagster-dag-mode` | Full asset-graph rendering from Rocky's unified DAG |
-| `08-circuit-breaker` | Trust arc 3: retry policy + three-state circuit breaker |
-| `09-idempotency-key` | `rocky run --idempotency-key` dedup + skip semantics (also available via `rocky plan` + `rocky apply`) |
-
-### Developer Experience ({pocCounts.perCategory["06-developer-experience"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `01-lineage-column-level` | Column-level lineage on a 4-model branching DAG |
-| `02-rocky-serve-api` | `rocky serve --watch` HTTP API with curl examples |
-| `03-import-dbt-validate` | `rocky import-dbt` + `rocky validate-migration` |
-| `04-shadow-mode-compare` | `rocky compare` shadow vs production |
-| `05-doctor-and-ci` | `rocky doctor` + `rocky ci --output json` |
-| `06-hybrid-dbt-packages` | Rocky alongside dbt packages in the same repo |
-| `07-run-trace-gantt` | Trust arc 4: render a run as a Gantt timeline (`rocky trace`) |
-| `08-portability-lint` | Trust arc 6: compile-time portability gate via `[portability]` |
-| `09-sql-types-blast-radius` | Trust arc 7: SQL as first-class with typed blast-radius |
-| `10-pr-preview-and-data-diff` | `rocky preview create / diff / cost` end-to-end PR bundle |
-| `11-lineage-diff` | `rocky lineage-diff <base_ref>` — per-changed-column downstream blast-radius for PR review |
-
-### Adapters ({pocCounts.perCategory["07-adapters"]} POCs)
-
-| POC | Feature |
-|---|---|
-| `01-snowflake-dynamic-table` | Dynamic tables with `target_lag` |
-| `02-databricks-materialized-view` | Materialized views on Databricks |
-| `03-fivetran-discover` | `rocky discover` against Fivetran REST API |
-| `04-custom-process-adapter` | Python adapter via JSON-RPC over stdio |
-| `05-bigquery-native-queries` | BigQuery adapter end-to-end with native query patterns |
-| `06-rust-native-adapter-skeleton` | Rust-native out-of-tree adapter via the `rocky-adapter-sdk` |
-
-### Running a POC
+Beyond this walkthrough, the playground ships {pocCounts.total} self-contained POCs across {pocCounts.categoryCount} categories, each demonstrating one Rocky capability end-to-end. Browse them, grouped by category with links to every one, in the [Examples & POC catalog](/getting-started/examples/). Or run one directly:
 
 ```bash
 cd examples/playground
 ./pocs/02-performance/01-incremental-watermark/run.sh
 ```
 
-Most POCs run with no external credentials. The exceptions: AI (`ANTHROPIC_API_KEY`), Governance (Databricks workspace), and the warehouse-specific adapter POCs (Snowflake / Databricks / Fivetran / BigQuery).
+Most run on local DuckDB with no credentials. The exceptions: AI (`ANTHROPIC_API_KEY`), Governance (a Databricks workspace), and the warehouse-specific adapter POCs.
 
 ## 9. Benchmarks
 


### PR DESCRIPTION
Net-new page. Closes the audit's #1 content gap: the docs surfaced only ~15 of the playground's POCs and never linked the catalog itself, so most of the runnable corpus was unreachable from the docs site.

## New page: `getting-started/examples.mdx`
A navigable catalog of the playground POCs:
- **Start with these** — the README's marquee demos (drift, contracts, branches/replay, lineage, AI loop, lineage-diff, masking, incremental, trace+cost+replay), each linking its `run.sh` folder.
- **Browse by category** — all 8 categories, each linking its folder on GitHub so every POC is one click away, with the per-category count.
- A link to the canonical full catalog (`examples/playground/README.md`) and the benchmark suite.

Counts come from the generated `poc-counts.json` (the same source `architecture.mdx` and `playground.mdx` use), so they stay accurate and don't drift.

## Trim: `guides/playground.mdx` §8
Replaced the stale, partial, unlinked POC list (it showed ~8 of 14 Foundations POCs, ~11 of 19 Dev-Experience, with plain-text names that didn't link anywhere) with a short pointer to the new catalog page.

Build is clean (83 pages); the new route renders with the live count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)