### PR TITLE
feat(engine): rocky run --defer resolves unchanged upstreams to prod

### DIFF
--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -226,6 +226,9 @@ async fn execute_run_plan(
         None, // cache_ttl_override — runtime-only, not part of the plan
         run_plan.idempotency_key.as_deref(),
         run_plan.env.as_deref(),
+        // `--defer` is a runtime-only dev convenience, not persisted on the
+        // plan; the two-step `rocky plan`/`apply` path always runs without it.
+        &crate::commands::run::DeferOptions::default(),
     )
     .await
     .with_context(|| format!("rocky apply run plan '{plan_id}' failed"))?;
@@ -437,6 +440,8 @@ async fn run_apply_replication_plan(
         None,
         replication_plan.idempotency_key.as_deref(),
         replication_plan.env.as_deref(),
+        // Replication apply never runs transformation models; defer is moot.
+        &crate::commands::run::DeferOptions::default(),
     )
     .await
     .with_context(|| format!("rocky apply replication plan '{plan_id}' failed"))?;
@@ -804,6 +809,7 @@ pub async fn run_apply_inline_for_run(
     cache_ttl_override: Option<u64>,
     idempotency_key: Option<&str>,
     env: Option<&str>,
+    defer_opts: &crate::commands::run::DeferOptions,
 ) -> Result<()> {
     // Thin passthrough — routes to the existing run implementation.
     crate::commands::run::run(
@@ -823,6 +829,7 @@ pub async fn run_apply_inline_for_run(
         cache_ttl_override,
         idempotency_key,
         env,
+        defer_opts,
     )
     .await
 }

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -130,7 +130,7 @@ pub use review::run_review;
 // Re-exported so the `rocky` bin can build a clap ValueEnum for
 // `--target-dialect` without taking a direct dep on rocky-sql.
 pub use rocky_sql::transpile::Dialect;
-pub use run::{Interrupted, PartialFailure, PartitionRunOptions, run};
+pub use run::{DeferOptions, Interrupted, PartialFailure, PartitionRunOptions, run};
 pub use run_dag_exec::run_with_dag;
 pub use run_watch::run_watch as run_with_watch;
 pub use seed::run_seed;

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -228,6 +228,30 @@ impl PartitionRunOptions {
     }
 }
 
+/// CLI selection state for `rocky run --defer` (dev-against-prod-upstreams).
+///
+/// When [`enabled`](Self::enabled) is set, transformation models that are
+/// **not** part of the build selection (`--model <name>`) have their bare
+/// `ref()` upstreams rewritten to resolve against an existing "defer target"
+/// — typically the production schema — instead of the working schema. This
+/// lets a developer build only their changed models locally while reading
+/// every unbuilt upstream from production, the standard dbt `--defer`
+/// convenience.
+///
+/// Default is OFF (`enabled = false`), in which case the run is byte-for-byte
+/// identical to today. `--defer` only takes effect alongside `--model`: a
+/// full run builds every model, so there are no unbuilt upstreams to defer.
+#[derive(Debug, Clone, Default)]
+pub struct DeferOptions {
+    /// Whether `--defer` was passed.
+    pub enabled: bool,
+    /// Optional `--defer-to <schema>` override. When `None`, each unbuilt
+    /// upstream's reference resolves to its own configured target schema (its
+    /// production home). When `Some(schema)`, every deferred reference is
+    /// pointed at that schema instead (catalog + table preserved).
+    pub defer_to: Option<String>,
+}
+
 /// Borrowed slice of compile-time facts that the per-model execution path
 /// needs at materialization time.
 ///
