### PR TITLE
feat(engine/rocky-snowflake): create local-load tables from the file schema

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4272,6 +4272,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 wiremock = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/engine/crates/rocky-snowflake/src/loader.rs
+++ b/engine/crates/rocky-snowflake/src/loader.rs
@@ -9,6 +9,29 @@
 //! Temporary stages auto-expire at session end, so a failed load still cleans
 //! up. The explicit `DROP STAGE IF EXISTS` after each load keeps long-running
 //! sessions tidy.
+//!
+//! ## Creating the target from a local CSV
+//!
+//! `COPY INTO` requires the target table to already exist. When loading a
+//! **local CSV** with [`LoadOptions::create_table`] set, the loader first
+//! infers column types from the file (via
+//! [`rocky_core::seeds::infer_schema_from_csv`]), maps them to Snowflake type
+//! names, and emits `CREATE TABLE IF NOT EXISTS` *before* the stage + PUT +
+//! COPY sequence. This unblocks loading a CSV into a fresh table — notably the
+//! typed contract-gate, which loads into a per-load staging table that doesn't
+//! exist yet.
+//!
+//! Scope of the create-from-file path:
+//! - **Local CSV only.** Type inference reads the local file, so it can't run
+//!   against a cloud URI. Auto-creating from `s3://` would need Snowflake's
+//!   server-side `INFER_SCHEMA` table function — left as a follow-up.
+//! - **Comma-delimited.** `infer_schema_from_csv` reads with a comma
+//!   delimiter; a non-comma local CSV with `create_table` won't auto-create
+//!   the right columns. `CREATE TABLE IF NOT EXISTS` keeps an existing table
+//!   safe regardless. A delimiter-aware inference is a follow-up.
+//! - **Local Parquet / JSONL fall through untouched** (no inference, no
+//!   create) — they only load into a pre-existing table today, and silently
+//!   skipping the create preserves that behavior rather than failing the load.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -20,13 +43,17 @@ use rocky_adapter_sdk::{
     AdapterError, AdapterResult, FileFormat, LoadOptions, LoadResult, LoadSource, LoaderAdapter,
     TableRef,
 };
+use rocky_core::sql_gen::validate_sql_type;
 use rocky_sql::validation::validate_identifier;
 
 use crate::connector::{QueryResult, SnowflakeConnector};
+use crate::dialect::SnowflakeSqlDialect;
 use crate::stage::{
     copy_into_sql, create_external_stage_sql, create_temporary_stage_sql, drop_stage_sql,
     generate_stage_name, put_file_sql,
 };
+
+use rocky_core::traits::SqlDialect;
 
 /// Snowflake loader adapter using temporary stages + COPY INTO.
 pub struct SnowflakeLoaderAdapter {
@@ -95,6 +122,66 @@ fn format_target(target: &TableRef) -> AdapterResult<String> {
     }
 }
 
