### PR TITLE
feat(engine): skip_hash + SQL normalizer + non-determinism scan (foundation for opt-in skip-unchanged)

### DIFF
--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -789,6 +789,62 @@ impl ModelIr {
         blake3::hash(canonical.as_bytes())
     }
 
+    /// Best-effort *cosmetic-invariant* key for this model's logic.
+    ///
+    /// Unlike [`Self::recipe_hash`] — which hashes the raw `sql` text so a
+    /// whitespace or alias edit changes the value — `skip_hash` hashes a
+    /// **normalised** projection: the model's SQL re-emitted through
+    /// [`rocky_sql::normalize`] (comments stripped, whitespace collapsed,
+    /// keyword case folded, internal table/CTE aliases positionally renamed)
+    /// plus the already-typed structural facts (output columns,
+    /// materialisation, target, sources, masks, governance, lakehouse
+    /// format, ...). Two models that differ only in cosmetic SQL edits map to
+    /// the **same** `skip_hash`; any semantic difference (a `WHERE` predicate,
+    /// a selected column, the materialisation strategy, a column mask) maps to
+    /// a **different** one.
+    ///
+    /// This is a heuristic equivalence key, **not** a guarantee of result
+    /// equivalence. Equal `skip_hash` means "the logic looks unchanged"; it
+    /// says nothing about non-deterministic SQL (timestamps, randomness,
+    /// session settings, user-defined functions) — those are screened
+    /// separately by [`rocky_sql::determinism`]. Never present an equal
+    /// `skip_hash` to a user as proof that two runs produce identical output.
+    ///
+    /// # Returns
+    ///
+    /// `None` — a never-equal sentinel — when the model cannot be safely
+    /// canonicalised: its SQL does not re-parse through the normaliser, or
+    /// `typed_columns` is empty (a partial typecheck). A `None` model is never
+    /// equal to any other, so a caller comparing two `skip_hash` values can
+    /// never wrongly treat such a model as unchanged.
+    #[must_use]
+    pub fn skip_hash(&self) -> Option<blake3::Hash> {
+        if self.typed_columns.is_empty() {
+            return None;
+        }
+        let normalized_sql = rocky_sql::normalize::normalize(&self.sql)?;
+        let projection = SkipHashProjection {
+            normalizer_version: NORMALIZER_VERSION,
+            normalized_sql,
+            typed_columns: &self.typed_columns,
+            materialization: &self.materialization,
+            target: &self.target,
+            source: self.source.as_ref(),
+            sources: &self.sources,
+            columns: self.columns.as_ref(),
+            metadata_columns: &self.metadata_columns,
+            unique_key: &self.unique_key,
+            updated_at: self.updated_at.as_deref(),
+            invalidate_hard_deletes: self.invalidate_hard_deletes,
+            column_masks: &self.column_masks,
+            governance: &self.governance,
+            format: self.format.as_ref(),
+            format_options: self.format_options.as_ref(),
+        };
+        let canonical = canonical_json(&projection);
+        Some(blake3::hash(canonical.as_bytes()))
+    }
+
     /// Predicate underlying variant inference for snapshot. The single
     /// source of truth shared by [`Self::variant`]. Snapshot takes
     /// priority over replication in inference: if both `unique_key`
@@ -871,6 +927,51 @@ impl ProjectIr {
         }
         hasher.finalize()
     }
+}
+
+/// Version byte folded into every [`ModelIr::skip_hash`] input.
+///
+/// Bump this whenever the SQL normaliser or the skip-hash projection changes
+/// in a way that could alter the hash for unchanged logic. The bump
+/// deterministically invalidates every previously-stored `skip_hash`, forcing
+/// a rebuild on first encounter rather than risking a silent collision across
+/// normaliser versions. Rebuild-on-upgrade is the safe direction.
+const NORMALIZER_VERSION: u8 = 1;
+
+/// Borrowed projection of [`ModelIr`] hashed by [`ModelIr::skip_hash`].
+///
+/// Holds the normalised SQL string plus the typed structural facts that
+/// define a model's logic, excluding cosmetic SQL text and runtime-derived
+/// fields (`lineage_edges`, partition `window`). Serialised through the same
+/// canonical-JSON machinery as [`ModelIr::recipe_hash`].
+#[derive(Serialize)]
+struct SkipHashProjection<'a> {
+    normalizer_version: u8,
+    normalized_sql: String,
+    typed_columns: &'a [crate::types::TypedColumn],
+    materialization: &'a MaterializationStrategy,
+    target: &'a TargetRef,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<&'a SourceRef>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    sources: &'a [SourceRef],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    columns: Option<&'a ColumnSelection>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    metadata_columns: &'a [MetadataColumn],
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    unique_key: &'a [Arc<str>],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<&'a str>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    invalidate_hard_deletes: bool,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    column_masks: &'a [ColumnMask],
+    governance: &'a GovernanceConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    format: Option<&'a LakehouseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    format_options: Option<&'a LakehouseOptions>,
 }
 
 /// Canonical-JSON encoder used by [`ModelIr::recipe_hash`].
@@ -1290,6 +1391,151 @@ mod tests {
             h1, h2,
             "SQL text changes must propagate into the recipe hash"
         );
