### PR TITLE
chore: triple-cut release — engine 1.48.0, dagster 1.44.0, vscode 1.31.2

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.2] — 2026-06-02
+
+### Changed
+
+- **Fewer redundant CLI spawns.** The extension now caches `rocky catalog` / `rocky compile` output and debounces high-frequency CLI invocations, so editing and switching models no longer re-shells out to `rocky` on every keystroke. (#785)
+- Bumped dependencies to their latest minor versions. (#772)
+
+### Fixed
+
+- **First-use onboarding for users without the CLI installed.** A fresh install with no `rocky` on `$PATH` now guides the user to install it instead of failing silently. (#760)
+- **Scoped `rocky.server.path` and `rocky.server.extraArgs` to machine-level settings**, so a workspace can't point the language server at an arbitrary binary or inject arbitrary arguments.
+- **Allowlisted the command URIs the doctor webview is permitted to invoke.**
+
 ## [1.31.1] — 2026-05-30
 
 ### Changed

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.48.0] — 2026-06-02
+
+### Added
+
+- **`rocky mcp` grounds AI suggestions in live warehouse data.** The MCP server's data-grounding tools (`inspect_schema`, `sample_rows`, `profile_column`) now query the configured warehouse directly — sampling real rows, profiling a column's distribution and top values, and discovering raw source tables — across DuckDB, Snowflake, BigQuery, and Databricks. A new `suggest_freshness_block` tool drafts a `[freshness]` block from a source's observed load pattern. (#775)
+- **Cross-team contracts via imported producer IR snapshots.** A consumer project can import an upstream producer's compiled IR snapshot and type-check its own models against the producer's published output schema, so a breaking change upstream surfaces at compile time downstream. (#774)
+
+### Changed
+
+- **`rocky run` is a first-class single-step alias again** — no longer deprecated. `run` is the fused plan+apply path for everyday use; `plan` + `apply` remain the canonical auditable two-step flow. (#763)
+- **Non-blocking DuckDB execution and opt-in intra-layer transformation concurrency.** DuckDB queries now run on a blocking-safe thread, and independent models within a layer can be transformed in parallel with the new `--parallel` flag. (#790)
+- **State-store writes are batched.** Per-run progress writes dropped from O(N²) to O(N), and the schema cache now fsyncs once per run instead of once per model. (#787)
+- Bumped workspace dependencies to their latest minor versions. (#776)
+
+### Fixed
+
+- **Live data grounding emits correct SQL for BigQuery and Databricks.** BigQuery table references are backtick-quoted with hyphen-allowing project-id validation, and Databricks profile casts use Spark's `STRING` type instead of `VARCHAR` (which Spark rejects with `DATATYPE_MISSING_SIZE`). (#778)
+- **Dialect adapter-gating and identifier quoting corrected across adapters**, verified against live warehouses. (#789)
+- **BigQuery async job failures now surface instead of hanging**, with automatic retries on HTTP 429/503. (#796)
+- **`rocky doctor` and logging no longer warn on a healthy default setup** — a clean local project reports clean.
+- **The playground DuckDB is auto-seeded** so the first-run quickstart works without a manual seed step.
+- CLI UX, diagnostics, and cross-platform fixes, plus dead-code cleanup. (#788)
+
+### Security
+
+- Addressed security and data-integrity findings from an internal audit. (#764)
+
 ## [1.47.1] — 2026-05-30
 
 ### Fixed

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "logos",
  "miette",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "miette",
  "regex",
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.47.1"
+version = "1.48.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.47.1"
+version = "1.48.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.47.1"
+version = "1.48.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.47.1"
+version = "1.48.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.47.1"
+version = "1.48.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.47.1"
+version = "1.48.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.47.1"
+version = "1.48.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.47.1"
+version = "1.48.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.47.1"
+version = "1.48.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.47.1"
+version = "1.48.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.47.1"
+version = "1.48.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.47.1"
+version = "1.48.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.47.1"
+version = "1.48.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.47.1"
+version = "1.48.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.47.1"
+version = "1.48.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.47.1"
+version = "1.48.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.47.1"
+version = "1.48.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.47.1"
+version = "1.48.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.47.1"
+version = "1.48.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.47.1"
+version = "1.48.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.47.1"
+version = "1.48.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.44.0] — 2026-06-02
+
 ### Changed
 
 - **Cache the resolved `rocky` binary path.** `shutil.which(binary_path)` previously ran on every subprocess spawn (each `_build_cmd`) and again on the version check, rescanning `$PATH` each time. The resolved path is now memoized once per resource lifetime, so each spawn skips the lookup. The missing-binary behaviour is preserved: when `which` returns `None` the configured `binary_path` is used unchanged, and the downstream subprocess `FileNotFoundError` still surfaces the install-hint `dg.Failure`.
 - **`run`/`run_streaming` collapse to a single `rocky run` spawn.** Both methods previously spawned `rocky plan` then `rocky apply <plan_id>` — two process cold starts per materialization. `rocky run` is the engine's fused plan+apply path and emits the same `RunOutput` (identical materializations, check results, drift, costs, and partial-success exit codes), so the run path now spawns one process instead of two. `run_streaming` consequently streams all engine output to `context.log` in a single pass. `run_pipes` deliberately keeps the two-step `rocky plan` + `rocky apply` shape so it can surface the persisted `plan_id` as Dagster Pipes `extras` for operator correlation. Note: the collapsed `run`/`run_streaming` paths no longer write the engine-side audit plan artifact at `.rocky/plans/<plan_id>.json` (it was never consumed by the integration); use `run_pipes`, or invoke `rocky plan` directly, when a persisted plan is required.
 - Refreshed the locked Python dependencies to their latest minor/patch within the current major (no major-version jumps). `ruff` `0.15.14` → `0.15.15` and `datamodel-code-generator` `0.58.0` → `0.59.0`; `dagster` (1.13.7), `pydantic` (2.13.4), `pygments` (2.20.0), and `pytest` (9.0.3) were already at the latest within-major. No caps added; full suite green.
 - Raised the minimum `dagster` version from `>=1.13.2` to `>=1.13.7` (the current latest) to match the version CI resolves and tests. The `RockyComponent` path relies on `dagster.components.*` APIs from preview namespaces; advertising the tested floor is more honest than an older lower bound that CI never exercises. This is a hygiene change — the previous floor was not broken (those symbols import on earlier releases), so no behaviour changes. The full suite passes against 1.13.7.
+
+### Fixed
+
+- **Guard against a non-dict `plan` JSON payload.** When the engine returned a plan document that wasn't a JSON object (for example an error payload), the resource raised an uncaught `AttributeError` while inspecting it. It now validates the shape and surfaces a clear `dg.Failure` instead.
 
 ## [1.43.0] — 2026-05-30
 

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.43.0"
+version = "1.44.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Triple-cut release. Version bumps + CHANGELOGs only — all functional changes already landed in their own PRs.

## engine 1.48.0 (minor)
- **Added** — `rocky mcp` live-warehouse data grounding (`inspect_schema` / `sample_rows` / `profile_column` query the configured warehouse across DuckDB, Snowflake, BigQuery, Databricks) + `suggest_freshness_block` (#775); cross-team contracts via imported producer IR snapshots (#774)
- **Changed** — `rocky run` un-deprecated as a first-class single-step alias (#763); non-blocking DuckDB + opt-in `--parallel` intra-layer transformation concurrency (#790); batched state-store writes (#787)
- **Fixed** — BigQuery/Databricks live-grounding dialect SQL (#778); cross-adapter dialect gating + quoting (#789); BigQuery async job failures + 429/503 retry (#796); doctor/logging no longer cry wolf on a healthy default; auto-seeded playground DuckDB; CLI UX + cross-platform cleanup (#788)
- **Security** — internal audit findings (#764)

## dagster 1.44.0 (minor)
- Cached binary-path resolution; `run`/`run_streaming` collapsed to one `rocky run` spawn (#786); floor raised to `dagster>=1.13.7`; non-dict plan-JSON guard; dependency refresh

## vscode 1.31.2 (patch)
- Cached catalog/compile output + debounced CLI spawns (#785); first-use onboarding without the CLI (#760); machine-scoped `server.path`/`extraArgs`; doctor webview URI allowlist; dependency refresh

Tags pushed after merge: `engine-v1.48.0`, `dagster-v1.44.0`, `vscode-v1.31.2`.