### PR TITLE
feat(engine/rocky-bigquery): load via native BigQuery load jobs

### DIFF
--- a/engine/crates/rocky-bigquery/src/connector.rs
+++ b/engine/crates/rocky-bigquery/src/connector.rs
@@ -46,6 +46,23 @@ pub enum BigQueryError {
     #[error("BigQuery job failed: {message} (reason: {reason})")]
     JobError { reason: String, message: String },
 
+    /// A **load** job (`jobs.insert` → polled via `jobs.get`) that reached
+    /// `status.state == "DONE"` carrying a `status.errorResult`.
+    ///
+    /// Unlike the query path — where an async failure surfaces as a
+    /// *top-level* `errors[]` array on the `jobs.query` /
+    /// `jobs.getQueryResults` response (see [`Self::JobError`]) — a load
+    /// job's terminal failure lives under the `Job` resource's
+    /// `status.errorResult` (an `ErrorProto`), with the full list under
+    /// `status.errors[]`. `jobs.insert` has no synchronous result
+    /// endpoint, so this is the only place a load failure can appear.
+    /// Classified **non-transient**: a malformed file or a schema
+    /// mismatch won't pass on retry. `message` aggregates the per-row /
+    /// per-file reasons from `status.errors[]` when present so the
+    /// operator sees *why* the load failed, not just "load job failed".
+    #[error("BigQuery load job failed: {message} (reason: {reason})")]
+    LoadJobError { reason: String, message: String },
+
     #[error("authentication error: {0}")]
     Auth(#[from] crate::auth::AuthError),
 
@@ -655,6 +672,218 @@ impl BigQueryAdapter {
             ),
         })
     }
+
+    /// Run a native BigQuery **load job** via `jobs.insert` and poll it to
+    /// completion.
+    ///
+    /// This is the bulk-ingest primitive behind the BigQuery `load`
+    /// pipeline. Unlike the query path (`jobs.query`, which can return
+    /// inline), a load job is **always asynchronous**: `jobs.insert`
+    /// accepts the configuration and returns a `Job` resource in
+    /// `PENDING`/`RUNNING`; the caller polls `jobs.get` until
+    /// `status.state == "DONE"`.
+    ///
+    /// # Source URIs
+    ///
+    /// `spec.source_uris` are `gs://bucket/object` paths (BigQuery load
+    /// jobs read only from Google Cloud Storage — local files are not a
+    /// load-job input, which is why the loader keeps an INSERT fallback
+    /// for `LocalFile`). Wildcards (`gs://bucket/prefix*`) are honoured by
+    /// BigQuery natively.
+    ///
+    /// # Errors
+    ///
+    /// - [`BigQueryError::ApiError`] — a non-2xx from `jobs.insert` /
+    ///   `jobs.get` (auth, malformed config, quota).
+    /// - [`BigQueryError::LoadJobError`] — the job reached `DONE` with a
+    ///   `status.errorResult`. The message aggregates `status.errors[]`
+    ///   so per-row / per-file reasons are visible.
+    /// - [`BigQueryError::Timeout`] — the job didn't finish within the
+    ///   adapter's configured timeout.
+    pub async fn load_via_job(&self, spec: &LoadJobSpec) -> Result<LoadJobOutcome, BigQueryError> {
+        let token = self.auth.get_token(&self.client).await?;
+        let url = format!(
+            "{}/bigquery/v2/projects/{}/jobs",
+            self.base_url(),
+            self.project_id
+        );
+
+        let request =
+            JobInsertRequest::for_load(self.project_id.clone(), self.location.clone(), spec);
+
+        debug!(
+            uris = ?spec.source_uris,
+            format = %spec.source_format.as_api_str(),
+            write_disposition = %spec.write_disposition.as_api_str(),
+            "submitting BigQuery load job"
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .json(&request)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().to_string();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(BigQueryError::ApiError {
+                status,
+                message: body,
+            });
+        }
+
+        // `jobs.insert` returns the freshly-created `Job` resource. It may
+        // already be `DONE` (a synchronous rejection, or a tiny load) or
+        // still `PENDING`/`RUNNING`.
+        let inserted: JobResource = resp.json().await?;
+        let job_ref = inserted
+            .job_reference
+            .ok_or_else(|| BigQueryError::ApiError {
+                status: "missing jobReference".into(),
+                message: "jobs.insert response had no jobReference; cannot poll the load job"
+                    .into(),
+            })?;
+
+        // Surface an inline failure immediately (the insert response can
+        // carry `status.errorResult` for a job rejected synchronously).
+        Self::check_load_status_error(inserted.status.as_ref())?;
+
+        // For rows-loaded, always resolve via `jobs.get`: the
+        // `statistics.load` block (and `outputRows` in particular) is only
+        // reliably populated on the `Job` resource returned by `jobs.get`,
+        // not necessarily on the `jobs.insert` response — even when that
+        // response already reports `state == DONE`. Reading stats from the
+        // insert body would risk reporting `rows_loaded = 0` on an inline
+        // DONE that omitted the stats. `poll_load_job`'s first GET returns
+        // immediately for an already-DONE job, so this is at most one extra
+        // (cheap) roundtrip on the rare inline-DONE path.
+        self.poll_load_job(&job_ref).await
+    }
+
+    /// Poll `jobs.get` for a load job until `status.state == "DONE"` or the
+    /// configured timeout elapses. Reuses the same fixed-ladder →
+    /// exponential-cap [`poll_delay`] cadence as the query poll loop.
+    async fn poll_load_job(&self, job_ref: &JobReference) -> Result<LoadJobOutcome, BigQueryError> {
+        let deadline = Instant::now() + Duration::from_secs(self.timeout_secs);
+        let token = self.auth.get_token(&self.client).await?;
+        let url = format!(
+            "{}/bigquery/v2/projects/{}/jobs/{}",
+            self.base_url(),
+            self.project_id,
+            job_ref.job_id
+        );
+
+        for attempt in 0..usize::MAX {
+            if Instant::now() >= deadline {
+                return Err(BigQueryError::Timeout {
+                    timeout_secs: self.timeout_secs,
+                });
+            }
+
+            tokio::time::sleep(poll_delay(attempt)).await;
+
+            let resp = self
+                .client
+                .get(&url)
+                .bearer_auth(&token)
+                .query(&[("location", self.location.as_str())])
+                .send()
+                .await?;
+
+            if !resp.status().is_success() {
+                let status = resp.status().to_string();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(BigQueryError::ApiError {
+                    status,
+                    message: body,
+                });
+            }
+
+            let job: JobResource = resp.json().await?;
+            if let Some(outcome) = Self::load_outcome_if_done(&job.status, &job.statistics)? {
+                debug!(
+                    job_id = %job_ref.job_id,
+                    attempts = attempt + 1,
+                    rows = outcome.rows_loaded,
+                    "BigQuery load job completed"
+                );
+                return Ok(outcome);
+            }
+        }
+
+        Err(BigQueryError::Timeout {
+            timeout_secs: self.timeout_secs,
+        })
+    }
+
+    /// Map a load job's `status.errorResult` (set once the job is `DONE`
+    /// and failed) to a [`BigQueryError::LoadJobError`]. No-op when the
+    /// status is absent, still running, or DONE without an error.
+    ///
+    /// A load job's terminal failure lives under `status.errorResult`
+    /// (an `ErrorProto`) — **not** the top-level `errors[]` the query path
+    /// uses — which is why this can't reuse
+    /// [`BigQueryResponse::check_job_error`]. Called both on the
+    /// `jobs.insert` response (synchronous rejections) and during the
+    /// `jobs.get` poll loop. No-op when `status` is absent or carries no
+    /// `errorResult`.
+    fn check_load_status_error(status: Option<&JobStatus>) -> Result<(), BigQueryError> {
+        let Some(status) = status else {
+            return Ok(());
+        };
+        let Some(err) = &status.error_result else {
+            return Ok(());
+        };
+        let reason = err.reason.clone().unwrap_or_else(|| "unknown".into());
+        // Aggregate per-row / per-file reasons from `errors[]` when present
+        // so the operator sees the underlying cause, not just the summary
+        // `errorResult`. Fall back to `errorResult.message`.
+        let detail: Vec<String> = status
+            .errors
+            .iter()
+            .flatten()
+            .filter_map(|e| e.message.clone())
+            .collect();
+        let message = if detail.is_empty() {
+            err.message.clone().unwrap_or_default()
+        } else {
+            detail.join("; ")
+        };
+        Err(BigQueryError::LoadJobError { reason, message })
+    }
+
+    /// If a load job's `status.state == "DONE"`, map it to either a
+    /// [`LoadJobOutcome`] (success — rows-loaded from
+    /// `statistics.load.outputRows`) or a
+    /// [`BigQueryError::LoadJobError`]. Returns `Ok(None)` while the job is
+    /// still `PENDING`/`RUNNING` so the poll loop keeps going.
+    fn load_outcome_if_done(
+        status: &Option<JobStatus>,
+        statistics: &Option<BigQueryStatistics>,
+    ) -> Result<Option<LoadJobOutcome>, BigQueryError> {
+        let Some(status) = status else {
+            // No status block yet → job hasn't reached a reportable state.
+            return Ok(None);
+        };
+        if status.state.as_deref() != Some("DONE") {
+            return Ok(None);
+        }
+
+        Self::check_load_status_error(Some(status))?;
+
+        let load_stats = statistics.as_ref().and_then(|s| s.load.as_ref());
+        let rows_loaded = load_stats
+            .and_then(BigQueryLoadStatistics::output_rows_u64)
+            .unwrap_or(0);
+        let input_bytes = load_stats.and_then(BigQueryLoadStatistics::input_file_bytes_u64);
+        Ok(Some(LoadJobOutcome {
+            rows_loaded,
+            input_file_bytes: input_bytes,
+        }))
+    }
 }
 
 #[async_trait]
