### PR TITLE
fix(engine/rocky-bigquery): surface async job failures and retry on 429/503

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -6,8 +6,11 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::time::Instant;
-use tracing::{Instrument, Span, debug, field, info_span};
+use tracing::{Instrument, Span, debug, field, info_span, warn};
 
+use rocky_core::config::RetryConfig;
+use rocky_core::retry::compute_backoff;
+use rocky_core::retry_budget::RetryBudget;
 use rocky_core::traits::{
     AdapterError, AdapterResult, ChunkChecksum, ExecutionStats, PkRange, QueryResult, SqlDialect,
     WarehouseAdapter,
@@ -28,11 +31,33 @@ pub enum BigQueryError {
     #[error("BigQuery API error: {message} (status: {status})")]
     ApiError { status: String, message: String },
 
+    /// A query job that BigQuery accepted (HTTP 200, `jobComplete=true`)
+    /// but which then *failed at the job level* — the response carries a
+    /// top-level `errors[]` array (an `ErrorProto`) and no result rows.
+    ///
+    /// Before this variant existed, `run_query` returned `Ok` on any
+    /// `jobComplete=true` response, so an async job failure was silently
+    /// swallowed and the caller saw an empty result set instead of an
+    /// error. This mirrors how the Databricks adapter maps a
+    /// `state == FAILED` statement to `ConnectorError::StatementFailed`
+    /// and the Snowflake adapter maps a non-success `statusCode`. It is
+    /// classified **non-transient** — a rejected query won't pass on
+    /// retry.
+    #[error("BigQuery job failed: {message} (reason: {reason})")]
+    JobError { reason: String, message: String },
+
     #[error("authentication error: {0}")]
     Auth(#[from] crate::auth::AuthError),
 
     #[error("query timed out after {timeout_secs}s")]
     Timeout { timeout_secs: u64 },
+
+    /// The run-level retry budget was exhausted before this statement's
+    /// transient error could be retried. Mirrors the sibling adapters'
+    /// `RetryBudgetExhausted` so one rate-limited statement can't drain
+    /// the whole run's quota and the failure stays attributable.
+    #[error("run-level retry budget exhausted (limit {limit}); aborting remaining retries")]
+    RetryBudgetExhausted { limit: u32 },
 
     #[error("Storage Read API error: {0}")]
     StorageRead(#[from] StorageReadError),
@@ -46,6 +71,20 @@ pub struct BigQueryAdapter {
     location: String,
     dialect: BigQueryDialect,
     timeout_secs: u64,
+    /// Retry policy for transient REST failures (429 / 502 / 503 / 504 +
+    /// connection/timeout). Mirrors the Snowflake and Databricks adapters,
+    /// which both carry a [`RetryConfig`] and retry transient errors with
+    /// exponential backoff. Defaults to [`RetryConfig::default`]
+    /// (`max_retries = 3`) so the bare `new()` constructor gains retry
+    /// without a signature change; the registry threads the pipeline's
+    /// `[retry]` config in via [`BigQueryAdapter::with_retry`].
+    retry: RetryConfig,
+    /// Shared run-level retry budget. Unbounded by default — set via
+    /// [`BigQueryAdapter::with_retry_budget`] from the top-level
+    /// `[retry] max_retries_per_run` so one rate-limited statement can't
+    /// drain the whole run's quota. Mirrors the sibling adapters' §P2.7
+    /// budget.
+    retry_budget: RetryBudget,
     /// Override for the REST API base URL (used by tests to point at a
     /// wiremock server instead of `bigquery.googleapis.com`). Always
     /// `None` in production builds — the field only exists under `test`
@@ -132,9 +171,30 @@ impl BigQueryAdapter {
             location: location.into(),
             dialect: BigQueryDialect,
             timeout_secs: DEFAULT_TIMEOUT_SECS,
+            retry: RetryConfig::default(),
+            retry_budget: RetryBudget::unbounded(),
             #[cfg(any(test, feature = "test-support"))]
             base_url_override: None,
         }
+    }
+
+    /// Set the retry policy for transient REST failures. The registry
+    /// threads the pipeline's `[retry]` config in here so a BigQuery
+    /// adapter honours the same `max_retries` / backoff knobs as the
+    /// Snowflake and Databricks adapters.
+    #[must_use]
+    pub fn with_retry(mut self, retry: RetryConfig) -> Self {
+        self.retry = retry;
+        self
+    }
+
+    /// Override the run-level [`RetryBudget`]. The registry passes the
+    /// shared cross-adapter budget built from the top-level `[retry]
+    /// max_retries_per_run` so all adapters in a run draw from one quota.
+    #[must_use]
+    pub fn with_retry_budget(mut self, budget: RetryBudget) -> Self {
+        self.retry_budget = budget;
+        self
     }
 
     /// Point this adapter at a custom REST API base URL (for testing with
@@ -226,65 +286,125 @@ impl BigQueryAdapter {
             "rocky.warehouse.name" = %self.project_id,
             "rocky.warehouse.query_id" = field::Empty,
             "rocky.warehouse.bytes_scanned" = field::Empty,
+            "rocky.retry.attempt" = field::Empty,
         );
-        async move {
-            let token = self.auth.get_token(&self.client).await?;
-            let url = format!(
-                "{}/bigquery/v2/projects/{}/queries",
-                self.base_url(),
-                self.project_id
-            );
+        self.run_query_with_retry(sql).instrument(span).await
+    }
 
-            let request = QueryRequest {
-                query: sql.to_string(),
-                use_legacy_sql: false,
-                location: self.location.clone(),
-                timeout_ms: self.timeout_secs * 1000,
-                max_results: MAX_RESULTS_PER_PAGE,
-            };
-
-            debug!(sql = sql, project = %self.project_id, "executing BigQuery query");
-
-            let resp = self
-                .client
-                .post(&url)
-                .bearer_auth(&token)
-                .json(&request)
-                .send()
-                .await?;
-
-            if !resp.status().is_success() {
-                let status = resp.status().to_string();
-                let body = resp.text().await.unwrap_or_default();
-                return Err(BigQueryError::ApiError {
-                    status,
-                    message: body,
-                });
+    /// Submit `sql` with bounded retry-with-backoff for transient REST
+    /// failures (429 / 502 / 503 / 504 + connection/timeout), mirroring the
+    /// Snowflake and Databricks adapters. Non-transient failures (auth
+    /// 401/403, a 400 syntax rejection, a job-level `errors[]`, or a poll
+    /// timeout) return on the first attempt — retrying them only burns
+    /// quota. The run-level [`RetryBudget`] caps total retries so one
+    /// rate-limited statement can't drain the whole run's quota.
+    async fn run_query_with_retry(&self, sql: &str) -> Result<BigQueryResponse, BigQueryError> {
+        for attempt in 0..=self.retry.max_retries {
+            match self.run_query_once(sql).await {
+                Ok(resp) => {
+                    if attempt > 0 {
+                        rocky_observe::metrics::METRICS.inc_retries_succeeded();
+                    }
+                    Span::current().record(span_attrs::RETRY_ATTEMPT, u64::from(attempt + 1));
+                    return Ok(resp);
+                }
+                Err(err) => {
+                    if attempt < self.retry.max_retries && is_transient(&err) {
+                        // Run-level retry budget: if exhausted, abort
+                        // remaining retries so one rate-limited statement
+                        // can't drain the run's quota. Unbounded budgets
+                        // always consume successfully.
+                        if !self.retry_budget.try_consume() {
+                            let limit = self.retry_budget.total().unwrap_or(0);
+                            warn!(
+                                attempt = attempt + 1,
+                                max_retries = self.retry.max_retries,
+                                budget_limit = limit,
+                                error = %err,
+                                "retry budget exhausted for this run; aborting further retries",
+                            );
+                            return Err(BigQueryError::RetryBudgetExhausted { limit });
+                        }
+                        rocky_observe::metrics::METRICS.inc_retries_attempted();
+                        let backoff_ms = compute_backoff(&self.retry, attempt);
+                        warn!(
+                            attempt = attempt + 1,
+                            max_retries = self.retry.max_retries,
+                            backoff_ms = backoff_ms,
+                            error = %err,
+                            "transient BigQuery error, retrying"
+                        );
+                        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
+                    return Err(err);
+                }
             }
-
-            let response: BigQueryResponse = resp.json().await?;
-
-            if response.job_complete {
-                record_warehouse_attrs_on_current_span(&response);
-                return Ok(response);
-            }
-
-            // Async job: BigQuery deferred the result. Poll jobs.getQueryResults
-            // until it reports `job_complete=true` or `timeout_secs` elapses.
-            // Without this, the previous behaviour silently returned an empty
-            // rows array for any query slower than BigQuery's sync window.
-            let job_ref = response
-                .job_reference
-                .ok_or_else(|| BigQueryError::ApiError {
-                    status: "missing jobReference".into(),
-                    message:
-                        "BigQuery returned job_complete=false with no job_reference; cannot poll"
-                            .into(),
-                })?;
-            self.poll_query_results(&job_ref).await
         }
-        .instrument(span)
-        .await
+        unreachable!("retry loop should always return")
+    }
+
+    /// One BigQuery `jobs.query` submission + poll, with no retry. The
+    /// retry/backoff loop lives in [`Self::run_query_with_retry`].
+    async fn run_query_once(&self, sql: &str) -> Result<BigQueryResponse, BigQueryError> {
+        let token = self.auth.get_token(&self.client).await?;
+        let url = format!(
+            "{}/bigquery/v2/projects/{}/queries",
+            self.base_url(),
+            self.project_id
+        );
+
+        let request = QueryRequest {
+            query: sql.to_string(),
+            use_legacy_sql: false,
+            location: self.location.clone(),
+            timeout_ms: self.timeout_secs * 1000,
+            max_results: MAX_RESULTS_PER_PAGE,
+        };
+
+        debug!(sql = sql, project = %self.project_id, "executing BigQuery query");
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .json(&request)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().to_string();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(BigQueryError::ApiError {
+                status,
+                message: body,
+            });
+        }
+
+        let response: BigQueryResponse = resp.json().await?;
+
+        if response.job_complete {
+            // Surface an async job-level failure as an error instead of
+            // swallowing it as an empty result set. BigQuery accepts the
+            // job (HTTP 200, `jobComplete=true`) but reports the failure
+            // via a top-level `errors[]` array with no rows.
+            response.check_job_error()?;
+            record_warehouse_attrs_on_current_span(&response);
+            return Ok(response);
+        }
+
+        // Async job: BigQuery deferred the result. Poll jobs.getQueryResults
+        // until it reports `job_complete=true` or `timeout_secs` elapses.
+        // Without this, the previous behaviour silently returned an empty
+        // rows array for any query slower than BigQuery's sync window.
+        let job_ref = response
+            .job_reference
+            .ok_or_else(|| BigQueryError::ApiError {
+                status: "missing jobReference".into(),
+                message: "BigQuery returned job_complete=false with no job_reference; cannot poll"
+                    .into(),
+            })?;
+        self.poll_query_results(&job_ref).await
     }
 
     /// Poll `jobs.getQueryResults` until the job finishes or the configured
@@ -343,6 +463,10 @@ impl BigQueryAdapter {
 
             let response: BigQueryResponse = resp.json().await?;
             if response.job_complete {
+                // Same async-failure guard as the sync path: a job that
+                // finished with a top-level `errors[]` is surfaced as a
+                // `JobError`, not swallowed as an empty result set.
+                response.check_job_error()?;
                 debug!(
                     job_id = %job_ref.job_id,
                     attempts = attempt + 1,
@@ -994,6 +1118,88 @@ struct BigQueryResponse {
     /// stays `Option` for forward compatibility with `jobs.get` paths.
     #[serde(default)]
     statistics: Option<BigQueryStatistics>,
+    /// Top-level `errors[]` array on the `jobs.query` `QueryResponse` /
+    /// `jobs.getQueryResults` `GetQueryResultsResponse`. When a query job
+    /// BigQuery *accepted* (HTTP 200, `jobComplete=true`) then *failed*,
+    /// the failure surfaces here as an `ErrorProto` array — there is no
+    /// top-level `status` block on these endpoints (that nesting belongs
+    /// to the `jobs.get` `Job` resource). Before this field existed, an
+    /// accepted-but-failed job was silently returned as `Ok` with an
+    /// empty result set. `check_job_error` maps a non-empty `errors[]` to
+    /// [`BigQueryError::JobError`].
+    ///
+    /// Note: BigQuery documents that `errors[]` can also carry *warnings*
+    /// on a successful job, in which case result rows are still present.
+    /// `check_job_error` keys on the first `ErrorProto` regardless; in
+    /// practice the synchronous query endpoint returns warnings rarely and
+    /// a true failure always carries no rows. Sync rejections at job
+    /// creation arrive as a non-2xx Google API `error` envelope instead
+    /// and are handled by the `!resp.status().is_success()` branch.
+    #[serde(default)]
+    errors: Option<Vec<ErrorProto>>,
+}
+
+impl BigQueryResponse {
+    /// Map a top-level `errors[]` on a completed job to a
+    /// [`BigQueryError::JobError`], so an async job failure surfaces as an
+    /// error instead of an empty result set. No-op when `errors` is absent
+    /// or empty (the common success case).
+    fn check_job_error(&self) -> Result<(), BigQueryError> {
+        let Some(first) = self.errors.as_ref().and_then(|e| e.first()) else {
+            return Ok(());
+        };
+        Err(BigQueryError::JobError {
+            reason: first.reason.clone().unwrap_or_else(|| "unknown".into()),
+            message: first.message.clone().unwrap_or_default(),
+        })
+    }
+}
+
+/// A single BigQuery `ErrorProto` entry from a job-level `errors[]` array.
+/// Only `reason` + `message` are read; the other documented fields
+/// (`location`, `locationType`, `debugInfo`) are ignored.
+#[derive(Debug, Deserialize)]
+struct ErrorProto {
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Classifies whether a [`BigQueryError`] is transient and worth retrying.
+///
+/// Transient (retried with backoff):
+/// - HTTP 429 (Too Many Requests), 502/503/504 (server errors)
+/// - Network connection or HTTP-request timeout errors
+///
+/// **Not** transient (returned on the first attempt):
+/// - Auth failures (401/403) and a 400 query rejection — retrying a bad
+///   token or a syntax error only burns quota. (Unlike the Databricks
+///   adapter, this connector does not refresh a cached token on 401/403;
+///   `BigQueryAuth::ServiceAccount` mints fresh JWTs per-exchange and a
+///   true bad-credential 401 would re-fail every attempt anyway.)
+/// - A job-level [`BigQueryError::JobError`] — a rejected query won't pass
+///   on retry.
+/// - A poll-loop [`BigQueryError::Timeout`] — the job already ran to the
+///   deadline; re-submitting it is a fresh statement's concern.
+fn is_transient(err: &BigQueryError) -> bool {
+    match err {
+        BigQueryError::ApiError { status, .. } => {
+            // `status` is the reqwest `StatusCode` `Display` form, e.g.
+            // "429 Too Many Requests". Match on the leading code.
+            let code = status
+                .split_whitespace()
+                .next()
+                .and_then(|c| c.parse::<u16>().ok());
+            matches!(code, Some(429 | 502 | 503 | 504))
+        }
+        BigQueryError::Http(e) => e.is_connect() || e.is_timeout(),
+        BigQueryError::JobError { .. }
+        | BigQueryError::Auth(_)
+        | BigQueryError::Timeout { .. }
+        | BigQueryError::RetryBudgetExhausted { .. }
+        | BigQueryError::StorageRead(_) => false,
+    }
 }
 
 /// Top-level `statistics` block on a BigQuery job response. Only the
@@ -1313,5 +1519,103 @@ mod tests {
         let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
         let stats = stats_from_response(&resp);
         assert_eq!(stats.bytes_scanned, Some(10_485_760));
+    }
+
+    #[test]
+    fn job_errors_array_real_shape_deserializes_and_maps_to_job_error() {
+        // The real top-level `errors[]` ErrorProto shape captured from a
+        // live BigQuery sandbox probe — `{message, reason, domain,
+        // location, locationType}` at the response top level. (The live
+        // `jobs.query` runtime-failure probe returned this wrapped in a
+        // 400 `error.errors[]` envelope; the same ErrorProto is the
+        // top-level `errors[]` on a `jobComplete=true` async-failure
+        // response.) `check_job_error` maps the first entry to a
+        // `JobError` carrying `reason` + `message`.
+        let json = r#"{
+            "jobComplete": true,
+            "jobReference": {"projectId": "p", "jobId": "job-x"},
+            "errors": [
+                {
+                    "message": "division by zero: 1 / 0",
+                    "domain": "global",
+                    "reason": "invalidQuery",
+                    "location": "q",
+                    "locationType": "parameter"
+                }
+            ]
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        let err = resp
+            .check_job_error()
+            .expect_err("a top-level errors[] must map to a JobError");
+        match err {
+            BigQueryError::JobError { reason, message } => {
+                assert_eq!(reason, "invalidQuery");
+                assert_eq!(message, "division by zero: 1 / 0");
+            }
+            other => panic!("expected JobError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_job_error_is_noop_without_errors() {
+        // A normal completed response (no `errors` field) — the happy
+        // path captured live had no `errors` key at all. Must stay Ok so
+        // empty-result / DDL responses aren't mistaken for failures.
+        let json = r#"{
+            "jobComplete": true,
+            "jobReference": {"projectId": "p", "jobId": "job-ok"},
+            "rows": [{"f": [{"v": "1"}]}]
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.errors.is_none());
+        assert!(resp.check_job_error().is_ok());
+    }
+
+    #[test]
+    fn check_job_error_is_noop_for_empty_errors_array() {
+        // Defensive: an empty `errors[]` array (not `null`) must not be
+        // treated as a failure.
+        let json = r#"{
+            "jobComplete": true,
+            "errors": []
+        }"#;
+        let resp: BigQueryResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.check_job_error().is_ok());
+    }
+
+    #[test]
+    fn is_transient_classifies_retryable_vs_terminal() {
+        // Retryable: 429 / 502 / 503 / 504 (status is the reqwest
+        // StatusCode Display form, e.g. "429 Too Many Requests").
+        for code in ["429 Too Many Requests", "502 Bad Gateway", "503", "504"] {
+            assert!(
+                is_transient(&BigQueryError::ApiError {
+                    status: code.into(),
+                    message: "x".into(),
+                }),
+                "{code} should be transient"
+            );
+        }
+        // Terminal: auth 401/403 and a 400 rejection are NOT retried.
+        for code in ["400 Bad Request", "401 Unauthorized", "403 Forbidden"] {
+            assert!(
+                !is_transient(&BigQueryError::ApiError {
+                    status: code.into(),
+                    message: "x".into(),
+                }),
+                "{code} should be terminal"
+            );
+        }
+        // Terminal: a job-level rejection and a poll timeout don't pass
+        // on retry.
+        assert!(!is_transient(&BigQueryError::JobError {
+            reason: "invalidQuery".into(),
+            message: "bad".into(),
+        }));
+        assert!(!is_transient(&BigQueryError::Timeout { timeout_secs: 1 }));
+        assert!(!is_transient(&BigQueryError::RetryBudgetExhausted {
+            limit: 1
+        }));
     }
 }

--- a/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
@@ -9,19 +9,32 @@
 //! worst structural-bug history of the adapters, every bug in the
 //! HTTP/parse path, so this closes a high-risk gap.
 //!
-//! ## Characterization, not aspiration
+//! ## Behavior these tests pin
 //!
-//! Snowflake and Databricks classify 429/503 as transient and **retry**,
-//! and map a job-level error (`status.error` / `status.errorResult`) to a
-//! typed "statement failed" / "query rejected" variant. **BigQuery's
-//! connector does neither today**: `run_query` / `poll_query_results`
-//! make a single request and return `BigQueryError::ApiError` on any
-//! non-2xx, and `BigQueryResponse` doesn't parse `status.errorResult` at
-//! all. These tests therefore *pin current behavior* (429/503 →
-//! `ApiError` on the first hit, no retry; a 200-with-`errorResult` body
-//! is silently ignored and yields empty rows) rather than asserting a
-//! retry/error-mapping feature that doesn't exist. Closing those gaps is
-//! a follow-up feature PR, deliberately kept out of this test-only change.
+//! Like the Snowflake and Databricks adapters, BigQuery now classifies
+//! 429/502/503/504 as transient and **retries** with bounded
+//! exponential backoff, and maps an accepted-but-failed job (a top-level
+//! `errors[]` array on a `jobComplete=true` 200 response) to a typed
+//! [`BigQueryError::JobError`] instead of swallowing it as an empty
+//! result set. The three tests that previously *characterized the gap*
+//! (429/503 → `ApiError` on the first hit; a 200-with-error body ignored)
+//! now assert the fixed behavior.
+//!
+//! ### Job-failure shape (captured live, not guessed)
+//!
+//! The `jobs.query` `QueryResponse` and `jobs.getQueryResults`
+//! `GetQueryResultsResponse` surface a *job-level* failure as a
+//! **top-level `errors[]`** array of `ErrorProto`
+//! (`{reason, message, location, ...}`) — there is **no** top-level
+//! `status.errorResult` block on these endpoints (that nesting belongs to
+//! the `jobs.get` `Job` resource). A live sandbox probe confirmed that a
+//! runtime failure submitted through `jobs.query` (`SELECT ERROR(col)`,
+//! div-by-zero on a real table) is in fact rejected *synchronously* with
+//! an HTTP 400 Google API `error` envelope, which the non-2xx branch
+//! already maps to `ApiError`. The 200-with-`errors[]` path is the
+//! documented async-failure surface on `getQueryResults`; these tests pin
+//! the `errors[]` parsing using that real `ErrorProto` shape so the
+//! connector is correct regardless of which path a given job takes.
 //!
 //! ## Test seam
 //!
@@ -36,6 +49,8 @@
 use rocky_bigquery::BigQueryAdapter;
 use rocky_bigquery::auth::BigQueryAuth;
 use rocky_bigquery::connector::BigQueryError;
+use rocky_core::config::RetryConfig;
+use rocky_core::retry_budget::RetryBudget;
 use rocky_core::traits::{AdapterError, WarehouseAdapter};
 use serde_json::{Value, json};
 use wiremock::matchers::{header, method, path, query_param};
@@ -48,11 +63,52 @@ const QUERIES_PATH: &str = "/bigquery/v2/projects/test-project/queries";
 /// `with_timeout` defaults to the production 300 s so the poll deadline
 /// doesn't bite on the happy paths; individual tests shrink it where the
 /// timeout itself is under test.
+///
+/// **Retries disabled** (`max_retries = 0`) by default so the single-
+/// request error-mapping tests (auth 401/403, the 400 rejection, the
+/// job-error path) assert exactly one request without a retry layer
+/// interfering. The retry tests opt in via [`retrying_adapter`].
 fn test_adapter(server: &MockServer) -> BigQueryAdapter {
     let auth = BigQueryAuth::Bearer(rocky_core::redacted::RedactedString::new(
         "test-bq-token".into(),
     ));
-    BigQueryAdapter::new("test-project", "EU", auth).with_base_url(server.uri())
+    BigQueryAdapter::new("test-project", "EU", auth)
+        .with_base_url(server.uri())
+        .with_retry(no_retry())
+}
+
+/// `RetryConfig` with retries disabled — the error-mapping characterization
+/// tests want exactly one request.
+fn no_retry() -> RetryConfig {
+    RetryConfig {
+        max_retries: 0,
+        ..Default::default()
+    }
+}
+
+/// A fast `RetryConfig` for the retry tests: `max_retries` retries with a
+/// 1 ms base backoff and no jitter so the test doesn't sleep on the
+/// production 1000 ms ladder. Assertions on request count use the mock's
+/// `.expect(N)` / `server.verify()`.
+fn fast_retry(max_retries: u32) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        initial_backoff_ms: 1,
+        max_backoff_ms: 5,
+        backoff_multiplier: 2.0,
+        jitter: false,
+        ..Default::default()
+    }
+}
+
+/// Adapter that retries transient errors with the fast backoff above.
+fn retrying_adapter(server: &MockServer, max_retries: u32) -> BigQueryAdapter {
+    let auth = BigQueryAuth::Bearer(rocky_core::redacted::RedactedString::new(
+        "test-bq-token".into(),
+    ));
+    BigQueryAdapter::new("test-project", "EU", auth)
+        .with_base_url(server.uri())
+        .with_retry(fast_retry(max_retries))
 }
 
 /// Downcast an [`AdapterError`] to the concrete [`BigQueryError`] so tests
@@ -244,38 +300,32 @@ async fn deferred_job_without_reference_errors_cleanly() {
 }
 
 // ---------------------------------------------------------------------------
-// (c) 429 / 503 — CHARACTERIZATION: current connector does NOT retry.
+// (c) 429 / 503 — transient: the connector classifies these as transient
+// and retries with bounded backoff, mirroring the SF/DBX adapters.
 // ---------------------------------------------------------------------------
-//
-// SF/DBX classify these as transient and retry. BigQuery's connector has
-// no retry layer (`new` takes no RetryConfig; `run_query` makes one
-// request), so a 429 or 503 maps straight to `ApiError` on the first hit.
-// These tests pin that: the error mock is `.expect(1)` and a "would only
-// be hit on retry" success mock is `.expect(0)`, with `server.verify()`
-// proving no second attempt fired. The BQ analog of "gives up after the
-// budget" is the poll-loop `Timeout` path, covered separately below.
 
-/// 429 (rate limited) is surfaced as `ApiError` on the first request, with
-/// no retry. The mock is `.expect(1)`: had the connector retried, the
-/// call count would be ≥2 and `verify()` would fail — proving the absence
-/// of a retry layer. (SF/DBX classify 429 as transient and retry to a
-/// success; BigQuery does not yet.)
+/// 429 (rate limited) is transient: the connector retries. Here every
+/// attempt returns 429, so after the budget is exhausted the call surfaces
+/// the final `ApiError(429)`. `.expect(max_retries + 1)` pins that all
+/// attempts fired — proving the retry layer engaged (the pre-fix
+/// connector would have made exactly one request).
 #[tokio::test]
-async fn rate_limit_429_maps_to_api_error_without_retry() {
+async fn rate_limit_429_is_retried_then_surfaces_after_budget() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
         .and(path(QUERIES_PATH))
         .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
-        .expect(1)
+        // 2 retries → 3 total attempts.
+        .expect(3)
         .mount(&server)
         .await;
 
-    let adapter = test_adapter(&server);
+    let adapter = retrying_adapter(&server, 2);
     let err = adapter
         .execute_query("SELECT 1")
         .await
-        .expect_err("429 should surface as an error");
+        .expect_err("429 on every attempt should surface as an error after retries");
     match as_bq_error(&err) {
         BigQueryError::ApiError { status, message } => {
             assert!(
@@ -284,31 +334,32 @@ async fn rate_limit_429_maps_to_api_error_without_retry() {
             );
             assert!(message.contains("rate limited"));
         }
-        other => panic!("expected ApiError(429), got: {other:?}"),
+        other => panic!("expected ApiError(429) after exhausting retries, got: {other:?}"),
     }
-    // Exactly one request — `.expect(1)` fires on drop if the connector
-    // retried (would be 2+) or never called (would be 0).
+    // 3 requests total (1 + 2 retries) — `.expect(3)` fails on drop if the
+    // connector made fewer (no retry) or more.
     server.verify().await;
 }
 
-/// 503 (service unavailable) likewise maps to `ApiError` on the first hit
-/// with no retry. Pins that BigQuery does not yet treat 503 as transient.
+/// 503 (service unavailable) is likewise transient and retried. Same
+/// shape: every attempt 503s, the final error is `ApiError(503)`, and the
+/// request count proves the retries fired.
 #[tokio::test]
-async fn service_unavailable_503_maps_to_api_error_without_retry() {
+async fn service_unavailable_503_is_retried_then_surfaces_after_budget() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
         .and(path(QUERIES_PATH))
         .respond_with(ResponseTemplate::new(503).set_body_string("service unavailable"))
-        .expect(1)
+        .expect(3)
         .mount(&server)
         .await;
 
-    let adapter = test_adapter(&server);
+    let adapter = retrying_adapter(&server, 2);
     let err = adapter
         .execute_query("SELECT 1")
         .await
-        .expect_err("503 should surface as an error");
+        .expect_err("503 on every attempt should surface as an error after retries");
     match as_bq_error(&err) {
         BigQueryError::ApiError { status, message } => {
             assert!(
@@ -317,8 +368,93 @@ async fn service_unavailable_503_maps_to_api_error_without_retry() {
             );
             assert!(message.contains("service unavailable"));
         }
-        other => panic!("expected ApiError(503), got: {other:?}"),
+        other => panic!("expected ApiError(503) after exhausting retries, got: {other:?}"),
     }
+    server.verify().await;
+}
+
+/// Retry **succeeds** after N transient 429s then a 200: the connector
+/// retries through the rate-limit responses and returns the eventual
+/// result. Two scoped mocks with priorities — the 429 mock answers the
+/// first two requests (`up_to_n_times(2)`), the success mock answers the
+/// third — let `server.verify()` assert the exact attempt counts.
+#[tokio::test]
+async fn retry_succeeds_after_two_429s_then_200() {
+    let server = MockServer::start().await;
+
+    // First two attempts: 429. Higher priority so it wins while it still
+    // has responses left.
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(429).set_body_string("slow down"))
+        .up_to_n_times(2)
+        .with_priority(1)
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    // Third attempt: success with a row.
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-retry-ok"},
+            "schema": {"fields": [{"name": "n", "type": "INTEGER"}]},
+            "rows": [{"f": [{"v": "7"}]}],
+            "totalRows": "1"
+        })))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // 3 retries available; only 2 are needed.
+    let adapter = retrying_adapter(&server, 3);
+    let result = adapter
+        .execute_query("SELECT 7 AS n")
+        .await
+        .expect("connector should retry through the 429s and return the eventual result");
+
+    assert_eq!(result.columns, vec!["n"]);
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0], json!("7"));
+
+    // 2 × 429 then 1 × 200 = exactly 3 requests.
+    server.verify().await;
+}
+
+/// Retry **exhausts the run-level budget**: with `max_retries` high enough
+/// to keep retrying but a `RetryBudget` of 1, the second transient failure
+/// can't consume a retry slot, so the call aborts with
+/// `RetryBudgetExhausted` rather than continuing to burn the warehouse's
+/// rate-limit quota. Exactly 2 requests fire (initial + the single budgeted
+/// retry).
+#[tokio::test]
+async fn retry_exhausts_budget_after_repeated_503() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(503).set_body_string("unavailable"))
+        // initial attempt + 1 budgeted retry.
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    // max_retries = 5 would otherwise allow 5 retries, but the shared
+    // budget caps total retries at 1.
+    let adapter = retrying_adapter(&server, 5).with_retry_budget(RetryBudget::new(1));
+    let err = adapter
+        .execute_query("SELECT 1")
+        .await
+        .expect_err("budget exhaustion should abort remaining retries with an error");
+    match as_bq_error(&err) {
+        BigQueryError::RetryBudgetExhausted { limit } => {
+            assert_eq!(*limit, 1, "budget limit should be reported");
+        }
+        other => panic!("expected RetryBudgetExhausted, got: {other:?}"),
+    }
+    // initial + 1 retry = 2 requests; the budget blocks any further retry.
     server.verify().await;
 }
 