+/// Map a [`rocky_core::seeds`]-inferred generic SQL type to its Snowflake
+/// equivalent.
+///
+/// `infer_schema_from_csv` emits a small, fixed set of generic type names
+/// (`BOOLEAN`, `BIGINT`, `DOUBLE`, `TIMESTAMP`, `STRING`). Snowflake accepts
+/// `BOOLEAN` and `TIMESTAMP` verbatim, but the canonical names that round-trip
+/// through `DESCRIBE TABLE` (and the dialect's safe-widening parsers) are
+/// `NUMBER(38,0)`, `FLOAT`, `TIMESTAMP_NTZ`, and `VARCHAR`. Mapping to those
+/// keeps a later schema-drift comparison stable.
+///
+/// Any name not in the known set is passed through unchanged — it's then
+/// validated by [`validate_sql_type`] before interpolation, so an unexpected
+/// value can't smuggle SQL into the DDL.
+fn map_inferred_type_to_snowflake(generic: &str) -> &str {
+    match generic {
+        "BIGINT" => "NUMBER(38,0)",
+        "DOUBLE" => "FLOAT",
+        "TIMESTAMP" => "TIMESTAMP_NTZ",
+        // `infer_schema_from_csv` emits the generic `STRING`; Snowflake's
+        // canonical text type is `VARCHAR` (its `STRING` alias also works,
+        // but `DESCRIBE` reports `VARCHAR`).
+        "STRING" => "VARCHAR",
+        // `BOOLEAN` and any already-Snowflake / overridden type pass through.
+        other => other,
+    }
+}
+
+/// Build a `CREATE TABLE IF NOT EXISTS <target> (<typed cols>)` statement from
+/// CSV-inferred columns.
+///
+/// Each column name is validated as a SQL identifier and double-quoted (the
+/// adapter's lowercase-preserving convention — matching `format_table_ref`,
+/// `merge_into`, and the COPY column resolution). Each mapped Snowflake type is
+/// validated by [`validate_sql_type`] before interpolation. `IF NOT EXISTS`
+/// makes the statement idempotent and avoids any existence round-trip
+/// (a `DESCRIBE`/exists probe is deliberately *not* issued).
+fn create_table_from_csv_sql(
+    target_ref: &str,
+    columns: &[rocky_core::seeds::ColumnDef],
+) -> AdapterResult<String> {
+    if columns.is_empty() {
+        return Err(AdapterError::msg(
+            "cannot create table from CSV with no columns",
+        ));
+    }
+    let dialect = SnowflakeSqlDialect;
+    let mut col_defs = Vec::with_capacity(columns.len());
+    for col in columns {
+        validate_identifier(&col.name).map_err(AdapterError::new)?;
+        let sf_type = map_inferred_type_to_snowflake(&col.data_type);
+        validate_sql_type(sf_type).map_err(AdapterError::new)?;
+        let col_q = dialect.quote_identifier(&col.name);
+        col_defs.push(format!("{col_q} {sf_type}"));
+    }
+    Ok(format!(
+        "CREATE TABLE IF NOT EXISTS {target_ref} ({})",
+        col_defs.join(", ")
+    ))
+}
+
 #[async_trait]
 impl LoaderAdapter for SnowflakeLoaderAdapter {
     async fn load(
@@ -107,6 +194,24 @@ impl LoaderAdapter for SnowflakeLoaderAdapter {
         let format = resolve_format(source, options)?;
         let target_ref = format_target(target)?;
         let stage = generate_stage_name();
+
+        // `create_table` for a LOCAL CSV: COPY INTO needs an existing table, so
+        // infer column types from the file and `CREATE TABLE IF NOT EXISTS`
+        // before the stage + PUT + COPY sequence. Runs ahead of the truncate
+        // block so a `create_table + truncate_first` combo against a missing
+        // table creates first (the DELETE would otherwise fail on a
+        // non-existent table). Local Parquet/JSONL and cloud URIs fall through
+        // untouched — see the module docs for the create-from-file scope.
+        if options.create_table
+            && format == FileFormat::Csv
+            && let LoadSource::LocalFile(local_path) = source
+        {
+            let columns = rocky_core::seeds::infer_schema_from_csv(local_path)
+                .map_err(|e| AdapterError::msg(format!("failed to infer CSV schema: {e}")))?;
+            let create_sql = create_table_from_csv_sql(&target_ref, &columns)?;
+            debug!(sql = %create_sql, "ensuring target table exists (create from CSV)");
+            self.exec(&create_sql).await?;
+        }
 
         // `truncate_first` → DELETE FROM before COPY INTO. Snowflake supports
         // TRUNCATE TABLE but DELETE is more portable and plays nicer with
@@ -402,5 +507,87 @@ mod tests {
     fn test_sum_rows_loaded_empty_result() {
         let qr = copy_into_result(&["rows_loaded"], vec![]);
         assert_eq!(sum_rows_loaded(&qr), Some(0));
+    }
+
+    use rocky_core::seeds::ColumnDef;
+
+    fn col(name: &str, data_type: &str) -> ColumnDef {
+        ColumnDef {
+            name: name.into(),
+            data_type: data_type.into(),
+        }
+    }
+
+    #[test]
+    fn test_map_inferred_type_to_snowflake_known_types() {
+        // The generic names `infer_schema_from_csv` emits map to Snowflake's
+        // canonical `DESCRIBE`-round-tripping names.
+        assert_eq!(map_inferred_type_to_snowflake("BIGINT"), "NUMBER(38,0)");
+        assert_eq!(map_inferred_type_to_snowflake("DOUBLE"), "FLOAT");
+        assert_eq!(map_inferred_type_to_snowflake("TIMESTAMP"), "TIMESTAMP_NTZ");
+        assert_eq!(map_inferred_type_to_snowflake("STRING"), "VARCHAR");
+        // BOOLEAN is accepted verbatim by Snowflake.
+        assert_eq!(map_inferred_type_to_snowflake("BOOLEAN"), "BOOLEAN");
+    }
+
+    #[test]
+    fn test_map_inferred_type_passthrough_for_unknown() {
+        // Already-Snowflake / overridden types pass through unchanged; the
+        // caller still runs them through `validate_sql_type`.
+        assert_eq!(
+            map_inferred_type_to_snowflake("NUMBER(10,2)"),
+            "NUMBER(10,2)"
+        );
+        assert_eq!(
+            map_inferred_type_to_snowflake("VARCHAR(255)"),
+            "VARCHAR(255)"
+        );
+    }
+
+    #[test]
+    fn test_create_table_from_csv_sql_quotes_and_maps_types() {
+        let cols = vec![
+            col("id", "BIGINT"),
+            col("name", "STRING"),
+            col("amount", "DOUBLE"),
+            col("active", "BOOLEAN"),
+            col("created_at", "TIMESTAMP"),
+        ];
+        let sql = create_table_from_csv_sql("DB.RAW.ORDERS", &cols).unwrap();
+        assert_eq!(
+            sql,
+            "CREATE TABLE IF NOT EXISTS DB.RAW.ORDERS \
+             (\"id\" NUMBER(38,0), \"name\" VARCHAR, \"amount\" FLOAT, \
+             \"active\" BOOLEAN, \"created_at\" TIMESTAMP_NTZ)"
+        );
+    }
+
+    #[test]
+    fn test_create_table_from_csv_sql_is_idempotent() {
+        let cols = vec![col("id", "BIGINT")];
+        let sql = create_table_from_csv_sql("T", &cols).unwrap();
+        // `IF NOT EXISTS` keeps the create safe when the table already exists —
+        // no DESCRIBE / existence round-trip is issued (the #826 lesson).
+        assert!(sql.starts_with("CREATE TABLE IF NOT EXISTS T ("));
+    }
+
+    #[test]
+    fn test_create_table_from_csv_sql_rejects_empty_columns() {
+        assert!(create_table_from_csv_sql("T", &[]).is_err());
+    }
+
+    #[test]
+    fn test_create_table_from_csv_sql_rejects_bad_column_identifier() {
+        // A header carrying SQL must be refused at identifier validation —
+        // never interpolated into the DDL.
+        let cols = vec![col("bad; DROP TABLE x; --", "BIGINT")];
+        assert!(create_table_from_csv_sql("T", &cols).is_err());
+    }
+
+    #[test]
+    fn test_create_table_from_csv_sql_rejects_bad_type() {
+        // A passthrough type carrying SQL must be refused by validate_sql_type.
+        let cols = vec![col("id", "BIGINT; DROP TABLE x")];
+        assert!(create_table_from_csv_sql("T", &cols).is_err());
     }
 }

--- a/engine/crates/rocky-snowflake/tests/load_create_live.rs
+++ b/engine/crates/rocky-snowflake/tests/load_create_live.rs
@@ -1,0 +1,259 @@
+//! Live Snowflake conformance test for the loader's
+//! create-the-target-table-from-a-local-CSV path
+//! ([`SnowflakeLoaderAdapter`] + `LoadOptions::create_table`).
+//!
+//! `#[ignore]`-gated because it requires a real Snowflake account. Run
+//! locally with:
+//!
+//! ```bash
+//! SNOWFLAKE_ACCOUNT=<your-account> \
+//! SNOWFLAKE_WAREHOUSE=<your-warehouse> \
+//! SNOWFLAKE_TEST_DATABASE=<your-database> \
+//! # one of:
+//! SNOWFLAKE_OAUTH_TOKEN=<your-oauth-token> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PASSWORD=<pwd> \
+//! # or:
+//! SNOWFLAKE_USERNAME=<user> SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-pem> \
+//! # optional:
+//! SNOWFLAKE_ROLE=<role> \
+//! cargo test -p rocky-snowflake --test load_create_live -- --ignored --nocapture
+//! ```
+//!
+//! The env-var convention mirrors `clone_live::adapter_from_env` /
+//! `bisection_live` verbatim; nothing is hardcoded.
+//!
+//! What it proves: loading a local CSV into a table that does NOT exist yet,
+//! with `create_table` set, (1) creates the table with column TYPES inferred
+//! from the CSV (id -> NUMBER(38,0), name -> VARCHAR, score -> FLOAT, active
+//! -> BOOLEAN, joined_at -> TIMESTAMP_NTZ) and (2) lands the rows.
+//!
+//! **Snowflake-specific test details (load-bearing).**
+//! - The loader's `format_target` emits an UNQUOTED `db.schema.table` ref, so
+//!   Snowflake folds the schema and table names to UPPER. Every reference in
+//!   this test (schema create/drop, the load target, and the verification
+//!   queries) therefore stays unquoted too, so they resolve the same folded
+//!   objects the loader's CREATE TABLE produced. The data *columns*, by
+//!   contrast, the loader creates double-quoted lowercase (`"id"`, `"name"`,
+//!   …) — so verification queries reference columns double-quoted.
+//! - The staging schema uses the `rocky_load_create_test_*` prefix with a
+//!   microsecond suffix for per-run isolation, and is dropped CASCADE before
+//!   assertions so a failed assertion still leaves the sandbox clean.
+
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rocky_adapter_sdk::{LoadOptions, LoadSource, LoaderAdapter, TableRef as SdkTableRef};
+use rocky_core::config::RetryConfig;
+use rocky_core::traits::WarehouseAdapter;
+use rocky_snowflake::adapter::SnowflakeWarehouseAdapter;
+use rocky_snowflake::auth::{Auth, AuthConfig};
+use rocky_snowflake::connector::{ConnectorConfig, SnowflakeConnector};
+use rocky_snowflake::loader::SnowflakeLoaderAdapter;
+
+/// Build a connector from env. Returns `None` (and the test self-skips) when
+/// the required vars are absent.
+fn connector_from_env() -> Option<(SnowflakeConnector, String)> {
+    let account = std::env::var("SNOWFLAKE_ACCOUNT").ok()?;
+    let warehouse = std::env::var("SNOWFLAKE_WAREHOUSE").ok()?;
+    let database = std::env::var("SNOWFLAKE_TEST_DATABASE")
+        .or_else(|_| std::env::var("SNOWFLAKE_DATABASE"))
+        .ok()?;
+
+    let auth = Auth::from_config(AuthConfig {
+        account: account.clone(),
+        username: std::env::var("SNOWFLAKE_USERNAME").ok(),
+        password: std::env::var("SNOWFLAKE_PASSWORD").ok(),
+        oauth_token: std::env::var("SNOWFLAKE_OAUTH_TOKEN").ok(),
+        private_key_path: std::env::var("SNOWFLAKE_PRIVATE_KEY_PATH").ok(),
+        pat: std::env::var("SNOWFLAKE_PAT").ok(),
+    })
+    .ok()?;
+
+    let config = ConnectorConfig {
+        account,
+        warehouse,
+        database: Some(database.clone()),
+        schema: None,
+        role: std::env::var("SNOWFLAKE_ROLE").ok(),
+        timeout: Duration::from_secs(180),
+        retry: RetryConfig::default(),
+    };
+    Some((SnowflakeConnector::new(config, auth), database))
+}
+
+fn schema_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+async fn create_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    // Unquoted, matching `format_target`: Snowflake folds the schema name to
+    // UPPER, so the loader's later unquoted CREATE TABLE resolves the same
+    // schema object.
+    adapter
+        .execute_statement(&format!("CREATE SCHEMA IF NOT EXISTS {database}.{schema}"))
+        .await
+        .expect("create schema");
+}
+
+async fn drop_schema(adapter: &SnowflakeWarehouseAdapter, database: &str, schema: &str) {
+    let _ = adapter
+        .execute_statement(&format!(
+            "DROP SCHEMA IF EXISTS {database}.{schema} CASCADE"
+        ))
+        .await;
+}
+
+/// Read the warehouse data type for `column` of `table` from
+/// `information_schema.columns`. Column/table identifiers were created
+/// unquoted-table / quoted-lowercase-columns by the loader, so they live
+/// upper-cased (table) / lowercase (columns) — match that here.
+async fn column_type(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+    column: &str,
+) -> Option<String> {
+    // `format_target` leaves schema + table unquoted, so Snowflake folds both
+    // to UPPER. information_schema stores names case-sensitively as resolved,
+    // so the SCHEMA / TABLE_NAME literals must be uppercased to match. The data
+    // columns were created double-quoted lowercase, so COLUMN_NAME stays
+    // lowercase.
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT DATA_TYPE FROM {database}.INFORMATION_SCHEMA.COLUMNS \
+             WHERE TABLE_SCHEMA = '{schema_upper}' \
+             AND TABLE_NAME = '{table_upper}' \
+             AND COLUMN_NAME = '{column}'",
+            schema_upper = schema.to_uppercase(),
+            table_upper = table.to_uppercase(),
+        ))
+        .await
+        .ok()?;
+    result.rows.first()?.first()?.as_str().map(str::to_string)
+}
+
+async fn count_rows(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+) -> Option<i64> {
+    // Schema + table unquoted (UPPER-folded, matching the loader); the COUNT
+    // alias is quoted only to fix the output column case for the reader.
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT COUNT(*) AS \"n\" FROM {database}.{schema}.{table}"
+        ))
+        .await
+        .ok()?;
+    let cell = result.rows.first()?.first()?.clone();
+    cell.as_i64()
+        .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
+}
+
+async fn fetch_name(
+    adapter: &SnowflakeWarehouseAdapter,
+    database: &str,
+    schema: &str,
+    table: &str,
+    id: i64,
+) -> Option<String> {
+    // Schema + table unquoted (UPPER-folded); data columns quoted lowercase.
+    let result = adapter
+        .execute_query(&format!(
+            "SELECT \"name\" FROM {database}.{schema}.{table} WHERE \"id\" = {id}"
+        ))
+        .await
+        .ok()?;
+    result.rows.first()?.first()?.as_str().map(str::to_string)
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_load_local_csv_creates_typed_table_and_lands_rows() {
+    let Some((connector, database)) = connector_from_env() else {
+        eprintln!("Snowflake env vars not set; skipping");
+        return;
+    };
+
+    // Share one connector: a clone (Arc-wrapped) drives the loader; the
+    // other backs a warehouse adapter for setup + verification queries.
+    let loader = SnowflakeLoaderAdapter::new(Arc::new(connector.clone()));
+    let adapter = SnowflakeWarehouseAdapter::new(connector);
+
+    let suffix = schema_suffix();
+    let schema = format!("rocky_load_create_test_{suffix}");
+    let table = "people"; // created unquoted -> folds to PEOPLE.
+
+    create_schema(&adapter, &database, &schema).await;
+
+    // Write a local CSV with one column per inferred type.
+    let mut csv = tempfile::NamedTempFile::with_suffix(".csv").expect("temp csv");
+    csv.write_all(
+        b"id,name,score,active,joined_at\n\
+          1,alice,1.5,true,2026-01-02 03:04:05\n\
+          2,bob,2.5,false,2026-02-03 04:05:06\n",
+    )
+    .expect("write csv");
+    csv.flush().expect("flush csv");
+
+    let source = LoadSource::LocalFile(csv.path().to_path_buf());
+    let target = SdkTableRef {
+        catalog: database.clone(),
+        schema: schema.clone(),
+        table: table.to_string(),
+    };
+    let options = LoadOptions {
+        create_table: true,
+        ..Default::default()
+    };
+
+    let load_result = loader.load(&source, &target, &options).await;
+
+    // Gather verification BEFORE the cleanup drop so assertions reflect the
+    // post-load state; drop CASCADE regardless so the sandbox stays clean.
+    let (rows, sample, ty_id, ty_name, ty_score, ty_active, ty_joined) = if load_result.is_ok() {
+        (
+            count_rows(&adapter, &database, &schema, table).await,
+            fetch_name(&adapter, &database, &schema, table, 2).await,
+            column_type(&adapter, &database, &schema, table, "id").await,
+            column_type(&adapter, &database, &schema, table, "name").await,
+            column_type(&adapter, &database, &schema, table, "score").await,
+            column_type(&adapter, &database, &schema, table, "active").await,
+            column_type(&adapter, &database, &schema, table, "joined_at").await,
+        )
+    } else {
+        (None, None, None, None, None, None, None)
+    };
+
+    drop_schema(&adapter, &database, &schema).await;
+
+    let result = load_result.expect("local CSV load into a fresh table should succeed");
+    assert_eq!(result.rows_loaded, 2, "both CSV rows should land");
+
+    assert_eq!(rows, Some(2), "target row count after load");
+    assert_eq!(
+        sample.as_deref(),
+        Some("bob"),
+        "sampled row content should round-trip"
+    );
+
+    // Inferred + mapped types, as reported by information_schema.
+    // (DATA_TYPE is the family name — NUMBER / FLOAT / TEXT / BOOLEAN /
+    // TIMESTAMP_NTZ — without precision; assert on the family.)
+    assert_eq!(ty_id.as_deref(), Some("NUMBER"), "id -> NUMBER(38,0)");
+    assert_eq!(ty_name.as_deref(), Some("TEXT"), "name -> VARCHAR (TEXT)");
+    assert_eq!(ty_score.as_deref(), Some("FLOAT"), "score -> FLOAT");
+    assert_eq!(ty_active.as_deref(), Some("BOOLEAN"), "active -> BOOLEAN");
+    assert_eq!(
+        ty_joined.as_deref(),
+        Some("TIMESTAMP_NTZ"),
+        "joined_at -> TIMESTAMP_NTZ"
+    );
+}

--- a/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
+++ b/engine/crates/rocky-snowflake/tests/wiremock_tests.rs
@@ -578,6 +578,150 @@ async fn test_loader_missing_rows_loaded_column() {
     assert_eq!(result.rows_loaded, 0);
 }
 
+/// End-to-end: loading a LOCAL CSV with `create_table` set first issues
+/// `CREATE TABLE IF NOT EXISTS` with column types inferred from the file and
+/// mapped to Snowflake type names, *then* runs the stage + PUT + COPY INTO
+/// sequence. Proves the infer + CREATE + type-mapping path without credentials.
+///
+/// This is the local-file analogue of `test_loader_surfaces_rows_loaded`
+/// (which uses a cloud URI and therefore skips the create path).
+#[tokio::test]
+async fn test_loader_local_csv_creates_typed_table() {
+    use std::io::Write;
+
+    let server = MockServer::start().await;
+
+    // CREATE TABLE IF NOT EXISTS — asserts the mapped Snowflake types are
+    // present in the DDL body. The CSV below infers id->BIGINT->NUMBER(38,0),
+    // name->STRING->VARCHAR, score->DOUBLE->FLOAT, active->BOOLEAN->BOOLEAN.
+    // `expect(1)` proves the create fires exactly once.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("CREATE TABLE IF NOT EXISTS"))
+        .and(body_string_contains("\\\"id\\\" NUMBER(38,0)"))
+        .and(body_string_contains("\\\"name\\\" VARCHAR"))
+        .and(body_string_contains("\\\"score\\\" FLOAT"))
+        .and(body_string_contains("\\\"active\\\" BOOLEAN"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-create-table",
+            "code": "00000",
+            "message": "Statement executed successfully.",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // CREATE TEMPORARY STAGE — result set not inspected.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("CREATE TEMPORARY STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-create-stage",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PUT file://... @stage — local-file upload. Result ignored. Match on
+    // the full `PUT 'file://` prefix, not bare "PUT": every request body
+    // carries `"warehouse":"COMPUTE_WH"`, and "COMPUTE_WH" contains the
+    // substring "PUT", so a bare "PUT" matcher would shadow the COPY mock.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("PUT 'file://"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-put",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // COPY INTO — one row loaded.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("COPY INTO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-copy",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": {
+                "numRows": 1,
+                "rowType": [
+                    {"name": "file", "type": "TEXT", "nullable": false},
+                    {"name": "status", "type": "TEXT", "nullable": false},
+                    {"name": "rows_parsed", "type": "FIXED", "nullable": false},
+                    {"name": "rows_loaded", "type": "FIXED", "nullable": false},
+                    {"name": "errors_seen", "type": "FIXED", "nullable": false}
+                ]
+            },
+            "data": [
+                ["data.csv", "LOADED", "2", "2", "0"]
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // DROP STAGE IF EXISTS — cleanup, result ignored.
+    Mock::given(method("POST"))
+        .and(path("/api/v2/statements"))
+        .and(body_string_contains("DROP STAGE"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "statementHandle": "sf-drop",
+            "code": "00000",
+            "message": "ok",
+            "statementStatusUrl": "",
+            "resultSetMetaData": null,
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    // Write a real CSV so `infer_schema_from_csv` has a file to read.
+    let mut csv = tempfile::NamedTempFile::with_suffix(".csv").unwrap();
+    csv.write_all(b"id,name,score,active\n1,alice,1.5,true\n2,bob,2.5,false\n")
+        .unwrap();
+    csv.flush().unwrap();
+
+    let connector = Arc::new(test_connector(&server));
+    let loader = SnowflakeLoaderAdapter::new(connector);
+
+    let source = LoadSource::LocalFile(csv.path().to_path_buf());
+    let target = TableRef {
+        catalog: "DB".into(),
+        schema: "RAW".into(),
+        table: "PEOPLE".into(),
+    };
+    // create_table defaults to true; be explicit for the contract this test
+    // pins.
+    let options = LoadOptions {
+        create_table: true,
+        ..Default::default()
+    };
+
+    let result = loader.load(&source, &target, &options).await.unwrap();
+    assert_eq!(
+        result.rows_loaded, 2,
+        "rows from COPY INTO should be surfaced after the create"
+    );
+    // Local file → byte count is read from disk.
+    assert!(result.bytes_read > 0);
+}
+
 /// Bearer token is sent correctly in the Authorization header for OAuth
 /// auth, and the matching `X-Snowflake-Authorization-Token-Type: OAUTH`
 /// header rides alongside it.


### PR DESCRIPTION
Adds create-from-file to the Snowflake loader: for a LOCAL CSV with `create_table`, infer column types (rocky-core `infer_schema_from_csv`) and emit `CREATE TABLE IF NOT EXISTS <target> (<typed cols>)` before the existing stage + PUT + COPY INTO. This lets the typed contract-gate (and `rocky load --create`) work on Snowflake. Generic inferred types map to Snowflake-canonical names: `BIGINT→NUMBER(38,0)`, `DOUBLE→FLOAT`, `TIMESTAMP→TIMESTAMP_NTZ`, `STRING→VARCHAR`, `BOOLEAN` verbatim. Idempotent `IF NOT EXISTS` — no DESCRIBE round-trip. Cloud-URI create-from-file (would need Snowflake `INFER_SCHEMA`) is a documented follow-up.

**Tested:** 164 lib + 29 wiremock (incl. a new test asserting the typed CREATE body) — the full suite was RUN, not just compiled. clippy `--all-targets` + fmt clean.

**Live-verify note:** the Snowflake sandbox account is currently **suspended (no payment method)**, so the generated DDL couldn't be executed against a live warehouse. Instead it was validated against the [Snowflake CREATE TABLE reference](https://docs.snowflake.com/en/sql-reference/sql/create-table): the `CREATE TABLE IF NOT EXISTS (<cols>)` form and the type names `NUMBER(38,0)` / `FLOAT` / `TIMESTAMP_NTZ` / `VARCHAR` / `BOOLEAN` are all confirmed valid. A full live round-trip (`#[ignore]` test `load_create_live`) is ready to run once the account is restored.
