### PR TITLE
fix(engine): CLI UX, diagnostics, cross-platform & dead-code cleanup

### DIFF
--- a/engine/crates/rocky-cli/src/commands/ai.rs
+++ b/engine/crates/rocky-cli/src/commands/ai.rs
@@ -312,8 +312,15 @@ pub async fn run_ai_sync(
     let mut proposals = Vec::new();
 
     for model in &models_with_intent {
-        // Get upstream changes for this model
-        let upstream_changes = Vec::new(); // TODO: compare against previous compilation from state store
+        // Upstream schema-change detection is not wired yet: it would
+        // require diffing the current compilation against a *persisted
+        // previous* one (see `rocky_ai::sync::detect_schema_changes`), but
+        // the state store does not yet snapshot prior `CompileResult`s.
+        // Until that snapshot store exists, sync proposals are driven by
+        // the model's declared intent alone, with no upstream diff. This
+        // is surfaced to the user below (TODO: persist compile snapshots
+        // so `detect_schema_changes` can feed this).
+        let upstream_changes = Vec::new();
 
         let proposal = rocky_ai::sync::sync_model(model, &upstream_changes, &client, &result)
             .await
@@ -339,6 +346,11 @@ pub async fn run_ai_sync(
         };
         print_json(&output)?;
     } else {
+        println!(
+            "Note: proposals are based on declared model intent only — \
+             upstream schema-change detection is not yet wired."
+        );
+        println!();
         for proposal in &proposals {
             println!(
                 "Model: {} (intent: \"{}\")",

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -34,7 +34,20 @@ pub struct DoctorOutput {
     pub suggestions: Vec<String>,
 }
 
-/// Execute `rocky doctor` — aggregate health checks.
+/// Exit code returned when `rocky doctor` finds at least one Critical
+/// health check.
+///
+/// Deliberately distinct from `2`: that code is reserved for `rocky run`
+/// partial-success (one or more tables materialized, one or more failed),
+/// which Dagster keys on via `allow_partial=True`. A doctor failure and a
+/// partial run are different conditions, so they must not share an exit
+/// code. See the exit-code convention in `rocky/src/main.rs`.
+const DOCTOR_CRITICAL_EXIT_CODE: i32 = 3;
+
+/// Execute `rocky doctor` — aggregate health checks, render, and exit.
+///
+/// Health-check collection is delegated to [`collect_health_checks`] so it
+/// can be unit-tested without the `process::exit` in this wrapper.
 pub async fn doctor(
     config_path: &Path,
     state_path: &Path,
@@ -42,6 +55,81 @@ pub async fn doctor(
     check_filter: Option<&str>,
     verbose: bool,
 ) -> Result<()> {
+    let (checks, suggestions) =
+        collect_health_checks(config_path, state_path, check_filter, verbose).await;
+
+    // Determine overall status
+    let has_critical = checks
+        .iter()
+        .any(|c| matches!(c.status, HealthStatus::Critical));
+    let has_warning = checks
+        .iter()
+        .any(|c| matches!(c.status, HealthStatus::Warning));
+    let overall = if has_critical {
+        "critical"
+    } else if has_warning {
+        "warning"
+    } else {
+        "healthy"
+    };
+
+    let doctor_output = DoctorOutput {
+        command: "doctor".into(),
+        overall: overall.into(),
+        checks,
+        suggestions,
+    };
+
+    if output_json {
+        println!("{}", serde_json::to_string_pretty(&doctor_output)?);
+    } else {
+        // Human-readable output
+        println!("\nRocky Doctor\n");
+        for check in &doctor_output.checks {
+            let icon = match check.status {
+                HealthStatus::Healthy => "  ok ",
+                HealthStatus::Warning => "  !! ",
+                HealthStatus::Critical => " ERR ",
+            };
+            println!(
+                "{} {} — {} ({}ms)",
+                icon, check.name, check.message, check.duration_ms
+            );
+            if !check.details.is_empty() {
+                for (label, value) in &check.details {
+                    println!("        {label}: {value}");
+                }
+            }
+        }
+        println!("\nOverall: {}\n", doctor_output.overall);
+        if !doctor_output.suggestions.is_empty() {
+            println!("Suggestions:");
+            for s in &doctor_output.suggestions {
+                println!("  - {s}");
+            }
+            println!();
+        }
+    }
+
+    if has_critical {
+        std::process::exit(DOCTOR_CRITICAL_EXIT_CODE);
+    }
+
+    Ok(())
+}
+
+/// Run every requested health check and return the results plus
+/// remediation suggestions.
+///
+/// Split out of [`doctor`] so tests can assert check outcomes (e.g. a
+/// broken `rocky.toml` under `--check adapters` produces a Critical)
+/// without the `process::exit` the wrapper performs.
+async fn collect_health_checks(
+    config_path: &Path,
+    state_path: &Path,
+    check_filter: Option<&str>,
+    verbose: bool,
+) -> (Vec<HealthCheck>, Vec<String>) {
     let mut checks: Vec<HealthCheck> = Vec::new();
     let mut suggestions: Vec<String> = Vec::new();
 
@@ -135,7 +223,9 @@ pub async fn doctor(
     // 3. Adapter configuration checks (without actual connectivity)
     if should_run("adapters", check_filter) {
         let start = Instant::now();
-        if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
+        match rocky_core::config::load_rocky_config(config_path) {
+            Err(e) => checks.push(config_load_failed("adapters", &e, start, &mut suggestions)),
+            Ok(cfg) => {
             let mut adapter_ok = true;
             let mut details = Vec::new();
             for (name, adapter) in &cfg.adapters {
@@ -182,13 +272,16 @@ pub async fn doctor(
                 duration_ms: start.elapsed().as_millis() as u64,
                 details,
             });
+            }
         }
     }
 
     // 4. Pipeline validation
     if should_run("pipelines", check_filter) {
         let start = Instant::now();
-        if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
+        match rocky_core::config::load_rocky_config(config_path) {
+            Err(e) => checks.push(config_load_failed("pipelines", &e, start, &mut suggestions)),
+            Ok(cfg) => {
             let mut issues = Vec::new();
             let mut details = Vec::new();
             for (name, pipeline) in &cfg.pipelines {
@@ -222,13 +315,16 @@ pub async fn doctor(
                 details,
             });
             suggestions.extend(issues);
+            }
         }
     }
 
     // 5. State sync configuration
     if should_run("state_sync", check_filter) {
         let start = Instant::now();
-        if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
+        match rocky_core::config::load_rocky_config(config_path) {
+            Err(e) => checks.push(config_load_failed("state_sync", &e, start, &mut suggestions)),
+            Ok(cfg) => {
             let backend = &cfg.state.backend;
             let details = if verbose {
                 vec![("backend".into(), backend.to_string())]
@@ -247,6 +343,7 @@ pub async fn doctor(
                 duration_ms: start.elapsed().as_millis() as u64,
                 details,
             });
+            }
         }
     }
 
@@ -257,7 +354,9 @@ pub async fn doctor(
     //    end-of-run upload time.
     if should_run("state_rw", check_filter) {
         let start = Instant::now();
-        if let Ok(cfg) = rocky_core::config::load_rocky_config(config_path) {
+        match rocky_core::config::load_rocky_config(config_path) {
+            Err(e) => checks.push(config_load_failed("state_rw", &e, start, &mut suggestions)),
+            Ok(cfg) => {
             let backend = &cfg.state.backend;
             let details = if verbose {
                 vec![("backend".into(), backend.to_string())]
@@ -298,6 +397,7 @@ pub async fn doctor(
                         ));
                     }
                 }
+            }
             }
         }
     }
@@ -423,68 +523,39 @@ pub async fn doctor(
         }
     }
 
-    // Determine overall status
-    let has_critical = checks
-        .iter()
-        .any(|c| matches!(c.status, HealthStatus::Critical));
-    let has_warning = checks
-        .iter()
-        .any(|c| matches!(c.status, HealthStatus::Warning));
-    let overall = if has_critical {
-        "critical"
-    } else if has_warning {
-        "warning"
-    } else {
-        "healthy"
-    };
-
-    let doctor_output = DoctorOutput {
-        command: "doctor".into(),
-        overall: overall.into(),
-        checks,
-        suggestions,
-    };
-
-    if output_json {
-        println!("{}", serde_json::to_string_pretty(&doctor_output)?);
-    } else {
-        // Human-readable output
-        println!("\nRocky Doctor\n");
-        for check in &doctor_output.checks {
-            let icon = match check.status {
-                HealthStatus::Healthy => "  ok ",
-                HealthStatus::Warning => "  !! ",
-                HealthStatus::Critical => " ERR ",
-            };
-            println!(
-                "{} {} — {} ({}ms)",
-                icon, check.name, check.message, check.duration_ms
-            );
-            if !check.details.is_empty() {
-                for (label, value) in &check.details {
-                    println!("        {label}: {value}");
-                }
-            }
-        }
-        println!("\nOverall: {}\n", doctor_output.overall);
-        if !doctor_output.suggestions.is_empty() {
-            println!("Suggestions:");
-            for s in &doctor_output.suggestions {
-                println!("  - {s}");
-            }
-            println!();
-        }
-    }
-
-    if has_critical {
-        std::process::exit(2);
-    }
-
-    Ok(())
+    (checks, suggestions)
 }
 
 fn should_run(name: &str, filter: Option<&str>) -> bool {
     filter.is_none_or(|f| f == name)
+}
+
+/// Build a Critical `HealthCheck` for a check whose config could not be
+/// loaded, and record a remediation suggestion.
+///
+/// Checks that need `rocky.toml` (`adapters`, `pipelines`, `state_sync`,
+/// `state_rw`) previously swallowed a load error and emitted no check at
+/// all, so `rocky doctor --check adapters` on a broken config reported
+/// "healthy" with exit 0. Surfacing the failure as Critical makes those
+/// scoped checks fail loudly and exit non-zero.
+fn config_load_failed(
+    check_name: &str,
+    err: &impl std::fmt::Display,
+    start: Instant,
+    suggestions: &mut Vec<String>,
+) -> HealthCheck {
+    suggestions.push(format!(
+        "{check_name}: could not load config — run `rocky doctor --check config` to diagnose"
+    ));
+    HealthCheck {
+        name: check_name.into(),
+        status: HealthStatus::Critical,
+        message: format!(
+            "could not load config: {err} — run `rocky doctor --check config`"
+        ),
+        duration_ms: start.elapsed().as_millis() as u64,
+        details: Vec::new(),
+    }
 }
 
 /// Best-effort label for the credential shape an adapter is configured to use.
@@ -534,6 +605,53 @@ mod tests {
     fn should_run_mismatch() {
         assert!(!should_run("auth", Some("config")));
         assert!(!should_run("config", Some("auth")));
+    }
+
+    // -----------------------------------------------------------------------
+    // A broken rocky.toml under a config-dependent check must surface as
+    // Critical, not silently report healthy (EF2).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn broken_config_under_adapters_check_is_critical() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("rocky.toml");
+        // Syntactically invalid TOML (unterminated string).
+        let mut f = std::fs::File::create(&config_path).unwrap();
+        write!(f, "[adapter.x]\ntype = \"duckdb\nbroken").unwrap();
+        drop(f);
+        let state_path = dir.path().join("state.redb");
+
+        let (checks, _suggestions) =
+            collect_health_checks(&config_path, &state_path, Some("adapters"), false).await;
+
+        // The check ran and reported Critical (rather than emitting nothing
+        // and letting the overall status default to healthy).
+        let adapters = checks
+            .iter()
+            .find(|c| c.name == "adapters")
+            .expect("adapters check must be emitted even when config fails to load");
+        assert!(
+            matches!(adapters.status, HealthStatus::Critical),
+            "broken config must yield a Critical adapters check, got {:?}",
+            adapters.status
+        );
+        assert!(
+            checks
+                .iter()
+                .any(|c| matches!(c.status, HealthStatus::Critical)),
+            "doctor must report at least one Critical so it exits non-zero"
+        );
+    }
+
+    #[test]
+    fn doctor_critical_exit_code_is_not_run_partial_success() {
+        // Doctor-critical and run-partial-success are different conditions
+        // and must not share exit code 2.
+        assert_eq!(DOCTOR_CRITICAL_EXIT_CODE, 3);
+        assert_ne!(DOCTOR_CRITICAL_EXIT_CODE, 2);
     }
 
     // -----------------------------------------------------------------------

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -226,52 +226,52 @@ async fn collect_health_checks(
         match rocky_core::config::load_rocky_config(config_path) {
             Err(e) => checks.push(config_load_failed("adapters", &e, start, &mut suggestions)),
             Ok(cfg) => {
-            let mut adapter_ok = true;
-            let mut details = Vec::new();
-            for (name, adapter) in &cfg.adapters {
-                if verbose {
-                    details.push((format!("{name}.type"), adapter.adapter_type.clone()));
-                    details.push((
-                        format!("{name}.credential"),
-                        credential_kind(adapter).into(),
-                    ));
-                }
-                match adapter.adapter_type.as_str() {
-                    "databricks" => {
-                        if adapter.host.is_none() || adapter.host.as_deref() == Some("") {
-                            suggestions.push(format!("adapters.{name}: host not configured"));
-                            adapter_ok = false;
-                        }
-                        if adapter.token.is_none() && adapter.client_id.is_none() {
-                            suggestions.push(format!(
-                                "adapters.{name}: no auth configured \
+                let mut adapter_ok = true;
+                let mut details = Vec::new();
+                for (name, adapter) in &cfg.adapters {
+                    if verbose {
+                        details.push((format!("{name}.type"), adapter.adapter_type.clone()));
+                        details.push((
+                            format!("{name}.credential"),
+                            credential_kind(adapter).into(),
+                        ));
+                    }
+                    match adapter.adapter_type.as_str() {
+                        "databricks" => {
+                            if adapter.host.is_none() || adapter.host.as_deref() == Some("") {
+                                suggestions.push(format!("adapters.{name}: host not configured"));
+                                adapter_ok = false;
+                            }
+                            if adapter.token.is_none() && adapter.client_id.is_none() {
+                                suggestions.push(format!(
+                                    "adapters.{name}: no auth configured \
                                  (set DATABRICKS_TOKEN or DATABRICKS_CLIENT_ID/SECRET)"
-                            ));
+                                ));
+                                adapter_ok = false;
+                            }
+                        }
+                        "fivetran" if adapter.api_key.is_none() => {
+                            suggestions.push(format!("adapters.{name}: FIVETRAN_API_KEY not set"));
                             adapter_ok = false;
                         }
+                        _ => {}
                     }
-                    "fivetran" if adapter.api_key.is_none() => {
-                        suggestions.push(format!("adapters.{name}: FIVETRAN_API_KEY not set"));
-                        adapter_ok = false;
-                    }
-                    _ => {}
                 }
-            }
-            checks.push(HealthCheck {
-                name: "adapters".into(),
-                status: if adapter_ok {
-                    HealthStatus::Healthy
-                } else {
-                    HealthStatus::Warning
-                },
-                message: if adapter_ok {
-                    format!("{} adapter(s) configured", cfg.adapters.len())
-                } else {
-                    "Some adapters have missing configuration".into()
-                },
-                duration_ms: start.elapsed().as_millis() as u64,
-                details,
-            });
+                checks.push(HealthCheck {
+                    name: "adapters".into(),
+                    status: if adapter_ok {
+                        HealthStatus::Healthy
+                    } else {
+                        HealthStatus::Warning
+                    },
+                    message: if adapter_ok {
+                        format!("{} adapter(s) configured", cfg.adapters.len())
+                    } else {
+                        "Some adapters have missing configuration".into()
+                    },
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    details,
+                });
             }
         }
     }
@@ -282,39 +282,39 @@ async fn collect_health_checks(
         match rocky_core::config::load_rocky_config(config_path) {
             Err(e) => checks.push(config_load_failed("pipelines", &e, start, &mut suggestions)),
             Ok(cfg) => {
-            let mut issues = Vec::new();
-            let mut details = Vec::new();
-            for (name, pipeline) in &cfg.pipelines {
-                if verbose {
-                    details.push((
-                        format!("pipeline.{name}"),
-                        pipeline.pipeline_type_str().into(),
-                    ));
+                let mut issues = Vec::new();
+                let mut details = Vec::new();
+                for (name, pipeline) in &cfg.pipelines {
+                    if verbose {
+                        details.push((
+                            format!("pipeline.{name}"),
+                            pipeline.pipeline_type_str().into(),
+                        ));
+                    }
+                    // Check schema pattern is parseable (replication pipelines only)
+                    if let Some(repl) = pipeline.as_replication()
+                        && let Err(e) = repl.schema_pattern()
+                    {
+                        issues.push(format!("pipeline '{name}': invalid schema pattern: {e}"));
+                    }
                 }
-                // Check schema pattern is parseable (replication pipelines only)
-                if let Some(repl) = pipeline.as_replication()
-                    && let Err(e) = repl.schema_pattern()
-                {
-                    issues.push(format!("pipeline '{name}': invalid schema pattern: {e}"));
-                }
-            }
-            let pipeline_count = cfg.pipelines.len();
-            checks.push(HealthCheck {
-                name: "pipelines".into(),
-                status: if issues.is_empty() {
-                    HealthStatus::Healthy
-                } else {
-                    HealthStatus::Warning
-                },
-                message: if issues.is_empty() {
-                    format!("{pipeline_count} pipeline(s) valid")
-                } else {
-                    format!("{} issue(s) found", issues.len())
-                },
-                duration_ms: start.elapsed().as_millis() as u64,
-                details,
-            });
-            suggestions.extend(issues);
+                let pipeline_count = cfg.pipelines.len();
+                checks.push(HealthCheck {
+                    name: "pipelines".into(),
+                    status: if issues.is_empty() {
+                        HealthStatus::Healthy
+                    } else {
+                        HealthStatus::Warning
+                    },
+                    message: if issues.is_empty() {
+                        format!("{pipeline_count} pipeline(s) valid")
+                    } else {
+                        format!("{} issue(s) found", issues.len())
+                    },
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    details,
+                });
+                suggestions.extend(issues);
             }
         }
     }
@@ -323,26 +323,31 @@ async fn collect_health_checks(
     if should_run("state_sync", check_filter) {
         let start = Instant::now();
         match rocky_core::config::load_rocky_config(config_path) {
-            Err(e) => checks.push(config_load_failed("state_sync", &e, start, &mut suggestions)),
+            Err(e) => checks.push(config_load_failed(
+                "state_sync",
+                &e,
+                start,
+                &mut suggestions,
+            )),
             Ok(cfg) => {
-            let backend = &cfg.state.backend;
-            let details = if verbose {
-                vec![("backend".into(), backend.to_string())]
-            } else {
-                Vec::new()
-            };
-            // A `local` state backend is the healthy default for a single-node
-            // project (it mirrors the `state_rw` check, which already treats
-            // local as Healthy — no remote probe needed). `Warning` is
-            // reserved for a misconfigured remote backend, surfaced by the
-            // `state_rw` RW probe below.
-            checks.push(HealthCheck {
-                name: "state_sync".into(),
-                status: HealthStatus::Healthy,
-                message: format!("State backend: {backend}"),
-                duration_ms: start.elapsed().as_millis() as u64,
-                details,
-            });
+                let backend = &cfg.state.backend;
+                let details = if verbose {
+                    vec![("backend".into(), backend.to_string())]
+                } else {
+                    Vec::new()
+                };
+                // A `local` state backend is the healthy default for a single-node
+                // project (it mirrors the `state_rw` check, which already treats
+                // local as Healthy — no remote probe needed). `Warning` is
+                // reserved for a misconfigured remote backend, surfaced by the
+                // `state_rw` RW probe below.
+                checks.push(HealthCheck {
+                    name: "state_sync".into(),
+                    status: HealthStatus::Healthy,
+                    message: format!("State backend: {backend}"),
+                    duration_ms: start.elapsed().as_millis() as u64,
+                    details,
+                });
             }
         }
     }
@@ -357,47 +362,47 @@ async fn collect_health_checks(
         match rocky_core::config::load_rocky_config(config_path) {
             Err(e) => checks.push(config_load_failed("state_rw", &e, start, &mut suggestions)),
             Ok(cfg) => {
-            let backend = &cfg.state.backend;
-            let details = if verbose {
-                vec![("backend".into(), backend.to_string())]
-            } else {
-                Vec::new()
-            };
-            if *backend == rocky_core::config::StateBackend::Local {
-                checks.push(HealthCheck {
-                    name: "state_rw".into(),
-                    status: HealthStatus::Healthy,
-                    message: "Local backend — no remote probe needed".into(),
-                    duration_ms: start.elapsed().as_millis() as u64,
-                    details,
-                });
-            } else {
-                match rocky_core::state_sync::probe_state_backend(&cfg.state).await {
-                    Ok(()) => {
-                        checks.push(HealthCheck {
-                            name: "state_rw".into(),
-                            status: HealthStatus::Healthy,
-                            message: format!("State backend RW probe succeeded ({backend})"),
-                            duration_ms: start.elapsed().as_millis() as u64,
-                            details,
-                        });
-                    }
-                    Err(e) => {
-                        checks.push(HealthCheck {
-                            name: "state_rw".into(),
-                            status: HealthStatus::Critical,
-                            message: format!("State backend RW probe failed: {e}"),
-                            duration_ms: start.elapsed().as_millis() as u64,
-                            details,
-                        });
-                        suggestions.push(format!(
-                            "state_rw: verify the '{backend}' backend has read+write access \
+                let backend = &cfg.state.backend;
+                let details = if verbose {
+                    vec![("backend".into(), backend.to_string())]
+                } else {
+                    Vec::new()
+                };
+                if *backend == rocky_core::config::StateBackend::Local {
+                    checks.push(HealthCheck {
+                        name: "state_rw".into(),
+                        status: HealthStatus::Healthy,
+                        message: "Local backend — no remote probe needed".into(),
+                        duration_ms: start.elapsed().as_millis() as u64,
+                        details,
+                    });
+                } else {
+                    match rocky_core::state_sync::probe_state_backend(&cfg.state).await {
+                        Ok(()) => {
+                            checks.push(HealthCheck {
+                                name: "state_rw".into(),
+                                status: HealthStatus::Healthy,
+                                message: format!("State backend RW probe succeeded ({backend})"),
+                                duration_ms: start.elapsed().as_millis() as u64,
+                                details,
+                            });
+                        }
+                        Err(e) => {
+                            checks.push(HealthCheck {
+                                name: "state_rw".into(),
+                                status: HealthStatus::Critical,
+                                message: format!("State backend RW probe failed: {e}"),
+                                duration_ms: start.elapsed().as_millis() as u64,
+                                details,
+                            });
+                            suggestions.push(format!(
+                                "state_rw: verify the '{backend}' backend has read+write access \
                              to the configured bucket / prefix (tried put/get/delete of a \
                              short-lived marker object)"
-                        ));
+                            ));
+                        }
                     }
                 }
-            }
             }
         }
     }
@@ -564,9 +569,7 @@ fn config_load_failed(
     HealthCheck {
         name: check_name.into(),
         status: HealthStatus::Critical,
-        message: format!(
-            "could not load config: {err} — run `rocky doctor --check config`"
-        ),
+        message: format!("could not load config: {err} — run `rocky doctor --check config`"),
         duration_ms: start.elapsed().as_millis() as u64,
         details: Vec::new(),
     }

--- a/engine/crates/rocky-cli/src/commands/doctor.rs
+++ b/engine/crates/rocky-cli/src/commands/doctor.rs
@@ -435,12 +435,26 @@ async fn collect_health_checks(
                                     }
                                     Err(e) => {
                                         all_ok = false;
+                                        // Frame common auth failures (403/401)
+                                        // into an actionable message; stash the
+                                        // raw error in verbose `details`.
+                                        let framed =
+                                            crate::output::frame_warehouse_adapter_error(&e, name);
+                                        let message = match &framed {
+                                            Some(m) => format!("Ping failed: {m}"),
+                                            None => format!("Ping failed: {e}"),
+                                        };
+                                        let details = if verbose || framed.is_some() {
+                                            vec![("raw".into(), format!("{e}"))]
+                                        } else {
+                                            Vec::new()
+                                        };
                                         checks.push(HealthCheck {
                                             name: format!("auth/{name}"),
                                             status: HealthStatus::Critical,
-                                            message: format!("Ping failed: {e}"),
+                                            message,
                                             duration_ms: ping_start.elapsed().as_millis() as u64,
-                                            details: Vec::new(),
+                                            details,
                                         });
                                         suggestions.push(format!(
                                             "Adapter '{name}': verify credentials and network access"

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -2286,26 +2286,40 @@ pub async fn run(
                 // the optional engine-supplied cooldown hint
                 // (warehouse-side breaker trip) is captured.
                 let (failure_kind, cooldown_seconds) = classify_anyhow_error_with_cooldown(&e);
-                let msg = format!("{e:#}");
-                if msg.contains("TABLE_OR_VIEW_NOT_FOUND") {
+                let raw = format!("{e:#}");
+                if raw.contains("TABLE_OR_VIEW_NOT_FOUND") {
                     warn!(
                         table_index = idx,
-                        error = msg.as_str(),
+                        error = raw.as_str(),
                         "source table not found, skipping"
                     );
                     continue;
                 }
+                // Frame common warehouse auth failures (403/401) into an
+                // actionable message for the user-facing `error` field.
+                // The raw status + body stays in the `warn!` below and in
+                // the structured `failure_kind`. Falls back to the raw
+                // chain for anything we don't recognise.
+                let target = tables_to_process
+                    .get(idx)
+                    .map(|t| format!("{}.{}.{}", t.target_catalog, t.target_schema, t.table_name))
+                    .unwrap_or_default();
+                let msg = crate::output::frame_warehouse_anyhow_error(&e, &target)
+                    .unwrap_or_else(|| raw.clone());
 
                 // Signal the adaptive throttle: rate limits reduce concurrency,
                 // other errors are treated as successes (they're permanent
-                // failures, not a signal to slow down).
+                // failures, not a signal to slow down). Detect on the raw
+                // chain — the framed `msg` only covers auth (403/401).
                 if let Some(t) = &throttle
-                    && is_rate_limit_error(&msg) {
+                    && is_rate_limit_error(&raw) {
                         t.on_rate_limit();
                         adjust_semaphore(t, &semaphore, &mut semaphore_capacity);
                     }
 
-                warn!(error = msg, "table processing failed");
+                // Log the raw status + body for debugging; `msg` (framed)
+                // is what surfaces to the user on `TableErrorOutput.error`.
+                warn!(error = raw.as_str(), framed = msg.as_str(), "table processing failed");
                 rocky_observe::metrics::METRICS.inc_tables_failed();
 
                 // Checkpoint: record failed table progress

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -999,18 +999,27 @@ fn lint_config(
     }
 }
 
+/// Line prefix for a message severity in human-readable validate output.
+///
+/// Errors render with a distinct ` ERR ` prefix (matching `rocky doctor`)
+/// so a failed validation is visually distinguishable from a warning —
+/// both previously shared the `  !! ` prefix, hiding the difference
+/// between a hard failure and an advisory.
+fn severity_prefix(severity: &str) -> &'static str {
+    match severity {
+        "ok" => "  ok ",
+        "warn" => "  !! ",
+        "error" => " ERR ",
+        "lint" => " note",
+        _ => "     ",
+    }
+}
+
 /// Render the structured output as human-readable text (matching today's
 /// format for backward compatibility).
 fn render_text(output: &ValidateOutput) {
     for msg in &output.messages {
-        let prefix = match msg.severity.as_str() {
-            "ok" => "  ok ",
-            "warn" => "  !! ",
-            "error" => "  !! ",
-            "lint" => " note",
-            _ => "     ",
-        };
-        println!("{prefix} {}", msg.message);
+        println!("{} {}", severity_prefix(&msg.severity), msg.message);
     }
     println!();
     println!("Validation complete.");
@@ -1672,5 +1681,16 @@ backend = "local"
             lint_codes.contains(&"L007"),
             "expected L007 (adapter repetition)"
         );
+    }
+
+    #[test]
+    fn test_error_and_warning_render_with_distinct_prefixes() {
+        // Errors must be visually distinguishable from warnings in the
+        // human-readable output — they previously shared `  !! `.
+        assert_eq!(severity_prefix("error"), " ERR ");
+        assert_eq!(severity_prefix("warn"), "  !! ");
+        assert_ne!(severity_prefix("error"), severity_prefix("warn"));
+        assert_eq!(severity_prefix("ok"), "  ok ");
+        assert_eq!(severity_prefix("lint"), " note");
     }
 }

--- a/engine/crates/rocky-cli/src/commands/validate.rs
+++ b/engine/crates/rocky-cli/src/commands/validate.rs
@@ -435,11 +435,24 @@ fn validate_adapter(
                     field: None,
                 });
             } else {
+                // Unknown adapter types are a hard error, not a cosmetic
+                // warning: `rocky run` rejects them outright (registry.rs
+                // `from_config` bails), so `rocky validate` must agree and
+                // set `valid = false`. Reuse the same supported-types list
+                // and `did_you_mean` suggestion the runtime error uses.
+                use crate::error_reporter::{self, KNOWN_ADAPTER_TYPES};
+                let mut message = format!(
+                    "adapter.{name}: unknown type '{other}'. Supported: {}",
+                    KNOWN_ADAPTER_TYPES.join(", "),
+                );
+                if let Some(suggestion) = error_reporter::did_you_mean(other, KNOWN_ADAPTER_TYPES) {
+                    message.push_str(&format!(". Did you mean '{suggestion}'?"));
+                }
                 ok = false;
                 msgs.push(ValidateMessage {
-                    severity: "warn".into(),
+                    severity: "error".into(),
                     code: "V017".into(),
-                    message: format!("adapter.{name}: unknown type '{other}'"),
+                    message,
                     file: None,
                     field: Some(format!("adapter.{name}.type")),
                 });
@@ -1439,6 +1452,50 @@ schema_template = "demo"
         let unknown: Vec<_> = out.messages.iter().filter(|m| m.code == "V017").collect();
         assert_eq!(unknown.len(), 1);
         assert!(unknown[0].message.contains("postgres"));
+        // An unknown adapter type is a hard error: `rocky run` rejects it,
+        // so `rocky validate` must report `valid = false` (non-zero exit),
+        // not a cosmetic warning.
+        assert_eq!(unknown[0].severity, "error");
+        assert!(!out.valid, "unknown adapter type must invalidate config");
+        // No close match for "postgres" — message lists supported types
+        // but offers no suggestion.
+        assert!(unknown[0].message.contains("Supported:"));
+        assert!(!unknown[0].message.contains("Did you mean"));
+    }
+
+    #[test]
+    fn test_unknown_adapter_type_suggests_near_miss() {
+        let out = validate_toml(
+            r#"
+[adapter.wh]
+type = "databrick"
+
+[pipeline.poc]
+type = "replication"
+
+[pipeline.poc.source]
+adapter = "wh"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.poc.target]
+adapter = "wh"
+catalog_template = "poc"
+schema_template = "demo"
+"#,
+        );
+        let v017: Vec<_> = out.messages.iter().filter(|m| m.code == "V017").collect();
+        assert_eq!(v017.len(), 1);
+        assert_eq!(v017[0].severity, "error");
+        assert!(!out.valid);
+        assert!(
+            v017[0].message.contains("Did you mean 'databricks'?"),
+            "expected a near-miss suggestion, got: {}",
+            v017[0].message
+        );
     }
 
     /// L002 must NOT fire when `target.table` is declared as a

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -630,6 +630,83 @@ pub fn classify_anyhow_error_with_cooldown(err: &anyhow::Error) -> (FailureKind,
     (FailureKind::Unknown, None)
 }
 
+/// Recover the HTTP status from a single error link if it is a Databricks
+/// or Snowflake `ConnectorError::ApiError`.
+fn api_status_from_cause(cause: &(dyn std::error::Error + 'static)) -> Option<u16> {
+    use rocky_databricks::connector::ConnectorError as Dbx;
+    use rocky_snowflake::connector::ConnectorError as Sf;
+    if let Some(Dbx::ApiError { status, .. }) = cause.downcast_ref::<Dbx>() {
+        return Some(*status);
+    }
+    if let Some(Sf::ApiError { status, .. }) = cause.downcast_ref::<Sf>() {
+        return Some(*status);
+    }
+    None
+}
+
+/// Frame a warehouse error into an actionable, user-facing message when
+/// it carries a recognised HTTP auth status.
+///
+/// Maps `403` and `401` (Databricks / Snowflake `ApiError`) to a concise
+/// remediation hint, keeping the raw status + body out of the headline.
+/// Returns `None` for any other failure (including BigQuery, which has no
+/// typed `ApiError` status path) so the caller falls back to the raw
+/// error string.
+///
+/// `target` is a human label for what was being accessed (a table ref or
+/// adapter name), interpolated into the framed message.
+fn frame_status(status: u16, target: &str) -> Option<String> {
+    match status {
+        403 => Some(format!(
+            "permission denied on `{target}` (HTTP 403) — verify the adapter principal \
+             has the required grants"
+        )),
+        401 => Some(
+            "authentication rejected (HTTP 401) — the token or credential may be \
+             expired or invalid"
+                .to_string(),
+        ),
+        _ => None,
+    }
+}
+
+/// Walk an `anyhow` error chain (including any `rocky_adapter_sdk::
+/// AdapterError` inner) for a recognised warehouse auth status and frame
+/// it. See [`frame_status`].
+pub fn frame_warehouse_anyhow_error(err: &anyhow::Error, target: &str) -> Option<String> {
+    for cause in err.chain() {
+        if let Some(status) = api_status_from_cause(cause) {
+            return frame_status(status, target);
+        }
+        if let Some(adapter_err) = cause.downcast_ref::<rocky_adapter_sdk::AdapterError>()
+            && let Some(status) = api_status_from_cause(adapter_err.inner())
+        {
+            return frame_status(status, target);
+        }
+    }
+    None
+}
+
+/// Frame a `rocky_core::traits::AdapterError` (the type returned by
+/// `WarehouseAdapter::ping`) for a recognised warehouse auth status.
+///
+/// Probes the boxed `inner` error and its `source()` chain for a
+/// Databricks / Snowflake `ConnectorError::ApiError`. See
+/// [`frame_status`].
+pub fn frame_warehouse_adapter_error(
+    err: &rocky_core::traits::AdapterError,
+    target: &str,
+) -> Option<String> {
+    let mut cause: Option<&(dyn std::error::Error + 'static)> = Some(err.inner());
+    while let Some(c) = cause {
+        if let Some(status) = api_status_from_cause(c) {
+            return frame_status(status, target);
+        }
+        cause = c.source();
+    }
+    None
+}
+
 /// Error from a table that failed during parallel processing.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TableErrorOutput {
@@ -6218,5 +6295,48 @@ mod failure_kind_tests {
         });
         let err = anyhow::anyhow!("{adapter_err}");
         assert_eq!(classify_anyhow_error(&err), FailureKind::Unknown);
+    }
+
+    // ---- EF8: user-facing framing of 403 / 401 ----------------------------
+
+    #[test]
+    fn frame_403_and_401_produce_distinct_actionable_messages() {
+        // anyhow path (run.rs table errors): wrap the typed ConnectorError
+        // through the SDK AdapterError, as the real run path does.
+        let e403: anyhow::Error = db_adapter_err(db_api(403)).into();
+        let e401: anyhow::Error = db_adapter_err(db_api(401)).into();
+
+        let m403 = frame_warehouse_anyhow_error(&e403, "cat.sch.tbl")
+            .expect("403 must frame");
+        let m401 = frame_warehouse_anyhow_error(&e401, "cat.sch.tbl")
+            .expect("401 must frame");
+
+        // The whole point of keying on status (not FailureKind, which
+        // collapses both to AuthFailed): the two messages differ.
+        assert_ne!(m403, m401);
+        assert!(m403.contains("permission denied"));
+        assert!(m403.contains("cat.sch.tbl"));
+        assert!(m401.contains("authentication rejected"));
+    }
+
+    #[test]
+    fn frame_non_auth_status_falls_back_to_none() {
+        // A 500 is not an auth failure — keep the raw error, don't frame.
+        let e: anyhow::Error = db_adapter_err(db_api(500)).into();
+        assert!(frame_warehouse_anyhow_error(&e, "t").is_none());
+    }
+
+    #[test]
+    fn frame_adapter_error_path_for_doctor_ping() {
+        // doctor pings return rocky_core::traits::AdapterError, whose inner
+        // is reached via the new inner() accessor.
+        let e = rocky_core::traits::AdapterError::new(db_api(403));
+        let framed = frame_warehouse_adapter_error(&e, "warehouse_a").expect("403 frames");
+        assert!(framed.contains("permission denied"));
+
+        let e_sf = rocky_core::traits::AdapterError::new(sn_api(401));
+        let framed_sf =
+            frame_warehouse_adapter_error(&e_sf, "warehouse_b").expect("401 frames");
+        assert!(framed_sf.contains("authentication rejected"));
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -6306,10 +6306,8 @@ mod failure_kind_tests {
         let e403: anyhow::Error = db_adapter_err(db_api(403)).into();
         let e401: anyhow::Error = db_adapter_err(db_api(401)).into();
 
-        let m403 = frame_warehouse_anyhow_error(&e403, "cat.sch.tbl")
-            .expect("403 must frame");
-        let m401 = frame_warehouse_anyhow_error(&e401, "cat.sch.tbl")
-            .expect("401 must frame");
+        let m403 = frame_warehouse_anyhow_error(&e403, "cat.sch.tbl").expect("403 must frame");
+        let m401 = frame_warehouse_anyhow_error(&e401, "cat.sch.tbl").expect("401 must frame");
 
         // The whole point of keying on status (not FailureKind, which
         // collapses both to AuthFailed): the two messages differ.
@@ -6335,8 +6333,7 @@ mod failure_kind_tests {
         assert!(framed.contains("permission denied"));
 
         let e_sf = rocky_core::traits::AdapterError::new(sn_api(401));
-        let framed_sf =
-            frame_warehouse_adapter_error(&e_sf, "warehouse_b").expect("401 frames");
+        let framed_sf = frame_warehouse_adapter_error(&e_sf, "warehouse_b").expect("401 frames");
         assert!(framed_sf.contains("authentication rejected"));
     }
 }

--- a/engine/crates/rocky-compiler/src/compile.rs
+++ b/engine/crates/rocky-compiler/src/compile.rs
@@ -112,7 +112,10 @@ pub struct CompileResult {
 /// Compile error.
 #[derive(Debug, thiserror::Error)]
 pub enum CompileError {
-    #[error("project loading failed: {0}")]
+    // Transparent: `ProjectError` variants are self-describing, so
+    // wrapping them with a "project loading failed:" prefix only added a
+    // redundant layer to the rendered `Caused by` chain.
+    #[error(transparent)]
     Project(#[from] ProjectError),
 
     #[error("semantic graph failed: {0}")]

--- a/engine/crates/rocky-compiler/src/contracts.rs
+++ b/engine/crates/rocky-compiler/src/contracts.rs
@@ -321,8 +321,7 @@ mod tests {
         let diags = validate_contract("test_model", &schema, &contract);
         let e011 = diags.iter().find(|d| &*d.code == "E011").expect("E011");
         assert!(
-            e011
-                .suggestion
+            e011.suggestion
                 .as_deref()
                 .is_some_and(|s| s.contains("CAST")),
             "E011 must suggest a CAST: {e011:?}"
@@ -366,8 +365,7 @@ mod tests {
         let diags = validate_contract("test_model", &schema, &contract);
         let e013 = diags.iter().find(|d| &*d.code == "E013").expect("E013");
         assert!(
-            e013
-                .suggestion
+            e013.suggestion
                 .as_deref()
                 .is_some_and(|s| s.contains("restore") || s.contains("protected")),
             "E013 must suggest restoring the column or relaxing the rule: {e013:?}"

--- a/engine/crates/rocky-compiler/src/contracts.rs
+++ b/engine/crates/rocky-compiler/src/contracts.rs
@@ -119,11 +119,16 @@ pub fn validate_contract(
     // Check required columns exist
     for required in &contract.rules.required {
         if !col_names.contains(&required.as_str()) {
-            diagnostics.push(Diagnostic::error(
-                E010,
-                model_name,
-                format!("required column '{required}' missing from model output"),
-            ));
+            diagnostics.push(
+                Diagnostic::error(
+                    E010,
+                    model_name,
+                    format!("required column '{required}' missing from model output"),
+                )
+                .with_suggestion(format!(
+                    "add `{required}` to the SELECT, or remove it from `[rules] required`"
+                )),
+            );
         }
     }
 
@@ -137,14 +142,20 @@ pub fn validate_contract(
                 if let Some(ref expected_type) = contract_col.type_name {
                     let matches = type_name_matches(&col.data_type, expected_type);
                     if !matches && col.data_type != RockyType::Unknown {
-                        diagnostics.push(Diagnostic::error(
-                            E011,
-                            model_name,
-                            format!(
-                                "column '{}' type mismatch: contract expects {}, got {:?}",
-                                contract_col.name, expected_type, col.data_type
-                            ),
-                        ));
+                        diagnostics.push(
+                            Diagnostic::error(
+                                E011,
+                                model_name,
+                                format!(
+                                    "column '{}' type mismatch: contract expects {}, got {:?}",
+                                    contract_col.name, expected_type, col.data_type
+                                ),
+                            )
+                            .with_suggestion(format!(
+                                "CAST `{}` to {} in the SELECT, or update the contract's expected type",
+                                contract_col.name, expected_type
+                            )),
+                        );
                     }
                 }
 
@@ -153,14 +164,21 @@ pub fn validate_contract(
                     && !nullable
                     && col.nullable
                 {
-                    diagnostics.push(Diagnostic::error(
-                        E012,
-                        model_name,
-                        format!(
-                            "column '{}' must be non-nullable per contract, but is nullable",
+                    diagnostics.push(
+                        Diagnostic::error(
+                            E012,
+                            model_name,
+                            format!(
+                                "column '{}' must be non-nullable per contract, but is nullable",
+                                contract_col.name
+                            ),
+                        )
+                        .with_suggestion(format!(
+                            "filter out NULLs (e.g. `WHERE {0} IS NOT NULL`) or COALESCE `{0}` to a default, \
+                             or relax `nullable = true` in the contract",
                             contract_col.name
-                        ),
-                    ));
+                        )),
+                    );
                 }
             }
             None => {
@@ -184,11 +202,16 @@ pub fn validate_contract(
     // Check protected columns
     for protected in &contract.rules.protected {
         if !col_names.contains(&protected.as_str()) {
-            diagnostics.push(Diagnostic::error(
-                E013,
-                model_name,
-                format!("protected column '{protected}' has been removed"),
-            ));
+            diagnostics.push(
+                Diagnostic::error(
+                    E013,
+                    model_name,
+                    format!("protected column '{protected}' has been removed"),
+                )
+                .with_suggestion(format!(
+                    "restore `{protected}` in the SELECT, or remove it from `[rules] protected`"
+                )),
+            );
         }
     }
 
@@ -274,7 +297,11 @@ mod tests {
         };
 
         let diags = validate_contract("test_model", &schema, &contract);
-        assert!(diags.iter().any(|d| &*d.code == "E010"));
+        let e010 = diags.iter().find(|d| &*d.code == "E010").expect("E010");
+        assert!(
+            e010.suggestion.as_deref().is_some_and(|s| s.contains("id")),
+            "E010 must carry an actionable suggestion: {e010:?}"
+        );
     }
 
     #[test]
@@ -292,7 +319,14 @@ mod tests {
         };
 
         let diags = validate_contract("test_model", &schema, &contract);
-        assert!(diags.iter().any(|d| &*d.code == "E011"));
+        let e011 = diags.iter().find(|d| &*d.code == "E011").expect("E011");
+        assert!(
+            e011
+                .suggestion
+                .as_deref()
+                .is_some_and(|s| s.contains("CAST")),
+            "E011 must suggest a CAST: {e011:?}"
+        );
     }
 
     #[test]
@@ -310,7 +344,11 @@ mod tests {
         };
 
         let diags = validate_contract("test_model", &schema, &contract);
-        assert!(diags.iter().any(|d| &*d.code == "E012"));
+        let e012 = diags.iter().find(|d| &*d.code == "E012").expect("E012");
+        assert!(
+            e012.suggestion.is_some(),
+            "E012 must carry a nullability hint: {e012:?}"
+        );
     }
 
     #[test]
@@ -326,7 +364,14 @@ mod tests {
         };
 
         let diags = validate_contract("test_model", &schema, &contract);
-        assert!(diags.iter().any(|d| &*d.code == "E013"));
+        let e013 = diags.iter().find(|d| &*d.code == "E013").expect("E013");
+        assert!(
+            e013
+                .suggestion
+                .as_deref()
+                .is_some_and(|s| s.contains("restore") || s.contains("protected")),
+            "E013 must suggest restoring the column or relaxing the rule: {e013:?}"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -7,7 +7,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use rayon::prelude::*;
 use rocky_core::models::{self, Model, ModelConfig, TargetConfig};
 use rocky_core::unified_dag::UnifiedDag;
 use rocky_ir::dag::{self, DagNode};
@@ -242,11 +241,11 @@ fn load_rocky_models_with_db(
     Ok(models)
 }
 
-/// Salsa-driven sibling of [`load_single_rocky_model`]. Uses
+/// Salsa-driven loader for a single `.rocky` file. Uses
 /// [`crate::salsa_compile::read_source`] +
 /// [`crate::salsa_compile::file_typecheck`] to get the lowered SQL
 /// through the database cache; the surrounding sidecar / defaults
-/// logic is identical.
+/// logic mirrors the `.sql` model loader.
 fn load_single_rocky_model_with_db(
     path: &Path,
     defaults: Option<&models::DirDefaults>,
@@ -341,143 +340,6 @@ fn load_single_rocky_model_with_db(
         }
     };
 
-    let contract_file = path.with_extension("contract.toml");
-    let contract_path = if contract_file.exists() {
-        Some(contract_file)
-    } else {
-        None
-    };
-
-    Ok(Model {
-        config,
-        sql,
-        file_path: path.display().to_string(),
-        contract_path,
-    })
-}
-
-/// Legacy non-salsa loader for `.rocky` files.
-///
-/// Kept for back-compat with call sites that construct projects
-/// without a salsa database — internally, [`Project::load`] now spins
-/// up a transient db and routes through [`load_rocky_models_with_db`].
-/// This function remains as a fallback used by tests that exercise
-/// the no-database path directly.
-#[allow(dead_code)]
-fn load_rocky_models(dir: &Path) -> Result<Vec<Model>, ProjectError> {
-    if !dir.exists() {
-        return Ok(Vec::new());
-    }
-
-    // Load optional directory defaults (shared with .sql model loader)
-    let defaults_path = dir.join("_defaults.toml");
-    let defaults = if defaults_path.exists() {
-        Some(models::load_dir_defaults(&defaults_path)?)
-    } else {
-        None
-    };
-
-    // 1. Collect .rocky file paths (lightweight sequential scan)
-    let rocky_paths: Vec<PathBuf> = std::fs::read_dir(dir)
-        .map_err(models::ModelError::ReadFile)?
-        .filter_map(|entry| {
-            let path = entry.ok()?.path();
-            if path.extension().is_some_and(|ext| ext == "rocky") {
-                Some(path)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if rocky_paths.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // 2. Parse + lower in parallel (CPU-bound per file)
-    let mut models: Vec<Model> = rocky_paths
-        .par_iter()
-        .map(|path| load_single_rocky_model(path, defaults.as_ref()))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // Sort by name for deterministic ordering
-    models.sort_by(|a, b| a.config.name.cmp(&b.config.name));
-    Ok(models)
-}
-
-/// Parse, lower, and configure a single `.rocky` file into a `Model`.
-fn load_single_rocky_model(
-    path: &Path,
-    defaults: Option<&models::DirDefaults>,
-) -> Result<Model, ProjectError> {
-    let name = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-
-    let content = std::fs::read_to_string(path).map_err(models::ModelError::ReadFile)?;
-
-    // Parse the .rocky file
-    let rocky_file = rocky_lang::parse(&content).map_err(|e| ProjectError::RockyParse {
-        path: path.display().to_string(),
-        reason: e.to_string(),
-    })?;
-
-    // Lower to SQL
-    let sql =
-        rocky_lang::lower::lower_to_sql(&rocky_file).map_err(|e| ProjectError::RockyLower {
-            path: path.display().to_string(),
-            reason: e,
-        })?;
-
-    // Check for sidecar .toml config
-    let toml_path = path.with_extension("toml");
-    let config = if toml_path.exists() {
-        // Use the sidecar loader which handles inference + defaults
-        models::load_model_pair(path, &toml_path, defaults)?.config
-    } else {
-        // No sidecar — use defaults or hardcoded fallback
-        let catalog = defaults
-            .as_ref()
-            .and_then(|d| d.target.as_ref())
-            .and_then(|t| t.catalog.clone())
-            .unwrap_or_else(|| "warehouse".to_string());
-        let schema = defaults
-            .as_ref()
-            .and_then(|d| d.target.as_ref())
-            .and_then(|t| t.schema.clone())
-            .unwrap_or_else(|| "default".to_string());
-        let strategy = defaults
-            .as_ref()
-            .and_then(|d| d.strategy.clone())
-            .unwrap_or_default();
-
-        ModelConfig {
-            name: name.clone(),
-            depends_on: vec![],
-            strategy,
-            target: TargetConfig {
-                catalog,
-                schema,
-                table: name.clone(),
-            },
-            sources: vec![],
-            adapter: None,
-            intent: defaults.as_ref().and_then(|d| d.intent.clone()),
-            freshness: defaults.as_ref().and_then(|d| d.freshness.clone()),
-            tests: vec![],
-            format: None,
-            format_options: None,
-            classification: Default::default(),
-            retention: None,
-            budget: None,
-            name_declared: String::new(),
-            target_table_declared: String::new(),
-        }
-    };
-
-    // Check for sibling contract file
     let contract_file = path.with_extension("contract.toml");
     let contract_path = if contract_file.exists() {
         Some(contract_file)

--- a/engine/crates/rocky-compiler/src/project.rs
+++ b/engine/crates/rocky-compiler/src/project.rs
@@ -49,7 +49,11 @@ pub enum ProjectError {
     #[error("dependency resolution failed: {0}")]
     Resolve(#[from] resolve::ResolveError),
 
-    #[error("DAG error: {0}")]
+    // Transparent: the leaf `DagError` already carries a fully
+    // self-describing message (incl. the `did you mean?` hint). Re-
+    // prefixing it here only produced a duplicated `Caused by` layer in
+    // the rendered anyhow chain.
+    #[error(transparent)]
     Dag(#[from] dag::DagError),
 
     #[error("no models found in {path}")]

--- a/engine/crates/rocky-core/src/hooks/mod.rs
+++ b/engine/crates/rocky-core/src/hooks/mod.rs
@@ -831,12 +831,30 @@ fn build_http_client() -> reqwest::Client {
 // Hook executor — runs a single shell command
 // ---------------------------------------------------------------------------
 
+/// Build the platform shell command that runs a hook's command string.
+///
+/// On Unix this is `sh -c <command>`; on Windows there is no `sh`, so it
+/// is `cmd /C <command>`. Returning a `tokio::process::Command` lets the
+/// caller wire up stdio / env without duplicating the cfg branch.
+fn shell_command(command: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    {
+        let mut cmd = tokio::process::Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    }
+    #[cfg(unix)]
+    {
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c").arg(command);
+        cmd
+    }
+}
+
 async fn execute_hook(hook: &HookConfig, json: &str) -> Result<(), HookError> {
     use tokio::io::AsyncWriteExt;
-    use tokio::process::Command;
 
-    let mut cmd = Command::new("sh");
-    cmd.arg("-c").arg(&hook.command);
+    let mut cmd = shell_command(&hook.command);
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
@@ -904,6 +922,26 @@ async fn execute_hook(hook: &HookConfig, json: &str) -> Result<(), HookError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- Shell-command platform builder --
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_command_uses_sh_on_unix() {
+        let cmd = shell_command("echo hi");
+        assert_eq!(cmd.as_std().get_program(), "sh");
+        let args: Vec<_> = cmd.as_std().get_args().collect();
+        assert_eq!(args, ["-c", "echo hi"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shell_command_uses_cmd_on_windows() {
+        let cmd = shell_command("echo hi");
+        assert_eq!(cmd.as_std().get_program(), "cmd");
+        let args: Vec<_> = cmd.as_std().get_args().collect();
+        assert_eq!(args, ["/C", "echo hi"]);
+    }
 
     // -- Registry tests --
 

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -47,6 +47,18 @@ impl AdapterError {
             inner: msg.into().into(),
         }
     }
+
+    /// The boxed underlying error.
+    ///
+    /// Exposed so callers can `downcast_ref` to a concrete adapter error
+    /// type (e.g. a warehouse `ConnectorError`) to recover typed details
+    /// such as an HTTP status. `source()` is insufficient here: it returns
+    /// `inner.source()`, which skips `inner` itself, so a leaf error
+    /// variant with no nested source (like `ApiError { status, body }`)
+    /// would be unreachable.
+    pub fn inner(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+        self.inner.as_ref()
+    }
 }
 
 impl std::fmt::Display for AdapterError {

--- a/engine/crates/rocky-engine/src/ci.rs
+++ b/engine/crates/rocky-engine/src/ci.rs
@@ -34,7 +34,14 @@ impl CiResult {
         self.compile_ok && self.tests_ok
     }
 
-    /// Exit code: 0 if pass, 1 if errors, 2 if warnings-only.
+    /// Exit code: 0 if pass, 1 if errors, 4 if warnings-only.
+    ///
+    /// The warnings-only code is deliberately `4`, not `2`: exit `2` is
+    /// reserved for `rocky run` partial-success (Dagster keys on it via
+    /// `allow_partial=True`). A `rocky ci` run that compiled and tested
+    /// clean but emitted advisory warnings is a different condition, so
+    /// it must not collide with that code. See the exit-code convention
+    /// in `rocky/src/main.rs`.
     pub fn exit_code(&self) -> i32 {
         if !self.compile_ok || !self.tests_ok {
             1
@@ -43,7 +50,7 @@ impl CiResult {
             .iter()
             .any(|d| d.severity == rocky_compiler::diagnostic::Severity::Warning)
         {
-            2
+            4
         } else {
             0
         }
@@ -117,5 +124,23 @@ mod tests {
         };
         assert_eq!(fail.exit_code(), 1);
         assert!(!fail.passed());
+
+        // Warnings-only: compile + tests pass, but a warning diagnostic is
+        // present. Distinct from run's partial-success exit 2.
+        let warn = CiResult {
+            compile_ok: true,
+            tests_ok: true,
+            models_compiled: 1,
+            tests_passed: 1,
+            tests_failed: 0,
+            diagnostics: vec![rocky_compiler::diagnostic::Diagnostic::warning(
+                "W001",
+                "m",
+                "advisory",
+            )],
+            failures: vec![],
+        };
+        assert_eq!(warn.exit_code(), 4);
+        assert!(warn.passed());
     }
 }

--- a/engine/crates/rocky-engine/src/ci.rs
+++ b/engine/crates/rocky-engine/src/ci.rs
@@ -134,9 +134,7 @@ mod tests {
             tests_passed: 1,
             tests_failed: 0,
             diagnostics: vec![rocky_compiler::diagnostic::Diagnostic::warning(
-                "W001",
-                "m",
-                "advisory",
+                "W001", "m", "advisory",
             )],
             failures: vec![],
         };

--- a/engine/crates/rocky-ir/src/dag.rs
+++ b/engine/crates/rocky-ir/src/dag.rs
@@ -9,8 +9,57 @@ pub enum DagError {
     #[error("circular dependency detected involving: {nodes:?}")]
     CyclicDependency { nodes: Vec<String> },
 
-    #[error("unknown dependency '{dependency}' referenced by '{node}'")]
-    UnknownDependency { node: String, dependency: String },
+    #[error(
+        "unknown dependency '{dependency}' referenced by '{node}'{}",
+        .suggestion.as_deref().map(|s| format!(" — did you mean '{s}'?")).unwrap_or_default()
+    )]
+    UnknownDependency {
+        node: String,
+        dependency: String,
+        /// Closest known model name to `dependency`, when one is a near
+        /// miss (helps the user spot a typo). `None` when nothing is close.
+        suggestion: Option<String>,
+    },
+}
+
+/// Case-insensitive Levenshtein edit distance.
+///
+/// Small inline implementation so `rocky-ir` (a data-only crate) can
+/// surface a "did you mean?" near-miss on an unknown `depends_on`
+/// reference without pulling in a string-similarity dependency.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.to_lowercase().chars().collect();
+    let b: Vec<char> = b.to_lowercase().chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Best near-miss for `name` among `candidates`, if one is close enough.
+///
+/// Threshold scales with the typo's length (distance must be at most a
+/// third of the longer string, capped at 3) so short names don't match
+/// everything and long names tolerate a couple of typos.
+fn nearest_name(name: &str, candidates: impl Iterator<Item = String>) -> Option<String> {
+    candidates
+        .map(|c| {
+            let d = edit_distance(name, &c);
+            (c, d)
+        })
+        .filter(|(c, d)| {
+            let limit = (name.len().max(c.len()) / 3).clamp(1, 3);
+            *d <= limit
+        })
+        .min_by_key(|(_, d)| *d)
+        .map(|(c, _)| c)
 }
 
 /// A node in the transformation DAG.
@@ -31,9 +80,12 @@ pub fn topological_sort(nodes: &[DagNode]) -> Result<Vec<String>, DagError> {
     for node in nodes {
         for dep in &node.depends_on {
             if !names.contains(dep.as_str()) {
+                let suggestion =
+                    nearest_name(dep, nodes.iter().map(|n| n.name.clone())).filter(|s| s != dep);
                 return Err(DagError::UnknownDependency {
                     node: node.name.clone(),
                     dependency: dep.clone(),
+                    suggestion,
                 });
             }
         }
@@ -221,6 +273,56 @@ mod tests {
         }];
         let result = topological_sort(&nodes);
         assert!(matches!(result, Err(DagError::UnknownDependency { .. })));
+    }
+
+    #[test]
+    fn test_unknown_dependency_suggests_near_miss() {
+        let nodes = vec![
+            DagNode {
+                name: "orders".into(),
+                depends_on: vec!["custmers".into()],
+            },
+            DagNode {
+                name: "customers".into(),
+                depends_on: vec![],
+            },
+        ];
+        let err = topological_sort(&nodes).unwrap_err();
+        let DagError::UnknownDependency {
+            dependency,
+            suggestion,
+            ..
+        } = &err
+        else {
+            panic!("expected UnknownDependency, got {err:?}");
+        };
+        assert_eq!(dependency, "custmers");
+        assert_eq!(suggestion.as_deref(), Some("customers"));
+        // The suggestion is folded into the single Display message.
+        assert!(
+            err.to_string().contains("did you mean 'customers'?"),
+            "message should carry the suggestion: {err}"
+        );
+    }
+
+    #[test]
+    fn test_unknown_dependency_no_suggestion_when_distant() {
+        let nodes = vec![
+            DagNode {
+                name: "orders".into(),
+                depends_on: vec!["zzzzzzzz".into()],
+            },
+            DagNode {
+                name: "customers".into(),
+                depends_on: vec![],
+            },
+        ];
+        let err = topological_sort(&nodes).unwrap_err();
+        let DagError::UnknownDependency { suggestion, .. } = &err else {
+            panic!("expected UnknownDependency");
+        };
+        assert!(suggestion.is_none(), "distant name must not match");
+        assert!(!err.to_string().contains("did you mean"));
     }
 
     #[test]

--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -591,10 +591,14 @@ pub struct ModelIr {
     ///
     /// # Runtime wiring
     ///
-    /// TODO(D-2): wire into `propagate_costs` once the
-    /// `CatalogClient::table_stats` provider spike (D-2) reaches a
-    /// go-decision. The field is populated today; the enforcement check is
-    /// not yet called.
+    /// Enforcement is wired: `rocky compile` runs
+    /// `cost_check::check_cost_ceilings` against the DAG-propagated
+    /// estimates from `propagate_costs`, and `rocky plan` runs
+    /// `check_cost_ceilings_plan`. Both compare each model's declared
+    /// ceiling against the estimated cost and emit a diagnostic on breach.
+    /// What remains pending is *real* warehouse statistics: today the
+    /// estimates come from offline heuristics, not live
+    /// `CatalogClient::table_stats` lookups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_ceiling: Option<CostBudget>,
 }

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -117,7 +117,6 @@ impl ServerState {
             mask,
             allow_unmasked,
             project_freshness_default,
-            ..Default::default()
         };
 
         // The compile pass walks the model directory, parses every

--- a/engine/crates/rocky-server/src/state.rs
+++ b/engine/crates/rocky-server/src/state.rs
@@ -89,16 +89,34 @@ impl ServerState {
         // `rocky-cli::source_schemas` for the CLI equivalent.
         let source_schemas = self.load_cached_source_schemas().await;
 
+        // Load `[mask]` + `[classifications.allow_unmasked]` (W004) and the
+        // `[freshness]` default bit (W005) from rocky.toml, mirroring the
+        // CLI compile path. Without a config_path (or on a parse error) both
+        // come through empty and the checks stay silent — matching standalone
+        // `rocky compile --models models/`.
+        let (mask, allow_unmasked, project_freshness_default) = match &self.config_path {
+            Some(path) => match rocky_core::config::load_rocky_config(path) {
+                Ok(cfg) => (
+                    cfg.mask.clone(),
+                    cfg.classifications.allow_unmasked.clone(),
+                    cfg.freshness.has_default(),
+                ),
+                Err(e) => {
+                    debug!(error = %e, "rocky.toml load failed; W004/W005 will be silent");
+                    (Default::default(), Vec::new(), false)
+                }
+            },
+            None => (Default::default(), Vec::new(), false),
+        };
+
         let config = CompilerConfig {
             models_dir: self.models_dir.clone(),
             contracts_dir: self.contracts_dir.clone(),
             source_schemas,
             source_column_info: HashMap::new(),
-            // TODO: wire `[mask]` + `[classifications.allow_unmasked]`
-            // from the loaded `RockyConfig` so W004 surfaces in
-            // `rocky-server`'s HTTP compile path too. Today the server
-            // compile happens without a rocky.toml load step in scope,
-            // so the check is a no-op here.
+            mask,
+            allow_unmasked,
+            project_freshness_default,
             ..Default::default()
         };
 
@@ -217,5 +235,81 @@ impl ServerState {
         }
 
         map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write a one-model project whose only column carries a `pii`
+    /// classification tag. Returns the temp dir (kept alive by the caller)
+    /// and the models dir + rocky.toml path.
+    fn pii_project(rocky_toml: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let models_dir = dir.path().join("models");
+        std::fs::create_dir(&models_dir).unwrap();
+
+        let mut sql = std::fs::File::create(models_dir.join("users.sql")).unwrap();
+        write!(sql, "SELECT 'a@b.com' AS email").unwrap();
+
+        let mut toml = std::fs::File::create(models_dir.join("users.toml")).unwrap();
+        write!(
+            toml,
+            "name = \"users\"\n\n[target]\ncatalog = \"demo\"\nschema = \"main\"\ntable = \"users\"\n\n[classification]\nemail = \"pii\"\n"
+        )
+        .unwrap();
+
+        let config_path = dir.path().join("rocky.toml");
+        let mut cfg = std::fs::File::create(&config_path).unwrap();
+        write!(cfg, "{rocky_toml}").unwrap();
+
+        (dir, models_dir, config_path)
+    }
+
+    fn w004_count(result: &CompileResult) -> usize {
+        result
+            .diagnostics
+            .iter()
+            .filter(|d| &*d.code == "W004")
+            .count()
+    }
+
+    /// The server compile path must consult rocky.toml: an
+    /// `allow_unmasked = ["pii"]` entry suppresses W004, which only
+    /// happens if `[classifications]` was actually loaded (previously the
+    /// server passed `..Default::default()` and the check was a no-op).
+    #[tokio::test]
+    async fn server_compile_honours_allow_unmasked_from_config() {
+        // No mask, but pii is explicitly allowed unmasked → W004 suppressed.
+        let (_dir, models_dir, config_path) =
+            pii_project("[classifications]\nallow_unmasked = [\"pii\"]\n");
+        let state = ServerState::new(models_dir, None, Some(config_path));
+        state.recompile().await;
+        let guard = state.compile_result.read().await;
+        let result = guard.as_ref().expect("compile result");
+        assert_eq!(
+            w004_count(result),
+            0,
+            "allow_unmasked must suppress W004 in the server compile path"
+        );
+    }
+
+    /// Conversely, with a config that does not mask or allow the `pii`
+    /// tag, W004 fires — confirming the check is live (not just always
+    /// silent) once the config is wired.
+    #[tokio::test]
+    async fn server_compile_fires_w004_when_tag_unmasked() {
+        let (_dir, models_dir, config_path) = pii_project("# empty config\n");
+        let state = ServerState::new(models_dir, None, Some(config_path));
+        state.recompile().await;
+        let guard = state.compile_result.read().await;
+        let result = guard.as_ref().expect("compile result");
+        assert_eq!(
+            w004_count(result),
+            1,
+            "an unmasked, unallowed classification tag must raise W004"
+        );
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -1998,6 +1998,23 @@ fn parse_governance_override(
     Ok(Some(parsed))
 }
 
+/// Process exit-code convention for the `rocky` CLI.
+///
+/// Each non-zero code means a distinct condition so wrappers
+/// (Dagster, CI, shell scripts) can branch without parsing output:
+///
+/// | code | meaning |
+/// |------|---------|
+/// | `0`  | success |
+/// | `1`  | total / generic failure (e.g. `rocky run` with no tables copied, config error) |
+/// | `2`  | `rocky run` partial success — some tables materialized, some failed (Dagster `allow_partial=True` keys on this) |
+/// | `3`  | `rocky doctor` found a Critical health check |
+/// | `4`  | `rocky ci` passed compile + tests but emitted advisory warnings |
+/// | `130`| interrupted by SIGINT / SIGTERM |
+///
+/// `2` is reserved exclusively for run partial-success; doctor-critical
+/// and ci-warnings were split off to `3` / `4` so they no longer collide
+/// with it.
 async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // Install miette's fancy handler for rich error rendering in text mode.
     // In JSON mode we skip it — errors are serialized as structured data.

--- a/integrations/dagster/tests/fixtures_generated/contracts/compile.json
+++ b/integrations/dagster/tests/fixtures_generated/contracts/compile.json
@@ -10,7 +10,7 @@
       "message": "required column 'customer_id' missing from model output",
       "span": null,
       "model": "broken_metrics",
-      "suggestion": null
+      "suggestion": "add `customer_id` to the SELECT, or remove it from `[rules] required`"
     },
     {
       "severity": "Error",
@@ -18,7 +18,7 @@
       "message": "protected column 'customer_id' has been removed",
       "span": null,
       "model": "broken_metrics",
-      "suggestion": null
+      "suggestion": "restore `customer_id` in the SELECT, or remove it from `[rules] protected`"
     }
   ],
   "has_errors": true,


### PR DESCRIPTION
A code-quality sweep of the Rocky engine: CLI UX consistency, sharper diagnostics, a cross-platform fix, and dead/stale-code cleanup. Each finding is its own commit with a focused test.

## CLI UX & exit codes

- **EF1 — `rocky validate` green-lit unknown adapter types.** V017 was a `warn` that left `valid = true` (exit 0), yet `rocky run` rejects the same config. Now a hard error that sets `valid = false`, deciding known/unknown via the same `AdapterRegistry::is_known` the runtime uses, and appending the supported-types list + a `did_you_mean` suggestion (folds in EF4).
- **EF2 — `rocky doctor --check adapters|pipelines|state_sync|state_rw` reported healthy on a broken `rocky.toml`.** Those checks swallowed the config-load error and emitted nothing, so a syntactically broken config exited 0. Each now pushes a Critical health check pointing at `rocky doctor --check config`. Check collection is extracted into a unit-testable `collect_health_checks`.
- **EF3 — exit code 2 was overloaded.** `rocky run` uses exit 2 for partial-success (Dagster `allow_partial=True`); `rocky doctor` also exited 2 on critical and `rocky ci`'s `exit_code()` returned 2 for warnings-only. Reassigned: doctor-critical → **3** (process exit, verified), ci warnings-only → **4** in the `CiOutput.exit_code` JSON field. Added a central exit-code convention doc-comment (0/1/2/3/4/130). `rocky run`'s exit 2 is unchanged.
- **EF7 — `rocky validate` rendered errors and warnings identically** (both `  !! `). Errors now use a distinct ` ERR ` prefix matching `rocky doctor`.

## Diagnostics

- **EF5 — contract diagnostics E010–E013 lacked suggestions** their peers carry. Each now suggests a concrete fix (add/remove column, CAST to the expected type, handle nullability, restore/relax a protected column). Contract diagnostics are TOML-sourced and carry no spans, so suggestions only.
- **EF6 — an unknown `depends_on` reference printed the same message three times** (top-level + two `Caused by` layers) with no guidance. `DagError::UnknownDependency` now carries a near-miss suggestion over the known model names (inline edit-distance, no new dependency), and the `ProjectError`/`CompileError` wrappers are now `#[error(transparent)]`, collapsing the chain to one line: `unknown dependency 'custmers' referenced by 'orders' — did you mean 'customers'?`
- **EF8 — warehouse failures surfaced raw HTTP status + body to the user.** Run table errors and `doctor` auth pings now frame `403` → `permission denied on <table> — verify the adapter principal has the required grants` and `401` → `authentication rejected — token/credential may be expired`. Keys off the typed `ConnectorError::ApiError { status }` (not `FailureKind`, which collapses 401/403), so the two messages differ. The raw body is preserved (run: tracing `error` field; doctor: verbose `details`). No `*Output` schema change. Databricks + Snowflake only; BigQuery has no typed status path and falls back to the raw error (best-effort).

## Cross-platform

- **XP1 — pipeline hooks spawned `sh -c` with no Windows fallback.** Extracted into a cfg-gated `shell_command`: `cmd /C` on Windows, `sh -c` on Unix (unchanged).

## Dead / stale / unfinished code

- **DC1 — removed dead `load_rocky_models`** (`#[allow(dead_code)]`, zero callers; the salsa `load_rocky_models_with_db` superseded it). Its only helper `load_single_rocky_model` was called solely by the dead loader, so it goes too; drops the now-unused `rayon::prelude` import.
- **DC3 — `ai-sync` upstream-changes was a silent hardcoded empty placeholder.** Choice: **documented limitation.** Wiring it needs a persisted previous `CompileResult` to diff (`detect_schema_changes`), but the state store does not yet snapshot prior compilations — out of scope for a UX PR. Replaced the bare `Vec::new()` with a documented limitation in code plus a one-line user note that proposals are intent-driven only.
- **DC4 — server compile silently no-op'd the W004 PII check.** Choice: **wired.** `config_path` is already on `ServerState`, so the server compile path now loads `[mask]` + `[classifications.allow_unmasked]` + the `[freshness]` default from `rocky.toml`, mirroring the CLI. Tests prove `allow_unmasked` suppresses W004 and an unmasked tag still raises it.
- **DC5 — corrected the stale `cost_ceiling` TODO.** It claimed enforcement was "not yet called", but `rocky compile`/`rocky plan` already run `check_cost_ceilings`/`check_cost_ceilings_plan`. Corrected to note that offline enforcement is wired and only real warehouse-stats propagation remains pending.

## ⚠ review

EF3 reassigns exit codes that wrappers observe: **doctor-critical process exit 2 → 3** (verified end-to-end), and **ci warnings-only `CiOutput.exit_code` JSON field 2 → 4**. Note `rocky ci`'s *process* exit is unchanged — it only exits non-zero when compile/tests fail (always 1), so the warnings-only `exit_code` value is surfaced in JSON, never as a process code. **`rocky run`'s exit 2 (partial-success) is unchanged.** No Dagster fixtures or schemas pin the affected values (verified).

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean. Tests green for rocky-cli (632), rocky-core (1270 lib + 33 e2e), rocky-server (86), rocky-compiler (323), rocky-ir, rocky-engine. No codegen/fixture drift (no `*Output` field added).