@@ -374,9 +510,11 @@ async fn never_completing_job_times_out() {
 // ---------------------------------------------------------------------------
 
 /// A 401 from BigQuery (expired/invalid token) maps to `ApiError` with the
-/// status and the error body preserved.
+/// status and the error body preserved, and is **not retried** — even with
+/// a retrying adapter, `.expect(1)` proves the classifier treats 401 as
+/// terminal (retrying a bad token only burns quota).
 #[tokio::test]
-async fn auth_failure_401_maps_to_api_error() {
+async fn auth_failure_401_maps_to_api_error_without_retry() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -392,7 +530,8 @@ async fn auth_failure_401_maps_to_api_error() {
         .mount(&server)
         .await;
 
-    let adapter = test_adapter(&server);
+    // Retrying adapter — a 401 must still surface on the first attempt.
+    let adapter = retrying_adapter(&server, 3);
     let err = adapter
         .execute_query("SELECT 1")
         .await
@@ -410,12 +549,13 @@ async fn auth_failure_401_maps_to_api_error() {
         }
         other => panic!("expected ApiError(401), got: {other:?}"),
     }
+    server.verify().await;
 }
 
 /// A 403 (e.g. `accessDenied` / quota or IAM denial) likewise maps to
-/// `ApiError` with the status and body preserved.
+/// `ApiError` with the status and body preserved, and is **not retried**.
 #[tokio::test]
-async fn auth_failure_403_maps_to_api_error() {
+async fn auth_failure_403_maps_to_api_error_without_retry() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -431,7 +571,7 @@ async fn auth_failure_403_maps_to_api_error() {
         .mount(&server)
         .await;
 
-    let adapter = test_adapter(&server);
+    let adapter = retrying_adapter(&server, 3);
     let err = adapter
         .execute_query("SELECT 1")
         .await
@@ -449,6 +589,7 @@ async fn auth_failure_403_maps_to_api_error() {
         }
         other => panic!("expected ApiError(403), got: {other:?}"),
     }
+    server.verify().await;
 }
 
 // ---------------------------------------------------------------------------
@@ -511,11 +652,13 @@ async fn truncated_json_body_maps_to_http_error() {
 // ---------------------------------------------------------------------------
 
 /// A SQL/job error returned as HTTP **400** with a BigQuery error envelope
-/// is the path the connector actually treats as a rejection today: any
-/// non-2xx → `ApiError` carrying the message. Mirrors how `jobs.query`
-/// returns syntax errors and invalid-query failures synchronously.
+/// maps to `ApiError` carrying the message, and is **not retried** — a
+/// retrying adapter with `.expect(1)` proves the 400 rejection is terminal.
+/// This is the path the connector takes for a synchronously-rejected query;
+/// the live sandbox probe confirmed `jobs.query` returns a runtime failure
+/// (`SELECT ERROR(col)`, div-by-zero) as exactly this 400 envelope.
 #[tokio::test]
-async fn job_error_http_400_maps_to_api_error() {
+async fn job_error_http_400_maps_to_api_error_without_retry() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -531,7 +674,7 @@ async fn job_error_http_400_maps_to_api_error() {
         .mount(&server)
         .await;
 
-    let adapter = test_adapter(&server);
+    let adapter = retrying_adapter(&server, 3);
     let err = adapter
         .execute_query("SELCT 1")
         .await
@@ -549,19 +692,23 @@ async fn job_error_http_400_maps_to_api_error() {
         }
         other => panic!("expected ApiError(400), got: {other:?}"),
     }
+    server.verify().await;
 }
 
-/// CHARACTERIZATION (documented gap): a 200 response carrying a job-level
-/// `status.errorResult` — BigQuery's async failure shape — is currently
-/// **ignored** by the connector. `BigQueryResponse` doesn't parse
-/// `status`, and `run_query` returns `Ok` whenever `jobComplete=true`, so
-/// the failure is swallowed and the caller sees an empty result set rather
-/// than a query-rejected error. SF/DBX map their equivalent to a typed
-/// "statement failed". This test pins the current (incorrect) behavior so
-/// a future fix that maps `errorResult` to an error is an intentional,
-/// visible change. See the module header.
+/// FIXED (was `job_error_result_in_200_body_is_currently_ignored`): a 200
+/// response on a *completed* job (`jobComplete=true`) that carries a
+/// top-level `errors[]` array — BigQuery's async job-failure shape on the
+/// `jobs.query` / `jobs.getQueryResults` endpoints — now maps to a typed
+/// [`BigQueryError::JobError`] instead of being swallowed as an empty
+/// result set.
+///
+/// The body uses the **real** `ErrorProto` shape captured live
+/// (`{reason, message, location, locationType, domain}` at the response
+/// top level — there is no `status.errorResult` nesting on these
+/// endpoints; that belongs to the `jobs.get` `Job` resource). The first
+/// `ErrorProto`'s `reason` / `message` flow into the typed error.
 #[tokio::test]
-async fn job_error_result_in_200_body_is_currently_ignored() {
+async fn job_error_in_200_body_maps_to_job_error() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -569,33 +716,89 @@ async fn job_error_result_in_200_body_is_currently_ignored() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "jobComplete": true,
             "jobReference": {"projectId": "test-project", "jobId": "job-errresult"},
-            "status": {
-                "state": "DONE",
-                "errorResult": {
+            // Real top-level `errors[]` ErrorProto shape (captured live).
+            "errors": [
+                {
                     "reason": "invalidQuery",
-                    "message": "Table not found: missing_table"
-                },
-                "errors": [
-                    {"reason": "invalidQuery", "message": "Table not found: missing_table"}
-                ]
-            }
+                    "message": "Table not found: missing_table",
+                    "domain": "global",
+                    "location": "q",
+                    "locationType": "parameter"
+                }
+            ]
         })))
         .expect(1)
         .mount(&server)
         .await;
 
     let adapter = test_adapter(&server);
