### PR TITLE
feat(engine/rocky-mcp): authoring prompt-trajectories + governance/drift preview

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4193,6 +4193,7 @@ dependencies = [
  "rocky-compiler",
  "rocky-core",
  "rocky-duckdb",
+ "rocky-ir",
  "rocky-snowflake",
  "rocky-sql",
  "schemars 1.2.1",

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -115,7 +115,9 @@ pub use load::run_load;
 pub use lsp::run_lsp;
 pub use metrics::{metrics_output, run_metrics};
 pub use optimize::{optimize_output, run_optimize};
-pub use plan::{PlanRunOptions, plan, plan_preview_output, plan_promote};
+pub use plan::{
+    PlanRunOptions, plan, plan_preview_output, plan_promote, populate_governance_actions,
+};
 pub use playground::{run_playground, run_playground_with_template};
 pub use preview::{
     PreviewDiffAlgorithmSelector, run_preview_cost, run_preview_create, run_preview_diff,

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -826,7 +826,16 @@ fn build_and_persist_replication_plan(
 /// [`rocky_core::config::RockyConfig::resolve_mask_for_env`] — unresolved
 /// tags are a compliance gap, reported by `rocky compliance`, not a
 /// preview row.
-fn populate_governance_actions(
+///
+/// This is the offline core of the governance preview: it compiles the
+/// `models/` directory and reads each model sidecar's
+/// `[classification]` / `mask` / `retention` declarations. It performs no
+/// warehouse I/O and applies nothing — the rows it pushes are a *preview*
+/// of the control-plane work `rocky run` would later issue through the
+/// [`GovernanceAdapter`](rocky_core::traits::GovernanceAdapter). It is
+/// public so the `rocky mcp` server can surface the same preview in-loop
+/// without shelling out or re-running source discovery.
+pub fn populate_governance_actions(
     cfg: &rocky_core::config::RockyConfig,
     models_dir: &Path,
     env: Option<&str>,

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -15,6 +15,10 @@ workspace = true
 rmcp = { workspace = true }
 rocky-cli = { path = "../rocky-cli" }
 rocky-core = { path = "../rocky-core" }
+# Typed IR data types: `TableRef` (parsed for drift_preview's describe_table
+# calls) and `DriftAction` (projected to a wire name). A leaf data crate — no
+# cycle (rocky-core already depends on it).
+rocky-ir = { path = "../rocky-ir" }
 rocky-sql = { path = "../rocky-sql" }
 rocky-compiler = { path = "../rocky-compiler" }
 # Direct dependency for the suggest_freshness_block tool: the hoisted

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -683,8 +683,12 @@ pub struct DriftedColumnLite {
 /// then empty. `added_columns` are present in the source but missing from
 /// the target (a `rocky run` would `ALTER TABLE ADD COLUMN`);
 /// `drifted_columns` carry a type change; `action` is the wire name of the
-/// [`DriftAction`](rocky_ir::DriftAction) the runtime would take
-/// (`ignore` / `alter_column_types` / `drop_and_recreate`).
+/// action the runtime would take (`ignore` / `add_columns` /
+/// `alter_column_types` / `drop_and_recreate`). `add_columns` covers the
+/// added-columns-only case: [`detect_drift`](rocky_core::drift::detect_drift)
+/// returns [`DriftAction::Ignore`](rocky_ir::DriftAction::Ignore) there
+/// (no type change), but a `rocky run` still issues `ALTER TABLE ADD COLUMN`,
+/// so the preview reports `add_columns` to match.
 #[derive(Debug, Default, Serialize, JsonSchema)]
 pub struct DriftPreviewResult {
     /// The source table the drift was checked against.
@@ -699,6 +703,6 @@ pub struct DriftPreviewResult {
     /// Columns present in the source but missing from the target table.
     pub added_columns: Vec<String>,
     /// Wire name of the action the runtime would take: `"ignore"`,
-    /// `"alter_column_types"`, or `"drop_and_recreate"`.
+    /// `"add_columns"`, `"alter_column_types"`, or `"drop_and_recreate"`.
     pub action: String,
 }

--- a/engine/crates/rocky-mcp/src/result_types.rs
+++ b/engine/crates/rocky-mcp/src/result_types.rs
@@ -585,3 +585,120 @@ pub struct ExplainModelResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
+
+// ---------------------------------------------------------------------------
+// Governance + drift preview (read-only, dry-run).
+// ---------------------------------------------------------------------------
+
+/// One classification-tag application in a `governance_preview` result —
+/// projected from `rocky_cli::output::ClassificationAction`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ClassificationActionLite {
+    /// Model the tag would be applied to.
+    pub model: String,
+    /// Column the tag would be applied to.
+    pub column: String,
+    /// Classification tag (e.g. `"pii"`, `"confidential"`).
+    pub tag: String,
+}
+
+/// One masking-policy application in a `governance_preview` result —
+/// projected from `rocky_cli::output::MaskAction`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct MaskActionLite {
+    /// Model the mask would be applied to.
+    pub model: String,
+    /// Column the mask would be applied to.
+    pub column: String,
+    /// Classification tag the mask resolves against.
+    pub tag: String,
+    /// Resolved strategy wire name (`"hash"`, `"redact"`, `"partial"`,
+    /// `"none"`) for the active environment.
+    pub resolved_strategy: String,
+}
+
+/// One retention-policy application in a `governance_preview` result —
+/// projected from `rocky_cli::output::RetentionAction`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RetentionActionLite {
+    /// Model the retention policy would be applied to.
+    pub model: String,
+    /// Retention duration in days, parsed from the sidecar (`"90d"` → 90,
+    /// `"1y"` → 365).
+    pub duration_days: u32,
+    /// Warehouse-native preview of the policy SQL / TBLPROPERTIES on the
+    /// active adapter, when the adapter has a first-class retention knob.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warehouse_preview: Option<String>,
+}
+
+/// `governance_preview` result — the pre-apply enforcement picture a
+/// subsequent `rocky run [--env <name>]` would reconcile: classification
+/// tags, masking policies, and retention policies declared across the
+/// project's model sidecars.
+///
+/// This is a DRY-RUN preview built offline (compile + sidecar read); it
+/// performs no warehouse I/O and applies nothing. Empty action lists mean
+/// the project declares no governance for that surface. There is no
+/// grants diff here — pre-apply governance covers classification / masking
+/// / retention only; grant reconciliation surfaces at `rocky run` time.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct GovernancePreviewResult {
+    /// The active environment the preview resolved masks against, when an
+    /// `env` was supplied (`[mask.<env>]` overrides on top of `[mask]`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    /// Classification tags the reconciler would apply.
+    pub classification_actions: Vec<ClassificationActionLite>,
+    /// Masking policies the reconciler would apply (only tags that resolve
+    /// to a strategy for the active environment).
+    pub mask_actions: Vec<MaskActionLite>,
+    /// Retention policies the reconciler would apply.
+    pub retention_actions: Vec<RetentionActionLite>,
+}
+
+/// One drifted column in a `drift_preview` result — a column present in
+/// both tables whose warehouse-reported type differs between source and
+/// target.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DriftedColumnLite {
+    /// Column name.
+    pub name: String,
+    /// The source table's reported type for this column.
+    pub source_type: String,
+    /// The target table's reported type for this column.
+    pub target_type: String,
+}
+
+/// `drift_preview` result — source-vs-target schema drift between two
+/// warehouse tables, computed via [`rocky_core::drift::detect_drift`] over
+/// the columns each table reports through `DESCRIBE`.
+///
+/// Read-only: it `DESCRIBE`s both tables and compares them, applying
+/// nothing. This is the same apples-to-apples comparison `rocky run`
+/// performs before an incremental load (both sides are warehouse-reported
+/// type strings, so there is no inferred-vs-observed type mismatch).
+/// `target_exists` is `false` when the target has not been materialized yet
+/// (the first `rocky run` would create it via CTAS) — the drift lists are
+/// then empty. `added_columns` are present in the source but missing from
+/// the target (a `rocky run` would `ALTER TABLE ADD COLUMN`);
+/// `drifted_columns` carry a type change; `action` is the wire name of the
+/// [`DriftAction`](rocky_ir::DriftAction) the runtime would take
+/// (`ignore` / `alter_column_types` / `drop_and_recreate`).
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct DriftPreviewResult {
+    /// The source table the drift was checked against.
+    pub source_table: String,
+    /// The target table the drift was checked against.
+    pub target_table: String,
+    /// Whether the target table exists in the warehouse. When `false`, the
+    /// target has not been materialized yet and the drift lists are empty.
+    pub target_exists: bool,
+    /// Columns present in both tables whose types differ.
+    pub drifted_columns: Vec<DriftedColumnLite>,
+    /// Columns present in the source but missing from the target table.
+    pub added_columns: Vec<String>,
+    /// Wire name of the action the runtime would take: `"ignore"`,
+    /// `"alter_column_types"`, or `"drop_and_recreate"`.
+    pub action: String,
+}

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -202,6 +202,27 @@ pub struct ExplainModelArgs {
     pub model: String,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct GovernancePreviewArgs {
+    /// Optional environment name (mirrors `rocky plan --env <name>`). When
+    /// set, masking policies resolve `[mask.<env>]` overrides on top of the
+    /// workspace `[mask]` defaults. Classification + retention previews are
+    /// env-invariant.
+    #[serde(default)]
+    pub env: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DriftPreviewArgs {
+    /// The source table to compare — a qualified `schema.table` (or
+    /// `catalog.schema.table`) reference. Both tables are `DESCRIBE`d and
+    /// their warehouse-reported types compared.
+    pub source_table: String,
+    /// The target table to compare against — a qualified `schema.table` (or
+    /// `catalog.schema.table`) reference.
+    pub target_table: String,
+}
+
 // ---------------------------------------------------------------------------
 // Prompt argument structs (schemars 1.x — rmcp's `Parameters<T>` bound).
 // MCP prompt arguments are string-typed on the wire; `Serialize` is part of
@@ -214,6 +235,20 @@ pub struct BuildModelArgs {
     /// (e.g. "daily completed-orders revenue by region"). The prompt threads
     /// this intent through Rocky's authoring loop.
     pub intent: String,
+}
+
+/// No-argument prompt args for the project-wide trajectories
+/// (`find_untested_models`, `summarize_project`). MCP prompts must declare a
+/// `Parameters<T>` type even when they take no input.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct NoArgs {}
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScopedModelArgs {
+    /// Optional single-model scope. When set, the trajectory focuses on this
+    /// model; when omitted, it sweeps the whole project.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1205,6 +1240,184 @@ impl RockyMcpServer {
         })
     }
 
+    // ----------------- governance + drift preview tools --------------------
+    // These let an agent see the full enforcement picture in-loop. Both are
+    // read-only DRY-RUNs — neither applies anything. `governance_preview` is
+    // offline (compile + sidecar read, the same core `rocky plan` uses);
+    // `drift_preview` hits the configured warehouse via the same adapter path
+    // as the grounding tools.
+
+    #[tool(
+        description = "Preview the pre-apply governance actions a subsequent `rocky run` would \
+         reconcile: classification tags, masking policies, and retention policies declared across \
+         the project's model sidecars. This is the same control-plane work `rocky plan` previews \
+         — a DRY-RUN computed offline from the compiled models + their `[classification]` / `mask` \
+         / `retention` config. It performs NO warehouse I/O and applies nothing. Empty action \
+         lists mean the project declares no governance for that surface. Pass `env` to resolve \
+         `[mask.<env>]` overrides (classification + retention are env-invariant). Use this to \
+         confirm a model's PII / masking / retention is wired before proposing — encode an \
+         invariant as governance, not just a WHERE clause."
+    )]
+    async fn governance_preview(
+        &self,
+        params: Parameters<GovernancePreviewArgs>,
+    ) -> Result<Json<GovernancePreviewResult>, String> {
+        let env = params.0.env;
+
+        let cfg = rocky_core::config::load_rocky_config(&self.config_path)
+            .map_err(|e| format!("could not load rocky.toml: {e:#}"))?;
+        // Resolve the active pipeline's target adapter type — the same input
+        // `rocky plan` feeds `populate_governance_actions` so retention's
+        // `warehouse_preview` renders the warehouse-native form. This is the
+        // ONLY thing the adapter type drives; classification + masking don't
+        // touch it, and retention already degrades to `None` on an unknown
+        // type. So a pipeline that won't resolve must not fail this offline
+        // tool — degrade to "" and the preview still reports every declared
+        // action, just without the warehouse-native retention rendering.
+        let adapter_type = rocky_cli::registry::resolve_pipeline(&cfg, None)
+            .ok()
+            .and_then(|(_, pipeline)| {
+                cfg.adapters
+                    .get(pipeline.target_adapter())
+                    .map(|a| a.adapter_type.clone())
+            })
+            .unwrap_or_default();
+
+        // Reuse the exact offline governance-preview core `rocky plan` uses —
+        // it compiles the models dir and reads each sidecar's governance
+        // config, populating a PlanOutput. No discovery, no adapter call.
+        let mut output = rocky_cli::output::PlanOutput::new(String::new());
+        output.env = env.clone();
+        commands::populate_governance_actions(
+            &cfg,
+            &self.models_dir,
+            env.as_deref(),
+            &adapter_type,
+            &mut output,
+        )
+        .map_err(|e| format!("governance preview failed: {e:#}"))?;
+
+        Ok(Json(GovernancePreviewResult {
+            env,
+            classification_actions: output
+                .classification_actions
+                .into_iter()
+                .map(|a| ClassificationActionLite {
+                    model: a.model,
+                    column: a.column,
+                    tag: a.tag,
+                })
+                .collect(),
+            mask_actions: output
+                .mask_actions
+                .into_iter()
+                .map(|a| MaskActionLite {
+                    model: a.model,
+                    column: a.column,
+                    tag: a.tag,
+                    resolved_strategy: a.resolved_strategy,
+                })
+                .collect(),
+            retention_actions: output
+                .retention_actions
+                .into_iter()
+                .map(|a| RetentionActionLite {
+                    model: a.model,
+                    duration_days: a.duration_days,
+                    warehouse_preview: a.warehouse_preview,
+                })
+                .collect(),
+        }))
+    }
+
+    #[tool(
+        description = "Preview source-vs-target schema drift between two warehouse tables — the \
+         same apples-to-apples comparison `rocky run` performs before an incremental load. Both \
+         tables are `DESCRIBE`d and their warehouse-reported column types compared via the engine's \
+         drift detector. Read-only: it applies nothing. Pass `source_table` and `target_table` as \
+         qualified `schema.table` (or `catalog.schema.table`) references. Returns drifted columns \
+         (type changed), added columns (in source, missing from target — a run would ADD COLUMN), \
+         and the action the runtime would take (`ignore` / `alter_column_types` / \
+         `drop_and_recreate`). When the target doesn't exist yet, `target_exists` is false and the \
+         lists are empty. Hits the configured warehouse — requires live credentials."
+    )]
+    async fn drift_preview(
+        &self,
+        params: Parameters<DriftPreviewArgs>,
+    ) -> Result<Json<DriftPreviewResult>, String> {
+        let args = params.0;
+
+        let adapter = self
+            .warehouse_adapter()
+            .map_err(|e| format!("could not resolve the warehouse adapter: {e:#}"))?
+            .ok_or_else(|| "could not resolve the target warehouse adapter".to_string())?;
+
+        let source_ref = parse_table_ref(&args.source_table)
+            .ok_or_else(|| format!("invalid source_table reference '{}'", args.source_table))?;
+        let target_ref = parse_table_ref(&args.target_table)
+            .ok_or_else(|| format!("invalid target_table reference '{}'", args.target_table))?;
+
+        // DESCRIBE both tables. A failed describe on the TARGET means it is not
+        // materialized yet (the first run would create it) — that's a clean
+        // "no drift, target absent" answer, not an error. A failed describe on
+        // the SOURCE is a genuine error (you asked to compare against a table
+        // that isn't there).
+        let source_cols = adapter.describe_table(&source_ref).await.map_err(|e| {
+            format!(
+                "could not describe source_table '{}': {e}",
+                args.source_table
+            )
+        })?;
+        // Most adapters `Err` on a missing table, but some report an empty
+        // column set instead; treat an empty source as not-found rather than
+        // letting it produce a vacuously "no drift" answer that would lie.
+        if source_cols.is_empty() {
+            return Err(format!(
+                "source_table '{}' has no columns (table not found or empty schema)",
+                args.source_table
+            ));
+        }
+        let target_cols = adapter
+            .describe_table(&target_ref)
+            .await
+            .unwrap_or_default();
+        let target_exists = !target_cols.is_empty();
+
+        if !target_exists {
+            return Ok(Json(DriftPreviewResult {
+                source_table: args.source_table,
+                target_table: args.target_table,
+                target_exists: false,
+                action: drift_action_wire_name(&rocky_ir::DriftAction::Ignore).to_string(),
+                ..Default::default()
+            }));
+        }
+
+        let result = rocky_core::drift::detect_drift(
+            &target_ref,
+            &source_cols,
+            &target_cols,
+            adapter.dialect(),
+        );
+
+        Ok(Json(DriftPreviewResult {
+            source_table: args.source_table,
+            target_table: args.target_table,
+            target_exists: true,
+            drifted_columns: result
+                .drifted_columns
+                .into_iter()
+                .map(|c| DriftedColumnLite {
+                    name: c.name,
+                    source_type: c.source_type,
+                    target_type: c.target_type,
+                })
+                .collect(),
+            added_columns: result.added_columns.into_iter().map(|c| c.name).collect(),
+            action: drift_action_wire_name(&result.action).to_string(),
+        }))
+    }
+
     // ------------------------- SHOULD tools --------------------------------
 
     #[tool(