@@ -825,6 +849,12 @@ pub async fn run(
     // override shape — so this value does NOT flow into
     // `reconcile_role_graph`.
     env: Option<&str>,
+    // `--defer` / `--defer-to`. Default OFF ⇒ byte-identical behavior. When
+    // enabled, transformation models outside the `--model` selection have
+    // their bare upstream `ref()`s rewritten to resolve against the defer
+    // target (its production schema, or `--defer-to`). Only meaningful with
+    // `--model`; a full run builds everything and defers nothing.
+    defer_opts: &DeferOptions,
 ) -> Result<()> {
     let start = Instant::now();
     let started_at = Utc::now();
@@ -990,6 +1020,7 @@ pub async fn run(
             None,
             &schema_cache_cfg,
             false, // model-only entry point has no pipeline governance context
+            defer_opts,
         )
         .await?;
 
@@ -3080,6 +3111,10 @@ pub async fn run(
                     Some(pipeline_name),
                     &schema_cache_cfg,
                     pipeline.target.governance.auto_create_schemas,
+                    // No `--model` selection on the full-pipeline path, so
+                    // `apply_defer_rewrite` is a no-op even when `--defer` is
+                    // set (a full run builds every model).
+                    defer_opts,
                 )
                 .await?;
                 Ok(())
@@ -3723,6 +3758,109 @@ pub(super) fn emit_pipes_events(pipes: &crate::pipes::PipesEmitter, output: &Run
 /// goes through `execute_time_interval_model()` (per-partition path);
 /// everything else (full_refresh / incremental / merge / materialized_view)
 /// uses the single-statement path via `generate_transformation_sql`.
+/// Rewrite the build-selected models' SQL so bare references to **unbuilt**
+/// upstreams resolve against the defer target (`--defer`).
+///
+/// The deferred set is every compiled project model whose name is not the
+/// `--model` selection. For each selected model, bare `ref()`s to a deferred
+/// model are qualified to `<defer_schema>.<table>` (or
+/// `<catalog>.<defer_schema>.<table>`), where `defer_schema` is the upstream's
+/// own configured target schema (its production home) unless `--defer-to`
+/// overrides it. Models in the selection build normally and keep bare refs to
+/// each other.
+///
+/// No-op (returns `Ok` without mutating) when there is no `--model` selection
+/// — a full run builds every model, so nothing is deferred.
+///
+/// # Errors
+///
+/// Returns an error when `--defer-to` (or a deferred upstream's catalog /
+/// table) fails SQL-identifier validation, or when a selected model's SQL is
+/// not parseable. Identifier validation guards against interpolating an
+/// unvalidated string into the rewritten reference.
+fn apply_defer_rewrite(
+    compile_result: &mut rocky_compiler::compile::CompileResult,
+    model_name_filter: Option<&str>,
+    defer_opts: &DeferOptions,
+) -> Result<()> {
+    use std::collections::{HashMap, HashSet};
+
+    // Without a `--model` selection every model is built; there are no
+    // unbuilt upstreams to defer. Leave the SQL untouched.
+    let Some(selected) = model_name_filter else {
+        return Ok(());
+    };
+
+    // Validate the `--defer-to` schema override once up front — it is user
+    // input that ends up serialized into SQL.
+    if let Some(schema) = &defer_opts.defer_to {
+        rocky_sql::validation::validate_identifier(schema)
+            .with_context(|| format!("invalid --defer-to schema '{schema}'"))?;
+    }
+
+    // Build the set of selected (built-locally) model names. Today `--model`
+    // selects exactly one model, but treat it as a set so the logic survives
+    // a future multi-select.
+    let selected_set: HashSet<&str> = std::iter::once(selected).collect();
+
+    // The deferred set = every compiled model not in the selection, mapped to
+    // its qualified defer target. `--defer-to` overrides the schema part;
+    // catalog + table always come from the upstream's own configured target.
+    let mut deferred: HashMap<String, rocky_sql::defer::DeferTarget> = HashMap::new();
+    for model in &compile_result.project.models {
+        let name = model.config.name.as_str();
+        if selected_set.contains(name) {
+            continue;
+        }
+        let target = &model.config.target;
+        let schema = defer_opts
+            .defer_to
+            .clone()
+            .unwrap_or_else(|| target.schema.clone());
+        // Defense in depth: validate the catalog/table parts too before they
+        // are serialized into the rewritten reference.
+        if !target.catalog.is_empty() {
+            rocky_sql::validation::validate_identifier(&target.catalog).with_context(|| {
+                format!("deferred upstream '{name}' has an invalid catalog identifier")
+            })?;
+        }
+        rocky_sql::validation::validate_identifier(&target.table).with_context(|| {
+            format!("deferred upstream '{name}' has an invalid table identifier")
+        })?;
+        deferred.insert(
+            model.config.name.clone(),
+            rocky_sql::defer::DeferTarget {
+                catalog: target.catalog.clone(),
+                schema,
+                table: target.table.clone(),
+            },
+        );
+    }
+
+    if deferred.is_empty() {
+        return Ok(());
+    }
+
+    // Rewrite each selected model's SQL in place. Only the selected models
+    // execute, so rewriting just those is sufficient (and avoids touching
+    // upstream SQL that won't run).
+    for model in &mut compile_result.project.models {
+        if !selected_set.contains(model.config.name.as_str()) {
+            continue;
+        }
+        let rewritten = rocky_sql::defer::qualify_deferred_refs(&model.sql, &deferred)
+            .with_context(|| {
+                format!(
+                    "failed to rewrite deferred upstream references in model '{}'",
+                    model.config.name
+                )
+            })?;
+        model.sql = rewritten;
+    }
+
+    Ok(())
+}
+
 #[tracing::instrument(skip_all, name = "execute_models")]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_models(
@@ -3746,6 +3884,12 @@ pub(crate) async fn execute_models(
     // `pipeline.target.governance.auto_create_schemas` here; defaults to
     // `false` for the model-only entry point that has no pipeline context.
     auto_create_schemas: bool,
+    // `--defer` selection state. When enabled (and a `model_name_filter` is
+    // set), every project model NOT in the selection is treated as a deferred
+    // upstream: the selected models' bare `ref()`s to those upstreams are
+    // rewritten to qualified `<defer_schema>.<table>` references before SQL
+    // generation. Default OFF ⇒ no rewrite, byte-identical behavior.
+    defer_opts: &DeferOptions,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
@@ -3780,7 +3924,7 @@ pub(crate) async fn execute_models(
         ..Default::default()
     };
 
-    let compile_result = match rocky_compiler::compile::compile(&compile_config) {
+    let mut compile_result = match rocky_compiler::compile::compile(&compile_config) {
         Ok(r) => r,
         Err(e) => {
             warn!(error = %e, "model compilation failed — skipping model execution");
@@ -3801,6 +3945,16 @@ pub(crate) async fn execute_models(
         }
         warn!("model compilation had errors — skipping model execution");
         return Ok(());
+    }
+
+    // `--defer`: rewrite the selected models' bare upstream `ref()`s to point
+    // at the defer target (production) for every model NOT in the selection.
+    // Lineage was already computed during compile, so mutating `.sql` now is
+    // safe — it only affects the SQL fed to `to_model_ir()` downstream. A
+    // no-op when `--defer` is off, when there's no `--model` selection, or
+    // when the selected models reference no deferred upstreams.
+    if defer_opts.enabled {
+        apply_defer_rewrite(&mut compile_result, model_name_filter, defer_opts)?;
     }
 
     // §P2.6 emit: compile_complete — fires once after a successful
@@ -6608,6 +6762,7 @@ adapter = "default"
             None,
             Some(key),
             None,
+            &DeferOptions::default(),
         )
         .await
         .expect("transformation run should succeed");
@@ -6712,6 +6867,7 @@ schema = "mart"
             None,
             None,
             None,
+            &DeferOptions::default(),
         )
         .await
         .expect(
@@ -7684,9 +7840,213 @@ merge_keys = ["id"]
             None,
             &rocky_core::config::SchemaCacheConfig::default(),
             false,
+            &DeferOptions::default(),
         )
         .await;
         (output, result)
+    }
+
+    /// `rocky run --model down --defer`: the selected model `down` reads its
+    /// unbuilt upstream `up` from the defer (production) schema, and only
+    /// `down` is materialized.
+    ///
+    /// Discriminator: `up` exists *only* in the defer schema (`prod`) with a
+    /// known row set, plus a decoy `up` with different rows in the working
+    /// schema (`main`). If defer works, `main.down` reflects the `prod` rows
+    /// and the decoy is never read; if it silently fell back to the working
+    /// schema, the row count would differ. We also assert `prod.up` is NOT
+    /// re-materialized (its rows are left exactly as seeded).
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn defer_resolves_unbuilt_upstream_to_prod_schema() {
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db_path = tmp.path().join("defer.duckdb");
+
+        // Seed the warehouse: `prod.up` has the real upstream rows; `main.up`
+        // is a decoy with a *different* row count that defer must NOT read.
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb for seeding");
+            seed.execute_statement("CREATE SCHEMA IF NOT EXISTS prod")
+                .await
+                .unwrap();
+            // 3 real upstream rows in the defer schema.
+            seed.execute_statement(
+                "CREATE TABLE prod.up AS SELECT * FROM (VALUES (1), (2), (3)) AS t(id)",
+            )
+            .await
+            .unwrap();
+            // Decoy with a single row in the working (main) schema. If defer
+            // wrongly resolved to `main`, `down` would have 1 row, not 3.
+            seed.execute_statement("CREATE TABLE main.up AS SELECT 99 AS id")
+                .await
+                .unwrap();
+        }
+
+        // Model `up` targets the prod schema (its production home). Model
+        // `down` targets `main` and selects from the bare upstream `up`.
+        std::fs::write(models_dir.join("up.sql"), "SELECT id FROM prod.up\n").unwrap();
+        std::fs::write(
+            models_dir.join("up.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"prod\"\ntable = \"up\"\n",
+        )
+        .unwrap();
+        std::fs::write(models_dir.join("down.sql"), "SELECT id FROM up\n").unwrap();
+        std::fs::write(
+            models_dir.join("down.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"down\"\n",
+        )
+        .unwrap();
+
+        let adapter = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb");
+        let opts = PartitionRunOptions::default();
+        let defer_opts = DeferOptions {
+            enabled: true,
+            defer_to: None,
+        };
+        let mut output = RunOutput::new(String::new(), 0, 1);
+
+        super::execute_models(
+            &models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &opts,
+            "test-defer",
+            Some("down"), // build only `down`
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            false,
+            &defer_opts,
+        )
+        .await
+        .expect("deferred run must succeed");
+
+        // Only `down` was materialized — `up` was deferred, not built.
+        assert_eq!(
+            output.materializations.len(),
+            1,
+            "exactly one model (down) should materialize: {:?}",
+            output
+                .materializations
+                .iter()
+                .map(|m| &m.asset_key)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            output.materializations[0].asset_key,
+            vec![String::new(), "main".to_string(), "down".to_string()],
+            "the materialized model must be main.down"
+        );
+
+        // DuckDB COUNT(*) may serialize as a JSON number or string depending
+        // on the adapter path; accept both, matching the existing tests.
+        let count_of = |v: &serde_json::Value| -> Option<i64> {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        };
+
+        // `main.down` must reflect the defer-schema (prod) rows: 3, not the
+        // decoy's 1.
+        let verify = DuckDbWarehouseAdapter::open(&db_path).expect("reopen");
+        let r = verify
+            .execute_query("SELECT COUNT(*) FROM main.down")
+            .await
+            .expect("main.down must exist");
+        assert_eq!(
+            count_of(&r.rows[0][0]),
+            Some(3),
+            "down must read the 3 rows from prod.up (defer schema), not the decoy in main.up"
+        );
+
+        // The deferred upstream `prod.up` was never re-materialized by this
+        // run — it still holds exactly its seeded 3 rows.
+        let up = verify
+            .execute_query("SELECT COUNT(*) FROM prod.up")
+            .await
+            .expect("prod.up must still exist");
+        assert_eq!(
+            count_of(&up.rows[0][0]),
+            Some(3),
+            "the deferred upstream prod.up is untouched"
+        );
+    }
+
+    /// Control: WITHOUT `--defer`, the same `--model down` run fails because
+    /// the bare `up` ref resolves against the working schema where the table
+    /// the model expects does not exist as a queryable bare name in a CTAS
+    /// targeting `main`. This pins that defer is what makes the cross-schema
+    /// read work — the behavior is genuinely off by default.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn without_defer_unbuilt_upstream_is_not_rewritten() {
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let models_dir = tmp.path().join("models");
+        std::fs::create_dir(&models_dir).expect("mkdir models");
+        let db_path = tmp.path().join("nodefer.duckdb");
+
+        {
+            let seed = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb for seeding");
+            seed.execute_statement("CREATE SCHEMA IF NOT EXISTS prod")
+                .await
+                .unwrap();
+            seed.execute_statement(
+                "CREATE TABLE prod.up AS SELECT * FROM (VALUES (1), (2), (3)) AS t(id)",
+            )
+            .await
+            .unwrap();
+        }
+
+        std::fs::write(models_dir.join("up.sql"), "SELECT id FROM prod.up\n").unwrap();
+        std::fs::write(
+            models_dir.join("up.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"prod\"\ntable = \"up\"\n",
+        )
+        .unwrap();
+        std::fs::write(models_dir.join("down.sql"), "SELECT id FROM up\n").unwrap();
+        std::fs::write(
+            models_dir.join("down.toml"),
+            "[strategy]\ntype = \"full_refresh\"\n\n[target]\ncatalog = \"\"\nschema = \"main\"\ntable = \"down\"\n",
+        )
+        .unwrap();
+
+        let adapter = DuckDbWarehouseAdapter::open(&db_path).expect("open duckdb");
+        let opts = PartitionRunOptions::default();
+        let mut output = RunOutput::new(String::new(), 0, 1);
+
+        // No defer: the bare `up` is not rewritten, and `main.up` does not
+        // exist, so building `down` alone fails on the unresolved upstream.
+        let result = super::execute_models(
+            &models_dir,
+            &adapter as &dyn rocky_core::traits::WarehouseAdapter,
+            None,
+            &opts,
+            "test-no-defer",
+            Some("down"),
+            &mut output,
+            None,
+            None,
+            &rocky_core::config::SchemaCacheConfig::default(),
+            false,
+            &DeferOptions::default(),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "without --defer the unbuilt bare upstream must not resolve, so the run fails"
+        );
+        assert!(
+            output.materializations.is_empty(),
+            "no model should materialize when the upstream is unresolved"
+        );
     }
 
     /// (a) A wide single-layer project (four dependency-free models) runs

--- a/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
+++ b/engine/crates/rocky-cli/src/commands/run_dag_exec.rs
@@ -191,6 +191,9 @@ impl NodeDispatcher for CliDispatcher {
                     // its own call path. Passing `None` preserves the
                     // pre-1.16 workspace-default resolution for DAG runs.
                     None,
+                    // DAG sub-runs build full pipelines (no `--model`
+                    // selection), so `--defer` would be inert anyway.
+                    &super::run::DeferOptions::default(),
                 )
                 .await
                 .map_err(|e| e.to_string())

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -77,6 +77,8 @@ pub async fn run_transformation(
             None,
             schema_cache_cfg,
             pipeline.target.governance.auto_create_schemas,
+            // run_local has no `--model` selection; defer is a no-op here.
+            &super::run::DeferOptions::default(),
         )
         .await?;
     } else {

--- a/engine/crates/rocky-cli/src/commands/run_watch.rs
+++ b/engine/crates/rocky-cli/src/commands/run_watch.rs
@@ -276,6 +276,9 @@ async fn iter_once(
         cache_ttl_override,
         None,
         env,
+        // `--watch` is mutually exclusive with `--model`, so there is no
+        // selection to defer against.
+        &super::run::DeferOptions::default(),
     )
     .await;
     let elapsed_ms = started.elapsed().as_millis();

--- a/engine/crates/rocky-sql/src/defer.rs
+++ b/engine/crates/rocky-sql/src/defer.rs
@@ -1,0 +1,281 @@
+//! Qualify deferred upstream model references in a model's SQL body.
+//!
+//! Rocky's transformation models reference upstream models by **bare name**
+//! (`FROM orders`). That bare name resolves against the warehouse's current
+//! schema at execution time — so a development run that builds only a subset
+//! of the DAG has no table to read for the upstreams it didn't build.
+//!
+//! [`qualify_deferred_refs`] rewrites those bare references to fully qualified
+//! `schema.table` (or `catalog.schema.table`) names pointing at an existing
+//! ("defer target") location — typically the production schema where the
+//! unbuilt upstream already lives. This is the engine half of the
+//! `rocky run --defer` developer convenience: build your changed models
+//! locally, read every unchanged upstream from production.
+//!
+//! The rewrite is purely additive: only **single-part bare names** that match
+//! a supplied deferred-model name are touched. Already-qualified references
+//! (`schema.table`, `catalog.schema.table`), names that don't match a deferred
+//! model, and CTE names defined inside the statement are all left untouched.
+
+use std::collections::{HashMap, HashSet};
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, Query, Statement, visit_relations_mut};
+
+use crate::parser::{ParseError, parse_single_statement};
+
+/// A fully resolved target for a deferred upstream reference.
+///
+/// Built from the upstream model's configured `target`, mirroring the
+/// warehouse dialect's empty-catalog rule: an empty `catalog` yields a
+/// two-part `schema.table` reference, a non-empty one yields the three-part
+/// `catalog.schema.table` form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferTarget {
+    /// Warehouse catalog. Empty string ⇒ omit the catalog part.
+    pub catalog: String,
+    /// Schema the deferred upstream table lives in.
+    pub schema: String,
+    /// Table name of the deferred upstream.
+    pub table: String,
+}
+
+impl DeferTarget {
+    /// Build the qualified `ObjectName` for this target, applying the
+    /// empty-catalog rule (`catalog.is_empty()` ⇒ `[schema, table]`, else
+    /// `[catalog, schema, table]`).
+    fn to_object_name(&self) -> ObjectName {
+        let mut parts: Vec<ObjectNamePart> = Vec::with_capacity(3);
+        if !self.catalog.is_empty() {
+            parts.push(ObjectNamePart::Identifier(Ident::new(self.catalog.clone())));
+        }
+        parts.push(ObjectNamePart::Identifier(Ident::new(self.schema.clone())));
+        parts.push(ObjectNamePart::Identifier(Ident::new(self.table.clone())));
+        ObjectName(parts)
+    }
+}
+
+/// Rewrite bare upstream model references in `sql` to their qualified
+/// [`DeferTarget`].
+///
+/// `deferred` maps a deferred model's bare name to the fully qualified
+/// location its reference should resolve to. Only single-part relations whose
+/// identifier matches a key in `deferred` (and that are not CTE names defined
+/// within the statement) are rewritten; everything else is preserved
+/// byte-for-byte by re-serializing the parsed AST.
+///
+/// Returns the rewritten SQL. When `deferred` is empty, or the SQL contains
+/// no matching bare references, the parsed-then-reserialized form of the
+/// input is returned unchanged in meaning (note: AST round-trip may
+/// normalize incidental whitespace — callers only invoke this in `--defer`
+/// mode, never on the default path).
+///
+/// # Errors
+///
+/// Returns [`ParseError`] when `sql` is not a single parseable statement.
+pub fn qualify_deferred_refs(
+    sql: &str,
+    deferred: &HashMap<String, DeferTarget>,
+) -> Result<String, ParseError> {
+    if deferred.is_empty() {
+        return Ok(sql.to_string());
+    }
+
+    let mut statement = parse_single_statement(sql)?;
+
+    // Collect every CTE name defined anywhere in the statement so a CTE that
+    // shadows a deferred model name is never rewritten — a `WITH orders AS
+    // (...) SELECT * FROM orders` must keep reading the CTE, not the deferred
+    // production table.
+    let mut cte_names: HashSet<String> = HashSet::new();
+    if let Statement::Query(query) = &statement {
+        collect_cte_names(query, &mut cte_names);
+    }
+
+    // The closure never breaks, so the `ControlFlow` is always `Continue`.
+    let _: ControlFlow<()> = visit_relations_mut(&mut statement, |relation: &mut ObjectName| {
+        // Only single-part bare names are candidates; anything already
+        // qualified (`schema.table`, `catalog.schema.table`) is left alone.
+        if relation.0.len() != 1 {
+            return ControlFlow::<()>::Continue(());
+        }
+        let Some(ident) = relation.0[0].as_ident() else {
+            return ControlFlow::Continue(());
+        };
+        let name = ident.value.clone();
+        if cte_names.contains(&name) {
+            return ControlFlow::Continue(());
+        }
+        if let Some(target) = deferred.get(&name) {
+            *relation = target.to_object_name();
+        }
+        ControlFlow::Continue(())
+    });
+
+    Ok(statement.to_string())
+}
+
+/// Recursively collect CTE alias names from a query's `WITH` clause and from
+/// every nested subquery's `WITH` clause.
+fn collect_cte_names(query: &Query, names: &mut HashSet<String>) {
+    if let Some(with) = &query.with {
+        for cte in &with.cte_tables {
+            names.insert(cte.alias.name.value.clone());
+            // A CTE body is itself a query and may declare further CTEs.
+            collect_cte_names(&cte.query, names);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(catalog: &str, schema: &str, table: &str) -> DeferTarget {
+        DeferTarget {
+            catalog: catalog.to_string(),
+            schema: schema.to_string(),
+            table: table.to_string(),
+        }
+    }
+
+    fn deferred_map(entries: &[(&str, DeferTarget)]) -> HashMap<String, DeferTarget> {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn qualifies_a_bare_upstream_ref() {
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs("SELECT * FROM orders", &deferred).unwrap();
+        assert_eq!(out, "SELECT * FROM prod.orders");
+    }
+
+    #[test]
+    fn qualifies_with_catalog_when_present() {
+        let deferred = deferred_map(&[("orders", target("warehouse", "prod", "orders"))]);
+        let out = qualify_deferred_refs("SELECT * FROM orders", &deferred).unwrap();
+        assert_eq!(out, "SELECT * FROM warehouse.prod.orders");
+    }
+
+    #[test]
+    fn leaves_aliased_ref_table_qualified_alias_intact() {
+        // `FROM orders o` — the relation is `orders`; the alias `o` and any
+        // `o.col` column refs are never in relation position, so only the
+        // table name is rewritten.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out =
+            qualify_deferred_refs("SELECT o.id FROM orders o WHERE o.id > 0", &deferred).unwrap();
+        // The table name is qualified; the alias `o` and the `o.col` column
+        // refs are untouched (they were never in relation position).
+        assert!(out.contains("prod.orders"), "got: {out}");
+        assert!(
+            out.contains("o.id"),
+            "alias-qualified columns intact: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrites_ref_inside_join() {
+        let deferred = deferred_map(&[
+            ("orders", target("", "prod", "orders")),
+            ("customers", target("", "prod", "customers")),
+        ]);
+        let out = qualify_deferred_refs(
+            "SELECT o.id, c.name FROM orders o JOIN customers c ON o.cid = c.id",
+            &deferred,
+        )
+        .unwrap();
+        assert!(out.contains("FROM prod.orders"), "got: {out}");
+        assert!(out.contains("JOIN prod.customers"), "got: {out}");
+    }
+
+    #[test]
+    fn rewrites_ref_inside_subquery() {
+        // extract_lineage only walks top-level FROM; the AST visitor reaches
+        // subquery relations too. This is the case that motivates visiting
+        // the whole AST.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out =
+            qualify_deferred_refs("SELECT * FROM (SELECT id FROM orders) sub", &deferred).unwrap();
+        assert!(
+            out.contains("prod.orders"),
+            "subquery ref must be qualified: {out}"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_cte_that_shadows_a_model_name() {
+        // `orders` is both a deferred model AND a CTE here. The CTE wins — the
+        // bare `FROM orders` after the WITH must read the CTE, not the
+        // deferred production table.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "WITH orders AS (SELECT 1 AS id) SELECT * FROM orders",
+            &deferred,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("prod.orders"),
+            "CTE shadowing a model name must not be qualified: {out}"
+        );
+    }
+
+    #[test]
+    fn leaves_already_qualified_ref_untouched() {
+        // A two-part `staging.orders` is an external source ref, not a model
+        // ref — it must not be rewritten even if `orders` is deferred.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs("SELECT * FROM staging.orders", &deferred).unwrap();
+        assert!(out.contains("staging.orders"), "got: {out}");
+        assert!(!out.contains("prod.orders"), "got: {out}");
+    }
+
+    #[test]
+    fn leaves_non_deferred_bare_ref_untouched() {
+        // `customers` is selected (built locally), not deferred — its bare
+        // ref stays bare so it resolves against the working schema.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT * FROM orders JOIN customers ON orders.cid = customers.id",
+            &deferred,
+        )
+        .unwrap();
+        assert!(out.contains("prod.orders"), "got: {out}");
+        // `customers` (not in the deferred set) stays bare.
+        assert!(
+            out.contains("JOIN customers"),
+            "non-deferred ref must stay bare: {out}"
+        );
+    }
+
+    #[test]
+    fn empty_deferred_map_is_a_noop() {
+        let deferred: HashMap<String, DeferTarget> = HashMap::new();
+        let sql = "SELECT * FROM orders";
+        let out = qualify_deferred_refs(sql, &deferred).unwrap();
+        assert_eq!(out, sql);
+    }
+
+    #[test]
+    fn rewrites_repeated_refs() {
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT a.id FROM orders a JOIN orders b ON a.id = b.id",
+            &deferred,
+        )
+        .unwrap();
+        // Both occurrences qualified; aliases `a`/`b` preserved.
+        assert!(out.contains("FROM prod.orders a"), "got: {out}");
+        assert!(out.contains("JOIN prod.orders b"), "got: {out}");
+    }
+
+    #[test]
+    fn unparseable_sql_returns_err() {
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let err = qualify_deferred_refs("NOT VALID SQL ;;;", &deferred);
+        assert!(err.is_err());
+    }
+}

--- a/engine/crates/rocky-sql/src/lib.rs
+++ b/engine/crates/rocky-sql/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod defer;
 pub mod dialect;
 pub mod lineage;
 pub mod parser;

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -627,6 +627,30 @@ enum Command {
             ],
         )]
         watch: bool,
+
+        /// Build only the selected models locally, resolving unbuilt upstream
+        /// `ref()`s to an existing (production) schema — the dbt-style "defer"
+        /// dev convenience.
+        ///
+        /// Takes effect together with `--model <name>`: the selected model
+        /// builds normally, while its bare references to models you did NOT
+        /// build are qualified to the deferred upstream's own target schema
+        /// (its production home) so they read existing tables instead of
+        /// failing on a missing local table. Without `--model`, a full run
+        /// builds every model and there is nothing to defer, so the flag is
+        /// inert. Default OFF ⇒ behavior is unchanged.
+        ///
+        /// Applies to transformation models. Mutually exclusive with `--dag`
+        /// (cross-pipeline defer is out of scope).
+        #[arg(long, conflicts_with = "dag")]
+        defer: bool,
+
+        /// Schema the deferred upstream `ref()`s resolve to when `--defer` is
+        /// set. Defaults to each unbuilt upstream's own configured target
+        /// schema (its production home); pass this to point every deferred
+        /// reference at a single schema instead (catalog + table preserved).
+        #[arg(long, value_name = "SCHEMA", requires = "defer")]
+        defer_to: Option<String>,
     },
 
     /// Compare shadow tables against production tables
@@ -2223,6 +2247,8 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             idempotency_key,
             env,
             watch,
+            defer,
+            defer_to,
         } => {
             // --idempotency-key is mutually exclusive with --resume / --resume-latest:
             // a resume is an explicit override and should never be short-circuited.
@@ -2270,6 +2296,11 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                 missing,
                 lookback,
                 parallel,
+            };
+
+            let defer_opts = rocky_cli::commands::DeferOptions {
+                enabled: defer,
+                defer_to,
             };
 
             if watch {
@@ -2333,6 +2364,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     cli.cache_ttl,
                     idempotency_key.as_deref(),
                     env.as_deref(),
+                    &defer_opts,
                 )
                 .await
             }