@@ -1077,6 +1306,116 @@ fn record_warehouse_attrs_on_current_span(response: &BigQueryResponse) {
     }
 }
 
+// -- BigQuery load-job public API --
+
+/// Source file format for a BigQuery load job. Maps to the
+/// `configuration.load.sourceFormat` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BigQuerySourceFormat {
+    /// `CSV` — header rows / delimiter controlled via [`LoadJobSpec`].
+    Csv,
+    /// `PARQUET` — self-describing; schema autodetect is implicit.
+    Parquet,
+    /// `NEWLINE_DELIMITED_JSON` (JSONL / NDJSON).
+    NewlineDelimitedJson,
+}
+
+impl BigQuerySourceFormat {
+    /// The exact `sourceFormat` string BigQuery's load config expects.
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            Self::Csv => "CSV",
+            Self::Parquet => "PARQUET",
+            Self::NewlineDelimitedJson => "NEWLINE_DELIMITED_JSON",
+        }
+    }
+}
+
+/// `configuration.load.writeDisposition` — what to do with existing rows
+/// in the destination table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteDisposition {
+    /// `WRITE_TRUNCATE` — overwrite the table (truncate then load).
+    Truncate,
+    /// `WRITE_APPEND` — append to existing rows.
+    Append,
+}
+
+impl WriteDisposition {
+    /// The exact `writeDisposition` string BigQuery expects.
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            Self::Truncate => "WRITE_TRUNCATE",
+            Self::Append => "WRITE_APPEND",
+        }
+    }
+}
+
+/// `configuration.load.createDisposition` — whether to create the table
+/// when it doesn't exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadCreateDisposition {
+    /// `CREATE_IF_NEEDED` — create the table if it doesn't exist
+    /// (autodetect or explicit schema).
+    IfNeeded,
+    /// `CREATE_NEVER` — fail if the table doesn't already exist.
+    Never,
+}
+
+impl LoadCreateDisposition {
+    /// The exact `createDisposition` string BigQuery expects.
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            Self::IfNeeded => "CREATE_IF_NEEDED",
+            Self::Never => "CREATE_NEVER",
+        }
+    }
+}
+
+/// A fully-resolved BigQuery load-job configuration, consumed by
+/// [`BigQueryAdapter::load_via_job`].
+///
+/// The caller (the [`crate::BigQueryLoaderAdapter`]) translates the
+/// generic [`rocky_adapter_sdk::LoadOptions`] into this BigQuery-specific
+/// shape so the connector stays free of SDK types.
+#[derive(Debug, Clone)]
+pub struct LoadJobSpec {
+    /// GCP project that owns the destination table. Empty means "use the
+    /// adapter's project".
+    pub destination_project: String,
+    /// Destination dataset (BigQuery "schema").
+    pub destination_dataset: String,
+    /// Destination table name.
+    pub destination_table: String,
+    /// `gs://bucket/object` source URIs (wildcards allowed).
+    pub source_uris: Vec<String>,
+    /// File format of the source data.
+    pub source_format: BigQuerySourceFormat,
+    /// Overwrite vs append.
+    pub write_disposition: WriteDisposition,
+    /// Create-if-needed vs never.
+    pub create_disposition: LoadCreateDisposition,
+    /// Let BigQuery infer the schema from the data. Set for CSV/JSONL when
+    /// no explicit schema is supplied; implicit/harmless for Parquet.
+    pub autodetect: bool,
+    /// CSV only: number of leading header rows to skip. `None` for
+    /// non-CSV formats (the field is omitted from the request).
+    pub skip_leading_rows: Option<u64>,
+    /// CSV only: field delimiter. `None` for non-CSV formats.
+    pub field_delimiter: Option<String>,
+}
+
+/// Outcome of a completed BigQuery load job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadJobOutcome {
+    /// Rows written into the destination table
+    /// (`statistics.load.outputRows`).
+    pub rows_loaded: u64,
+    /// Bytes read from the source URIs (`statistics.load.inputFileBytes`),
+    /// when BigQuery reported it.
+    pub input_file_bytes: Option<u64>,
+}
+
 // -- BigQuery REST API types --
 
 #[derive(Debug, Serialize)]
