### PR TITLE
feat(engine/rocky-mcp): expose AI generators + on-demand dialect lint over MCP

### DIFF
--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -509,3 +509,79 @@ pub struct SuggestFreshnessBlockResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
+
+/// `draft_contract` result — an LLM-drafted `.contract.toml` grounded in the
+/// observed profile of a model's target table, compile-verified against the
+/// model's inferred schema before it is returned.
+///
+/// `contract_toml` is the ready-to-save contract when drafting succeeds; it is
+/// a DRAFT — the caller writes it next to the model and runs `compile` to
+/// enforce it. `message` explains why no contract was produced (the API key is
+/// unset, the target isn't materialized, or the warehouse isn't reachable) so a
+/// graceful no-op is distinguishable from an error.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct DraftContractResult {
+    /// The model the contract was drafted for.
+    pub model: String,
+    /// The drafted `.contract.toml`, when one was produced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_toml: Option<String>,
+    /// Number of LLM attempts the compile-verify loop took, when it ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempts: Option<usize>,
+    /// Why no contract was produced (key unset / target unavailable), when
+    /// `contract_toml` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// One generated test assertion in a `generate_tests` result.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TestAssertionLite {
+    /// Short assertion name (also the suggested test filename stem).
+    pub name: String,
+    /// The assertion SQL — returns 0 rows when the invariant holds.
+    pub sql: String,
+    /// What the assertion checks, in plain language.
+    pub description: String,
+}
+
+/// `generate_tests` result — LLM-drafted test assertions for a model, derived
+/// from its intent + schema + source code.
+///
+/// `assertions` are DRAFTS the caller writes into the project's `tests/`
+/// directory (each becomes a `<model>_<name>.sql` file) and runs via the `test`
+/// tool. `message` explains why no assertions were produced (the API key is
+/// unset, or the model wasn't found) so a no-op is distinguishable from an
+/// error.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct GenerateTestsResult {
+    /// The model the tests were drafted for.
+    pub model: String,
+    /// The drafted assertions, when any were produced.
+    pub assertions: Vec<TestAssertionLite>,
+    /// Why no assertions were produced (key unset / model missing), when
+    /// `assertions` is empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// `explain_model` result — an LLM-drafted intent description for a model,
+/// derived from its source code, schema, and upstream dependencies.
+///
+/// `intent` is the drafted 2-3 sentence description when drafting succeeds; the
+/// caller can save it to the model's sidecar as `intent = "..."`. `message`
+/// explains why no description was produced (the API key is unset, or the model
+/// wasn't found) so a no-op is distinguishable from an error.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct ExplainModelResult {
+    /// The model the description was drafted for.
+    pub model: String,
+    /// The drafted intent description, when one was produced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent: Option<String>,
+    /// Why no description was produced (key unset / model missing), when
+    /// `intent` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -55,6 +55,14 @@ pub struct CompileArgs {
     /// way but scopes the returned diagnostics to this model when set.
     #[serde(default)]
     pub model: Option<String>,
