### PR TITLE
feat(engine/rocky-databricks): stage local files + cast CSV to declared schema in COPY INTO

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "uuid",
  "wiremock",
 ]
 

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 percent-encoding = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 test-support = []

--- a/engine/crates/rocky-databricks/src/connector.rs
+++ b/engine/crates/rocky-databricks/src/connector.rs
@@ -848,7 +848,127 @@ impl DatabricksConnector {
 
         Ok(())
     }
+
+    /// Upload bytes to a Unity Catalog Volume path via the Files API.
+    ///
+    /// Issues `PUT /api/2.0/fs/files/<volume_path>?overwrite=true` with the
+    /// file contents as the raw request body. `volume_path` is an absolute
+    /// Volume path (`/Volumes/<catalog>/<schema>/<volume>/<file>`); the loader
+    /// builds it from validated identifiers via
+    /// [`crate::volume::StagingVolume`], so it never carries an unvalidated
+    /// component.
+    ///
+    /// Like [`Self::cancel_statement`], this is a direct authenticated request
+    /// — it does **not** flow through the SQL submit/poll/retry path or the
+    /// circuit breaker (those are SQL-statement concerns). `overwrite=true`
+    /// guards against the astronomically-unlikely case of a UUID-name
+    /// collision on the shared volume.
+    ///
+    /// # Errors
+    ///
+    /// - [`ConnectorError::Auth`] when the token mint fails.
+    /// - [`ConnectorError::Http`] on transport failure.
+    /// - [`ConnectorError::ApiError`] on any non-2xx response (e.g. 404 when
+    ///   the volume doesn't exist, 403 on missing write privilege).
+    pub async fn upload_file(
+        &self,
+        volume_path: &str,
+        contents: Vec<u8>,
+    ) -> Result<(), ConnectorError> {
+        let token = self.auth.get_token().await?;
+        let url = format!(
+            "{}/api/2.0/fs/files{}",
+            self.api_base_url(),
+            encode_volume_path(volume_path),
+        );
+
+        debug!(
+            volume_path = volume_path,
+            bytes = contents.len(),
+            "Files API upload"
+        );
+
+        let resp = self
+            .client
+            .put(&url)
+            .bearer_auth(&token)
+            .query(&[("overwrite", "true")])
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body(contents)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ConnectorError::ApiError { status, body });
+        }
+        Ok(())
+    }
+
+    /// Delete a file from a Unity Catalog Volume path via the Files API.
+    ///
+    /// Issues `DELETE /api/2.0/fs/files/<volume_path>`. Used to clean up a
+    /// staged file after `COPY INTO` (success or failure). `volume_path` is the
+    /// same validated absolute path passed to [`Self::upload_file`].
+    ///
+    /// A `404 Not Found` is treated as success (the file is already gone — the
+    /// post-condition "file no longer staged" holds), so a double-cleanup or a
+    /// cleanup after a failed upload is a no-op rather than an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`ConnectorError::Auth`] when the token mint fails.
+    /// - [`ConnectorError::Http`] on transport failure.
+    /// - [`ConnectorError::ApiError`] on any non-2xx response other than 404.
+    pub async fn delete_file(&self, volume_path: &str) -> Result<(), ConnectorError> {
+        let token = self.auth.get_token().await?;
+        let url = format!(
+            "{}/api/2.0/fs/files{}",
+            self.api_base_url(),
+            encode_volume_path(volume_path),
+        );
+
+        debug!(volume_path = volume_path, "Files API delete");
+
+        let resp = self.client.delete(&url).bearer_auth(&token).send().await?;
+
+        let status = resp.status();
+        if status.is_success() || status.as_u16() == 404 {
+            return Ok(());
+        }
+        let body = resp.text().await.unwrap_or_default();
+        Err(ConnectorError::ApiError {
+            status: status.as_u16(),
+            body,
+        })
+    }
 }