@@ -3340,6 +3372,81 @@ mod tests {
         remove_env("ROCKY_IDEMPOTENCY_KEY");
         let key = parse_run_idempotency_key(&["rocky", "run"]);
         assert!(key.is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // `rocky run --defer` flag-surface tests.
+    // ------------------------------------------------------------------------
+
+    fn parse_run_defer(args: &[&str]) -> (bool, Option<String>) {
+        let cli = try_parse_with_big_stack(args);
+        match cli.command {
+            Command::Run {
+                defer, defer_to, ..
+            } => (defer, defer_to),
+            _ => panic!("expected Run subcommand"),
+        }
+    }
+
+    /// Parse on the 8 MiB stack and return whether parsing *succeeded* — used
+    /// by the conflict / requires tests (the recursive clap derive overflows
+    /// the default test-thread stack).
+    fn parse_run_ok(args: &[&str]) -> bool {
+        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        std::thread::scope(|s| {
+            std::thread::Builder::new()
+                .stack_size(8 * 1024 * 1024)
+                .spawn_scoped(s, || Cli::try_parse_from(&owned).is_ok())
+                .expect("spawn parser thread")
+                .join()
+                .expect("parser thread panicked")
+        })
+    }
+
+    #[test]
+    fn defer_defaults_off() {
+        let (defer, defer_to) = parse_run_defer(&["rocky", "run"]);
+        assert!(!defer, "--defer is off by default");
+        assert!(defer_to.is_none());
+    }
+
+    #[test]
+    fn defer_flag_parses() {
+        let (defer, defer_to) = parse_run_defer(&["rocky", "run", "--model", "x", "--defer"]);
+        assert!(defer);
+        assert!(defer_to.is_none());
+    }
+
+    #[test]
+    fn defer_to_sets_schema_and_implies_defer_required() {
+        let (defer, defer_to) = parse_run_defer(&[
+            "rocky",
+            "run",
+            "--model",
+            "x",
+            "--defer",
+            "--defer-to",
+            "prod",
+        ]);
+        assert!(defer);
+        assert_eq!(defer_to.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn defer_to_without_defer_is_rejected() {
+        // `--defer-to` requires `--defer`.
+        assert!(
+            !parse_run_ok(&["rocky", "run", "--defer-to", "prod"]),
+            "--defer-to without --defer must be rejected at parse time"
+        );
+    }
+
+    #[test]
+    fn defer_conflicts_with_dag() {
+        assert!(
+            !parse_run_ok(&["rocky", "run", "--defer", "--dag"]),
+            "--defer and --dag are mutually exclusive (cross-pipeline defer is out of scope)"
+        );
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `--defer` and `--defer-to <schema>` to `rocky run`. With `--defer` set alongside `--model <name>`, the selected model builds locally while its bare references to models you did **not** build are rewritten to qualify against the deferred upstream's own target schema (its production home), or `--defer-to` when given.

This is the standard dbt-style developer convenience: build your changed models locally, read every unchanged upstream from production.

## Why

Rocky transformation models reference upstreams by **bare name** (`FROM orders`), which only resolves against the warehouse's current schema. So a dev run that builds a subset of the DAG has no table to read for the upstreams it skipped — cross-schema bare refs don't resolve. `--defer` qualifies those unbuilt refs to an existing location so the partial build can run.

## How

- New `rocky-sql::defer::qualify_deferred_refs` helper: parses the model statement, walks every relation via the sqlparser visitor, qualifies single-part bare names that match a deferred model (skipping CTE names that shadow a model name and leaving already-qualified refs alone), then re-serializes the AST. Identifier-validated before anything reaches SQL.
- The rewrite runs **once** in `execute_models`, mutating the selected models' SQL before SQL generation. The deferred set is every compiled model not in the `--model` selection, mapped to its qualified target.
- Flags thread through `main.rs` (clap) → `run()` → `execute_models()`.

## Safety / scope

- **Default OFF ⇒ byte-identical behavior.** The rewrite is gated behind `--defer`; nothing is parsed or touched on the default path.
- A full run (no `--model`) builds every model, so `--defer` is **inert** — verified.
- `--defer` conflicts with `--dag` (cross-pipeline defer is out of scope); `--defer-to` requires `--defer`.
- No `*Output` struct changed → no codegen / dagster / vscode cascade.

## Tests

- `rocky-sql` unit coverage: CTE shadowing, subquery/join refs, two-part refs untouched, non-deferred refs untouched, no-op cases.
- DuckDB e2e: a deferred `--model down --defer` run reads its upstream from the defer schema (3 prod rows, not the local decoy) and materializes only the selected model, with the deferred upstream left untouched; a control proves the same run fails without `--defer`.
- clap surface tests for the flags + conflicts.

Verified end-to-end against the freshly built binary (defer reads prod; no-defer fails; `--defer-to` override works; default full run unchanged).