### PR TITLE
feat(engine): version + document the graph-export JSON contract

### DIFF
--- a/editors/vscode/src/types/generated/dag.ts
+++ b/editors/vscode/src/types/generated/dag.ts
@@ -139,6 +139,12 @@ export interface DagOutput {
    */
   nodes: DagNodeOutput[];
   /**
+   * Version of the graph-export contract this payload conforms to.
+   *
+   * Distinct from `version` (the engine release, which churns every release): `schema_version` identifies the *shape* of the graph export — the node/edge/lineage fields orchestrators build an asset graph from. It is bumped only on a backward-incompatible change to that shape, so an orchestrator can pin against it across engine releases. Additive, backward-compatible field additions do not bump it (and surface through codegen-drift CI instead). Always emitted; older payloads that predate the field are treated as `"1"`.
+   */
+  schema_version?: string;
+  /**
    * Summary counts for the DAG.
    */
   summary: DagSummaryOutput;

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -22,6 +22,11 @@ use crate::output::*;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Version of the `rocky dag` graph-export contract. Bumped only on a
+/// backward-incompatible change to the node/edge/lineage shape orchestrators
+/// consume; see [`crate::output::DagOutput::schema_version`].
+const DAG_SCHEMA_VERSION: &str = "1";
+
 /// Execute `rocky dag`.
 ///
 /// `cache_ttl_override`: CLI `--cache-ttl` flag override for the
@@ -224,6 +229,7 @@ fn build_dag_output(
 
     Ok(DagOutput {
         version: VERSION.to_string(),
+        schema_version: DAG_SCHEMA_VERSION.to_string(),
         command: "dag".to_string(),
         nodes,
         edges,

--- a/engine/crates/rocky-cli/src/commands/dag.rs
+++ b/engine/crates/rocky-cli/src/commands/dag.rs
@@ -25,6 +25,12 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Version of the `rocky dag` graph-export contract. Bumped only on a
 /// backward-incompatible change to the node/edge/lineage shape orchestrators
 /// consume; see [`crate::output::DagOutput::schema_version`].
+///
+/// This is the version the CURRENT engine emits, and is intentionally SEPARATE
+/// from `default_dag_schema_version()` in `output.rs` (the value a consumer
+/// assumes when the field is absent, which stays `"1"` across future bumps
+/// because an absent field means a pre-field engine emitting the original v1
+/// shape). The two must NOT be collapsed into one shared const.
 const DAG_SCHEMA_VERSION: &str = "1";
 
 /// Execute `rocky dag`.

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2750,6 +2750,13 @@ fn default_parallel() -> u32 {
     1
 }
 
+/// Current version of the `rocky dag` graph-export contract.
+///
+/// See [`DagOutput::schema_version`] for the bump policy.
+fn default_dag_schema_version() -> String {
+    "1".to_string()
+}
+
 // Phase 2 plan-spine note: plan_id / plan_kind / created_at / models /
 // execution_layers fields are added directly to `PlanOutput` (inline fields,
 // not a wrapper) so the existing `"plan"` command wire key in
@@ -3965,6 +3972,18 @@ impl RetentionSweepOutput {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct DagOutput {
     pub version: String,
+    /// Version of the graph-export contract this payload conforms to.
+    ///
+    /// Distinct from `version` (the engine release, which churns every
+    /// release): `schema_version` identifies the *shape* of the graph
+    /// export — the node/edge/lineage fields orchestrators build an asset
+    /// graph from. It is bumped only on a backward-incompatible change to
+    /// that shape, so an orchestrator can pin against it across engine
+    /// releases. Additive, backward-compatible field additions do not bump
+    /// it (and surface through codegen-drift CI instead). Always emitted;
+    /// older payloads that predate the field are treated as `"1"`.
+    #[serde(default = "default_dag_schema_version")]
+    pub schema_version: String,
     pub command: String,
     /// Every stage in the pipeline as an enriched DAG node.
     pub nodes: Vec<DagNodeOutput>,

--- a/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/dag_schema.py
@@ -398,6 +398,12 @@ class DagOutput(BaseModel):
     """
     Every stage in the pipeline as an enriched DAG node.
     """
+    schema_version: str | None = "1"
+    """
+    Version of the graph-export contract this payload conforms to.
+
+    Distinct from `version` (the engine release, which churns every release): `schema_version` identifies the *shape* of the graph export — the node/edge/lineage fields orchestrators build an asset graph from. It is bumped only on a backward-incompatible change to that shape, so an orchestrator can pin against it across engine releases. Additive, backward-compatible field additions do not bump it (and surface through codegen-drift CI instead). Always emitted; older payloads that predate the field are treated as `"1"`.
+    """
     summary: DagSummaryOutput
     """
     Summary counts for the DAG.

--- a/integrations/dagster/tests/fixtures_generated/dag.json
+++ b/integrations/dagster/tests/fixtures_generated/dag.json
@@ -1,5 +1,6 @@
 {
   "version": "0.0.0-SENTINEL",
+  "schema_version": "1",
   "command": "dag",
   "nodes": [
     {

--- a/schemas/dag.schema.json
+++ b/schemas/dag.schema.json
@@ -578,6 +578,11 @@
       },
       "type": "array"
     },
+    "schema_version": {
+      "default": "1",
+      "description": "Version of the graph-export contract this payload conforms to.\n\nDistinct from `version` (the engine release, which churns every release): `schema_version` identifies the *shape* of the graph export — the node/edge/lineage fields orchestrators build an asset graph from. It is bumped only on a backward-incompatible change to that shape, so an orchestrator can pin against it across engine releases. Additive, backward-compatible field additions do not bump it (and surface through codegen-drift CI instead). Always emitted; older payloads that predate the field are treated as `\"1\"`.",
+      "type": "string"
+    },
     "summary": {
       "allOf": [
         {


### PR DESCRIPTION
## What

Add a `schema_version` field to `rocky dag`'s JSON output (`DagOutput`) — the *graph-export* contract that the dagster-rocky integration parses to build a Dagster asset graph (nodes, edges, dependencies, column lineage).

## Why

`DagOutput` already carries a `version` field, but it's the engine release (`CARGO_PKG_VERSION`), which churns on every release. An orchestrator has no stable marker to pin the graph-export *shape* against across engine versions.

`schema_version` identifies the shape of the export — the node/edge/lineage fields consumers depend on — and is bumped only on a **backward-incompatible** change to that shape. Additive, backward-compatible field additions don't bump it; those surface through the `codegen-drift` CI check instead.

## Compatibility

The field is optional in the schema (serde default `"1"`), so a newer dagster-rocky parsing an *older* binary's `rocky dag` output still works — payloads that predate the field are treated as `"1"`. The engine always emits it on the wire.

Scope is the graph export (`rocky dag`) only; `rocky dag --run` (`DagRunOutput`, execution results) is intentionally untouched.

## Changes

- `DagOutput.schema_version` field + bump-policy doc-comment (`engine/crates/rocky-cli/src/output.rs`, `commands/dag.rs`)
- Regenerated JSON schema, Pydantic, and TypeScript bindings via `just codegen`
- Regenerated the dagster `dag.json` live-binary fixture via `just regen-fixtures`

## Verification

- `cargo build/clippy --all-targets --all-features -D warnings/fmt/test -p rocky-cli` — clean
- `just codegen` idempotent; `codegen-drift` scoped diff clean
- dagster `pytest` (573 passed), `ruff check`, `ruff format --check` — clean