### PR TITLE
feat(engine/rocky-bigquery): create local-load tables with inferred column types

### DIFF
--- a/engine/crates/rocky-bigquery/src/loader.rs
+++ b/engine/crates/rocky-bigquery/src/loader.rs
@@ -40,7 +40,9 @@ use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
-use rocky_core::arrow_loader::{CsvBatchReader, generate_batch_insert_sql};
+use rocky_core::arrow_loader::{
+    CsvBatchReader, RowBatch, generate_batch_insert_sql, infer_column_types,
+};
 use rocky_core::traits::WarehouseAdapter;
 
 use crate::BigQueryAdapter;
@@ -93,6 +95,62 @@ fn format_target(target: &TableRef) -> String {
             target.catalog, target.schema, target.table
         )
     }
+}
+
+/// Map a generic inferred SQL type name (as produced by
+/// [`infer_column_types`]) to its canonical BigQuery type name.
+///
+/// [`infer_column_types`] emits the DuckDB/generic family
+/// (`BOOLEAN` / `BIGINT` / `DOUBLE` / `TIMESTAMP` / `STRING`); BigQuery's
+/// canonical names are `BOOL` / `INT64` / `FLOAT64` / `TIMESTAMP` /
+/// `STRING` (the names BQ itself logs — see the `FLOAT64` / `INT64`
+/// rationale in `connector.rs`). Anything unrecognized falls back to
+/// `STRING`, which is lossless for the CSV INSERT path.
+fn bq_column_type(generic_type: &str) -> &'static str {
+    match generic_type.to_ascii_uppercase().as_str() {
+        "BOOLEAN" | "BOOL" => "BOOL",
+        "BIGINT" | "INTEGER" | "INT" | "INT64" => "INT64",
+        "DOUBLE" | "FLOAT" | "FLOAT64" => "FLOAT64",
+        "TIMESTAMP" => "TIMESTAMP",
+        _ => "STRING",
+    }
+}
+
+/// Build a `CREATE TABLE IF NOT EXISTS {target_ref} (`col` TYPE, …)`
+/// statement with column types inferred from the CSV batches.
+///
+/// The column list is driven by the CSV header (`column_names`) so a
+/// header-only file (zero data rows, hence no inferred types) still
+/// produces every column — those default to `STRING`. Returns `None`
+/// when there are no columns at all.
+fn build_create_table_sql(
+    target_ref: &str,
+    column_names: &[String],
+    batches: &[RowBatch],
+) -> Option<String> {
+    if column_names.is_empty() {
+        return None;
+    }
+
+    // Inferred types keyed by column name; absent columns (e.g. a
+    // header-only CSV) fall back to STRING below.
+    let inferred: std::collections::HashMap<String, String> = infer_column_types(batches)
+        .into_iter()
+        .map(|c| (c.name, c.data_type))
+        .collect();
+
+    let col_defs: Vec<String> = column_names
+        .iter()
+        .map(|name| {
+            let generic = inferred.get(name).map_or("STRING", String::as_str);
+            format!("`{name}` {}", bq_column_type(generic))
+        })
+        .collect();
+
+    Some(format!(
+        "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
+        col_defs.join(", ")
+    ))
 }
 
 /// Map the SDK [`FileFormat`] to the BigQuery load-job source format.
