### PR TITLE
perf(vscode): cache catalog/compile output and debounce high-frequency CLI spawns

### DIFF
--- a/editors/vscode/src/__tests__/rockyCli.test.ts
+++ b/editors/vscode/src/__tests__/rockyCli.test.ts
@@ -35,8 +35,10 @@ import {
   RockyCliError,
   clearCliVersionCache,
   getCliVersion,
+  invalidateRockyCache,
   runRocky,
   runRockyJson,
+  runRockyJsonCached,
 } from "../rockyCli";
 
 type ExecCallback = (
@@ -441,5 +443,81 @@ describe("runRocky (unbounded subcommands → spawn)", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runRockyJsonCached — catalog/compile result cache + in-flight coalescing.
+// `compile` is a bounded subcommand, so it routes through execFileMock.
+// ---------------------------------------------------------------------------
+
+describe("runRockyJsonCached", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    invalidateRockyCache();
+  });
+
+  it("returns the cached result on the second call without re-spawning", async () => {
+    mockSuccess('{"models_detail":[]}');
+    const first = await runRockyJsonCached(["compile", "--output", "json"]);
+    const second = await runRockyJsonCached(["compile", "--output", "json"]);
+
+    expect(first).toEqual({ models_detail: [] });
+    expect(second).toEqual({ models_detail: [] });
+    // Only the first call shelled out; the second was served from the cache.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces two concurrent identical calls into one spawn", async () => {
+    mockSuccess('{"ok":true}');
+    const [a, b] = await Promise.all([
+      runRockyJsonCached(["compile", "--output", "json"]),
+      runRockyJsonCached(["compile", "--output", "json"]),
+    ]);
+    expect(a).toEqual({ ok: true });
+    expect(b).toEqual({ ok: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys on the full argument vector — compile and compile --model differ", async () => {
+    mockSuccess('{"scope":"all"}');
+    mockSuccess('{"scope":"model"}');
+    const all = await runRockyJsonCached(["compile", "--output", "json"]);
+    const one = await runRockyJsonCached([
+      "compile",
+      "--model",
+      "orders",
+      "--output",
+      "json",
+    ]);
+    expect(all).toEqual({ scope: "all" });
+    expect(one).toEqual({ scope: "model" });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-spawns after invalidateRockyCache()", async () => {
+    mockSuccess('{"gen":1}');
+    expect(await runRockyJsonCached(["compile", "--output", "json"])).toEqual({
+      gen: 1,
+    });
+    invalidateRockyCache();
+    mockSuccess('{"gen":2}');
+    expect(await runRockyJsonCached(["compile", "--output", "json"])).toEqual({
+      gen: 2,
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a rejection — a later call re-spawns and can succeed", async () => {
+    mockFailure("boom", "compile failed", 1);
+    await expect(
+      runRockyJsonCached(["compile", "--output", "json"]),
+    ).rejects.toBeInstanceOf(RockyCliError);
+
+    mockSuccess('{"recovered":true}');
+    expect(await runRockyJsonCached(["compile", "--output", "json"])).toEqual({
+      recovered: true,
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/editors/vscode/src/commands/inspector.ts
+++ b/editors/vscode/src/commands/inspector.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import { RockyCliError, runRockyJson } from "../rockyCli";
+import { resolveProjectRoot } from "../config";
+import { RockyCliError, runRockyJson, runRockyJsonCached } from "../rockyCli";
 import type { CatalogOutput } from "../types/generated/catalog";
 import type { CompileOutput } from "../types/generated/compile";
 import type { PreviewRowsOutput } from "../types/generated/preview_rows";
@@ -118,9 +119,14 @@ export async function showLineage(arg?: unknown): Promise<void> {
 
 /** Fan-in `rocky catalog` + `rocky compile` into one model-scoped summary. */
 async function loadModelData(model: string): Promise<InspectorModelData> {
+  // Pass an explicit project root so this shares a cache key with buildGraph()
+  // (which keys on resolveProjectRoot()). Both then dedup to one catalog + one
+  // compile spawn on Inspector open, and every node-click is a cache hit rather
+  // than another project-wide pair of spawns just to .find() one model.
+  const cwd = resolveProjectRoot();
   const [catalog, compile] = await Promise.all([
-    runRockyJson<CatalogOutput>(["catalog", "--output", "json"]),
-    runRockyJson<CompileOutput>(["compile", "--output", "json"]),
+    runRockyJsonCached<CatalogOutput>(["catalog", "--output", "json"], { cwd }),
+    runRockyJsonCached<CompileOutput>(["compile", "--output", "json"], { cwd }),
   ]);
   const asset = catalog.assets.find((a) => a.model_name === model);
   if (!asset) {

--- a/editors/vscode/src/commands/lineage.ts
+++ b/editors/vscode/src/commands/lineage.ts
@@ -3,6 +3,7 @@ import { resolveProjectRoot } from "../config";
 import {
   RockyCliError,
   runRockyJson,
+  runRockyJsonCached,
   runRockyJsonWithProgress,
   showRockyError,
 } from "../rockyCli";
@@ -38,11 +39,14 @@ import { runAiExplain, runAiGenerate, runAiTest } from "./ai";
  */
 export async function buildGraph(): Promise<GraphData> {
   const cwd = resolveProjectRoot();
+  // catalog + compile are idempotent between edits, so route them through the
+  // shared cache: the Inspector's `graph` and `model` requests fire together on
+  // open, and this coalesces them into one spawn each (see runRockyJsonCached).
   const [catalog, compile] = await Promise.all([
-    runRockyJson<CatalogOutput>(["catalog", "--output", "json"], { cwd }),
-    runRockyJson<CompileOutput>(["compile", "--output", "json"], { cwd }).catch(
-      () => null,
-    ),
+    runRockyJsonCached<CatalogOutput>(["catalog", "--output", "json"], { cwd }),
+    runRockyJsonCached<CompileOutput>(["compile", "--output", "json"], {
+      cwd,
+    }).catch(() => null),
   ]);
 
   const details = new Map<string, ModelDetail>();

--- a/editors/vscode/src/driftDiagnostics.ts
+++ b/editors/vscode/src/driftDiagnostics.ts
@@ -237,11 +237,18 @@ export function registerDriftDiagnostics(
     );
   }
 
-  // Refresh on file open.
+  // Refresh on file open. The compile spawn (model files) is debounced through
+  // the same per-URI 500ms timer as save, so opening a burst of model files —
+  // or VS Code re-opening a session's tabs on startup — doesn't fire a
+  // `rocky compile --model` per file at once. Non-model files spawn nothing, so
+  // they clear any stale diagnostics eagerly (no point debouncing a cheap delete).
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
-      if (!shouldRunCli()) return;
-      void refreshDiagnostics(document, collection);
+      if (!modelNameFromFile(document.fileName)) {
+        collection.delete(document.uri);
+        return;
+      }
+      scheduleRefresh(document);
     }),
   );
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import { registerFormattingProvider } from "./formattingProvider";
 import { startLspClient, stopLspClient } from "./lspClient";
 import { registerRockyMcpProvider } from "./mcpServer";
 import { disposeOutputChannel } from "./output";
+import { registerRockyCacheInvalidation } from "./rockyCli";
 import { registerRunDecorations } from "./runDecorations";
 import { registerTaskProvider } from "./taskProvider";
 import { registerTestExplorer } from "./testExplorer";
@@ -27,6 +28,7 @@ export function activate(context: vscode.ExtensionContext): void {
     context.extensionMode === vscode.ExtensionMode.Development,
   );
   startLspClient(context);
+  registerRockyCacheInvalidation(context);
   registerCommands(context);
   registerChatParticipant(context);
   registerRockyMcpProvider(context);

--- a/editors/vscode/src/rockyCli.ts
+++ b/editors/vscode/src/rockyCli.ts
@@ -296,6 +296,125 @@ export async function runRockyJson<T = unknown>(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Idempotent-output cache (catalog / compile)
+// ---------------------------------------------------------------------------
+
+/**
+ * Short-lived, in-memory cache for the *idempotent* project-wide CLI outputs —
+ * `rocky catalog` and `rocky compile`. Both are pure functions of the model
+ * sources on disk between edits, so the Inspector can fan several requests into
+ * one spawn instead of re-shelling per UI event.
+ *
+ * Why this exists: opening the Inspector fires two RPC requests concurrently —
+ * the Lineage tab's `graph` (catalog + compile) and the focused model's
+ * `model` (catalog + compile) — and every node-click re-runs the model request.
+ * Without coalescing, that is 4 cold-start spawns on open and 2 more per click.
+ *
+ * The cache has three layers:
+ * - an **in-flight** map so two identical requests issued before the first
+ *   resolves share one spawn (a completion-populated TTL store alone would let
+ *   both miss);
+ * - a **completed** store with a {@link CACHE_TTL_MS} fallback so a request that
+ *   arrives shortly after still hits without re-spawning;
+ * - **explicit invalidation** via {@link invalidateRockyCache}, wired to the
+ *   extension's `.rocky` / model FS watchers so an edit drops stale results.
+ *
+ * Only call {@link runRockyJsonCached} for `catalog` / `compile`. Mutating or
+ * per-run commands (run / apply / test / preview / history) must never be
+ * routed through it.
+ */
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry<T> {
+  value: T;
+  fetchedAt: number;
+}
+
+const completedCache = new Map<string, CacheEntry<unknown>>();
+const inFlight = new Map<string, Promise<unknown>>();
+
+/** Stable cache key: the normalized cwd plus the full argument vector. */
+function cacheKey(args: readonly string[], cwd: string | undefined): string {
+  return `${cwd ?? ""} ${args.join(" ")}`;
+}
+
+/**
+ * JSON-parsing CLI call with the catalog/compile cache in front of it. On a
+ * fresh miss it coalesces concurrent identical calls into a single spawn,
+ * stores the parsed result for {@link CACHE_TTL_MS}, and returns it. Rejections
+ * are never cached — the in-flight entry is removed and nothing is written to
+ * the completed store, so one transient failure does not stick for the TTL.
+ *
+ * The `cwd` is normalized to the value {@link runRocky} would actually use
+ * (`opts.cwd ?? workspace root`) so two call sites that resolve to the same
+ * project root share one key.
+ */
+export function runRockyJsonCached<T = unknown>(
+  args: string[],
+  opts: RunRockyOptions = {},
+): Promise<T> {
+  const cwd = opts.cwd ?? getWorkspaceFolder();
+  const key = cacheKey(args, cwd);
+
+  const now = Date.now();
+  const cached = completedCache.get(key);
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    return Promise.resolve(cached.value as T);
+  }
+
+  const pending = inFlight.get(key);
+  if (pending) return pending as Promise<T>;
+
+  const promise = runRockyJson<T>(args, opts)
+    .then((value) => {
+      completedCache.set(key, { value, fetchedAt: Date.now() });
+      return value;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+    });
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Drop every cached catalog/compile result. Called from the extension's FS
+ * watchers when a model source changes — editing one model can change a
+ * downstream model's compile output, so invalidation is whole-store, not
+ * per-key. In-flight requests are left to settle (they reflect the on-disk
+ * state at spawn time and their callers already awaited them).
+ */
+export function invalidateRockyCache(): void {
+  completedCache.clear();
+}
+
+/**
+ * Wire the catalog/compile cache invalidation to file-system change signals.
+ *
+ * Compile freshness depends on model *content*, not just the file set, so this
+ * watches create / delete **and** change for `.rocky` / `.sql` model sources
+ * and `rocky.toml` (the brace group stays around the extensions only — the
+ * proven glob form). It also invalidates on document save — `onDidChange` from
+ * the FS watcher can lag an in-editor save, and a save is the moment a
+ * re-inspect most wants fresh output. Called once from `activate()`.
+ */
+export function registerRockyCacheInvalidation(
+  context: vscode.ExtensionContext,
+): void {
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    "**/*.{rocky,sql,toml}",
+  );
+  watcher.onDidCreate(invalidateRockyCache);
+  watcher.onDidDelete(invalidateRockyCache);
+  watcher.onDidChange(invalidateRockyCache);
+  context.subscriptions.push(
+    watcher,
+    vscode.workspace.onDidSaveTextDocument(() => invalidateRockyCache()),
+  );
+}
+
 /**
  * Wrap {@link runRocky} in a cancellable progress notification. The notification
  * cancel button propagates as an `AbortSignal` to the underlying process.

--- a/editors/vscode/src/runDecorations.ts
+++ b/editors/vscode/src/runDecorations.ts
@@ -78,6 +78,36 @@ const ALL_DECORATION_TYPES = [
 ];
 
 // ---------------------------------------------------------------------------
+// Per-model history cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Short-TTL cache of `rocky history --model <name>` results, keyed by model.
+ * Switching tabs between two model files (or flipping back and forth) used to
+ * re-shell on every `onDidChangeActiveTextEditor`; this serves a recent result
+ * instead. Busted wholesale by {@link refreshRunDecorations} so a fresh run's
+ * decoration is never masked by a stale cached entry.
+ */
+const HISTORY_TTL_MS = 30_000;
+
+interface HistoryCacheEntry {
+  value: ModelHistoryOutput;
+  fetchedAt: number;
+}
+
+const historyCache = new Map<string, HistoryCacheEntry>();
+
+function getCachedHistory(model: string): ModelHistoryOutput | undefined {
+  const entry = historyCache.get(model);
+  if (!entry) return undefined;
+  if (Date.now() - entry.fetchedAt >= HISTORY_TTL_MS) {
+    historyCache.delete(model);
+    return undefined;
+  }
+  return entry.value;
+}
+
+// ---------------------------------------------------------------------------
 // Core logic
 // ---------------------------------------------------------------------------
 
@@ -111,28 +141,34 @@ async function applyRunDecoration(editor: vscode.TextEditor): Promise<void> {
   const range = new vscode.Range(line, 0, line, document.lineAt(line).text.length);
 
   let result: ModelHistoryOutput;
-  try {
-    result = await runRockyJson<ModelHistoryOutput>(
-      ["history", "--model", modelName, "--output", "json"],
-      { timeoutMs: 10_000 },
-    );
-  } catch (err) {
-    // CLI not available or model not found — show gray "no history"
-    if (err instanceof RockyCliError) {
-      const channel = getOutputChannel();
-      channel.appendLine(
-        `[runDecorations] history lookup failed for ${modelName}: ${err.message}`,
+  const cached = getCachedHistory(modelName);
+  if (cached) {
+    result = cached;
+  } else {
+    try {
+      result = await runRockyJson<ModelHistoryOutput>(
+        ["history", "--model", modelName, "--output", "json"],
+        { timeoutMs: 10_000 },
       );
-    }
-    editor.setDecorations(noHistoryDecorationType, [
-      {
-        range,
-        renderOptions: {
-          after: { contentText: "○  no run history" },
+      historyCache.set(modelName, { value: result, fetchedAt: Date.now() });
+    } catch (err) {
+      // CLI not available or model not found — show gray "no history"
+      if (err instanceof RockyCliError) {
+        const channel = getOutputChannel();
+        channel.appendLine(
+          `[runDecorations] history lookup failed for ${modelName}: ${err.message}`,
+        );
+      }
+      editor.setDecorations(noHistoryDecorationType, [
+        {
+          range,
+          renderOptions: {
+            after: { contentText: "○  no run history" },
+          },
         },
-      },
-    ]);
-    return;
+      ]);
+      return;
+    }
   }
 
   const executions = result.executions ?? [];
@@ -208,6 +244,9 @@ export const onRunDecorationsRefreshRequested = refreshEmitter.event;
 
 /** Request a decoration refresh on all visible editors. */
 export function refreshRunDecorations(): void {
+  // A run just completed — the cached history is now stale for every model, so
+  // drop it before re-decorating or the fresh run wouldn't show until the TTL.
+  historyCache.clear();
   refreshEmitter.fire();
 }
 
@@ -227,11 +266,20 @@ export function refreshRunDecorations(): void {
 export function registerRunDecorations(
   context: vscode.ExtensionContext,
 ): void {
-  // Decorate when an editor becomes active
+  // Decorate when an editor becomes active, debounced (250ms, matching the
+  // Inspector's auto-follow) so rapid tab-flipping doesn't spawn a
+  // `rocky history` per switch — only the editor the user settles on is queried.
+  let activeEditorTimer: ReturnType<typeof setTimeout> | undefined;
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (editor) applyRunDecoration(editor);
+      if (!editor) return;
+      if (activeEditorTimer) clearTimeout(activeEditorTimer);
+      activeEditorTimer = setTimeout(() => {
+        activeEditorTimer = undefined;
+        applyRunDecoration(editor);
+      }, 250);
     }),
+    { dispose: () => activeEditorTimer && clearTimeout(activeEditorTimer) },
   );
 
   // Refresh on file save — the model may have been re-run

--- a/editors/vscode/webview-ui/panels/inspector/Toolbar.tsx
+++ b/editors/vscode/webview-ui/panels/inspector/Toolbar.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useRef, useState } from "react";
 import type { ColorMode, OverlayKind } from "./context";
+
+/** Delay before a keystroke propagates to the (graph-rebuilding) search filter. */
+const SEARCH_DEBOUNCE_MS = 180;
 
 const OVERLAY_LABELS: Record<OverlayKind, string> = {
   cost: "Cost",
@@ -33,11 +37,26 @@ export function Toolbar({
   activeOverlays: Set<OverlayKind>;
   onToggleOverlay: (kind: OverlayKind) => void;
 }) {
+  // Local state keeps the input responsive on every keystroke; the
+  // graph-rebuilding `onSearch` is debounced so each keypress doesn't re-derive
+  // every node/edge in the canvas. Kept in sync when `search` is reset upstream.
+  const [draft, setDraft] = useState(search);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => setDraft(search), [search]);
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  const onChange = (value: string): void => {
+    setDraft(value);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => onSearch(value), SEARCH_DEBOUNCE_MS);
+  };
+
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-vscode-border px-3 py-2">
       <input
-        value={search}
-        onChange={(e) => onSearch(e.target.value)}
+        value={draft}
+        onChange={(e) => onChange(e.target.value)}
         placeholder="Filter models (substring or /regex/)…"
         className="w-56 rounded border border-vscode-border bg-transparent px-2 py-1 text-sm text-vscode-fg outline-none focus:border-vscode-focus"
       />


### PR DESCRIPTION
The Inspector and the editor-driven providers were re-spawning cold-start `rocky` subprocesses on high-frequency UI events. This caches the idempotent project-wide outputs and debounces the three remaining undebounced spawn triggers.

## Host-side cache for `catalog` + `compile`

These two outputs are pure functions of the model sources on disk between edits, so they are safe to cache. Opening the Rocky Inspector fired two RPC requests concurrently — the Lineage tab's graph (`catalog` + `compile`) and the focused model's detail (`catalog` + `compile`) — so a single open cost four spawns, and every node-click re-ran the model request just to find one model in the project catalog.

`runRockyJsonCached` sits in front of those two call sites only (mutating/per-run commands and the explicit refresh commands are untouched):

- **In-flight coalescing** — two identical requests issued before the first resolves share one spawn, so the Inspector's concurrent graph + model requests dedup.
- **60s TTL** — a request arriving shortly after still hits without re-spawning (mirrors the existing cost-lens and CLI-version caches).
- **Invalidation** — a file-system watcher on `.rocky` / `.sql` / `.toml` (create, delete, **and** change) plus document save clears the whole store. Invalidation is whole-store, not per-key, because editing one model changes a downstream model's compile output.

Rejections are never cached, and the key is the normalized working directory plus the full argument vector, so `compile` and `compile --model X` never collide and the two Inspector call sites resolve to the same key.

Result: Inspector open is now 1×(`catalog` + `compile`); subsequent node-clicks are in-memory lookups instead of another project-wide pair of spawns.

## Three debounces

- **Run decorations** — `rocky history --model` ran on every active-editor change with no debounce. Now debounced 250ms (matching the Inspector's auto-follow) with a short-TTL per-model history cache that is busted whenever a run completes, so a fresh run's decoration is never masked.
- **Lineage search box** — rebuilt the entire graph on every keystroke. The input stays responsive via local state; propagation to the (graph-rebuilding) filter is debounced ~180ms.
- **Drift diagnostics** — `rocky compile --model` ran on every document open with no debounce. The open path now routes through the same per-URI 500ms debounce as save. Non-model files still clear stale diagnostics eagerly.

## Verification

- `npm install` (no lockfile drift), `npm run compile`, `typecheck:webview`, `npm run lint`, `npm run test:unit` — all green (199 tests).
- New unit tests cover the cache: second call served without re-spawning, concurrent calls coalesced into one spawn, full-arg-vector keying, re-spawn after invalidation, and rejections not cached.
- The full Electron integration suite needs a display and was not run here.