@@ -1550,6 +1763,231 @@ impl RockyMcpServer {
         Ok(GetPromptResult::new(messages)
             .with_description(format!("Rocky model-authoring loop for: {intent}")))
     }
+
+    /// Sweep the project for models with no declarative tests and draft tests
+    /// for them. Orchestrates the read-only catalog + generator tools and stops
+    /// at *propose* — never applies.
+    #[prompt(
+        name = "find_untested_models",
+        description = "Find models with no declarative tests and draft tests for them: catalog \
+         -> identify untested models -> generate_tests / draft_contract -> propose. Stops at the \
+         human approval gate."
+    )]
+    async fn find_untested_models(
+        &self,
+        Parameters(_args): Parameters<NoArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let messages = vec![
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "I'll find the models that carry no declarative tests, draft tests grounded in \
+                 their real data, and stop at a proposed plan for you to review and apply. A model \
+                 that compiles is not the same as a model that is checked — tests are what make \
+                 the substrate trust a future run.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                "Find the untested models in this Rocky project and draft tests for them, using \
+                 the MCP tools at each step:\n\n\
+                 1. catalog — enumerate every model with its declared tests, checks, and \
+                 contract. Treat a model with no checks, no contract, and no test files as \
+                 untested. Prioritise leaf/marts models and anything carrying a primary key or a \
+                 grain you can name.\n\
+                 2. For each untested model, ground before you assert: sample_rows to see real \
+                 values, and profile_column on any key, status, or amount column to learn its null \
+                 rate, distinct count, and domain. The schema says a column exists; only the data \
+                 tells you whether it is unique, non-null, or bounded.\n\
+                 3. generate_tests — draft SQL assertions (not-null, grain uniqueness, value \
+                 ranges, referential integrity) from what you observed. For invariants better \
+                 expressed as required/protected columns, draft_contract instead. Both return \
+                 DRAFTS — write each assertion into the project's tests/ directory and the \
+                 contract next to its model.\n\
+                 4. compile — type-check after writing, and run the new tests via the `test` tool. \
+                 Fix against any diagnostic and re-run until clean.\n\
+                 5. propose — generate the plan that records the new tests/contracts. It is an \
+                 AI-authored plan with a plan_id.\n\n\
+                 RECONCILE DISCIPLINE: a test that asserts the wrong invariant passes and is still \
+                 wrong. Confirm the grain, the not-null columns, and the value domain against the \
+                 sampled data before you encode them — do not assume `id` is unique or `status` is \
+                 non-null without checking.\n\n\
+                 STOP at propose. Never apply an AI-authored change directly — a bare apply is \
+                 refused by design. Surface the plan_id and the review report, then the human runs \
+                 `rocky review <plan-id> --approve` and `rocky apply <plan-id>`. Do not approve on \
+                 the user's behalf unless they explicitly tell you to.",
+            ),
+        ];
+
+        Ok(GetPromptResult::new(messages).with_description(
+            "Find untested Rocky models and draft tests, stopping at the approval gate",
+        ))
+    }
+
+    /// Add uniqueness + not-null tests to a model's primary-key / unique
+    /// columns. Inspects the schema, identifies the key columns, drafts tests,
+    /// and stops at *propose*.
+    #[prompt(
+        name = "add_tests_to_pks",
+        description = "Add uniqueness + not-null tests to a model's primary-key / unique columns: \
+         inspect_schema -> identify key columns -> generate_tests for uniqueness + not-null -> \
+         propose. Stops at the human approval gate."
+    )]
+    async fn add_tests_to_pks(
+        &self,
+        Parameters(args): Parameters<ScopedModelArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let scope = match args.model.as_deref().map(str::trim) {
+            Some(m) if !m.is_empty() => format!("the model `{m}`"),
+            _ => "every model".to_string(),
+        };
+        let messages = vec![
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "I'll identify the primary-key and unique columns, draft uniqueness and not-null \
+                 tests grounded in the real data, and stop at a proposed plan for you to review \
+                 and apply. A declared key is a claim; the data is what proves it.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                format!(
+                    "Add uniqueness + not-null tests to the key columns of {scope} in this Rocky \
+                     project, using the MCP tools at each step:\n\n\
+                     1. inspect_schema — read the typed columns. Identify the primary-key / unique \
+                     / grain columns: an explicit key in the sidecar, an `id`-shaped column, or \
+                     the columns that define the model's grain.\n\
+                     2. profile_column — for each candidate key column, confirm it is actually \
+                     unique (distinct count == row count) and non-null before you assert it. A \
+                     column named `id` that has duplicates or nulls is not a key, and a test that \
+                     claims it is will fail on the next run — find that out now, from the data.\n\
+                     3. generate_tests — draft a uniqueness assertion and a not-null assertion for \
+                     each confirmed key column (each returns 0 rows when the invariant holds). \
+                     These are DRAFTS — write each into the project's tests/ directory as \
+                     `<model>_<name>.sql`.\n\
+                     4. compile, then run the new tests via the `test` tool. Loop until clean.\n\
+                     5. propose — generate the plan recording the new tests. It is an AI-authored \
+                     plan with a plan_id.\n\n\
+                     RECONCILE DISCIPLINE: only assert uniqueness/not-null on columns the profile \
+                     actually shows to be unique/non-null. Encoding a wrong key invariant is worse \
+                     than none — it green-lights a future run that should have failed.\n\n\
+                     STOP at propose. Never apply an AI-authored change directly — a bare apply is \
+                     refused by design. Surface the plan_id and the review report, then the human \
+                     runs `rocky review <plan-id> --approve` and `rocky apply <plan-id>`. Do not \
+                     approve on the user's behalf unless they explicitly tell you to."
+                ),
+            ),
+        ];
+
+        Ok(GetPromptResult::new(messages).with_description(format!(
+            "Add uniqueness + not-null tests to the keys of {scope}"
+        )))
+    }
+
+    /// Produce a structured, read-only summary of the project from the catalog
+    /// and lineage. No edits, no propose — purely informational.
+    #[prompt(
+        name = "summarize_project",
+        description = "Produce a structured, read-only summary of the Rocky project: catalog + \
+         lineage -> grouped overview of models, their grain, governance, tests, and DAG shape. \
+         Read-only — no edits, no propose."
+    )]
+    async fn summarize_project(
+        &self,
+        Parameters(_args): Parameters<NoArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let messages = vec![
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "I'll summarize this Rocky project from the catalog and lineage. This is a \
+                 read-only orientation — I will not edit, propose, or apply anything.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                "Summarize this Rocky project, using only the read-only MCP tools:\n\n\
+                 1. catalog — enumerate every model with its target table, materialization \
+                 strategy, declared tests/checks, contract, and governance (classification / mask \
+                 / retention).\n\
+                 2. lineage — for the key models (sources, marts/leaf models), trace upstream \
+                 dependencies to understand the DAG shape and how data flows.\n\
+                 3. Group the result into a structured summary: sources and raw inputs; \
+                 intermediate transforms; marts / leaf outputs. For each, note its grain (one row \
+                 per what?), its materialization strategy, whether it carries tests / a contract / \
+                 governance, and its place in the DAG.\n\
+                 4. Call out gaps an owner would care about: untested leaf models, PII columns \
+                 with no mask, models with no contract, or long undocumented dependency chains. \
+                 Frame these as observations, not actions.\n\n\
+                 This is purely informational — do NOT write SQL, draft tests, propose a plan, or \
+                 apply anything. If the user then wants to act on a gap, the find_untested_models \
+                 or build_model trajectory is the next step.",
+            ),
+        ];
+
+        Ok(GetPromptResult::new(messages)
+            .with_description("Read-only structured summary of the Rocky project"))
+    }
+
+    /// Diagnose and fix failing declarative tests: run the tests, ground each
+    /// failure with profile_column, propose a fix. Stops at *propose*.
+    #[prompt(
+        name = "fix_failing_test",
+        description = "Diagnose and fix failing declarative tests: run `test` -> for each failure \
+         profile_column the implicated columns to ground the cause -> propose a fix. Stops at the \
+         human approval gate."
+    )]
+    async fn fix_failing_test(
+        &self,
+        Parameters(args): Parameters<ScopedModelArgs>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, McpError> {
+        let scope = match args.model.as_deref().map(str::trim) {
+            Some(m) if !m.is_empty() => format!("the model `{m}`"),
+            _ => "the project".to_string(),
+        };
+        let messages = vec![
+            PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                "I'll run the tests, ground each failure in the real data before changing \
+                 anything, and stop at a proposed fix for you to review and apply. A failing test \
+                 is a signal — I will find out whether the test is wrong or the data is wrong \
+                 before I touch either.",
+            ),
+            PromptMessage::new_text(
+                PromptMessageRole::User,
+                format!(
+                    "Diagnose and fix the failing tests in {scope}, using the MCP tools at each \
+                     step:\n\n\
+                     1. test — run the declarative tests and read which assertions fail, on which \
+                     model, and the failing-row count. Each failure names the invariant it \
+                     checks.\n\
+                     2. For each failure, ground the cause before deciding the fix: profile_column \
+                     the implicated columns (the ones the assertion references) to see their \
+                     actual null rate, distinct count, and value domain, and sample_rows to look \
+                     at offending rows. The failure tells you WHAT broke; the data tells you \
+                     WHY.\n\
+                     3. Decide which side is wrong. Either the model SQL is wrong (it produces \
+                     duplicates / nulls / out-of-domain values it shouldn't) — fix the SQL — or \
+                     the test encodes an invariant the data was never meant to hold — fix the \
+                     assertion. Do not weaken a test just to make it pass; that hides the \
+                     defect.\n\
+                     4. compile, then re-run the `test` tool. Loop until the failure is genuinely \
+                     resolved, not silenced.\n\
+                     5. propose — generate the plan recording the fix. It is an AI-authored plan \
+                     with a plan_id.\n\n\
+                     RECONCILE DISCIPLINE: the whole point is to check the data, not just the \
+                     schema. A uniqueness test failing because the grain is actually composite \
+                     (two columns, not one) is a real finding you can only see in the rows.\n\n\
+                     STOP at propose. Never apply an AI-authored change directly — a bare apply is \
+                     refused by design. Surface the plan_id and the review report, then the human \
+                     runs `rocky review <plan-id> --approve` and `rocky apply <plan-id>`. Do not \
+                     approve on the user's behalf unless they explicitly tell you to."
+                ),
+            ),
+        ];
+
+        Ok(GetPromptResult::new(messages)
+            .with_description(format!("Diagnose and fix failing tests in {scope}")))
+    }
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -1670,6 +2108,43 @@ fn column_stats_sql(table_ref: &str, col: &str) -> String {
         "SELECT COUNT(*) AS n, COUNT({col}) AS non_null, COUNT(DISTINCT {col}) AS distinct_n \
          FROM {table_ref}"
     )
