### PR TITLE
test(engine): wiremock + live coverage for Snowflake/BigQuery batch-describe

### DIFF
--- a/engine/crates/rocky-bigquery/src/batch.rs
+++ b/engine/crates/rocky-bigquery/src/batch.rs
@@ -51,6 +51,53 @@ fn generate_batch_describe_sql(catalog: &str, schema: &str) -> String {
     )
 }
 
+/// Parse the four-column `INFORMATION_SCHEMA.COLUMNS` result
+/// (`table_name`, `column_name`, `data_type`, `is_nullable`) into a map of
+/// table name → columns. Rows are expected pre-grouped by table + ordinal
+/// (the query's `ORDER BY`); blank table/column rows are skipped.
+///
+/// Pure (rows in, map out) so the casing + `is_nullable` parsing can be
+/// unit-tested without an HTTP round trip — the BigQuery connector has no
+/// base-URL override for wiremock, unlike the Snowflake connector.
+fn parse_describe_rows(rows: &[Vec<serde_json::Value>]) -> HashMap<String, Vec<ColumnInfo>> {
+    let mut map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
+
+    for row in rows {
+        let table = row
+            .first()
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let col_name = row
+            .get(1)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let data_type = row
+            .get(2)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let nullable = row
+            .get(3)
+            .and_then(|v| v.as_str())
+            .map(|s| s.eq_ignore_ascii_case("YES"))
+            .unwrap_or(true);
+
+        if table.is_empty() || col_name.is_empty() {
+            continue;
+        }
+
+        map.entry(table).or_default().push(ColumnInfo {
+            name: col_name,
+            data_type,
+            nullable,
+        });
+    }
+
+    map
+}
+
 #[async_trait]
 impl BatchCheckAdapter for BigQueryBatchCheckAdapter {
     async fn batch_row_counts(&self, _tables: &[TableRef]) -> AdapterResult<Vec<RowCountResult>> {
@@ -76,43 +123,7 @@ impl BatchCheckAdapter for BigQueryBatchCheckAdapter {
     ) -> AdapterResult<HashMap<String, Vec<ColumnInfo>>> {
         let sql = generate_batch_describe_sql(catalog, schema);
         let result = self.adapter.execute_query(&sql).await?;
-
-        let mut map: HashMap<String, Vec<ColumnInfo>> = HashMap::new();
-
-        for row in &result.rows {
-            let table = row
-                .first()
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let col_name = row
-                .get(1)
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let data_type = row
-                .get(2)
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let nullable = row
-                .get(3)
-                .and_then(|v| v.as_str())
-                .map(|s| s.eq_ignore_ascii_case("YES"))
-                .unwrap_or(true);
-
-            if table.is_empty() || col_name.is_empty() {
-                continue;
-            }
-
-            map.entry(table).or_default().push(ColumnInfo {
-                name: col_name,
-                data_type,
-                nullable,
-            });
-        }
-
-        Ok(map)
+        Ok(parse_describe_rows(&result.rows))
     }
 }
 
@@ -132,5 +143,53 @@ mod tests {
         let sql = generate_batch_describe_sql("p", "s");
         assert!(sql.contains("is_nullable"));
         assert!(sql.contains("data_type"));
+    }
+
+    fn row(table: &str, col: &str, ty: &str, nullable: &str) -> Vec<serde_json::Value> {
+        vec![table.into(), col.into(), ty.into(), nullable.into()]
+    }
+
+    #[test]
+    fn parse_groups_columns_by_table_and_parses_nullability() {
+        let rows = vec![
+            row("orders", "id", "INT64", "NO"),
+            row("orders", "customer", "STRING", "YES"),
+            row("events", "event_id", "INT64", "YES"),
+        ];
+        let map = parse_describe_rows(&rows);
+
+        assert_eq!(map.len(), 2);
+        let orders = &map["orders"];
+        assert_eq!(orders.len(), 2);
+        assert_eq!(orders[0].name, "id");
+        assert_eq!(orders[0].data_type, "INT64");
+        assert!(!orders[0].nullable, "is_nullable=NO -> not nullable");
+        assert_eq!(orders[1].name, "customer");
+        assert!(orders[1].nullable, "is_nullable=YES -> nullable");
+        assert_eq!(map["events"].len(), 1);
+    }
+
+    #[test]
+    fn parse_is_nullable_is_case_insensitive() {
+        let rows = vec![row("t", "c", "STRING", "yes")];
+        let map = parse_describe_rows(&rows);
+        assert!(map["t"][0].nullable);
+    }
+
+    #[test]
+    fn parse_skips_blank_table_or_column_rows() {
+        let rows = vec![
+            row("", "c", "STRING", "YES"),
+            row("t", "", "STRING", "YES"),
+            row("t", "c", "STRING", "YES"),
+        ];
+        let map = parse_describe_rows(&rows);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map["t"].len(), 1);
+    }
+
+    #[test]
+    fn parse_empty_rows_yields_empty_map() {
+        assert!(parse_describe_rows(&[]).is_empty());
     }
 }

