### PR TITLE
fix(ci): harden engine-bench swap setup against the runner's active swapfile

### DIFF
--- a/.github/workflows/engine-bench.yml
+++ b/.github/workflows/engine-bench.yml
@@ -31,10 +31,15 @@ jobs:
           workspaces: engine
           key: bench
 
-      # DuckDB C++ compilation needs swap on CI
+      # DuckDB C++ compilation needs swap on CI. ubuntu-latest runners ship with
+      # an active /swapfile, so disable and remove it before reallocating —
+      # otherwise `fallocate` fails with "Text file busy". `dd` is a fallback for
+      # filesystems where fallocate is unsupported.
       - name: Configure swap
         run: |
-          sudo fallocate -l 4G /swapfile
+          sudo swapoff /swapfile 2>/dev/null || true
+          sudo rm -f /swapfile
+          sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile


### PR DESCRIPTION
The `engine-bench` workflow's swap-setup step ran `fallocate -l 4G /swapfile` directly, but `ubuntu-latest` runners ship with an **active** `/swapfile`, so `fallocate` failed with `Text file busy` on every `perf`-labeled run — the benchmark job never executed.

Fix: `swapoff` + `rm` the existing swapfile before reallocating, with a `dd` fallback for filesystems where `fallocate` is unsupported. Idempotent and safe whether or not a swapfile is already present.

Validated by running the workflow on this PR (it touches `engine-bench.yml`, which is in the workflow's path filter) with the `perf` label — the swap step now succeeds and the benches run.