### PR TITLE
docs: fix rocky-config skill load-contract key (contract, not contracts)

### DIFF
--- a/.claude/skills/rocky-config/SKILL.md
+++ b/.claude/skills/rocky-config/SKILL.md
@@ -291,8 +291,10 @@ threshold = 0                                            # max failing rows
 
 ## Contracts
 
+Enforced on `load` pipelines: the load runs into a staging table, validates the landed schema against the contract, and promotes to the target only on pass — a violation drops staging and fails, so non-conforming data never lands. Types compare in Rocky's normalized vocabulary, so one contract ports across warehouses.
+
 ```toml
-[pipeline.<name>.contracts]
+[pipeline.<name>.contract]
 required_columns = [
     { name = "id", type = "BIGINT", nullable = false },
 ]


### PR DESCRIPTION
The rocky-config skill documented [pipeline.<name>.contracts] (plural), but the implemented key on load pipelines is contract (singular). Since load config has no deny_unknown_fields, the plural key silently no-ops on a load pipeline. Fixes the key and adds a note on the load staging-promote enforcement.