@@ -229,37 +287,42 @@ impl LoaderAdapter for BigQueryLoaderAdapter {
                 let reader = CsvBatchReader::with_delimiter(local_path, options.batch_size, delim)
                     .map_err(|e| AdapterError::msg(format!("failed to open CSV: {e}")))?;
 
-                // If create_table is requested, infer column names from the
-                // header and create a STRING-columns table. BigQuery type
-                // inference is more involved (would need a sample pass);
-                // STRING is a safe, lossless fallback for the dev-scale
-                // INSERT path.
-                if options.create_table {
-                    let columns = reader.column_names();
-                    if !columns.is_empty() {
-                        let col_defs: Vec<String> =
-                            columns.iter().map(|c| format!("`{c}` STRING")).collect();
-                        let sql = format!(
-                            "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
-                            col_defs.join(", ")
-                        );
-                        debug!(sql = %sql, "ensuring target table exists");
-                        self.adapter
-                            .execute_statement(&sql)
-                            .await
-                            .map_err(|e| AdapterError::msg(e.to_string()))?;
-                    }
+                // Read all batches up front with the caller's delimiter
+                // (re-reading via the comma-only `read_csv_batches` would
+                // misparse a TSV as one column). The whole file is buffered:
+                // this INSERT path is dev-scale by design (see module docs),
+                // and type inference needs the rows anyway. The same batches
+                // then drive the INSERT loop, so the file is read exactly
+                // once.
+                let column_names = reader.column_names().to_vec();
+                let batches: Vec<RowBatch> = reader
+                    .collect::<Result<_, _>>()
+                    .map_err(|e| AdapterError::msg(format!("failed to read CSV batch: {e}")))?;
+
+                // If create_table is requested, infer column TYPES from the
+                // sampled rows and create the table with those types (mapped
+                // to BigQuery's canonical type names). All-STRING would defeat
+                // the typed contract-gate (`rocky load` with a `[contract]`),
+                // which a header-derived STRING column always fails against a
+                // declared `id INT64`. Idempotent via IF NOT EXISTS — no
+                // DESCRIBE / existence round-trip.
+                if options.create_table
+                    && let Some(sql) = build_create_table_sql(&target_ref, &column_names, &batches)
+                {
+                    debug!(sql = %sql, "ensuring target table exists with inferred types");
+                    self.adapter
+                        .execute_statement(&sql)
+                        .await
+                        .map_err(|e| AdapterError::msg(e.to_string()))?;
                 }
 
                 let mut rows_loaded: u64 = 0;
                 let dialect = self.adapter.dialect();
 
-                for batch_res in reader {
-                    let batch = batch_res
-                        .map_err(|e| AdapterError::msg(format!("failed to read CSV batch: {e}")))?;
+                for batch in &batches {
                     let batch_row_count = batch.row_count as u64;
                     let sql =
-                        generate_batch_insert_sql(&batch, &target_ref, dialect).map_err(|e| {
+                        generate_batch_insert_sql(batch, &target_ref, dialect).map_err(|e| {
                             AdapterError::msg(format!("failed to build INSERT SQL: {e}"))
                         })?;
                     debug!(rows = batch_row_count, "inserting CSV batch");
@@ -413,6 +476,88 @@ mod tests {
         let spec = build_load_spec("gs://b/o.csv", &target, FileFormat::Csv, &opts);
         assert_eq!(spec.skip_leading_rows, Some(0));
         assert_eq!(spec.field_delimiter.as_deref(), Some("\t"));
+    }
+
+    #[test]
+    fn bq_column_type_maps_generic_to_canonical_bq_names() {
+        // The generic family infer_column_types emits.
+        assert_eq!(bq_column_type("BOOLEAN"), "BOOL");
+        assert_eq!(bq_column_type("BIGINT"), "INT64");
+        assert_eq!(bq_column_type("DOUBLE"), "FLOAT64");
+        assert_eq!(bq_column_type("TIMESTAMP"), "TIMESTAMP");
+        assert_eq!(bq_column_type("STRING"), "STRING");
+        // Case-insensitive + canonical-name passthrough.
+        assert_eq!(bq_column_type("bigint"), "INT64");
+        assert_eq!(bq_column_type("INT64"), "INT64");
+        assert_eq!(bq_column_type("FLOAT64"), "FLOAT64");
+        // Unknown → STRING (lossless fallback for the INSERT path).
+        assert_eq!(bq_column_type("DECIMAL(10,2)"), "STRING");
+        assert_eq!(bq_column_type(""), "STRING");
+    }
+
+    #[test]
+    fn build_create_table_sql_uses_inferred_types_not_all_string() {
+        let batches = vec![RowBatch {
+            column_names: vec![
+                "id".into(),
+                "amount".into(),
+                "name".into(),
+                "active".into(),
+                "created_at".into(),
+            ],
+            rows: vec![
+                vec![
+                    "1".into(),
+                    "9.99".into(),
+                    "alice".into(),
+                    "true".into(),
+                    "2024-01-15".into(),
+                ],
+                vec![
+                    "2".into(),
+                    "8.50".into(),
+                    "bob".into(),
+                    "false".into(),
+                    "2024-02-20".into(),
+                ],
+            ],
+            row_count: 2,
+        }];
+        let cols = batches[0].column_names.clone();
+        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &batches).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE TABLE IF NOT EXISTS `p`.`d`.`t` \
+             (`id` INT64, `amount` FLOAT64, `name` STRING, `active` BOOL, `created_at` TIMESTAMP)"
+        );
+        // The whole point: id is NOT all-STRING.
+        assert!(sql.contains("`id` INT64"));
+        assert!(!sql.contains("`id` STRING"));
+        // A date-looking column infers to TIMESTAMP (kept TIMESTAMP, not
+        // downgraded to STRING — STRING would re-fail a `created_at TIMESTAMP`
+        // contract). The INSERT path feeds rocky-core's `format_cell` quoted
+        // string literal `'2024-01-15'` into this column, relying on BigQuery
+        // coercing a string literal to TIMESTAMP — exercised by the live
+        // `load_local_csv_creates_inferred_types` test.
+        assert!(sql.contains("`created_at` TIMESTAMP"));
+    }
+
+    #[test]
+    fn build_create_table_sql_header_only_defaults_to_string() {
+        // A CSV with a header but no data rows: infer_column_types returns
+        // nothing, so every column falls back to STRING — but all columns
+        // are still present (no regression from the old header-derived path).
+        let cols = vec!["id".to_string(), "name".to_string()];
+        let sql = build_create_table_sql("`p`.`d`.`t`", &cols, &[]).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE TABLE IF NOT EXISTS `p`.`d`.`t` (`id` STRING, `name` STRING)"
+        );
+    }
+
+    #[test]
+    fn build_create_table_sql_no_columns_is_none() {
+        assert!(build_create_table_sql("`p`.`d`.`t`", &[], &[]).is_none());
     }
 
     #[test]

--- a/engine/crates/rocky-bigquery/tests/integration.rs
+++ b/engine/crates/rocky-bigquery/tests/integration.rs
@@ -1226,6 +1226,171 @@ async fn load_via_gcs_csv() {
     outcome.expect("GCS CSV load + verification");
 }
 
+/// End-to-end: load a local CSV into a *fresh* table via the INSERT-fallback
+/// path (`LoadSource::LocalFile` + `create_table: true`) and assert the
+/// auto-created columns are **inferred + typed**, not all-STRING. This is
+/// the live merge-gate for the typed-create fix: an all-STRING `id` column
+/// would silently pass the wiremock row-count assertions but defeat the
+/// typed contract-gate, so only a real BigQuery readback proves the types.
+///
+/// Required env (all `ROCKY_TEST_*`, scrubbed of any committed identifiers):
+///   - `ROCKY_TEST_BIGQUERY_PROJECT` — GCP project for the ephemeral dataset.
+///   - `GOOGLE_APPLICATION_CREDENTIALS` *or* `BIGQUERY_TOKEN` — auth (the SA
+///     / token needs `bigquery.dataEditor` + `bigquery.jobUser` on the
+///     project). No GCS object or bucket grant is needed — the CSV is local.
+/// Optional:
+///   - `ROCKY_TEST_BIGQUERY_LOCATION` — dataset location (default `EU`).
+///
+/// Run with:
+///   cargo test -p rocky-bigquery --test integration \
+///     load_local_csv_creates_inferred_types -- --ignored --nocapture
+///
+/// Creates `hc_loadlocal_<ts>` (the sandbox `hc_` housekeeping prefix),
+/// loads a 4-column CSV, reads the column types back from the
+/// dataset-qualified `INFORMATION_SCHEMA.COLUMNS`, then DROPs the dataset
+/// CASCADE regardless of outcome.
+#[tokio::test]
+#[ignore]
+async fn load_local_csv_creates_inferred_types() {
+    use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter};
+
+    let project = match std::env::var("ROCKY_TEST_BIGQUERY_PROJECT") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!(
+                "skipping load_local_csv_creates_inferred_types: set \
+                 ROCKY_TEST_BIGQUERY_PROJECT and GCP auth to run"
+            );
+            return;
+        }
+    };
+    let location =
+        std::env::var("ROCKY_TEST_BIGQUERY_LOCATION").unwrap_or_else(|_| "EU".to_string());
+    let Some(auth) = BigQueryAuth::from_env().ok() else {
+        eprintln!("skipping load_local_csv_creates_inferred_types: no GCP auth in env");
+        return;
+    };
+
+    let adapter = std::sync::Arc::new(BigQueryAdapter::new(
+        project.clone(),
+        location.clone(),
+        auth,
+    ));
+    let loader = rocky_bigquery::BigQueryLoaderAdapter::new(adapter.clone());
+
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros();
+    let dataset = format!("hc_loadlocal_{suffix}");
+    let table = "typed_create";
+
+    // Distinct inferred types: int / float / string / bool / timestamp.
+    // `id` must land as INT64, not STRING. `created_at` is the one INSERT
+    // path that's new behaviorally: a date cell infers to TIMESTAMP, but
+    // rocky-core's `format_cell` emits it as a quoted string literal — this
+    // live test is what confirms BigQuery coerces `'2024-01-15'` into the
+    // TIMESTAMP column on INSERT VALUES (the wiremock test can't, it doesn't
+    // execute SQL).
+    let csv = "id,amount,name,active,created_at\n\
+               1,9.99,alice,true,2024-01-15\n\
+               2,8.50,bob,false,2024-02-20\n";
+    let csv_path = std::env::temp_dir().join(format!("rocky_bq_live_{suffix}.csv"));
+    std::fs::write(&csv_path, csv).expect("write temp CSV");
+
+    adapter
+        .execute_statement(&format!(
+            "CREATE SCHEMA IF NOT EXISTS `{project}`.`{dataset}` OPTIONS(location='{location}')"
+        ))
+        .await
+        .expect("create dataset");
+
+    let outcome = async {
+        let target = rocky_adapter_sdk::TableRef {
+            catalog: project.clone(),
+            schema: dataset.clone(),
+            table: table.into(),
+        };
+        let options = LoadOptions {
+            create_table: true,
+            csv_has_header: true,
+            ..Default::default()
+        };
+
+        let result = loader
+            .load(&LoadSource::LocalFile(csv_path.clone()), &target, &options)
+            .await?;
+        assert_eq!(result.rows_loaded, 2, "expected 2 rows from the local CSV");
+
+        // Read the auto-created column types back from the dataset-qualified
+        // INFORMATION_SCHEMA (the dialect's bare `describe_table_sql` view
+        // doesn't resolve a specific dataset).
+        let schema_rows = adapter
+            .execute_query(&format!(
+                "SELECT column_name, data_type \
+                 FROM `{project}`.`{dataset}`.INFORMATION_SCHEMA.COLUMNS \
+                 WHERE table_name = '{table}' ORDER BY ordinal_position"
+            ))
+            .await
+            .expect("read INFORMATION_SCHEMA.COLUMNS");
+
+        let types: std::collections::HashMap<String, String> = schema_rows
+            .rows
+            .iter()
+            .map(|r| {
+                (
+                    r[0].as_str().unwrap_or_default().to_string(),
+                    r[1].as_str().unwrap_or_default().to_string(),
+                )
+            })
+            .collect();
+
+        // The crux: `id` is an integer type, NOT STRING.
+        assert_eq!(
+            types.get("id").map(String::as_str),
+            Some("INT64"),
+            "id must be created as INT64, not STRING; got {types:?}"
+        );
+        assert_eq!(
+            types.get("amount").map(String::as_str),
+            Some("FLOAT64"),
+            "amount must be FLOAT64; got {types:?}"
+        );
+        assert_eq!(
+            types.get("active").map(String::as_str),
+            Some("BOOL"),
+            "active must be BOOL; got {types:?}"
+        );
+        assert_eq!(
+            types.get("name").map(String::as_str),
+            Some("STRING"),
+            "name must be STRING; got {types:?}"
+        );
+        // Confirms both the inference (date → TIMESTAMP column) and that the
+        // INSERT actually landed — the load() above would have errored if BQ
+        // rejected the `'2024-01-15'` string literal against a TIMESTAMP
+        // column, so reaching here with a TIMESTAMP type proves the coercion.
+        assert_eq!(
+            types.get("created_at").map(String::as_str),
+            Some("TIMESTAMP"),
+            "created_at must be TIMESTAMP; got {types:?}"
+        );
+
+        Ok::<_, rocky_adapter_sdk::AdapterError>(())
+    }
+    .await;
+
+    // Teardown regardless of outcome.
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS `{project}`.`{dataset}` CASCADE"
+        ))
+        .await;
+    let _ = std::fs::remove_file(&csv_path);
+
+    outcome.expect("local CSV typed-create load + schema verification");
+}
+
 /// Admin adapter built from the `ROCKY_TEST_*` env (mirrors `load_env`'s
 /// project/location/auth) for the setup + teardown SQL in the load test.
 fn adapter_from_rocky_env() -> Option<BigQueryAdapter> {

--- a/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-bigquery/tests/wiremock_tests.rs
@@ -54,7 +54,9 @@ use rocky_core::config::RetryConfig;
 use rocky_core::retry_budget::RetryBudget;
 use rocky_core::traits::{AdapterError, WarehouseAdapter};
 use serde_json::{Value, json};
-use wiremock::matchers::{body_partial_json, header, method, path, path_regex, query_param};
+use wiremock::matchers::{
+    body_partial_json, body_string_contains, header, method, path, path_regex, query_param,
+};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Path of the `jobs.query` endpoint for the test project.
@@ -1359,4 +1361,102 @@ async fn load_job_poll_times_out_when_never_done() {
         matches!(err, BigQueryError::Timeout { timeout_secs: 1 }),
         "expected Timeout, got: {err:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// (f) Local-file INSERT-fallback: create_table emits INFERRED column types
+// ---------------------------------------------------------------------------
+
+/// The local-file loader path (`LoadSource::LocalFile`, CSV-only INSERT
+/// fallback) must create a missing table with **inferred, typed** columns —
+/// not all-STRING. All-STRING defeats the typed contract-gate (a contract
+/// `id INT64` fails against an all-STRING `id`).
+///
+/// This is the credential-free behavioral proof of the typed-create fix:
+/// the loader issues its `CREATE TABLE IF NOT EXISTS …` and each `INSERT`
+/// through `execute_statement` → `jobs.query`, which the mock server
+/// captures. A high-priority mock matches the CREATE TABLE body for the
+/// canonical BigQuery types (`` `id` INT64 ``, `` `amount` FLOAT64 ``,
+/// `` `active` BOOL ``) and `.expect(1)`; a catch-all absorbs the INSERTs.
+/// `server.verify()` fails if the typed CREATE never went out — i.e. if the
+/// loader regressed to all-STRING (`` `id` STRING ``).
+///
+/// Note the deliberate single behavioral test on the loader's local path:
+/// `--lib` + `clippy --all-targets` *compile* this file but don't run it,
+/// so without a mounted-and-verified expectation the all-STRING→typed
+/// change could pass both and still be wrong at runtime.
+#[tokio::test]
+async fn local_file_create_table_uses_inferred_types() {
+    use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter, TableRef as SdkTableRef};
+    use rocky_bigquery::BigQueryLoaderAdapter;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // A CSV whose columns infer to distinct BigQuery types: int / float /
+    // string / bool. The point of the fix is that `id` lands as INT64, not
+    // STRING.
+    let csv = "id,amount,name,active\n1,9.99,alice,true\n2,8.50,bob,false\n";
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let csv_path = std::env::temp_dir().join(format!("rocky_bq_loader_{suffix}.csv"));
+    std::fs::write(&csv_path, csv).expect("write temp CSV");
+
+    let server = MockServer::start().await;
+
+    // Happy `jobs.query` response body for a DDL/DML statement — the loader
+    // ignores the body and only checks success.
+    let ok_body = json!({
+        "jobComplete": true,
+        "jobReference": {"projectId": "test-project", "jobId": "job-load"}
+    });
+
+    // High-priority: the CREATE TABLE with the inferred, canonical BQ types.
+    // Each `body_string_contains` is an AND, so all four column/type pairs
+    // must appear in the same statement.
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .and(body_string_contains("`id` INT64"))
+        .and(body_string_contains("`amount` FLOAT64"))
+        .and(body_string_contains("`name` STRING"))
+        .and(body_string_contains("`active` BOOL"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_body.clone()))
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Catch-all for the INSERT batch(es) that follow the CREATE.
+    Mock::given(method("POST"))
+        .and(path(QUERIES_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(ok_body))
+        .mount(&server)
+        .await;
+
+    let adapter = std::sync::Arc::new(test_adapter(&server).with_timeout(5));
+    let loader = BigQueryLoaderAdapter::new(adapter);
+
+    let target = SdkTableRef {
+        catalog: "test-project".into(),
+        schema: "ds".into(),
+        table: "tbl".into(),
+    };
+    let options = LoadOptions {
+        create_table: true,
+        csv_has_header: true,
+        ..Default::default()
+    };
+
+    let result = loader
+        .load(&LoadSource::LocalFile(csv_path.clone()), &target, &options)
+        .await
+        .expect("local-file CSV load should succeed");
+    assert_eq!(result.rows_loaded, 2, "two data rows should be inserted");
+
+    // Fails iff the typed CREATE TABLE was never emitted (i.e. a regression
+    // back to all-STRING columns).
+    server.verify().await;
+
+    let _ = std::fs::remove_file(&csv_path);
 }


### PR DESCRIPTION
BigQuery's local-file `create_table` load previously created the target with **all-STRING** columns; this infers column TYPES from the CSV and creates the table with them (`BIGINT→INT64`, `DOUBLE→FLOAT64`, `BOOLEAN→BOOL`, `TIMESTAMP→TIMESTAMP`, else `STRING`), reusing rocky-core's `infer_column_types`. Idempotent `CREATE TABLE IF NOT EXISTS` — no DESCRIBE round-trip. The `gs://` load-job path (already type-autodetecting) is untouched.

This makes typed tables — and the typed contract-gate — work for local BigQuery loads (all-STRING previously hard-failed any typed contract under the widening-aware match).

**Tested:** 98 lib + 29 wiremock (incl. a new credential-free test that runs a real `load()` against a mock server and `server.verify()`-asserts the typed CREATE body) — the full suite was RUN, not just compiled. **Live-verified** against real BigQuery: a local CSV creates `id INT64 / amount FLOAT64 / active BOOL / name STRING / created_at TIMESTAMP` (the date→TIMESTAMP INSERT coercion confirmed live).

**Follow-up (out of scope here):** rocky-core's `warehouse_type_to_rocky` has no `INT64`/`FLOAT64` arms, so BQ types normalize to `Unknown` — the contract gate's *type* check is currently a no-op on BQ (presence + nullability still enforced) until those arms are added.