@@ -1087,6 +1426,134 @@ struct QueryRequest {
     location: String,
     timeout_ms: u64,
     max_results: u32,
+}
+
+// -- load-job (`jobs.insert`) wire request --
+
+/// `jobs.insert` request body: a `Job` resource carrying only a
+/// `configuration.load` block and a `jobReference.location`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobInsertRequest {
+    job_reference: JobReferenceRequest,
+    configuration: JobConfigurationRequest,
+}
+
+impl JobInsertRequest {
+    /// Build the request from a [`LoadJobSpec`], pinning the job to the
+    /// adapter's `project`/`location` and translating the typed
+    /// dispositions to BigQuery's enum strings. An empty
+    /// `destination_project` falls back to the adapter's project so the
+    /// destinationTable never carries an empty `projectId`.
+    fn for_load(project: String, location: String, spec: &LoadJobSpec) -> Self {
+        let destination_project = if spec.destination_project.is_empty() {
+            project.clone()
+        } else {
+            spec.destination_project.clone()
+        };
+        JobInsertRequest {
+            job_reference: JobReferenceRequest {
+                project_id: project,
+                location,
+            },
+            configuration: JobConfigurationRequest {
+                load: JobConfigurationLoad {
+                    source_uris: spec.source_uris.clone(),
+                    source_format: spec.source_format.as_api_str().to_string(),
+                    write_disposition: spec.write_disposition.as_api_str().to_string(),
+                    create_disposition: spec.create_disposition.as_api_str().to_string(),
+                    autodetect: spec.autodetect,
+                    destination_table: DestinationTableRef {
+                        project_id: destination_project,
+                        dataset_id: spec.destination_dataset.clone(),
+                        table_id: spec.destination_table.clone(),
+                    },
+                    skip_leading_rows: spec.skip_leading_rows,
+                    field_delimiter: spec.field_delimiter.clone(),
+                },
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobReferenceRequest {
+    project_id: String,
+    location: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobConfigurationRequest {
+    load: JobConfigurationLoad,
+}
+
+/// `configuration.load` — the load-job knobs. Optional CSV fields are
+/// omitted entirely (not sent as `null`) for non-CSV formats so the
+/// request mirrors what a hand-written BigQuery load config looks like.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobConfigurationLoad {
+    source_uris: Vec<String>,
+    source_format: String,
+    write_disposition: String,
+    create_disposition: String,
+    autodetect: bool,
+    destination_table: DestinationTableRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skip_leading_rows: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field_delimiter: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DestinationTableRef {
+    project_id: String,
+    dataset_id: String,
+    table_id: String,
+}
+
+// -- load-job (`jobs.insert` / `jobs.get`) wire response --
+
+/// A BigQuery `Job` resource as returned by `jobs.insert` and `jobs.get`.
+/// Only the slices the load path reads are modelled; everything else is
+/// ignored by serde.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobResource {
+    #[serde(default)]
+    job_reference: Option<JobReference>,
+    #[serde(default)]
+    status: Option<JobStatus>,
+    #[serde(default)]
+    statistics: Option<BigQueryStatistics>,
+}
+
+/// `Job.status`. `state` is `PENDING` / `RUNNING` / `DONE`; a terminal
+/// failure carries `errorResult` (the summary `ErrorProto`) plus the full
+/// `errors[]` list.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobStatus {
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    error_result: Option<JobErrorProto>,
+    #[serde(default)]
+    errors: Option<Vec<JobErrorProto>>,
+}
+
+/// An `ErrorProto` under `Job.status`. Distinct from the query path's
+/// top-level [`ErrorProto`] only in where it lives on the wire; the shape
+/// (`reason` + `message`) is the same subset.
+#[derive(Debug, Deserialize)]
+struct JobErrorProto {
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1195,6 +1662,7 @@ fn is_transient(err: &BigQueryError) -> bool {
         }
         BigQueryError::Http(e) => e.is_connect() || e.is_timeout(),
         BigQueryError::JobError { .. }
+        | BigQueryError::LoadJobError { .. }
         | BigQueryError::Auth(_)
         | BigQueryError::Timeout { .. }
         | BigQueryError::RetryBudgetExhausted { .. }
@@ -1210,6 +1678,44 @@ fn is_transient(err: &BigQueryError) -> bool {
 struct BigQueryStatistics {
     #[serde(default)]
     query: Option<BigQueryQueryStatistics>,
+    /// `statistics.load` slice — populated on a load job's `jobs.get`
+    /// response. Carries `outputRows` (rows landed in the target) and
+    /// `inputFileBytes` (bytes read from the source URIs). Both are
+    /// decimal-string int64s, parsed best-effort.
+    #[serde(default)]
+    load: Option<BigQueryLoadStatistics>,
+}
+
+/// `statistics.load` subset for a BigQuery load job.
+///
+/// BigQuery encodes int64 figures as decimal strings (JSON has no native
+/// 64-bit int), so both fields are `Option<String>` parsed to `u64`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BigQueryLoadStatistics {
+    /// Number of rows the load job wrote into the destination table.
+    #[serde(default)]
+    output_rows: Option<String>,
+    /// Bytes read from the source URIs. Used as `LoadResult.bytes_read`
+    /// on the cloud-URI path, where the caller has no local file size.
+    #[serde(default)]
+    input_file_bytes: Option<String>,
+}
+
+impl BigQueryLoadStatistics {
+    /// Parse `outputRows` to `u64`. Missing / unparseable → `None`.
+    fn output_rows_u64(&self) -> Option<u64> {
+        self.output_rows
+            .as_deref()
+            .and_then(|s| s.parse::<u64>().ok())
+    }
+
+    /// Parse `inputFileBytes` to `u64`. Missing / unparseable → `None`.
+    fn input_file_bytes_u64(&self) -> Option<u64> {
+        self.input_file_bytes
+            .as_deref()
+            .and_then(|s| s.parse::<u64>().ok())
+    }
 }
 
 /// `statistics.query` subset we care about today.

--- a/engine/crates/rocky-bigquery/src/lib.rs
+++ b/engine/crates/rocky-bigquery/src/lib.rs
@@ -14,7 +14,10 @@ pub mod governance;
 pub mod loader;
 pub mod storage_read;
 
-pub use connector::BigQueryAdapter;
+pub use connector::{
+    BigQueryAdapter, BigQuerySourceFormat, LoadCreateDisposition, LoadJobOutcome, LoadJobSpec,
+    WriteDisposition,
+};
 pub use dialect::BigQueryDialect;
 pub use discovery::BigQueryDiscoveryAdapter;
 pub use loader::BigQueryLoaderAdapter;

--- a/engine/crates/rocky-bigquery/src/loader.rs
+++ b/engine/crates/rocky-bigquery/src/loader.rs
@@ -1,26 +1,34 @@
-//! BigQuery [`LoaderAdapter`] implementation — INSERT-fallback path.
+//! BigQuery [`LoaderAdapter`] implementation.
 //!
-//! BigQuery has no SQL `COPY INTO`. This adapter uses the shared
-//! [`CsvBatchReader`][rocky_core::arrow_loader::CsvBatchReader] +
-//! [`generate_batch_insert_sql`][rocky_core::arrow_loader::generate_batch_insert_sql]
-//! utilities to stream a local CSV file into `INSERT INTO ... VALUES (...)`
-//! batches, executed via the existing warehouse adapter's `execute_statement`.
+//! Two ingest paths, dispatched on the [`LoadSource`] variant:
 //!
-//! # Status: starter / dev-scale only
+//! - **Cloud URIs (`gs://…`) → native BigQuery LOAD JOB.** Submits a
+//!   `jobs.insert` load configuration via
+//!   [`BigQueryAdapter::load_via_job`][crate::BigQueryAdapter::load_via_job],
+//!   polls it to completion, and reads rows-loaded from the job
+//!   statistics. This is the production-scale path and supports **CSV,
+//!   Parquet, and newline-delimited JSON** — the load job reads the files
+//!   directly from Google Cloud Storage, so there's no per-row REST tax.
+//!   `writeDisposition`, `createDisposition`, schema autodetect, and the
+//!   CSV header/delimiter options all map onto the load config.
 //!
-//! INSERT-over-REST is ~3 orders of magnitude slower than native bulk load.
-//! **Production-scale BigQuery loading requires the Storage Write API**
-//! (gRPC streaming via `tonic`), which is deferred until the need arises.
-//! This loader is appropriate for:
-//! - Small reference datasets (seeds, lookup tables)
-//! - Dev/CI smoke tests
-//! - Proof-of-concept pipelines
+//! - **Local files → `INSERT INTO … VALUES` fallback (CSV only).**
+//!   BigQuery load jobs read only from GCS, so a `LoadSource::LocalFile`
+//!   can't feed one without first uploading to a bucket. Rather than take
+//!   a hard dependency on a GCS client, local files keep the original
+//!   batched-INSERT path (via the shared
+//!   [`CsvBatchReader`][rocky_core::arrow_loader::CsvBatchReader]). It is
+//!   ~3 orders of magnitude slower than a native load and appropriate for
+//!   small reference datasets, dev/CI smoke tests, and POCs. Parquet /
+//!   JSONL local files are rejected with a message pointing at the
+//!   `gs://` path.
 //!
-//! # Cloud URIs
+//! # Future work
 //!
-//! [`LoadSource::CloudUri`] is **not supported** — returns
-//! `AdapterError::not_supported`. Cloud-storage loading will land with the
-//! Storage Write API work.
+//! A `jobs.insert` *multipart* upload can stream a local file into a load
+//! job without a GCS round-trip; it's deferred (MIME-body complexity, and
+//! the local path is dev-scale by definition). Local→GCS upload + load is
+//! the other option, gated on adding a GCS client dependency.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -36,8 +44,14 @@ use rocky_core::arrow_loader::{CsvBatchReader, generate_batch_insert_sql};
 use rocky_core::traits::WarehouseAdapter;
 
 use crate::BigQueryAdapter;
+use crate::connector::{
+    BigQuerySourceFormat, LoadCreateDisposition, LoadJobSpec, WriteDisposition,
+};
 
-/// BigQuery loader adapter — CSV-only, INSERT-over-REST fallback.
+/// BigQuery loader adapter.
+///
+/// Cloud URIs use native LOAD JOBS; local files fall back to batched
+/// `INSERT INTO … VALUES`. See the module docs.
 pub struct BigQueryLoaderAdapter {
     adapter: Arc<BigQueryAdapter>,
 }
@@ -68,7 +82,8 @@ fn resolve_format(source: &LoadSource, options: &LoadOptions) -> AdapterResult<F
     })
 }
 
-/// Render a BigQuery target as `` `project`.`dataset`.`table` ``.
+/// Render a BigQuery target as `` `project`.`dataset`.`table` `` for the
+/// SQL (INSERT-fallback) path. Mirrors how the connector formats refs.
 fn format_target(target: &TableRef) -> String {
     if target.catalog.is_empty() {
         format!("`{}`.`{}`", target.schema, target.table)
@@ -77,6 +92,66 @@ fn format_target(target: &TableRef) -> String {
             "`{}`.`{}`.`{}`",
             target.catalog, target.schema, target.table
         )
+    }
+}
+
+/// Map the SDK [`FileFormat`] to the BigQuery load-job source format.
+fn source_format(format: FileFormat) -> BigQuerySourceFormat {
+    match format {
+        FileFormat::Csv => BigQuerySourceFormat::Csv,
+        FileFormat::Parquet => BigQuerySourceFormat::Parquet,
+        FileFormat::JsonLines => BigQuerySourceFormat::NewlineDelimitedJson,
+    }
+}
+
+/// Build a [`LoadJobSpec`] from the generic SDK options for the cloud path.
+///
+/// - `writeDisposition` = `WRITE_TRUNCATE` when `truncate_first`, else
+///   `WRITE_APPEND`.
+/// - `createDisposition` = `CREATE_IF_NEEDED` when `create_table`, else
+///   `CREATE_NEVER`.
+/// - CSV-only knobs (`skipLeadingRows`, `fieldDelimiter`) are threaded
+///   from [`LoadOptions`] and left `None` for Parquet / JSONL.
+/// - `autodetect` is on for CSV/JSONL (no explicit schema is available
+///   here); harmless for Parquet, which is self-describing.
+fn build_load_spec(
+    uri: &str,
+    target: &TableRef,
+    format: FileFormat,
+    options: &LoadOptions,
+) -> LoadJobSpec {
+    let write_disposition = if options.truncate_first {
+        WriteDisposition::Truncate
+    } else {
+        WriteDisposition::Append
+    };
+    let create_disposition = if options.create_table {
+        LoadCreateDisposition::IfNeeded
+    } else {
+        LoadCreateDisposition::Never
+    };
+
+    let (skip_leading_rows, field_delimiter) = if format == FileFormat::Csv {
+        // BigQuery's `skipLeadingRows` counts header lines to skip; map
+        // the boolean `csv_has_header` to 1/0. The delimiter is a single
+        // character on the SDK side.
+        let skip = u64::from(options.csv_has_header);
+        (Some(skip), Some(options.csv_delimiter.to_string()))
+    } else {
+        (None, None)
+    };
+
+    LoadJobSpec {
+        destination_project: target.catalog.clone(),
+        destination_dataset: target.schema.clone(),
+        destination_table: target.table.clone(),
+        source_uris: vec![uri.to_string()],
+        source_format: source_format(format),
+        write_disposition,
+        create_disposition,
+        autodetect: true,
+        skip_leading_rows,
+        field_delimiter,
     }
 }
 
@@ -89,99 +164,133 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
         options: &LoadOptions,
     ) -> AdapterResult<LoadResult> {
         let start = Instant::now();
-
-        // Cloud URIs require the Storage Write API — not implemented yet.
-        let local_path = match source {
-            LoadSource::LocalFile(p) => p.clone(),
-            LoadSource::CloudUri(uri) => {
-                return Err(AdapterError::msg(format!(
-                    "BigQuery CloudUri loading (got '{uri}') requires the Storage Write API \
-                     which is not yet implemented; use a LocalFile source for now"
-                )));
-            }
-        };
-
         let format = resolve_format(source, options)?;
-        if format != FileFormat::Csv {
-            return Err(AdapterError::msg(format!(
-                "BigQuery loader currently supports only CSV (got {format}); \
-                 Parquet/JSONL will land with the Storage Write API"
-            )));
-        }
 
-        let target_ref = format_target(target);
-        let file_size = std::fs::metadata(&local_path)
-            .map(|m| m.len())
-            .unwrap_or_default();
-
-        // Optional: truncate target before load.
-        if options.truncate_first {
-            let sql = format!("TRUNCATE TABLE {target_ref}");
-            debug!(sql = %sql, "truncating target before load");
-            self.adapter
-                .execute_statement(&sql)
-                .await
-                .map_err(|e| AdapterError::msg(e.to_string()))?;
-        }
-
-        let delim = options.csv_delimiter as u8;
-        let reader = CsvBatchReader::with_delimiter(&local_path, options.batch_size, delim)
-            .map_err(|e| AdapterError::msg(format!("failed to open CSV: {e}")))?;
-
-        // If create_table is requested, infer column names from the header and
-        // create a STRING-columns table. BigQuery inference is more involved
-        // (would need a sample pass); strings are a safe, lossless fallback.
-        if options.create_table {
-            let columns = reader.column_names();
-            if !columns.is_empty() {
-                let col_defs: Vec<String> =
-                    columns.iter().map(|c| format!("`{c}` STRING")).collect();
-                let sql = format!(
-                    "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
-                    col_defs.join(", ")
+        match source {
+            // --- Native LOAD JOB path: gs:// → jobs.insert ---
+            LoadSource::CloudUri(uri) => {
+                if !uri.starts_with("gs://") {
+                    return Err(AdapterError::msg(format!(
+                        "BigQuery load jobs read only from Google Cloud Storage; \
+                         got non-gs:// URI '{uri}'"
+                    )));
+                }
+                let spec = build_load_spec(uri, target, format, options);
+                debug!(
+                    uri = %uri,
+                    format = %format,
+                    truncate = options.truncate_first,
+                    "submitting BigQuery load job for cloud URI"
                 );
-                debug!(sql = %sql, "ensuring target table exists");
-                self.adapter
-                    .execute_statement(&sql)
+                let outcome = self
+                    .adapter
+                    .load_via_job(&spec)
                     .await
-                    .map_err(|e| AdapterError::msg(e.to_string()))?;
+                    .map_err(AdapterError::new)?;
+
+                info!(
+                    uri = %uri,
+                    rows = outcome.rows_loaded,
+                    bytes = outcome.input_file_bytes.unwrap_or_default(),
+                    "bigquery load job complete"
+                );
+                Ok(LoadResult {
+                    rows_loaded: outcome.rows_loaded,
+                    bytes_read: outcome.input_file_bytes.unwrap_or_default(),
+                    duration_ms: start.elapsed().as_millis() as u64,
+                })
+            }
+
+            // --- INSERT fallback path: local file (CSV only) ---
+            LoadSource::LocalFile(local_path) => {
+                if format != FileFormat::Csv {
+                    return Err(AdapterError::msg(format!(
+                        "BigQuery local-file loading supports only CSV (got {format}); \
+                         stage the file in Google Cloud Storage and load via a gs:// URI \
+                         for Parquet/JSONL (native load jobs)"
+                    )));
+                }
+
+                let target_ref = format_target(target);
+                let file_size = std::fs::metadata(local_path)
+                    .map(|m| m.len())
+                    .unwrap_or_default();
+
+                if options.truncate_first {
+                    let sql = format!("TRUNCATE TABLE {target_ref}");
+                    debug!(sql = %sql, "truncating target before load");
+                    self.adapter
+                        .execute_statement(&sql)
+                        .await
+                        .map_err(|e| AdapterError::msg(e.to_string()))?;
+                }
+
+                let delim = options.csv_delimiter as u8;
+                let reader = CsvBatchReader::with_delimiter(local_path, options.batch_size, delim)
+                    .map_err(|e| AdapterError::msg(format!("failed to open CSV: {e}")))?;
+
+                // If create_table is requested, infer column names from the
+                // header and create a STRING-columns table. BigQuery type
+                // inference is more involved (would need a sample pass);
+                // STRING is a safe, lossless fallback for the dev-scale
+                // INSERT path.
+                if options.create_table {
+                    let columns = reader.column_names();
+                    if !columns.is_empty() {
+                        let col_defs: Vec<String> =
+                            columns.iter().map(|c| format!("`{c}` STRING")).collect();
+                        let sql = format!(
+                            "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
+                            col_defs.join(", ")
+                        );
+                        debug!(sql = %sql, "ensuring target table exists");
+                        self.adapter
+                            .execute_statement(&sql)
+                            .await
+                            .map_err(|e| AdapterError::msg(e.to_string()))?;
+                    }
+                }
+
+                let mut rows_loaded: u64 = 0;
+                let dialect = self.adapter.dialect();
+
+                for batch_res in reader {
+                    let batch = batch_res
+                        .map_err(|e| AdapterError::msg(format!("failed to read CSV batch: {e}")))?;
+                    let batch_row_count = batch.row_count as u64;
+                    let sql =
+                        generate_batch_insert_sql(&batch, &target_ref, dialect).map_err(|e| {
+                            AdapterError::msg(format!("failed to build INSERT SQL: {e}"))
+                        })?;
+                    debug!(rows = batch_row_count, "inserting CSV batch");
+                    self.adapter
+                        .execute_statement(&sql)
+                        .await
+                        .map_err(|e| AdapterError::msg(e.to_string()))?;
+                    rows_loaded += batch_row_count;
+                }
+
+                info!(
+                    file = %local_path.display(),
+                    rows = rows_loaded,
+                    bytes = file_size,
+                    "bigquery local-file load complete (INSERT fallback)"
+                );
+
+                Ok(LoadResult {
+                    rows_loaded,
+                    bytes_read: file_size,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                })
             }
         }
-
-        let mut rows_loaded: u64 = 0;
-        let dialect = self.adapter.dialect();
-
-        for batch_res in reader {
-            let batch = batch_res
-                .map_err(|e| AdapterError::msg(format!("failed to read CSV batch: {e}")))?;
-            let batch_row_count = batch.row_count as u64;
-            let sql = generate_batch_insert_sql(&batch, &target_ref, dialect)
-                .map_err(|e| AdapterError::msg(format!("failed to build INSERT SQL: {e}")))?;
-            debug!(rows = batch_row_count, "inserting CSV batch");
-            self.adapter
-                .execute_statement(&sql)
-                .await
-                .map_err(|e| AdapterError::msg(e.to_string()))?;
-            rows_loaded += batch_row_count;
-        }
-
-        info!(
-            file = %local_path.display(),
-            rows = rows_loaded,
-            bytes = file_size,
-            "bigquery load complete"
-        );
-
-        Ok(LoadResult {
-            rows_loaded,
-            bytes_read: file_size,
-            duration_ms: start.elapsed().as_millis() as u64,
-        })
     }
 
     fn supported_formats(&self) -> Vec<FileFormat> {
-        // Parquet/JSONL need the Storage Write API; only CSV for now.
-        vec![FileFormat::Csv]
+        // Cloud-URI loads support all three via native load jobs. The
+        // local-file INSERT fallback is CSV-only, enforced at `load` time
+        // with an explicit error pointing at the gs:// path.
+        vec![FileFormat::Csv, FileFormat::Parquet, FileFormat::JsonLines]
     }
 }
 
@@ -226,5 +335,104 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(resolve_format(&src, &opts).unwrap(), FileFormat::Parquet);
+    }
+
+    #[test]
+    fn source_format_maps_all_three() {
+        assert_eq!(source_format(FileFormat::Csv), BigQuerySourceFormat::Csv);
+        assert_eq!(
+            source_format(FileFormat::Parquet),
+            BigQuerySourceFormat::Parquet
+        );
+        assert_eq!(
+            source_format(FileFormat::JsonLines),
+            BigQuerySourceFormat::NewlineDelimitedJson
+        );
+    }
+
+    #[test]
+    fn build_load_spec_truncate_maps_to_write_truncate() {
+        let target = TableRef {
+            catalog: "proj".into(),
+            schema: "ds".into(),
+            table: "tbl".into(),
+        };
+        let opts = LoadOptions {
+            truncate_first: true,
+            create_table: true,
+            ..Default::default()
+        };
+        let spec = build_load_spec("gs://b/o.csv", &target, FileFormat::Csv, &opts);
+        assert_eq!(spec.write_disposition, WriteDisposition::Truncate);
+        assert_eq!(spec.create_disposition, LoadCreateDisposition::IfNeeded);
+        assert_eq!(spec.source_uris, vec!["gs://b/o.csv".to_string()]);
+        assert_eq!(spec.destination_project, "proj");
+        assert_eq!(spec.destination_dataset, "ds");
+        assert_eq!(spec.destination_table, "tbl");
+        // CSV → header skip + delimiter present.
+        assert_eq!(spec.skip_leading_rows, Some(1));
+        assert_eq!(spec.field_delimiter.as_deref(), Some(","));
+    }
+
+    #[test]
+    fn build_load_spec_append_and_create_never() {
+        let target = TableRef {
+            catalog: String::new(),
+            schema: "ds".into(),
+            table: "tbl".into(),
+        };
+        let opts = LoadOptions {
+            truncate_first: false,
+            create_table: false,
+            ..Default::default()
+        };
+        let spec = build_load_spec("gs://b/o.parquet", &target, FileFormat::Parquet, &opts);
+        assert_eq!(spec.write_disposition, WriteDisposition::Append);
+        assert_eq!(spec.create_disposition, LoadCreateDisposition::Never);
+        // Parquet → no CSV knobs.
+        assert_eq!(spec.skip_leading_rows, None);
+        assert_eq!(spec.field_delimiter, None);
+        assert_eq!(spec.source_format, BigQuerySourceFormat::Parquet);
+        // Empty catalog is preserved here; the connector backfills the
+        // adapter's project when building the wire request.
+        assert_eq!(spec.destination_project, "");
+    }
+
+    #[test]
+    fn build_load_spec_no_header_skips_zero_rows() {
+        let target = TableRef {
+            catalog: "proj".into(),
+            schema: "ds".into(),
+            table: "tbl".into(),
+        };
+        let opts = LoadOptions {
+            csv_has_header: false,
+            csv_delimiter: '\t',
+            ..Default::default()
+        };
+        let spec = build_load_spec("gs://b/o.csv", &target, FileFormat::Csv, &opts);
+        assert_eq!(spec.skip_leading_rows, Some(0));
+        assert_eq!(spec.field_delimiter.as_deref(), Some("\t"));
+    }
+
+    #[test]
+    fn build_load_spec_jsonl_has_no_csv_knobs() {
+        let target = TableRef {
+            catalog: "proj".into(),
+            schema: "ds".into(),
+            table: "tbl".into(),
+        };
+        let spec = build_load_spec(
+            "gs://b/o.jsonl",
+            &target,
+            FileFormat::JsonLines,
+            &LoadOptions::default(),
+        );
+        assert_eq!(
+            spec.source_format,
+            BigQuerySourceFormat::NewlineDelimitedJson
+        );
+        assert_eq!(spec.skip_leading_rows, None);
+        assert_eq!(spec.field_delimiter, None);
     }
 }

