### PR TITLE
fix(engine): harden skip-hash determinism scan + normalizer against false-pure

### DIFF
--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -817,6 +817,14 @@ impl ModelIr {
     /// `typed_columns` is empty (a partial typecheck). A `None` model is never
     /// equal to any other, so a caller comparing two `skip_hash` values can
     /// never wrongly treat such a model as unchanged.
+    ///
+    /// # Call-time contract
+    ///
+    /// Call this on the **static** form of the IR — the
+    /// [`MaterializationStrategy::TimeInterval`] `window` must be `None`, the
+    /// same invariant [`Self::recipe_hash`] requires. Hashing a resolved
+    /// partition window would yield a different `skip_hash` per partition,
+    /// defeating the partition-invariant intent. See [`SkipHashProjection`].
     #[must_use]
     pub fn skip_hash(&self) -> Option<blake3::Hash> {
         if self.typed_columns.is_empty() {
@@ -941,9 +949,21 @@ const NORMALIZER_VERSION: u8 = 1;
 /// Borrowed projection of [`ModelIr`] hashed by [`ModelIr::skip_hash`].
 ///
 /// Holds the normalised SQL string plus the typed structural facts that
-/// define a model's logic, excluding cosmetic SQL text and runtime-derived
-/// fields (`lineage_edges`, partition `window`). Serialised through the same
-/// canonical-JSON machinery as [`ModelIr::recipe_hash`].
+/// define a model's logic. The whole [`MaterializationStrategy`] *is* hashed
+/// via the `materialization` field — including, for
+/// [`MaterializationStrategy::TimeInterval`], its `time_column` and
+/// `granularity`. The per-partition `window` is part of that strategy but is
+/// runtime-derived, not a property of the model's logic, so the hash must be
+/// computed from the **static** form of the IR where `window` is `None`
+/// (exactly as [`ModelIr::recipe_hash`] requires). Computing the key against
+/// the static form keeps it partition-invariant: the same model produces the
+/// same `skip_hash` regardless of which partition is being built.
+///
+/// Two `ModelIr` fields are intentionally **excluded** from the projection as
+/// non-output identity: `name` (the model's identifier, not its computed
+/// result) and `cost_ceiling` (a budget guard that does not change the rows
+/// produced). Serialised through the same canonical-JSON machinery as
+/// [`ModelIr::recipe_hash`].
 #[derive(Serialize)]
 struct SkipHashProjection<'a> {
     normalizer_version: u8,

--- a/engine/crates/rocky-sql/src/determinism.rs
+++ b/engine/crates/rocky-sql/src/determinism.rs
@@ -29,7 +29,7 @@
 
 use std::ops::ControlFlow;
 
-use sqlparser::ast::{Expr, Query, SetExpr, Statement, visit_expressions};
+use sqlparser::ast::{Expr, Query, SetExpr, Statement, Visit, Visitor, visit_expressions};
 
 use crate::parser::parse_single_statement;
 
@@ -67,15 +67,24 @@ const VOLATILE_FUNCTIONS: &[&str] = &[
 
 /// Volatile builtins that take no parentheses and therefore parse as a bare
 /// [`Expr::Identifier`] (not [`Expr::Function`]) under the engine's dialect —
-/// `SELECT current_user`, `SELECT session_user`. Matched case-insensitively.
+/// `SELECT current_user`, `SELECT current_catalog`. Matched case-insensitively.
 /// A user column that happens to share one of these names is flagged volatile,
 /// which is the safe direction (a redundant rebuild, never a wrong skip).
+///
+/// The session/role/catalog niladic builtins (`CURRENT_CATALOG`,
+/// `CURRENT_SCHEMA`, `CURRENT_DATABASE`) parse as bare identifiers under
+/// `DatabricksDialect` — the [`Expr::Function`] fast-path only fires for the
+/// Postgres/Generic dialects — so they must be screened here as well as in
+/// [`VOLATILE_FUNCTIONS`] (which catches the parenthesised forms).
 const VOLATILE_BARE_IDENTIFIERS: &[&str] = &[
     "CURRENT_USER",
     "SESSION_USER",
     "SYSTEM_USER",
     "USER",
     "CURRENT_ROLE",
+    "CURRENT_CATALOG",
+    "CURRENT_SCHEMA",
+    "CURRENT_DATABASE",
 ];
 
 /// Builtin functions known to be pure (deterministic over the same input
@@ -83,6 +92,14 @@ const VOLATILE_BARE_IDENTIFIERS: &[&str] = &[
 /// transformation SQL (casts, arithmetic, common aggregates and string/date
 /// manipulation) read as deterministic while still flagging anything novel.
 /// Anything absent here is treated as non-deterministic.
+///
+/// Deliberately **absent** for the byte-equality use case: `ANY_VALUE`
+/// (returns an arbitrary group member), and the order/tie-break-unstable
+/// collection and ranking aggregates `ARRAY_AGG`, `COLLECT_LIST`,
+/// `COLLECT_SET`, `MODE` — without a `WITHIN GROUP (ORDER BY ...)` their
+/// output ordering (or, for `MODE`, the tie-break among equally frequent
+/// values) is engine-defined and can differ run to run. Excluding them takes
+/// the fail-safe direction (a redundant rebuild, never a wrong skip).
 const PURE_FUNCTIONS: &[&str] = &[
     // Aggregates
     "COUNT",
@@ -97,11 +114,9 @@ const PURE_FUNCTIONS: &[&str] = &[
     "STDDEV_POP",
     "STDDEV_SAMP",
     "MEDIAN",
-    "MODE",
     "CORR",
     "COVAR_POP",
     "COVAR_SAMP",
-    "ANY_VALUE",
     "APPROX_COUNT_DISTINCT",
     "BIT_AND",
     "BIT_OR",
@@ -241,9 +256,6 @@ const PURE_FUNCTIONS: &[&str] = &[
     "CUME_DIST",
     // Collections / structs
     "ARRAY",
-    "ARRAY_AGG",
-    "COLLECT_LIST",
-    "COLLECT_SET",
     "MAP",
     "STRUCT",
     "NAMED_STRUCT",
@@ -288,6 +300,11 @@ fn query_is_deterministic(query: &Query) -> bool {
     // 1. A row limit with no total ORDER BY — a *structural* property of the
     //    query (and every nested query), invisible to an expression visitor
     //    because it lives on the limit/order-by clauses, not in an `Expr`.
+    //    `any_unordered_limit` runs a query-level `Visitor` whose
+    //    `pre_visit_query` fires on every nested `Query` uniformly — CTE
+    //    bodies, FROM-derived sub-queries, set-op branches, and sub-queries
+    //    embedded in expressions (`IN (...)`, `EXISTS (...)`, scalar
+    //    sub-selects) — so no nested limit is silently skipped.
     // 2. A volatile expression anywhere — a projection, `WHERE`, `HAVING`,
     //    `GROUP BY`, `ORDER BY`, `JOIN ... ON`, or sub-query. A single
     //    statement-wide `visit_expressions` pass reaches every `Expr` node,
@@ -309,34 +326,36 @@ fn query_is_deterministic(query: &Query) -> bool {
 /// Returns `true` if this query or any nested query carries a row limit
 /// (`LIMIT` / `FETCH` / `TOP`) without a total `ORDER BY` — the rows returned
 /// are then implementation-defined.
+///
+/// The check is query-level and recursive: a [`Visitor`] whose
+/// `pre_visit_query` runs the limit-without-order-by test on every `Query`
+/// node the derived `Visit` walk reaches. That walk descends uniformly into
+/// CTE bodies (`WITH c AS (... LIMIT n)`), FROM-derived sub-queries, set-op
+/// branches, and sub-queries embedded in expressions (`x IN (... LIMIT n)`,
+/// `EXISTS (... LIMIT n)`, scalar sub-selects) — a `LIMIT` is not an `Expr`,
+/// so the separate `visit_expressions` pass cannot carry it, but this
+/// query-level visit reaches every one.
 fn any_unordered_limit(query: &Query) -> bool {
-    if query_has_limit(query) && query.order_by.is_none() {
-        return true;
-    }
-    set_expr_has_unordered_limit(&query.body)
+    let mut visitor = UnorderedLimitVisitor { found: false };
+    let _: ControlFlow<()> = query.visit(&mut visitor);
+    visitor.found
 }
 
-fn set_expr_has_unordered_limit(body: &SetExpr) -> bool {
-    match body {
-        SetExpr::Select(select) => select.from.iter().any(|twj| {
-            table_factor_has_unordered_limit(&twj.relation)
-                || twj
-                    .joins
-                    .iter()
-                    .any(|join| table_factor_has_unordered_limit(&join.relation))
-        }),
-        SetExpr::Query(inner) => any_unordered_limit(inner),
-        SetExpr::SetOperation { left, right, .. } => {
-            set_expr_has_unordered_limit(left) || set_expr_has_unordered_limit(right)
+/// Trips its `found` flag on the first `Query` carrying a row limit with no
+/// total `ORDER BY`. Breaks the walk early once such a query is seen.
+struct UnorderedLimitVisitor {
+    found: bool,
+}
+
+impl Visitor for UnorderedLimitVisitor {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<()> {
+        if query_has_limit(query) && query.order_by.is_none() {
+            self.found = true;
+            return ControlFlow::Break(());
         }
-        _ => false,
-    }
-}
-
-fn table_factor_has_unordered_limit(factor: &sqlparser::ast::TableFactor) -> bool {
-    match factor {
-        sqlparser::ast::TableFactor::Derived { subquery, .. } => any_unordered_limit(subquery),
-        _ => false,
+        ControlFlow::Continue(())
     }
 }
 
@@ -507,6 +526,101 @@ mod tests {
         // when the outer query is fully ordered.
         assert!(!is_deterministic(
             "SELECT id FROM (SELECT id FROM cat.sch.t LIMIT 5) AS s ORDER BY id"
+        ));
+    }
+
+    #[test]
+    fn unordered_limit_in_cte_body_is_caught() {
+        // A LIMIT without ORDER BY inside a CTE body is non-deterministic.
+        // The CTE query is not a FROM-derived sub-query, so the old
+        // structural walk missed it; the query-level visitor reaches it.
+        assert!(!is_deterministic(
+            "WITH c AS (SELECT id FROM cat.sch.t LIMIT 5) SELECT id FROM c"
+        ));
+    }
+
+    #[test]
+    fn unordered_limit_in_expression_subquery_is_caught() {
+        // A LIMIT without ORDER BY inside an `IN (...)` sub-query is
+        // non-deterministic. The sub-query is embedded in an `Expr`, not in a
+        // FROM clause, so only a query-level visit reaches it.
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE id IN (SELECT id FROM cat.sch.u LIMIT 5)"
+        ));
+    }
+
+    #[test]
+    fn unordered_limit_in_exists_subquery_is_caught() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t \
+             WHERE EXISTS (SELECT 1 FROM cat.sch.u LIMIT 5)"
+        ));
+    }
+
+    #[test]
+    fn unordered_limit_in_set_operation_branch_is_caught() {
+        // A LIMIT without ORDER BY on one branch of a UNION is
+        // non-deterministic. The query-level visitor recurses through the
+        // set-op into each branch query.
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t UNION ALL (SELECT id FROM cat.sch.u LIMIT 5)"
+        ));
+    }
+
+    #[test]
+    fn ordered_limit_in_cte_body_is_deterministic() {
+        // The fail-safe must not over-fire: a CTE LIMIT *with* a total
+        // ORDER BY is deterministic.
+        assert!(is_deterministic(
+            "WITH c AS (SELECT id FROM cat.sch.t ORDER BY id LIMIT 5) SELECT id FROM c"
+        ));
+    }
+
+    #[test]
+    fn bare_current_catalog_is_non_deterministic() {
+        // Under DatabricksDialect, bare `current_catalog` parses as
+        // Expr::Identifier, not Expr::Function — it must be screened as a
+        // volatile bare identifier.
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE x = current_catalog"
+        ));
+    }
+
+    #[test]
+    fn bare_current_schema_is_non_deterministic() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE x = current_schema"
+        ));
+    }
+
+    #[test]
+    fn bare_current_database_is_non_deterministic() {
+        assert!(!is_deterministic(
+            "SELECT id FROM cat.sch.t WHERE x = current_database"
+        ));
+    }
+
+    #[test]
+    fn any_value_is_non_deterministic() {
+        // ANY_VALUE returns an arbitrary group member — not byte-stable.
+        assert!(!is_deterministic(
+            "SELECT k, ANY_VALUE(v) AS v FROM cat.sch.t GROUP BY k"
+        ));
+    }
+
+    #[test]
+    fn array_agg_is_non_deterministic() {
+        // Order-unstable without WITHIN GROUP ORDER BY — fail-safe excludes it.
+        assert!(!is_deterministic(
+            "SELECT k, ARRAY_AGG(v) AS vs FROM cat.sch.t GROUP BY k"
+        ));
+    }
+
+    #[test]
+    fn mode_is_non_deterministic() {
+        // Tie-break among equally frequent values is engine-defined.
+        assert!(!is_deterministic(
+            "SELECT k, MODE(v) AS m FROM cat.sch.t GROUP BY k"
         ));
     }
 

--- a/engine/crates/rocky-sql/src/normalize.rs
+++ b/engine/crates/rocky-sql/src/normalize.rs
@@ -26,23 +26,40 @@
 //! ## Conservatism
 //!
 //! This is a best-effort *cosmetic* canonicaliser, deliberately biased toward
-//! under-normalising. When an alias cannot be unambiguously renamed (for
-//! example a name reused across nested scopes) it is left as-is: a missed
-//! collapse costs one redundant comparison-miss, whereas a wrong collapse
-//! would equate two genuinely different queries. The function errs toward
-//! distinctness.
+//! under-normalising. A missed collapse costs one redundant comparison-miss,
+//! whereas a wrong collapse would equate two genuinely different queries, so
+//! the function errs toward distinctness.
 //!
-//! Alias *collection* walks `FROM` / `JOIN` / `WITH` positions; aliases bound
-//! only inside a `WHERE` / projection sub-query are not collected, so they are
-//! not renamed. The effect is purely under-normalisation (such queries stay
-//! more distinct), never a wrong collapse.
+//! Alias references are rewritten by a **flat, statement-wide** token map: a
+//! name is assigned one positional token (`_t0`, `_t1`, ...) in first-seen
+//! traversal order, and every reference to it anywhere in the statement is
+//! rewritten to that token. To keep the flat rewrite sound, a name is renamed
+//! **only when it is defined exactly once** across the whole statement. Two
+//! definition classes are therefore excluded from renaming and left verbatim:
+//!
+//! - A name *reused across scopes* (shadowed) — bound by more than one
+//!   definition. A single flat token cannot distinguish the scopes, so the
+//!   name is left as-is rather than risk retargeting a reference to the wrong
+//!   definition.
+//! - A name that is collected from a `FROM` / `JOIN` / `WITH` position **and
+//!   also** bound inside a `WHERE` / projection sub-query the collector skips.
+//!   The collected definition would be rewritten but the sub-query definition
+//!   would not, so a flat rewrite of the sub-query's references would dangle.
+//!   A whole-statement definition count (which *does* reach the sub-query
+//!   binding) sees the name defined more than once and keeps it out of the
+//!   rename map.
+//!
+//! A name whose *only* definition lives in such an uncollected sub-query is
+//! simply never collected, so it is never a rename candidate in the first
+//! place. All of these are pure under-normalisation: the affected query stays
+//! more distinct, never collapsing onto a different one.
 
 use std::collections::BTreeMap;
 use std::ops::ControlFlow;
 
 use sqlparser::ast::{
-    Cte, Expr, Ident, Query, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins,
-    visit_expressions_mut, visit_relations_mut,
+    Cte, Expr, Ident, Query, SetExpr, Statement, TableAlias, TableFactor, TableWithJoins, Visit,
+    Visitor, visit_expressions_mut, visit_relations_mut,
 };
 
 use crate::parser::parse_single_statement;
@@ -70,7 +87,32 @@ pub fn normalize(sql: &str) -> Option<String> {
     if let Statement::Query(query) = &statement {
         collect_aliases(query, &mut order);
     }
+
+    // Pass 1b: count *every* alias definition site in the statement — including
+    // the aliases bound only inside `WHERE` / projection sub-queries that Pass 1
+    // deliberately does not collect. A name that is defined more than once
+    // anywhere is *ambiguous*: it is either shadowed across collected scopes,
+    // or it also names an alias in an uncollected scope. Renaming such a name
+    // via the flat statement-wide reference rewrite (Passes 2b/2c) would be
+    // unsound — references in a scope whose definition was never collected
+    // (and so never rewritten) would be retargeted to a token with no matching
+    // definition, producing a dangling alias. Excluding every ambiguous name
+    // keeps the function under-normalising (the colliding query stays as-is),
+    // which is the safe direction.
+    let mut def_counts: BTreeMap<String, usize> = BTreeMap::new();
+    if let Statement::Query(query) = &statement {
+        let mut counter = AliasDefCounter {
+            counts: &mut def_counts,
+        };
+        let _: ControlFlow<()> = query.visit(&mut counter);
+    }
+
     for name in order {
+        // Skip ambiguous (multiply-defined) names: leaving them untouched
+        // under-normalises but never mangles a reference.
+        if def_counts.get(&name).copied().unwrap_or(0) > 1 {
+            continue;
+        }
         let next = renames.len();
         renames.entry(name).or_insert_with(|| format!("_t{next}"));
     }
@@ -101,15 +143,20 @@ pub fn normalize(sql: &str) -> Option<String> {
         ControlFlow::Continue(())
     });
 
-    // Pass 2c: rewrite the table-qualifier of `alias.col` column references.
+    // Pass 2c: rewrite the table-qualifier of an `alias.col` column reference.
+    // Only an *exactly two-part* identifier matches the `alias.col` contract.
+    // A longer compound (`cat.sch.tbl.col`) is a fully-qualified column whose
+    // table component is a real table name, never a table alias — rewriting
+    // its `tbl` part just because the name happens to collide with an alias
+    // would mangle a real reference. Restricting to `len == 2` keeps the
+    // rewrite to genuine alias qualifiers.
     let _: ControlFlow<()> = visit_expressions_mut(&mut statement, |expr| {
         if let Expr::CompoundIdentifier(parts) = expr
-            && parts.len() >= 2
+            && parts.len() == 2
         {
-            let qualifier = &parts[parts.len() - 2].value;
+            let qualifier = &parts[0].value;
             if let Some(token) = renames.get(qualifier) {
-                let idx = parts.len() - 2;
-                parts[idx] = plain_ident(token);
+                parts[0] = plain_ident(token);
             }
         }
         ControlFlow::Continue(())
@@ -122,6 +169,77 @@ pub fn normalize(sql: &str) -> Option<String> {
 /// `^_t[0-9]+$`, always safe to emit bare.
 fn plain_ident(value: &str) -> Ident {
     Ident::new(value.to_string())
+}
+
+/// Counts every table-level alias *definition* site across the whole
+/// statement, one [`Query`] scope at a time.
+///
+/// `pre_visit_query` fires on every `Query` the derived `Visit` walk reaches —
+/// the top-level query, CTE bodies, FROM-derived sub-queries, set-op branches,
+/// and the sub-queries embedded in `WHERE` / projection expressions that the
+/// Pass-1 collector skips. For each such query it tallies that query's *own*
+/// CTE and FROM/JOIN/derived-table aliases; it does **not** recurse into nested
+/// sub-queries itself (the visitor walk does), so each definition is counted
+/// exactly once. A count greater than one for a name means that name is bound
+/// in more than one place — ambiguous — and must not be globally renamed.
+struct AliasDefCounter<'a> {
+    counts: &'a mut BTreeMap<String, usize>,
+}
+
+impl AliasDefCounter<'_> {
+    fn tally(&mut self, name: &str) {
+        *self.counts.entry(name.to_string()).or_insert(0) += 1;
+    }
+}
+
+impl Visitor for AliasDefCounter<'_> {
+    type Break = ();
+
+    fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<()> {
+        if let Some(with) = &query.with {
+            for cte in &with.cte_tables {
+                self.tally(&cte.alias.name.value);
+            }
+        }
+        count_set_expr_immediate_aliases(&query.body, self);
+        ControlFlow::Continue(())
+    }
+}
+
+/// Tally the aliases defined *directly* in this `SetExpr`'s FROM/JOIN clauses.
+/// Derived-table aliases are counted here (they belong to this scope); the
+/// derived sub-query's *internal* aliases belong to the nested `Query` and are
+/// counted when the visitor reaches it.
+fn count_set_expr_immediate_aliases(body: &SetExpr, counter: &mut AliasDefCounter<'_>) {
+    match body {
+        SetExpr::Select(select) => {
+            for twj in &select.from {
+                count_twj_immediate_aliases(twj, counter);
+            }
+        }
+        SetExpr::SetOperation { left, right, .. } => {
+            count_set_expr_immediate_aliases(left, counter);
+            count_set_expr_immediate_aliases(right, counter);
+        }
+        // `SetExpr::Query(inner)` is a nested `Query`; the visitor walk reaches
+        // it via `pre_visit_query`, so it is not descended here.
+        _ => {}
+    }
+}
+
+fn count_twj_immediate_aliases(twj: &TableWithJoins, counter: &mut AliasDefCounter<'_>) {
+    count_factor_immediate_alias(&twj.relation, counter);
+    for join in &twj.joins {
+        count_factor_immediate_alias(&join.relation, counter);
+    }
+}
+
+fn count_factor_immediate_alias(factor: &TableFactor, counter: &mut AliasDefCounter<'_>) {
+    match factor {
+        TableFactor::Table { alias: Some(a), .. } => counter.tally(&a.name.value),
+        TableFactor::Derived { alias: Some(a), .. } => counter.tally(&a.name.value),
+        _ => {}
+    }
 }
 
 /// Collect internal table-level alias names in deterministic traversal order.
@@ -341,5 +459,56 @@ mod tests {
         let once = normalize(sql).unwrap();
         let twice = normalize(&once).unwrap();
         assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn four_part_column_ref_table_component_is_not_mangled() {
+        // A fully-qualified `cat.sch.tbl.col` reference whose `tbl` component
+        // collides with a collected alias name must NOT have `tbl` rewritten:
+        // it is a real table name, not an alias qualifier. Only the genuine
+        // two-part `alias.col` reference is rewritten.
+        let out = normalize("SELECT cat.sch.orders.col FROM cat.sch.t AS orders").unwrap();
+        // The real table component survives verbatim.
+        assert!(
+            out.contains("cat.sch.orders.col"),
+            "4-part table component must not be mangled, got: {out}"
+        );
+        // The alias definition was still rewritten to a positional token.
+        assert!(out.contains("_t0"), "alias should be tokenised, got: {out}");
+    }
+
+    #[test]
+    fn outer_inner_alias_collision_does_not_dangle() {
+        // Outer FROM alias `a` is collected; an inner `WHERE`-sub-query also
+        // binds `a` but is not collected. Renaming `a` globally would leave the
+        // inner definition `AS a` intact while rewriting its references to a
+        // token — a dangling alias. The ambiguity guard leaves both verbatim.
+        let sql = "SELECT a.id FROM cat.sch.t AS a \
+                   WHERE a.id IN (SELECT a.id FROM cat.sch.u AS a WHERE a.id > 0)";
+        let out = normalize(sql).unwrap();
+        // No positional token is introduced (the only alias name is ambiguous).
+        assert!(
+            !out.contains("_t"),
+            "ambiguous alias must be left untouched, got: {out}"
+        );
+        // Every reference still resolves to a real, present alias definition.
+        assert!(
+            out.contains("AS a") && out.contains("a.id"),
+            "both alias definition and references stay consistent, got: {out}"
+        );
+    }
+
+    #[test]
+    fn distinct_scoped_aliases_still_normalise() {
+        // Sanity: when alias names do *not* collide across scopes, the flat
+        // rename still collapses cosmetic alias differences as before. Both the
+        // outer FROM alias and the FROM-derived sub-query's inner alias are
+        // collected, so distinct choices normalise to the same token sequence.
+        let a = "SELECT o.id FROM cat.sch.t AS o \
+                 JOIN (SELECT u.id FROM cat.sch.u AS u) AS d ON o.id = d.id";
+        let b = "SELECT x.id FROM cat.sch.t AS x \
+                 JOIN (SELECT y.id FROM cat.sch.u AS y) AS e ON x.id = e.id";
+        assert_eq!(normalize(a), normalize(b));
+        assert!(normalize(a).unwrap().contains("_t0"));
     }
 }


### PR DESCRIPTION
Adversarial-review fixes to the skip-hash machinery introduced in #823. That PR
was squash-merged before these review findings were addressed, so this is the
follow-up. The code is still unwired (no skip gate consumes it yet); every fix
closes a dangerous false-pure / over-collapse direction before a future gate
relies on it.

## determinism scan (`rocky-sql/determinism.rs`)

- **Unordered LIMIT in nested scopes (HIGH).** The check was query-structural
  and only descended FROM-derived sub-queries and set-op branches, so an
  unordered `LIMIT` inside a CTE body or an `IN`/`EXISTS` sub-query read
  deterministic. Replaced with a query-level `Visitor` whose `pre_visit_query`
  fires on every nested `Query` uniformly — CTE bodies, FROM-derived, set-op
  branches, and expression sub-queries (`IN`, `EXISTS`, scalar sub-selects).
- **Bare niladic session funcs (HIGH).** Under the Databricks dialect, bare
  `CURRENT_CATALOG` / `CURRENT_SCHEMA` / `CURRENT_DATABASE` parse as
  `Expr::Identifier`, not `Expr::Function`, so the function path never saw them.
  Added to the bare-identifier volatile list.
- **`ANY_VALUE` mislabeled pure (HIGH)** and **order/tie-break-unstable
  aggregates (LOW).** Dropped `ANY_VALUE`, `ARRAY_AGG`, `COLLECT_LIST`,
  `COLLECT_SET`, `MODE` from the pure allowlist so the unknown-function
  fail-safe flags them non-deterministic (no `WITHIN GROUP ORDER BY` ⇒
  unstable output).

## normalizer (`rocky-sql/normalize.rs`)

- **4-part qualifier mangle (MEDIUM).** The Pass-2c qualifier rewrite matched
  `parts.len() >= 2`, so a fully-qualified `cat.sch.tbl.col` whose table
  component collided with an alias name was mangled. Restricted to exactly
  two-part `alias.col`.
- **Scope leak (MEDIUM).** Aliases were collected only from FROM/JOIN/WITH but
  references were rewritten statement-wide via a flat rename map, so an
  inner-subquery alias colliding with a collected outer alias had its
  references rewritten without its definition — a dangling token. A
  whole-statement definition count now excludes any multiply-defined name from
  the rename map (conservative under-normalization).
- Rewrote the module "Conservatism" doc to describe the actual flat global
  token assignment and the two safe-direction exclusions.

## ir (`rocky-ir/ir.rs`)

- Corrected the `SkipHashProjection` doc: the partition `window` is included via
  the hashed `materialization` strategy; the call-time contract is to hash the
  static (`window = None`) form, exactly as `recipe_hash` requires. Documented
  that `name` and `cost_ceiling` are intentionally excluded as non-output
  identity. Mirrored the contract onto `skip_hash()`'s own doc.

`recipe_hash()` is untouched. The change is additive — no output struct, no
schema or binding drift (`just codegen` no-op). New regression tests cover every
fix.

## Verify

- `cargo build -p rocky-sql -p rocky-ir` ✓
- `cargo clippy -p rocky-sql -p rocky-ir --all-targets --all-features -- -D warnings` ✓
- `cargo fmt -- --check` ✓
- `cargo test -p rocky-sql -p rocky-ir` ✓ (144 + 79)