--- a/engine/crates/rocky-bigquery/tests/batch_describe_live.rs
+++ b/engine/crates/rocky-bigquery/tests/batch_describe_live.rs
@@ -1,0 +1,198 @@
+//! Live BigQuery conformance test for the batched schema-describe path.
+//!
+//! `#[ignore]`-gated because it requires a real GCP project + BigQuery
+//! credentials. Run locally with:
+//!
+//! ```bash
+//! BIGQUERY_TEST_PROJECT=<your-project> \
+//! BIGQUERY_TEST_LOCATION=EU \
+//! GOOGLE_APPLICATION_CREDENTIALS=<path-to-sa-json> \
+//! cargo test -p rocky-bigquery --test batch_describe_live -- --ignored --nocapture
+//! ```
+//!
+//! What this test pins (closes the `feedback_sql_dialect_live_execute_tests`
+//! gap for the per-dataset `INFORMATION_SCHEMA.COLUMNS` batch query):
+//!
+//! 1. `BigQueryBatchCheckAdapter::batch_describe_schema` returns one entry
+//!    per table in the dataset in a single round trip (BigQuery scopes
+//!    `INFORMATION_SCHEMA.COLUMNS` to a single dataset), keyed by lowercase
+//!    table name.
+//! 2. The batched column set matches the per-table
+//!    `WarehouseAdapter::describe_table` path for the same table — same
+//!    column names (compared case-insensitively, since the batch path
+//!    lowercases names via `LOWER(column_name)` while the per-table path
+//!    does not), same `data_type`, same nullability. Both paths read
+//!    `INFORMATION_SCHEMA.COLUMNS`, so `data_type` strings *are* expected
+//!    to match here.
+//!
+//! Without this test, the inline SQL-shape unit tests in `batch.rs` would
+//! pass while a result-shape or region-qualification regression against the
+//! real warehouse shipped silently — the class of bug stub tests have
+//! repeatedly hidden on the BigQuery adapter.
+
+use std::collections::BTreeSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rocky_bigquery::auth::BigQueryAuth;
+use rocky_bigquery::batch::BigQueryBatchCheckAdapter;
+use rocky_bigquery::connector::BigQueryAdapter;
+use rocky_core::traits::{BatchCheckAdapter, WarehouseAdapter};
+use rocky_ir::TableRef;
+
+/// Build a shared adapter from env, or `None` when creds aren't plumbed in
+/// so the `#[ignore]`d test skips silently on a dev box.
+fn adapter_from_env() -> Option<(std::sync::Arc<BigQueryAdapter>, String)> {
+    let project = std::env::var("BIGQUERY_TEST_PROJECT").ok()?;
+    let location = std::env::var("BIGQUERY_TEST_LOCATION").unwrap_or_else(|_| "EU".to_string());
+    let auth = BigQueryAuth::from_env().ok()?;
+    Some((
+        std::sync::Arc::new(BigQueryAdapter::new(project.clone(), location, auth)),
+        project,
+    ))
+}
+
+fn dataset_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &BigQueryAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+#[tokio::test]
+#[ignore = "requires live BigQuery project"]
+async fn live_batch_describe_matches_per_table_describe() {
+    let Some((adapter, project)) = adapter_from_env() else {
+        eprintln!("BIGQUERY_* env vars unset; skipping");
+        return;
+    };
+
+    let dataset = format!("hc_batch_describe_{}", dataset_suffix());
+
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS `{project}`.`{dataset}`"),
+    )
+    .await;
+
+    // Two tables with mixed types + nullability so the batched query has to
+    // group multiple tables and parse `is_nullable` (YES/NO) correctly.
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE `{project}`.`{dataset}`.`orders` (\
+                id INT64 NOT NULL, \
+                customer STRING, \
+                amount FLOAT64\
+            )"
+        ),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE `{project}`.`{dataset}`.`events` (\
+                event_id INT64, \
+                payload JSON, \
+                created_at TIMESTAMP NOT NULL\
+            )"
+        ),
+    )
+    .await;
+
+    // Run the unit under test, then compare against per-table describe.
+    let batch = BigQueryBatchCheckAdapter::new(adapter.clone());
+    let result = batch.batch_describe_schema(&project, &dataset).await;
+
+    let cleanup = format!("DROP SCHEMA IF EXISTS `{project}`.`{dataset}` CASCADE");
+
+    let batched = match result {
+        Ok(map) => map,
+        Err(e) => {
+            exec(&adapter, &cleanup).await;
+            panic!("batch_describe_schema failed: {e:?}");
+        }
+    };
+
+    let mut mismatch: Option<String> = None;
+    for table in ["orders", "events"] {
+        let per_table = adapter
+            .describe_table(&TableRef {
+                catalog: project.clone(),
+                schema: dataset.clone(),
+                table: table.to_string(),
+            })
+            .await;
+
+        let per_table = match per_table {
+            Ok(c) => c,
+            Err(e) => {
+                mismatch = Some(format!("per-table describe of {table} failed: {e:?}"));
+                break;
+            }
+        };
+
+        let Some(batch_cols) = batched.get(table) else {
+            mismatch = Some(format!(
+                "batched result missing table {table:?}; keys present: {:?}",
+                batched.keys().collect::<Vec<_>>()
+            ));
+            break;
+        };
+
+        // The batch path lowercases names; the per-table path does not — so
+        // compare names case-insensitively.
+        let batch_names: BTreeSet<String> =
+            batch_cols.iter().map(|c| c.name.to_lowercase()).collect();
+        let per_table_names: BTreeSet<String> =
+            per_table.iter().map(|c| c.name.to_lowercase()).collect();
+        if batch_names != per_table_names {
+            mismatch = Some(format!(
+                "{table}: column-name set mismatch\n  batch     = {batch_names:?}\n  per-table = {per_table_names:?}"
+            ));
+            break;
+        }
+
+        // Both paths read INFORMATION_SCHEMA.COLUMNS, so data_type + nullable
+        // must agree column-for-column.
+        for col in &per_table {
+            let b = batch_cols
+                .iter()
+                .find(|c| c.name.eq_ignore_ascii_case(&col.name))
+                .expect("name sets already proven equal");
+            if b.data_type != col.data_type {
+                mismatch = Some(format!(
+                    "{table}.{}: data_type mismatch — batch={:?} per-table={:?}",
+                    col.name, b.data_type, col.data_type
+                ));
+                break;
+            }
+            if b.nullable != col.nullable {
+                mismatch = Some(format!(
+                    "{table}.{}: nullability mismatch — batch={} per-table={}",
+                    col.name, b.nullable, col.nullable
+                ));
+                break;
+            }
+        }
+        if mismatch.is_some() {
+            break;
+        }
+        eprintln!(
+            "OK: {table} — {} columns match per-table describe (names + data_type + nullability)",
+            batch_cols.len()
+        );
+    }
+
+    exec(&adapter, &cleanup).await;
+
+    if let Some(msg) = mismatch {
+        panic!("{msg}");
+    }
+}