+}
+
+/// Parse a qualified `schema.table` / `catalog.schema.table` reference into a
+/// [`TableRef`](rocky_ir::TableRef) for `drift_preview`'s `describe_table`
+/// calls.
+///
+/// Mirrors `commands/profile.rs::observed_column_types`: a two-part name has an
+/// empty catalog (DuckDB / catalog-less dialects), a three-part name carries
+/// one. Any other arity is rejected (returns `None`). Segments are not
+/// validated here — `describe_table` is parameter-safe (the adapter quotes the
+/// ref); a bad name surfaces as a describe error, not SQL injection.
+fn parse_table_ref(reference: &str) -> Option<rocky_ir::TableRef> {
+    let parts: Vec<&str> = reference.split('.').collect();
+    match parts.as_slice() {
+        [schema, table] => Some(rocky_ir::TableRef {
+            catalog: String::new(),
+            schema: (*schema).to_string(),
+            table: (*table).to_string(),
+        }),
+        [catalog, schema, table] => Some(rocky_ir::TableRef {
+            catalog: (*catalog).to_string(),
+            schema: (*schema).to_string(),
+            table: (*table).to_string(),
+        }),
+        _ => None,
+    }
+}
+
+/// Stable wire name for a [`DriftAction`](rocky_ir::DriftAction) in a
+/// `drift_preview` result — snake_case, matching the strings `rocky run`
+/// emits in `DriftActionOutput.action`.
+fn drift_action_wire_name(action: &rocky_ir::DriftAction) -> &'static str {
+    match action {
+        rocky_ir::DriftAction::DropAndRecreate => "drop_and_recreate",
+        rocky_ir::DriftAction::AlterColumnTypes => "alter_column_types",
+        rocky_ir::DriftAction::Ignore => "ignore",
+    }
 }
 
 /// Read a `serde_json::Value` grounding cell as a `u64`, tolerating the

