### PR TITLE
fix(ci): green the engine-bench workflow (upload results as artifact)

### DIFF
--- a/.github/workflows/engine-bench.yml
+++ b/.github/workflows/engine-bench.yml
@@ -49,13 +49,15 @@ jobs:
           cargo bench --bench compile -p rocky-cli -- --output-format bencher | tee bench-output.txt
           cargo bench --bench state_store -p rocky-core -- --output-format bencher | tee -a bench-output.txt
 
-      - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
+      # This workflow runs only on perf-labeled PRs (no push trigger), so there
+      # is no main-branch baseline to compare against — github-action-benchmark
+      # requires a `gh-pages` history branch and fails without one. Instead we
+      # surface the raw bencher output as a downloadable artifact. Maintaining a
+      # benchmark history would mean running these expensive builds on every main
+      # push, which this workflow deliberately avoids.
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          tool: 'cargo'
-          output-file-path: engine/bench-output.txt
-          alert-threshold: '120%'
-          comment-on-alert: true
-          fail-on-alert: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          name: bench-output
+          path: engine/bench-output.txt
+          if-no-files-found: error


### PR DESCRIPTION
Follow-up to #793 (swap-step hardening). With swap fixed, the `engine-bench` job got far enough to reach its final step — which then failed: `github-action-benchmark` runs `git fetch … gh-pages:gh-pages` and dies with `fatal: couldn't find remote ref gh-pages`. The repo has no `gh-pages` branch, and this workflow only runs on `perf`-labeled PRs (no `push` trigger, `auto-push` never fires), so there is no benchmark baseline to fetch or store.

Replace the storage step with `upload-artifact` of the `bench-output.txt` the run already produces. The workflow now goes fully green and the bencher numbers are downloadable from the run. Maintaining a real benchmark history would require running these expensive DuckDB-compiling benches on every main push, which this workflow deliberately avoids.

Validated by running the workflow on this PR (it touches `engine-bench.yml`, in the path filter) with the `perf` label.