### PR TITLE
feat(engine): opt-in per-namespace state files (relieve redb single-writer fan-out)

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2999,6 +2999,15 @@
           },
           "description": "Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as \"deduplicated\", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`]."
         },
+        "namespacing": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StateNamespacing"
+            }
+          ],
+          "default": "none",
+          "description": "Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = \"pipeline\"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run."
+        },
         "on_upload_failure": {
           "allOf": [
             {
@@ -3082,6 +3091,25 @@
         }
       },
       "type": "object"
+    },
+    "StateNamespacing": {
+      "description": "Per-pipeline / per-client state-file namespacing policy.\n\nredb permits one writer per file, so fanning out one `rocky run` process per pipeline or client against the single global state file forces those independent runs to serialize on one advisory lock. Namespacing gives each namespace its own `<models>/.rocky-state/<namespace>.redb` file (its own lock, its own redb handle, its own remote object key), so runs on distinct namespaces proceed concurrently with zero shared corruption surface.\n\nDefault is [`StateNamespacing::None`] — behavior is **byte-identical** to a project that never sets this key. Namespacing is purely opt-in.",
+      "oneOf": [
+        {
+          "description": "One global `<models>/.rocky-state.redb` for the whole project (default). Identical to today's behavior.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "One state file per pipeline, under `<models>/.rocky-state/<pipeline>.redb`. The per-invocation `--state-namespace <key>` flag takes precedence over this config and is the explicit way to fan out by client/tenant rather than by pipeline name. An explicit `--state-path` disables namespacing entirely for that invocation.",
+          "enum": [
+            "pipeline"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "StateRetentionConfig": {
       "additionalProperties": false,
@@ -3710,6 +3738,7 @@
           "in_flight_ttl_hours": 24,
           "retention_days": 30
         },
+        "namespacing": "none",
         "on_upload_failure": "skip",
         "retention": {
           "applies_to": [

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -309,6 +309,14 @@ export type StateBackend = "local" | "s3" | "gcs" | "valkey" | "tiered";
  */
 export type DedupPolicy = "success" | "any";
 /**
+ * Per-pipeline / per-client state-file namespacing policy.
+ *
+ * redb permits one writer per file, so fanning out one `rocky run` process per pipeline or client against the single global state file forces those independent runs to serialize on one advisory lock. Namespacing gives each namespace its own `<models>/.rocky-state/<namespace>.redb` file (its own lock, its own redb handle, its own remote object key), so runs on distinct namespaces proceed concurrently with zero shared corruption surface.
+ *
+ * Default is [`StateNamespacing::None`] — behavior is **byte-identical** to a project that never sets this key. Namespacing is purely opt-in.
+ */
+export type StateNamespacing = "none" | "pipeline";
+/**
  * Policy applied when state upload fails after retries + circuit-breaker are exhausted. See [`StateConfig::on_upload_failure`].
  */
 export type StateUploadFailureMode = "skip" | "fail";
@@ -1731,6 +1739,10 @@ export interface StateConfig {
    * Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as "deduplicated", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`].
    */
   idempotency?: IdempotencyConfig;
+  /**
+   * Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = "pipeline"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run.
+   */
+  namespacing?: StateNamespacing & string;
   /**
    * What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
    */

--- a/engine/crates/rocky-cli/src/commands/apply.rs
+++ b/engine/crates/rocky-cli/src/commands/apply.rs
@@ -54,9 +54,21 @@ use super::compact::run_compact_apply_in;
 ///
 /// Reads the plan from `.rocky/plans/<plan_id>.json`, dispatches by kind,
 /// and emits an `ApplyOutput` envelope wrapping the inner result.
-pub async fn run_apply(config_path: &Path, plan_id: &str, output_json: bool) -> Result<()> {
+///
+/// `state_path` is the already-resolved state-file path threaded from
+/// `main.rs` — it is namespace-aware (`resolve_state_path_ns`), so
+/// `rocky --state-namespace <ns> apply <plan>` opens the namespaced state
+/// file rather than re-resolving the global one. This keeps the canonical
+/// `rocky plan` → `rocky apply` workflow consistent with `rocky run`, whose
+/// inline apply already receives the same path.
+pub async fn run_apply(
+    config_path: &Path,
+    plan_id: &str,
+    state_path: &Path,
+    output_json: bool,
+) -> Result<()> {
     let cwd = std::env::current_dir().context("failed to get current working directory")?;
-    run_apply_in(&cwd, config_path, plan_id, output_json).await
+    run_apply_in(&cwd, config_path, plan_id, state_path, output_json).await
 }
 
 /// Inner implementation — takes an explicit `root` for the plans directory so
@@ -65,6 +77,7 @@ pub(crate) async fn run_apply_in(
     root: &Path,
     config_path: &Path,
     plan_id: &str,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let plan =
@@ -80,13 +93,15 @@ pub(crate) async fn run_apply_in(
             // Delegate to the existing archive apply path.
             run_archive_apply_in(root, config_path, plan_id, output_json).await
         }
-        PlanKind::Run => run_apply_run_plan(root, config_path, plan_id, output_json).await,
+        PlanKind::Run => {
+            run_apply_run_plan(root, config_path, plan_id, state_path, output_json).await
+        }
         PlanKind::Replication => {
-            run_apply_replication_plan(root, config_path, plan_id, output_json).await
+            run_apply_replication_plan(root, config_path, plan_id, state_path, output_json).await
         }
         PlanKind::Promote => run_apply_promote_plan(root, config_path, plan_id, output_json).await,
         PlanKind::AiAuthored => {
-            run_apply_ai_authored_plan(root, config_path, plan_id, output_json).await
+            run_apply_ai_authored_plan(root, config_path, plan_id, state_path, output_json).await
         }
     }
 }
@@ -104,6 +119,7 @@ async fn run_apply_run_plan(
     root: &Path,
     config_path: &Path,
     plan_id: &str,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let plan =
@@ -121,7 +137,7 @@ async fn run_apply_run_plan(
     let run_plan: RunPlan = serde_json::from_value(plan.payload.clone())
         .context("failed to deserialize run plan payload")?;
 
-    execute_run_plan(config_path, plan_id, run_plan, output_json).await
+    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await
 }
 
 /// Execute a deserialized [`RunPlan`] against the warehouse.
@@ -138,6 +154,7 @@ async fn execute_run_plan(
     config_path: &Path,
     plan_id: &str,
     run_plan: RunPlan,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     // Build partition options from the persisted flags.
@@ -151,10 +168,11 @@ async fn execute_run_plan(
         parallel: run_plan.parallel,
     };
 
-    // Resolve the state path via the standard resolver (mirrors main.rs).
-    // Used both by branch→shadow resolution below and by `run` itself.
-    let resolved = rocky_core::state::resolve_state_path(None, std::path::Path::new("models"));
-    let state_path = resolved.path;
+    // `state_path` is the namespace-aware path threaded from main.rs (mirrors
+    // how `rocky run`'s inline apply receives it). Used both by branch→shadow
+    // resolution below and by `run` itself, so `rocky --state-namespace <ns>
+    // apply <plan>` writes to the namespaced state file rather than the global
+    // one.
 
     // Shadow config. Mirrors the `Command::Run` dispatch in main.rs:
     // `--branch` is internally equivalent to `--shadow --shadow-schema
@@ -167,7 +185,7 @@ async fn execute_run_plan(
         .clone()
         .unwrap_or_else(|| "_rocky_shadow".to_string());
     let shadow_config = if let Some(ref name) = run_plan.branch {
-        let store = rocky_core::state::StateStore::open_read_only(&state_path)
+        let store = rocky_core::state::StateStore::open_read_only(state_path)
             .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
         let record = store.get_branch(name)?.with_context(|| {
             format!("branch '{name}' not found — create it with `rocky branch create {name}`")
@@ -213,7 +231,7 @@ async fn execute_run_plan(
         config_path,
         run_plan.filter.as_deref(),
         run_plan.pipeline.as_deref(),
-        &state_path,
+        state_path,
         run_plan.governance_override.as_ref(),
         output_json,
         models_dir_path.as_deref(),
@@ -270,6 +288,7 @@ async fn run_apply_ai_authored_plan(
     root: &Path,
     config_path: &Path,
     plan_id: &str,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let plan = read_plan(root, plan_id)
@@ -295,7 +314,7 @@ async fn run_apply_ai_authored_plan(
     let run_plan: RunPlan = serde_json::from_value(plan.payload.clone())
         .context("failed to deserialize ai_authored plan payload")?;
 
-    execute_run_plan(config_path, plan_id, run_plan, output_json).await
+    execute_run_plan(config_path, plan_id, run_plan, state_path, output_json).await
 }
 
 /// Apply a `PlanKind::Replication` plan by re-running discovery, asserting
@@ -312,6 +331,7 @@ async fn run_apply_replication_plan(
     root: &Path,
     config_path: &Path,
     plan_id: &str,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let plan = read_plan(root, plan_id)
@@ -409,17 +429,15 @@ async fn run_apply_replication_plan(
     // Snapshot matched — delegate to the existing replication codepath
     // by calling `commands::run::run` with model-related args set to
     // defaults. The replication arm inside `run` handles everything
-    // from here.
-    let resolved = rocky_core::state::resolve_state_path(None, std::path::Path::new("models"));
-    let state_path = resolved.path;
-
+    // from here. `state_path` is the namespace-aware path threaded from
+    // main.rs, so a namespaced replication apply writes the namespaced file.
     let partition_opts = crate::commands::run::PartitionRunOptions::default();
 
     crate::commands::run::run(
         config_path,
         replication_plan.filter.as_deref(),
         replication_plan.pipeline.as_deref(),
-        &state_path,
+        state_path,
         replication_plan.governance_override.as_ref(),
         output_json,
         // No models directory — replication-only apply does not run
@@ -955,6 +973,7 @@ mod tests {
             dir.path(),
             std::path::Path::new("rocky.toml"),
             &plan_id,
+            std::path::Path::new("models/.rocky-state.redb"),
             true,
         )
         .await

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1234,7 +1234,11 @@ fn render_budget_diagnostics_text(output: &PlanOutput) {
 /// - `base_ref` — git ref to diff against.
 /// - `branch_name` — branch being promoted.
 /// - `filter` — optional replication filter (e.g. `"client=acme"`).
+/// - `pipeline_name` — optional pipeline selector.
 /// - `allow_breaking` — bypass the breaking-change block gate.
+/// - `state_path` — already-resolved (namespace-aware) state-file path threaded
+///   from `main.rs`, so `rocky --state-namespace <ns> plan promote` reads the
+///   namespaced branch state rather than the global file.
 /// - `output_json` — emit machine-readable JSON instead of text.
 #[allow(clippy::too_many_arguments)]
 pub async fn plan_promote(
@@ -1246,6 +1250,7 @@ pub async fn plan_promote(
     filter: Option<&str>,
     pipeline_name: Option<&str>,
     allow_breaking: bool,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let result = build_promote_plan_inner(
@@ -1257,6 +1262,7 @@ pub async fn plan_promote(
         filter,
         pipeline_name,
         allow_breaking,
+        state_path,
     )
     .await?;
 
@@ -1314,6 +1320,7 @@ pub(crate) async fn build_promote_plan_inner(
     filter: Option<&str>,
     pipeline_name: Option<&str>,
     allow_breaking: bool,
+    state_path: &Path,
 ) -> Result<PromotePlanResult> {
     use crate::commands::branch::{
         APPROVAL_SKIP_ENV, approver_identity_pub, compute_branch_state_hash_pub,
@@ -1324,9 +1331,9 @@ pub(crate) async fn build_promote_plan_inner(
 
     validate_branch_name_pub(branch_name)?;
 
-    let state_path =
-        rocky_core::state::resolve_state_path(None, std::path::Path::new("models")).path;
-    let store = StateStore::open_read_only(&state_path).with_context(|| {
+    // `state_path` is the namespace-aware path threaded from main.rs; the
+    // branch record lives in whichever state file this invocation targets.
+    let store = StateStore::open_read_only(state_path).with_context(|| {
         format!(
             "failed to open state store at {} — run `rocky branch create {}` first",
             state_path.display(),

--- a/engine/crates/rocky-cli/src/commands/watch.rs
+++ b/engine/crates/rocky-cli/src/commands/watch.rs
@@ -14,9 +14,16 @@ use super::compile::run_compile;
 ///
 /// Watches `models_dir` for `.sql`, `.rocky`, and `.toml` file changes,
 /// debounces for 200 ms, then runs `rocky compile`. Blocks until Ctrl-C.
+///
+/// `state_namespace` is the resolved `--state-namespace` (or
+/// `[state] namespacing`) value threaded from `main.rs`, so the compile-time
+/// schema-cache read sees the same namespaced state file that `rocky run`
+/// targets. `None` (the default) keeps the global file, byte-identical to
+/// before.
 pub async fn run_watch(
     models_dir: &Path,
     contracts_dir: Option<&Path>,
+    state_namespace: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
     // Validate the models directory exists before starting the watcher.
@@ -26,7 +33,7 @@ pub async fn run_watch(
 
     // Initial compile so the user gets immediate feedback.
     println!("[watch] compiling...");
-    print_compile_result(models_dir, contracts_dir, output_json);
+    print_compile_result(models_dir, contracts_dir, state_namespace, output_json);
     println!("[watch] waiting for changes...");
 
     // Channel for watcher → debounce task communication.
@@ -86,7 +93,7 @@ pub async fn run_watch(
                 }
 
                 println!("[watch] compiling...");
-                print_compile_result(models_dir, contracts_dir, output_json);
+                print_compile_result(models_dir, contracts_dir, state_namespace, output_json);
                 println!("[watch] waiting for changes...");
             }
             _ = tokio::signal::ctrl_c() => {
@@ -99,14 +106,22 @@ pub async fn run_watch(
 
 /// Run compile and print the result. Errors are printed, not propagated,
 /// so the watch loop continues after a failed compilation.
-fn print_compile_result(models_dir: &Path, contracts_dir: Option<&Path>, output_json: bool) {
+fn print_compile_result(
+    models_dir: &Path,
+    contracts_dir: Option<&Path>,
+    state_namespace: Option<&str>,
+    output_json: bool,
+) {
     // Watch doesn't take a `--state-path` arg today; resolve via the
-    // unified helper so the compile-time schema-cache read sees the same
-    // file that `rocky run` and the LSP see. Fresh projects with no
-    // runs yet still land on the new default
-    // `<models>/.rocky-state.redb` and the cache loader gracefully
-    // returns an empty map.
-    let resolved = rocky_core::state::resolve_state_path(None, models_dir);
+    // namespace-aware helper so the compile-time schema-cache read sees the
+    // same file that `rocky run` and the LSP see. The resolver is keyed off
+    // this command's `models_dir` (which honors `--models`), not the global
+    // `"models"` default, so threading the namespace here — rather than the
+    // already-resolved global state_path — preserves `--models`-relative
+    // resolution. Fresh projects with no runs yet still land on the default
+    // (`<models>/.rocky-state.redb` or `<models>/.rocky-state/<ns>.redb`) and
+    // the cache loader gracefully returns an empty map.
+    let resolved = rocky_core::state::resolve_state_path_ns(None, models_dir, state_namespace);
     if let Some(ref w) = resolved.warning {
         warn!(target: "rocky::state_path", "{w}");
     }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -520,6 +520,32 @@ pub enum StateUploadFailureMode {
     Fail,
 }
 
+/// Per-pipeline / per-client state-file namespacing policy.
+///
+/// redb permits one writer per file, so fanning out one `rocky run` process
+/// per pipeline or client against the single global state file forces those
+/// independent runs to serialize on one advisory lock. Namespacing gives each
+/// namespace its own `<models>/.rocky-state/<namespace>.redb` file (its own
+/// lock, its own redb handle, its own remote object key), so runs on distinct
+/// namespaces proceed concurrently with zero shared corruption surface.
+///
+/// Default is [`StateNamespacing::None`] — behavior is **byte-identical** to a
+/// project that never sets this key. Namespacing is purely opt-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum StateNamespacing {
+    /// One global `<models>/.rocky-state.redb` for the whole project (default).
+    /// Identical to today's behavior.
+    #[default]
+    None,
+    /// One state file per pipeline, under `<models>/.rocky-state/<pipeline>.redb`.
+    /// The per-invocation `--state-namespace <key>` flag takes precedence over
+    /// this config and is the explicit way to fan out by client/tenant rather
+    /// than by pipeline name. An explicit `--state-path` disables namespacing
+    /// entirely for that invocation.
+    Pipeline,
+}
+
 /// State persistence configuration.
 ///
 /// Controls where Rocky stores watermarks and anomaly history between runs.
@@ -582,6 +608,15 @@ pub struct StateConfig {
     /// [`crate::retention::StateRetentionConfig`].
     #[serde(default)]
     pub retention: crate::retention::StateRetentionConfig,
+    /// Per-pipeline / per-client state-file namespacing. Defaults to
+    /// [`StateNamespacing::None`] (one global state file — byte-identical to a
+    /// project that omits this key). Set `namespacing = "pipeline"` to give
+    /// each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so
+    /// independent fan-out runs don't serialize on one advisory lock. The
+    /// per-invocation `--state-namespace <key>` flag overrides this; an
+    /// explicit `--state-path` disables namespacing for that run.
+    #[serde(default)]
+    pub namespacing: StateNamespacing,
 }
 
 impl Default for StateConfig {
@@ -599,6 +634,7 @@ impl Default for StateConfig {
             on_upload_failure: StateUploadFailureMode::default(),
             idempotency: IdempotencyConfig::default(),
             retention: crate::retention::StateRetentionConfig::default(),
+            namespacing: StateNamespacing::default(),
         }
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -2605,6 +2605,15 @@ pub fn detect_anomaly(
 /// on spelling.
 pub const STATE_FILE_NAME: &str = ".rocky-state.redb";
 
+/// Directory (under `models_dir`) that holds per-namespace state files.
+///
+/// When per-pipeline / per-client namespacing is on, each namespace gets its
+/// own `<models_dir>/.rocky-state/<namespace>.redb`. The directory name is a
+/// dotfile sibling of the legacy global [`STATE_FILE_NAME`] so the two modes
+/// never collide on disk: `.rocky-state.redb` (global file) vs
+/// `.rocky-state/` (namespaced dir).
+pub const STATE_NAMESPACE_DIR: &str = ".rocky-state";
+
 /// Resolution outcome for [`resolve_state_path`].
 ///
 /// `path` is always the state file the caller should open. `warning` is
@@ -2731,6 +2740,117 @@ pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> Resolve
             warning: None,
         }
     }
+}
+
+/// Namespace-aware wrapper around [`resolve_state_path`].
+///
+/// redb permits exactly one writer per file (its own `flock` plus Rocky's
+/// advisory `.redb.lock`), so fanning out one `rocky run` process per pipeline
+/// or per client against the single global `<models_dir>/.rocky-state.redb`
+/// forces those independent runs to serialize on one lock. Giving each
+/// namespace its own file gives it its own lock and its own redb handle, so
+/// runs on distinct namespaces proceed concurrently with zero shared
+/// corruption surface — every single-writer invariant still holds *inside*
+/// each file.
+///
+/// Resolution policy:
+///
+/// 1. `namespace` is `None` → delegate verbatim to [`resolve_state_path`].
+///    This is the default and is **byte-identical** to today's behavior;
+///    namespacing is purely opt-in.
+/// 2. `namespace` is `Some(_)` **and** `explicit` is `Some(_)` → the explicit
+///    `--state-path` is a hard override that **disables** namespacing for that
+///    invocation, so this also delegates to [`resolve_state_path`] (which
+///    honors the explicit path verbatim). This mirrors the existing
+///    "`--state-path` wins" rule.
+/// 3. `namespace` is `Some(ns)` and `explicit` is `None` → resolve to
+///    `<models_dir>/.rocky-state/<ns>.redb`. `ns` is validated as a SQL
+///    identifier (`^[a-zA-Z0-9_]+$`) by the caller before reaching here
+///    (see [`validate_namespace`]), which makes path traversal impossible.
+///    The `.rocky-state/` parent directory is created on resolution so the
+///    later advisory-lock open (whose first filesystem op is opening
+///    `<...>/<ns>.redb.lock`) doesn't fail on a missing parent.
+///
+/// The advisory `.redb.lock` derivation in [`StateStore::open`] needs no
+/// change: `path.with_extension("redb.lock")` composes with the nested path,
+/// so `<...>/acme.redb` yields `<...>/acme.redb.lock` — a distinct lock per
+/// namespace.
+///
+/// # Migration
+///
+/// Namespaced files start **fresh**. A pre-existing global
+/// `<models_dir>/.rocky-state.redb` is never moved, deleted, or auto-seeded —
+/// watermark ownership (which `catalog.schema.table` rows belong to a given
+/// pipeline) is not derivable from the state file alone, so seeding can't live
+/// here. Operators who want to carry watermarks forward copy the legacy file
+/// to `<models_dir>/.rocky-state/<ns>.redb` once, or point `--state-path` at
+/// the legacy file for the namespace's first run.
+///
+/// # Panics
+///
+/// Does not panic. If `namespace` somehow reaches this function unvalidated
+/// (it shouldn't — callers validate first), [`sanitize_namespace`] is applied
+/// defensively and an invalid namespace falls back to the global resolution
+/// rather than composing a traversal path.
+pub fn resolve_state_path_ns(
+    explicit: Option<&Path>,
+    models_dir: &Path,
+    namespace: Option<&str>,
+) -> ResolvedStatePath {
+    // Cases 1 + 2: no namespace, or an explicit `--state-path` that disables
+    // it. Both delegate verbatim — transparency by construction (R1).
+    let Some(ns) = namespace else {
+        return resolve_state_path(explicit, models_dir);
+    };
+    if explicit.is_some() {
+        return resolve_state_path(explicit, models_dir);
+    }
+
+    // Defensive sanitize: callers validate the namespace as a SQL identifier
+    // before reaching here, but if an unvalidated value slips through we must
+    // never compose a path-traversal segment. An invalid namespace falls back
+    // to the global resolution (it can't safely become a file name).
+    let Some(sanitized) = sanitize_namespace(ns) else {
+        return resolve_state_path(explicit, models_dir);
+    };
+
+    let ns_dir = models_dir.join(STATE_NAMESPACE_DIR);
+    // Best-effort create of the namespaced parent dir. If creation fails the
+    // later `StateStore::open` will surface the I/O error with a clear
+    // `LockIo`/redb message; we don't swallow-and-fall-back here because the
+    // namespaced path is what the caller asked for.
+    let _ = std::fs::create_dir_all(&ns_dir);
+
+    ResolvedStatePath {
+        path: ns_dir.join(format!("{sanitized}.redb")),
+        warning: None,
+    }
+}
+
+/// Validate a state namespace as a SQL identifier (`^[a-zA-Z0-9_]+$`).
+///
+/// This is the path-traversal guard for `--state-namespace` /
+/// `[state] namespacing`: the namespace becomes a path segment, so anything
+/// outside the SQL-identifier alphabet (`/`, `.`, `..`, spaces, …) is rejected
+/// rather than silently rewritten — silent rewriting would collide distinct
+/// tenants (`acme-1` and `acme_1`) onto the same file. Reuses the same
+/// validator the rest of the engine uses for catalog/schema/table identifiers.
+///
+/// # Errors
+///
+/// Returns [`rocky_sql::validation::ValidationError`] when `ns` is empty or
+/// contains a character outside `[a-zA-Z0-9_]`.
+pub fn validate_namespace(ns: &str) -> Result<&str, rocky_sql::validation::ValidationError> {
+    rocky_sql::validation::validate_identifier(ns)
+}
+
+/// Return `Some(ns)` if `ns` is a valid state namespace, else `None`.
+///
+/// Used by [`resolve_state_path_ns`] as a defensive last line — the real
+/// rejection happens at the CLI boundary via [`validate_namespace`], which
+/// surfaces a clean error to the user.
+fn sanitize_namespace(ns: &str) -> Option<&str> {
+    validate_namespace(ns).ok()
 }
 
 #[cfg(test)]

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -2769,7 +2769,10 @@ pub fn resolve_state_path(explicit: Option<&Path>, models_dir: &Path) -> Resolve
 ///    (see [`validate_namespace`]), which makes path traversal impossible.
 ///    The `.rocky-state/` parent directory is created on resolution so the
 ///    later advisory-lock open (whose first filesystem op is opening
-///    `<...>/<ns>.redb.lock`) doesn't fail on a missing parent.
+///    `<...>/<ns>.redb.lock`) doesn't fail on a missing parent. If that
+///    directory can't be created — or already exists as a non-directory — this
+///    falls back to the global resolution with a `rocky::state_path` warning
+///    rather than composing a path that would only fail later at lock-open.
 ///
 /// The advisory `.redb.lock` derivation in [`StateStore::open`] needs no
 /// change: `path.with_extension("redb.lock")` composes with the nested path,
@@ -2815,11 +2818,29 @@ pub fn resolve_state_path_ns(
     };
 
     let ns_dir = models_dir.join(STATE_NAMESPACE_DIR);
-    // Best-effort create of the namespaced parent dir. If creation fails the
-    // later `StateStore::open` will surface the I/O error with a clear
-    // `LockIo`/redb message; we don't swallow-and-fall-back here because the
-    // namespaced path is what the caller asked for.
-    let _ = std::fs::create_dir_all(&ns_dir);
+    // Create the namespaced parent dir up front. If the path already exists as
+    // a non-directory (e.g. a stray `.rocky-state` file from the legacy global
+    // layout), or creation fails for any other reason, fall back to the global
+    // resolution with a targeted warning rather than composing a path that
+    // would only fail later with an opaque lock-open I/O error.
+    if ns_dir.exists() && !ns_dir.is_dir() {
+        tracing::warn!(
+            target: "rocky::state_path",
+            path = %ns_dir.display(),
+            "state namespace directory path exists but is not a directory; \
+             falling back to the global state file (move or remove it to enable namespacing)"
+        );
+        return resolve_state_path(explicit, models_dir);
+    }
+    if let Err(e) = std::fs::create_dir_all(&ns_dir) {
+        tracing::warn!(
+            target: "rocky::state_path",
+            path = %ns_dir.display(),
+            error = %e,
+            "failed to create state namespace directory; falling back to the global state file"
+        );
+        return resolve_state_path(explicit, models_dir);
+    }
 
     ResolvedStatePath {
         path: ns_dir.join(format!("{sanitized}.redb")),

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -97,6 +97,16 @@ fn cloud_provider(
     bucket: &str,
     prefix: &str,
 ) -> Result<ObjectStoreProvider, StateSyncError> {
+    // Test seam: when a test has installed an in-memory provider via
+    // `test_support::install`, route every object-store construction to it so
+    // the real `upload_state → strip → dispatch → upload_to_object_store` path
+    // can be exercised end-to-end without a live cloud client. Production
+    // builds never compile this branch.
+    #[cfg(test)]
+    if let Some(provider) = test_support::current_override() {
+        return Ok(provider);
+    }
+
     let trimmed_prefix = prefix.trim_end_matches('/');
     let uri = if trimmed_prefix.is_empty() {
         format!("{scheme}://{bucket}")
@@ -104,6 +114,48 @@ fn cloud_provider(
         format!("{scheme}://{bucket}/{trimmed_prefix}")
     };
     Ok(ObjectStoreProvider::from_uri(&uri)?)
+}
+
+/// Test-only support for injecting an in-memory object store into the upload
+/// dispatch path. Lets a `#[cfg(test)]` test drive the real
+/// `upload_state → strip → dispatch → upload_to_object_store → cloud_provider`
+/// chain against [`ObjectStoreProvider::in_memory`] instead of a live cloud
+/// client, so it observes the *actual* remote key the upload path computes
+/// (the round-trip-via-`provider.upload_file` test cannot, because it
+/// precomputes the key and skips dispatch entirely).
+#[cfg(test)]
+mod test_support {
+    use super::ObjectStoreProvider;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static PROVIDER_OVERRIDE: RefCell<Option<ObjectStoreProvider>> =
+            const { RefCell::new(None) };
+    }
+
+    /// Install `provider` as the next provider [`super::cloud_provider`] hands
+    /// out on this thread. Returns a clone so the caller retains a handle to
+    /// assert on after the upload (the in-memory store is `Arc`-backed, so the
+    /// clone shares storage with the installed copy).
+    pub(super) fn install(provider: ObjectStoreProvider) -> ObjectStoreProvider {
+        let handle = provider.clone();
+        PROVIDER_OVERRIDE.with(|cell| *cell.borrow_mut() = Some(provider));
+        handle
+    }
+
+    /// Clone the installed override, if any. Returns a clone (rather than
+    /// removing it) so every object-store construction on this thread — e.g.
+    /// both the Valkey and S3 legs of a tiered upload — sees the same
+    /// `Arc`-backed store until the test calls [`clear`].
+    pub(super) fn current_override() -> Option<ObjectStoreProvider> {
+        PROVIDER_OVERRIDE.with(|cell| cell.borrow().clone())
+    }
+
+    /// Clear any installed override so it can't leak into a later test on the
+    /// same thread.
+    pub(super) fn clear() {
+        PROVIDER_OVERRIDE.with(|cell| *cell.borrow_mut() = None);
+    }
 }
 
 /// Resolve the per-transfer wall-clock budget from `StateConfig`.
@@ -202,9 +254,19 @@ pub async fn upload_state_with_excluded_tables(
         debug!("No local state file to upload");
         return Ok(());
     }
+    // Derive the remote object key ONCE from the original local path, before
+    // any strip/scratch copy. The strip path writes the filtered copy under
+    // `std::env::temp_dir()`, whose parent is `/tmp` — re-deriving the key
+    // from the scratch path would always yield the legacy `state.redb`, so a
+    // namespaced upload would silently clobber the shared object while the
+    // download read the (never-written) namespaced key. Computing it here and
+    // threading it down keeps the key tied to the namespace regardless of
+    // which physical file reaches the upload leaf.
+    let remote_key = remote_state_key(local_path);
+
     if excluded_tables.is_empty() || matches!(config.backend, StateBackend::Local) {
         // Fast path: nothing to strip or local backend is a no-op anyway.
-        let result = dispatch_upload(config, local_path).await;
+        let result = dispatch_upload(config, local_path, &remote_key).await;
         return apply_upload_failure_policy(config, result);
     }
 
@@ -220,11 +282,11 @@ pub async fn upload_state_with_excluded_tables(
             // Fall back to the unfiltered local path so a transient filter
             // failure doesn't block state durability. The filter is a
             // correctness hedge, not a hard privacy boundary.
-            let result = dispatch_upload(config, local_path).await;
+            let result = dispatch_upload(config, local_path, &remote_key).await;
             return apply_upload_failure_policy(config, result);
         }
     };
-    let result = dispatch_upload(config, &scratch).await;
+    let result = dispatch_upload(config, &scratch, &remote_key).await;
     // Scratch files live under `std::env::temp_dir()`; best-effort cleanup
     // on success or failure. A leaked scratch DB on this run is a small
     // cost the OS cleans up at reboot.
@@ -298,7 +360,18 @@ fn strip_local_only_tables(
 /// applying the `on_upload_failure` policy. Tiered recursion uses this
 /// directly so the skip/fail decision is evaluated exactly once at the
 /// outermost `upload_state` call, not per-leg.
-async fn dispatch_upload(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
+///
+/// `remote_key` is the object key derived from the *original* local path by
+/// [`upload_state_with_excluded_tables`]. It is threaded explicitly (rather
+/// than re-derived from `local_path`) because the filter path passes a scratch
+/// copy under `std::env::temp_dir()` whose parent would resolve back to the
+/// legacy `state.redb` key — see the comment at the top of
+/// [`upload_state_with_excluded_tables`].
+async fn dispatch_upload(
+    config: &StateConfig,
+    local_path: &Path,
+    remote_key: &str,
+) -> Result<(), StateSyncError> {
     match config.backend {
         StateBackend::Local => {
             debug!("State backend: local (no sync needed)");
@@ -314,6 +387,7 @@ async fn dispatch_upload(config: &StateConfig, local_path: &Path) -> Result<(), 
                 bucket,
                 prefix,
                 local_path,
+                remote_key,
                 transfer_timeout(config),
                 &config.retry,
             )
@@ -329,12 +403,13 @@ async fn dispatch_upload(config: &StateConfig, local_path: &Path) -> Result<(), 
                 bucket,
                 prefix,
                 local_path,
+                remote_key,
                 transfer_timeout(config),
                 &config.retry,
             )
             .await
         }
-        StateBackend::Valkey => upload_to_valkey(config, local_path).await,
+        StateBackend::Valkey => upload_to_valkey(config, local_path, remote_key).await,
         StateBackend::Tiered => {
             // Write to both Valkey (fast) and S3 (durable)
             info!("State backend: tiered (uploading to Valkey + S3)");
@@ -350,13 +425,15 @@ async fn dispatch_upload(config: &StateConfig, local_path: &Path) -> Result<(), 
             // Valkey first (fast, best-effort). Recurse into the *inner*
             // dispatch so `on_upload_failure` is not applied here — the
             // outer `upload_state` owns that decision for the tiered leg
-            // as a whole.
-            if let Err(e) = Box::pin(dispatch_upload(&valkey_config, local_path)).await {
+            // as a whole. The same `remote_key` flows to both legs so a
+            // namespaced upload lands at `<ns>.redb` on Valkey and S3 alike.
+            if let Err(e) = Box::pin(dispatch_upload(&valkey_config, local_path, remote_key)).await
+            {
                 warn!(error = %e, "Valkey upload failed (non-fatal, S3 is durable)");
             }
 
             // S3 second (durable, required)
-            Box::pin(dispatch_upload(&s3_config, local_path)).await
+            Box::pin(dispatch_upload(&s3_config, local_path, remote_key)).await
         }
     }
 }
@@ -447,11 +524,11 @@ async fn upload_to_object_store(
     bucket: &str,
     prefix: &str,
     local_path: &Path,
+    key: &str,
     timeout: Duration,
     retry: &RetryConfig,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
-    let key = remote_state_key(local_path);
     let size_bytes = local_path.metadata().map(|m| m.len()).unwrap_or(0);
     let span = info_span!(
         "state.upload",
@@ -467,7 +544,7 @@ async fn upload_to_object_store(
         let retries = with_transfer_timeout(timeout, async {
             retry_transient(retry, "state.upload.object_store", || async {
                 provider
-                    .upload_file(local_path, &key)
+                    .upload_file(local_path, key)
                     .await
                     .map_err(StateSyncError::from)
             })
@@ -589,7 +666,11 @@ async fn download_from_valkey(
 /// Mirrors [`download_from_valkey`]: offloads the blocking redis SET via
 /// `spawn_blocking` and wraps the handle with `with_transfer_timeout` so a
 /// hung Valkey peer cannot stall the run past the configured budget.
-async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(), StateSyncError> {
+async fn upload_to_valkey(
+    config: &StateConfig,
+    local_path: &Path,
+    remote_key: &str,
+) -> Result<(), StateSyncError> {
     let url = config
         .valkey_url
         .as_deref()
@@ -600,7 +681,7 @@ async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(),
         .as_deref()
         .unwrap_or(DEFAULT_VALKEY_PREFIX)
         .to_string();
-    let key = format!("{prefix}{}", remote_state_key(local_path));
+    let key = format!("{prefix}{remote_key}");
     let data = std::fs::read(local_path)?;
     let size_bytes = data.len() as u64;
     let timeout = transfer_timeout(config);
@@ -1049,6 +1130,71 @@ mod tests {
         provider.download_file(&key_b, &b_back).await.unwrap();
         assert_eq!(std::fs::read(&a_back).unwrap(), b"AAAA");
         assert_eq!(std::fs::read(&b_back).unwrap(), b"BBBB");
+    }
+
+    // Regression: the *upload* dispatch must land a namespaced state file at
+    // its `<ns>.redb` remote key, NOT the legacy shared `state.redb`. The
+    // strip path copies the file to a scratch under `std::env::temp_dir()`;
+    // before the fix the leaf re-derived the key from that scratch's parent
+    // (`/tmp`) and always wrote `state.redb`, so every namespace clobbered the
+    // shared object on upload while download read the never-written namespaced
+    // key (perpetual cold start). This drives the *real*
+    // `upload_state → strip → dispatch → upload_to_object_store → cloud_provider`
+    // chain via an injected in-memory store — it does NOT precompute the key
+    // and call `provider.upload_file` directly the way
+    // `test_remote_keys_round_trip_without_clobber` does, so it exercises the
+    // path that was actually broken.
+    //
+    // The seed writes a real redb with a schema_cache entry (a local-only
+    // table), so the strip path genuinely runs and the scratch copy is taken —
+    // a non-redb seed would make strip fail, fall back to the unfiltered local
+    // path, and the test would pass against the *unfixed* code.
+    async fn assert_namespaced_upload_key(backend: StateBackend) {
+        // Defensive: clear any override a prior test on this worker thread may
+        // have left armed (the thread-local persists across tests on reuse).
+        test_support::clear();
+        let dir = TempDir::new().unwrap();
+        let ns_dir = dir.path().join(crate::state::STATE_NAMESPACE_DIR);
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        let local = ns_dir.join("acme.redb");
+        seed_watermark_and_cache(&local);
+
+        let label = backend.to_string();
+        let provider = test_support::install(ObjectStoreProvider::in_memory());
+
+        let config = StateConfig {
+            backend,
+            s3_bucket: Some("test-bucket".into()),
+            gcs_bucket: Some("test-bucket".into()),
+            ..Default::default()
+        };
+
+        // Default upload path: strips the schema cache into a /tmp scratch,
+        // then dispatches. The remote key must still be derived from `local`.
+        upload_state(&config, &local).await.unwrap();
+
+        test_support::clear();
+
+        // The namespaced object exists at `acme.redb`...
+        assert!(
+            provider.exists("acme.redb").await.unwrap(),
+            "{label} upload must land at the namespaced key `acme.redb`"
+        );
+        // ...and the legacy shared key was NOT written (the clobber).
+        assert!(
+            !provider.exists("state.redb").await.unwrap(),
+            "{label} upload must NOT write the shared legacy `state.redb` for a namespaced file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_namespaced_upload_lands_at_ns_key_s3() {
+        assert_namespaced_upload_key(StateBackend::S3).await;
+    }
+
+    #[tokio::test]
+    async fn test_namespaced_upload_lands_at_ns_key_gcs() {
+        assert_namespaced_upload_key(StateBackend::Gcs).await;
     }
 
     #[test]

--- a/engine/crates/rocky-core/src/state_sync.rs
+++ b/engine/crates/rocky-core/src/state_sync.rs
@@ -64,6 +64,33 @@ const DEFAULT_S3_PREFIX: &str = "rocky/state/";
 const DEFAULT_GCS_PREFIX: &str = "rocky/state/";
 const DEFAULT_VALKEY_PREFIX: &str = "rocky:state:";
 
+/// Derive the remote object key (within the configured prefix) for a local
+/// state file.
+///
+/// The local file name and the remote key are intentionally decoupled: the
+/// global local file `<models>/.rocky-state.redb` maps to the fixed remote key
+/// `state.redb`. When per-namespace state-file namespacing is on, the local
+/// file lives under a `.rocky-state/` directory as `<namespace>.redb`; this
+/// returns `<namespace>.redb` so each namespace round-trips to a distinct
+/// remote object instead of every pipeline clobbering the same `state.redb`
+/// (silent cross-pod state loss).
+///
+/// The gate is the **parent directory name**, not the local file stem: the
+/// legacy global file's stem is `.rocky-state`, which must keep mapping to the
+/// unchanged `state.redb` key so the namespacing-OFF path is byte-identical on
+/// the wire.
+fn remote_state_key(local_path: &Path) -> String {
+    let is_namespaced = local_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        == Some(crate::state::STATE_NAMESPACE_DIR);
+    if is_namespaced && let Some(name) = local_path.file_name().and_then(|n| n.to_str()) {
+        return name.to_string();
+    }
+    STATE_FILE.to_string()
+}
+
 /// Build an `ObjectStoreProvider` rooted at `<scheme>://<bucket>/<prefix>`.
 fn cloud_provider(
     scheme: &str,
@@ -369,6 +396,7 @@ async fn download_from_object_store(
     timeout: Duration,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
+    let key = remote_state_key(local_path);
     let span = info_span!(
         "state.download",
         backend = %provider.scheme(),
@@ -376,15 +404,15 @@ async fn download_from_object_store(
     );
     async {
         info!(
-            uri = format!("{scheme}://{bucket}/{prefix}{STATE_FILE}"),
+            uri = format!("{scheme}://{bucket}/{prefix}{key}"),
             local = %local_path.display(),
             "downloading state from object store"
         );
 
         with_transfer_timeout(timeout, async {
-            match provider.exists(STATE_FILE).await {
+            match provider.exists(&key).await {
                 Ok(true) => {
-                    provider.download_file(STATE_FILE, local_path).await?;
+                    provider.download_file(&key, local_path).await?;
                     info!(
                         size = local_path.metadata().map(|m| m.len()).unwrap_or(0),
                         outcome = "ok",
@@ -423,6 +451,7 @@ async fn upload_to_object_store(
     retry: &RetryConfig,
 ) -> Result<(), StateSyncError> {
     let provider = cloud_provider(scheme, bucket, prefix)?;
+    let key = remote_state_key(local_path);
     let size_bytes = local_path.metadata().map(|m| m.len()).unwrap_or(0);
     let span = info_span!(
         "state.upload",
@@ -432,13 +461,13 @@ async fn upload_to_object_store(
     );
     async {
         info!(
-            uri = format!("{scheme}://{bucket}/{prefix}{STATE_FILE}"),
+            uri = format!("{scheme}://{bucket}/{prefix}{key}"),
             "uploading state to object store"
         );
         let retries = with_transfer_timeout(timeout, async {
             retry_transient(retry, "state.upload.object_store", || async {
                 provider
-                    .upload_file(local_path, STATE_FILE)
+                    .upload_file(local_path, &key)
                     .await
                     .map_err(StateSyncError::from)
             })
@@ -502,7 +531,7 @@ async fn download_from_valkey(
         .as_deref()
         .unwrap_or(DEFAULT_VALKEY_PREFIX)
         .to_string();
-    let key = format!("{prefix}{STATE_FILE}");
+    let key = format!("{prefix}{}", remote_state_key(local_path));
     let local_path_owned = local_path.to_path_buf();
     let timeout = transfer_timeout(config);
 
@@ -571,7 +600,7 @@ async fn upload_to_valkey(config: &StateConfig, local_path: &Path) -> Result<(),
         .as_deref()
         .unwrap_or(DEFAULT_VALKEY_PREFIX)
         .to_string();
-    let key = format!("{prefix}{STATE_FILE}");
+    let key = format!("{prefix}{}", remote_state_key(local_path));
     let data = std::fs::read(local_path)?;
     let size_bytes = data.len() as u64;
     let timeout = transfer_timeout(config);
@@ -964,6 +993,62 @@ mod tests {
     #[test]
     fn test_state_backend_display_includes_gcs() {
         assert_eq!(StateBackend::Gcs.to_string(), "gcs");
+    }
+
+    // R8 (part 1) — remote key derivation. The legacy global file maps to the
+    // unchanged `state.redb` key (namespacing OFF is byte-identical on the
+    // wire); namespaced files under `.rocky-state/` map to distinct
+    // `<namespace>.redb` keys so pipelines don't clobber a shared object.
+    #[test]
+    fn test_remote_state_key_legacy_vs_namespaced() {
+        // Legacy global file (stem is `.rocky-state`) -> fixed `state.redb`.
+        let legacy = std::path::Path::new("models/.rocky-state.redb");
+        assert_eq!(remote_state_key(legacy), "state.redb");
+
+        // A bare custom --state-path also keeps the fixed key (not under a
+        // `.rocky-state/` parent) — OFF/override paths never gain a key.
+        let custom = std::path::Path::new("/var/data/my-state.redb");
+        assert_eq!(remote_state_key(custom), "state.redb");
+
+        // Namespaced files -> distinct per-namespace keys.
+        let acme = std::path::Path::new("models/.rocky-state/acme.redb");
+        let globex = std::path::Path::new("models/.rocky-state/globex.redb");
+        assert_eq!(remote_state_key(acme), "acme.redb");
+        assert_eq!(remote_state_key(globex), "globex.redb");
+        assert_ne!(remote_state_key(acme), remote_state_key(globex));
+    }
+
+    // R8 (part 2) — no clobber. Two namespaced files round-trip through a real
+    // object store at distinct keys and do not overwrite each other.
+    #[tokio::test]
+    async fn test_remote_keys_round_trip_without_clobber() {
+        let dir = TempDir::new().unwrap();
+        let provider = crate::object_store::ObjectStoreProvider::in_memory();
+
+        // Two namespaced local files with distinct contents.
+        let ns_dir = dir.path().join(crate::state::STATE_NAMESPACE_DIR);
+        std::fs::create_dir_all(&ns_dir).unwrap();
+        let a_local = ns_dir.join("ns_a.redb");
+        let b_local = ns_dir.join("ns_b.redb");
+        std::fs::write(&a_local, b"AAAA").unwrap();
+        std::fs::write(&b_local, b"BBBB").unwrap();
+
+        let key_a = remote_state_key(&a_local);
+        let key_b = remote_state_key(&b_local);
+        assert_ne!(key_a, key_b);
+
+        // Upload both; the second must not overwrite the first.
+        provider.upload_file(&a_local, &key_a).await.unwrap();
+        provider.upload_file(&b_local, &key_b).await.unwrap();
+
+        // Download each back into fresh local paths and assert contents are
+        // intact (no clobber).
+        let a_back = dir.path().join("a_back.redb");
+        let b_back = dir.path().join("b_back.redb");
+        provider.download_file(&key_a, &a_back).await.unwrap();
+        provider.download_file(&key_b, &b_back).await.unwrap();
+        assert_eq!(std::fs::read(&a_back).unwrap(), b"AAAA");
+        assert_eq!(std::fs::read(&b_back).unwrap(), b"BBBB");
     }
 
     #[test]

--- a/engine/crates/rocky-core/tests/state_namespace.rs
+++ b/engine/crates/rocky-core/tests/state_namespace.rs
@@ -1,0 +1,374 @@
+//! Per-namespace state-file resolution + concurrency.
+//!
+//! Covers the A2 "redb single-writer relief" feature: opt-in, default-off
+//! per-pipeline / per-client state-file namespacing. Each namespace gets its
+//! own `<models>/.rocky-state/<ns>.redb` file (its own advisory `.redb.lock`
+//! and its own redb handle), so independent fan-out runs stop serializing on
+//! one global lock.
+//!
+//! The non-negotiable here is the *default-safe floor*: with no namespace,
+//! resolution is byte-identical to today (R1). The relief claim is that N
+//! distinct-namespace writers proceed with zero lock contention (R2), while
+//! the single-file guard is unweakened (R3) and namespaces never cross-talk
+//! (R4).
+//!
+//! Concurrency discipline mirrors `state_lock.rs`: same-file contention is
+//! simulated by holding the `fs4` advisory lock externally (so redb's own
+//! per-file `DatabaseAlreadyOpen` doesn't muddy the assertion), and the
+//! N-writer relief test opens N *distinct* files, which is exactly the
+//! cross-process fan-out shape — distinct files have no shared redb handle.
+
+use std::fs::OpenOptions;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::thread;
+
+use chrono::Utc;
+use fs4::FileExt;
+use rocky_core::state::{
+    STATE_FILE_NAME, STATE_NAMESPACE_DIR, StateError, StateStore, resolve_state_path,
+    resolve_state_path_ns, validate_namespace,
+};
+use rocky_ir::WatermarkState;
+use tempfile::TempDir;
+
+fn watermark(value: chrono::DateTime<Utc>) -> WatermarkState {
+    WatermarkState {
+        last_value: value,
+        updated_at: value,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// R1 — transparency invariant (the default-safe floor, most important test).
+//
+// `resolve_state_path_ns(explicit, models, None)` must be byte-identical to
+// `resolve_state_path(explicit, models)` across every resolution case, so a
+// user who never opts in sees identical behavior.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r1_none_namespace_is_byte_identical_to_legacy_resolver() {
+    // Case 1: explicit --state-path (hard override).
+    let explicit = std::path::PathBuf::from("/tmp/custom-state.redb");
+    let models = std::path::Path::new("models");
+    assert_eq!(
+        resolve_state_path_ns(Some(&explicit), models, None),
+        resolve_state_path(Some(&explicit), models),
+    );
+
+    // Case 5: fresh project, models dir exists.
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+    assert_eq!(
+        resolve_state_path_ns(None, &models_dir, None),
+        resolve_state_path(None, &models_dir),
+    );
+
+    // Case 5: fresh project, no models dir (CWD fallback path).
+    let no_models = dir.path().join("nope");
+    assert_eq!(
+        resolve_state_path_ns(None, &no_models, None),
+        resolve_state_path(None, &no_models),
+    );
+
+    // Case 2: canonical <models>/.rocky-state.redb already exists.
+    std::fs::write(models_dir.join(STATE_FILE_NAME), b"x").unwrap();
+    assert_eq!(
+        resolve_state_path_ns(None, &models_dir, None),
+        resolve_state_path(None, &models_dir),
+    );
+}
+
+#[test]
+fn r1_explicit_path_disables_namespacing_even_when_namespace_set() {
+    // An explicit --state-path is a hard override: namespacing is disabled for
+    // that invocation, so the result equals the legacy resolver's verbatim
+    // honoring of the explicit path.
+    let explicit = std::path::PathBuf::from("/tmp/pinned-state.redb");
+    let models = std::path::Path::new("models");
+    assert_eq!(
+        resolve_state_path_ns(Some(&explicit), models, Some("acme")),
+        resolve_state_path(Some(&explicit), models),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R7 — lock-path derivation under namespacing.
+//
+// `<models>/.rocky-state/acme.redb` must yield advisory lock
+// `<models>/.rocky-state/acme.redb.lock` — distinct per namespace, so two
+// namespaces never share a lock file.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r7_namespaced_path_and_lock_derivation() {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+
+    let resolved = resolve_state_path_ns(None, &models_dir, Some("acme"));
+    let expected = models_dir.join(STATE_NAMESPACE_DIR).join("acme.redb");
+    assert_eq!(resolved.path(), expected.as_path());
+    assert!(resolved.warning.is_none());
+
+    // The parent .rocky-state/ dir is created on resolution so the later
+    // advisory-lock open doesn't fail on a missing parent.
+    assert!(models_dir.join(STATE_NAMESPACE_DIR).is_dir());
+
+    // `with_extension("redb.lock")` (used by StateStore::open) composes with
+    // the nested path: acme.redb -> acme.redb.lock, in the namespace dir.
+    let lock = resolved.path().with_extension("redb.lock");
+    assert_eq!(
+        lock,
+        models_dir.join(STATE_NAMESPACE_DIR).join("acme.redb.lock"),
+    );
+
+    // A second namespace lands on a sibling file with its own lock.
+    let other = resolve_state_path_ns(None, &models_dir, Some("globex"));
+    assert_ne!(other.path(), resolved.path());
+    assert_ne!(
+        other.path().with_extension("redb.lock"),
+        resolved.path().with_extension("redb.lock"),
+    );
+}
+
+#[test]
+fn namespace_validation_rejects_path_traversal() {
+    assert!(validate_namespace("acme").is_ok());
+    assert!(validate_namespace("acme_us_west_1").is_ok());
+    assert!(validate_namespace("Tenant123").is_ok());
+
+    // Path traversal / separators / dots / spaces are all rejected — the
+    // namespace becomes a file segment.
+    assert!(validate_namespace("../etc").is_err());
+    assert!(validate_namespace("a/b").is_err());
+    assert!(validate_namespace("a.b").is_err());
+    assert!(validate_namespace("has space").is_err());
+    assert!(validate_namespace("").is_err());
+
+    // An unvalidated invalid namespace must never compose a traversal path:
+    // resolve_state_path_ns falls back to the global resolution instead.
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+    let resolved = resolve_state_path_ns(None, &models_dir, Some("../escape"));
+    // Falls back to the global path; never lands outside the project.
+    assert_eq!(
+        resolved.path(),
+        resolve_state_path(None, &models_dir).path()
+    );
+    assert!(!resolved.path().to_string_lossy().contains("escape"));
+}
+
+// ---------------------------------------------------------------------------
+// R2 — N concurrent namespaced writers, zero lock contention (core relief).
+//
+// N writers each open a *distinct* `.rocky-state/ns_{i}.redb` and run a write
+// loop. Distinct files => distinct advisory locks => distinct redb handles, so
+// there must be zero `LockHeldByOther` / `Busy` and every commit must succeed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r2_n_concurrent_namespaced_writers_no_lock_errors() {
+    const N: usize = 6;
+    const WRITES_PER_WRITER: usize = 25;
+
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+
+    // Resolve each namespace up front (creates the shared .rocky-state/ dir).
+    let paths: Vec<_> = (0..N)
+        .map(|i| {
+            resolve_state_path_ns(None, &models_dir, Some(&format!("ns_{i}")))
+                .path()
+                .to_path_buf()
+        })
+        .collect();
+
+    let barrier = Arc::new(Barrier::new(N));
+    let handles: Vec<_> = paths
+        .into_iter()
+        .enumerate()
+        .map(|(i, path)| {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                // Open the writer BEFORE the barrier so all N hold their
+                // advisory lock simultaneously — this is the contended window
+                // a global file would serialize on.
+                let store = StateStore::open(&path).expect("namespaced open must succeed");
+                barrier.wait();
+                for w in 0..WRITES_PER_WRITER {
+                    let ts = Utc::now();
+                    store
+                        .set_watermark(&format!("cat.sch.t_{i}_{w}"), &watermark(ts))
+                        .expect("watermark write must succeed under concurrency");
+                }
+                // Every write committed; read one back to prove durability.
+                let got = store
+                    .get_watermark(&format!("cat.sch.t_{i}_0"))
+                    .expect("read back");
+                assert!(got.is_some());
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join()
+            .expect("no writer thread panicked (no lock contention)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// R3 — shared file still serializes (single-file guard unweakened).
+//
+// Mirrors state_lock.rs::second_writer_fails_when_lock_held_externally, but on
+// a *namespaced* file: holding the fs4 advisory lock externally must still
+// make a same-file StateStore::open fail with LockHeldByOther. Proves we did
+// not weaken the single-file guard — same namespace still serializes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r3_same_namespaced_file_still_serializes() {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+    let path = resolve_state_path_ns(None, &models_dir, Some("acme"))
+        .path()
+        .to_path_buf();
+
+    // Simulate another process holding the advisory lock on THIS namespace's
+    // lock file (no redb open, exactly like state_lock.rs).
+    let lock_path = path.with_extension("redb.lock");
+    let external = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .unwrap();
+    FileExt::try_lock(&external).expect("external lock acquired in clean temp dir");
+
+    match StateStore::open(&path) {
+        Err(StateError::LockHeldByOther { .. }) => {}
+        Err(other) => panic!("expected LockHeldByOther on the same namespaced file, got {other:?}"),
+        Ok(_) => panic!("same-namespace open must fail while the lock is held externally"),
+    }
+
+    // A DIFFERENT namespace is unaffected — its lock is a separate file.
+    let other_path = resolve_state_path_ns(None, &models_dir, Some("globex"))
+        .path()
+        .to_path_buf();
+    let _other = StateStore::open(&other_path)
+        .expect("a different namespace must open while acme's lock is held");
+}
+
+// ---------------------------------------------------------------------------
+// R4 — no cross-talk between namespaces.
+//
+// Writer A writes WATERMARKS[t1]=X to ns_a; writer B writes WATERMARKS[t1]=Y
+// to ns_b. Each file must read back its OWN value (no bleed), and opening one
+// namespace must never observe the other's run history / watermarks.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r4_no_cross_talk_between_namespaces() {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+
+    let path_a = resolve_state_path_ns(None, &models_dir, Some("ns_a"))
+        .path()
+        .to_path_buf();
+    let path_b = resolve_state_path_ns(None, &models_dir, Some("ns_b"))
+        .path()
+        .to_path_buf();
+    assert_ne!(path_a, path_b);
+
+    let ts_x = Utc::now();
+    let ts_y = ts_x + chrono::Duration::hours(1);
+
+    {
+        let a = StateStore::open(&path_a).unwrap();
+        let b = StateStore::open(&path_b).unwrap();
+        // Same logical key, different namespace -> different file.
+        a.set_watermark("cat.sch.t1", &watermark(ts_x)).unwrap();
+        b.set_watermark("cat.sch.t1", &watermark(ts_y)).unwrap();
+        // A also writes a key B never sees.
+        a.set_watermark("cat.sch.only_a", &watermark(ts_x)).unwrap();
+    }
+
+    // Reopen each and assert each reads back ONLY its own value.
+    let a = StateStore::open(&path_a).unwrap();
+    let b = StateStore::open(&path_b).unwrap();
+
+    assert_eq!(
+        a.get_watermark("cat.sch.t1").unwrap().unwrap().last_value,
+        ts_x,
+    );
+    assert_eq!(
+        b.get_watermark("cat.sch.t1").unwrap().unwrap().last_value,
+        ts_y,
+    );
+    // ns_a's exclusive key must be invisible in ns_b.
+    assert!(b.get_watermark("cat.sch.only_a").unwrap().is_none());
+
+    // Full watermark listing is disjoint: ns_b never sees ns_a's only_a key.
+    let b_keys: Vec<String> = b
+        .list_watermarks()
+        .unwrap()
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect();
+    assert!(!b_keys.iter().any(|k| k == "cat.sch.only_a"));
+}
+
+// ---------------------------------------------------------------------------
+// R10 — migration non-destructiveness (the core safety guarantee).
+//
+// A pre-existing legacy <models>/.rocky-state.redb with watermarks must be
+// byte-unchanged when namespacing is on, and the namespaced file must start
+// FRESH (no auto-seed).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn r10_legacy_file_untouched_namespaced_file_starts_fresh() {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+
+    // Seed a legacy global file with a watermark.
+    let legacy_path = models_dir.join(STATE_FILE_NAME);
+    {
+        let legacy = StateStore::open(&legacy_path).unwrap();
+        legacy
+            .set_watermark("cat.sch.legacy", &watermark(Utc::now()))
+            .unwrap();
+    }
+    let legacy_bytes_before = std::fs::read(&legacy_path).unwrap();
+
+    // Open a namespaced store with namespacing on.
+    let ns_path = resolve_state_path_ns(None, &models_dir, Some("acme"))
+        .path()
+        .to_path_buf();
+    {
+        let ns = StateStore::open(&ns_path).unwrap();
+        // No auto-seed: the legacy watermark must NOT be present.
+        assert!(
+            ns.get_watermark("cat.sch.legacy").unwrap().is_none(),
+            "namespaced file must start fresh, not inherit legacy watermarks"
+        );
+        // The namespaced file is genuinely a fresh, separate file.
+        assert_ne!(ns_path, legacy_path);
+    }
+
+    // The legacy file is byte-unchanged on disk (never moved, deleted, or
+    // mutated by enabling namespacing).
+    let legacy_bytes_after = std::fs::read(&legacy_path).unwrap();
+    assert_eq!(
+        legacy_bytes_before, legacy_bytes_after,
+        "legacy global state file must be byte-identical after namespacing is enabled"
+    );
+}

--- a/engine/crates/rocky-core/tests/state_namespace.rs
+++ b/engine/crates/rocky-core/tests/state_namespace.rs
@@ -162,6 +162,30 @@ fn namespace_validation_rejects_path_traversal() {
     assert!(!resolved.path().to_string_lossy().contains("escape"));
 }
 
+// FIX 3 — when the `.rocky-state/` namespace dir can't be created because the
+// path already exists as a *file* (e.g. a stray dotfile), resolution falls
+// back to the global state path instead of composing a path that would only
+// fail later at lock-open with an opaque I/O error.
+#[test]
+fn ns_dir_collides_with_file_falls_back_to_global() {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+
+    // Plant a regular file where the namespace directory would go.
+    let collision = models_dir.join(STATE_NAMESPACE_DIR);
+    std::fs::write(&collision, b"not a directory").unwrap();
+
+    let resolved = resolve_state_path_ns(None, &models_dir, Some("acme"));
+    // Falls back to the global resolution rather than the namespaced file.
+    assert_eq!(
+        resolved.path(),
+        resolve_state_path(None, &models_dir).path(),
+        "a non-directory namespace path must fall back to the global state file"
+    );
+    assert!(!resolved.path().ends_with("acme.redb"));
+}
+
 // ---------------------------------------------------------------------------
 // R2 — N concurrent namespaced writers, zero lock contention (core relief).
 //

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -2184,7 +2184,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
     let result: Result<()> = match cli.command {
         Command::Init { path, template } => rocky_cli::commands::init(&path, Some(&template)),
         Command::Apply { plan_id } => {
-            rocky_cli::commands::run_apply(&cli.config, &plan_id, json).await
+            rocky_cli::commands::run_apply(&cli.config, &plan_id, &state_path, json).await
         }
         Command::Review {
             plan_id,
@@ -2308,6 +2308,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     promote_filter.as_deref(),
                     promote_pipeline.as_deref(),
                     allow_breaking,
+                    &state_path,
                     json,
                 )
                 .await
@@ -3247,7 +3248,13 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             }
         }
         Command::Watch { models, contracts } => {
-            rocky_cli::commands::run_watch(&models, contracts.as_deref(), json).await
+            rocky_cli::commands::run_watch(
+                &models,
+                contracts.as_deref(),
+                state_namespace.as_deref(),
+                json,
+            )
+            .await
         }
         Command::Fmt { paths, check } => rocky_cli::commands::run_fmt(&paths, check),
         Command::ExportSchemas { output_dir } => rocky_cli::commands::export_schemas(&output_dir),

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -86,6 +86,31 @@ struct Cli {
     #[arg(long)]
     state_path: Option<PathBuf>,
 
+    /// Per-pipeline / per-client state-file namespace.
+    ///
+    /// redb permits one writer per state file, so fanning out one `rocky run`
+    /// per pipeline or client against the single global
+    /// `<models>/.rocky-state.redb` forces those independent runs to serialize
+    /// on one advisory lock. Passing `--state-namespace <key>` routes this
+    /// invocation to its own `<models>/.rocky-state/<key>.redb` (its own lock,
+    /// its own remote object key), so runs on distinct namespaces proceed
+    /// concurrently with zero shared corruption surface.
+    ///
+    /// `<key>` must be a SQL identifier (`^[a-zA-Z0-9_]+$`) — it becomes a
+    /// path segment, so anything else is rejected.
+    ///
+    /// Precedence: an explicit `--state-path` is a hard override that
+    /// **disables** namespacing for that invocation. Otherwise this flag wins
+    /// over `[state] namespacing` in `rocky.toml`. Default (neither set) is the
+    /// single global state file — byte-identical to today.
+    ///
+    /// Namespaced files start fresh; the legacy global file is never moved or
+    /// auto-seeded. Carry watermarks forward manually if needed (copy the
+    /// global file to `<models>/.rocky-state/<key>.redb`, or point
+    /// `--state-path` at it for the first run).
+    #[arg(long)]
+    state_namespace: Option<String>,
+
     /// Override `[cache.schemas] ttl_seconds` for this invocation.
     ///
     /// Precedence: `--cache-ttl` > `[cache.schemas] ttl_seconds` in
@@ -2043,6 +2068,61 @@ fn parse_governance_override(
 /// `2` is reserved exclusively for run partial-success; doctor-critical
 /// and ci-warnings were split off to `3` / `4` so they no longer collide
 /// with it.
+/// Resolve the state-file namespace for this invocation, if any.
+///
+/// Precedence:
+/// 1. An explicit `--state-path` disables namespacing entirely (returns
+///    `None`); the explicit path is honored verbatim downstream. Checked here
+///    so a `--state-namespace` typo doesn't error out a run that the explicit
+///    path already pins.
+/// 2. `--state-namespace <key>` — validated as a SQL identifier
+///    (`^[a-zA-Z0-9_]+$`); an invalid key is a hard error so a path-traversal
+///    or tenant-collision value never silently composes a file path.
+/// 3. `[state] namespacing = "pipeline"` — best-effort: load the config and, if
+///    exactly one pipeline is defined (or it resolves unambiguously), use its
+///    name. If the config can't be loaded or the pipeline is ambiguous, fall
+///    back to the global state file rather than failing the invocation (a
+///    convenience knob should never block a command that doesn't even touch a
+///    single pipeline). Use `--state-namespace` for explicit multi-pipeline /
+///    multi-tenant fan-out.
+fn resolve_state_namespace(cli: &Cli) -> Result<Option<String>> {
+    // Explicit --state-path wins and disables namespacing.
+    if cli.state_path.is_some() {
+        return Ok(None);
+    }
+
+    if let Some(ns) = cli.state_namespace.as_deref() {
+        rocky_core::state::validate_namespace(ns).map_err(|e| {
+            anyhow::anyhow!(
+                "invalid --state-namespace '{ns}': {e}. A state namespace becomes a \
+                 file path segment, so it must be a SQL identifier (^[a-zA-Z0-9_]+$)."
+            )
+        })?;
+        return Ok(Some(ns.to_string()));
+    }
+
+    // Config-driven `[state] namespacing = "pipeline"`. Best-effort: this site
+    // runs for every command, so a config that doesn't parse (or isn't a
+    // single-pipeline project) must not hard-fail here.
+    let Ok(cfg) = rocky_core::config::load_rocky_config(&cli.config) else {
+        return Ok(None);
+    };
+    if cfg.state.namespacing != rocky_core::config::StateNamespacing::Pipeline {
+        return Ok(None);
+    }
+    match rocky_cli::registry::resolve_pipeline(&cfg, None) {
+        Ok((name, _)) => match rocky_core::state::validate_namespace(name) {
+            Ok(_) => Ok(Some(name.to_string())),
+            // A pipeline name that isn't a valid identifier (unusual) can't be a
+            // file segment; fall back to the global file rather than erroring.
+            Err(_) => Ok(None),
+        },
+        // Ambiguous (multiple pipelines, no selector) or empty: fall back to
+        // the global file. The user should pass `--state-namespace` to fan out.
+        Err(_) => Ok(None),
+    }
+}
+
 async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // Install miette's fancy handler for rich error rendering in text mode.
     // In JSON mode we skip it — errors are serialized as structured data.
@@ -2082,9 +2162,19 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
     // per-command `--models` override (on `rocky run`, `rocky compile`,
     // etc.) intentionally doesn't feed back in — the state file lives
     // with the project, not with a one-shot `--models` override.
-    let resolved = rocky_core::state::resolve_state_path(
+    //
+    // Namespacing (opt-in, default off): redb permits one writer per state
+    // file, so fanning out one `rocky run` per pipeline/client against the
+    // single global file serializes them on one advisory lock.
+    // `--state-namespace <key>` (or `[state] namespacing = "pipeline"`) routes
+    // this invocation to its own `<models>/.rocky-state/<key>.redb`. An
+    // explicit `--state-path` is a hard override that disables namespacing.
+    // The default (neither set) is byte-identical to today.
+    let state_namespace: Option<String> = resolve_state_namespace(&cli)?;
+    let resolved = rocky_core::state::resolve_state_path_ns(
         cli.state_path.as_deref(),
         std::path::Path::new("models"),
+        state_namespace.as_deref(),
     );
     if let Some(ref w) = resolved.warning {
         warn!(target: "rocky::state_path", "{w}");

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1152,6 +1152,22 @@ class StateBackend5(StrEnum):
     tiered = "tiered"
 
 
+class StateNamespacing1(StrEnum):
+    """
+    One global `<models>/.rocky-state.redb` for the whole project (default). Identical to today's behavior.
+    """
+
+    none = "none"
+
+
+class StateNamespacing2(StrEnum):
+    """
+    One state file per pipeline, under `<models>/.rocky-state/<pipeline>.redb`. The per-invocation `--state-namespace <key>` flag takes precedence over this config and is the explicit way to fan out by client/tenant rather than by pipeline name. An explicit `--state-path` disables namespacing entirely for that invocation.
+    """
+
+    pipeline = "pipeline"
+
+
 class StateRetentionDomain1(StrEnum):
     """
     Pipeline run records (`run_history` table). Each row carries `started_at`/`finished_at` and the governance audit trail.
@@ -2591,6 +2607,10 @@ class StateConfig(BaseModel):
     """
     Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as "deduplicated", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`].
     """
+    namespacing: StateNamespacing1 | StateNamespacing2 | None = "none"
+    """
+    Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = "pipeline"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run.
+    """
     on_upload_failure: StateUploadFailureMode1 | StateUploadFailureMode2 | None = "skip"
     """
     What to do when state upload exhausts retries + circuit-breaker. Defaults to `skip` — rocky continues the run and the next run re-derives state from target-table metadata. See [`StateUploadFailureMode`].
@@ -3087,6 +3107,7 @@ class RockyConfig(BaseModel):
                 "in_flight_ttl_hours": 24,
                 "retention_days": 30,
             },
+            "namespacing": "none",
             "on_upload_failure": "skip",
             "retention": {
                 "applies_to": ["history", "lineage", "audit"],

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2998,6 +2998,15 @@
           },
           "description": "Per-run idempotency-key policy (`rocky run --idempotency-key`). Controls retention of stamped keys, what terminal statuses count as \"deduplicated\", and how long an `InFlight` entry survives before it's treated as a crashed-pod corpse and adopted by a fresh caller. See [`IdempotencyConfig`]."
         },
+        "namespacing": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StateNamespacing"
+            }
+          ],
+          "default": "none",
+          "description": "Per-pipeline / per-client state-file namespacing. Defaults to [`StateNamespacing::None`] (one global state file — byte-identical to a project that omits this key). Set `namespacing = \"pipeline\"` to give each pipeline its own `<models>/.rocky-state/<pipeline>.redb` so independent fan-out runs don't serialize on one advisory lock. The per-invocation `--state-namespace <key>` flag overrides this; an explicit `--state-path` disables namespacing for that run."
+        },
         "on_upload_failure": {
           "allOf": [
             {
@@ -3081,6 +3090,25 @@
         }
       },
       "type": "object"
+    },
+    "StateNamespacing": {
+      "description": "Per-pipeline / per-client state-file namespacing policy.\n\nredb permits one writer per file, so fanning out one `rocky run` process per pipeline or client against the single global state file forces those independent runs to serialize on one advisory lock. Namespacing gives each namespace its own `<models>/.rocky-state/<namespace>.redb` file (its own lock, its own redb handle, its own remote object key), so runs on distinct namespaces proceed concurrently with zero shared corruption surface.\n\nDefault is [`StateNamespacing::None`] — behavior is **byte-identical** to a project that never sets this key. Namespacing is purely opt-in.",
+      "oneOf": [
+        {
+          "description": "One global `<models>/.rocky-state.redb` for the whole project (default). Identical to today's behavior.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "One state file per pipeline, under `<models>/.rocky-state/<pipeline>.redb`. The per-invocation `--state-namespace <key>` flag takes precedence over this config and is the explicit way to fan out by client/tenant rather than by pipeline name. An explicit `--state-path` disables namespacing entirely for that invocation.",
+          "enum": [
+            "pipeline"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "StateRetentionConfig": {
       "additionalProperties": false,
@@ -3709,6 +3737,7 @@
           "in_flight_ttl_hours": 24,
           "retention_days": 30
         },
+        "namespacing": "none",
         "on_upload_failure": "skip",
         "retention": {
           "applies_to": [


### PR DESCRIPTION
## What

Opt-in, **default-OFF** per-pipeline / per-client state-file namespacing.

redb permits exactly one writer per state file (its own `flock` plus Rocky's advisory `.redb.lock`). The CLI resolves **one** state file per invocation (`<models>/.rocky-state.redb`) and threads it everywhere, so fanning out one `rocky run` per pipeline/client makes them all contend on that single file ("state store is locked by another process"). Namespacing gives each pipeline/client its own file ⇒ its own lock ⇒ concurrent writers on different namespaces with **zero shared corruption surface** — every existing single-writer invariant still holds unchanged *inside* each file.

## Default is byte-identical to today

With no namespace set, `resolve_state_path_ns(.., None)` **delegates verbatim** to the existing `resolve_state_path` — transparency by construction. A user who upgrades and does nothing sees identical files, history, and idempotency semantics. This is the non-negotiable safety floor (test R1).

## Opt in

- Per-invocation: `--state-namespace <key>` (the explicit fan-out knob — `<key>` is the tenant/client).
- Per-project: `[state] namespacing = "pipeline"` in `rocky.toml`.
- Precedence: an explicit `--state-path` is a **hard override** that disables namespacing for that invocation; otherwise `--state-namespace` wins over the config; default is the single global file.

`<key>` must be a SQL identifier (`^[a-zA-Z0-9_]+$`) — it becomes a path segment, so anything else is rejected (path-traversal / tenant-collision guard).

## Changes

- **`rocky-core/src/state.rs`** — `resolve_state_path_ns(explicit, models_dir, namespace)` + `validate_namespace`. None ⇒ delegate; `Some(ns)` ⇒ `<models>/.rocky-state/<ns>.redb` (parent created on resolve). The `.redb.lock` derivation composes for free (distinct lock per namespace).
- **`rocky-core/src/config.rs`** — `StateNamespacing` enum (`none` default | `pipeline`) on `StateConfig`.
- **`rocky/src/main.rs`** — `--state-namespace` on the top-level `Cli`, resolved at the single state-path site. Pipeline config mode resolves a namespace only for single-pipeline projects with identifier-safe names; **multi-pipeline projects in pipeline mode silently fall back to the global file** — use `--state-namespace` for multi-tenant fan-out.
- **`rocky-core/src/state_sync.rs`** — remote object key derived per-namespace (`<prefix>/<ns>.redb`) instead of the fixed `state.redb`, so concurrent pipelines don't clobber the same remote object. The OFF path keeps `state.redb` (byte-identical on the wire).

No `CURRENT_SCHEMA_VERSION` bump — on-disk table layout is unchanged; only the file location/count changes. Each namespaced file stamps fresh as the current version.

## Migration (non-destructive)

Namespaced files start **fresh**. The legacy global `.rocky-state.redb` is never moved, deleted, or auto-seeded (watermark ownership isn't derivable in the resolver). Carry watermarks forward manually if needed: copy the global file to `<models>/.rocky-state/<ns>.redb`, or point `--state-path` at it for the namespace's first run.

## Tests

- **R1** transparency — `resolve_state_path_ns(.., None)` is byte-identical to `resolve_state_path` across all resolution cases (the default-safe floor).
- **R2** N concurrent namespaced writers — zero lock errors, all commits succeed (the core relief).
- **R3** shared file still serializes — a second writer on the same namespaced file still gets `LockHeldByOther` (single-file guard unweakened).
- **R4** no cross-talk — namespace A never observes B's watermarks.
- **R7** lock-path derivation — `.rocky-state/acme.redb` ⇒ `.rocky-state/acme.redb.lock`.
- **R8** remote-key no-clobber — distinct namespaces round-trip to distinct remote keys.
- **R10** migration non-destructive — legacy file byte-unchanged; namespaced file starts fresh.
- Existing `state_lock.rs` tests pass **unchanged** (proves the OFF path is untouched).

## Codegen note

`StateConfig` feeds the autogenerated **project-config** schema (`rocky_project`), so adding the `[state] namespacing` field regenerates the project schema + its vscode TS + dagster Pydantic bindings (committed here, codegen re-run is a no-op). **No CLI command `*Output` schema changes** — this is purely the config schema gaining one field.

---

**DRAFT** — for review, do not merge.