--- a/engine/crates/rocky-mcp/src/tools.rs
+++ b/engine/crates/rocky-mcp/src/tools.rs
@@ -1337,7 +1337,7 @@ impl RockyMcpServer {
          drift detector. Read-only: it applies nothing. Pass `source_table` and `target_table` as \
          qualified `schema.table` (or `catalog.schema.table`) references. Returns drifted columns \
          (type changed), added columns (in source, missing from target — a run would ADD COLUMN), \
-         and the action the runtime would take (`ignore` / `alter_column_types` / \
+         and the action the runtime would take (`ignore` / `add_columns` / `alter_column_types` / \
          `drop_and_recreate`). When the target doesn't exist yet, `target_exists` is false and the \
          lists are empty. Hits the configured warehouse — requires live credentials."
     )]
@@ -1400,6 +1400,20 @@ impl RockyMcpServer {
             adapter.dialect(),
         );
 
+        // `detect_drift` returns `DriftAction::Ignore` whenever there are no
+        // type-changed columns — INCLUDING the added-columns-only case. But
+        // `rocky run` does NOT ignore that case: its `else if
+        // !added_columns.is_empty()` branch (commands/run.rs) issues
+        // `ALTER TABLE ADD COLUMN` and reports the action as `add_columns`.
+        // Mirror the runtime's emitted action here so the preview doesn't tell
+        // an agent "no action" for a run that would actually ALTER the target.
+        let action =
+            if result.action == rocky_ir::DriftAction::Ignore && !result.added_columns.is_empty() {
+                "add_columns".to_string()
+            } else {
+                drift_action_wire_name(&result.action).to_string()
+            };
+
         Ok(Json(DriftPreviewResult {
             source_table: args.source_table,
             target_table: args.target_table,
@@ -1414,7 +1428,7 @@ impl RockyMcpServer {
                 })
                 .collect(),
             added_columns: result.added_columns.into_iter().map(|c| c.name).collect(),
-            action: drift_action_wire_name(&result.action).to_string(),
+            action,
         }))
     }
 

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -83,8 +83,10 @@ async fn tools_list_returns_expected_set() {
             "compile",
             "dependents",
             "draft_contract",
+            "drift_preview",
             "explain_model",
             "generate_tests",
+            "governance_preview",
             "history",
             "inspect_schema",
             "lineage",
@@ -304,17 +306,25 @@ async fn dependents_returns_downstream_consumers() {
 }
 
 #[tokio::test]
-async fn prompts_list_includes_build_model() {
+async fn prompts_list_returns_expected_set() {
     let dir = TempDir::new().unwrap();
     write_project(dir.path(), &dir.path().join("test.duckdb"));
     let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
 
     let client = connect(server).await;
     let prompts = client.list_all_prompts().await.expect("list prompts");
-    let names: Vec<String> = prompts.iter().map(|p| p.name.clone()).collect();
-    assert!(
-        names.iter().any(|n| n == "build_model"),
-        "prompts/list must include build_model, got {names:?}"
+    let mut names: Vec<String> = prompts.iter().map(|p| p.name.clone()).collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "add_tests_to_pks",
+            "build_model",
+            "find_untested_models",
+            "fix_failing_test",
+            "summarize_project",
+        ],
+        "prompts/list must enumerate the full trajectory set"
     );
 
     // The build_model prompt declares its single `intent` argument.
@@ -329,6 +339,19 @@ async fn prompts_list_includes_build_model() {
     assert!(
         args.iter().any(|a| a.name == "intent"),
         "build_model must declare an `intent` argument"
+    );
+
+    // The scoped trajectories declare an optional `model` argument.
+    let add_tests = prompts
+        .iter()
+        .find(|p| p.name == "add_tests_to_pks")
+        .expect("add_tests_to_pks prompt present");
+    assert!(
+        add_tests
+            .arguments
+            .as_ref()
+            .is_some_and(|a| a.iter().any(|arg| arg.name == "model")),
+        "add_tests_to_pks must declare a `model` argument"
     );
 
     client.cancel().await.unwrap();
@@ -390,6 +413,121 @@ async fn prompt_get_build_model_returns_authoring_loop() {
     assert!(
         haystack.to_lowercase().contains("reconcile"),
         "build_model must emphasize the reconcile discipline"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// Flatten a prompt result's text messages into one searchable haystack.
+fn prompt_text(result: &rmcp::model::GetPromptResult) -> String {
+    use rmcp::model::PromptMessageContent;
+    result
+        .messages
+        .iter()
+        .filter_map(|m| match &m.content {
+            PromptMessageContent::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Each authoring trajectory orchestrates the existing read-only / grounding
+/// MCP tools and stops at the human gate — the propose-stop discipline must
+/// survive copy edits, so assert on the load-bearing anchors. `summarize_project`
+/// is the read-only exception: it must NOT propose.
+#[tokio::test]
+async fn authoring_trajectories_orchestrate_tools_and_stop_at_the_gate() {
+    let dir = TempDir::new().unwrap();
+    write_project(dir.path(), &dir.path().join("test.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // find_untested_models — catalog -> generate_tests/draft_contract -> propose,
+    // stopping at the review/apply gate.
+    let untested = client
+        .get_prompt(GetPromptRequestParams::new("find_untested_models"))
+        .await
+        .expect("get_prompt find_untested_models");
+    let haystack = prompt_text(&untested);
+    for anchor in [
+        "catalog",
+        "generate_tests",
+        "draft_contract",
+        "propose",
+        "review",
+        "apply",
+    ] {
+        assert!(
+            haystack.contains(anchor),
+            "find_untested_models should mention `{anchor}`; full text:\n{haystack}"
+        );
+    }
+    assert!(
+        haystack.to_lowercase().contains("reconcile"),
+        "find_untested_models must carry the reconcile discipline"
+    );
+
+    // add_tests_to_pks — inspect_schema -> profile_column -> generate_tests ->
+    // propose. The optional `model` arg scopes the trajectory text.
+    let pk_args = serde_json::json!({ "model": "orders" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let pks = client
+        .get_prompt(GetPromptRequestParams::new("add_tests_to_pks").with_arguments(pk_args))
+        .await
+        .expect("get_prompt add_tests_to_pks");
+    let haystack = prompt_text(&pks);
+    for anchor in [
+        "orders", // the scoped model name threads into the text
+        "inspect_schema",
+        "profile_column",
+        "generate_tests",
+        "propose",
+        "review",
+        "apply",
+    ] {
+        assert!(
+            haystack.contains(anchor),
+            "add_tests_to_pks should mention `{anchor}`; full text:\n{haystack}"
+        );
+    }
+
+    // fix_failing_test — test -> profile_column -> propose, stopping at the gate.
+    let fix = client
+        .get_prompt(GetPromptRequestParams::new("fix_failing_test"))
+        .await
+        .expect("get_prompt fix_failing_test");
+    let haystack = prompt_text(&fix);
+    for anchor in ["test", "profile_column", "propose", "review", "apply"] {
+        assert!(
+            haystack.contains(anchor),
+            "fix_failing_test should mention `{anchor}`; full text:\n{haystack}"
+        );
+    }
+
+    // summarize_project — read-only: catalog + lineage, and explicitly NOT a
+    // propose/apply trajectory.
+    let summary = client
+        .get_prompt(GetPromptRequestParams::new("summarize_project"))
+        .await
+        .expect("get_prompt summarize_project");
+    let haystack = prompt_text(&summary);
+    for anchor in ["catalog", "lineage"] {
+        assert!(
+            haystack.contains(anchor),
+            "summarize_project should mention `{anchor}`; full text:\n{haystack}"
+        );
+    }
+    assert!(
+        haystack.to_lowercase().contains("read-only")
+            || haystack.to_lowercase().contains("read only"),
+        "summarize_project must declare itself read-only"
+    );
+    assert!(
+        !haystack.contains("plan_id"),
+        "summarize_project is read-only and must not drive a propose/plan flow:\n{haystack}"
     );
 
     client.cancel().await.unwrap();
@@ -1009,6 +1147,236 @@ async fn generator_tools_degrade_without_api_key() {
             .as_str()
             .unwrap()
             .contains(rocky_ai::client::AI_API_KEY_ENV)
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// Write a DuckDB project whose single model declares governance — a
+/// `[classification]` tag + a `retention` policy, with a workspace `[mask]`
+/// resolving the tag. `governance_preview` reads this offline (no warehouse).
+fn write_governed_project(dir: &Path, db_path: &Path) {
+    std::fs::create_dir_all(dir.join("models")).unwrap();
+    std::fs::write(
+        dir.join("rocky.toml"),
+        format!(
+            r#"[adapter]
+type = "duckdb"
+path = "{}"
+
+[mask]
+pii = "hash"
+
+[mask.prod]
+pii = "redact"
+
+[pipeline.p]
+strategy = "full_refresh"
+
+[pipeline.p.source.discovery]
+adapter = "default"
+
+[pipeline.p.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["source"]
+
+[pipeline.p.target]
+catalog_template = "warehouse"
+schema_template = "out"
+"#,
+            db_path.display()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("models").join("orders.sql"),
+        "SELECT 1 AS id, 'a@b.com' AS email\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("models").join("orders.toml"),
+        r#"name = "orders"
+retention = "90d"
+
+[strategy]
+type = "full_refresh"
+
+[target]
+catalog = "warehouse"
+schema = "out"
+table = "orders"
+
+[classification]
+email = "pii"
+"#,
+    )
+    .unwrap();
+}
+
+/// `governance_preview` is offline (compile + sidecar read, no warehouse): it
+/// surfaces the classification / mask / retention the model declares, resolving
+/// the mask against the active env. Requires no API key and no live creds.
+#[tokio::test]
+async fn governance_preview_surfaces_declared_actions_offline() {
+    let dir = TempDir::new().unwrap();
+    // No DuckDB file is created — the tool must not touch the warehouse.
+    write_governed_project(dir.path(), &dir.path().join("warehouse.duckdb"));
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    // Default env → `pii` resolves to `hash`.
+    let result = client
+        .call_tool(CallToolRequestParams::new("governance_preview"))
+        .await
+        .expect("governance_preview call");
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "governance_preview is offline and must not error"
+    );
+    let sc = result.structured_content.expect("structured content");
+
+    let classifications = sc["classification_actions"].as_array().unwrap();
+    assert_eq!(classifications.len(), 1, "one (model,column,tag): {sc:?}");
+    assert_eq!(classifications[0]["model"], serde_json::json!("orders"));
+    assert_eq!(classifications[0]["column"], serde_json::json!("email"));
+    assert_eq!(classifications[0]["tag"], serde_json::json!("pii"));
+
+    let masks = sc["mask_actions"].as_array().unwrap();
+    assert_eq!(masks.len(), 1, "pii resolves to a strategy: {sc:?}");
+    assert_eq!(masks[0]["resolved_strategy"], serde_json::json!("hash"));
+
+    let retentions = sc["retention_actions"].as_array().unwrap();
+    assert_eq!(retentions.len(), 1, "one retention policy: {sc:?}");
+    assert_eq!(retentions[0]["duration_days"], serde_json::json!(90));
+
+    // The `prod` env override resolves `pii` to `redact` instead.
+    let prod_args = serde_json::json!({ "env": "prod" })
+        .as_object()
+        .unwrap()
+        .clone();
+    let prod = client
+        .call_tool(CallToolRequestParams::new("governance_preview").with_arguments(prod_args))
+        .await
+        .expect("governance_preview --env prod call")
+        .structured_content
+        .expect("structured content");
+    assert_eq!(prod["env"], serde_json::json!("prod"));
+    assert_eq!(
+        prod["mask_actions"][0]["resolved_strategy"],
+        serde_json::json!("redact"),
+        "prod env must resolve pii to redact: {prod:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// `drift_preview` DESCRIBEs two warehouse tables and compares their reported
+/// column types — the same apples-to-apples comparison `rocky run` performs.
+/// Source has a widened `id` (BIGINT vs INTEGER) plus an extra column the
+/// target lacks; the tool must surface both, and report a missing target as
+/// `target_exists: false`.
+#[tokio::test]
+async fn drift_preview_compares_source_and_target_on_duckdb() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("warehouse.duckdb");
+    write_project(dir.path(), &db_path);
+
+    {
+        use rocky_core::traits::WarehouseAdapter;
+        let adapter = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(&db_path).unwrap();
+        adapter
+            .execute_statement("CREATE SCHEMA IF NOT EXISTS out")
+            .await
+            .unwrap();
+        // Target: id INTEGER, status VARCHAR.
+        adapter
+            .execute_statement(
+                "CREATE OR REPLACE TABLE out.orders AS \
+                 SELECT CAST(1 AS INTEGER) AS id, 'COMPLETE' AS status",
+            )
+            .await
+            .unwrap();
+        // Source: id BIGINT (widened), status VARCHAR, plus a new `region` column.
+        adapter
+            .execute_statement(
+                "CREATE OR REPLACE TABLE out.orders_next AS \
+                 SELECT CAST(1 AS BIGINT) AS id, 'COMPLETE' AS status, 'EU' AS region",
+            )
+            .await
+            .unwrap();
+    }
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let args = serde_json::json!({
+        "source_table": "out.orders_next",
+        "target_table": "out.orders",
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("drift_preview").with_arguments(args))
+        .await
+        .expect("drift_preview call");
+    assert_ne!(result.is_error, Some(true), "drift_preview must not error");
+    let sc = result.structured_content.expect("structured content");
+
+    assert_eq!(sc["target_exists"], serde_json::json!(true));
+    // `id` drifted (BIGINT vs INTEGER) — a type change between the two tables.
+    let drifted = sc["drifted_columns"].as_array().unwrap();
+    assert!(
+        drifted.iter().any(|d| d["name"] == serde_json::json!("id")),
+        "id must drift (BIGINT vs INTEGER): {sc:?}"
+    );
+    // `region` is present in the source but absent from the target.
+    let added = sc["added_columns"].as_array().unwrap();
+    assert!(
+        added.iter().any(|c| *c == serde_json::json!("region")),
+        "region must be an added column: {sc:?}"
+    );
+
+    // A non-existent target → target_exists false, empty drift lists.
+    let absent_args = serde_json::json!({
+        "source_table": "out.orders_next",
+        "target_table": "out.does_not_exist",
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let absent = client
+        .call_tool(CallToolRequestParams::new("drift_preview").with_arguments(absent_args))
+        .await
+        .expect("drift_preview call (absent target)")
+        .structured_content
+        .expect("structured content");
+    assert_eq!(absent["target_exists"], serde_json::json!(false));
+    assert!(
+        absent["drifted_columns"].as_array().unwrap().is_empty(),
+        "absent target → no drift rows: {absent:?}"
+    );
+
+    // A missing SOURCE is an error, never a vacuously-clean "no drift" answer —
+    // the source side is the thing being compared against, so its absence must
+    // surface, not silently report zero drift.
+    let bad_source_args = serde_json::json!({
+        "source_table": "out.does_not_exist",
+        "target_table": "out.orders",
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let bad_source = client
+        .call_tool(CallToolRequestParams::new("drift_preview").with_arguments(bad_source_args))
+        .await
+        .expect("drift_preview call (absent source)");
+    assert_eq!(
+        bad_source.is_error,
+        Some(true),
+        "a missing source_table must be an error, not a clean no-drift result"
     );
 
     client.cancel().await.unwrap();

--- a/engine/crates/rocky-mcp/tests/roundtrip.rs
+++ b/engine/crates/rocky-mcp/tests/roundtrip.rs
@@ -1382,6 +1382,87 @@ async fn drift_preview_compares_source_and_target_on_duckdb() {
     client.cancel().await.unwrap();
 }
 
+/// The added-columns-only case: the source has a column the target lacks, but
+/// NO existing column drifted in type. `detect_drift` returns
+/// `DriftAction::Ignore` for this (it tracks only type changes), yet a
+/// `rocky run` would issue `ALTER TABLE ADD COLUMN` and report the action as
+/// `add_columns`. `drift_preview` must mirror the runtime, not the raw enum —
+/// reporting `ignore` here would tell an agent "no action" for a run that
+/// actually alters the target. The existing drift test combines a type-drift
+/// with an added column (which resolves to `alter_column_types`), so it does
+/// not exercise this path.
+#[tokio::test]
+async fn drift_preview_reports_add_columns_when_only_columns_added() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("warehouse.duckdb");
+    write_project(dir.path(), &db_path);
+
+    {
+        use rocky_core::traits::WarehouseAdapter;
+        let adapter = rocky_duckdb::adapter::DuckDbWarehouseAdapter::open(&db_path).unwrap();
+        adapter
+            .execute_statement("CREATE SCHEMA IF NOT EXISTS out")
+            .await
+            .unwrap();
+        // Target and source share IDENTICAL types for `id`/`status` (no type
+        // drift); the source carries one extra column the target lacks.
+        adapter
+            .execute_statement(
+                "CREATE OR REPLACE TABLE out.orders AS \
+                 SELECT CAST(1 AS INTEGER) AS id, 'COMPLETE' AS status",
+            )
+            .await
+            .unwrap();
+        adapter
+            .execute_statement(
+                "CREATE OR REPLACE TABLE out.orders_next AS \
+                 SELECT CAST(1 AS INTEGER) AS id, 'COMPLETE' AS status, 'EU' AS region",
+            )
+            .await
+            .unwrap();
+    }
+
+    let server = RockyMcpServer::new(dir.path().join("rocky.toml"));
+    let client = connect(server).await;
+
+    let args = serde_json::json!({
+        "source_table": "out.orders_next",
+        "target_table": "out.orders",
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new("drift_preview").with_arguments(args))
+        .await
+        .expect("drift_preview call");
+    assert_ne!(result.is_error, Some(true), "drift_preview must not error");
+    let sc = result.structured_content.expect("structured content");
+
+    assert_eq!(sc["target_exists"], serde_json::json!(true));
+    // No existing column changed type — the empty drift list proves we are on
+    // the added-columns-only path, not `alter_column_types`.
+    assert!(
+        sc["drifted_columns"].as_array().unwrap().is_empty(),
+        "no column drifted in type: {sc:?}"
+    );
+    // The new column is surfaced.
+    let added = sc["added_columns"].as_array().unwrap();
+    assert!(
+        added.iter().any(|c| *c == serde_json::json!("region")),
+        "region must be an added column: {sc:?}"
+    );
+    // And the action must mirror what `rocky run` emits, not the raw
+    // `DriftAction::Ignore` the detector returns.
+    assert_eq!(
+        sc["action"],
+        serde_json::json!("add_columns"),
+        "added-columns-only must report add_columns (run would ALTER TABLE ADD COLUMN): {sc:?}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn suggest_freshness_block_returns_null_without_api_key() {
     // Without ANTHROPIC_API_KEY the tool degrades gracefully: a null block


### PR DESCRIPTION
Completes the `rocky-mcp` authoring substrate: four scripted prompt
trajectories and two read-only preview tools. Builds on the existing
`build_model` prompt + generator tools — no logic is duplicated.

## Prompt trajectories (new `prompt_router` entries — not tools)

Each scripts a disciplined, SQL-first message sequence that orchestrates
the existing MCP tools and stops at the human approval gate.

- `find_untested_models` — `catalog` → identify models with no declarative
  tests → `generate_tests` / `draft_contract` → propose.
- `add_tests_to_pks` — `inspect_schema` → identify key columns → confirm
  uniqueness/not-null from the profile → `generate_tests` → propose.
- `summarize_project` — `catalog` + `lineage` → a read-only structured
  summary (no edits, no propose).
- `fix_failing_test` — run `test` → `profile_column` the implicated columns
  to ground each failure → propose a fix.

Each carries the reconcile discipline ("it compiled" is not "it's correct")
and the never-self-apply gate.

## Preview tools (new read-only tools — no warehouse mutation)

- `governance_preview` — the pre-apply enforcement picture a subsequent
  `rocky run` would reconcile: classification tags, masking policies, and
  retention policies declared across the model sidecars. Computed offline
  by reusing `rocky plan`'s governance-preview core (compile + sidecar
  read); no warehouse I/O, no discovery, applies nothing. An optional `env`
  resolves `[mask.<env>]` overrides.
- `drift_preview` — source-vs-target schema drift between two warehouse
  tables, via the engine's drift detector over each table's reported
  columns — the same apples-to-apples comparison `rocky run` performs before
  an incremental load. Hits the configured warehouse like the grounding
  tools; requires live credentials.

## Scope / codegen

Result types are crate-local rmcp `Json<T>` projections in
`result_types.rs`. `output.rs` / `export-schemas` are untouched, so
`just codegen` produces no diff (verified: re-export → empty `git status`
for `schemas/` + generated bindings). The only `rocky-cli` change is making
`populate_governance_actions` public so the MCP server can reuse the offline
preview core without shelling out.

## Verify

- `cargo build -p rocky-mcp` ✓
- `cargo clippy -p rocky-mcp --all-targets --all-features -- -D warnings` ✓
- `cargo fmt -- --check` ✓
- `cargo test -p rocky-mcp` ✓ (26 round-trip tests) · `cargo test -p rocky-cli` ✓ (639 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)