-    // GAP: this resolves to Ok with no rows instead of a query-rejected
-    // error. Asserting Ok pins the current behavior; flip this assertion
-    // when the connector learns to map `status.errorResult`.
-    let result = adapter
+    let err = adapter
         .execute_query("SELECT * FROM missing_table")
         .await
-        .expect("connector currently ignores status.errorResult and returns Ok");
-    assert!(
-        result.rows.is_empty(),
-        "errorResult body carries no rows; current behavior yields an empty result set"
-    );
+        .expect_err("a job-level errors[] must surface as an error, not empty rows");
+    match as_bq_error(&err) {
+        BigQueryError::JobError { reason, message } => {
+            assert_eq!(reason, "invalidQuery");
+            assert!(
+                message.contains("Table not found"),
+                "job error message should be preserved, got: {message}"
+            );
+        }
+        other => panic!("expected JobError, got: {other:?}"),
+    }
+    server.verify().await;
+}
+
+/// The same async job-failure shape on the **poll path**: the initial
+/// `jobs.query` defers (`jobComplete=false` + `jobReference`), and the
+/// eventual `getQueryResults` poll returns `jobComplete=true` with a
+/// top-level `errors[]`. The connector applies the same `check_job_error`
+/// guard at the poll completion point, so a job that fails *after* being
+/// deferred also surfaces as `JobError`.
+#[tokio::test]
+async fn job_error_in_poll_result_maps_to_job_error() {
+    let server = MockServer::start().await;
+
+    // Submit defers.
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": false,
+            "jobReference": {"projectId": "test-project", "jobId": "job-poll-fail"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Poll completes — but with a job-level error and no rows.
+    Mock::given(method("GET"))
+        .and(path(
+            "/bigquery/v2/projects/test-project/queries/job-poll-fail",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobComplete": true,
+            "jobReference": {"projectId": "test-project", "jobId": "job-poll-fail"},
+            "errors": [
+                {"reason": "resourcesExceeded", "message": "Query exceeded resource limits"}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server);
+    let err = adapter
+        .execute_query("SELECT heavy()")
+        .await
+        .expect_err("a deferred job that fails on poll must surface as an error");
+    match as_bq_error(&err) {
+        BigQueryError::JobError { reason, message } => {
+            assert_eq!(reason, "resourcesExceeded");
+            assert!(message.contains("resource limits"));
+        }
+        other => panic!("expected JobError from poll path, got: {other:?}"),
+    }
+    server.verify().await;
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -430,10 +430,13 @@ impl AdapterRegistry {
                     let bq_auth = rocky_bigquery::auth::BigQueryAuth::from_env()
                         .context(format!("adapters.{name}: auth configuration error"))?;
 
-                    let adapter = Arc::new(
-                        BigQueryAdapter::new(project_id, location, bq_auth)
-                            .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300)),
-                    );
+                    let mut bq_adapter = BigQueryAdapter::new(project_id, location, bq_auth)
+                        .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300))
+                        .with_retry(adapter_cfg.retry.clone());
+                    if let Some(ref budget) = shared_retry_budget {
+                        bq_adapter = bq_adapter.with_retry_budget(budget.clone());
+                    }
+                    let adapter = Arc::new(bq_adapter);
                     bigquery_adapters.insert(name.clone(), adapter.clone());
                     let discovery_adapter = Arc::new(
                         rocky_bigquery::BigQueryDiscoveryAdapter::new(adapter.clone()),
@@ -699,7 +702,8 @@ impl AdapterRegistry {
 
         let adapter =
             rocky_bigquery::connector::BigQueryAdapter::new(project_id, location, bq_auth)
-                .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300));
+                .with_timeout(adapter_cfg.timeout_secs.unwrap_or(300))
+                .with_retry(adapter_cfg.retry.clone());
         Ok(Box::new(rocky_bigquery::BigQueryLoaderAdapter::new(
             Arc::new(adapter),
         )))


### PR DESCRIPTION
Fixes two real defects in the BigQuery adapter that the wiremock coverage in #795 surfaced and characterized. Brings BigQuery in line with the Snowflake/Databricks adapters.

## Defect 1 — silent async-failure swallow

`BigQueryResponse` didn't parse the job-level error array, so a query job that BigQuery **accepted** (HTTP 200, `jobComplete=true`) but which then **failed** was returned as `Ok` with an empty result set. A failed query looked like an empty success.

Now a non-empty top-level `errors[]` on a completed job maps to a new, non-transient `BigQueryError::JobError { reason, message }` (mirrors how Databricks maps a `FAILED` statement to `StatementFailed`). The guard is applied at **both** completion points — the sync `run_query` return and the deferred `poll_query_results` return — so a job that fails after being deferred is caught too. A successful job (no `errors[]`) is unaffected.

### Real response shape (captured live, not guessed)

A live sandbox probe of the `jobs.query` endpoint established the actual shapes:

- The `ErrorProto` BigQuery returns is, at the response top level:
  ```json
  { "message": "...", "domain": "global", "reason": "invalidQuery",
    "location": "q", "locationType": "parameter" }
  ```
  There is **no** top-level `status.errorResult` block on the `jobs.query` / `getQueryResults` endpoints — that nesting belongs to the `jobs.get` `Job` resource (which is what #795's mock had used). The deserializer + the flipped test now use the real top-level `errors[]` ErrorProto shape.

- Honest scope note: on this sandbox, **every** runtime failure submitted through `jobs.query` (`SELECT ERROR(col)`, division-by-zero on a real table, bad cast) was rejected **synchronously** as an HTTP 400 Google API `error` envelope:
  ```json
  { "error": { "code": 400, "status": "INVALID_ARGUMENT",
      "message": "division by zero: 1 / 0",
      "errors": [ { "message": "division by zero: 1 / 0",
        "reason": "invalidQuery", "domain": "global",
        "location": "q", "locationType": "parameter" } ] } }
  ```
  Even `timeoutMs: 1` did not defer — the 400 came back before any `jobReference` was issued. The async **200-with-`errors[]`** swallow path therefore could not be forced live on this sandbox; it is the documented async-failure surface on `getQueryResults` and is pinned by wiremock using the real `ErrorProto` shape captured from the 400 envelope. The sync 400 is already mapped to `ApiError` by the existing non-2xx branch.

## Defect 2 — no 429/503 retry

Unlike Snowflake/Databricks, `run_query` made one request and returned `ApiError` on any non-2xx — no retry/backoff. It now retries transient failures with bounded exponential backoff, mirroring the siblings:

- **Transient (retried):** HTTP 429 / 502 / 503 / 504, plus connection / request-timeout errors.
- **Terminal (returned on the first attempt):** auth 401/403, a 400 query rejection, a job-level `JobError`, and the poll-loop `Timeout`.
- **Policy:** shared `rocky_core::config::RetryConfig` (`compute_backoff` — exponential + jitter, same helper the SF/DBX loops use) + run-level `rocky_core::retry_budget::RetryBudget` so one rate-limited statement can't drain the run's quota (adds a non-transient `RetryBudgetExhausted` variant).
- **Wiring:** `new()` stays signature-stable (defaults to `RetryConfig::default()` + unbounded budget), so all existing call sites compile unchanged. New `with_retry` / `with_retry_budget` builders; the registry threads the pipeline `[retry]` config + shared budget into both BigQuery construction sites.

## Test changes (wiremock suite)

Flipped the three #795 characterization tests to assert the fixed behavior, renamed away from `_currently_ignored` / `_without_retry`:

- `job_error_in_200_body_maps_to_job_error` — 200-body `errors[]` → `JobError` (was: ignored → empty rows).
- `rate_limit_429_is_retried_then_surfaces_after_budget` — 429 retried, count pinned via `server.verify()`.
- `service_unavailable_503_is_retried_then_surfaces_after_budget` — same for 503.

Added:

- `retry_succeeds_after_two_429s_then_200` — retries through 2× 429 and returns the eventual result (exactly 3 requests verified).
- `retry_exhausts_budget_after_repeated_503` — `RetryBudget::new(1)` aborts with `RetryBudgetExhausted` after the budget (exactly 2 requests).
- `job_error_in_poll_result_maps_to_job_error` — the async-failure guard on the deferred poll path.
- Strengthened the auth-401/403 and 400 tests to run through a *retrying* adapter with `.expect(1)`, proving the classifier treats them as terminal.
- Unit tests in `connector.rs`: ErrorProto parse against the captured shape, `check_job_error` no-op on no/empty errors, and the `is_transient` retryable-vs-terminal matrix.

All assertions downcast via `AdapterError::inner().downcast_ref::<BigQueryError>()` — never bare `is_err()`. All other #795 tests stay green (18/18 wiremock, 89/89 lib unit).

## Live verification (real BigQuery sandbox)

Built the connector from sandbox creds and ran through the real adapter:

- **Failing query** `SELECT ERROR('rocky-bqretry-live')` **surfaces an error** through the connector (`is_err=true`), mapped to `ApiError(400 Bad Request)` carrying the full `error.errors[]` envelope. This query is rejected as a synchronous 400, which the pre-fix code *also* mapped to `ApiError` — so the live value here is warehouse reachability + proof that the `run_query` → `run_query_once` + retry-loop refactor still surfaces sync rejections as errors, **not** a behavior change. The swallow → `JobError` change lives on the async 200-with-`errors[]` path, which couldn't be forced live on this sandbox and is pinned by wiremock with the captured `ErrorProto` shape.
- **Happy query** `SELECT 1 AS x, 'hi' AS y` still returns its row correctly: `columns=["x","y"]`, `rows=[["1","hi"]]` — no regression from the retry/errorResult changes, and proves warehouse reachability.
- 429/503 **retry** is verified by wiremock only — a live 429 can't be forced on demand.
- No objects created (the `ERROR`/`SELECT` probes need no tables); nothing to clean up.

## Gates

`cargo build --workspace` (production compiles), `cargo clippy --all-targets --all-features -D warnings` (clean), `cargo fmt --check` (clean), `cargo test -p rocky-bigquery --all-features` (89 lib + 18 wiremock pass). No `*Output` struct changed, so no codegen.