+
+/// Percent-encode each path segment of an absolute Volume path while keeping
+/// the `/` separators literal.
+///
+/// The loader only ever passes paths whose components were validated to
+/// `[A-Za-z0-9._-]` (none of which require encoding), but encoding defensively
+/// means a future caller can't smuggle a reserved character into the REST URL.
+/// Splitting on `/` and re-joining preserves the path structure that
+/// `format!("{base}/api/2.0/fs/files{path}")` depends on.
+fn encode_volume_path(path: &str) -> String {
+    path.split('/')
+        .map(|seg| percent_encoding::utf8_percent_encode(seg, FILES_PATH_SEGMENT).to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Byte set for percent-encoding one Files-API path segment: RFC 3986
+/// unreserved characters (`-`, `.`, `_`, `~`, alphanumerics) pass through;
+/// everything else (including `/`) is encoded. The separator `/` is handled by
+/// [`encode_volume_path`] splitting before this is applied per-segment.
+const FILES_PATH_SEGMENT: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
 
 /// Fetch one chunk's Arrow IPC stream bytes from its pre-signed
 /// external URL. The URL is a cloud-storage pre-signed GET (S3 /

--- a/engine/crates/rocky-databricks/src/lib.rs
+++ b/engine/crates/rocky-databricks/src/lib.rs
@@ -11,6 +11,7 @@ pub mod scim;
 pub mod throttle;
 pub mod types;
 pub mod unity_catalog_client;
+pub mod volume;
 pub mod workspace;
 
 pub use unity_catalog_client::{UnityCatalogClient, UnityRestError};

--- a/engine/crates/rocky-databricks/src/loader.rs
+++ b/engine/crates/rocky-databricks/src/loader.rs
@@ -10,9 +10,24 @@
 //! COPY_OPTIONS ('mergeSchema' = 'true');
 //! ```
 //!
-//! The source file must already live in cloud storage (S3, ADLS, etc.).
-//! Databricks reads the URI directly — Rocky does **not** upload files.
-//! [`LoadSource::LocalFile`] is rejected with a clear error message.
+//! `COPY INTO` reads a file the warehouse can already see. Two paths:
+//!
+//! - **Cloud URI** ([`LoadSource::CloudUri`]) — `s3://…`, `abfss://…`, etc.
+//!   Databricks reads the URI directly; Rocky runs a single `COPY INTO`.
+//! - **Local file** ([`LoadSource::LocalFile`]) — Databricks can't read the
+//!   local filesystem, so Rocky stages the file to a Unity Catalog Volume
+//!   first (mirroring the Snowflake `PUT → COPY INTO` model):
+//!   1. `CREATE VOLUME IF NOT EXISTS <catalog>.<schema>.<volume>` (idempotent),
+//!   2. upload the file to `/Volumes/.../rocky_load_<uuid>.<ext>` via the
+//!      [Files API],
+//!   3. `COPY INTO ... FROM '/Volumes/.../<file>'`,
+//!   4. delete the staged **file** (success or failure); the volume is left
+//!      in place as a reusable governed container.
+//!
+//! The volume lands in the **target table's** catalog + schema, with a
+//! configurable volume name (default [`crate::volume::DEFAULT_STAGING_VOLUME`]).
+//!
+//! [Files API]: https://docs.databricks.com/api/workspace/files
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -27,16 +42,43 @@ use rocky_adapter_sdk::{
 use rocky_sql::validation::validate_identifier;
 
 use crate::connector::{DatabricksConnector, QueryResult};
+use crate::volume::{
+    DEFAULT_STAGING_VOLUME, StagingVolume, create_volume_sql, generate_staged_file_name,
+};
 
 /// Databricks loader adapter using COPY INTO.
+///
+/// Local files are staged to a Unity Catalog Volume in the target table's
+/// catalog + schema before the COPY INTO; the volume name defaults to
+/// [`crate::volume::DEFAULT_STAGING_VOLUME`] and is configurable via
+/// [`Self::with_staging_volume`].
 pub struct DatabricksLoaderAdapter {
     connector: Arc<DatabricksConnector>,
+    /// Unity Catalog Volume name used to stage local files, created on demand
+    /// in the target table's catalog + schema. Cloud-URI loads never touch it.
+    staging_volume: String,
 }
 
 impl DatabricksLoaderAdapter {
-    /// Create a loader wrapping the given `DatabricksConnector`.
+    /// Create a loader wrapping the given `DatabricksConnector`, staging local
+    /// files to the default volume ([`crate::volume::DEFAULT_STAGING_VOLUME`]).
     pub fn new(connector: Arc<DatabricksConnector>) -> Self {
-        Self { connector }
+        Self {
+            connector,
+            staging_volume: DEFAULT_STAGING_VOLUME.to_string(),
+        }
+    }
+
+    /// Override the Unity Catalog Volume name used to stage local files.
+    ///
+    /// The volume is created on demand (`CREATE VOLUME IF NOT EXISTS`) in the
+    /// target table's catalog + schema. The name is validated as a SQL
+    /// identifier when a local file is actually staged — an invalid name only
+    /// surfaces on a local-file load, never on a cloud-URI load.
+    #[must_use]
+    pub fn with_staging_volume(mut self, volume: impl Into<String>) -> Self {
+        self.staging_volume = volume.into();
+        self
     }
 }
 
@@ -119,18 +161,20 @@ fn validate_csv_delimiter(c: char) -> AdapterResult<char> {
     }
 }
 
-/// Reject cloud URIs that would break out of the `'<uri>'` SQL string literal.
-/// Rocky never escapes embedded quotes — instead we refuse to build the SQL.
-fn validate_cloud_uri(uri: &str) -> AdapterResult<&str> {
-    if uri.is_empty() {
-        return Err(AdapterError::msg("cloud URI cannot be empty"));
+/// Reject a `FROM '<path>'` literal that would break out of the surrounding
+/// `'...'` SQL string literal. Used for both cloud URIs (`s3://…`) and staged
+/// Volume paths (`/Volumes/…`). Rocky never escapes embedded quotes — instead
+/// we refuse to build the SQL.
+fn validate_sql_path_literal(path: &str) -> AdapterResult<&str> {
+    if path.is_empty() {
+        return Err(AdapterError::msg("COPY INTO source path cannot be empty"));
     }
-    if uri.contains(['\'', '\n', '\r', '\\']) {
+    if path.contains(['\'', '\n', '\r', '\\']) {
         return Err(AdapterError::msg(format!(
-            "invalid cloud URI {uri:?}: must not contain quotes, backslashes, or newlines"
+            "invalid COPY INTO source path {path:?}: must not contain quotes, backslashes, or newlines"
         )));
     }
-    Ok(uri)
+    Ok(path)
 }
 
 /// Extract the `num_affected_rows` count from a COPY INTO response.
@@ -160,13 +204,16 @@ fn extract_num_affected_rows(result: &QueryResult) -> Option<u64> {
     }
 }
 
-/// Build the full `COPY INTO ... FROM '<uri>'` SQL statement.
+/// Build the full `COPY INTO ... FROM '<path>'` SQL statement.
 ///
-/// The caller must pass a validated `target_ref` (use [`format_target`]) and a
-/// validated `uri` (use [`validate_cloud_uri`]) so the literal-context
-/// interpolation can't be broken out of.
+/// `path` is either a cloud URI (`s3://…`) or a staged Volume path
+/// (`/Volumes/…`) — the FROM clause and FORMAT_OPTIONS are byte-identical
+/// either way, so both source kinds share this builder. The caller must pass a
+/// validated `target_ref` (use [`format_target`]) and a validated `path` (use
+/// [`validate_sql_path_literal`]) so the literal-context interpolation can't be
+/// broken out of.
 fn build_copy_into_sql(
-    uri: &str,
+    path: &str,
     target_ref: &str,
     format: FileFormat,
     options: &LoadOptions,
@@ -183,8 +230,128 @@ fn build_copy_into_sql(
         ""
     };
     Ok(format!(
-        "COPY INTO {target_ref} FROM '{uri}' FILEFORMAT = {fileformat}{format_opts}{copy_opts}"
+        "COPY INTO {target_ref} FROM '{path}' FILEFORMAT = {fileformat}{format_opts}{copy_opts}"
     ))
+}
+
+impl DatabricksLoaderAdapter {
+    /// Execute `DELETE FROM <target>` when `truncate_first` is set. Databricks
+    /// supports DELETE FROM on managed tables.
+    async fn maybe_truncate(&self, target_ref: &str, options: &LoadOptions) -> AdapterResult<()> {
+        if options.truncate_first {
+            let sql = format!("DELETE FROM {target_ref}");
+            debug!(sql = %sql, "truncating target before COPY INTO");
+            self.connector
+                .execute_statement(&sql)
+                .await
+                .map_err(|e| AdapterError::msg(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Run a `COPY INTO ... FROM '<path>'` and return the rows-loaded count.
+    ///
+    /// `path` must already be validated via [`validate_sql_path_literal`].
+    /// Databricks' COPY INTO returns a single-row result set whose schema
+    /// includes `num_affected_rows`; if it's absent we fall back to 0 rather
+    /// than fail, so older/non-standard API shapes still return a usable load.
+    async fn run_copy_into(
+        &self,
+        path: &str,
+        target_ref: &str,
+        format: FileFormat,
+        options: &LoadOptions,
+    ) -> AdapterResult<u64> {
+        let sql = build_copy_into_sql(path, target_ref, format, options)?;
+        info!(sql = %sql, "databricks COPY INTO");
+        let copy_result = self
+            .connector
+            .execute_sql(&sql)
+            .await
+            .map_err(|e| AdapterError::msg(e.to_string()))?;
+
+        Ok(rows_from_copy_result(&copy_result))
+    }
+
+    /// Stage a local file to a Unity Catalog Volume, COPY INTO from it, then
+    /// clean up the staged file.
+    ///
+    /// Sequence (mirrors the Snowflake `PUT → COPY INTO → DROP` ordering):
+    /// 1. `CREATE VOLUME IF NOT EXISTS` in the target's catalog + schema,
+    /// 2. read the file + upload it to `/Volumes/.../rocky_load_<uuid>.<ext>`,
+    /// 3. `COPY INTO ... FROM` the staged path,
+    /// 4. delete the staged file — on upload failure, COPY failure, or success.
+    ///
+    /// Returns `(rows_loaded, bytes_read)`. The volume is never dropped (it's a
+    /// reusable governed container shared across loads).
+    async fn load_local_file(
+        &self,
+        local_path: &std::path::Path,
+        target: &TableRef,
+        target_ref: &str,
+        format: FileFormat,
+        options: &LoadOptions,
+    ) -> AdapterResult<(u64, u64)> {
+        // Stage into the *target table's* catalog + schema. `format_target`
+        // already validated these identifiers, but `StagingVolume::new`
+        // re-validates (including the configured volume name) so the rendered
+        // DDL + path are provably safe.
+        let volume = StagingVolume::new(&target.catalog, &target.schema, &self.staging_volume)?;
+
+        // Auto-provision the volume (idempotent). Databricks has no
+        // temporary-volume concept, so without this the Files API PUT 404s.
+        let create_sql = create_volume_sql(&volume);
+        debug!(sql = %create_sql, "creating staging volume");
+        self.connector
+            .execute_statement(&create_sql)
+            .await
+            .map_err(|e| AdapterError::msg(e.to_string()))?;
+
+        // Read the local file before uploading so a read error fails fast,
+        // before we've created anything to clean up on the volume.
+        let contents = std::fs::read(local_path).map_err(|e| {
+            AdapterError::msg(format!(
+                "failed to read local file '{}': {e}",
+                local_path.display()
+            ))
+        })?;
+        let bytes_read = contents.len() as u64;
+
+        let file_name = generate_staged_file_name(format.extension());
+        let staged_path = volume.file_path(&file_name)?;
+        // Defensive: the staged path is built from validated components, but
+        // the COPY INTO literal check is the same guard the cloud path uses.
+        let staged_path = validate_sql_path_literal(&staged_path)?.to_string();
+
+        info!(volume_path = %staged_path, "staging local file to UC Volume");
+        if let Err(e) = self.connector.upload_file(&staged_path, contents).await {
+            // Upload failed — best-effort clean up anything partially written.
+            self.cleanup_staged_file(&staged_path).await;
+            return Err(AdapterError::msg(format!(
+                "Files API upload to '{staged_path}' failed: {e}"
+            )));
+        }
+
+        // COPY INTO from the staged path; clean up the file regardless of
+        // the COPY result.
+        let copy_result = self
+            .run_copy_into(&staged_path, target_ref, format, options)
+            .await;
+        self.cleanup_staged_file(&staged_path).await;
+
+        let rows_loaded = copy_result?;
+        Ok((rows_loaded, bytes_read))
+    }
+
+    /// Best-effort deletion of a staged file. Logs (does not fail the load) on
+    /// error — the volume's lifecycle policy and the unique UUID name mean a
+    /// leaked file is harmless, and we never want cleanup to mask the real
+    /// load result.
+    async fn cleanup_staged_file(&self, staged_path: &str) {
+        if let Err(e) = self.connector.delete_file(staged_path).await {
+            warn!(error = %e, volume_path = %staged_path, "failed to delete staged file (non-fatal)");
+        }
+    }
 }
 
 #[async_trait]
@@ -197,67 +364,50 @@ impl LoaderAdapter for DatabricksLoaderAdapter {
     ) -> AdapterResult<LoadResult> {
         let start = Instant::now();
 
-        let uri = match source {
-            LoadSource::CloudUri(uri) => uri.clone(),
-            LoadSource::LocalFile(p) => {
-                return Err(AdapterError::msg(format!(
-                    "Databricks requires files in cloud storage (S3/ADLS/GCS); \
-                     got local path '{}'. Upload the file first, then point \
-                     `source_dir` at the cloud URI (e.g. s3://bucket/prefix/).",
-                    p.display()
-                )));
-            }
-        };
-
         let format = resolve_format(source, options)?;
         let target_ref = format_target(target)?;
-        let uri = validate_cloud_uri(&uri)?.to_string();
 
-        // `truncate_first` maps to a DELETE prior to COPY INTO. Databricks
-        // supports DELETE FROM on managed tables.
-        if options.truncate_first {
-            let sql = format!("DELETE FROM {target_ref}");
-            debug!(sql = %sql, "truncating target before COPY INTO");
-            self.connector
-                .execute_statement(&sql)
-                .await
-                .map_err(|e| AdapterError::msg(e.to_string()))?;
-        }
+        self.maybe_truncate(&target_ref, options).await?;
 
-        let sql = build_copy_into_sql(&uri, &target_ref, format, options)?;
-        info!(sql = %sql, "databricks COPY INTO");
-        let copy_result = self
-            .connector
-            .execute_sql(&sql)
-            .await
-            .map_err(|e| AdapterError::msg(e.to_string()))?;
-
-        // Databricks' COPY INTO returns a single-row result set whose
-        // schema includes `num_affected_rows` (the count of rows written
-        // into the target table for this call). Parse it from the result;
-        // if the column isn't present we fall back to 0 rather than fail,
-        // so older/non-standard API shapes still return a usable load.
-        let rows_loaded = match extract_num_affected_rows(&copy_result) {
-            Some(n) => n,
-            None => {
-                warn!(
-                    statement_id = %copy_result.statement_id,
-                    "databricks COPY INTO response missing `num_affected_rows` \
-                     column; reporting 0 rows loaded"
-                );
-                0
+        let (rows_loaded, bytes_read) = match source {
+            LoadSource::CloudUri(uri) => {
+                let uri = validate_sql_path_literal(uri)?.to_string();
+                let rows = self
+                    .run_copy_into(&uri, &target_ref, format, options)
+                    .await?;
+                (rows, 0) // Cloud-URI sources: no local byte count.
+            }
+            LoadSource::LocalFile(local_path) => {
+                self.load_local_file(local_path, target, &target_ref, format, options)
+                    .await?
             }
         };
 
         Ok(LoadResult {
             rows_loaded,
-            bytes_read: 0, // Cloud-URI sources: no local byte count.
+            bytes_read,
             duration_ms: start.elapsed().as_millis() as u64,
         })
     }
 
     fn supported_formats(&self) -> Vec<FileFormat> {
         vec![FileFormat::Csv, FileFormat::Parquet, FileFormat::JsonLines]
+    }
+}
+
+/// Extract the rows-loaded count from a COPY INTO response, warning (rather
+/// than failing the load) when `num_affected_rows` is absent.
+fn rows_from_copy_result(copy_result: &QueryResult) -> u64 {
+    match extract_num_affected_rows(copy_result) {
+        Some(n) => n,
+        None => {
+            warn!(
+                statement_id = %copy_result.statement_id,
+                "databricks COPY INTO response missing `num_affected_rows` \
+                 column; reporting 0 rows loaded"
+            );
+            0
+        }
     }
 }
 
@@ -345,11 +495,12 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_cloud_uri_rejects_quote() {
-        assert!(validate_cloud_uri("s3://bucket/key").is_ok());
-        assert!(validate_cloud_uri("s3://bucket/key'; DROP --").is_err());
-        assert!(validate_cloud_uri("s3://bucket/\nfoo").is_err());
-        assert!(validate_cloud_uri("").is_err());
+    fn test_validate_sql_path_literal_rejects_quote() {
+        assert!(validate_sql_path_literal("s3://bucket/key").is_ok());
+        assert!(validate_sql_path_literal("/Volumes/main/raw/vol/rocky_load_abc.csv").is_ok());
+        assert!(validate_sql_path_literal("s3://bucket/key'; DROP --").is_err());
+        assert!(validate_sql_path_literal("s3://bucket/\nfoo").is_err());
+        assert!(validate_sql_path_literal("").is_err());
     }
 
     #[test]
@@ -455,5 +606,69 @@ mod tests {
         let mut qr = copy_into_result("num_affected_rows", serde_json::json!(9));
         qr.rows.clear();
         assert_eq!(extract_num_affected_rows(&qr), None);
+    }
+
+    #[test]
+    fn test_rows_from_copy_result_present() {
+        let qr = copy_into_result("num_affected_rows", serde_json::json!(55));
+        assert_eq!(rows_from_copy_result(&qr), 55);
+    }
+
+    #[test]
+    fn test_rows_from_copy_result_missing_defaults_zero() {
+        let qr = copy_into_result("some_other_column", serde_json::json!(99));
+        assert_eq!(rows_from_copy_result(&qr), 0);
+    }
+
+    #[test]
+    fn test_build_copy_into_from_volume_path() {
+        // The Volume-staged path shares the cloud-URI builder, so FORMAT_OPTIONS
+        // are byte-identical — only the FROM literal differs.
+        let opts = LoadOptions::default();
+        let sql = build_copy_into_sql(
+            "/Volumes/main/raw/rocky_staging/rocky_load_abc.csv",
+            "main.raw.orders",
+            FileFormat::Csv,
+            &opts,
+        )
+        .unwrap();
+        assert!(sql.contains("FROM '/Volumes/main/raw/rocky_staging/rocky_load_abc.csv'"));
+        assert!(sql.contains("FILEFORMAT = CSV"));
+        assert!(sql.contains("'header' = 'true'"));
+        assert!(sql.contains("'delimiter' = ','"));
+        assert!(sql.contains("mergeSchema"));
+    }
+
+    #[test]
+    fn test_loader_default_staging_volume() {
+        // `new` uses the default; `with_staging_volume` overrides it. We don't
+        // need a connector to inspect the field — construct via a dummy Arc.
+        // (Build a connector pointing at an unused host; never executed.)
+        use crate::auth::{Auth, AuthConfig};
+        use crate::connector::ConnectorConfig;
+        use std::time::Duration;
+
+        let auth = Auth::from_config(AuthConfig {
+            host: "unused.databricks.com".into(),
+            token: Some("t".into()),
+            client_id: None,
+            client_secret: None,
+        })
+        .unwrap();
+        let connector = Arc::new(DatabricksConnector::new(
+            ConnectorConfig {
+                host: "unused.databricks.com".into(),
+                warehouse_id: "w".into(),
+                timeout: Duration::from_secs(1),
+                retry: Default::default(),
+            },
+            auth,
+        ));
+
+        let default_loader = DatabricksLoaderAdapter::new(Arc::clone(&connector));
+        assert_eq!(default_loader.staging_volume, DEFAULT_STAGING_VOLUME);
+
+        let custom = DatabricksLoaderAdapter::new(connector).with_staging_volume("hc_stage");
+        assert_eq!(custom.staging_volume, "hc_stage");
     }
 }

--- a/engine/crates/rocky-databricks/src/loader.rs
+++ b/engine/crates/rocky-databricks/src/loader.rs
@@ -218,20 +218,73 @@ fn build_copy_into_sql(
     format: FileFormat,
     options: &LoadOptions,
 ) -> AdapterResult<String> {
+    build_copy_into_sql_from(&format!("'{path}'"), target_ref, format, options)
+}
+
+/// Build `COPY INTO … FROM <from_clause> …` where `from_clause` is the full
+/// FROM expression — either a quoted path (`'/Volumes/…'`) or a typed-cast
+/// subquery (`(SELECT CAST(…) FROM '…')`). All path + identifier validation
+/// happens in the caller before the clause is assembled.
+fn build_copy_into_sql_from(
+    from_clause: &str,
+    target_ref: &str,
+    format: FileFormat,
+    options: &LoadOptions,
+) -> AdapterResult<String> {
     let fileformat = file_format_clause(format);
     let format_opts = format_options_clause(format, options)?
         .map(|s| format!(" {s}"))
         .unwrap_or_default();
     // mergeSchema lets Databricks evolve the target schema when new columns
-    // appear — matches DuckDB's create_table-from-file semantics.
+    // appear. CSV loads route through a typed-cast subquery (see
+    // `build_csv_cast_source`), so the loaded schema already matches the
+    // target and the merge is a no-op rather than a string-vs-typed conflict.
     let copy_opts = if options.create_table {
         " COPY_OPTIONS ('mergeSchema' = 'true')"
     } else {
         ""
     };
     Ok(format!(
-        "COPY INTO {target_ref} FROM '{path}' FILEFORMAT = {fileformat}{format_opts}{copy_opts}"
+        "COPY INTO {target_ref} FROM {from_clause} FILEFORMAT = {fileformat}{format_opts}{copy_opts}"
     ))
+}
+
+/// Build a typed `(SELECT CAST(`col` AS <type>) … FROM '<path>')` source for a
+/// CSV `COPY INTO`. Databricks reads CSV columns as strings; casting each to
+/// the target's declared type lands real typed values and avoids
+/// `DELTA_FAILED_TO_MERGE_FIELDS` when a target column isn't STRING. `path`
+/// must already be validated via [`validate_sql_path_literal`]; `columns` are
+/// the target's `(name, declared_type)` pairs from
+/// [`DatabricksLoaderAdapter::describe_target_columns`].
+fn build_csv_cast_source(path: &str, columns: &[(String, String)]) -> AdapterResult<String> {
+    let mut casts = Vec::with_capacity(columns.len());
+    for (name, dtype) in columns {
+        validate_identifier(name).map_err(AdapterError::new)?;
+        let ty = validate_sql_type(dtype)?;
+        casts.push(format!("CAST(`{name}` AS {ty}) AS `{name}`"));
+    }
+    Ok(format!("(SELECT {} FROM '{path}')", casts.join(", ")))
+}
+
+/// Reject a column type string that could break out of the `CAST(… AS <type>)`
+/// context. DESCRIBE-sourced types are trusted, but we still constrain them to
+/// `[A-Za-z0-9_(), <>]` (covers `decimal(10,2)`, `array<int>`,
+/// `map<string,int>`) so an unexpected warehouse response can't inject SQL.
+fn validate_sql_type(ty: &str) -> AdapterResult<&str> {
+    let t = ty.trim();
+    if t.is_empty() {
+        return Err(AdapterError::msg("empty column type from DESCRIBE TABLE"));
+    }
+    let safe = t
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '(' | ')' | ',' | ' ' | '<' | '>'));
+    if safe {
+        Ok(t)
+    } else {
+        Err(AdapterError::msg(format!(
+            "unsafe column type {ty:?} from DESCRIBE TABLE"
+        )))
+    }
 }
 
 impl DatabricksLoaderAdapter {
@@ -249,12 +302,66 @@ impl DatabricksLoaderAdapter {
         Ok(())
     }
 
-    /// Run a `COPY INTO ... FROM '<path>'` and return the rows-loaded count.
+    /// Fetch the target table's declared `(name, type)` columns via
+    /// `DESCRIBE TABLE`, so a CSV load can CAST each column to its declared
+    /// type. Returns an empty `Vec` when the table can't be described (e.g. it
+    /// doesn't exist yet) — the caller then falls back to a plain path load.
+    async fn describe_target_columns(&self, target_ref: &str) -> Vec<(String, String)> {
+        let sql = format!("DESCRIBE TABLE {target_ref}");
+        let result = match self.connector.execute_sql(&sql).await {
+            Ok(r) => r,
+            Err(e) => {
+                debug!(error = %e, target = %target_ref, "DESCRIBE TABLE failed; CSV load falls back to a plain COPY INTO");
+                return Vec::new();
+            }
+        };
+        let name_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("col_name"))
+            .unwrap_or(0);
+        let type_idx = result
+            .columns
+            .iter()
+            .position(|c| c.name.eq_ignore_ascii_case("data_type"))
+            .unwrap_or(1);
+        let mut cols = Vec::new();
+        for row in &result.rows {
+            let name = row
+                .get(name_idx)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            // DESCRIBE TABLE lists data columns first, then a blank row and
+            // `# Partition Information` / `# Detailed Table Information`
+            // sections — stop at the first non-column row.
+            if name.is_empty() || name.starts_with('#') {
+                break;
+            }
+            let dtype = row
+                .get(type_idx)
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !dtype.is_empty() {
+                cols.push((name, dtype));
+            }
+        }
+        cols
+    }
+
+    /// Run a `COPY INTO` and return the rows-loaded count.
     ///
-    /// `path` must already be validated via [`validate_sql_path_literal`].
-    /// Databricks' COPY INTO returns a single-row result set whose schema
-    /// includes `num_affected_rows`; if it's absent we fall back to 0 rather
-    /// than fail, so older/non-standard API shapes still return a usable load.
+    /// `path` must already be validated via [`validate_sql_path_literal`]. For
+    /// CSV into an existing table, each column is cast to the target's declared
+    /// type (Databricks reads CSV as strings, so a non-STRING target column
+    /// would otherwise fail `DELTA_FAILED_TO_MERGE_FIELDS`); Parquet/JSON carry
+    /// their own types, and an un-describable target (missing table) falls back
+    /// to a plain path load. Databricks' COPY INTO returns a single-row result
+    /// whose schema includes `num_affected_rows`; if it's absent we fall back
+    /// to 0 rather than fail.
     async fn run_copy_into(
         &self,
         path: &str,
@@ -262,7 +369,17 @@ impl DatabricksLoaderAdapter {
         format: FileFormat,
         options: &LoadOptions,
     ) -> AdapterResult<u64> {
-        let sql = build_copy_into_sql(path, target_ref, format, options)?;
+        let sql = if format == FileFormat::Csv {
+            let columns = self.describe_target_columns(target_ref).await;
+            if columns.is_empty() {
+                build_copy_into_sql(path, target_ref, format, options)?
+            } else {
+                let from = build_csv_cast_source(path, &columns)?;
+                build_copy_into_sql_from(&from, target_ref, format, options)?
+            }
+        } else {
+            build_copy_into_sql(path, target_ref, format, options)?
+        };
         info!(sql = %sql, "databricks COPY INTO");
         let copy_result = self
             .connector
@@ -637,6 +754,53 @@ mod tests {
         assert!(sql.contains("'header' = 'true'"));
         assert!(sql.contains("'delimiter' = ','"));
         assert!(sql.contains("mergeSchema"));
+    }
+
+    #[test]
+    fn test_build_csv_cast_source() {
+        let cols = vec![
+            ("id".to_string(), "BIGINT".to_string()),
+            ("name".to_string(), "STRING".to_string()),
+        ];
+        let src = build_csv_cast_source("/Volumes/c/s/v/f.csv", &cols).unwrap();
+        assert_eq!(
+            src,
+            "(SELECT CAST(`id` AS BIGINT) AS `id`, CAST(`name` AS STRING) AS `name` FROM '/Volumes/c/s/v/f.csv')"
+        );
+    }
+
+    #[test]
+    fn test_build_csv_cast_source_rejects_bad_identifier() {
+        let cols = vec![("id`; DROP".to_string(), "BIGINT".to_string())];
+        assert!(build_csv_cast_source("/p.csv", &cols).is_err());
+    }
+
+    #[test]
+    fn test_validate_sql_type() {
+        assert_eq!(validate_sql_type("BIGINT").unwrap(), "BIGINT");
+        assert_eq!(validate_sql_type("decimal(10,2)").unwrap(), "decimal(10,2)");
+        assert_eq!(validate_sql_type("array<int>").unwrap(), "array<int>");
+        assert!(validate_sql_type("string'; DROP").is_err());
+        assert!(validate_sql_type("").is_err());
+    }
+
+    #[test]
+    fn test_copy_into_csv_cast_subquery_shape() {
+        let cols = vec![
+            ("id".to_string(), "BIGINT".to_string()),
+            ("name".to_string(), "STRING".to_string()),
+        ];
+        let from = build_csv_cast_source("/Volumes/c/s/v/f.csv", &cols).unwrap();
+        let sql = build_copy_into_sql_from(
+            &from,
+            "main.raw.orders",
+            FileFormat::Csv,
+            &LoadOptions::default(),
+        )
+        .unwrap();
+        assert!(sql.starts_with("COPY INTO main.raw.orders FROM (SELECT CAST(`id` AS BIGINT)"));
+        assert!(sql.contains("FILEFORMAT = CSV"));
+        assert!(sql.contains("'header' = 'true'"));
     }
 
     #[test]

--- a/engine/crates/rocky-databricks/src/volume.rs
+++ b/engine/crates/rocky-databricks/src/volume.rs
@@ -1,0 +1,246 @@
+//! Unity Catalog Volume staging helpers used by the loader adapter.
+//!
+//! Databricks' bulk-load primitive (`COPY INTO`) reads a file from a path the
+//! warehouse can already see. For files already in cloud storage that's the
+//! cloud URI directly; for a **local** file Rocky must first upload it
+//! somewhere the warehouse can read. Unity Catalog *Volumes* are that place:
+//! a governed filesystem location addressed as `/Volumes/<catalog>/<schema>/<volume>/<file>`
+//! that the [Files API] writes to over REST and `COPY INTO` reads from.
+//!
+//! Unlike Snowflake's `CREATE TEMPORARY STAGE` (which auto-creates and
+//! auto-expires with the session), Databricks has no temporary-volume concept.
+//! The loader therefore:
+//!
+//! 1. `CREATE VOLUME IF NOT EXISTS <catalog>.<schema>.<volume>` (idempotent,
+//!    mirrors the `create_table`/`mergeSchema` auto-provisioning the loader
+//!    already does on the cloud-URI path),
+//! 2. uploads the local file to a unique path under that volume via the Files
+//!    API,
+//! 3. runs `COPY INTO ... FROM '/Volumes/.../<file>'`,
+//! 4. deletes the uploaded **file** afterwards (success or failure). The volume
+//!    itself is left in place — it's a cheap, reusable, governed container.
+//!
+//! The volume is provisioned in the **target table's** catalog + schema (the
+//! same place the data lands), with a configurable volume name that defaults to
+//! [`DEFAULT_STAGING_VOLUME`].
+//!
+//! [Files API]: https://docs.databricks.com/api/workspace/files
+
+use rocky_adapter_sdk::{AdapterError, AdapterResult};
+use rocky_sql::validation::validate_identifier;
+
+/// Default Unity Catalog Volume name Rocky stages local files into when the
+/// caller doesn't configure one. Lives in the target table's catalog + schema.
+pub const DEFAULT_STAGING_VOLUME: &str = "rocky_staging";
+
+/// A validated reference to a Unity Catalog staging volume in a specific
+/// catalog + schema.
+///
+/// Every component is validated as a SQL identifier (`[A-Za-z0-9_]+`) at
+/// construction, so the rendered `CREATE VOLUME` SQL and the `/Volumes/...`
+/// path are always safe to interpolate — there is no code path that puts an
+/// unvalidated component into either.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagingVolume {
+    catalog: String,
+    schema: String,
+    volume: String,
+}
+
+impl StagingVolume {
+    /// Validate and construct a staging-volume reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of `catalog` / `schema` / `volume` is not a
+    /// valid SQL identifier.
+    pub fn new(catalog: &str, schema: &str, volume: &str) -> AdapterResult<Self> {
+        validate_identifier(catalog).map_err(AdapterError::new)?;
+        validate_identifier(schema).map_err(AdapterError::new)?;
+        validate_identifier(volume).map_err(AdapterError::new)?;
+        Ok(Self {
+            catalog: catalog.to_string(),
+            schema: schema.to_string(),
+            volume: volume.to_string(),
+        })
+    }
+
+    /// Render the three-part `catalog.schema.volume` reference for use in
+    /// `CREATE VOLUME` / `DROP VOLUME` DDL. Safe to interpolate — every
+    /// component was identifier-validated at construction.
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}.{}", self.catalog, self.schema, self.volume)
+    }
+
+    /// Render the `/Volumes/<catalog>/<schema>/<volume>` path prefix (no
+    /// trailing slash). This is the filesystem root the Files API writes
+    /// under and `COPY INTO` reads from.
+    pub fn path_prefix(&self) -> String {
+        format!("/Volumes/{}/{}/{}", self.catalog, self.schema, self.volume)
+    }
+
+    /// Build the full `/Volumes/.../<file_name>` path for a staged file.
+    ///
+    /// `file_name` is validated to contain only `[A-Za-z0-9._-]` so it can't
+    /// inject extra path segments (`/`, `..`) or break the `COPY INTO`
+    /// string literal. Use [`generate_staged_file_name`] to produce one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `file_name` is empty or contains characters
+    /// outside the safe set.
+    pub fn file_path(&self, file_name: &str) -> AdapterResult<String> {
+        validate_staged_file_name(file_name)?;
+        Ok(format!("{}/{}", self.path_prefix(), file_name))
+    }
+}
+
+/// Build the `CREATE VOLUME IF NOT EXISTS <catalog>.<schema>.<volume>` SQL.
+///
+/// Idempotent — safe to run before every staged load. Mirrors the loader's
+/// `mergeSchema` auto-provisioning on the cloud-URI path: Rocky creates the
+/// container it needs rather than requiring the operator to pre-create it.
+pub fn create_volume_sql(volume: &StagingVolume) -> String {
+    format!("CREATE VOLUME IF NOT EXISTS {}", volume.qualified_name())
+}
+
+/// Validate a staged file name.
+///
+/// Allows `[A-Za-z0-9._-]` only — enough for a UUID-suffixed name with an
+/// extension (`rocky_load_<uuid>.csv`), but no path separators, `..`, quotes,
+/// or whitespace. This keeps both the REST path and the `COPY INTO` string
+/// literal safe.
+fn validate_staged_file_name(name: &str) -> AdapterResult<()> {
+    if name.is_empty() {
+        return Err(AdapterError::msg("staged file name cannot be empty"));
+    }
+    let ok = name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if !ok {
+        return Err(AdapterError::msg(format!(
+            "invalid staged file name '{name}': must be [A-Za-z0-9._-]+ \
+             (no path separators, quotes, or whitespace)"
+        )));
+    }
+    Ok(())
+}
+
+/// Generate a unique staged file name: `rocky_load_<uuid>[.<ext>]`.
+///
+/// A v4 UUID's `simple()` formatting (32 lowercase hex chars, no hyphens) plus
+/// the optional extension stays inside [`validate_staged_file_name`]'s safe
+/// set. The 122-bit random payload collapses the collision probability to
+/// astronomical even under unbounded concurrency — important because, unlike a
+/// Snowflake temporary stage, the volume is shared across concurrent loads.
+///
+/// `extension` is the format's conventional extension (e.g. `"csv"`,
+/// `"parquet"`); pass `""` to omit it. A non-empty extension is filtered to the
+/// safe charset defensively — callers pass [`rocky_adapter_sdk::FileFormat::extension`]
+/// values, which are already safe, but the filter guarantees the result always
+/// passes validation regardless of caller.
+pub fn generate_staged_file_name(extension: &str) -> String {
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    let ext: String = extension
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect();
+    if ext.is_empty() {
+        format!("rocky_load_{uuid}")
+    } else {
+        format!("rocky_load_{uuid}.{ext}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_staging_volume_valid() {
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert_eq!(v.qualified_name(), "main.raw.rocky_staging");
+        assert_eq!(v.path_prefix(), "/Volumes/main/raw/rocky_staging");
+    }
+
+    #[test]
+    fn test_staging_volume_rejects_injection() {
+        assert!(StagingVolume::new("main; DROP", "raw", "rocky_staging").is_err());
+        assert!(StagingVolume::new("main", "raw'", "rocky_staging").is_err());
+        assert!(StagingVolume::new("main", "raw", "vol/../etc").is_err());
+        assert!(StagingVolume::new("", "raw", "vol").is_err());
+    }
+
+    #[test]
+    fn test_create_volume_sql() {
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert_eq!(
+            create_volume_sql(&v),
+            "CREATE VOLUME IF NOT EXISTS main.raw.rocky_staging"
+        );
+    }
+
+    #[test]
+    fn test_file_path() {
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert_eq!(
+            v.file_path("rocky_load_abc123.csv").unwrap(),
+            "/Volumes/main/raw/rocky_staging/rocky_load_abc123.csv"
+        );
+    }
+
+    #[test]
+    fn test_file_path_rejects_separators_and_quotes() {
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert!(v.file_path("sub/dir/file.csv").is_err());
+        assert!(v.file_path("../escape.csv").is_err());
+        assert!(v.file_path("name'; DROP --.csv").is_err());
+        assert!(v.file_path("has space.csv").is_err());
+        assert!(v.file_path("").is_err());
+    }
+
+    #[test]
+    fn test_generate_staged_file_name_with_extension() {
+        let name = generate_staged_file_name("csv");
+        assert!(name.starts_with("rocky_load_"));
+        assert!(name.ends_with(".csv"));
+        // Must pass the staged-file-name validator.
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert!(v.file_path(&name).is_ok());
+    }
+
+    #[test]
+    fn test_generate_staged_file_name_no_extension() {
+        let name = generate_staged_file_name("");
+        assert!(name.starts_with("rocky_load_"));
+        assert!(!name.contains('.'));
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert!(v.file_path(&name).is_ok());
+    }
+
+    #[test]
+    fn test_generate_staged_file_name_filters_unsafe_extension() {
+        // Defensive: an extension with unsafe chars is filtered, not rejected,
+        // so the result still passes validation.
+        let name = generate_staged_file_name("cs'v; --");
+        let v = StagingVolume::new("main", "raw", "rocky_staging").unwrap();
+        assert!(
+            v.file_path(&name).is_ok(),
+            "filtered extension must yield a valid file name, got {name}"
+        );
+        assert!(name.ends_with(".csv"));
+    }
+
+    #[test]
+    fn test_generate_staged_file_name_unique() {
+        let n = 1_000;
+        let mut names = std::collections::HashSet::with_capacity(n);
+        for _ in 0..n {
+            let name = generate_staged_file_name("csv");
+            assert!(
+                names.insert(name.clone()),
+                "duplicate staged file name {name} generated in tight loop"
+            );
+        }
+    }
+}

--- a/engine/crates/rocky-databricks/tests/integration.rs
+++ b/engine/crates/rocky-databricks/tests/integration.rs
@@ -453,3 +453,145 @@ async fn live_list_tables_rest_and_sql_paths_agree() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Local-file staging via UC Volume (live merge gate)
+// ---------------------------------------------------------------------------
+//
+// This is the live verification of the local-file → COPY INTO path. It reads
+// ALL sandbox config from `ROCKY_TEST_*` env vars (per the scrubbing rule;
+// note this diverges from the `DATABRICKS_*` convention the other live tests
+// in this file use — the main session must set the `ROCKY_TEST_*` set below to
+// run this gate). The catalog/schema MUST be one where the PAT/SP can
+// `CREATE VOLUME IF NOT EXISTS`, `PUT` to the Files API, and `COPY INTO` — a
+// read-only schema will 403 (a privilege issue, not a bug).
+//
+// Required env vars:
+//   ROCKY_TEST_DATABRICKS_HOST          — workspace hostname (no https://)
+//   ROCKY_TEST_DATABRICKS_HTTP_PATH     — SQL warehouse HTTP path
+//   ROCKY_TEST_DATABRICKS_TOKEN         — PAT
+//     (or ROCKY_TEST_DATABRICKS_CLIENT_ID + ROCKY_TEST_DATABRICKS_CLIENT_SECRET)
+//   ROCKY_TEST_DATABRICKS_CATALOG       — catalog to stage + load into
+//   ROCKY_TEST_DATABRICKS_SCHEMA        — schema to stage + load into
+//   ROCKY_TEST_DATABRICKS_STAGING_VOLUME — optional; defaults to rocky_staging
+//
+// Run with:
+//   cargo test -p rocky-databricks --test integration \
+//     live_load_local_csv_via_volume -- --ignored
+
+/// Build a connector from the `ROCKY_TEST_*` sandbox env vars. Returns `None`
+/// (test skips via `.expect`) when the host/http-path aren't set.
+fn rocky_test_connector_from_env() -> Option<DatabricksConnector> {
+    let host = std::env::var("ROCKY_TEST_DATABRICKS_HOST").ok()?;
+    let http_path = std::env::var("ROCKY_TEST_DATABRICKS_HTTP_PATH").ok()?;
+    let warehouse_id = ConnectorConfig::warehouse_id_from_http_path(&http_path)?;
+
+    let auth = Auth::from_config(AuthConfig {
+        host: host.clone(),
+        token: std::env::var("ROCKY_TEST_DATABRICKS_TOKEN").ok(),
+        client_id: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_ID").ok(),
+        client_secret: std::env::var("ROCKY_TEST_DATABRICKS_CLIENT_SECRET").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        host,
+        warehouse_id,
+        timeout: Duration::from_secs(120),
+        retry: Default::default(),
+    };
+    Some(DatabricksConnector::new(config, auth))
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_load_local_csv_via_volume() {
+    use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter, TableRef as SdkTableRef};
+    use rocky_databricks::loader::DatabricksLoaderAdapter;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    let connector = rocky_test_connector_from_env().expect("ROCKY_TEST_DATABRICKS_* not set");
+    let catalog = std::env::var("ROCKY_TEST_DATABRICKS_CATALOG")
+        .expect("ROCKY_TEST_DATABRICKS_CATALOG must be set");
+    let schema = std::env::var("ROCKY_TEST_DATABRICKS_SCHEMA")
+        .expect("ROCKY_TEST_DATABRICKS_SCHEMA must be set");
+    let staging_volume = std::env::var("ROCKY_TEST_DATABRICKS_STAGING_VOLUME")
+        .unwrap_or_else(|_| "rocky_staging".into());
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let table = format!("hc_load_local_{suffix}");
+
+    // Write a small CSV to the OS temp dir.
+    let csv_path = std::env::temp_dir().join(format!("rocky_live_load_{suffix}.csv"));
+    {
+        let mut f = std::fs::File::create(&csv_path).expect("create temp csv");
+        f.write_all(b"id,name\n1,alice\n2,bob\n3,carol\n")
+            .expect("write temp csv");
+    }
+
+    // Pre-create the (empty) target table so this gate exercises *staging*, not
+    // COPY INTO's create-from-scratch semantics. Databricks COPY INTO loads
+    // into an existing table (the canonical pattern is CREATE TABLE; then COPY
+    // INTO ... mergeSchema='true'). A separate connector is used for setup /
+    // verify / cleanup since the loader consumes its own Arc.
+    let setup_connector = rocky_test_connector_from_env().expect("ROCKY_TEST_DATABRICKS_* not set");
+    setup_connector
+        .execute_statement(&format!(
+            "CREATE TABLE IF NOT EXISTS {catalog}.{schema}.{table} (id BIGINT, name STRING)"
+        ))
+        .await
+        .expect("create target table");
+
+    let loader =
+        DatabricksLoaderAdapter::new(Arc::new(connector)).with_staging_volume(&staging_volume);
+    let target = SdkTableRef {
+        catalog: catalog.clone(),
+        schema: schema.clone(),
+        table: table.clone(),
+    };
+
+    // Run the load, capturing the result so cleanup always runs.
+    let load_result = loader
+        .load(
+            &LoadSource::LocalFile(csv_path.clone()),
+            &target,
+            &LoadOptions::default(),
+        )
+        .await;
+
+    // Verify row count via the setup connector (the loader consumed its Arc).
+    let verify_connector = setup_connector;
+    let count = if load_result.is_ok() {
+        verify_connector
+            .execute_sql(&format!(
+                "SELECT COUNT(*) AS n FROM {catalog}.{schema}.{table}"
+            ))
+            .await
+            .ok()
+            .and_then(|r| r.rows.first().and_then(|row| row.first().cloned()))
+    } else {
+        None
+    };
+
+    // Unconditional cleanup (best-effort): drop the loaded table. The staging
+    // volume is intentionally left in place (reusable container).
+    let _ = verify_connector
+        .execute_statement(&format!("DROP TABLE IF EXISTS {catalog}.{schema}.{table}"))
+        .await;
+    let _ = std::fs::remove_file(&csv_path);
+
+    let result = load_result.expect("local-file load via UC Volume should succeed");
+    assert_eq!(result.rows_loaded, 3, "expected 3 rows loaded");
+    assert!(result.bytes_read > 0, "should report local byte count");
+
+    let n = count.expect("loaded table should be queryable");
+    let n_num: i64 = n
+        .as_i64()
+        .or_else(|| n.as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(-1);
+    assert_eq!(n_num, 3, "table should contain 3 rows, got {n:?}");
+}

--- a/engine/crates/rocky-databricks/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-databricks/tests/wiremock_tests.rs
@@ -12,7 +12,7 @@ use rocky_core::config::RetryConfig;
 use rocky_databricks::auth::{Auth, AuthConfig};
 use rocky_databricks::connector::{ConnectorConfig, ConnectorError, DatabricksConnector};
 use rocky_databricks::loader::DatabricksLoaderAdapter;
-use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::matchers::{body_string_contains, header, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Creates a PAT-authenticated connector pointing at the given wiremock server.
@@ -625,6 +625,344 @@ async fn test_loader_missing_num_affected_rows() {
         .unwrap();
 
     assert_eq!(result.rows_loaded, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Local-file staging (Unity Catalog Volume + Files API)
+// ---------------------------------------------------------------------------
+//
+// For a LOCAL file the loader can't hand Databricks a cloud URI — the file
+// isn't visible to the warehouse. Instead it:
+//   1. CREATE VOLUME IF NOT EXISTS <catalog>.<schema>.<volume>   (SQL)
+//   2. PUT  /api/2.0/fs/files/<volume-path>?overwrite=true       (Files API)
+//   3. COPY INTO ... FROM '/Volumes/.../<file>'                  (SQL)
+//   4. DELETE /api/2.0/fs/files/<volume-path>                    (Files API)
+// These tests pin that wire sequence: the upload request, the COPY-INTO-from-
+// Volume SQL, and the post-load file cleanup.
+
+/// Write `contents` to a uniquely-named file under the OS temp dir and return
+/// its path. Avoids a `tempfile` dev-dep; caller removes it when done.
+fn write_temp_file(contents: &[u8], ext: &str) -> std::path::PathBuf {
+    use std::io::Write;
+    let unique = format!(
+        "rocky_db_loader_test_{}_{}.{ext}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let path = std::env::temp_dir().join(unique);
+    let mut f = std::fs::File::create(&path).expect("create temp file");
+    f.write_all(contents).expect("write temp file");
+    path
+}
+
+/// Happy path: a local CSV is staged to a UC Volume and loaded.
+///
+/// Asserts the full sequence: CREATE VOLUME → Files API PUT (with the file
+/// bytes in the body) → COPY INTO from the `/Volumes/...` path → Files API
+/// DELETE cleanup. Each mock carries `.expect(1)`, so a missed or extra call
+/// fails the test.
+#[tokio::test]
+async fn test_loader_local_file_stages_to_volume() {
+    let server = MockServer::start().await;
+    let file = write_temp_file(b"id,name\n1,alice\n2,bob\n", "csv");
+
+    // 1. CREATE VOLUME IF NOT EXISTS main.raw.rocky_staging
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains(
+            "CREATE VOLUME IF NOT EXISTS main.raw.rocky_staging",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-create-vol",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": null,
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // 2. Files API upload — PUT under /Volumes/main/raw/rocky_staging/ with the
+    //    file bytes as the body and overwrite=true.
+    Mock::given(method("PUT"))
+        .and(path_regex(
+            r"^/api/2\.0/fs/files/Volumes/main/raw/rocky_staging/rocky_load_[0-9a-f]+\.csv$",
+        ))
+        .and(header("Authorization", "Bearer test-token"))
+        .and(query_param("overwrite", "true"))
+        .and(body_string_contains("alice"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // 3. COPY INTO ... FROM '/Volumes/.../<file>'
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("COPY INTO main.raw.orders"))
+        .and(body_string_contains(
+            "FROM '/Volumes/main/raw/rocky_staging/rocky_load_",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-copy-local",
+            "status": { "state": "SUCCEEDED" },
+            "manifest": {
+                "schema": {
+                    "columns": [
+                        {"name": "num_affected_rows", "type_name": "LONG", "position": 0}
+                    ]
+                },
+                "total_row_count": 1
+            },
+            "result": { "data_array": [["2"]] }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // 4. Files API cleanup — DELETE the staged file.
+    Mock::given(method("DELETE"))
+        .and(path_regex(
+            r"^/api/2\.0/fs/files/Volumes/main/raw/rocky_staging/rocky_load_[0-9a-f]+\.csv$",
+        ))
+        .and(header("Authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector);
+
+    let source = LoadSource::LocalFile(file.clone());
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "orders".into(),
+    };
+
+    let result = loader
+        .load(&source, &target, &LoadOptions::default())
+        .await
+        .expect("local-file load should succeed");
+
+    let _ = std::fs::remove_file(&file);
+
+    assert_eq!(result.rows_loaded, 2, "should surface num_affected_rows");
+    assert!(
+        result.bytes_read > 0,
+        "local-file load should report the on-disk byte count"
+    );
+    // `.expect(1)` on every mock asserts the full CREATE→PUT→COPY→DELETE sequence.
+    server.verify().await;
+}
+
+/// A configured staging-volume name flows into both the CREATE VOLUME DDL and
+/// the `/Volumes/.../` upload + COPY paths.
+#[tokio::test]
+async fn test_loader_local_file_custom_volume_name() {
+    let server = MockServer::start().await;
+    let file = write_temp_file(b"col\nv\n", "csv");
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains(
+            "CREATE VOLUME IF NOT EXISTS main.raw.hc_custom_stage",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-create-vol",
+            "status": { "state": "SUCCEEDED" }, "manifest": null, "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path_regex(
+            r"^/api/2\.0/fs/files/Volumes/main/raw/hc_custom_stage/rocky_load_[0-9a-f]+\.csv$",
+        ))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains(
+            "FROM '/Volumes/main/raw/hc_custom_stage/rocky_load_",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-copy", "status": { "state": "SUCCEEDED" },
+            "manifest": { "schema": { "columns": [
+                {"name": "num_affected_rows", "type_name": "LONG", "position": 0}
+            ]}, "total_row_count": 1 },
+            "result": { "data_array": [["1"]] }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path_regex(
+            r"^/api/2\.0/fs/files/Volumes/main/raw/hc_custom_stage/rocky_load_[0-9a-f]+\.csv$",
+        ))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector).with_staging_volume("hc_custom_stage");
+
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "orders".into(),
+    };
+    let result = loader
+        .load(
+            &LoadSource::LocalFile(file.clone()),
+            &target,
+            &LoadOptions::default(),
+        )
+        .await
+        .expect("custom-volume local load should succeed");
+    let _ = std::fs::remove_file(&file);
+    assert_eq!(result.rows_loaded, 1);
+    server.verify().await;
+}
+
+/// COPY INTO failure still cleans up the staged file — the DELETE fires even
+/// when the COPY errors, and the load surfaces the error.
+#[tokio::test]
+async fn test_loader_local_file_cleans_up_on_copy_failure() {
+    let server = MockServer::start().await;
+    let file = write_temp_file(b"id\n1\n", "csv");
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("CREATE VOLUME IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-create-vol",
+            "status": { "state": "SUCCEEDED" }, "manifest": null, "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/api/2\.0/fs/files/Volumes/.*"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // COPY INTO fails.
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-copy-fail",
+            "status": {
+                "state": "FAILED",
+                "error": { "error_code": "COPY_INTO_SOURCE_FILE_FORMAT_ERROR", "message": "bad data" }
+            },
+            "manifest": null, "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Cleanup DELETE must still fire after the failed COPY.
+    Mock::given(method("DELETE"))
+        .and(path_regex(r"^/api/2\.0/fs/files/Volumes/.*"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector);
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "orders".into(),
+    };
+
+    let err = loader
+        .load(
+            &LoadSource::LocalFile(file.clone()),
+            &target,
+            &LoadOptions::default(),
+        )
+        .await
+        .expect_err("COPY INTO failure should surface as Err");
+    let _ = std::fs::remove_file(&file);
+    assert!(
+        err.to_string().to_lowercase().contains("bad data")
+            || err.to_string().to_lowercase().contains("copy"),
+        "error should carry COPY context, got: {err}"
+    );
+    // `.expect(1)` on the DELETE mock proves cleanup ran despite the failure.
+    server.verify().await;
+}
+
+/// Upload (Files API PUT) failure aborts before COPY INTO, still attempts a
+/// best-effort cleanup DELETE, and surfaces the upload error.
+#[tokio::test]
+async fn test_loader_local_file_upload_failure_aborts_before_copy() {
+    let server = MockServer::start().await;
+    let file = write_temp_file(b"id\n1\n", "csv");
+
+    Mock::given(method("POST"))
+        .and(path("/api/2.0/sql/statements"))
+        .and(body_string_contains("CREATE VOLUME IF NOT EXISTS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statement_id": "stmt-create-vol",
+            "status": { "state": "SUCCEEDED" }, "manifest": null, "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Upload returns 403 (e.g. no write privilege on the volume).
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/api/2\.0/fs/files/Volumes/.*"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("PERMISSION_DENIED"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Best-effort cleanup DELETE after the failed upload — 404 (nothing was
+    // written) is treated as success by the connector.
+    Mock::given(method("DELETE"))
+        .and(path_regex(r"^/api/2\.0/fs/files/Volumes/.*"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("NOT_FOUND"))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // No COPY INTO mock mounted — a COPY call would surface as an unmatched
+    // request and fail the test, proving the upload failure aborts first.
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = DatabricksLoaderAdapter::new(connector);
+    let target = TableRef {
+        catalog: "main".into(),
+        schema: "raw".into(),
+        table: "orders".into(),
+    };
+
+    let err = loader
+        .load(
+            &LoadSource::LocalFile(file.clone()),
+            &target,
+            &LoadOptions::default(),
+        )
+        .await
+        .expect_err("upload failure should surface as Err");
+    let _ = std::fs::remove_file(&file);
+    assert!(
+        err.to_string().to_lowercase().contains("upload")
+            || err.to_string().contains("403")
+            || err.to_string().contains("PERMISSION_DENIED"),
+        "error should carry upload context, got: {err}"
+    );
+    server.verify().await;
 }
 
 /// Bearer token is sent correctly in the Authorization header.


### PR DESCRIPTION
Two changes to the Databricks loader, both exercised by the new live test.

**Local-file staging.** Local files now load on Databricks (previously `LoadSource::LocalFile` was rejected). The file is staged to a Unity Catalog Volume via the Files API — `CREATE VOLUME IF NOT EXISTS` → `PUT` → `COPY INTO` from `/Volumes/…` → cleanup — mirroring the Snowflake `PUT → COPY INTO` model. The staging volume name is configurable (default `rocky_staging`).

**Typed CSV loads.** Loading a CSV into a typed Delta table previously failed with `DELTA_FAILED_TO_MERGE_FIELDS`, because `COPY INTO` reads CSV columns as strings and can't reconcile a string `id` against a `BIGINT` column. The loader now `DESCRIBE`s the target and emits `COPY INTO … FROM (SELECT CAST(col AS <declared_type>) … FROM '<path>')`, so values land as their declared types — no `inferSchema` guessing. This fixes both the local-Volume and cloud-URI CSV paths (shared builder).

**Tested:** new wiremock unit tests (Files API upload + `COPY INTO` SQL, cast subquery, type validation) plus a live run against real Databricks — CSV → UC Volume → typed `(id BIGINT, name STRING)` table, 3 rows verified.