+    /// Optional portability target dialect — one of `"databricks"`,
+    /// `"snowflake"`, `"bigquery"`, or `"duckdb"`. When set, the P001
+    /// dialect-divergence lint runs against it on demand: each model's SQL is
+    /// checked for constructs that won't port to the named dialect, surfaced as
+    /// P001 diagnostics. When absent, behaviour is unchanged — the lint runs
+    /// only if `rocky.toml` declares `[portability] target_dialect`.
+    #[serde(default)]
+    pub target_dialect: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -171,6 +179,27 @@ pub struct SuggestFreshnessBlockArgs {
     /// duplicate or conflict with an existing block. Optional.
     #[serde(default)]
     pub current_sidecar: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DraftContractArgs {
+    /// The model to draft a `.contract.toml` for. Its target table must be
+    /// materialized in the warehouse (run the model first) — the contract is
+    /// grounded in the table's observed per-column profile.
+    pub model: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct GenerateTestsArgs {
+    /// The model to draft test assertions for, from its intent + schema + SQL.
+    pub model: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ExplainModelArgs {
+    /// The model to draft an intent description for, from its SQL, output
+    /// schema, and upstream dependencies.
+    pub model: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -333,13 +362,24 @@ impl RockyMcpServer {
     #[tool(
         description = "Type-check the Rocky project and return diagnostics (errors/warnings) \
          plus model count. Always reflects the current on-disk models. Read diagnostics' \
-         code/span/suggestion and fix against them — this is the fast feedback loop."
+         code/span/suggestion and fix against them — this is the fast feedback loop. Pass \
+         `target_dialect` (databricks/snowflake/bigquery/duckdb) to additionally run the P001 \
+         portability lint on demand: SQL that won't port to that dialect surfaces as P001."
     )]
     async fn compile(
         &self,
         params: Parameters<CompileArgs>,
     ) -> Result<Json<CompileResult>, String> {
-        let model = params.0.model.as_deref();
+        let args = params.0;
+        let model = args.model.as_deref();
+        // On-demand portability lint: parse the requested dialect (case-
+        // insensitive, matching the `Dialect` serde vocabulary). When absent,
+        // pass `None` so the lint stays driven solely by `[portability]` in
+        // rocky.toml — i.e. behaviour is unchanged.
+        let target_dialect = match args.target_dialect.as_deref() {
+            Some(d) => Some(parse_target_dialect(d)?),
+            None => None,
+        };
         // `--with-seed` hard-fails when `data/seed.sql` is absent, so opt in
         // only when the project actually ships a seed (the playground does);
         // otherwise rely on the warm schema cache / cold-cache degradation.
@@ -351,7 +391,7 @@ impl RockyMcpServer {
             None,
             model,
             false,
-            None,
+            target_dialect,
             with_seed,
             None,
         )
@@ -879,6 +919,292 @@ impl RockyMcpServer {
         }))
     }
 
+    // ------------------------- generator tools -----------------------------
+    // These wrap the existing `rocky-ai` generators (the CLI's `rocky ai-*`
+    // commands). Each is an LLM/BYOK tool gated on ANTHROPIC_API_KEY, exactly
+    // like `suggest_freshness_block`. They return DRAFTS — the agent then runs
+    // `compile` / `propose` to act on them; nothing here mutates the warehouse
+    // or applies anything.
+
+    #[tool(
+        description = "Draft a `.contract.toml` for a model from the aggregate per-column \
+         profile of its target table (the `rocky ai-contract` generator). An LLM proposes \
+         required/protected columns and per-column types; the draft is compile-verified against \
+         the model's inferred schema before it is returned. Returns the contract TOML as a DRAFT \
+         — save it next to the model and run `compile` to enforce it; it mutates nothing. The \
+         model's target table must be materialized. Egress: only aggregate STATISTICS \
+         (row/null/distinct counts) are sent to the LLM — no raw cell values. Requires \
+         ANTHROPIC_API_KEY in the server environment — without it (or when the target isn't \
+         reachable), `contract_toml` is null and `message` explains why."
+    )]
+    async fn draft_contract(
+        &self,
+        params: Parameters<DraftContractArgs>,
+    ) -> Result<Json<DraftContractResult>, String> {
+        let model_name = params.0.model;
+
+        let client = match self.make_ai_client() {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Ok(Json(DraftContractResult {
+                    model: model_name,
+                    message: Some(format!(
+                        "{} not set in the server environment",
+                        rocky_ai::client::AI_API_KEY_ENV
+                    )),
+                    ..Default::default()
+                }));
+            }
+            Err(e) => return Err(format!("AI client init failed: {e}")),
+        };
+
+        // The model's inferred output schema — the basis for compile-verifying
+        // the drafted contract.
+        let compiled = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let inferred_schema: Vec<rocky_compiler::types::TypedColumn> = compiled
+            .type_check
+            .typed_models
+            .get(&model_name)
+            .cloned()
+            .ok_or_else(|| {
+                format!("model '{model_name}' not found in compiled project (or has no schema)")
+            })?;
+
+        // Profile each column against the live target table.
+        let profile = match self
+            .profile_table_columns(&model_name, &inferred_schema)
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                return Ok(Json(DraftContractResult {
+                    model: model_name,
+                    message: Some(format!("could not profile the target table: {e:#}")),
+                    ..Default::default()
+                }));
+            }
+        };
+
+        let drafted = rocky_ai::contract::draft_contract(&profile, &inferred_schema, &client, 3)
+            .await
+            .map_err(|e| format!("contract draft failed: {e}"))?;
+
+        Ok(Json(DraftContractResult {
+            model: model_name,
+            contract_toml: Some(drafted.toml),
+            attempts: Some(drafted.attempts),
+            message: None,
+        }))
+    }
+
+    #[tool(
+        description = "Draft test assertions for a model from its intent, schema, and SQL (the \
+         `rocky ai-test` generator). An LLM proposes SQL assertions that each return 0 rows when \
+         the invariant holds (not-null, grain uniqueness, value ranges, referential integrity). \
+         Returns the assertions as DRAFTS — write each into the project's `tests/` directory \
+         (`<model>_<name>.sql`) and run them via the `test` tool; it mutates nothing. Requires \
+         ANTHROPIC_API_KEY in the server environment — without it, `assertions` is empty and \
+         `message` explains why."
+    )]
+    async fn generate_tests(
+        &self,
+        params: Parameters<GenerateTestsArgs>,
+    ) -> Result<Json<GenerateTestsResult>, String> {
+        let model_name = params.0.model;
+
+        let client = match self.make_ai_client() {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Ok(Json(GenerateTestsResult {
+                    model: model_name,
+                    message: Some(format!(
+                        "{} not set in the server environment",
+                        rocky_ai::client::AI_API_KEY_ENV
+                    )),
+                    ..Default::default()
+                }));
+            }
+            Err(e) => return Err(format!("AI client init failed: {e}")),
+        };
+
+        let (compiled, model) = self.compile_and_find_model(&model_name)?;
+        let assertions = rocky_ai::testgen::generate_tests(&model, &compiled, &client)
+            .await
+            .map_err(|e| format!("test generation failed: {e}"))?;
+
+        let assertions = assertions
+            .into_iter()
+            .map(|a| TestAssertionLite {
+                name: a.name,
+                sql: a.sql,
+                description: a.description,
+            })
+            .collect();
+
+        Ok(Json(GenerateTestsResult {
+            model: model_name,
+            assertions,
+            message: None,
+        }))
+    }
+
+    #[tool(
+        description = "Draft an intent description for a model from its SQL, output schema, and \
+         upstream dependencies (the `rocky ai-explain` generator). An LLM writes a 2-3 sentence \
+         business-logic summary (grain, key filters/joins/aggregations). Returns the description \
+         as a DRAFT — save it to the model's sidecar as `intent = \"...\"` if useful; it mutates \
+         nothing. Requires ANTHROPIC_API_KEY in the server environment — without it, `intent` is \
+         null and `message` explains why."
+    )]
+    async fn explain_model(
+        &self,
+        params: Parameters<ExplainModelArgs>,
+    ) -> Result<Json<ExplainModelResult>, String> {
+        let model_name = params.0.model;
+
+        let client = match self.make_ai_client() {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Ok(Json(ExplainModelResult {
+                    model: model_name,
+                    message: Some(format!(
+                        "{} not set in the server environment",
+                        rocky_ai::client::AI_API_KEY_ENV
+                    )),
+                    ..Default::default()
+                }));
+            }
+            Err(e) => return Err(format!("AI client init failed: {e}")),
+        };
+
+        let (compiled, model) = self.compile_and_find_model(&model_name)?;
+        let intent = rocky_ai::explain::explain_model(&model, &compiled, &client)
+            .await
+            .map_err(|e| format!("explain failed: {e}"))?;
+
+        Ok(Json(ExplainModelResult {
+            model: model_name,
+            intent: Some(intent),
+            message: None,
+        }))
+    }
+
+    /// Build an [`LlmClient`](rocky_ai::client::LlmClient) for the generator
+    /// tools, BYOK via `ANTHROPIC_API_KEY`. Returns `Ok(None)` when the key is
+    /// unset so each tool degrades to a null draft + explanatory message (the
+    /// same graceful no-op as `suggest_freshness_block`). `[ai] max_tokens`
+    /// from `rocky.toml` is honoured when the config loads.
+    fn make_ai_client(&self) -> anyhow::Result<Option<rocky_ai::client::LlmClient>> {
+        let api_key = match std::env::var(rocky_ai::client::AI_API_KEY_ENV) {
+            Ok(v) if !v.is_empty() => v,
+            _ => return Ok(None),
+        };
+        let max_tokens = rocky_core::config::load_rocky_config(&self.config_path)
+            .map(|cfg| cfg.ai.max_tokens)
+            .unwrap_or(rocky_ai::client::DEFAULT_MAX_TOKENS);
+        let ai_config = rocky_ai::client::AiConfig {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            api_key: rocky_core::redacted::RedactedString::new(api_key),
+            default_format: "rocky".to_string(),
+            max_attempts: 3,
+            max_tokens,
+        };
+        rocky_ai::client::LlmClient::new(ai_config)
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Compile the project and resolve `model_name` to its loaded
+    /// [`Model`](rocky_core::models::Model). The generators that read source +
+    /// intent (`generate_tests`, `explain_model`) need both the compile result
+    /// and the owned model.
+    fn compile_and_find_model(
+        &self,
+        model_name: &str,
+    ) -> Result<(CompilerResult, rocky_core::models::Model), String> {
+        let compiled = self.compile_full().map_err(|e| format!("{e:#}"))?;
+        let model = compiled
+            .project
+            .models
+            .iter()
+            .find(|m| m.config.name == model_name)
+            .cloned()
+            .ok_or_else(|| format!("model '{model_name}' not found in project"))?;
+        Ok((compiled, model))
+    }
+
+    /// Profile each column of a model's target table into a
+    /// [`TableProfile`](rocky_ai::contract::TableProfile) for `draft_contract`.
+    ///
+    /// Reuses the grounding path (`prepare_table_query` + `query_grounding`), so
+    /// it works on any configured warehouse, not just DuckDB.
+    ///
+    /// # Egress
+    ///
+    /// Issues **aggregate statistics only** — `COUNT(*)`, `COUNT(col)`,
+    /// `COUNT(DISTINCT col)` — and never selects `MIN`/`MAX` or a domain sample.
+    /// No raw cell value leaves the machine; the prompt the LLM sees carries
+    /// counts, not data. This mirrors the default of the `rocky ai-contract`
+    /// generator this tool wraps (whose `--with-data` opt-in, which would send
+    /// observed min/max and low-cardinality samples, is intentionally NOT
+    /// exposed over MCP). `null_rate` + `distinct` are enough to draft the
+    /// nullable / required / protected constraints; `min`/`max`/`observed_values`
+    /// are left empty. SQL is built only from validated identifiers.
+    async fn profile_table_columns(
+        &self,
+        model_name: &str,
+        schema: &[rocky_compiler::types::TypedColumn],
+    ) -> anyhow::Result<rocky_ai::contract::TableProfile> {
+        let prepared = self.prepare_table_query(model_name).await?;
+
+        let mut columns = Vec::with_capacity(schema.len());
+        for typed_col in schema {
+            let col = rocky_sql::validation::validate_identifier(&typed_col.name)
+                .map_err(|e| anyhow::anyhow!("invalid column identifier: {e}"))?;
+            // Statistics only — counts, never raw cell values. No MIN/MAX, no
+            // domain query, so nothing observable from the table's contents
+            // reaches the LLM prompt.
+            let agg_sql = column_stats_sql(&prepared.table_ref, col);
+            let qr = query_grounding(prepared.adapter.as_ref(), &agg_sql)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("profile query failed for column '{}': {e}", typed_col.name)
+                })?;
+            let row = qr.rows.first().ok_or_else(|| {
+                anyhow::anyhow!("profile query returned no rows for '{}'", typed_col.name)
+            })?;
+
+            let total = row.first().map(json_as_u64).unwrap_or(0);
+            let non_null = row.get(1).map(json_as_u64).unwrap_or(0);
+            let distinct = row.get(2).map(json_as_u64).unwrap_or(0);
+            let nulls = total.saturating_sub(non_null);
+            let null_rate = if total == 0 {
+                0.0
+            } else {
+                nulls as f64 / total as f64
+            };
+
+            columns.push(rocky_ai::contract::ColumnProfile {
+                name: typed_col.name.clone(),
+                type_name: rocky_ai::contract::contract_type_name(typed_col),
+                rows: total,
+                nulls,
+                null_rate,
+                distinct,
+                // Raw cell values are never sent over MCP (see # Egress).
+                observed_values: Vec::new(),
+                min: None,
+                max: None,
+            });
+        }
+
+        Ok(rocky_ai::contract::TableProfile {
+            model: model_name.to_string(),
+            columns,
+        })
+    }
+
     // ------------------------- SHOULD tools --------------------------------
 
     #[tool(