--- a/engine/crates/rocky-snowflake/tests/batch_describe_live.rs
+++ b/engine/crates/rocky-snowflake/tests/batch_describe_live.rs
@@ -1,0 +1,216 @@
+//! Live Snowflake conformance test for the batched schema-describe path.
+//!
+//! `#[ignore]`-gated because it requires a real Snowflake account.
+//! Run locally with:
+//!
+//! ```bash
+//! SNOWFLAKE_ACCOUNT=<your-account> \
+//! SNOWFLAKE_WAREHOUSE=<your-warehouse> \
+//! SNOWFLAKE_TEST_DATABASE=<your-database> \
+//! # one of the supported auth modes (PAT shown here):
+//! SNOWFLAKE_PAT=<your-pat> \
+//! cargo test -p rocky-snowflake --test batch_describe_live -- --ignored --nocapture
+//! ```
+//!
+//! What this test pins (closes the `feedback_sql_dialect_live_execute_tests`
+//! gap for the `INFORMATION_SCHEMA.COLUMNS` batch query):
+//!
+//! 1. `SnowflakeBatchCheckAdapter::batch_describe_schema` returns one entry
+//!    per table in the schema in a single round trip, with every column
+//!    keyed by its lowercase table name.
+//! 2. The batched column set matches the per-table `DESCRIBE TABLE` path
+//!    (`WarehouseAdapter::describe_table`) for the same table — same column
+//!    names (lowercased), same nullability. Snowflake's `INFORMATION_SCHEMA`
+//!    reports `data_type` families (`NUMBER`, `TEXT`) where `DESCRIBE` reports
+//!    precise types (`NUMBER(38,0)`, `VARCHAR(...)`), so the type *string* is
+//!    deliberately not asserted equal — only that both paths see the same
+//!    columns.
+//!
+//! Without this test, the inline SQL-shape unit tests in `batch.rs` would
+//! pass while a casing or result-shape regression against the real
+//! warehouse shipped silently — exactly the class of bug stub tests have
+//! repeatedly hidden on the Snowflake adapter.
+
+use std::collections::BTreeSet;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::{BatchCheckAdapter, WarehouseAdapter};
+use rocky_ir::TableRef;
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::batch::SnowflakeBatchCheckAdapter;
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+
+/// Build a shared connector from env, returning it alongside the resolved
+/// database name. Returns `None` when the env isn't plumbed in so the
+/// `#[ignore]`d test skips silently rather than panicking on a dev box.
+fn connector_from_env() -> Option<(std::sync::Arc<SnowflakeConnector>, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    Some((
+        std::sync::Arc::new(SnowflakeConnector::new(config, auth)),
+        database,
+    ))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn exec(adapter: &SnowflakeWarehouseAdapter, sql: &str) {
+    adapter
+        .execute_statement(sql)
+        .await
+        .unwrap_or_else(|e| panic!("statement failed: {sql}\nerror: {e:?}"));
+}
+
+#[tokio::test]
+#[ignore = "requires live Snowflake account"]
+async fn live_batch_describe_matches_per_table_describe() {
+    let Some((connector, database)) = connector_from_env() else {
+        eprintln!("SNOWFLAKE_* env vars unset; skipping");
+        return;
+    };
+    let adapter = SnowflakeWarehouseAdapter::new((*connector).clone());
+
+    let schema = format!("rocky_batch_describe_{}", schema_suffix());
+
+    exec(
+        &adapter,
+        &format!("CREATE SCHEMA IF NOT EXISTS \"{database}\".\"{schema}\""),
+    )
+    .await;
+
+    // Two tables with mixed types + nullability so the batched query has to
+    // group multiple tables and parse `is_nullable` (YES/NO) correctly.
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"orders\" (\
+                \"id\" NUMBER(38,0) NOT NULL, \
+                \"customer\" VARCHAR(255), \
+                \"amount\" FLOAT\
+            )"
+        ),
+    )
+    .await;
+    exec(
+        &adapter,
+        &format!(
+            "CREATE TABLE \"{database}\".\"{schema}\".\"events\" (\
+                \"event_id\" NUMBER(38,0), \
+                \"payload\" VARIANT, \
+                \"created_at\" TIMESTAMP_NTZ NOT NULL\
+            )"
+        ),
+    )
+    .await;
+
+    // Run the unit under test, then compare against per-table DESCRIBE.
+    let batch = SnowflakeBatchCheckAdapter::new(connector.clone());
+    let result = batch.batch_describe_schema(&database, &schema).await;
+
+    // Always drop the schema before asserting so a failure can't leak it.
+    let cleanup = format!("DROP SCHEMA IF EXISTS \"{database}\".\"{schema}\"");
+
+    let batched = match result {
+        Ok(map) => map,
+        Err(e) => {
+            exec(&adapter, &cleanup).await;
+            panic!("batch_describe_schema failed: {e:?}");
+        }
+    };
+
+    // The batched map must key both tables by their lowercase name and carry
+    // every column. Compare names + nullability against per-table DESCRIBE.
+    let mut mismatch: Option<String> = None;
+    for table in ["orders", "events"] {
+        let per_table = adapter
+            .describe_table(&TableRef {
+                catalog: database.clone(),
+                schema: schema.clone(),
+                table: table.to_string(),
+            })
+            .await;
+
+        let per_table = match per_table {
+            Ok(c) => c,
+            Err(e) => {
+                mismatch = Some(format!("per-table describe of {table} failed: {e:?}"));
+                break;
+            }
+        };
+
+        let Some(batch_cols) = batched.get(table) else {
+            mismatch = Some(format!(
+                "batched result missing table {table:?}; keys present: {:?}",
+                batched.keys().collect::<Vec<_>>()
+            ));
+            break;
+        };
+
+        let batch_names: BTreeSet<String> = batch_cols.iter().map(|c| c.name.clone()).collect();
+        let per_table_names: BTreeSet<String> = per_table.iter().map(|c| c.name.clone()).collect();
+        if batch_names != per_table_names {
+            mismatch = Some(format!(
+                "{table}: column-name set mismatch\n  batch     = {batch_names:?}\n  per-table = {per_table_names:?}"
+            ));
+            break;
+        }
+
+        // Nullability must agree column-for-column.
+        for col in &per_table {
+            let b = batch_cols
+                .iter()
+                .find(|c| c.name == col.name)
+                .expect("name sets already proven equal");
+            if b.nullable != col.nullable {
+                mismatch = Some(format!(
+                    "{table}.{}: nullability mismatch — batch={} per-table={}",
+                    col.name, b.nullable, col.nullable
+                ));
+                break;
+            }
+        }
+        if mismatch.is_some() {
+            break;
+        }
+        eprintln!(
+            "OK: {table} — {} columns match per-table DESCRIBE (names + nullability)",
+            batch_cols.len()
+        );
+    }
+
+    exec(&adapter, &cleanup).await;
+
+    if let Some(msg) = mismatch {
+        panic!("{msg}");
+    }
+}

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -1223,6 +1223,114 @@ async fn rate_limit_below_threshold_does_not_trip_breaker() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Batched schema-describe (BatchCheckAdapter)
+// ---------------------------------------------------------------------------
+
+/// One batched `INFORMATION_SCHEMA.COLUMNS` query replaces N per-table
+/// `DESCRIBE TABLE` round trips. Mounts a mock that only matches the batched
+/// query (scoped to `<db>.information_schema.columns`), returns a 4-column
+/// rowset covering two tables, and asserts: the query fires exactly once, the
+/// result groups by lowercase table name, column names are lowercased, and
+/// `is_nullable` (YES/NO) parses into the right `nullable` flag.
+#[tokio::test]
+async fn test_batch_describe_single_query_groups_by_table() {
+    use rocky_core::traits::BatchCheckAdapter;
+    use rocky_snowflake::batch::SnowflakeBatchCheckAdapter;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        // The batched describe targets the database-scoped information_schema.
+        .and(body_string_contains("information_schema.columns"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-batch-describe",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": {
+                "numRows": 4,
+                "rowType": [
+                    {"name": "LOWER(TABLE_NAME)", "type": "TEXT", "nullable": false},
+                    {"name": "LOWER(COLUMN_NAME)", "type": "TEXT", "nullable": false},
+                    {"name": "DATA_TYPE", "type": "TEXT", "nullable": false},
+                    {"name": "IS_NULLABLE", "type": "TEXT", "nullable": false}
+                ]
+            },
+            // Snowflake returns INFORMATION_SCHEMA values as JSON strings.
+            "data": [
+                ["orders", "id", "NUMBER", "NO"],
+                ["orders", "customer", "TEXT", "YES"],
+                ["events", "event_id", "NUMBER", "YES"],
+                ["events", "created_at", "TIMESTAMP_NTZ", "NO"]
+            ]
+        })))
+        // Exactly one batched query — not one DESCRIBE per table.
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = std::sync::Arc::new(test_connector(&server));
+    let batch = SnowflakeBatchCheckAdapter::new(connector);
+
+    let map = batch
+        .batch_describe_schema("TEST_DB", "analytics")
+        .await
+        .expect("batch describe should succeed");
+
+    // Grouped by lowercase table name.
+    assert_eq!(map.len(), 2, "two tables in the schema");
+
+    let orders = map.get("orders").expect("orders table present");
+    assert_eq!(orders.len(), 2);
+    assert_eq!(orders[0].name, "id");
+    assert_eq!(orders[0].data_type, "NUMBER");
+    assert!(!orders[0].nullable, "id is_nullable=NO -> not nullable");
+    assert_eq!(orders[1].name, "customer");
+    assert!(orders[1].nullable, "customer is_nullable=YES -> nullable");
+
+    let events = map.get("events").expect("events table present");
+    assert_eq!(events.len(), 2);
+    assert!(events.iter().any(|c| c.name == "event_id" && c.nullable));
+    assert!(events.iter().any(|c| c.name == "created_at" && !c.nullable));
+}
+
+/// An empty `INFORMATION_SCHEMA.COLUMNS` result (schema with no tables, or a
+/// missing schema) yields an empty map rather than an error — the run loop
+/// treats a prefetch miss the same as a per-table describe miss.
+#[tokio::test]
+async fn test_batch_describe_empty_schema_yields_empty_map() {
+    use rocky_core::traits::BatchCheckAdapter;
+    use rocky_snowflake::batch::SnowflakeBatchCheckAdapter;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("information_schema.columns"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-batch-empty",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": { "numRows": 0, "rowType": [] },
+            "data": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = std::sync::Arc::new(test_connector(&server));
+    let batch = SnowflakeBatchCheckAdapter::new(connector);
+
+    let map = batch
+        .batch_describe_schema("TEST_DB", "empty_schema")
+        .await
+        .expect("empty result should not error");
+    assert!(map.is_empty());
+}
+
 #[tokio::test]
 async fn breaker_trip_without_recovery_timeout_emits_none_cooldown() {
     let server = MockServer::start().await;


### PR DESCRIPTION
The batched \`INFORMATION_SCHEMA.COLUMNS\` schema-describe path for Snowflake and BigQuery (replacing N×2 per-table \`DESCRIBE TABLE\` round trips in the replication run loop) already landed in #131 and #132 — impl, registry wiring, and adapter-agnostic dispatch are live on \`main\`. This PR adds the wiremock/unit + live \`#[ignore]\` coverage that was missing, and live-verifies both adapters against the sandboxes.

## What this adds

**Snowflake** (\`rocky-snowflake\`)
- wiremock tests asserting one batched \`INFORMATION_SCHEMA.COLUMNS\` query replaces the per-table describes, results group by lowercase table name, and \`is_nullable\` (YES/NO) parses correctly — plus an empty-schema case.
- an \`#[ignore]\` live test that runs \`batch_describe_schema\` against a real account and asserts the column names + nullability match the per-table \`DESCRIBE TABLE\` path.

**BigQuery** (\`rocky-bigquery\`)
- extracts the row → \`ColumnInfo\` parsing into a pure \`parse_describe_rows\` fn (the connector has no base-URL override for wiremock, unlike Snowflake), unit-tested for table grouping, case-insensitive \`is_nullable\`, blank-row skipping, and the empty result.
- an \`#[ignore]\` live test asserting the batched columns match the per-table describe path (names + \`data_type\` + nullability).

\`batch_row_counts\` / \`batch_freshness\` remain the intentional not-yet-implemented stubs for both adapters — describe-only, as before.

## Verification

Live-verified against the Snowflake and BigQuery sandboxes (read-only \`INFORMATION_SCHEMA\` metadata queries):
- Snowflake live suite + new batch-describe live test: pass.
- BigQuery live suite + new batch-describe live test: pass.

Local gates: \`cargo build\` (workspace), per-crate \`cargo test\` (Snowflake 28 wiremock, BigQuery 84 lib), \`cargo clippy --all-targets -D warnings\`, \`cargo fmt --check\`, and \`export-schemas\` (no schema drift) all green.