### PR TITLE
docs: standardize diagnostic-code citations + align replay doc-comments

### DIFF
--- a/docs/src/content/docs/advanced/failure-modes.md
+++ b/docs/src/content/docs/advanced/failure-modes.md
@@ -13,7 +13,7 @@ For symptom-first lookup ("I got error X, what do I do?"), see [Troubleshooting]
 
 | Category | Detection signal | Surface |
 |---|---|---|
-| [Compile-time](#1-compile-time-failures) | `severity: Error` diagnostic with code `E001`, `E020`–`E026` | `rocky compile`, `rocky ci`, LSP red squiggles |
+| [Compile-time](#1-compile-time-failures) | `severity: Error` diagnostic with code `E001`, `E020`–`E028` | `rocky compile`, `rocky ci`, LSP red squiggles |
 | [Contract violations](#2-contract-violations) | Diagnostic codes `E010`–`E013` | `rocky compile`, `rocky ci`, `rocky apply` (pre-flight) |
 | [Schema drift](#3-schema-drift) | `DriftAction` enum on `rocky drift` / `rocky apply` output | `rocky drift`, `rocky apply` materialisation block |
 | [Quality check failures](#4-quality-check-failures) | `check_results[].status == "Failed"` | `rocky apply --output json` |

--- a/docs/src/content/docs/concepts/architecture-of-trust.md
+++ b/docs/src/content/docs/concepts/architecture-of-trust.md
@@ -128,7 +128,7 @@ Every load-bearing claim, in one table. Read the partial and not-yet rows carefu
 
 | Claim | Grade | What that means |
 |---|---|---|
-| Compile-time column-level types and diagnostics (`E001`–`E027`) | Shipped | Compilation fails on any error-level diagnostic. |
+| Compile-time column-level types and diagnostics (`E###` errors) | Shipped | Compilation fails on any error-level diagnostic. |
 | Compile-time column-level lineage + `lineage-diff` blast radius | Shipped | Intra-project; computed at compile time. |
 | Compile-time contracts (`E010`–`E013`) | Shipped | Intra-project contract validation against inferred schema. |
 | Schema drift handling (ignore / safe widen / drop-and-recreate) | Shipped | Explicit graded response with a grace period. |

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -47,7 +47,7 @@ A typed compiler that drives your warehouse. Storage and compute stay where they
 
 ## The seven trust dimensions
 
-1. **SQL as a typed, compiled language.** Column-level type inference across the full DAG. 35+ diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`) with actionable suggestions. Not text macros, but a real compiler with a real LSP.
+1. **SQL as a typed, compiled language.** Column-level type inference across the full DAG. 35+ diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints) with actionable suggestions. Not text macros, but a real compiler with a real LSP.
 2. **Compile-time column-level lineage.** Every column traced through every transformation, before execution. `rocky lineage-diff main` lists per-column downstream blast radius for PR review. That CI gate is impossible without a compiled engine.
 3. **Branches + a content-addressed run record.** Named branches as isolated schemas. `rocky branch create` / `rocky run --branch` / `rocky replay <run_id>`. Each run records per-model SQL hashes, row counts, and bytes, and content-addresses the written artifacts; `rocky replay` inspects and verifies that record against the ledger. (Re-execution from the pinned record is on the roadmap.)
 4. **Per-model cost attribution.** Cost is a column on every run record, not an afterthought dashboard. `[budget]` blocks fail the run on overspend; `budget_breach` fires the hook; `rocky preview cost` projects spend at PR time.

--- a/docs/src/content/docs/reference/commands/modeling.md
+++ b/docs/src/content/docs/reference/commands/modeling.md
@@ -76,7 +76,7 @@ rocky compile --model fct_revenue --contracts contracts/
 }
 ```
 
-Every diagnostic carries a severity (`"error"`, `"warning"`, `"info"`), a code (`E001`–`E026`, `W001`–`W011`, `V001`–`V020`), the owning model, and — when the compiler can locate it — a `span` and `suggestion`.
+Every diagnostic carries a severity (`"error"`, `"warning"`, `"info"`), a code (`E###` errors, `W###` warnings, `P###` portability lints, or `V###` validation), the owning model, and — when the compiler can locate it — a `span` and `suggestion`.
 
 Compile models from a non-default directory:
 

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -37,7 +37,7 @@ Identified by the hash of its contents rather than a name or timestamp. Rocky re
 
 ### Diagnostic code
 
-A stable identifier for a compiler finding: errors (`E001`–`E026`), warnings (`W001`–`W011`), and portability lints (`P001`–`P002`). Codes are searchable and map to a fix. See the [compiler](/concepts/compiler/).
+A stable identifier for a compiler finding: errors (`E###`), warnings (`W###`), portability lints (`P###`), and validation diagnostics (`V###`). Codes are searchable and map to a fix. See the [compiler](/concepts/compiler/).
 
 ### Drift
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -32,7 +32,7 @@ dbt Core 1.x is a templating engine with no compile-time type checker; contracts
 
 ## The seven trust dimensions
 
-1. **SQL as a typed, compiled language.** Real type inference, diagnostic codes (`E001`–`E026`, `W001`–`W011`, `P001`–`P002`), and a real LSP, not text macros or runtime checks.
+1. **SQL as a typed, compiled language.** Real type inference, diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints), and a real LSP, not text macros or runtime checks.
 2. **Compile-time column-level lineage.** Rocky knows every column's lineage before a row is written, so `rocky lineage-diff main` can block a PR when a downstream contract breaks.
 3. **Branches and an inspectable run ledger.** `rocky branch create`, `rocky run --branch`, and `rocky replay <run_id>`: branches are isolated schemas, and every run is recorded in an auditable ledger (who ran it, the commit, the per-model SQL hash, and row counts). On the content-addressed materialization path, output files are named by the hash of their bytes, so an auditor can confirm the recorded output is exactly what shipped.
 4. **Per-model cost attribution.** Cost is a column on every run record. `[budget]` blocks fail the run, `budget_breach` fires a hook, and `rocky preview cost` projects spend at PR time.

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -19,8 +19,8 @@
 //! model list, execution layers) rather than a full `ProjectIr` snapshot.
 //! `rocky apply` re-derives `ProjectIr` by calling `commands::run::run` with
 //! the same flags — a fast, CPU-only recompile step. Full IR persistence is
-//! deferred to a future phase if deterministic replay without recompile
-//! becomes a hard requirement.
+//! deferred to a future phase if re-execution from the pinned record without
+//! recompile becomes a hard requirement.
 //!
 //! ## Plan payload for Replication kind (Phase 5b)
 //!

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2651,8 +2651,8 @@ pub struct ArchiveApplyOutput {
 /// produced this plan — `rocky apply` re-derives the `ProjectIr` by
 /// re-compiling with the same flags. The trade-off: apply always re-compiles
 /// (fast, CPU-only, no network) rather than deserialising a potentially
-/// large IR snapshot. Phase 3 can sharpen this if deterministic replay
-/// without re-compile becomes a requirement.
+/// large IR snapshot. Phase 3 can sharpen this if re-execution from the
+/// pinned record without re-compile becomes a requirement.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RunPlan {
     /// Optional filter that was passed to `rocky plan` (e.g. `"client=acme"`).

--- a/examples/playground/benchmarks/FEATURE_COMPARISON.md
+++ b/examples/playground/benchmarks/FEATURE_COMPARISON.md
@@ -77,7 +77,7 @@ This document provides a factual feature-by-feature comparison of the major SQL 
 | **Error suggestions** | Yes (fix hints per diagnostic) | No | Partial | No | No | No |
 | **Parallel type checking** | Yes (rayon, per-layer) | No | Unknown | No | N/A | N/A |
 
-**Rocky's compiler advantage:** 35+ diagnostic codes (E001-E026, W001-W003, W010-W011, E010-E013, V001-V020) with actionable suggestions. Parallel type checking across DAG execution layers via rayon. Safe type widening allowlist prevents accidental data loss from ALTER TABLE operations.
+**Rocky's compiler advantage:** 35+ diagnostic codes (`E###` errors, `W###` warnings, `P###` portability lints, `V###` validation) with actionable suggestions. Parallel type checking across DAG execution layers via rayon. Safe type widening allowlist prevents accidental data loss from ALTER TABLE operations.
 
 ---
 


### PR DESCRIPTION
Two small cleanups deferred from #810.

## 1. Diagnostic-code citations

They were inconsistent and brittle across the docs — most said `E001`–`E026`, the architecture page said `E001`–`E027`, and a contiguous range implies a contiguous set. The engine's codes are **non-contiguous**: `E001`–`E033`, `W001`–`W012`, `P001`–`P002`, `V001`–`V033` (~51 distinct). Replaced the ranges with **family prefixes** — `E###` errors, `W###` warnings, `P###` portability lints, `V###` validation — so the copy is accurate, internally consistent, and won't go stale on the next code added. The "35+" count is kept (a conservative floor). The SQL-compiler trust-dimension copy cites `E`/`W`/`P`; the general-reference docs add `V`.

`failure-modes.md`: bumped the illustrative time-interval range `E020`–`E026` → `E020`–`E028` (the actual range).

## 2. Replay doc-comments

Two internal Rust doc-comments (`output.rs` `RunPlan`, `apply.rs` module) still said "deterministic replay"; reworded to "re-execution from the pinned record" to match the public vocabulary settled in #810. **Verified zero schema drift** — regenerated schemas are byte-identical to the committed ones, so codegen-drift is unaffected.

Docs site builds clean (83 pages); `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)