@@ -1332,6 +1658,50 @@ fn commands_adapter_registry(
     rocky_cli::registry::AdapterRegistry::from_config(cfg)
 }
 
+/// Build the per-column **statistics** query for `draft_contract`'s profiler.
+///
+/// Aggregate counts only — `COUNT(*)`, `COUNT(col)`, `COUNT(DISTINCT col)`.
+/// Deliberately selects no `MIN`/`MAX` and issues no domain query, so no raw
+/// cell value can reach the LLM prompt (the egress contract the MCP
+/// `draft_contract` tool upholds — see `profile_table_columns`). `table_ref`
+/// and `col` are already validated by the caller.
+fn column_stats_sql(table_ref: &str, col: &str) -> String {
+    format!(
+        "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n \
+         FROM {table_ref}"
+    )
+}
+
+/// Read a `serde_json::Value` grounding cell as a `u64`, tolerating the
+/// string-encoded integers some adapters return.
+fn json_as_u64(v: &serde_json::Value) -> u64 {
+    match v {
+        serde_json::Value::Number(n) => n.as_u64().unwrap_or(0),
+        serde_json::Value::String(s) => s.parse().unwrap_or(0),
+        _ => 0,
+    }
+}
+
+/// Parse a `target_dialect` tool argument into the engine's [`Dialect`].
+///
+/// Accepts the `Dialect` serde vocabulary case-insensitively
+/// (`databricks`/`snowflake`/`bigquery`/`duckdb`). An unrecognised value is a
+/// caller error returned as a `String` (the tool's `Err` arm), naming the
+/// accepted values rather than silently ignoring the request.
+fn parse_target_dialect(raw: &str) -> Result<rocky_sql::transpile::Dialect, String> {
+    use rocky_sql::transpile::Dialect;
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "databricks" => Ok(Dialect::Databricks),
+        "snowflake" => Ok(Dialect::Snowflake),
+        "bigquery" => Ok(Dialect::BigQuery),
+        "duckdb" => Ok(Dialect::DuckDB),
+        other => Err(format!(
+            "unknown target_dialect '{other}': expected one of \
+             databricks, snowflake, bigquery, duckdb"
+        )),
+    }
+}
+
 /// Project a `CompileOutput` into the trimmed [`CompileResult`].
 fn project_compile_result(output: &rocky_cli::output::CompileOutput) -> CompileResult {
     use rocky_compiler::diagnostic::Severity;
@@ -1608,6 +1978,58 @@ mod tests {
         assert_eq!(SAMPLE_MAX_ROWS, 50);
         assert_eq!(SAMPLE_MAX_BYTES, 16 * 1024);
         assert_eq!(CELL_MAX_CHARS, 256);
+    }
+
+    #[test]
+    fn parse_target_dialect_accepts_known_values_case_insensitively() {
+        use rocky_sql::transpile::Dialect;
+        assert_eq!(parse_target_dialect("bigquery"), Ok(Dialect::BigQuery));
+        assert_eq!(parse_target_dialect("BigQuery"), Ok(Dialect::BigQuery));
+        assert_eq!(parse_target_dialect(" snowflake "), Ok(Dialect::Snowflake));
+        assert_eq!(parse_target_dialect("DATABRICKS"), Ok(Dialect::Databricks));
+        assert_eq!(parse_target_dialect("duckdb"), Ok(Dialect::DuckDB));
+    }
+
+    #[test]
+    fn parse_target_dialect_rejects_unknown_value() {
+        let err = parse_target_dialect("redshift").expect_err("unknown dialect must error");
+        assert!(
+            err.contains("redshift"),
+            "error should name the input: {err}"
+        );
+        assert!(
+            err.contains("bigquery"),
+            "error should list the accepted values: {err}"
+        );
+    }
+
+    /// Egress contract: the `draft_contract` profiler issues STATISTICS only —
+    /// it must never select raw cell values (`MIN`/`MAX`) nor a domain sample,
+    /// matching the default of the `rocky ai-contract` generator it wraps.
+    #[test]
+    fn column_stats_sql_sends_no_raw_cell_values() {
+        let sql = column_stats_sql("out.orders", "status");
+        assert!(
+            sql.contains("COUNT(DISTINCT status)"),
+            "distinct COUNT is a statistic and is expected: {sql}"
+        );
+        let upper = sql.to_uppercase();
+        assert!(
+            !upper.contains("MIN(") && !upper.contains("MAX("),
+            "statistics-only query must not select MIN/MAX: {sql}"
+        );
+        assert!(
+            !upper.contains("DISTINCT CAST"),
+            "statistics-only query must not issue the domain-values query: {sql}"
+        );
+    }
+
+    #[test]
+    fn json_as_u64_handles_null_number_and_string() {
+        assert_eq!(json_as_u64(&serde_json::json!(42)), 42);
+        assert_eq!(json_as_u64(&serde_json::json!("17")), 17);
+        assert_eq!(json_as_u64(&serde_json::json!(null)), 0);
+        assert_eq!(json_as_u64(&serde_json::json!("nope")), 0);
     }
 
     #[test]

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -82,6 +82,9 @@ async fn tools_list_returns_expected_set() {
             "catalog",
             "compile",
             "dependents",
+            "draft_contract",
+            "explain_model",
+            "generate_tests",
             "history",
             "inspect_schema",
             "lineage",
@@ -850,6 +853,162 @@ async fn inspect_schema_discovers_raw_sources_and_tolerates_cold_start() {
         cols.iter()
             .any(|c| c["name"] == serde_json::json!("status")),
         "discovered source carries its columns; got {cols:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn compile_runs_p001_dialect_lint_on_demand() {
+    // Passing `target_dialect` to the compile tool runs the P001 portability
+    // lint on demand, even with no `[portability]` in rocky.toml.
+    // `NVL(...)` does not port to BigQuery, so it must surface as P001.
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    std::fs::write(
+        dir.path().join("models").join("orders.sql"),
+        "SELECT 1 AS id, NVL('COMPLETE', 'PENDING') AS status\n",
+    )
+    .unwrap();
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // Without target_dialect → no P001 (behaviour unchanged).
+    let baseline = client
+        .call_tool(CallToolRequestParams::new("compile"))
+        .await
+        .expect("compile call")
+        .structured_content
+        .expect("structured content");
+    let baseline_diags = baseline["diagnostics"].as_array().unwrap();
+    assert!(
+        !baseline_diags
+            .iter()
+            .any(|d| d["code"] == serde_json::json!("P001")),
+        "no P001 without target_dialect; got {baseline_diags:?}"
+    );
+
+    // With target_dialect = bigquery → P001 fires for NVL.
+    let args = serde_json::json!({ "target_dialect": "bigquery" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let linted = client
+        .call_tool(CallToolRequestParams::new("compile").with_arguments(args))
+        .await
+        .expect("compile call with target_dialect")
+        .structured_content
+        .expect("structured content");
+    let diags = linted["diagnostics"].as_array().unwrap();
+    assert!(
+        diags.iter().any(|d| d["code"] == serde_json::json!("P001")),
+        "target_dialect=bigquery must surface P001 for NVL; got {diags:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn compile_rejects_unknown_target_dialect() {
+    // An unrecognised target_dialect is a caller error, not a silent no-op.
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let args = serde_json::json!({ "target_dialect": "redshift" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("compile").with_arguments(args))
+        .await
+        .expect("compile call returns a result");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "unknown target_dialect must be an error"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// The three generator tools degrade gracefully without an API key: a null
+/// draft + a message naming the missing env var, never an error and never a
+/// network call. Driven from one test so the `remove_var` happens once.
+#[tokio::test]
+async fn generator_tools_degrade_without_api_key() {
+    // SAFETY: `#[tokio::test]` runs on a current-thread runtime, so the spawned
+    // server task shares this single thread; nothing else reads the env
+    // concurrently.
+    unsafe {
+        std::env::remove_var(rocky_ai::client::AI_API_KEY_ENV);
+    }
+
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+
+    // draft_contract: contract_toml null, message names the env var.
+    let dc = client
+        .call_tool(CallToolRequestParams::new("draft_contract").with_arguments(args.clone()))
+        .await
+        .expect("draft_contract call");
+    assert_ne!(dc.is_error, Some(true), "missing key is a no-op, not error");
+    let sc = dc.structured_content.expect("structured content");
+    assert!(
+        sc.get("contract_toml").is_none() || sc["contract_toml"].is_null(),
+        "no contract without a key; got {sc:?}"
+    );
+    assert!(
+        sc["message"]
+            .as_str()
+            .unwrap()
+            .contains(rocky_ai::client::AI_API_KEY_ENV),
+        "draft_contract message should name the env var; got {sc:?}"
+    );
+
+    // generate_tests: assertions empty, message names the env var.
+    let gt = client
+        .call_tool(CallToolRequestParams::new("generate_tests").with_arguments(args.clone()))
+        .await
+        .expect("generate_tests call");
+    assert_ne!(gt.is_error, Some(true));
+    let sc = gt.structured_content.expect("structured content");
+    assert!(
+        sc["assertions"].as_array().unwrap().is_empty(),
+        "no assertions without a key; got {sc:?}"
+    );
+    assert!(
+        sc["message"]
+            .as_str()
+            .unwrap()
+            .contains(rocky_ai::client::AI_API_KEY_ENV)
+    );
+
+    // explain_model: intent null, message names the env var.
+    let em = client
+        .call_tool(CallToolRequestParams::new("explain_model").with_arguments(args))
+        .await
+        .expect("explain_model call");
+    assert_ne!(em.is_error, Some(true));
+    let sc = em.structured_content.expect("structured content");
+    assert!(
+        sc.get("intent").is_none() || sc["intent"].is_null(),
+        "no intent without a key; got {sc:?}"
+    );
+    assert!(
+        sc["message"]
+            .as_str()
+            .unwrap()
+            .contains(rocky_ai::client::AI_API_KEY_ENV)
     );
 
     client.cancel().await.unwrap();


### PR DESCRIPTION
## What

Completes the rocky-mcp authoring substrate with two additions:

**AI generators over MCP.** Three new BYOK tools wrap the existing `rocky-ai` generators (the CLI's `rocky ai-contract` / `ai-test` / `ai-explain`) — no generation logic is duplicated. Each mirrors the existing `suggest_freshness_block` tool's `ANTHROPIC_API_KEY` gating: without a key it degrades to a null draft plus an explanatory message, never an error and never a network call.

- `draft_contract` — profiles a model's target table and drafts a compile-verified `.contract.toml`. Egress is aggregate **statistics only** (row/null/distinct counts); no raw cell values leave the machine, matching the default of the `ai-contract` generator it wraps (whose opt-in raw-data flag is deliberately not exposed over MCP).
- `generate_tests` — drafts SQL test assertions from a model's intent, schema, and SQL.
- `explain_model` — drafts an intent description from a model's SQL, output schema, and upstream dependencies.

All three return **drafts** — the agent then runs `compile` / `propose` / `test` to act on them. None mutate the warehouse or apply anything.

**On-demand dialect lint.** The `compile` tool gains an optional `target_dialect` argument (`databricks` / `snowflake` / `bigquery` / `duckdb`). When set, the P001 dialect-divergence lint runs against it on demand — previously it fired over MCP only when `rocky.toml` declared `[portability] target_dialect`. When the argument is absent, behaviour is unchanged.

## Why

The generators were CLI-only, so an agent driving Rocky over MCP could author a model but not draft its contract, tests, or intent through the same interface. And portability linting was config-gated, so an agent couldn't ask "would this port to BigQuery?" without editing config. Both are now reachable through the MCP authoring loop.

## Scope

Three files in `engine/crates/rocky-mcp/` only — new result types, the tools, and round-trip tests. No CLI output struct changed, so no codegen is involved.

## Verification

- `cargo build -p rocky-mcp`
- `cargo clippy -p rocky-mcp --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo test -p rocky-mcp` — 13 unit + 23 round-trip tests pass

Tests cover tool registration (the new tools appear in `tools/list`), the no-API-key graceful-degradation path for all three generators, the statistics-only egress contract, on-demand P001 firing for a non-portable construct, the unchanged default when `target_dialect` is absent, and rejection of an unknown dialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)