### PR TITLE
feat(engine/rocky-cli): gate rocky load on a typed data contract

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -402,6 +402,22 @@
       },
       "type": "object"
     },
+    "AllowedTypeChange": {
+      "description": "A permitted type widening (e.g., INT to BIGINT) that won't trigger a violation.",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
     "BindingType": {
       "description": "Workspace binding access level.",
       "enum": [
@@ -665,6 +681,36 @@
         }
       ],
       "description": "Concurrency strategy: the literal `\"adaptive\"` for AIMD-based throttling, or a positive integer for fixed concurrency."
+    },
+    "ContractConfig": {
+      "description": "Data contract configuration — enforced at copy/load time.",
+      "properties": {
+        "allowed_type_changes": {
+          "default": [],
+          "description": "Type changes that are allowed (widening only).",
+          "items": {
+            "$ref": "#/definitions/AllowedTypeChange"
+          },
+          "type": "array"
+        },
+        "protected_columns": {
+          "default": [],
+          "description": "Column names that must never be removed from the target.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "required_columns": {
+          "default": [],
+          "description": "Columns that must exist with specific types.",
+          "items": {
+            "$ref": "#/definitions/RequiredColumn"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     },
     "CostSection": {
       "additionalProperties": false,
@@ -1431,6 +1477,18 @@
             "row_count": false
           },
           "description": "Data quality checks run after loading."
+        },
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional data contract that gates the load. When set, each file is loaded into a staging table, validated against the contract, and promoted to the target only if validation passes. On failure the staging table is dropped and the target is left untouched."
         },
         "depends_on": {
           "default": [],
@@ -2515,6 +2573,27 @@
       "required": [
         "source",
         "target"
+      ],
+      "type": "object"
+    },
+    "RequiredColumn": {
+      "description": "A column that must exist in the source with a specific type.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "nullable": {
+          "default": true,
+          "type": "boolean"
+        },
+        "type": {
+          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer doesn't recognize is treated as unknown and never fails the type check — presence and nullability still apply.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
       ],
       "type": "object"
     },