+    }
+
+    // ── skip_hash ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn skip_hash_is_deterministic() {
+        let m1 = sample_transformation_model();
+        let m2 = sample_transformation_model();
+        assert_eq!(
+            m1.skip_hash(),
+            m2.skip_hash(),
+            "identical IR must produce identical skip_hash"
+        );
+        assert!(m1.skip_hash().is_some());
+    }
+
+    #[test]
+    fn skip_hash_invariant_to_whitespace_but_recipe_hash_is_not() {
+        // The deliberate divergence: a whitespace-only SQL edit leaves
+        // skip_hash unchanged (cosmetic-invariant) while changing recipe_hash
+        // (text-sensitive). Pinning both halves guards the divergence against
+        // a future normaliser regression.
+        let mut m = sample_transformation_model();
+        let skip_before = m.skip_hash();
+        let recipe_before = m.recipe_hash();
+
+        m.sql = "SELECT   customer_id,\n   email\nFROM   stg_customers".into();
+
+        assert_eq!(
+            skip_before,
+            m.skip_hash(),
+            "whitespace-only edit must NOT change skip_hash"
+        );
+        assert_ne!(
+            recipe_before,
+            m.recipe_hash(),
+            "whitespace-only edit MUST change recipe_hash (pins the divergence)"
+        );
+    }
+
+    #[test]
+    fn skip_hash_invariant_to_comment_edits() {
+        let mut m = sample_transformation_model();
+        let before = m.skip_hash();
+        m.sql = "SELECT customer_id, email FROM stg_customers -- staging".into();
+        assert_eq!(
+            before,
+            m.skip_hash(),
+            "comment edit must not change skip_hash"
+        );
+    }
+
+    #[test]
+    fn skip_hash_invariant_to_internal_alias_rename() {
+        // Same output columns, only the internal table alias differs → same
+        // skip_hash. typed_columns is identical, so the output column names are
+        // unaffected by the rename.
+        let mut a = sample_transformation_model();
+        let mut b = sample_transformation_model();
+        a.sql = "SELECT s.customer_id, s.email FROM stg_customers AS s".into();
+        b.sql = "SELECT z.customer_id, z.email FROM stg_customers AS z".into();
+        assert_eq!(
+            a.skip_hash(),
+            b.skip_hash(),
+            "internal alias rename with identical output columns must not change skip_hash"
+        );
+    }
+
+    #[test]
+    fn skip_hash_changes_when_where_predicate_changes() {
+        let mut a = sample_transformation_model();
+        let mut b = sample_transformation_model();
+        a.sql = "SELECT customer_id, email FROM stg_customers WHERE customer_id > 10".into();
+        b.sql = "SELECT customer_id, email FROM stg_customers WHERE customer_id > 20".into();
+        assert_ne!(
+            a.skip_hash(),
+            b.skip_hash(),
+            "a changed WHERE predicate is a semantic change → different skip_hash"
+        );
+    }
+
+    #[test]
+    fn skip_hash_changes_when_selected_column_changes() {
+        let mut m = sample_transformation_model();
+        let before = m.skip_hash();
+        // A genuinely different output column changes typed_columns too.
+        m.sql = "SELECT customer_id, phone FROM stg_customers".into();
+        m.typed_columns[1] = TypedColumn {
+            name: "phone".into(),
+            data_type: RockyType::String,
+            nullable: true,
+        };
+        assert_ne!(before, m.skip_hash());
+    }
+
+    #[test]
+    fn skip_hash_changes_when_materialization_strategy_changes() {
+        let mut m = sample_transformation_model();
+        let before = m.skip_hash();
+        m.materialization = MaterializationStrategy::FullRefresh;
+        assert_ne!(
+            before,
+            m.skip_hash(),
+            "materialization strategy is part of the logic identity"
+        );
+    }
+
+    #[test]
+    fn skip_hash_changes_when_column_mask_changes() {
+        let mut m = sample_transformation_model();
+        let before = m.skip_hash();
+        m.column_masks[0].strategy = MaskStrategy::Redact;
+        assert_ne!(
+            before,
+            m.skip_hash(),
+            "a changed column mask changes skip_hash"
+        );
+    }
+
+    #[test]
+    fn skip_hash_is_none_when_typed_columns_empty() {
+        // Empty typed_columns simulates a partial typecheck — the never-equal
+        // sentinel so the model can never be wrongly treated as unchanged.
+        let mut m = sample_transformation_model();
+        m.typed_columns.clear();
+        assert_eq!(m.skip_hash(), None);
+    }
+
+    #[test]
+    fn skip_hash_is_none_when_sql_unparseable() {
+        let mut m = sample_transformation_model();
+        m.sql = "SELCT FROM nowhere".into();
+        assert_eq!(m.skip_hash(), None);
+    }
+
+    #[test]
+    fn skip_hash_none_is_never_equal_to_itself_via_option_semantics() {
+        // Two unhashable models both yield None; a caller comparing
+        // `Some == Some` can never match them. (Documents the sentinel
+        // contract rather than asserting None != None.)
+        let mut a = sample_transformation_model();
+        let mut b = sample_transformation_model();
+        a.typed_columns.clear();
+        b.typed_columns.clear();
+        assert!(a.skip_hash().is_none() && b.skip_hash().is_none());
     }
 
     #[test]

