### PR TITLE
docs: fix command-reference drift, clarify cli.md vs commands/* layering

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -15,7 +15,7 @@ Rocky provides a single binary with subcommands for the full pipeline lifecycle.
 - **Administration**: `history`, `replay`, `trace`, `metrics`, `optimize`, `compact`, `profile-storage`, `archive`, `compliance`, `retention-status`
 - **Diagnostics**: `doctor`, `compare`
 
-See the dedicated command reference pages for detailed documentation of each category.
+This page is the complete reference: every command and flag, with examples and JSON output. The pages under **Reference → Commands** cover the same commands grouped by category.
 
 ## Global Flags
 

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -9,13 +9,7 @@ The core pipeline commands cover the full lifecycle of a Rocky pipeline: project
 
 ## Global Flags
 
-These flags apply to all commands and are documented in the [CLI Reference](/reference/cli/).
-
-| Flag | Short | Type | Default | Description |
-|------|-------|------|---------|-------------|
-| `--config <PATH>` | `-c` | `PathBuf` | `rocky.toml` | Path to the pipeline configuration file. |
-| `--output <FORMAT>` | `-o` | `string` | `json` | Output format: `json` or `table`. |
-| `--state-path <PATH>` | | `PathBuf` | `.rocky-state.redb` | Path to the embedded state store for watermarks. |
+The global flags (`--config`, `--output`, `--state-path`, `--cache-ttl`) apply to every command. See [Global Flags in the CLI Reference](/reference/cli/#global-flags) for the canonical list, defaults, and the `--state-path` resolution order.
 
 ---
 


### PR DESCRIPTION
Part 2 of the IA restructure, scoped to the low-risk fix after discovering the command references are **layered**, not duplicated: `cli.md` is the complete reference (every command, full flags + examples + JSON) and the `commands/*` pages are category views that link into it (13 inbound links across 9 files; the `seed`/`compare`/`snapshot`/`docs`/`shell`/`watch`/`fmt` entries live only in `cli.md`).

Rather than invert that (migrate orphans, expand summaries, repoint 13 links, thin a 765-line page — a large, error-prone diff), this keeps `cli.md` canonical and fixes the genuine drift the audit flagged:

- **`core-pipeline.md`** duplicated a **Global Flags** table that had drifted from `cli.md` — it showed the stale `.rocky-state.redb` default and omitted `--cache-ttl`. Replaced the stale copy with a pointer to `cli.md`'s canonical `#global-flags` section (verified the anchor resolves).
- **`cli.md`** intro now states plainly that it's the complete reference and that `commands/*` group the same commands by category, instead of implying `commands/*` is the more detailed source.

No orphan migration, no link churn, no URL changes. Build clean (83 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)