### PR TITLE
fix(engine): scope-aware + BigQuery-safe rewrite in rocky run --defer

### DIFF
--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3772,16 +3772,26 @@ pub(super) fn emit_pipes_events(pipes: &crate::pipes::PipesEmitter, output: &Run
 /// No-op (returns `Ok` without mutating) when there is no `--model` selection
 /// — a full run builds every model, so nothing is deferred.
 ///
+/// The deferred upstream's **catalog** is validated with the rule that matches
+/// `dialect`: BigQuery allows hyphenated project IDs (validated via
+/// `validate_gcp_project_id`) and the rewritten reference is backtick-quoted to
+/// match the dialect's emitted form; every other dialect keeps the strict
+/// `validate_identifier` rule and renders bare identifiers. Schema and table
+/// always use `validate_identifier` — datasets/schemas and tables have no
+/// hyphens on any supported warehouse.
+///
 /// # Errors
 ///
 /// Returns an error when `--defer-to` (or a deferred upstream's catalog /
-/// table) fails SQL-identifier validation, or when a selected model's SQL is
-/// not parseable. Identifier validation guards against interpolating an
-/// unvalidated string into the rewritten reference.
+/// schema / table) fails the applicable identifier-validation rule, or when a
+/// selected model's SQL cannot be parsed and rewritten. Identifier validation
+/// guards against interpolating an unvalidated string into the rewritten
+/// reference.
 fn apply_defer_rewrite(
     compile_result: &mut rocky_compiler::compile::CompileResult,
     model_name_filter: Option<&str>,
     defer_opts: &DeferOptions,
+    dialect: &dyn rocky_core::traits::SqlDialect,
 ) -> Result<()> {
     use std::collections::{HashMap, HashSet};
 
@@ -3791,8 +3801,17 @@ fn apply_defer_rewrite(
         return Ok(());
     };
 
+    // BigQuery is the one shipping dialect whose qualified parts (the project /
+    // catalog) may contain characters bare SQL identifiers reject — hyphens.
+    // For it the catalog is validated with the GCP-project rule and the
+    // rewritten reference is backtick-quoted to match `format_table_ref`; every
+    // other dialect keeps the strict identifier rule and renders bare names.
+    let is_bigquery = dialect.name() == "bigquery";
+    let quote_style: Option<char> = if is_bigquery { Some('`') } else { None };
+
     // Validate the `--defer-to` schema override once up front — it is user
-    // input that ends up serialized into SQL.
+    // input that ends up serialized into SQL. Schemas/datasets never carry
+    // hyphens, so the strict identifier rule applies on every dialect.
     if let Some(schema) = &defer_opts.defer_to {
         rocky_sql::validation::validate_identifier(schema)
             .with_context(|| format!("invalid --defer-to schema '{schema}'"))?;
@@ -3817,13 +3836,27 @@ fn apply_defer_rewrite(
             .defer_to
             .clone()
             .unwrap_or_else(|| target.schema.clone());
-        // Defense in depth: validate the catalog/table parts too before they
-        // are serialized into the rewritten reference.
+        // Defense in depth: validate every part before it is serialized into
+        // the rewritten reference. The catalog uses the dialect-appropriate
+        // rule (BigQuery project IDs allow hyphens); schema + table always use
+        // the strict identifier rule regardless of where the schema came from
+        // (config target or `--defer-to`).
         if !target.catalog.is_empty() {
-            rocky_sql::validation::validate_identifier(&target.catalog).with_context(|| {
-                format!("deferred upstream '{name}' has an invalid catalog identifier")
-            })?;
+            if is_bigquery {
+                rocky_sql::validation::validate_gcp_project_id(&target.catalog).with_context(
+                    || format!("deferred upstream '{name}' has an invalid BigQuery project ID"),
+                )?;
+            } else {
+                rocky_sql::validation::validate_identifier(&target.catalog).with_context(|| {
+                    format!("deferred upstream '{name}' has an invalid catalog identifier")
+                })?;
+            }
         }
+        rocky_sql::validation::validate_identifier(&schema).with_context(|| {
+            format!(
+                "deferred upstream '{name}' resolves to an invalid schema identifier '{schema}'"
+            )
+        })?;
         rocky_sql::validation::validate_identifier(&target.table).with_context(|| {
             format!("deferred upstream '{name}' has an invalid table identifier")
         })?;
@@ -3833,6 +3866,7 @@ fn apply_defer_rewrite(
                 catalog: target.catalog.clone(),
                 schema,
                 table: target.table.clone(),
+                quote_style,
             },
         );
     }
@@ -3848,11 +3882,16 @@ fn apply_defer_rewrite(
         if !selected_set.contains(model.config.name.as_str()) {
             continue;
         }
-        let rewritten = rocky_sql::defer::qualify_deferred_refs(&model.sql, &deferred)
-            .with_context(|| {
-                format!(
-                    "failed to rewrite deferred upstream references in model '{}'",
-                    model.config.name
+        let rewritten =
+            rocky_sql::defer::qualify_deferred_refs(&model.sql, &deferred).map_err(|e| {
+                anyhow::anyhow!(
+                    "`--defer` could not rewrite the upstream references in model '{}': its SQL \
+                     did not parse ({e}). `--defer` parses each selected model's SQL to qualify \
+                     deferred upstreams; constructs the parser does not yet support (e.g. \
+                     `SELECT * EXCEPT (...)`, trailing-comma select lists, `STRUCT(...)` \
+                     literals) cannot be rewritten. Build this model without `--defer`, or \
+                     adjust its SQL.",
+                    model.config.name,
                 )
             })?;
         model.sql = rewritten;
@@ -3954,7 +3993,12 @@ pub(crate) async fn execute_models(
     // no-op when `--defer` is off, when there's no `--model` selection, or
     // when the selected models reference no deferred upstreams.
     if defer_opts.enabled {
-        apply_defer_rewrite(&mut compile_result, model_name_filter, defer_opts)?;
+        apply_defer_rewrite(
+            &mut compile_result,
+            model_name_filter,
+            defer_opts,
+            warehouse.dialect(),
+        )?;
     }
 
     // §P2.6 emit: compile_complete — fires once after a successful

--- a/engine/crates/rocky-sql/src/defer.rs
+++ b/engine/crates/rocky-sql/src/defer.rs
@@ -20,7 +20,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::ControlFlow;
 
-use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, Query, Statement, visit_relations_mut};
+use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, Query, VisitMut, VisitorMut};
 
 use crate::parser::{ParseError, parse_single_statement};
 
@@ -38,19 +38,40 @@ pub struct DeferTarget {
     pub schema: String,
     /// Table name of the deferred upstream.
     pub table: String,
+    /// Optional identifier quote character to wrap each part in when the
+    /// reference is re-serialized.
+    ///
+    /// `None` renders bare identifiers (`catalog.schema.table`) — the default
+    /// for warehouses whose qualified parts always match the strict
+    /// SQL-identifier rule (Databricks, Snowflake, DuckDB). Dialects that
+    /// permit characters bare identifiers reject — notably BigQuery, whose
+    /// project IDs allow hyphens (`my-gcp-project-123`) — set this so the
+    /// rewritten reference is quoted exactly as the warehouse expects
+    /// (`` `my-gcp-project-123`.`schema`.`table` ``) instead of parsing the
+    /// hyphen as subtraction.
+    pub quote_style: Option<char>,
 }
 
 impl DeferTarget {
     /// Build the qualified `ObjectName` for this target, applying the
     /// empty-catalog rule (`catalog.is_empty()` ⇒ `[schema, table]`, else
-    /// `[catalog, schema, table]`).
+    /// `[catalog, schema, table]`) and the configured [`quote_style`].
+    ///
+    /// [`quote_style`]: DeferTarget::quote_style
     fn to_object_name(&self) -> ObjectName {
+        let ident = |value: &str| -> ObjectNamePart {
+            let part = match self.quote_style {
+                Some(q) => Ident::with_quote(q, value.to_string()),
+                None => Ident::new(value.to_string()),
+            };
+            ObjectNamePart::Identifier(part)
+        };
         let mut parts: Vec<ObjectNamePart> = Vec::with_capacity(3);
         if !self.catalog.is_empty() {
-            parts.push(ObjectNamePart::Identifier(Ident::new(self.catalog.clone())));
+            parts.push(ident(&self.catalog));
         }
-        parts.push(ObjectNamePart::Identifier(Ident::new(self.schema.clone())));
-        parts.push(ObjectNamePart::Identifier(Ident::new(self.table.clone())));
+        parts.push(ident(&self.schema));
+        parts.push(ident(&self.table));
         ObjectName(parts)
     }
 }
@@ -60,15 +81,20 @@ impl DeferTarget {
 ///
 /// `deferred` maps a deferred model's bare name to the fully qualified
 /// location its reference should resolve to. Only single-part relations whose
-/// identifier matches a key in `deferred` (and that are not CTE names defined
-/// within the statement) are rewritten; everything else is preserved
-/// byte-for-byte by re-serializing the parsed AST.
+/// identifier matches a key in `deferred` — and that are not shadowed by a CTE
+/// in scope at that point — are rewritten; everything else is left as parsed.
 ///
-/// Returns the rewritten SQL. When `deferred` is empty, or the SQL contains
-/// no matching bare references, the parsed-then-reserialized form of the
-/// input is returned unchanged in meaning (note: AST round-trip may
-/// normalize incidental whitespace — callers only invoke this in `--defer`
-/// mode, never on the default path).
+/// CTE shadowing is resolved with lexical scope: the rewrite walks the AST
+/// maintaining a stack of the CTE names in scope (each query's `WITH` names
+/// cover its own body and every CTE body nested under it), so a `WITH orders
+/// AS (…)` inside a derived-table / `IN` / `UNION` subquery only shadows the
+/// deferred `orders` *within that subquery*, while a genuine top-level `FROM
+/// orders` with no shadowing CTE is still qualified.
+///
+/// Re-serialization preserves the statement's semantics, but the AST round
+/// trip may strip comments and trailing semicolons and normalize incidental
+/// whitespace — callers only invoke this in `--defer` mode, never on the
+/// default path.
 ///
 /// # Errors
 ///
@@ -83,47 +109,77 @@ pub fn qualify_deferred_refs(
 
     let mut statement = parse_single_statement(sql)?;
 
-    // Collect every CTE name defined anywhere in the statement so a CTE that
-    // shadows a deferred model name is never rewritten — a `WITH orders AS
-    // (...) SELECT * FROM orders` must keep reading the CTE, not the deferred
-    // production table.
-    let mut cte_names: HashSet<String> = HashSet::new();
-    if let Statement::Query(query) = &statement {
-        collect_cte_names(query, &mut cte_names);
+    // Walk the whole AST with a scope-aware visitor. `visit_relations_mut`
+    // reaches every relation (including those inside derived-table / scalar /
+    // `IN` subqueries and set-op branches), but it is scope-blind — so the
+    // visitor tracks the CTE names in scope on a stack and only rewrites a
+    // bare reference that is *not* shadowed at that point. The visitor never
+    // breaks, so the `ControlFlow` is always `Continue`.
+    let mut rewriter = DeferRewriter {
+        deferred,
+        scopes: Vec::new(),
+    };
+    let _: ControlFlow<()> = statement.visit(&mut rewriter);
+
+    Ok(statement.to_string())
+}
+
+/// Scope-aware visitor that qualifies bare deferred-model references while
+/// honouring lexical CTE shadowing.
+///
+/// `scopes` is a stack of the CTE names introduced by each enclosing query's
+/// `WITH` clause. A query's frame is pushed in `pre_visit_query` (before its
+/// body *and* its CTE bodies are walked) and popped in `post_visit_query`, so
+/// a name on the stack shadows the deferred model for exactly the subtree
+/// where that `WITH` is in scope.
+struct DeferRewriter<'a> {
+    deferred: &'a HashMap<String, DeferTarget>,
+    scopes: Vec<HashSet<String>>,
+}
+
+impl DeferRewriter<'_> {
+    /// Whether `name` is shadowed by a CTE in any enclosing scope.
+    fn is_shadowed(&self, name: &str) -> bool {
+        self.scopes.iter().any(|frame| frame.contains(name))
+    }
+}
+
+impl VisitorMut for DeferRewriter<'_> {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &mut Query) -> ControlFlow<Self::Break> {
+        let mut frame: HashSet<String> = HashSet::new();
+        if let Some(with) = &query.with {
+            for cte in &with.cte_tables {
+                frame.insert(cte.alias.name.value.clone());
+            }
+        }
+        self.scopes.push(frame);
+        ControlFlow::Continue(())
     }
 
-    // The closure never breaks, so the `ControlFlow` is always `Continue`.
-    let _: ControlFlow<()> = visit_relations_mut(&mut statement, |relation: &mut ObjectName| {
+    fn post_visit_query(&mut self, _query: &mut Query) -> ControlFlow<Self::Break> {
+        self.scopes.pop();
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_relation(&mut self, relation: &mut ObjectName) -> ControlFlow<Self::Break> {
         // Only single-part bare names are candidates; anything already
         // qualified (`schema.table`, `catalog.schema.table`) is left alone.
         if relation.0.len() != 1 {
-            return ControlFlow::<()>::Continue(());
+            return ControlFlow::Continue(());
         }
         let Some(ident) = relation.0[0].as_ident() else {
             return ControlFlow::Continue(());
         };
         let name = ident.value.clone();
-        if cte_names.contains(&name) {
+        if self.is_shadowed(&name) {
             return ControlFlow::Continue(());
         }
-        if let Some(target) = deferred.get(&name) {
+        if let Some(target) = self.deferred.get(&name) {
             *relation = target.to_object_name();
         }
         ControlFlow::Continue(())
-    });
-
-    Ok(statement.to_string())
-}
-
-/// Recursively collect CTE alias names from a query's `WITH` clause and from
-/// every nested subquery's `WITH` clause.
-fn collect_cte_names(query: &Query, names: &mut HashSet<String>) {
-    if let Some(with) = &query.with {
-        for cte in &with.cte_tables {
-            names.insert(cte.alias.name.value.clone());
-            // A CTE body is itself a query and may declare further CTEs.
-            collect_cte_names(&cte.query, names);
-        }
     }
 }
 
@@ -136,6 +192,16 @@ mod tests {
             catalog: catalog.to_string(),
             schema: schema.to_string(),
             table: table.to_string(),
+            quote_style: None,
+        }
+    }
+
+    fn quoted_target(catalog: &str, schema: &str, table: &str, quote: char) -> DeferTarget {
+        DeferTarget {
+            catalog: catalog.to_string(),
+            schema: schema.to_string(),
+            table: table.to_string(),
+            quote_style: Some(quote),
         }
     }
 
@@ -221,6 +287,115 @@ mod tests {
             !out.contains("prod.orders"),
             "CTE shadowing a model name must not be qualified: {out}"
         );
+    }
+
+    #[test]
+    fn does_not_rewrite_cte_shadow_inside_derived_table_subquery() {
+        // Case A: the shadowing `WITH orders` lives inside a derived-table
+        // subquery (`FROM (... ) sub`). Its inner `FROM orders` must read the
+        // CTE, not the deferred production table — the scope-aware walk must
+        // not flatten the nested CTE name into a global shadow set either, but
+        // here we only assert the inner ref stays unqualified.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT * FROM (WITH orders AS (SELECT 1 AS id) SELECT * FROM orders) sub",
+            &deferred,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("prod.orders"),
+            "CTE inside a derived-table subquery must shadow the deferred ref: {out}"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_cte_shadow_inside_in_subquery() {
+        // Case B: the shadowing `WITH orders` lives inside an `IN (...)`
+        // scalar subquery — an `Expr`, not a `TableFactor`. The whole-AST
+        // visitor still reaches it, and the scope stack keeps the inner
+        // `FROM orders` reading the CTE.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT id FROM events WHERE id IN \
+             (WITH orders AS (SELECT 1 AS id) SELECT id FROM orders)",
+            &deferred,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("prod.orders"),
+            "CTE inside an IN-subquery must shadow the deferred ref: {out}"
+        );
+    }
+
+    #[test]
+    fn does_not_rewrite_cte_shadow_inside_union_branch() {
+        // Case C: the shadowing `WITH orders` lives inside a set-op (UNION)
+        // branch. The visitor descends into both branches; the inner branch's
+        // CTE shadows its own `FROM orders`.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT 1 AS id UNION ALL \
+             (WITH orders AS (SELECT 2 AS id) SELECT id FROM orders)",
+            &deferred,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("prod.orders"),
+            "CTE inside a UNION branch must shadow the deferred ref: {out}"
+        );
+    }
+
+    #[test]
+    fn qualifies_top_level_ref_with_no_shadowing_cte() {
+        // Case D (positive control): a genuine top-level `FROM orders` with no
+        // shadowing CTE anywhere is still qualified.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs("SELECT * FROM orders", &deferred).unwrap();
+        assert!(
+            out.contains("prod.orders"),
+            "top-level deferred ref with no shadow must be qualified: {out}"
+        );
+    }
+
+    #[test]
+    fn qualifies_outer_ref_but_not_nested_cte_shadow() {
+        // Case E (the discriminating case): a flat global shadow set would
+        // wrongly skip the top-level `FROM orders`, and a scope-blind walk
+        // would wrongly qualify the inner one. Only a scope-aware stack gets
+        // both: the top-level ref IS qualified, the nested CTE-shadowed ref is
+        // NOT.
+        let deferred = deferred_map(&[("orders", target("", "prod", "orders"))]);
+        let out = qualify_deferred_refs(
+            "SELECT * FROM orders WHERE id IN \
+             (WITH orders AS (SELECT 1 AS id) SELECT id FROM orders)",
+            &deferred,
+        )
+        .unwrap();
+        // Exactly one occurrence of the qualified production ref (the outer
+        // FROM); the inner CTE ref stays bare.
+        assert_eq!(
+            out.matches("prod.orders").count(),
+            1,
+            "outer ref qualified, nested CTE-shadowed ref left bare: {out}"
+        );
+        assert!(
+            out.contains("FROM prod.orders WHERE"),
+            "the outer FROM must be the qualified one: {out}"
+        );
+    }
+
+    #[test]
+    fn quotes_hyphenated_catalog_for_bigquery_style_target() {
+        // A BigQuery-style defer target: the project (catalog) contains
+        // hyphens, so the rewritten reference must be backtick-quoted to match
+        // what the BigQuery dialect emits — bare hyphens would parse as
+        // subtraction and the warehouse would reject the SQL.
+        let deferred = deferred_map(&[(
+            "orders",
+            quoted_target("my-gcp-project-123", "prod", "orders", '`'),
+        )]);
+        let out = qualify_deferred_refs("SELECT * FROM orders", &deferred).unwrap();
+        assert_eq!(out, "SELECT * FROM `my-gcp-project-123`.`prod`.`orders`");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #817 (`rocky run --defer`), landing the adversarial-review fixes that missed that squash-merge.

## What this fixes
- **CTE silent-SQL scope bug (HIGH).** The old shadow guard used a global set of CTE names, so a `WITH orders AS (...)` nested inside a derived-table / `IN` / `UNION` subquery silently suppressed the rewrite of a genuine top-level `FROM orders` — emitting wrong-but-valid SQL against the production table. `qualify_deferred_refs` now walks the AST with a `VisitorMut` that maintains a per-query stack of in-scope CTE names (pushed in `pre_visit_query`, popped in `post_visit_query`), so a shadow only masks the deferred ref *within its own subquery*. Regression tests cover all three nesting forms, the positive control, and the discriminating outer-qualified / inner-shadowed case.
- **BigQuery-catalog gap.** `DeferTarget` now carries a `quote_style`; the rewrite validates the catalog with `validate_gcp_project_id` (permits hyphenated project IDs) and backtick-quotes the reference so hyphens aren't parsed as subtraction.
- **Unconditional defer-schema validation.** The resolved schema is validated with `validate_identifier` regardless of source (config target or `--defer-to`).
- **Doc-comment fix** on `qualify_deferred_refs` (re-serialization preserves semantics but may strip comments / trailing semicolons and normalize whitespace).
- **Clearer `--defer` parse-failure error** naming the parse error and the unsupported-construct cause.

## Verify
`cargo build`, `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`, and `cargo test --features duckdb` all clean for `rocky-sql` + `rocky-cli`; the 6 new defer scope/BigQuery tests pass.

## Known limitations
- A CTE that shadows a deferred name **and** reads the base table in its own body over-skips the rewrite → clean table-not-found error (fail-safe; never wrong SQL).
- The rewrite parses with the Databricks dialect, so `SELECT * EXCEPT` / trailing-comma selects / `STRUCT` literals fail cleanly; multi-dialect parse is a separate change.