--- a/engine/crates/rocky-sql/src/determinism.rs
+++ b/engine/crates/rocky-sql/src/determinism.rs
@@ -1,0 +1,518 @@
+//! Conservative static scan for SQL non-determinism.
+//!
+//! [`is_deterministic`] returns `true` only when a model's SQL is *provably*
+//! free of constructs whose result can vary between two executions over the
+//! same input data. The scan is deliberately pessimistic: anything it cannot
+//! positively classify as pure — an unrecognised function, an unparseable
+//! body, a row-limit without a total order — is treated as **non**-
+//! deterministic.
+//!
+//! This is the eligibility guard for any consumer that wants to treat
+//! "same logic + same inputs" as "same output". A false "volatile" verdict
+//! costs at most a redundant recomputation; a false "pure" verdict would let
+//! a genuinely time-, randomness-, or session-dependent model be wrongly
+//! treated as stable. The scan tilts hard toward the cheap error.
+//!
+//! ## What is flagged non-deterministic
+//!
+//! - Calls to known volatile builtins — `CURRENT_TIMESTAMP`, `NOW`,
+//!   `GETDATE`, `CURRENT_DATE`, `RANDOM`, `RAND`, `UUID`, `NEWID`,
+//!   `GEN_RANDOM_UUID`, `CURRENT_USER`, `SESSION_USER`, `CURRENT_ROLE`, ...
+//! - Any function name not on the small known-pure allowlist (fail-safe:
+//!   unknown ⇒ volatile).
+//! - A `LIMIT` / `TOP` / `FETCH` on a query that has no `ORDER BY` — the rows
+//!   returned are then implementation-defined.
+//!
+//! The scan does not attempt to resolve user-defined functions or to reason
+//! about session settings (timezone, collation); those are exactly the cases
+//! the unknown-function rule conservatively rejects.
+
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{Expr, Query, SetExpr, Statement, visit_expressions};
+
+use crate::parser::parse_single_statement;
+
+/// Builtin functions whose value can change between two executions over the
+/// same data. Compared case-insensitively (stored upper-case).
+const VOLATILE_FUNCTIONS: &[&str] = &[
+    "CURRENT_TIMESTAMP",
+    "LOCALTIMESTAMP",
+    "NOW",
+    "GETDATE",
+    "SYSDATE",
+    "SYSDATETIME",
+    "CURRENT_DATE",
+    "CURRENT_TIME",
+    "CURTIME",
+    "CURDATE",
+    "UNIX_TIMESTAMP",
+    "RANDOM",
+    "RAND",
+    "RANDN",
+    "UUID",
+    "NEWID",
+    "UUID_STRING",
+    "GEN_RANDOM_UUID",
+    "RANDOM_UUID",
+    "CURRENT_USER",
+    "SESSION_USER",
+    "SYSTEM_USER",
+    "USER",
+    "CURRENT_ROLE",
+    "CURRENT_CATALOG",
+    "CURRENT_SCHEMA",
+    "CURRENT_DATABASE",
+];
+
+/// Volatile builtins that take no parentheses and therefore parse as a bare
+/// [`Expr::Identifier`] (not [`Expr::Function`]) under the engine's dialect —
+/// `SELECT current_user`, `SELECT session_user`. Matched case-insensitively.
+/// A user column that happens to share one of these names is flagged volatile,
+/// which is the safe direction (a redundant rebuild, never a wrong skip).
+const VOLATILE_BARE_IDENTIFIERS: &[&str] = &[
+    "CURRENT_USER",
+    "SESSION_USER",
+    "SYSTEM_USER",
+    "USER",
+    "CURRENT_ROLE",
+];
+
+/// Builtin functions known to be pure (deterministic over the same input
+/// row). The allowlist is intentionally small: the goal is to let ordinary
+/// transformation SQL (casts, arithmetic, common aggregates and string/date
+/// manipulation) read as deterministic while still flagging anything novel.
+/// Anything absent here is treated as non-deterministic.
+const PURE_FUNCTIONS: &[&str] = &[
+    // Aggregates
+    "COUNT",
+    "SUM",
+    "AVG",
+    "MIN",
+    "MAX",
+    "STDDEV",
+    "VARIANCE",
+    "VAR_POP",
+    "VAR_SAMP",
+    "STDDEV_POP",
+    "STDDEV_SAMP",
+    "MEDIAN",
+    "MODE",
+    "CORR",
+    "COVAR_POP",
+    "COVAR_SAMP",
+    "ANY_VALUE",
+    "APPROX_COUNT_DISTINCT",
+    "BIT_AND",
+    "BIT_OR",
+    "BIT_XOR",
+    "BOOL_AND",
+    "BOOL_OR",
+    // Null / conditional
+    "COALESCE",
+    "NULLIF",
+    "IFNULL",
+    "NVL",
+    "NVL2",
+    "ISNULL",
+    "IIF",
+    "IF",
+    "GREATEST",
+    "LEAST",
+    "DECODE",
+    // Cast / convert
+    "CAST",
+    "CONVERT",
+    "TRY_CAST",
+    "TO_CHAR",
+    "TO_DATE",
+    "TO_TIMESTAMP",
+    "TO_NUMBER",
+    "TO_JSON",
+    // Math
+    "ABS",
+    "CEIL",
+    "CEILING",
+    "FLOOR",
+    "ROUND",
+    "TRUNC",
+    "TRUNCATE",
+    "POWER",
+    "POW",
+    "SQRT",
+    "EXP",
+    "LN",
+    "LOG",
+    "LOG10",
+    "LOG2",
+    "MOD",
+    "SIGN",
+    "PI",
+    "DEGREES",
+    "RADIANS",
+    "SIN",
+    "COS",
+    "TAN",
+    "ASIN",
+    "ACOS",
+    "ATAN",
+    "ATAN2",
+    "CBRT",
+    // String
+    "LENGTH",
+    "LEN",
+    "CHAR_LENGTH",
+    "CHARACTER_LENGTH",
+    "UPPER",
+    "LOWER",
+    "INITCAP",
+    "TRIM",
+    "LTRIM",
+    "RTRIM",
+    "LPAD",
+    "RPAD",
+    "SUBSTR",
+    "SUBSTRING",
+    "LEFT",
+    "RIGHT",
+    "CONCAT",
+    "CONCAT_WS",
+    "REPLACE",
+    "TRANSLATE",
+    "REVERSE",
+    "REPEAT",
+    "SPLIT",
+    "SPLIT_PART",
+    "POSITION",
+    "INSTR",
+    "STRPOS",
+    "REGEXP_REPLACE",
+    "REGEXP_EXTRACT",
+    "REGEXP_LIKE",
+    "REGEXP_COUNT",
+    "STARTSWITH",
+    "ENDSWITH",
+    "CONTAINS",
+    "ASCII",
+    "CHR",
+    "FORMAT",
+    "FORMAT_NUMBER",
+    // Date / time arithmetic (pure given their args; the volatile "now"
+    // builtins are blocked above)
+    "DATE",
+    "TIMESTAMP",
+    "YEAR",
+    "MONTH",
+    "DAY",
+    "HOUR",
+    "MINUTE",
+    "SECOND",
+    "QUARTER",
+    "WEEK",
+    "DAYOFWEEK",
+    "DAYOFYEAR",
+    "DAYOFMONTH",
+    "EXTRACT",
+    "DATE_PART",
+    "DATE_TRUNC",
+    "DATE_ADD",
+    "DATE_SUB",
+    "DATE_DIFF",
+    "DATEDIFF",
+    "DATEADD",
+    "ADD_MONTHS",
+    "LAST_DAY",
+    "NEXT_DAY",
+    "MONTHS_BETWEEN",
+    "FROM_UNIXTIME",
+    "DATE_FORMAT",
+    // Window / ordering helpers (deterministic given a total ORDER BY in the
+    // window spec; pure builtins themselves)
+    "ROW_NUMBER",
+    "RANK",
+    "DENSE_RANK",
+    "PERCENT_RANK",
+    "NTILE",
+    "LAG",
+    "LEAD",
+    "FIRST_VALUE",
+    "LAST_VALUE",
+    "NTH_VALUE",
+    "CUME_DIST",
+    // Collections / structs
+    "ARRAY",
+    "ARRAY_AGG",
+    "COLLECT_LIST",
+    "COLLECT_SET",
+    "MAP",
+    "STRUCT",
+    "NAMED_STRUCT",
+    "ELEMENT_AT",
+    "SIZE",
+    "CARDINALITY",
+    "EXPLODE",
+    "FLATTEN",
+    "GET_JSON_OBJECT",
+    "JSON_EXTRACT",
+    "FROM_JSON",
+    "HASH",
+    "MD5",
+    "SHA",
+    "SHA1",
+    "SHA2",
+    "CRC32",
+];
+
+/// Returns `true` iff `sql` parses and contains no construct the scan
+/// recognises as non-deterministic.
+///
+/// Fail-safe: an un-parseable body returns `false` (treat as volatile). A
+/// caller that needs the result to be trustworthy must treat `false` as
+/// "cannot establish determinism", not merely "is volatile".
+#[must_use]
+pub fn is_deterministic(sql: &str) -> bool {
+    let Ok(statement) = parse_single_statement(sql) else {
+        return false;
+    };
+    let Statement::Query(query) = statement else {
+        // Only SELECT/query bodies are model SQL; anything else is out of
+        // scope and treated conservatively.
+        return false;
+    };
+    query_is_deterministic(&query)
+}
+
+fn query_is_deterministic(query: &Query) -> bool {
+    // Two independent reasons a query can be non-deterministic:
+    //
+    // 1. A row limit with no total ORDER BY — a *structural* property of the
+    //    query (and every nested query), invisible to an expression visitor
+    //    because it lives on the limit/order-by clauses, not in an `Expr`.
+    // 2. A volatile expression anywhere — a projection, `WHERE`, `HAVING`,
+    //    `GROUP BY`, `ORDER BY`, `JOIN ... ON`, or sub-query. A single
+    //    statement-wide `visit_expressions` pass reaches every `Expr` node,
+    //    so no position is silently skipped.
+    if any_unordered_limit(query) {
+        return false;
+    }
+    let mut deterministic = true;
+    let _: ControlFlow<()> = visit_expressions(query, |expr| {
+        if !expr_is_deterministic(expr) {
+            deterministic = false;
+            return ControlFlow::Break(());
+        }
+        ControlFlow::Continue(())
+    });
+    deterministic
+}
+
+/// Returns `true` if this query or any nested query carries a row limit
+/// (`LIMIT` / `FETCH` / `TOP`) without a total `ORDER BY` — the rows returned
+/// are then implementation-defined.
+fn any_unordered_limit(query: &Query) -> bool {
+    if query_has_limit(query) && query.order_by.is_none() {
+        return true;
+    }
+    set_expr_has_unordered_limit(&query.body)
+}
+
+fn set_expr_has_unordered_limit(body: &SetExpr) -> bool {
+    match body {
+        SetExpr::Select(select) => select.from.iter().any(|twj| {
+            table_factor_has_unordered_limit(&twj.relation)
+                || twj
+                    .joins
+                    .iter()
+                    .any(|join| table_factor_has_unordered_limit(&join.relation))
+        }),
+        SetExpr::Query(inner) => any_unordered_limit(inner),
+        SetExpr::SetOperation { left, right, .. } => {
+            set_expr_has_unordered_limit(left) || set_expr_has_unordered_limit(right)
+        }
+        _ => false,
+    }
+}
+
+fn table_factor_has_unordered_limit(factor: &sqlparser::ast::TableFactor) -> bool {
+    match factor {
+        sqlparser::ast::TableFactor::Derived { subquery, .. } => any_unordered_limit(subquery),
+        _ => false,
+    }
+}
+
+fn query_has_limit(query: &Query) -> bool {
+    if query.limit_clause.is_some() || query.fetch.is_some() {
+        return true;
+    }
+    if let SetExpr::Select(select) = query.body.as_ref()
+        && select.top.is_some()
+    {
+        return true;
+    }
+    false
+}
+
+/// Classify a single expression node. Only function calls and bare niladic
+/// builtins carry a verdict; every other node is deterministic *on its own*
+/// (its children are visited separately by the statement-wide
+/// `visit_expressions` walk).
+fn expr_is_deterministic(expr: &Expr) -> bool {
+    match expr {
+        // Niladic volatile builtins (`current_user`, `session_user`) parse as
+        // bare identifiers under the engine's dialect.
+        Expr::Identifier(ident) => {
+            !VOLATILE_BARE_IDENTIFIERS.contains(&ident.value.to_uppercase().as_str())
+        }
+        Expr::Function(func) => {
+            let Some(name) = func.name.0.last().and_then(|p| p.as_ident()) else {
+                // A function we can't even name — be conservative.
+                return false;
+            };
+            let upper = name.value.to_uppercase();
+            if VOLATILE_FUNCTIONS.contains(&upper.as_str()) {
+                return false;
+            }
+            // Unknown function ⇒ assume non-deterministic (fail-safe).
+            PURE_FUNCTIONS.contains(&upper.as_str())
+        }
+        // Every other node is deterministic on its own; its children are
+        // visited separately by the statement-wide `visit_expressions` walk.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_select_is_deterministic() {
+        // Function-free SELECT — the unambiguous deterministic baseline.
+        assert!(is_deterministic(
+            "SELECT id, name FROM cat.sch.t WHERE id > 10"
+        ));
+    }
+
+    #[test]
+    fn pure_functions_are_deterministic() {
+        assert!(is_deterministic(
+            "SELECT customer_id, SUM(amount) AS total FROM cat.sch.o GROUP BY customer_id"
+        ));
+        assert!(is_deterministic(
+            "SELECT CAST(id AS BIGINT) AS id, COALESCE(name, 'n/a') AS name FROM cat.sch.t"
+        ));
+    }
+
+    #[test]
+    fn current_timestamp_is_non_deterministic() {
+        assert!(!is_deterministic(
+            "SELECT id, CURRENT_TIMESTAMP AS loaded_at FROM cat.sch.t"
+        ));
+    }
+
+    #[test]
+    fn now_is_non_deterministic() {
+        assert!(!is_deterministic("SELECT id, NOW() AS t FROM cat.sch.t"));
+    }
+
+    #[test]
+    fn current_date_is_non_deterministic() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE d = CURRENT_DATE"
+        ));
+    }
+
+    #[test]
+    fn random_is_non_deterministic() {
+        assert!(!is_deterministic("SELECT id, RANDOM() AS r FROM cat.sch.t"));
+        assert!(!is_deterministic("SELECT id, RAND() AS r FROM cat.sch.t"));
+    }
+
+    #[test]
+    fn uuid_functions_are_non_deterministic() {
+        assert!(!is_deterministic("SELECT UUID() AS u FROM cat.sch.t"));
+        assert!(!is_deterministic(
+            "SELECT GEN_RANDOM_UUID() AS u FROM cat.sch.t"
+        ));
+    }
+
+    #[test]
+    fn session_functions_are_non_deterministic() {
+        assert!(!is_deterministic("SELECT CURRENT_USER AS u FROM cat.sch.t"));
+        assert!(!is_deterministic("SELECT SESSION_USER AS u FROM cat.sch.t"));
+    }
+
+    #[test]
+    fn unknown_function_is_non_deterministic() {
+        // A function the scan has never heard of ⇒ assume volatile (fail-safe).
+        assert!(!is_deterministic(
+            "SELECT my_custom_udf(id) AS x FROM cat.sch.t"
+        ));
+    }
+
+    #[test]
+    fn limit_without_order_by_is_non_deterministic() {
+        assert!(!is_deterministic("SELECT id FROM cat.sch.t LIMIT 10"));
+    }
+
+    #[test]
+    fn limit_with_total_order_by_is_deterministic() {
+        assert!(is_deterministic(
+            "SELECT id FROM cat.sch.t ORDER BY id LIMIT 10"
+        ));
+    }
+
+    #[test]
+    fn volatile_function_in_where_is_caught() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE created_at > NOW()"
+        ));
+    }
+
+    #[test]
+    fn volatile_function_in_subquery_is_caught() {
+        assert!(!is_deterministic(
+            "SELECT id FROM (SELECT id, RANDOM() AS r FROM cat.sch.t) AS s"
+        ));
+    }
+
+    #[test]
+    fn volatile_in_order_by_is_caught() {
+        // The textbook case: a total ORDER BY satisfies the LIMIT rule, but
+        // ordering *by* a volatile function is still non-deterministic. The
+        // statement-wide expression walk must reach ORDER BY exprs.
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t ORDER BY RANDOM() LIMIT 10"
+        ));
+    }
+
+    #[test]
+    fn volatile_in_join_on_is_caught() {
+        assert!(!is_deterministic(
+            "SELECT a.id FROM cat.sch.x AS a JOIN cat.sch.y AS b \
+             ON a.id = b.id AND b.ts > NOW()"
+        ));
+    }
+
+    #[test]
+    fn volatile_in_between_is_caught() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE x BETWEEN 1 AND RANDOM()"
+        ));
+    }
+
+    #[test]
+    fn unordered_limit_in_subquery_is_caught() {
+        // A nested query with LIMIT but no ORDER BY is non-deterministic even
+        // when the outer query is fully ordered.
+        assert!(!is_deterministic(
+            "SELECT id FROM (SELECT id FROM cat.sch.t LIMIT 5) AS s ORDER BY id"
+        ));
+    }
+
+    #[test]
+    fn unparseable_sql_is_non_deterministic() {
+        assert!(!is_deterministic("SELCT FROM"));
+        assert!(!is_deterministic(""));
+    }
+}

