### PR TITLE
test(dagster): assert state writer emits by_alias keys and round-trips

### DIFF
--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -611,6 +611,59 @@ def test_write_state_writes_to_tmp_then_replaces(monkeypatch: pytest.MonkeyPatch
     assert not captured["src"].exists()
 
 
+def test_write_state_emits_alias_keys_and_round_trips(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """The state writer must serialize with ``by_alias=True`` so the on-disk
+    JSON uses the canonical CLI-shape field names, not the Python attribute
+    names. Otherwise a consumer re-parsing the cached state through Pydantic
+    (which has no ``populate_by_name``) fails to validate.
+
+    ``FailedSourceOutput.schema_`` carries an ``alias="schema"`` whose alias
+    differs from the attribute name — so it discriminates ``by_alias=True``
+    from the bare dump: without the alias the writer would emit ``"schema_"``
+    and the round-trip ``model_validate`` would raise ``ValidationError``.
+    """
+    discover = DiscoverResult.model_validate(
+        {
+            "version": "0.0.0",
+            "command": "discover",
+            "sources": [],
+            "failed_sources": [
+                {
+                    "id": "conn_1",
+                    "source_type": "fivetran",
+                    "schema": "raw_shopify",
+                    "error_class": "transient",
+                    "message": "transient fetch failure",
+                }
+            ],
+        }
+    )
+    stub = _StubResource(discover_result=discover)
+    _install_stub_resource(monkeypatch, stub)
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        models_dir=_missing_models_dir(tmp_path),  # skip compile
+        surface_optimize_metadata=False,
+    )
+    state_path = tmp_path / "state"
+
+    component.write_state_to_path(state_path)
+
+    state = json.loads(state_path.read_text())
+    failed_source = state["discover"]["failed_sources"][0]
+    # On-disk JSON carries the canonical alias key, not the Python attribute.
+    assert "schema" in failed_source
+    assert "schema_" not in failed_source
+
+    # The persisted discover slot round-trips cleanly back through the model.
+    round_tripped = DiscoverResult.model_validate(state["discover"])
+    assert round_tripped.failed_sources[0].schema_ == "raw_shopify"
+
+
 # ---------------------------------------------------------------------------
 # FR-011: surface_column_lineage walks models_dir and attaches metadata.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds a regression test that the `RockyComponent` state writer serializes its cached payloads with `by_alias=True`, so the on-disk state JSON uses canonical CLI-shape field names that re-parse cleanly through Pydantic.

## Why

The writer (`write_state_to_path`) already emits aliased keys at every slot (discover / compile / optimize / dag) — but that behavior had no test guarding it. Without `by_alias`, a field whose Pydantic attribute name differs from its wire alias (e.g. `FailedSourceOutput.schema_` → `"schema"`) gets written under the attribute name, and a consumer re-parsing the cached state through the model — which has no `populate_by_name` — fails to validate.

## The test

Drives `write_state_to_path` with a discover payload containing a `FailedSourceOutput` (the `schema_`/`"schema"` alias diverges), then asserts:

- the written JSON carries the `"schema"` alias key and not the `"schema_"` attribute name, and
- the persisted discover slot round-trips back through `model_validate`.

The divergent alias makes the assertion discriminating: dropping `by_alias=True` from the writer makes the test fail (verified locally).

Test-only change; no source or public-API change.

## Verification

- `uv run pytest` — 574 passed
- `uv run python -m ruff check src/ tests/` — clean
- `uv run python -m ruff format --check src/ tests/` — clean