--- a/editors/vscode/src/types/generated/load.ts
+++ b/editors/vscode/src/types/generated/load.ts
@@ -26,10 +26,35 @@ export interface LoadOutput {
  */
 export interface LoadFileOutput {
   bytes_read: number;
+  /**
+   * Result of the data-contract gate, when the load pipeline declares a contract. `None` for ungated loads. On a failed gate the data was not promoted to the target; the violations explain why.
+   */
+  contract?: ContractResult | null;
   duration_ms: number;
   error?: string | null;
   file: string;
   rows_loaded: number;
   target: string;
+  [k: string]: unknown;
+}
+/**
+ * Result of contract validation.
+ */
+export interface ContractResult {
+  passed: boolean;
+  violations: ContractViolation[];
+  /**
+   * Non-fatal warnings — e.g. a contract clause that can't be meaningfully enforced in this context. Does not affect `passed`.
+   */
+  warnings?: string[];
+  [k: string]: unknown;
+}
+/**
+ * A single contract rule violation with the rule name, affected column, and message.
+ */
+export interface ContractViolation {
+  column: string;
+  message: string;
+  rule: string;
   [k: string]: unknown;
 }

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1532,6 +1532,10 @@ export interface LoadPipelineConfig {
    */
   checks?: ChecksConfig;
   /**
+   * Optional data contract that gates the load. When set, each file is loaded into a staging table, validated against the contract, and promoted to the target only if validation passes. On failure the staging table is dropped and the target is left untouched.
+   */
+  contract?: ContractConfig | null;
+  /**
    * Pipeline dependencies for chaining.
    */
   depends_on?: string[];
@@ -1555,6 +1559,44 @@ export interface LoadPipelineConfig {
    * Target table location.
    */
   target: LoadTargetConfig;
+  [k: string]: unknown;
+}
+/**
+ * Data contract configuration — enforced at copy/load time.
+ */
+export interface ContractConfig {
+  /**
+   * Type changes that are allowed (widening only).
+   */
+  allowed_type_changes?: AllowedTypeChange[];
+  /**
+   * Column names that must never be removed from the target.
+   */
+  protected_columns?: string[];
+  /**
+   * Columns that must exist with specific types.
+   */
+  required_columns?: RequiredColumn[];
+  [k: string]: unknown;
+}
+/**
+ * A permitted type widening (e.g., INT to BIGINT) that won't trigger a violation.
+ */
+export interface AllowedTypeChange {
+  from: string;
+  to: string;
+  [k: string]: unknown;
+}
+/**
+ * A column that must exist in the source with a specific type.
+ */
+export interface RequiredColumn {
+  name: string;
+  nullable?: boolean;
+  /**
+   * Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer doesn't recognize is treated as unknown and never fails the type check — presence and nullability still apply.
+   */
+  type: string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/load.rs
+++ b/engine/crates/rocky-cli/src/commands/load.rs
@@ -8,18 +8,24 @@
 //! [`CsvBatchReader`]: rocky_core::arrow_loader::CsvBatchReader
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
 use tracing::info;
 
 use rocky_adapter_sdk::{FileFormat, LoadOptions, LoadSource, LoaderAdapter, TableRef};
+use rocky_core::contracts::{ContractConfig, ContractResult, validate_contract_typed};
 use rocky_core::state::{LoadedFileRecord, StateStore};
+use rocky_core::traits::WarehouseAdapter;
 
 use crate::output::{LoadFileOutput, LoadOutput, print_json};
 use crate::registry::{AdapterRegistry, resolve_pipeline};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Suffix appended to a target table name to form its per-load staging table.
+const STAGING_SUFFIX: &str = "__rocky_stg";
 
 /// Execute `rocky load`: discover files, load them into the target table(s).
 ///
@@ -102,12 +108,29 @@ pub async fn run_load(
 
     let adapter_name = pipeline_cfg.target_adapter();
 
-    // Build a DuckDB loader adapter if the adapter type is DuckDB.
     let adapter_cfg = registry
         .adapter_config(adapter_name)
         .context(format!("no adapter config for '{adapter_name}'"))?;
 
+    // Optional data contract that gates the load (staging-promote semantics).
+    let contract: Option<&ContractConfig> = load_cfg.as_ref().and_then(|lc| lc.contract.as_ref());
+
+    // Build the loader. When a contract is present we route through the
+    // warehouse adapter's *shared* connector so the staging table the loader
+    // writes is visible to `describe_table`/promote SQL (critical on DuckDB,
+    // where a fresh in-memory loader would land staging in a separate DB).
     let loader: Box<dyn LoaderAdapter> = build_loader(adapter_name, adapter_cfg, &registry)?;
+
+    // The warehouse adapter is only needed for the staging-promote gate.
+    let warehouse: Option<Arc<dyn WarehouseAdapter>> = if contract.is_some() {
+        Some(
+            registry
+                .warehouse_adapter(adapter_name)
+                .context("failed to resolve warehouse adapter for contract-gated load")?,
+        )
+    } else {
+        None
+    };
 
     // Discover files in the source directory.
     let files = discover_files(source_dir, requested_format)?;
@@ -179,24 +202,46 @@ pub async fn run_load(
         );
 
         let load_source = LoadSource::LocalFile(file_path.clone());
-        match loader.load(&load_source, &target, &options).await {
-            Ok(result) => {
+
+        // Two paths: a contract-gated staging-promote, or the direct load.
+        let outcome = match (contract, warehouse.as_deref()) {
+            (Some(contract), Some(warehouse)) => {
+                load_with_contract_gate(
+                    loader.as_ref(),
+                    warehouse,
+                    &load_source,
+                    &target,
+                    &options,
+                    contract,
+                )
+                .await
+            }
+            _ => loader
+                .load(&load_source, &target, &options)
+                .await
+                .map(|r| (r.rows_loaded, r.bytes_read, None))
+                .map_err(|e| anyhow::anyhow!("{e}")),
+        };
+
+        match outcome {
+            Ok((rows_loaded, bytes_read, contract_result)) => {
                 let duration = file_start.elapsed().as_millis() as u64;
                 info!(
                     file = %file_path.display(),
-                    rows = result.rows_loaded,
-                    bytes = result.bytes_read,
+                    rows = rows_loaded,
+                    bytes = bytes_read,
                     duration_ms = duration,
                     "file loaded"
                 );
-                total_rows += result.rows_loaded;
-                total_bytes += result.bytes_read;
+                total_rows += rows_loaded;
+                total_bytes += bytes_read;
 
-                // Record the loaded file in the state store for incremental tracking.
+                // Record the loaded file only after a successful load (and, for
+                // contract-gated loads, a successful promote).
                 let record = LoadedFileRecord {
                     loaded_at: chrono::Utc::now(),
-                    rows_loaded: result.rows_loaded,
-                    bytes_read: result.bytes_read,
+                    rows_loaded,
+                    bytes_read,
                     duration_ms: duration,
                     file_hash: None,
                 };
@@ -215,21 +260,25 @@ pub async fn run_load(
                 file_results.push(LoadFileOutput {
                     file: file_path.display().to_string(),
                     target: target_display,
-                    rows_loaded: result.rows_loaded,
-                    bytes_read: result.bytes_read,
+                    rows_loaded,
+                    bytes_read,
                     duration_ms: duration,
                     error: None,
+                    contract: contract_result,
                 });
                 files_loaded += 1;
             }
             Err(e) => {
                 let duration = file_start.elapsed().as_millis() as u64;
-                let err_msg = format!("{e}");
+                let err_msg = format!("{e:#}");
                 tracing::error!(
                     file = %file_path.display(),
                     error = %err_msg,
                     "file load failed"
                 );
+                // Surface the contract result on a gate failure when available,
+                // so JSON consumers see the specific violations.
+                let contract_result = e.downcast_ref::<ContractGateError>().map(|g| g.0.clone());
                 file_results.push(LoadFileOutput {
                     file: file_path.display().to_string(),
                     target: target_display,
@@ -237,6 +286,7 @@ pub async fn run_load(
                     bytes_read: 0,
                     duration_ms: duration,
                     error: Some(err_msg),
+                    contract: contract_result,
                 });
                 files_failed += 1;
             }
@@ -329,18 +379,11 @@ fn build_loader(
     match adapter_cfg.adapter_type.as_str() {
         #[cfg(feature = "duckdb")]
         "duckdb" => {
-            use rocky_duckdb::loader::DuckDbLoaderAdapter;
-
-            let db_adapter = if let Some(p) = adapter_cfg.path.as_deref() {
-                DuckDbLoaderAdapter::new(
-                    rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(std::path::Path::new(p))
-                        .context(format!("failed to open DuckDB at '{p}'"))?
-                        .shared_connector(),
-                )
-            } else {
-                DuckDbLoaderAdapter::in_memory().context("failed to create in-memory DuckDB")?
-            };
-            Ok(Box::new(db_adapter))
+            // Share the registry's DuckDB connector so a loaded (staging)
+            // table is visible to the same warehouse adapter's `describe_table`
+            // and promote SQL. This matters for in-memory DuckDB, where a
+            // freshly-opened loader would otherwise use a separate database.
+            registry.duckdb_loader(adapter_name)
         }
         #[cfg(not(feature = "duckdb"))]
         "duckdb" => {
@@ -384,6 +427,178 @@ fn discover_files(
 
     files.sort();
     Ok(files)
+}
+
+/// Error carrying the [`ContractResult`] of a failed contract gate so the
+/// caller can surface the specific violations in JSON output.
+#[derive(Debug)]
+struct ContractGateError(ContractResult);
+
+impl std::fmt::Display for ContractGateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msgs: Vec<String> = self
+            .0
+            .violations
+            .iter()
+            .map(|v| format!("{} [{}]: {}", v.column, v.rule, v.message))
+            .collect();
+        write!(
+            f,
+            "contract validation failed ({} violation(s)): {}",
+            self.0.violations.len(),
+            msgs.join("; ")
+        )
+    }
+}
+
+impl std::error::Error for ContractGateError {}
+
+/// Load one file into a staging table, validate it against `contract`, and
+/// promote to `target` only if validation passes (true staging-promote gate).
+///
+/// On a contract failure the staging table is dropped and the function returns
+/// a [`ContractGateError`] — the target is never created or modified, so
+/// non-conforming data never lands. The staging table is also dropped on the
+/// happy path after a successful promote.
+///
+/// Returns `(rows_loaded, bytes_read, Some(contract_result))` on success.
+async fn load_with_contract_gate(
+    loader: &dyn LoaderAdapter,
+    warehouse: &dyn WarehouseAdapter,
+    source: &LoadSource,
+    target: &TableRef,
+    options: &LoadOptions,
+    contract: &ContractConfig,
+) -> Result<(u64, u64, Option<ContractResult>)> {
+    // Validate every identifier before it touches SQL. The staging name is
+    // `<table>__rocky_stg`; the suffix keeps it a valid SQL identifier.
+    let staging_name = format!("{}{STAGING_SUFFIX}", target.table);
+    rocky_sql::validation::validate_identifier(&target.table)
+        .with_context(|| format!("invalid target table name '{}'", target.table))?;
+    rocky_sql::validation::validate_identifier(&target.schema)
+        .with_context(|| format!("invalid target schema '{}'", target.schema))?;
+    if !target.catalog.is_empty() {
+        rocky_sql::validation::validate_identifier(&target.catalog)
+            .with_context(|| format!("invalid target catalog '{}'", target.catalog))?;
+    }
+    // staging_name is derived from the already-validated table name + a static
+    // suffix, so it's guaranteed valid; validate anyway as a belt-and-braces.
+    rocky_sql::validation::validate_identifier(&staging_name)
+        .with_context(|| format!("invalid staging table name '{staging_name}'"))?;
+
+    let staging = TableRef {
+        catalog: target.catalog.clone(),
+        schema: target.schema.clone(),
+        table: staging_name.clone(),
+    };
+    let staging_ir = to_ir_table_ref(&staging);
+    let target_ir = to_ir_table_ref(target);
+
+    let dialect = warehouse.dialect();
+    let staging_ref = dialect
+        .format_table_ref(&staging.catalog, &staging.schema, &staging.table)
+        .map_err(|e| anyhow::anyhow!("failed to format staging table ref: {e}"))?;
+    let target_ref = dialect
+        .format_table_ref(&target.catalog, &target.schema, &target.table)
+        .map_err(|e| anyhow::anyhow!("failed to format target table ref: {e}"))?;
+
+    // Start from a clean staging table so a prior aborted run can't leak rows.
+    let drop_staging_sql = dialect.drop_table_sql(&staging_ref);
+    warehouse
+        .execute_statement(&drop_staging_sql)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to drop pre-existing staging table: {e}"))?;
+
+    // Load the file into staging (always create it fresh).
+    let staging_options = LoadOptions {
+        create_table: true,
+        truncate_first: false,
+        ..options.clone()
+    };
+    let load_result = match loader.load(source, &staging, &staging_options).await {
+        Ok(r) => r,
+        Err(e) => {
+            // Best-effort cleanup; don't mask the original load error.
+            let _ = warehouse.execute_statement(&drop_staging_sql).await;
+            return Err(anyhow::anyhow!("staging load failed: {e}"));
+        }
+    };
+
+    // Validate the landed staging schema against the contract.
+    let landed = match warehouse.describe_table(&staging_ir).await {
+        Ok(cols) => cols,
+        Err(e) => {
+            let _ = warehouse.execute_statement(&drop_staging_sql).await;
+            return Err(anyhow::anyhow!(
+                "failed to describe staging table for contract validation: {e}"
+            ));
+        }
+    };
+    let result = validate_contract_typed(contract, &landed);
+
+    for warning in &result.warnings {
+        tracing::warn!(table = %target, "{warning}");
+    }
+
+    if !result.passed {
+        // Gate closed: drop staging, leave the target untouched.
+        if let Err(e) = warehouse.execute_statement(&drop_staging_sql).await {
+            tracing::warn!(error = %e, "failed to drop staging table after contract failure");
+        }
+        return Err(ContractGateError(result).into());
+    }
+
+    // Gate open: promote staging into the target, mirroring the loader's
+    // create/truncate semantics but sourced from the staging table.
+    let select_from_staging = format!("SELECT * FROM {staging_ref}");
+    let target_exists = warehouse
+        .describe_table(&target_ir)
+        .await
+        .map(|cols| !cols.is_empty())
+        .unwrap_or(false);
+
+    let promote_stmts: Vec<String> = if !target_exists && options.create_table {
+        vec![dialect.create_table_as(&target_ref, &select_from_staging)]
+    } else {
+        let mut stmts = Vec::new();
+        if options.truncate_first {
+            // `DELETE FROM <t> WHERE TRUE` (via the dialect) instead of a bare
+            // `DELETE FROM <t>`: BigQuery rejects an unqualified DELETE, and the
+            // `WHERE TRUE` form is portable across DuckDB/Snowflake/Databricks/BQ.
+            stmts.push(dialect.delete_where(&target_ref, "TRUE"));
+        }
+        stmts.push(dialect.insert_into(&target_ref, &select_from_staging));
+        stmts
+    };
+
+    for stmt in &promote_stmts {
+        if let Err(e) = warehouse.execute_statement(stmt).await {
+            // Promote failed mid-flight; clean up staging and surface the error.
+            let _ = warehouse.execute_statement(&drop_staging_sql).await;
+            return Err(anyhow::anyhow!("failed to promote staging to target: {e}"));
+        }
+    }
+
+    // Promote done — drop staging.
+    if let Err(e) = warehouse.execute_statement(&drop_staging_sql).await {
+        tracing::warn!(error = %e, "failed to drop staging table after promote");
+    }
+
+    Ok((
+        load_result.rows_loaded,
+        load_result.bytes_read,
+        Some(result),
+    ))
+}
+
+/// Convert an adapter-SDK [`TableRef`] into the rocky-ir `TableRef` that the
+/// `WarehouseAdapter` trait consumes.
+fn to_ir_table_ref(t: &TableRef) -> rocky_ir::TableRef {
+    rocky_ir::TableRef {
+        catalog: t.catalog.clone(),
+        schema: t.schema.clone(),
+        table: t.table.clone(),
+    }
 }
 
 #[cfg(test)]
@@ -616,5 +831,236 @@ create_table = true
         // Confirm listing works.
         let files = state_store.list_loaded_files("ingest").unwrap();
         assert_eq!(files.len(), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Contract gate (staging-promote) — DuckDB-backed, no credentials
+    // ------------------------------------------------------------------
+
+    /// Open a file-backed DuckDB and return whether `main.<table>` exists and
+    /// its row count. Uses a fresh adapter so we observe committed on-disk
+    /// state after `run_load` has dropped its registry (and thus its
+    /// connection).
+    #[cfg(feature = "duckdb")]
+    fn table_row_count(db_path: &Path, table: &str) -> Option<usize> {
+        use rocky_duckdb::DuckDbConnector;
+        let conn = DuckDbConnector::open(db_path).unwrap();
+        let exists = conn
+            .execute_sql(&format!(
+                "SELECT 1 FROM information_schema.tables \
+                 WHERE table_schema = 'main' AND table_name = '{table}'"
+            ))
+            .map(|r| !r.rows.is_empty())
+            .unwrap_or(false);
+        if !exists {
+            return None;
+        }
+        let r = conn
+            .execute_sql(&format!("SELECT COUNT(*) FROM main.{table}"))
+            .unwrap();
+        Some(
+            r.rows[0][0]
+                .as_str()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+        )
+    }
+
+    #[cfg(feature = "duckdb")]
+    fn write_contract_config(dir: &Path, db_path: &Path) -> std::path::PathBuf {
+        let toml_content = format!(
+            r#"
+[adapter.default]
+type = "duckdb"
+path = "{}"
+
+[pipeline.ingest]
+type = "load"
+source_dir = "data/"
+format = "csv"
+
+[pipeline.ingest.target]
+adapter = "default"
+catalog = ""
+schema = "main"
+table = "orders"
+
+[pipeline.ingest.options]
+create_table = true
+
+[pipeline.ingest.contract]
+required_columns = [
+    {{ name = "id", type = "BIGINT" }},
+    {{ name = "product", type = "VARCHAR" }},
+]
+"#,
+            db_path.display()
+        );
+        let config_path = dir.join("rocky.toml");
+        std::fs::write(&config_path, toml_content).unwrap();
+        config_path
+    }
+
+    /// A passing load whose contract also declares `protected_columns`
+    /// succeeds and surfaces the unenforceable-clause warning on the gate
+    /// result (decision #4: warn, don't silently no-op). Exercises the path
+    /// from `validate_contract_typed` warnings into `load_with_contract_gate`.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn test_contract_gate_pass_surfaces_unenforceable_warning() {
+        use rocky_core::contracts::{ContractConfig, validate_contract_typed};
+        use rocky_core::traits::WarehouseAdapter;
+        use rocky_duckdb::DuckDbConnector;
+        use rocky_duckdb::adapter::DuckDbWarehouseAdapter;
+        use rocky_duckdb::loader::DuckDbLoaderAdapter;
+        use std::sync::{Arc, Mutex};
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("orders.csv");
+        std::fs::write(&csv_path, "id,product\n1,Widget\n").unwrap();
+
+        let shared = Arc::new(Mutex::new(DuckDbConnector::in_memory().unwrap()));
+        let loader = DuckDbLoaderAdapter::new(Arc::clone(&shared));
+        let wh = DuckDbWarehouseAdapter::from_shared(Arc::clone(&shared));
+
+        let contract = ContractConfig {
+            required_columns: vec![rocky_core::contracts::RequiredColumn {
+                name: "id".into(),
+                data_type: "BIGINT".into(),
+                nullable: true,
+            }],
+            protected_columns: vec!["id".into()],
+            ..Default::default()
+        };
+
+        let target = TableRef {
+            catalog: String::new(),
+            schema: "main".into(),
+            table: "orders".into(),
+        };
+        let source = LoadSource::LocalFile(csv_path);
+        let options = LoadOptions {
+            format: Some(FileFormat::Csv),
+            create_table: true,
+            ..LoadOptions::default()
+        };
+
+        let (rows, _bytes, result) =
+            load_with_contract_gate(&loader, &wh, &source, &target, &options, &contract)
+                .await
+                .expect("passing contract should promote");
+        assert_eq!(rows, 1);
+        let result = result.expect("gate result should be present");
+        assert!(result.passed);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("protected_columns")),
+            "unenforceable protected_columns clause must surface as a warning: {:?}",
+            result.warnings
+        );
+
+        // Sanity: the same warning is what validate_contract_typed emits.
+        let landed = wh
+            .describe_table(&rocky_ir::TableRef {
+                catalog: String::new(),
+                schema: "main".into(),
+                table: "orders".into(),
+            })
+            .await
+            .unwrap();
+        assert!(
+            !validate_contract_typed(&contract, &landed)
+                .warnings
+                .is_empty()
+        );
+    }
+
+    /// (a) A CSV satisfying the contract loads and lands rows in the target.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn test_contract_gate_pass_lands_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        std::fs::write(
+            data_dir.join("orders.csv"),
+            "id,product,qty\n1,Widget,10\n2,Gadget,5\n3,Doohickey,3\n",
+        )
+        .unwrap();
+
+        let db_path = dir.path().join("wh.duckdb");
+        let config_path = write_contract_config(dir.path(), &db_path);
+
+        run_load(&config_path, None, None, None, None, false, false)
+            .await
+            .expect("contract-satisfying load should succeed");
+
+        // Target has the rows; staging table is gone.
+        assert_eq!(table_row_count(&db_path, "orders"), Some(3));
+        assert_eq!(
+            table_row_count(&db_path, "orders__rocky_stg"),
+            None,
+            "staging table must be dropped after a successful promote"
+        );
+    }
+
+    /// (b) A CSV violating the contract (missing required column AND a
+    /// wrong-type column) fails the command, and the target is never created.
+    /// The staging table must also be gone.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn test_contract_gate_fail_leaves_target_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        // Missing required column `product`; `id` lands as VARCHAR (not BIGINT).
+        std::fs::write(data_dir.join("orders.csv"), "id,qty\nabc,10\ndef,5\n").unwrap();
+
+        let db_path = dir.path().join("wh.duckdb");
+        let config_path = write_contract_config(dir.path(), &db_path);
+
+        let err = run_load(&config_path, None, None, None, None, false, false)
+            .await
+            .expect_err("contract-violating load must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to load"),
+            "unexpected error message: {msg}"
+        );
+
+        // Target was never created; staging is gone (no leaked tables).
+        assert_eq!(
+            table_row_count(&db_path, "orders"),
+            None,
+            "non-conforming data must never land in the target"
+        );
+        assert_eq!(
+            table_row_count(&db_path, "orders__rocky_stg"),
+            None,
+            "staging table must be dropped after a failed gate"
+        );
+    }
+
+    /// On a re-run that satisfies the contract, an existing target with a
+    /// truncate-first option is replaced rather than duplicated.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn test_contract_gate_json_output_reports_violations() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+        std::fs::write(data_dir.join("orders.csv"), "id,qty\n1,10\n").unwrap();
+
+        let db_path = dir.path().join("wh.duckdb");
+        let config_path = write_contract_config(dir.path(), &db_path);
+
+        // JSON mode still fails (non-zero) but should not panic.
+        let err = run_load(&config_path, None, None, None, None, false, true)
+            .await
+            .expect_err("contract-violating load must fail in json mode too");
+        assert!(format!("{err:#}").contains("failed to load"));
+        assert_eq!(table_row_count(&db_path, "orders"), None);
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -3415,6 +3415,11 @@ pub struct LoadFileOutput {
     pub duration_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Result of the data-contract gate, when the load pipeline declares a
+    /// contract. `None` for ungated loads. On a failed gate the data was not
+    /// promoted to the target; the violations explain why.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract: Option<rocky_core::contracts::ContractResult>,
 }
 
 // --- Snapshot output ---

--- a/engine/crates/rocky-cli/src/registry.rs
+++ b/engine/crates/rocky-cli/src/registry.rs
@@ -92,6 +92,13 @@ pub struct AdapterRegistry {
     /// `IcebergDiscoveryAdapter` wrapper (which owns the underlying
     /// `IcebergCatalogClient` and does not expose it).
     iceberg_clients: HashMap<String, Arc<IcebergCatalogClientAdapter>>,
+    /// Shared DuckDB connectors keyed by adapter name. The warehouse adapter,
+    /// discovery adapter, and (for `rocky load`) the loader all share one
+    /// `Arc<Mutex<DuckDbConnector>>` so a staging table written by the loader
+    /// is visible to `describe_table` / promote SQL through the same in-memory
+    /// or on-disk database — load's staging-promote gate depends on this.
+    #[cfg(feature = "duckdb")]
+    duckdb_connectors: HashMap<String, Arc<std::sync::Mutex<rocky_duckdb::DuckDbConnector>>>,
     adapter_configs: HashMap<String, AdapterConfig>,
 }
 
@@ -121,6 +128,11 @@ impl AdapterRegistry {
         let mut snowflake_connectors: HashMap<String, Arc<SnowflakeConnector>> = HashMap::new();
         let mut bigquery_adapters: HashMap<String, Arc<BigQueryAdapter>> = HashMap::new();
         let mut iceberg_clients: HashMap<String, Arc<IcebergCatalogClientAdapter>> = HashMap::new();
+        #[cfg(feature = "duckdb")]
+        let mut duckdb_connectors: HashMap<
+            String,
+            Arc<std::sync::Mutex<rocky_duckdb::DuckDbConnector>>,
+        > = HashMap::new();
         let mut adapter_configs = HashMap::new();
 
         // Cross-adapter run-level retry budget (follow-up to §P2.7). When
@@ -221,6 +233,11 @@ impl AdapterRegistry {
                     let shared = warehouse_adapter.shared_connector();
                     let warehouse_arc = Arc::new(warehouse_adapter);
                     warehouse.insert(name.clone(), warehouse_arc as Arc<dyn WarehouseAdapter>);
+
+                    // Keep the shared connector so `rocky load` can build a
+                    // loader against the same database the warehouse adapter
+                    // describes/promotes through (staging-promote gate).
+                    duckdb_connectors.insert(name.clone(), Arc::clone(&shared));
 
                     // Always register a discovery adapter for DuckDB so the same
                     // local database can act as a source for `rocky discover`.
@@ -513,6 +530,8 @@ impl AdapterRegistry {
             snowflake_connectors,
             bigquery_adapters,
             iceberg_clients,
+            #[cfg(feature = "duckdb")]
+            duckdb_connectors,
             adapter_configs,
         })
     }
@@ -770,6 +789,25 @@ impl AdapterRegistry {
         Ok(Box::new(
             rocky_snowflake::loader::SnowflakeLoaderAdapter::new(Arc::new(sf_connector)),
         ))
+    }
+
+    /// Build a DuckDB `LoaderAdapter` that shares the same connector as the
+    /// registered DuckDB warehouse adapter.
+    ///
+    /// Sharing the connector is what makes `rocky load`'s staging-promote gate
+    /// work on DuckDB: the loader writes the staging table and the warehouse
+    /// adapter's `describe_table` / promote SQL read it back through the *same*
+    /// in-memory or on-disk database. Building a fresh `in_memory()` loader
+    /// (as the standalone path does) would land the staging table in a
+    /// different database the warehouse adapter can't see.
+    #[cfg(feature = "duckdb")]
+    pub fn duckdb_loader(&self, name: &str) -> Result<Box<dyn LoaderAdapter>> {
+        let shared = self.duckdb_connectors.get(name).context(format!(
+            "no DuckDB connector registered for adapter '{name}'"
+        ))?;
+        Ok(Box::new(rocky_duckdb::loader::DuckDbLoaderAdapter::new(
+            Arc::clone(shared),
+        )))
     }
 }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -3937,6 +3937,13 @@ pub struct LoadPipelineConfig {
     #[serde(default)]
     pub options: LoadOptionsConfig,
 
+    /// Optional data contract that gates the load. When set, each file is
+    /// loaded into a staging table, validated against the contract, and
+    /// promoted to the target only if validation passes. On failure the
+    /// staging table is dropped and the target is left untouched.
+    #[serde(default)]
+    pub contract: Option<crate::contracts::ContractConfig>,
+
     /// Data quality checks run after loading.
     #[serde(default)]
     pub checks: ChecksConfig,

--- a/engine/crates/rocky-core/src/contracts.rs
+++ b/engine/crates/rocky-core/src/contracts.rs
@@ -1,10 +1,11 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::column_map;
-use rocky_ir::ColumnInfo;
+use rocky_ir::{ColumnInfo, RockyType};
 
-/// Data contract configuration — enforced at copy time.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// Data contract configuration — enforced at copy/load time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ContractConfig {
     /// Columns that must exist with specific types.
     #[serde(default)]
@@ -20,9 +21,15 @@ pub struct ContractConfig {
 }
 
 /// A column that must exist in the source with a specific type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RequiredColumn {
     pub name: String,
+    /// Expected type, written in warehouse vocabulary (e.g. `BIGINT`,
+    /// `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type
+    /// before comparison, so the same contract ports across warehouses
+    /// (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the
+    /// normalizer doesn't recognize is treated as unknown and never fails the
+    /// type check — presence and nullability still apply.
     #[serde(rename = "type")]
     pub data_type: String,
     #[serde(default = "default_true")]
@@ -34,21 +41,25 @@ fn default_true() -> bool {
 }
 
 /// A permitted type widening (e.g., INT to BIGINT) that won't trigger a violation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AllowedTypeChange {
     pub from: String,
     pub to: String,
 }
 
 /// Result of contract validation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ContractResult {
     pub passed: bool,
     pub violations: Vec<ContractViolation>,
+    /// Non-fatal warnings — e.g. a contract clause that can't be
+    /// meaningfully enforced in this context. Does not affect `passed`.
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
 /// A single contract rule violation with the rule name, affected column, and message.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ContractViolation {
     pub rule: String,
     pub column: String,
@@ -143,7 +154,168 @@ pub fn validate_contract(
     ContractResult {
         passed: violations.is_empty(),
         violations,
+        warnings: Vec::new(),
     }
+}
+
+/// Validate freshly-landed warehouse columns against a data contract,
+/// comparing types in Rocky's portable type vocabulary.
+///
+/// This is the contract gate for `rocky load`: `landed_columns` come from a
+/// live `DESCRIBE` of the staging table (raw warehouse type strings such as
+/// DuckDB `VARCHAR` or Snowflake `NUMBER(38,0)`), so type comparison can't
+/// be raw string equality if contracts are to port across warehouses.
+///
+/// Checks performed:
+/// - **Presence** (fully portable): every `required_columns` entry must
+///   exist in the landed data.
+/// - **Nullability** (fully portable): a required column declared
+///   `nullable = false` whose landed column is nullable is a violation.
+/// - **Type match** (best-effort): both the landed raw type and the
+///   contract's expected type string are normalized to [`RockyType`]; a
+///   violation is emitted only when both normalize to a *known* type and
+///   those types differ. If either side normalizes to [`RockyType::Unknown`],
+///   the match is skipped (never a false failure) — mirroring the compiler's
+///   contract type-checking.
+///
+/// `protected_columns` and `allowed_type_changes` describe source-vs-target
+/// *evolution*, which a single-table load can't meaningfully evaluate (there
+/// is no prior target snapshot in scope). When declared, they are surfaced
+/// as warnings rather than silently ignored.
+pub fn validate_contract_typed(
+    contract: &ContractConfig,
+    landed_columns: &[ColumnInfo],
+) -> ContractResult {
+    let mut violations = Vec::new();
+    let mut warnings = Vec::new();
+
+    let landed_map = column_map::build_column_map(landed_columns);
+
+    for req in &contract.required_columns {
+        let key = column_map::CiStr::new(&req.name);
+        let Some(col) = landed_map.get(key) else {
+            violations.push(ContractViolation {
+                rule: "required_column".to_string(),
+                column: req.name.clone(),
+                message: format!("required column '{}' not found in loaded data", req.name),
+            });
+            continue;
+        };
+
+        // Nullability — fully portable.
+        if !req.nullable && col.nullable {
+            violations.push(ContractViolation {
+                rule: "required_column_nullability".to_string(),
+                column: req.name.clone(),
+                message: format!(
+                    "column '{}' is nullable but the contract requires it to be non-nullable",
+                    req.name
+                ),
+            });
+        }
+
+        // Type match — best-effort in Rocky's type vocabulary.
+        let landed_ty = warehouse_type_to_rocky(&col.data_type);
+        let expected_ty = warehouse_type_to_rocky(&req.data_type);
+        if !rocky_types_match(&landed_ty, &expected_ty) {
+            violations.push(ContractViolation {
+                rule: "required_column_type".to_string(),
+                column: req.name.clone(),
+                message: format!(
+                    "column '{}' has type '{}' ({landed_ty}), expected '{}' ({expected_ty})",
+                    req.name, col.data_type, req.data_type
+                ),
+            });
+        }
+    }
+
+    if !contract.protected_columns.is_empty() {
+        warnings.push(
+            "`protected_columns` is declared but cannot be enforced on a load contract: \
+             it compares source columns against a prior target snapshot, which is not \
+             available when loading files. Ignored for this load."
+                .to_string(),
+        );
+    }
+    if !contract.allowed_type_changes.is_empty() {
+        warnings.push(
+            "`allowed_type_changes` is declared but cannot be enforced on a load contract: \
+             it gates type evolution against a prior target snapshot, which is not available \
+             when loading files. Ignored for this load."
+                .to_string(),
+        );
+    }
+
+    ContractResult {
+        passed: violations.is_empty(),
+        violations,
+        warnings,
+    }
+}
+
+/// Normalize a raw warehouse type string into a [`RockyType`].
+///
+/// Mirrors the compiler's `default_type_mapper` so the load gate compares
+/// types in the same vocabulary the rest of Rocky uses. Lives in rocky-core
+/// (not rocky-compiler) so the runtime load path can reach it without a
+/// dependency cycle; [`RockyType`] is shared via rocky-ir.
+///
+/// Unrecognized types map to [`RockyType::Unknown`] (which matches anything),
+/// so a type the map doesn't cover never produces a false failure.
+pub fn warehouse_type_to_rocky(warehouse_type: &str) -> RockyType {
+    let upper = warehouse_type.trim().to_uppercase();
+    match upper.as_str() {
+        "BOOLEAN" | "BOOL" => RockyType::Boolean,
+        "TINYINT" | "BYTE" | "SMALLINT" | "SHORT" | "INT" | "INTEGER" => RockyType::Int32,
+        "BIGINT" | "LONG" => RockyType::Int64,
+        "FLOAT" | "REAL" => RockyType::Float32,
+        "DOUBLE" | "DOUBLE PRECISION" => RockyType::Float64,
+        "STRING" | "VARCHAR" | "TEXT" => RockyType::String,
+        "BINARY" => RockyType::Binary,
+        "DATE" => RockyType::Date,
+        "TIMESTAMP" => RockyType::Timestamp,
+        "TIMESTAMP_NTZ" => RockyType::TimestampNtz,
+        "VARIANT" => RockyType::Variant,
+        // DECIMAL / NUMERIC (ANSI, Databricks, BigQuery) and NUMBER
+        // (Snowflake's fixed-point name). Snowflake's `DESCRIBE` returns
+        // `NUMBER(38,0)`, so it must normalize to the same RockyType as a
+        // contract written `DECIMAL(38,0)` for the contract to port.
+        _ if upper.starts_with("DECIMAL")
+            || upper.starts_with("NUMERIC")
+            || upper.starts_with("NUMBER") =>
+        {
+            if let Some(params) = upper
+                .strip_prefix("DECIMAL(")
+                .or_else(|| upper.strip_prefix("NUMERIC("))
+                .or_else(|| upper.strip_prefix("NUMBER("))
+                .and_then(|s| s.strip_suffix(')'))
+            {
+                let parts: Vec<&str> = params.split(',').collect();
+                if parts.len() == 2
+                    && let (Ok(p), Ok(s)) = (parts[0].trim().parse(), parts[1].trim().parse())
+                {
+                    return RockyType::Decimal {
+                        precision: p,
+                        scale: s,
+                    };
+                }
+            }
+            RockyType::Decimal {
+                precision: 38,
+                scale: 0,
+            }
+        }
+        _ => RockyType::Unknown,
+    }
+}
+
+/// Compare two normalized [`RockyType`]s for contract purposes.
+///
+/// Returns `true` (a match, so no violation) when either side is
+/// [`RockyType::Unknown`] — an un-normalizable type is never a false
+/// failure. Otherwise compares by equality.
+fn rocky_types_match(a: &RockyType, b: &RockyType) -> bool {
+    *a == RockyType::Unknown || *b == RockyType::Unknown || a == b
 }
 
 #[cfg(test)]
@@ -327,6 +499,170 @@ mod tests {
         let result = validate_contract(&contract, &[col("name", "STRING")], &[]);
         assert!(!result.passed);
         assert_eq!(result.violations.len(), 2);
+    }
+
+    // --- Typed (load-gate) validation path ---
+
+    fn col_n(name: &str, data_type: &str, nullable: bool) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            nullable,
+        }
+    }
+
+    #[test]
+    fn test_warehouse_type_to_rocky() {
+        assert_eq!(warehouse_type_to_rocky("VARCHAR"), RockyType::String);
+        assert_eq!(warehouse_type_to_rocky("varchar"), RockyType::String);
+        assert_eq!(warehouse_type_to_rocky("BIGINT"), RockyType::Int64);
+        assert_eq!(warehouse_type_to_rocky("BOOLEAN"), RockyType::Boolean);
+        assert_eq!(
+            warehouse_type_to_rocky("NUMBER(38,0)"),
+            RockyType::Decimal {
+                precision: 38,
+                scale: 0
+            }
+        );
+        assert_eq!(
+            warehouse_type_to_rocky("SOMETHING_WEIRD"),
+            RockyType::Unknown
+        );
+    }
+
+    #[test]
+    fn test_typed_required_present_and_type_matches() {
+        // Landed types mirror DuckDB DESCRIBE output (BIGINT, VARCHAR).
+        let contract = ContractConfig {
+            required_columns: vec![
+                RequiredColumn {
+                    name: "id".into(),
+                    data_type: "BIGINT".into(),
+                    nullable: true,
+                },
+                RequiredColumn {
+                    name: "name".into(),
+                    data_type: "VARCHAR".into(),
+                    nullable: true,
+                },
+            ],
+            ..Default::default()
+        };
+        let landed = vec![col_n("id", "BIGINT", true), col_n("name", "VARCHAR", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(result.passed, "violations: {:?}", result.violations);
+    }
+
+    #[test]
+    fn test_typed_required_missing() {
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "id".into(),
+                data_type: "BIGINT".into(),
+                nullable: true,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("name", "VARCHAR", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "required_column");
+    }
+
+    #[test]
+    fn test_typed_wrong_type_both_known() {
+        // Landed BIGINT (Int64) vs contract VARCHAR (String) — both known, differ.
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "id".into(),
+                data_type: "VARCHAR".into(),
+                nullable: true,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("id", "BIGINT", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "required_column_type");
+    }
+
+    #[test]
+    fn test_typed_portable_aliases_match() {
+        // Contract written as Rocky-ish "STRING" must match DuckDB's "VARCHAR"
+        // because both normalize to RockyType::String — the portability point.
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "name".into(),
+                data_type: "STRING".into(),
+                nullable: true,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("name", "VARCHAR", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(result.passed, "violations: {:?}", result.violations);
+    }
+
+    #[test]
+    fn test_typed_unknown_type_never_fails() {
+        // An un-normalizable landed type must not produce a type violation.
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "geo".into(),
+                data_type: "BIGINT".into(),
+                nullable: true,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("geo", "GEOMETRY", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(result.passed, "violations: {:?}", result.violations);
+    }
+
+    #[test]
+    fn test_typed_nullability_violation() {
+        let contract = ContractConfig {
+            required_columns: vec![RequiredColumn {
+                name: "id".into(),
+                data_type: "BIGINT".into(),
+                nullable: false,
+            }],
+            ..Default::default()
+        };
+        let landed = vec![col_n("id", "BIGINT", true)]; // landed nullable
+        let result = validate_contract_typed(&contract, &landed);
+        assert!(!result.passed);
+        assert_eq!(result.violations[0].rule, "required_column_nullability");
+    }
+
+    #[test]
+    fn test_typed_protected_and_type_changes_warn() {
+        let contract = ContractConfig {
+            required_columns: vec![],
+            protected_columns: vec!["id".into()],
+            allowed_type_changes: vec![AllowedTypeChange {
+                from: "INT".into(),
+                to: "BIGINT".into(),
+            }],
+        };
+        let landed = vec![col_n("id", "BIGINT", true)];
+        let result = validate_contract_typed(&contract, &landed);
+        // Unenforceable clauses must surface as warnings, not silently no-op,
+        // and must not fail the contract.
+        assert!(result.passed);
+        assert_eq!(result.warnings.len(), 2);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("protected_columns"))
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("allowed_type_changes"))
+        );
     }
 
     #[test]

--- a/integrations/dagster/src/dagster_rocky/types_generated/load_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/load_schema.py
@@ -6,12 +6,39 @@ from __future__ import annotations
 from pydantic import BaseModel, conint
 
 
+class ContractViolation(BaseModel):
+    """
+    A single contract rule violation with the rule name, affected column, and message.
+    """
+
+    column: str
+    message: str
+    rule: str
+
+
+class ContractResult(BaseModel):
+    """
+    Result of contract validation.
+    """
+
+    passed: bool
+    violations: list[ContractViolation]
+    warnings: list[str] | None = []
+    """
+    Non-fatal warnings — e.g. a contract clause that can't be meaningfully enforced in this context. Does not affect `passed`.
+    """
+
+
 class LoadFileOutput(BaseModel):
     """
     A single file result within `LoadOutput`.
     """
 
     bytes_read: conint(ge=0)
+    contract: ContractResult | None = None
+    """
+    Result of the data-contract gate, when the load pipeline declares a contract. `None` for ungated loads. On a failed gate the data was not promoted to the target; the violations explain why.
+    """
     duration_ms: conint(ge=0)
     error: str | None = None
     file: str

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -104,6 +104,15 @@ class AiSection(BaseModel):
     """
 
 
+class AllowedTypeChange(BaseModel):
+    """
+    A permitted type widening (e.g., INT to BIGINT) that won't trigger a violation.
+    """
+
+    from_: str = Field(..., alias="from")
+    to: str
+
+
 class BindingType(StrEnum):
     """
     Workspace binding access level.
@@ -930,6 +939,19 @@ class QuarantineMode3(StrEnum):
     drop = "drop"
 
 
+class RequiredColumn(BaseModel):
+    """
+    A column that must exist in the source with a specific type.
+    """
+
+    name: str
+    nullable: bool | None = True
+    type: str
+    """
+    Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer doesn't recognize is treated as unknown and never fails the type check — presence and nullability still apply.
+    """
+
+
 class RetryConfig(BaseModel):
     """
     Retry policy for transient warehouse errors (HTTP 429/503, rate limits, timeouts).
@@ -1499,6 +1521,27 @@ class CacheConfig(BaseModel):
     )
     """
     Schema cache. Stores `DESCRIBE TABLE` results in `state.redb` so leaf models typecheck against real warehouse types without a live round-trip on every compile.
+    """
+
+
+class ContractConfig(BaseModel):
+    """
+    Data contract configuration — enforced at copy/load time.
+    """
+
+    allowed_type_changes: list[AllowedTypeChange] | None = Field(
+        [], validate_default=True
+    )
+    """
+    Type changes that are allowed (widening only).
+    """
+    protected_columns: list[str] | None = []
+    """
+    Column names that must never be removed from the target.
+    """
+    required_columns: list[RequiredColumn] | None = Field([], validate_default=True)
+    """
+    Columns that must exist with specific types.
     """
 
 
@@ -2664,6 +2707,10 @@ class LoadPipelineConfig(BaseModel):
     )
     """
     Data quality checks run after loading.
+    """
+    contract: ContractConfig | None = None
+    """
+    Optional data contract that gates the load. When set, each file is loaded into a staging table, validated against the contract, and promoted to the target only if validation passes. On failure the staging table is dropped and the target is left untouched.
     """
     depends_on: list[str] | None = []
     """

--- a/schemas/load.schema.json
+++ b/schemas/load.schema.json
@@ -1,6 +1,53 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "ContractResult": {
+      "description": "Result of contract validation.",
+      "properties": {
+        "passed": {
+          "type": "boolean"
+        },
+        "violations": {
+          "items": {
+            "$ref": "#/definitions/ContractViolation"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "default": [],
+          "description": "Non-fatal warnings — e.g. a contract clause that can't be meaningfully enforced in this context. Does not affect `passed`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "passed",
+        "violations"
+      ],
+      "type": "object"
+    },
+    "ContractViolation": {
+      "description": "A single contract rule violation with the rule name, affected column, and message.",
+      "properties": {
+        "column": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "rule": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "column",
+        "message",
+        "rule"
+      ],
+      "type": "object"
+    },
     "LoadFileOutput": {
       "description": "A single file result within `LoadOutput`.",
       "properties": {
@@ -8,6 +55,17 @@
           "format": "uint64",
           "minimum": 0.0,
           "type": "integer"
+        },
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractResult"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Result of the data-contract gate, when the load pipeline declares a contract. `None` for ungated loads. On a failed gate the data was not promoted to the target; the violations explain why."
         },
         "duration_ms": {
           "format": "uint64",

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -401,6 +401,22 @@
       },
       "type": "object"
     },
+    "AllowedTypeChange": {
+      "description": "A permitted type widening (e.g., INT to BIGINT) that won't trigger a violation.",
+      "properties": {
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
     "BindingType": {
       "description": "Workspace binding access level.",
       "enum": [
@@ -664,6 +680,36 @@
         }
       ],
       "description": "Concurrency strategy: the literal `\"adaptive\"` for AIMD-based throttling, or a positive integer for fixed concurrency."
+    },
+    "ContractConfig": {
+      "description": "Data contract configuration — enforced at copy/load time.",
+      "properties": {
+        "allowed_type_changes": {
+          "default": [],
+          "description": "Type changes that are allowed (widening only).",
+          "items": {
+            "$ref": "#/definitions/AllowedTypeChange"
+          },
+          "type": "array"
+        },
+        "protected_columns": {
+          "default": [],
+          "description": "Column names that must never be removed from the target.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "required_columns": {
+          "default": [],
+          "description": "Columns that must exist with specific types.",
+          "items": {
+            "$ref": "#/definitions/RequiredColumn"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
     },
     "CostSection": {
       "additionalProperties": false,
@@ -1430,6 +1476,18 @@
             "row_count": false
           },
           "description": "Data quality checks run after loading."
+        },
+        "contract": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ContractConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional data contract that gates the load. When set, each file is loaded into a staging table, validated against the contract, and promoted to the target only if validation passes. On failure the staging table is dropped and the target is left untouched."
         },
         "depends_on": {
           "default": [],
@@ -2514,6 +2572,27 @@
       "required": [
         "source",
         "target"
+      ],
+      "type": "object"
+    },
+    "RequiredColumn": {
+      "description": "A column that must exist in the source with a specific type.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "nullable": {
+          "default": true,
+          "type": "boolean"
+        },
+        "type": {
+          "description": "Expected type, written in warehouse vocabulary (e.g. `BIGINT`, `VARCHAR`, `NUMBER(38,0)`). It is normalized to a portable Rocky type before comparison, so the same contract ports across warehouses (DuckDB `VARCHAR` and Snowflake `STRING` both match). A type the normalizer doesn't recognize is treated as unknown and never fails the type check — presence and nullability still apply.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
       ],
       "type": "object"
     },


### PR DESCRIPTION
`rocky load` can now enforce a typed data contract with **staging-promote** semantics, so non-conforming data never lands in the target.

Declare a contract on a load pipeline:

```toml
[pipeline.ingest.contract]
required_columns = [
  { name = "id", type = "BIGINT" },
  { name = "email", type = "VARCHAR" },
]
```

Per file (only when a contract is declared): load into a staging table → `DESCRIBE` → validate → **promote on pass, or drop staging and fail on violation**. The target is never created or modified on a failed load.

**Portable typed validation.** The landed warehouse types and the contract's expected types both normalize to `RockyType` and compare in Rocky's vocabulary, so one contract ports across warehouses. Required-column **presence + nullability** are hard gates; a type mismatch flags only when both sides are known (`Unknown` never false-fails). `protected_columns` / `allowed_type_changes` can't be enforced against a single-file load, so they emit a warning rather than silently no-opping.

Adds `contract: Option<ContractConfig>` to the load pipeline config and a `contract` result to `LoadFileOutput`; codegen bindings (schema + Pydantic + TypeScript) regenerated.

**Tested:** 643 rocky-cli + 1294 rocky-core tests. The gate is proven **both directions** on DuckDB — a conforming CSV loads (3 rows), and a CSV missing a required column with `VARCHAR`≠`BIGINT` fails the command with the target absent and staging dropped. Cross-warehouse live verification of the promote SQL + type normalization (Snowflake / BigQuery / Databricks) is a follow-up.