--- a/engine/crates/rocky-sql/src/lib.rs
+++ b/engine/crates/rocky-sql/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod defer;
+pub mod determinism;
 pub mod dialect;
 pub mod lineage;
+pub mod normalize;
 pub mod parser;
 pub mod portability;
 pub mod pragma;

--- a/engine/crates/rocky-sql/src/normalize.rs
+++ b/engine/crates/rocky-sql/src/normalize.rs
@@ -1,0 +1,345 @@
+//! Canonical re-emit of model SQL for cosmetic-invariant comparison.
+//!
+//! [`normalize`] parses a single model `SELECT` through the same parser the
+//! rest of the engine uses, deterministically renames *internal* table /
+//! CTE / derived-table aliases to positional tokens (`_t0`, `_t1`, ...), and
+//! re-emits the AST via its `Display` impl. The re-emit alone collapses
+//! whitespace and strips comments, and the parser's `Display` canonicalises
+//! keyword case (`select` and `SELECT` render identically) — so the returned
+//! string is invariant to those cosmetic edits.
+//!
+//! ## What is and is not normalised
+//!
+//! - **Renamed:** table-level aliases — the alias on a `FROM` / `JOIN`
+//!   relation, on a derived (sub-query) table, and on a `WITH` CTE — plus
+//!   every reference to them (a bare relation name that points at a CTE, and
+//!   the table-qualifier of a `t.col` column reference). References are
+//!   rewritten in lockstep with their definition so `t AS a` and `t AS b`
+//!   normalise to the same string.
+//! - **Untouched:** projection / output column aliases (`SELECT expr AS foo`).
+//!   Output column names are a *semantic* fact — they are carried separately
+//!   in the typed schema — so they must survive normalisation unchanged.
+//!   String and quoted-identifier *contents* are likewise never rewritten:
+//!   the re-emit is structural, never a blanket `to_lowercase`, so two queries
+//!   differing only in a literal can never collapse to the same string.
+//!
+//! ## Conservatism
+//!
+//! This is a best-effort *cosmetic* canonicaliser, deliberately biased toward
+//! under-normalising. When an alias cannot be unambiguously renamed (for
+//! example a name reused across nested scopes) it is left as-is: a missed
+//! collapse costs one redundant comparison-miss, whereas a wrong collapse
+//! would equate two genuinely different queries. The function errs toward
+//! distinctness.
+//!
+//! Alias *collection* walks `FROM` / `JOIN` / `WITH` positions; aliases bound
+//! only inside a `WHERE` / projection sub-query are not collected, so they are
+//! not renamed. The effect is purely under-normalisation (such queries stay
+//! more distinct), never a wrong collapse.
+
+use std::collections::BTreeMap;
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{
+    Cte, Expr, Ident, Query, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins,
+    visit_expressions_mut, visit_relations_mut,
+};
+
+use crate::parser::parse_single_statement;
+
+/// Re-emit `sql` in a canonical, cosmetic-invariant form.
+///
+/// Returns `Some(normalized)` when `sql` parses as a single statement, or
+/// `None` when it does not. A `None` here is a deliberate fail-safe signal:
+/// callers that compare normalised forms must treat an un-normalisable model
+/// as *never equal* to any other, never as a match.
+///
+/// The result is invariant to comment edits, insignificant whitespace,
+/// keyword case, and internal table/CTE/derived-table alias renames. It is
+/// **not** a semantic-equivalence oracle — it does not fold join-order,
+/// parenthesisation, or `AS`-keyword optionality, and it never rewrites
+/// string-literal or output-column-name content.
+#[must_use]
+pub fn normalize(sql: &str) -> Option<String> {
+    let mut statement = parse_single_statement(sql).ok()?;
+
+    // Pass 1: collect internal table-level alias names in deterministic
+    // first-seen traversal order and assign each a positional token.
+    let mut renames: BTreeMap<String, String> = BTreeMap::new();
+    let mut order: Vec<String> = Vec::new();
+    if let Statement::Query(query) = &statement {
+        collect_aliases(query, &mut order);
+    }
+    for name in order {
+        let next = renames.len();
+        renames.entry(name).or_insert_with(|| format!("_t{next}"));
+    }
+
+    if renames.is_empty() {
+        // No internal aliases to rewrite — the Display re-emit already gives
+        // us comment/whitespace/keyword-case invariance.
+        return Some(statement.to_string());
+    }
+
+    // Pass 2a: rewrite the alias *definitions* (CTE alias, table/derived
+    // alias). Neither `visit_relations_mut` nor `visit_expressions_mut`
+    // reaches these, so they need a dedicated structural walk.
+    if let Statement::Query(query) = &mut statement {
+        rewrite_alias_defs(query, &renames);
+    }
+
+    // Pass 2b: rewrite bare relation references that point at a renamed CTE.
+    // A multi-part name (`schema.table`) is a real table, never a CTE alias,
+    // so only single-part names are candidates.
+    let _: ControlFlow<()> = visit_relations_mut(&mut statement, |relation| {
+        if relation.0.len() == 1
+            && let Some(ident) = relation.0[0].as_ident()
+            && let Some(token) = renames.get(&ident.value)
+        {
+            relation.0[0] = sqlparser::ast::ObjectNamePart::Identifier(plain_ident(token));
+        }
+        ControlFlow::Continue(())
+    });
+
+    // Pass 2c: rewrite the table-qualifier of `alias.col` column references.
+    let _: ControlFlow<()> = visit_expressions_mut(&mut statement, |expr| {
+        if let Expr::CompoundIdentifier(parts) = expr
+            && parts.len() >= 2
+        {
+            let qualifier = &parts[parts.len() - 2].value;
+            if let Some(token) = renames.get(qualifier) {
+                let idx = parts.len() - 2;
+                parts[idx] = plain_ident(token);
+            }
+        }
+        ControlFlow::Continue(())
+    });
+
+    Some(statement.to_string())
+}
+
+/// Build an unquoted identifier carrying the positional token. Tokens are
+/// `^_t[0-9]+$`, always safe to emit bare.
+fn plain_ident(value: &str) -> Ident {
+    Ident::new(value.to_string())
+}
+
+/// Collect internal table-level alias names in deterministic traversal order.
+///
+/// Order is fixed by the AST shape: a query's `WITH` CTEs in declaration
+/// order, then the body. The same name may appear more than once (shadowing);
+/// the caller's first-seen numbering handles that. Names that flow into the
+/// rename map are matched verbatim later, so collection is purely additive.
+fn collect_aliases(query: &Query, order: &mut Vec<String>) {
+    if let Some(with) = &query.with {
+        for cte in &with.cte_tables {
+            order.push(cte.alias.name.value.clone());
+            collect_aliases(&cte.query, order);
+        }
+    }
+    collect_set_expr_aliases(&query.body, order);
+}
+
+fn collect_set_expr_aliases(body: &SetExpr, order: &mut Vec<String>) {
+    match body {
+        SetExpr::Select(select) => {
+            for twj in &select.from {
+                collect_table_with_joins(twj, order);
+            }
+        }
+        SetExpr::Query(inner) => collect_aliases(inner, order),
+        SetExpr::SetOperation { left, right, .. } => {
+            collect_set_expr_aliases(left, order);
+            collect_set_expr_aliases(right, order);
+        }
+        _ => {}
+    }
+}
+
+fn collect_table_with_joins(twj: &TableWithJoins, order: &mut Vec<String>) {
+    collect_table_factor(&twj.relation, order);
+    for join in &twj.joins {
+        collect_table_factor(&join.relation, order);
+    }
+}
+
+fn collect_table_factor(factor: &TableFactor, order: &mut Vec<String>) {
+    match factor {
+        TableFactor::Table { alias: Some(a), .. } => order.push(a.name.value.clone()),
+        TableFactor::Derived {
+            subquery, alias, ..
+        } => {
+            if let Some(a) = alias {
+                order.push(a.name.value.clone());
+            }
+            collect_aliases(subquery, order);
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite every internal alias *definition* to its positional token.
+fn rewrite_alias_defs(query: &mut Query, renames: &BTreeMap<String, String>) {
+    if let Some(with) = &mut query.with {
+        for cte in &mut with.cte_tables {
+            rewrite_cte_alias(cte, renames);
+            rewrite_alias_defs(&mut cte.query, renames);
+        }
+    }
+    rewrite_set_expr_alias_defs(&mut query.body, renames);
+}
+
+fn rewrite_cte_alias(cte: &mut Cte, renames: &BTreeMap<String, String>) {
+    if let Some(token) = renames.get(&cte.alias.name.value) {
+        cte.alias.name = plain_ident(token);
+    }
+}
+
+fn rewrite_set_expr_alias_defs(body: &mut SetExpr, renames: &BTreeMap<String, String>) {
+    match body {
+        SetExpr::Select(select) => {
+            for twj in &mut select.from {
+                rewrite_table_with_joins_alias(twj, renames);
+            }
+        }
+        SetExpr::Query(inner) => rewrite_alias_defs(inner, renames),
+        SetExpr::SetOperation { left, right, .. } => {
+            rewrite_set_expr_alias_defs(left, renames);
+            rewrite_set_expr_alias_defs(right, renames);
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_table_with_joins_alias(twj: &mut TableWithJoins, renames: &BTreeMap<String, String>) {
+    rewrite_table_factor_alias(&mut twj.relation, renames);
+    for join in &mut twj.joins {
+        rewrite_table_factor_alias(&mut join.relation, renames);
+    }
+}
+
+fn rewrite_table_factor_alias(factor: &mut TableFactor, renames: &BTreeMap<String, String>) {
+    match factor {
+        TableFactor::Table { alias, .. } => rewrite_alias_opt(alias, renames),
+        TableFactor::Derived {
+            subquery, alias, ..
+        } => {
+            rewrite_alias_opt(alias, renames);
+            rewrite_alias_defs(subquery, renames);
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_alias_opt(alias: &mut Option<TableAlias>, renames: &BTreeMap<String, String>) {
+    if let Some(a) = alias
+        && let Some(token) = renames.get(&a.name.value)
+    {
+        a.name = plain_ident(token);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn comments_are_stripped() {
+        let with_comment = "SELECT id /* the key */ FROM cat.sch.t -- trailing\n WHERE id > 0";
+        let without = "SELECT id FROM cat.sch.t WHERE id > 0";
+        assert_eq!(normalize(with_comment), normalize(without));
+        assert!(!normalize(with_comment).unwrap().contains("the key"));
+    }
+
+    #[test]
+    fn whitespace_is_collapsed() {
+        let spaced = "SELECT     id,\n\n   name\nFROM    cat.sch.t";
+        let tight = "SELECT id, name FROM cat.sch.t";
+        assert_eq!(normalize(spaced), normalize(tight));
+    }
+
+    #[test]
+    fn keyword_case_is_invariant() {
+        // The end is case-invariance, delivered by the AST Display re-emit —
+        // not a blanket lowercase. Mixed- and upper-case keyword inputs must
+        // normalise to the *same* string.
+        let lower = "select id from cat.sch.t where id > 10";
+        let upper = "SELECT id FROM cat.sch.t WHERE id > 10";
+        assert_eq!(normalize(lower), normalize(upper));
+    }
+
+    #[test]
+    fn string_literal_case_is_preserved() {
+        // A blanket lowercase would collapse these into a false match. The
+        // structural re-emit keeps literal contents byte-exact, so they must
+        // normalise to *different* strings.
+        let a = "SELECT id FROM cat.sch.t WHERE name = 'Alice'";
+        let b = "SELECT id FROM cat.sch.t WHERE name = 'alice'";
+        assert_ne!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn internal_table_alias_rename_is_invariant() {
+        let a = "SELECT a.id FROM cat.sch.orders AS a WHERE a.id > 0";
+        let b = "SELECT z.id FROM cat.sch.orders AS z WHERE z.id > 0";
+        assert_eq!(normalize(a), normalize(b));
+        // The alias really was rewritten to a positional token.
+        assert!(normalize(a).unwrap().contains("_t0"));
+    }
+
+    #[test]
+    fn join_alias_rename_is_invariant() {
+        let a =
+            "SELECT o.id, c.name FROM cat.sch.orders o JOIN cat.sch.customers c ON o.cid = c.id";
+        let b =
+            "SELECT x.id, y.name FROM cat.sch.orders x JOIN cat.sch.customers y ON x.cid = y.id";
+        assert_eq!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn cte_alias_rename_is_invariant() {
+        let a = "WITH foo AS (SELECT id FROM cat.sch.t) SELECT id FROM foo";
+        let b = "WITH bar AS (SELECT id FROM cat.sch.t) SELECT id FROM bar";
+        assert_eq!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn derived_table_alias_rename_is_invariant() {
+        let a = "SELECT s.id FROM (SELECT id FROM cat.sch.t) AS s";
+        let b = "SELECT q.id FROM (SELECT id FROM cat.sch.t) AS q";
+        assert_eq!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn output_column_alias_is_preserved() {
+        // Renaming the *output* column name is a semantic change and must NOT
+        // be collapsed by the alias normaliser.
+        let a = "SELECT id AS customer_id FROM cat.sch.t";
+        let b = "SELECT id AS user_id FROM cat.sch.t";
+        assert_ne!(normalize(a), normalize(b));
+        assert!(normalize(a).unwrap().contains("customer_id"));
+    }
+
+    #[test]
+    fn semantic_predicate_change_is_distinct() {
+        let a = "SELECT id FROM cat.sch.t WHERE id > 10";
+        let b = "SELECT id FROM cat.sch.t WHERE id > 20";
+        assert_ne!(normalize(a), normalize(b));
+    }
+
+    #[test]
+    fn unparseable_sql_returns_none() {
+        assert_eq!(normalize("SELCT FROM"), None);
+        assert_eq!(normalize(""), None);
+        // Multiple statements are not a single model body.
+        assert_eq!(normalize("SELECT 1; SELECT 2"), None);
+    }
+
+    #[test]
+    fn normalization_is_idempotent() {
+        let sql = "SELECT a.id FROM cat.sch.orders AS a";
+        let once = normalize(sql).unwrap();
+        let twice = normalize(&once).unwrap();
+        assert_eq!(once, twice);
+    }
+}


### PR DESCRIPTION
## What

Stage 1 of an opt-in **skip-unchanged** optimization: three foundational,
purely-additive primitives. **No wiring into run/state/config — zero behavior
change.** The skip *gate* (reading these back to decide whether to build) is a
separate follow-up; this PR lands the primitives as a small, fully-unit-tested
base.

### `rocky-sql::normalize` (new)
A canonical AST re-emit of model SQL for cosmetic-invariant comparison. Parses
through the existing parser, then via the AST `Display`: strips comments,
collapses whitespace, folds keyword case, and positionally renames internal
table / CTE / derived-table aliases (`_t0`, `_t1`, ...) — rewriting every
reference (CTE relation names, `t.col` qualifiers) in lockstep. Output column
names and string-literal contents are preserved (the re-emit is structural,
never a blanket lowercase). Returns `None` when the SQL won't parse — a
never-equal fail-safe signal.

### `rocky-sql::determinism` (new)
A conservative static scan: `is_deterministic(sql) -> bool`. Flags volatile
builtins (`CURRENT_TIMESTAMP` / `NOW` / `RANDOM` / `UUID` / `CURRENT_USER` /
...), a `LIMIT` / `TOP` / `FETCH` without a total `ORDER BY` (including nested
queries), and any **unknown** function (fail-safe: unknown ⇒ non-deterministic).
A plain function-free `SELECT` reads deterministic. Volatile expressions are
caught wherever they appear — projection, `WHERE`, `HAVING`, `GROUP BY`,
`ORDER BY`, `JOIN ... ON`, sub-queries — via a statement-wide expression walk.

### `rocky-ir`: `ModelIr::skip_hash()`
Added alongside the untouched `recipe_hash()`. `blake3` over the canonical JSON
of a normalized projection — the normalized SQL plus the already-typed
structural facts (typed columns, materialization, target, sources, masks,
governance, format, ...) — with a `NORMALIZER_VERSION` byte folded in so a
future normalizer change deterministically invalidates rather than risking a
silent collision. Returns `None` when normalization fails or `typed_columns` is
empty, so a model can **never** be wrongly considered unchanged. Documented as a
best-effort cosmetic-invariant key, **not** a result-equivalence guarantee.

## Why split this out

A wrong skip is silent staleness — the worst failure mode for a transformation
engine. Landing the primitives first, with exhaustive unit coverage and zero
behavior change, keeps the eventual gate PR small and reviewable.

## Tests

Unit-tested in both crates (no warehouse needed):
- normalize: comment strip, whitespace collapse, keyword-case invariance,
  string-literal-case *preservation*, internal table/join/CTE/derived alias
  rename invariance, output-column-alias preservation, parse-failure ⇒ `None`,
  idempotence.
- determinism: each volatile construct flagged (incl. `ORDER BY RANDOM()`,
  volatile in `JOIN ON` / `BETWEEN` / sub-query), unordered `LIMIT` (incl.
  nested), unknown function ⇒ non-deterministic, plain SELECT ⇒ deterministic.
- skip_hash: deterministic; whitespace-only edit ⇒ **same** skip_hash AND
  **changed** recipe_hash (pins the divergence); internal alias rename ⇒ same;
  semantic change (WHERE / selected column / materialization / column mask) ⇒
  different; empty typed_columns or unparseable SQL ⇒ `None` sentinel.

## Scope

No `*Output` struct touched — `just codegen` produces no diff (verified). No
changes to `run.rs` / `state.rs` / `config.rs` / `main.rs`.