--- a/engine/crates/rocky-bigquery/tests/integration.rs
+++ b/engine/crates/rocky-bigquery/tests/integration.rs
@@ -1070,3 +1070,168 @@ async fn test_governance_set_tags_applies_labels() {
         "table labels should contain env + owner; got {table_label_value}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Native LOAD JOB — end-to-end against a real GCS object
+// ---------------------------------------------------------------------------
+//
+// This is the live merge-gate for the `gs://` native-load path (the
+// headline feature). Because the loader does **not** upload local files to
+// GCS, the cloud-load path can't self-create its source — the test reads a
+// pre-staged GCS object from the sandbox bucket.
+//
+// Required env (all `ROCKY_TEST_*`, scrubbed of any committed identifiers):
+//   - `ROCKY_TEST_BIGQUERY_PROJECT`  — GCP project for the ephemeral
+//     dataset + load job.
+//   - `ROCKY_TEST_BIGQUERY_GCS_URI`  — a `gs://bucket/object.csv` that the
+//     tester has staged in the sandbox bucket. A 1-header-row CSV; the
+//     test counts the loaded rows and asserts they match the table.
+//   - `GOOGLE_APPLICATION_CREDENTIALS` *or* `BIGQUERY_TOKEN` — auth (the
+//     Google contract `BigQueryAuth::from_env()` already honours). The
+//     service account / token needs `bigquery.dataEditor` +
+//     `bigquery.jobUser` on the project and `storage.objects.get` on the
+//     bucket object.
+// Optional:
+//   - `ROCKY_TEST_BIGQUERY_LOCATION` — dataset location (default `EU`);
+//     **must** match the bucket's region/multi-region or BigQuery rejects
+//     the load.
+//
+// Run with:
+//   cargo test -p rocky-bigquery --test integration \
+//     load_via_gcs_csv -- --ignored --nocapture
+//
+// The test creates `hc_load_<ts>` (matching the sandbox `hc_` housekeeping
+// prefix), loads the object, verifies, and DROPs the dataset CASCADE in a
+// `finally`-style block so a mid-test failure still cleans up.
+
+/// Build a loader + the destination `TableRef` from `ROCKY_TEST_*` env.
+/// Returns `None` (skip) when the required vars aren't present.
+fn load_env() -> Option<(rocky_bigquery::BigQueryLoaderAdapter, String, String)> {
+    let project = std::env::var("ROCKY_TEST_BIGQUERY_PROJECT").ok()?;
+    let gcs_uri = std::env::var("ROCKY_TEST_BIGQUERY_GCS_URI").ok()?;
+    let location =
+        std::env::var("ROCKY_TEST_BIGQUERY_LOCATION").unwrap_or_else(|_| "EU".to_string());
+    let auth = BigQueryAuth::from_env().ok()?;
+    let adapter = std::sync::Arc::new(BigQueryAdapter::new(project.clone(), location, auth));
+    let loader = rocky_bigquery::BigQueryLoaderAdapter::new(adapter);
+    Some((loader, project, gcs_uri))
+}
+
+/// End-to-end: load a pre-staged GCS CSV into a fresh table via the native
+/// BigQuery load-job path (`LoadSource::CloudUri` → `jobs.insert`), then
+/// verify the row count. Exercises the *full* loader dispatch, not just
+/// the connector primitive.
+#[tokio::test]
+#[ignore]
+async fn load_via_gcs_csv() {
+    use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter};
+
+    let Some((loader, project, gcs_uri)) = load_env() else {
+        eprintln!(
+            "skipping load_via_gcs_csv: set ROCKY_TEST_BIGQUERY_PROJECT, \
+             ROCKY_TEST_BIGQUERY_GCS_URI, and GCP auth to run"
+        );
+        return;
+    };
+
+    // A second adapter for verification / setup / teardown SQL. (The
+    // loader owns its own Arc<BigQueryAdapter>; this one issues the
+    // dataset DDL and the post-load COUNT.)
+    let admin = adapter_from_rocky_env().expect("ROCKY_TEST_BIGQUERY_PROJECT must be set");
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let dataset = format!("hc_load_{suffix}");
+    let table = "loaded";
+    let location =
+        std::env::var("ROCKY_TEST_BIGQUERY_LOCATION").unwrap_or_else(|_| "EU".to_string());
+
+    // Create the dataset in the right location so the load (and the bucket
+    // region) line up.
+    admin
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{project}`.`{dataset}` OPTIONS(location='{location}')"
+        ))
+        .await
+        .expect("create dataset");
+
+    // Run the load + verification, capturing the result so we always drop
+    // the dataset afterwards. The loader takes the adapter-SDK `TableRef`
+    // (a distinct type from the `rocky_ir::TableRef` the admin adapter
+    // uses), so it's fully qualified here.
+    let outcome = async {
+        let target = rocky_adapter_sdk::TableRef {
+            catalog: project.clone(),
+            schema: dataset.clone(),
+            table: table.into(),
+        };
+        let source = LoadSource::CloudUri(gcs_uri.clone());
+        let options = LoadOptions {
+            // Native load job: CREATE_IF_NEEDED + autodetect + skip 1
+            // header row. WRITE_TRUNCATE so a re-run is idempotent.
+            create_table: true,
+            truncate_first: true,
+            csv_has_header: true,
+            ..Default::default()
+        };
+
+        let result = loader.load(&source, &target, &options).await?;
+        assert!(
+            result.rows_loaded > 0,
+            "expected the GCS CSV to load at least one row; loaded {}",
+            result.rows_loaded
+        );
+
+        // Cross-check against a COUNT(*) on the destination table. The
+        // admin adapter's query error type differs from the loader's, so
+        // this uses `.expect()` rather than `?` to keep the closure's
+        // error type purely the loader's `AdapterError`.
+        let count_res = admin
+            .execute_query(&format!(
+                "SELECT COUNT(*) FROM `{project}`.`{dataset}`.`{table}`"
+            ))
+            .await
+            .expect("COUNT(*) on loaded table");
+        let counted: u64 = count_res.rows[0][0]
+            .as_str()
+            .unwrap_or("0")
+            .parse()
+            .unwrap_or(0);
+        assert_eq!(
+            counted, result.rows_loaded,
+            "COUNT(*) ({counted}) should equal rows_loaded ({})",
+            result.rows_loaded
+        );
+
+        // Idempotency: a second WRITE_TRUNCATE load yields the same count.
+        let result2 = loader.load(&source, &target, &options).await?;
+        assert_eq!(
+            result2.rows_loaded, result.rows_loaded,
+            "WRITE_TRUNCATE re-load should land the same row count"
+        );
+
+        Ok::<_, rocky_adapter_sdk::AdapterError>(result)
+    }
+    .await;
+
+    // Teardown regardless of outcome.
+    let _ = admin
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{dataset}` CASCADE"
+        ))
+        .await;
+
+    outcome.expect("GCS CSV load + verification");
+}
+
+/// Admin adapter built from the `ROCKY_TEST_*` env (mirrors `load_env`'s
+/// project/location/auth) for the setup + teardown SQL in the load test.
+fn adapter_from_rocky_env() -> Option<BigQueryAdapter> {
+    let project = std::env::var("ROCKY_TEST_BIGQUERY_PROJECT").ok()?;
+    let location =
+        std::env::var("ROCKY_TEST_BIGQUERY_LOCATION").unwrap_or_else(|_| "EU".to_string());
+    let auth = BigQueryAuth::from_env().ok()?;
+    Some(BigQueryAdapter::new(project, location, auth))
+}

--- a/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
@@ -49,15 +49,18 @@
 use rocky_bigquery::BigQueryAdapter;
 use rocky_bigquery::auth::BigQueryAuth;
 use rocky_bigquery::connector::BigQueryError;
+use rocky_bigquery::{BigQuerySourceFormat, LoadCreateDisposition, LoadJobSpec, WriteDisposition};
 use rocky_core::config::RetryConfig;
 use rocky_core::retry_budget::RetryBudget;
 use rocky_core::traits::{AdapterError, WarehouseAdapter};
 use serde_json::{Value, json};
-use wiremock::matchers::{header, method, path, query_param};
+use wiremock::matchers::{body_partial_json, header, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Path of the `jobs.query` endpoint for the test project.
 const QUERIES_PATH: &str = "/bigquery/v2/projects/test-project/queries";
+/// Path of the `jobs.insert` endpoint for the test project.
+const JOBS_PATH: &str = "/bigquery/v2/projects/test-project/jobs";
 
 /// Build an adapter with a static bearer token pointed at the mock server.
 /// `with_timeout` defaults to the production 300 s so the poll deadline
@@ -860,4 +863,500 @@ async fn missing_schema_yields_empty_columns_and_rows() {
 
     assert!(result.columns.is_empty());
     assert!(result.rows.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// (f) Native LOAD JOBS (`jobs.insert` → poll `jobs.get`)
+// ---------------------------------------------------------------------------
+//
+// The load path is `POST /…/jobs` (insert) followed by `GET /…/jobs/{id}`
+// (get) polled until `status.state == "DONE"`. Unlike the query path, a
+// load failure surfaces under `status.errorResult` on the `Job` resource,
+// not a top-level `errors[]` — these tests pin that distinction plus the
+// request-body shape per source format and per writeDisposition.
+
+/// A CSV `LoadJobSpec` for `test-project`, WRITE_TRUNCATE + CREATE_IF_NEEDED.
+fn csv_truncate_spec() -> LoadJobSpec {
+    LoadJobSpec {
+        destination_project: "test-project".into(),
+        destination_dataset: "ds".into(),
+        destination_table: "tbl".into(),
+        source_uris: vec!["gs://bucket/data.csv".into()],
+        source_format: BigQuerySourceFormat::Csv,
+        write_disposition: WriteDisposition::Truncate,
+        create_disposition: LoadCreateDisposition::IfNeeded,
+        autodetect: true,
+        skip_leading_rows: Some(1),
+        field_delimiter: Some(",".into()),
+    }
+}
+
+/// `jobs.get` (or inline `jobs.insert`) DONE response carrying load
+/// statistics. `output_rows` and `input_file_bytes` are decimal strings
+/// (BigQuery's int64-as-string).
+fn load_done_body(job_id: &str, output_rows: &str, input_bytes: &str) -> Value {
+    json!({
+        "jobReference": {"projectId": "test-project", "jobId": job_id},
+        "status": {"state": "DONE"},
+        "statistics": {
+            "load": {
+                "outputRows": output_rows,
+                "inputFileBytes": input_bytes
+            }
+        }
+    })
+}
+
+/// Mount a `jobs.get` mock for `job_id` that returns a DONE body with the
+/// given load stats. The request-shape tests assert the *insert* body; the
+/// connector always resolves rows-loaded from `jobs.get`, so they need a
+/// matching GET to complete.
+async fn mount_get_done(server: &MockServer, job_id: &str, output_rows: &str, input_bytes: &str) {
+    Mock::given(method("GET"))
+        .and(path_regex(format!(
+            r"^/bigquery/v2/projects/test-project/jobs/{job_id}$"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(load_done_body(
+            job_id,
+            output_rows,
+            input_bytes,
+        )))
+        .mount(server)
+        .await;
+}
+
+/// Happy path: insert returns RUNNING, the poll loop hits `jobs.get` which
+/// returns DONE with `statistics.load.outputRows`. Asserts rows-loaded and
+/// bytes-read are parsed from the load statistics.
+#[tokio::test]
+async fn load_job_polls_to_done_and_parses_output_rows() {
+    let server = MockServer::start().await;
+
+    // jobs.insert → RUNNING, no statistics yet.
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .and(header("authorization", "Bearer test-bq-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-1"},
+            "status": {"state": "RUNNING"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // jobs.get → DONE with load stats.
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/bigquery/v2/projects/test-project/jobs/load-1$",
+        ))
+        .and(header("authorization", "Bearer test-bq-token"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(load_done_body("load-1", "1000", "204800")),
+        )
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let outcome = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect("load job should complete");
+
+    assert_eq!(outcome.rows_loaded, 1000);
+    assert_eq!(outcome.input_file_bytes, Some(204_800));
+}
+
+/// Inline DONE: `jobs.insert` returns `state=DONE` but **without** a
+/// `statistics.load` block (BigQuery only reliably populates `outputRows`
+/// on the `Job` resource from `jobs.get`, not on the insert response). The
+/// connector must therefore still call `jobs.get` for the authoritative
+/// rows-loaded rather than reporting `0` from the stats-less insert body.
+/// This pins the fix for that silent-zero-rows hazard.
+#[tokio::test]
+async fn load_job_inline_done_still_fetches_stats_via_get() {
+    let server = MockServer::start().await;
+
+    // Insert → DONE but no statistics block.
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-inline"},
+            "status": {"state": "DONE"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // jobs.get → DONE with the real load stats.
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/bigquery/v2/projects/test-project/jobs/load-inline$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(load_done_body(
+            "load-inline",
+            "7",
+            "512",
+        )))
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let outcome = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect("inline-DONE load job should still resolve stats via jobs.get");
+
+    assert_eq!(outcome.rows_loaded, 7);
+    assert_eq!(outcome.input_file_bytes, Some(512));
+}
+
+/// Request-shape: a CSV WRITE_TRUNCATE load sends the right
+/// `configuration.load` block — sourceFormat=CSV, writeDisposition,
+/// createDisposition, the structured destinationTable, and the CSV-only
+/// knobs (skipLeadingRows / fieldDelimiter). `body_partial_json` asserts
+/// the request the connector PUT on the wire.
+#[tokio::test]
+async fn load_job_csv_truncate_request_shape() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .and(body_partial_json(json!({
+            "jobReference": {"projectId": "test-project", "location": "EU"},
+            "configuration": {
+                "load": {
+                    "sourceUris": ["gs://bucket/data.csv"],
+                    "sourceFormat": "CSV",
+                    "writeDisposition": "WRITE_TRUNCATE",
+                    "createDisposition": "CREATE_IF_NEEDED",
+                    "autodetect": true,
+                    "destinationTable": {
+                        "projectId": "test-project",
+                        "datasetId": "ds",
+                        "tableId": "tbl"
+                    },
+                    "skipLeadingRows": 1,
+                    "fieldDelimiter": ","
+                }
+            }
+        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(load_done_body("load-csv", "1", "10")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_get_done(&server, "load-csv", "1", "10").await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect("csv truncate load should submit");
+    server.verify().await;
+}
+
+/// Request-shape: a PARQUET WRITE_APPEND / CREATE_NEVER load. Asserts the
+/// sourceFormat + flipped dispositions on the wire. (The CSV-only knobs
+/// `skipLeadingRows` / `fieldDelimiter` are omitted from the body via
+/// `skip_serializing_if` for non-CSV formats — absence is covered by the
+/// `build_load_spec_*` unit tests; `body_partial_json` here only asserts
+/// the keys that *are* present.)
+#[tokio::test]
+async fn load_job_parquet_append_request_shape() {
+    let server = MockServer::start().await;
+
+    let spec = LoadJobSpec {
+        destination_project: "test-project".into(),
+        destination_dataset: "ds".into(),
+        destination_table: "tbl".into(),
+        source_uris: vec!["gs://bucket/data.parquet".into()],
+        source_format: BigQuerySourceFormat::Parquet,
+        write_disposition: WriteDisposition::Append,
+        create_disposition: LoadCreateDisposition::Never,
+        autodetect: true,
+        skip_leading_rows: None,
+        field_delimiter: None,
+    };
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .and(body_partial_json(json!({
+            "configuration": {
+                "load": {
+                    "sourceUris": ["gs://bucket/data.parquet"],
+                    "sourceFormat": "PARQUET",
+                    "writeDisposition": "WRITE_APPEND",
+                    "createDisposition": "CREATE_NEVER"
+                }
+            }
+        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(load_done_body("load-pq", "42", "9999")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_get_done(&server, "load-pq", "42", "9999").await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let outcome = adapter
+        .load_via_job(&spec)
+        .await
+        .expect("parquet append load");
+    assert_eq!(outcome.rows_loaded, 42);
+    server.verify().await;
+}
+
+/// Request-shape: a NEWLINE_DELIMITED_JSON load sends `sourceFormat =
+/// NEWLINE_DELIMITED_JSON`. Pins the JSONL → API-enum mapping.
+#[tokio::test]
+async fn load_job_jsonl_source_format_request_shape() {
+    let server = MockServer::start().await;
+
+    let spec = LoadJobSpec {
+        destination_project: "test-project".into(),
+        destination_dataset: "ds".into(),
+        destination_table: "tbl".into(),
+        source_uris: vec!["gs://bucket/data.jsonl".into()],
+        source_format: BigQuerySourceFormat::NewlineDelimitedJson,
+        write_disposition: WriteDisposition::Truncate,
+        create_disposition: LoadCreateDisposition::IfNeeded,
+        autodetect: true,
+        skip_leading_rows: None,
+        field_delimiter: None,
+    };
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .and(body_partial_json(json!({
+            "configuration": {
+                "load": {
+                    "sourceFormat": "NEWLINE_DELIMITED_JSON",
+                    "writeDisposition": "WRITE_TRUNCATE"
+                }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(load_done_body(
+            "load-jsonl",
+            "3",
+            "120",
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_get_done(&server, "load-jsonl", "3", "120").await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    adapter.load_via_job(&spec).await.expect("jsonl load");
+    server.verify().await;
+}
+
+/// Empty `destination_project` on the spec falls back to the adapter's
+/// project so the wire `destinationTable.projectId` is never empty.
+#[tokio::test]
+async fn load_job_empty_destination_project_falls_back_to_adapter_project() {
+    let server = MockServer::start().await;
+
+    let spec = LoadJobSpec {
+        destination_project: String::new(),
+        destination_dataset: "ds".into(),
+        destination_table: "tbl".into(),
+        source_uris: vec!["gs://bucket/data.csv".into()],
+        source_format: BigQuerySourceFormat::Csv,
+        write_disposition: WriteDisposition::Append,
+        create_disposition: LoadCreateDisposition::IfNeeded,
+        autodetect: true,
+        skip_leading_rows: Some(1),
+        field_delimiter: Some(",".into()),
+    };
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .and(body_partial_json(json!({
+            "configuration": {
+                "load": {
+                    "destinationTable": {"projectId": "test-project"}
+                }
+            }
+        })))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(load_done_body("load-fb", "1", "10")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_get_done(&server, "load-fb", "1", "10").await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    adapter
+        .load_via_job(&spec)
+        .await
+        .expect("load with project fallback");
+    server.verify().await;
+}
+
+/// A load job that reaches DONE with a `status.errorResult` maps to
+/// [`BigQueryError::LoadJobError`], and the message aggregates the
+/// per-file reasons from `status.errors[]` (not just the summary). This is
+/// the load path's analogue of the query path's top-level-`errors[]`
+/// handling — and proves the connector reads the *right* nesting.
+#[tokio::test]
+async fn load_job_error_result_maps_to_load_job_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-bad"},
+            "status": {"state": "RUNNING"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/bigquery/v2/projects/test-project/jobs/load-bad$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-bad"},
+            "status": {
+                "state": "DONE",
+                "errorResult": {
+                    "reason": "invalid",
+                    "message": "Error while reading data, error message: CSV table references column position 3, but line contains only 2 columns."
+                },
+                "errors": [
+                    {"reason": "invalid", "message": "Error while reading data: field count mismatch (line 1)"},
+                    {"reason": "invalid", "message": "Error while reading data: field count mismatch (line 2)"}
+                ]
+            }
+        })))
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let err = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect_err("a DONE job with errorResult must be an error");
+
+    match err {
+        BigQueryError::LoadJobError { reason, message } => {
+            assert_eq!(reason, "invalid");
+            // Message aggregates the two per-line errors[] entries.
+            assert!(
+                message.contains("line 1") && message.contains("line 2"),
+                "expected aggregated per-line reasons, got: {message}"
+            );
+        }
+        other => panic!("expected LoadJobError, got: {other:?}"),
+    }
+}
+
+/// A load job whose `errorResult` has no `errors[]` detail falls back to
+/// the `errorResult.message` summary.
+#[tokio::test]
+async fn load_job_error_result_without_errors_uses_summary_message() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-bad2"},
+            "status": {
+                "state": "DONE",
+                "errorResult": {"reason": "notFound", "message": "Not found: URI gs://bucket/missing.csv"}
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let err = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect_err("missing-source load must error");
+
+    match err {
+        BigQueryError::LoadJobError { reason, message } => {
+            assert_eq!(reason, "notFound");
+            assert!(message.contains("missing.csv"), "got: {message}");
+        }
+        other => panic!("expected LoadJobError, got: {other:?}"),
+    }
+}
+
+/// A non-2xx from `jobs.insert` (e.g. a 403 from a missing
+/// `bigquery.jobUser` role) maps to [`BigQueryError::ApiError`] on the
+/// first attempt — no poll, retries disabled by `test_adapter`.
+#[tokio::test]
+async fn load_job_insert_non_2xx_maps_to_api_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "error": {"code": 403, "message": "Access Denied: missing bigquery.jobs.create"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(5);
+    let err = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect_err("403 insert must error");
+
+    match err {
+        BigQueryError::ApiError { status, message } => {
+            assert!(status.starts_with("403"), "status: {status}");
+            assert!(message.contains("Access Denied"), "message: {message}");
+        }
+        other => panic!("expected ApiError, got: {other:?}"),
+    }
+}
+
+/// The poll loop respects the configured timeout: if `jobs.get` never
+/// reports DONE, the call returns [`BigQueryError::Timeout`] rather than
+/// looping forever. A 1 s timeout keeps the test fast.
+#[tokio::test]
+async fn load_job_poll_times_out_when_never_done() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(JOBS_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-stuck"},
+            "status": {"state": "RUNNING"}
+        })))
+        .mount(&server)
+        .await;
+
+    // Always RUNNING — never reaches DONE.
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/bigquery/v2/projects/test-project/jobs/load-stuck$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jobReference": {"projectId": "test-project", "jobId": "load-stuck"},
+            "status": {"state": "RUNNING"}
+        })))
+        .mount(&server)
+        .await;
+
+    let adapter = test_adapter(&server).with_timeout(1);
+    let err = adapter
+        .load_via_job(&csv_truncate_spec())
+        .await
+        .expect_err("a never-DONE load job must time out");
+
+    assert!(
+        matches!(err, BigQueryError::Timeout { timeout_secs: 1 }),
+        "expected Timeout, got: {err:?}"
+    );
 }


### PR DESCRIPTION
Replaces the per-row `INSERT … VALUES` fallback with native BigQuery **load jobs** for `gs://` sources.

- `jobs.insert` (load config) then poll to `DONE`, parsing `statistics.load.outputRows`
- Supports **CSV, Parquet, and NEWLINE_DELIMITED_JSON** (Parquet/JSONL were previously unsupported)
- `writeDisposition` from `truncate_first`, `createDisposition` from `create_table`; CSV `skipLeadingRows` / `fieldDelimiter` threaded from load options
- Maps load failures from `status.errorResult` (a different nesting from the query path's top-level `errors[]`)
- Local files keep the `INSERT … VALUES` path (CSV-only)

**Tested:** 11 new wiremock unit tests (per-format request shape, job-stats + error parsing) plus a live run against real BigQuery — `gs://` CSV load job with a `WRITE_TRUNCATE` re-load idempotency check.
