### PR TITLE
feat(engine): input-match index + provenance for auditable reuse (B5 spine, dormant)

### DIFF
--- a/docs/src/content/docs/guides/verify-a-run.md
+++ b/docs/src/content/docs/guides/verify-a-run.md
@@ -188,6 +188,57 @@ Because the filename *is* the hash, and the ledger row carries that hash, three 
 
 This stronger guarantee applies specifically to the content-addressed materialization path. A general run against DuckDB, Snowflake, BigQuery, or Databricks records the ledger and `sql_hash` (the walkthrough above), but does not emit a hash-named Parquet.
 
+## Auditable reuse: the input-match index and provenance record
+
+The content-addressed hash above proves *what bytes a run produced*. A reuse claim asks a different question: *can a later run legitimately stand on an earlier run's bytes?* When the opt-in `[reuse]` block is enabled, Rocky records an **input-match index** and a per-build **provenance record** that make that question answerable offline. These tables are populated but **dormant**: in the current stage Rocky records them and reads nothing back to skip or reuse anything — they exist so the claim is auditable before any reuse decision is wired.
+
+```toml
+# rocky.toml — opt in (default off; absent block ⇒ nothing is recorded)
+[reuse]
+enabled = true
+```
+
+Two more on-disk tables join the redb reader's vocabulary:
+
+| Logical name (Rocky source) | On-disk table name | Value |
+|---|---|---|
+| `INPUT_INDEX` | `input_index` | one `InputIndexEntry` JSON blob per indexed build, keyed by the model's `input_hash` |
+| `INPUT_PROVENANCE` | `input_provenance` | one `ProvenanceRecord` JSON blob per indexed build, keyed by `"{run_id}|{model_name}"` |
+
+A `ProvenanceRecord` embeds everything the recompute needs:
+
+```json
+{
+  "run_id": "run_2026-05-30T11-04-22Z_8f1a",
+  "model_name": "fct_revenue",
+  "input_hash": "<hex>",
+  "skip_hash": "<hex>",
+  "model_ir_canonical_json": "{...canonical, key-sorted ModelIr JSON...}",
+  "output_blake3": ["736713a2611f762af09ee4445c09157bcfdbf6e07145dd8edf2cfd203d8d5bf0"],
+  "output_path": ["s3://bucket/analytics_prod/fct_revenue/736713a2…parquet"],
+  "proof_class": "strong"
+}
+```
+
+### The two-claim split — read this carefully
+
+The record carries two *separate* claims, proven by two *different* artifacts. Conflating them is the one mistake to avoid:
+
+- **Input-logic match — proven by `skip_hash`.** `skip_hash` is a cosmetic-invariant hash of the model's normalised SQL plus its typed structural facts. Equal `skip_hash` means *the logic looks unchanged*. It is explicitly **not** a guarantee that two runs produce identical rows — non-deterministic SQL (timestamps, randomness, session settings, UDFs) can diverge under an identical `skip_hash`. Use it to attest *what was declared*, never *what was produced*.
+- **Byte-identity of the reused bytes — proven by `b3sum`.** The `output_blake3` is the BLAKE3 of the recorded Parquet, re-derivable exactly as in the previous section. This attests *the recorded bytes are exactly these bytes* — and nothing about whether re-executing the model would reproduce them.
+
+So the provenance record attests an **input-logic match plus the byte-identity of the recorded bytes**. It is **not** a reproducibility claim: it does not assert that a fresh re-run of the model would reproduce the recorded output.
+
+### Recompute it yourself
+
+Three independent checks, none of which needs the `rocky` binary:
+
+1. **IR-hash check.** Read the `ProvenanceRecord`, parse `model_ir_canonical_json` back into a `ModelIr` (it is the exact canonical, key-sorted JSON the recorder hashed), recompute its `skip_hash`, and confirm it equals the recorded `skip_hash`. This is the input-logic half — it confirms the embedded logic matches what was indexed.
+2. **Byte-identity check.** For each `output_blake3` / `output_path` pair, fetch the Parquet at the path, `b3sum` it, and confirm the hash equals the recorded `output_blake3` and the file's own content-addressed name (the previous section's check, applied to the reused file).
+3. **Refcount sanity.** Once a reuse backend lands (a later stage) and two runs genuinely share one set of bytes, `refcount_for_hash(blake3)` over the `output_artifacts` table returns `≥ 2` — both the original run's and the reusing run's `ArtifactRecord` rows point at the same hash. That is the evidence the reuse was *recorded*, not merely asserted. In the current dormant stage no reuse occurs, so a freshly recorded build's hash has a refcount of `1`; the `≥ 2` condition is the verification contract the provenance record *enables*, live the moment a reuse backend records the shared reference.
+
+The `proof_class` label — `strong` or `heuristic` — tells a consumer which guarantee applies. `strong` means every upstream identity folded into the `input_hash` was itself a content hash, so the whole chain is `b3sum`-verifiable. `heuristic` means at least one upstream was attested by a freshness signal (a watermark or row count) rather than a content hash; that attests *freshness*, not byte-identity, and a `heuristic` record must never be read as a byte-proof.
+
 ## What this verifies, and what it does not
 
 Verifies, with the tools above and no `rocky` binary:
@@ -196,10 +247,11 @@ Verifies, with the tools above and no `rocky` binary:
 - What code ran, fingerprinted by `sql_hash` and anchored to an immutable `git_commit`.
 - The output table's live schema and row count, checked against the warehouse directly.
 - On the content-addressed path, that the output bytes match the recorded hash exactly.
+- With `[reuse]` enabled, that an indexed build's declared inputs match (recompute `skip_hash` from the embedded canonical IR) and that the recorded output bytes are exactly those bytes (`b3sum`), each labelled `strong` or `heuristic`.
 
 Does **not** verify:
 
-- That re-running the SQL would reproduce the same output. Rocky's `replay` is an *inspection* of the recorded run, not a re-execution with pinned inputs; re-execution is a planned follow-up.
+- That re-running the SQL would reproduce the same output. Rocky's `replay` is an *inspection* of the recorded run, not a re-execution with pinned inputs; re-execution is a planned follow-up. The reuse provenance record makes the same input-logic + byte-identity attestation — it is likewise **not** a reproducibility claim.
 - That the warehouse table was not mutated by something else after the run. The ledger records what Rocky wrote; a later out-of-band `UPDATE` is outside its scope (this is exactly why step 5 checks the live warehouse).
 
 ## Implementation honesty
@@ -212,7 +264,9 @@ Every load-bearing claim above, graded against what ships today:
 | `rocky replay` surfaces the recorded run | Shipped (inspection only) |
 | Re-execution with pinned inputs reproduces the output | Not yet — planned follow-up |
 | Content-addressed Parquet named by BLAKE3 + recorded in `output_artifacts` | Shipped, but on the S3 content-addressed path only — not what a general DuckDB/Snowflake/BigQuery/Databricks run produces |
+| `[reuse]` input-match index + provenance record (offline-recomputable `skip_hash` + `b3sum` + `proof_class`) | Shipped as an opt-in, **dormant** record on the content-addressed path — populated, but nothing reads it back to skip or reuse yet |
+| Reuse *decision*: actually skipping a build by pointing at or cloning a prior run's bytes | Not yet — the index is recorded; consuming it to reuse bytes is a later stage |
 | `bytes_written` per model | Not yet — `null` on every adapter today |
 | Warehouse-native zero-copy clones for branches | Not yet — branches are isolated schema prefixes, not engine-native clones |
 
-The ledger inspection and the content-addressed hash check are real and verifiable now. The two "not yet" execution claims (re-execution, native clones) are deliberately excluded from what this guide promises.
+The ledger inspection, the content-addressed hash check, and the dormant reuse provenance record are real and verifiable now. The execution and reuse-decision claims (re-execution, native clones, byte-reuse) are deliberately excluded from what this guide promises.

--- a/docs/src/content/docs/guides/verify-a-run.md
+++ b/docs/src/content/docs/guides/verify-a-run.md
@@ -214,11 +214,20 @@ A `ProvenanceRecord` embeds everything the recompute needs:
   "input_hash": "<hex>",
   "skip_hash": "<hex>",
   "model_ir_canonical_json": "{...canonical, key-sorted ModelIr JSON...}",
+  "upstreams": [
+    {
+      "kind": "content",
+      "upstream_key": "analytics_prod.staging__orders.stg_orders",
+      "blake3_hash": "<hex of stg_orders' recorded output>"
+    }
+  ],
   "output_blake3": ["736713a2611f762af09ee4445c09157bcfdbf6e07145dd8edf2cfd203d8d5bf0"],
   "output_path": ["s3://bucket/analytics_prod/fct_revenue/736713a2…parquet"],
   "proof_class": "strong"
 }
 ```
+
+The `upstreams` array is the exact `Vec<UpstreamIdentity>` that was folded into `input_hash`. Each entry is either a `"content"` identity (a `strong` upstream — carries the upstream's recorded `blake3_hash`) or a `"watermark"` identity (a `heuristic` upstream — carries a `max_ts` and/or `row_count`). Persisting it is what makes the input side recomputable offline: without it you would have to trust Rocky's recorded `input_hash`; with it you re-derive `input_hash` yourself.
 
 ### The two-claim split — read this carefully
 
@@ -231,13 +240,14 @@ So the provenance record attests an **input-logic match plus the byte-identity o
 
 ### Recompute it yourself
 
-Three independent checks, none of which needs the `rocky` binary:
+Four independent checks, none of which needs the `rocky` binary:
 
 1. **IR-hash check.** Read the `ProvenanceRecord`, parse `model_ir_canonical_json` back into a `ModelIr` (it is the exact canonical, key-sorted JSON the recorder hashed), recompute its `skip_hash`, and confirm it equals the recorded `skip_hash`. This is the input-logic half — it confirms the embedded logic matches what was indexed.
-2. **Byte-identity check.** For each `output_blake3` / `output_path` pair, fetch the Parquet at the path, `b3sum` it, and confirm the hash equals the recorded `output_blake3` and the file's own content-addressed name (the previous section's check, applied to the reused file).
-3. **Refcount sanity.** Once a reuse backend lands (a later stage) and two runs genuinely share one set of bytes, `refcount_for_hash(blake3)` over the `output_artifacts` table returns `≥ 2` — both the original run's and the reusing run's `ArtifactRecord` rows point at the same hash. That is the evidence the reuse was *recorded*, not merely asserted. In the current dormant stage no reuse occurs, so a freshly recorded build's hash has a refcount of `1`; the `≥ 2` condition is the verification contract the provenance record *enables*, live the moment a reuse backend records the shared reference.
+2. **Input-hash recompute.** Re-derive `input_hash` from the bytes of the record alone and confirm it equals the recorded `input_hash`. The key is `blake3` over a canonical (key-sorted, whitespace-free) JSON projection of: a version byte, the `skip_hash`, the target `catalog.schema.table` identity (read it off the `target` in the parsed `model_ir_canonical_json`), and the `upstreams` array sorted by `upstream_key`. Because the projection and its inputs are all in the record, the recompute needs no live model and no Rocky binary — it confirms the recorded `input_hash` is the one those inputs actually produce, closing the input side that step 1 only half-covers.
+3. **Byte-identity check.** For each `output_blake3` / `output_path` pair, fetch the Parquet at the path, `b3sum` it, and confirm the hash equals the recorded `output_blake3` and the file's own content-addressed name (the previous section's check, applied to the reused file). For a `strong` record you can extend this one hop upstream: each `"content"` entry in `upstreams` carries the upstream's recorded `blake3_hash`, which you cross-check against *that upstream's own* `ProvenanceRecord` (its `output_blake3`), whose `output_path` then locates the upstream bytes to `b3sum`. The `UpstreamIdentity` itself carries only the key and hash — the path to the bytes lives on the upstream's record, not on this one.
+4. **Refcount sanity.** Once a reuse backend lands (a later stage) and two runs genuinely share one set of bytes, `refcount_for_hash(blake3)` over the `output_artifacts` table returns `≥ 2` — both the original run's and the reusing run's `ArtifactRecord` rows point at the same hash. That is the evidence the reuse was *recorded*, not merely asserted. In the current dormant stage no reuse occurs, so a freshly recorded build's hash has a refcount of `1`; the `≥ 2` condition is the verification contract the provenance record *enables*, live the moment a reuse backend records the shared reference.
 
-The `proof_class` label — `strong` or `heuristic` — tells a consumer which guarantee applies. `strong` means every upstream identity folded into the `input_hash` was itself a content hash, so the whole chain is `b3sum`-verifiable. `heuristic` means at least one upstream was attested by a freshness signal (a watermark or row count) rather than a content hash; that attests *freshness*, not byte-identity, and a `heuristic` record must never be read as a byte-proof.
+The `proof_class` label — `strong` or `heuristic` — tells a consumer which guarantee applies. `strong` means every upstream identity folded into the `input_hash` was itself a content hash, so every link in the chain has a recorded `b3sum` you can check against its own provenance record (this attests the *recorded* bytes, not that re-execution reproduces them). `heuristic` means at least one upstream was attested by a freshness signal (a watermark or row count) rather than a content hash; that attests *freshness*, not byte-identity, and a `heuristic` record must never be read as a byte-proof.
 
 ## What this verifies, and what it does not
 
@@ -247,7 +257,7 @@ Verifies, with the tools above and no `rocky` binary:
 - What code ran, fingerprinted by `sql_hash` and anchored to an immutable `git_commit`.
 - The output table's live schema and row count, checked against the warehouse directly.
 - On the content-addressed path, that the output bytes match the recorded hash exactly.
-- With `[reuse]` enabled, that an indexed build's declared inputs match (recompute `skip_hash` from the embedded canonical IR) and that the recorded output bytes are exactly those bytes (`b3sum`), each labelled `strong` or `heuristic`.
+- With `[reuse]` enabled, that an indexed build's declared inputs are internally consistent — recompute `skip_hash` from the embedded canonical IR, then recompute `input_hash` from the persisted `skip_hash` + target identity + `upstreams` and confirm it matches the recorded value — and that the recorded output bytes are exactly those bytes (`b3sum`, extendable one hop to each `strong` upstream's recorded bytes via its own record), each labelled `strong` or `heuristic`.
 
 Does **not** verify:
 
@@ -264,7 +274,7 @@ Every load-bearing claim above, graded against what ships today:
 | `rocky replay` surfaces the recorded run | Shipped (inspection only) |
 | Re-execution with pinned inputs reproduces the output | Not yet — planned follow-up |
 | Content-addressed Parquet named by BLAKE3 + recorded in `output_artifacts` | Shipped, but on the S3 content-addressed path only — not what a general DuckDB/Snowflake/BigQuery/Databricks run produces |
-| `[reuse]` input-match index + provenance record (offline-recomputable `skip_hash` + `b3sum` + `proof_class`) | Shipped as an opt-in, **dormant** record on the content-addressed path — populated, but nothing reads it back to skip or reuse yet |
+| `[reuse]` input-match index + provenance record (offline-recomputable `skip_hash` *and* `input_hash` over persisted `upstreams` + `b3sum` + `proof_class`) | Shipped as an opt-in, **dormant** record on the content-addressed path — populated, but nothing reads it back to skip or reuse yet |
 | Reuse *decision*: actually skipping a build by pointing at or cloning a prior run's bytes | Not yet — the index is recorded; consuming it to reuse bytes is a later stage |
 | `bytes_written` per model | Not yet — `null` on every adapter today |
 | Warehouse-native zero-copy clones for branches | Not yet — branches are isolated schema prefixes, not engine-native clones |

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2663,6 +2663,18 @@
       },
       "type": "object"
     },
+    "ReuseConfig": {
+      "additionalProperties": false,
+      "description": "`[reuse]` — opt-in population of the auditable-reuse input-match spine.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.\n\n**Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "RoleConfig": {
       "additionalProperties": false,
       "description": "A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.\n\n```toml [role.reader] permissions = [\"SELECT\", \"USE CATALOG\", \"USE SCHEMA\"]\n\n[role.analytics_engineer] inherits = [\"reader\"] permissions = [\"MODIFY\"]\n\n[role.admin] inherits = [\"analytics_engineer\"] permissions = [\"MANAGE\"] ```\n\nResolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.\n\nPermission strings must match the canonical uppercase spellings of [`rocky_ir::Permission`] (`\"SELECT\"`, `\"USE CATALOG\"`, ...).",
@@ -3727,6 +3739,17 @@
       ],
       "default": null,
       "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
+    },
+    "reuse": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReuseConfig"
+        }
+      ],
+      "default": {
+        "enabled": false
+      },
+      "description": "Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`]."
     },
     "role": {
       "additionalProperties": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -414,6 +414,10 @@ export interface RockyConfig {
    */
   retry?: RunRetryConfig | null;
   /**
+   * Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`].
+   */
+  reuse?: ReuseConfig;
+  /**
    * Hierarchical role declarations reconciled against the warehouse's native role/group system.
    *
    * See [`RoleConfig`] for the TOML shape and [`crate::role_graph::flatten_role_graph`] for the inheritance resolution semantics (DAG walk with cycle detection).
@@ -1684,6 +1688,19 @@ export interface RunRetryConfig {
    * Total number of retries allowed across every adapter for this run. `None` means no cross-adapter cap (each adapter's own `retry.max_retries_per_run` still applies in isolation).
    */
   max_retries_per_run?: number | null;
+}
+/**
+ * `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+ *
+ * When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.
+ *
+ * **Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.
+ */
+export interface ReuseConfig {
+  /**
+   * Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.
+   */
+  enabled?: boolean;
 }
 /**
  * A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4144,24 +4144,18 @@ pub(crate) async fn execute_models(
         std::collections::HashMap::new();
 
     // Static lookup built once when reuse is on: every lowercased identity a
-    // model can be *read by* in SQL (its bare name and its `schema.table`
-    // form) → that model's target `catalog.schema.table` full name. Lets the
-    // read-set resolver map a table reference from SQL lineage to the producing
-    // model's recorded output. Empty when reuse is off so the default path
-    // allocates nothing. Mirrors the identity set `skip_gate` builds for the
-    // same raw-source-vs-project-model distinction.
+    // model can be UNAMBIGUOUSLY *read by* in SQL → that model's target
+    // `catalog.schema.table` full name. Lets the read-set resolver map a table
+    // reference from SQL lineage to the producing model's recorded output.
+    // Empty when reuse is off so the default path allocates nothing.
     let reuse_target_by_model: std::collections::HashMap<String, String> = if reuse_enabled {
-        let mut map = std::collections::HashMap::new();
-        for m in &compile_result.project.models {
-            let t = &m.config.target;
-            let target_full = format!("{}.{}.{}", t.catalog, t.schema, t.table);
-            map.insert(m.config.name.to_lowercase(), target_full.clone());
-            map.insert(
-                format!("{}.{}", t.schema, t.table).to_lowercase(),
-                target_full,
-            );
-        }
-        map
+        build_reuse_target_by_model(
+            compile_result
+                .project
+                .models
+                .iter()
+                .map(|m| (m.config.name.as_str(), &m.config.target)),
+        )
     } else {
         Default::default()
     };
@@ -4741,6 +4735,37 @@ pub(crate) async fn execute_models(
     Ok(())
 }
 
+/// Build the static `read-identity → target catalog.schema.table` lookup the
+/// reuse read-set resolver consults.
+///
+/// Keys a model only by identities that bind UNAMBIGUOUSLY to it:
+///
+/// - its lowercased bare model NAME (the compiler rejects duplicate model
+///   names at `project.rs`, so a 1-part read resolves to exactly one model);
+/// - its lowercased fully-qualified `catalog.schema.table` target identity (a
+///   3-part read names a single catalog).
+///
+/// The catalog-less `schema.table` form is deliberately **omitted**: two
+/// models targeting `cat1.marts.orders` and `cat2.marts.orders` share the same
+/// `marts.orders` and the compiler permits that (it only rejects duplicate
+/// model names). Keying on `schema.table` would let a catalog-ambiguous 2-part
+/// read bind to an arbitrary one of them and inherit its content hash under a
+/// `strong` label — the exact false-strong this resolver must refuse. A 2-part
+/// read therefore finds no key here and is left unresolved (see
+/// [`resolve_read_set_content_upstreams`]).
+fn build_reuse_target_by_model<'a, I>(models: I) -> std::collections::HashMap<String, String>
+where
+    I: IntoIterator<Item = (&'a str, &'a rocky_core::models::TargetConfig)>,
+{
+    let mut map = std::collections::HashMap::new();
+    for (name, t) in models {
+        let target_full = format!("{}.{}.{}", t.catalog, t.schema, t.table);
+        map.insert(target_full.to_lowercase(), target_full.clone());
+        map.insert(name.to_lowercase(), target_full);
+    }
+    map
+}
+
 /// Resolve a content-addressed model's immediate upstreams to STRONG
 /// content-hash identities for the auditable-reuse spine.
 ///
@@ -4753,14 +4778,25 @@ pub(crate) async fn execute_models(
 /// un-enumerable read can never be mistaken for "no raw-source reads". This is
 /// the same completeness fail-safe `skip_gate` uses.
 ///
+/// Only an UNAMBIGUOUS read resolves: a 1-part bare name (unique per project)
+/// or a 3-part `catalog.schema.table` (names a single catalog). A 2-part
+/// `schema.table` read is **catalog-ambiguous** — it binds to the session
+/// default catalog at runtime and `classify_table_ref` already treats it as an
+/// external source with no DAG edge — so it is refused here (returns `None` for
+/// that read ⇒ the whole model is left UNINDEXED, the same fail-safe as a
+/// raw-source read). Without this guard a 2-part read could collide with a
+/// project model in a *different* catalog and inherit its content hash under a
+/// `strong` label.
+///
 /// Returns `Some(_)` **only when every** read table maps (via
-/// `target_by_model`, keyed by lowercased bare name and `schema.table`) to a
-/// producing model whose unpartitioned content hash is in `outputs_by_target`.
-/// A read of a raw source (absent from `target_by_model`), a model not written
-/// content-addressed, or a model not built this run leaves the read unresolved
-/// ⇒ `None` ⇒ the model is not indexed. A model that reads nothing resolves to
-/// an empty (vacuously strong) set. This keeps a `strong` label honest: a
-/// mixed-input model is never mislabeled — it is simply deferred.
+/// `target_by_model`, keyed by lowercased bare name and full 3-part identity)
+/// to a producing model whose unpartitioned content hash is in
+/// `outputs_by_target`. A read of a raw source (absent from `target_by_model`),
+/// a catalog-ambiguous 2-part read, a model not written content-addressed, or a
+/// model not built this run leaves the read unresolved ⇒ `None` ⇒ the model is
+/// not indexed. A model that reads nothing resolves to an empty (vacuously
+/// strong) set. This keeps a `strong` label honest: a mixed-input or ambiguous
+/// model is never mislabeled — it is simply deferred.
 fn resolve_read_set_content_upstreams(
     sql: &str,
     target_by_model: &std::collections::HashMap<String, String>,
@@ -4782,6 +4818,18 @@ fn resolve_read_set_content_upstreams(
         return None;
     }
     rocky_core::reuse::resolve_content_upstreams(&read_tables, |table| {
+        // Only an UNAMBIGUOUS read may resolve to a project model's content
+        // hash: a 1-part bare name or a 3-part `catalog.schema.table`. A 2-part
+        // `schema.table` read is catalog-ambiguous — refuse it (and defensively
+        // any other arity) so it can never be bound to an arbitrary
+        // same-`schema.table` model in a different catalog under a strong
+        // label. `target_by_model` carries no 2-part keys either; the explicit
+        // guard is the load-bearing fail-safe, the key omission is defence in
+        // depth.
+        match table.matches('.').count() {
+            0 | 2 => {}
+            _ => return None,
+        }
         let target = target_by_model.get(table)?;
         let blake3_hash = outputs_by_target.get(target)?;
         Some((target.clone(), blake3_hash.clone()))
@@ -9987,5 +10035,136 @@ merge_keys = ["id"]
             built(&out2, "agg"),
             "an IN-subquery source is invisible to lineage — the model must always build"
         );
+    }
+
+    // -- reuse spine: catalog-ambiguous read must not false-strong -----------
+    //
+    // These exercise the *production* lookup builder + resolver
+    // (`build_reuse_target_by_model` / `resolve_read_set_content_upstreams`),
+    // not a hand-rolled map, so the "no catalog-less `schema.table` key"
+    // guarantee is genuinely under test.
+
+    fn target_cfg(catalog: &str, schema: &str, table: &str) -> rocky_core::models::TargetConfig {
+        rocky_core::models::TargetConfig {
+            catalog: catalog.to_string(),
+            schema: schema.to_string(),
+            table: table.to_string(),
+        }
+    }
+
+    #[test]
+    fn reuse_target_map_omits_catalog_less_schema_table_key() {
+        // Two models share `marts.orders` across distinct catalogs — exactly
+        // the collision the compiler permits (it only rejects duplicate model
+        // NAMES). The map must carry no `marts.orders` key, only the bare names
+        // and the full 3-part identities.
+        let t1 = target_cfg("cat1", "marts", "orders");
+        let t2 = target_cfg("cat2", "marts", "orders");
+        let map = build_reuse_target_by_model([("orders_a", &t1), ("orders_b", &t2)]);
+
+        assert!(
+            !map.contains_key("marts.orders"),
+            "a catalog-less schema.table key would let a 2-part read false-strong"
+        );
+        assert_eq!(map.get("orders_a"), Some(&"cat1.marts.orders".to_string()));
+        assert_eq!(map.get("orders_b"), Some(&"cat2.marts.orders".to_string()));
+        assert_eq!(
+            map.get("cat1.marts.orders"),
+            Some(&"cat1.marts.orders".to_string())
+        );
+        assert_eq!(
+            map.get("cat2.marts.orders"),
+            Some(&"cat2.marts.orders".to_string())
+        );
+    }
+
+    #[test]
+    fn reuse_two_part_ambiguous_read_leaves_model_unindexed() {
+        // (a) Two models cat1.marts.orders + cat2.marts.orders both built this
+        // run; a downstream content-addressed model reads the catalog-ambiguous
+        // 2-part `FROM marts.orders`. It must NOT resolve to either upstream's
+        // content hash — the whole model is left UNINDEXED (None).
+        let t1 = target_cfg("cat1", "marts", "orders");
+        let t2 = target_cfg("cat2", "marts", "orders");
+        let target_by_model = build_reuse_target_by_model([("orders_a", &t1), ("orders_b", &t2)]);
+
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert("cat1.marts.orders".to_string(), "hash-cat1".to_string());
+        outputs.insert("cat2.marts.orders".to_string(), "hash-cat2".to_string());
+
+        let resolved = resolve_read_set_content_upstreams(
+            "SELECT id FROM marts.orders",
+            &target_by_model,
+            &outputs,
+        );
+        assert!(
+            resolved.is_none(),
+            "a catalog-ambiguous 2-part read must leave the downstream unindexed, \
+             not bind it to an arbitrary upstream's hash under a strong label"
+        );
+    }
+
+    #[test]
+    fn reuse_three_part_qualified_read_resolves_to_named_catalog() {
+        // (b) A fully-qualified 3-part read names a single catalog and must
+        // resolve to THAT catalog's content hash — the legitimate strong chain
+        // still works.
+        let t1 = target_cfg("cat1", "marts", "orders");
+        let t2 = target_cfg("cat2", "marts", "orders");
+        let target_by_model = build_reuse_target_by_model([("orders_a", &t1), ("orders_b", &t2)]);
+
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert("cat1.marts.orders".to_string(), "hash-cat1".to_string());
+        outputs.insert("cat2.marts.orders".to_string(), "hash-cat2".to_string());
+
+        let resolved = resolve_read_set_content_upstreams(
+            "SELECT id FROM cat1.marts.orders",
+            &target_by_model,
+            &outputs,
+        )
+        .expect("a fully-qualified 3-part read resolves");
+        assert_eq!(resolved.len(), 1);
+        match &resolved[0] {
+            rocky_core::reuse::UpstreamIdentity::Content {
+                upstream_key,
+                blake3_hash,
+            } => {
+                assert_eq!(upstream_key, "cat1.marts.orders");
+                assert_eq!(
+                    blake3_hash, "hash-cat1",
+                    "must bind cat1's hash, not cat2's"
+                );
+            }
+            other => panic!("expected a Content identity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reuse_one_part_bare_name_read_still_resolves() {
+        // (c) A 1-part bare model-name read still resolves (names are unique
+        // per project, so there is no ambiguity to refuse).
+        let t1 = target_cfg("cat1", "marts", "orders");
+        let target_by_model = build_reuse_target_by_model([("orders_a", &t1)]);
+
+        let mut outputs = std::collections::HashMap::new();
+        outputs.insert("cat1.marts.orders".to_string(), "hash-cat1".to_string());
+
+        let resolved = resolve_read_set_content_upstreams(
+            "SELECT id FROM orders_a",
+            &target_by_model,
+            &outputs,
+        )
+        .expect("a 1-part bare-name read resolves");
+        assert_eq!(resolved.len(), 1);
+        match &resolved[0] {
+            rocky_core::reuse::UpstreamIdentity::Content {
+                upstream_key,
+                blake3_hash,
+            } => {
+                assert_eq!(upstream_key, "cat1.marts.orders");
+                assert_eq!(blake3_hash, "hash-cat1");
+            }
+            other => panic!("expected a Content identity, got {other:?}"),
+        }
     }
 }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -1115,6 +1115,7 @@ pub async fn run(
             false, // model-only entry point has no pipeline governance context
             defer_opts,
             skip_gate,
+            rocky_cfg.reuse.enabled,
         )
         .await?;
 
@@ -3211,6 +3212,7 @@ pub async fn run(
                     // set (a full run builds every model).
                     defer_opts,
                     skip_gate,
+                    rocky_cfg.reuse.enabled,
                 )
                 .await?;
                 Ok(())
@@ -4029,6 +4031,12 @@ pub(crate) async fn execute_models(
     // the gate is inert and this function builds every selected model
     // exactly as before — no extra state reads or warehouse queries.
     skip_gate: SkipGateConfig,
+    // Opt-in `[reuse]` spine population. When `false` (the default) no
+    // input-match index entry or provenance record is written and no
+    // per-model spine hashing cost is paid — the run is byte- and
+    // cost-identical. Dormant even when `true`: it only records the index,
+    // it makes no reuse decision and skips nothing.
+    reuse_enabled: bool,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
 
@@ -4116,6 +4124,54 @@ pub(crate) async fn execute_models(
     }
 
     let dialect = warehouse.dialect();
+
+    // Auditable-reuse spine accumulator (dormant). When `[reuse]` is enabled,
+    // each successfully-built content-addressed model contributes an
+    // input-match index entry + an offline-verifiable provenance record,
+    // flushed in one transaction at end-of-run. Empty (and never touched)
+    // when reuse is off, so the default path pays nothing.
+    //
+    // `reuse_outputs` maps a built model's fully-qualified target identity to
+    // its output blake3, so a *downstream* content-addressed model in a later
+    // layer can resolve its upstreams to STRONG content-hash identities
+    // without any extra warehouse query. Stage 1 indexes only models whose
+    // every upstream resolves to a content hash; watermark/heuristic upstream
+    // population is deferred (it needs the freshness-signal machinery).
+    let mut reuse_index_entries: Vec<rocky_core::state::InputIndexEntry> = Vec::new();
+    let mut reuse_provenance: Vec<rocky_core::state::ProvenanceRecord> = Vec::new();
+    let mut reuse_outputs: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    // Static lookups for upstream resolution, built once when reuse is on:
+    // model name → its immediate upstream **model** names (DAG edges), and
+    // model name → its target `catalog.schema.table` identity. Empty when
+    // reuse is off so the default path allocates nothing.
+    let (reuse_depends_on, reuse_target_by_model): (
+        std::collections::HashMap<String, Vec<String>>,
+        std::collections::HashMap<String, String>,
+    ) = if reuse_enabled {
+        let depends = compile_result
+            .project
+            .dag_nodes
+            .iter()
+            .map(|n| (n.name.clone(), n.depends_on.clone()))
+            .collect();
+        let targets = compile_result
+            .project
+            .models
+            .iter()
+            .map(|m| {
+                let t = &m.config.target;
+                (
+                    m.config.name.to_string(),
+                    format!("{}.{}.{}", t.catalog, t.schema, t.table),
+                )
+            })
+            .collect();
+        (depends, targets)
+    } else {
+        Default::default()
+    };
 
     // Pre-create target schemas when the caller requested auto-create.
     // Mirrors the replication path's per-source loop (see the
@@ -4479,6 +4535,51 @@ pub(crate) async fn execute_models(
                                 );
                             }
                         }
+                        // Auditable-reuse spine (dormant). When `[reuse]` is
+                        // enabled, accumulate this model's input-match index
+                        // entry + provenance record. Stage 1 indexes only when
+                        // every immediate upstream resolves to a STRONG
+                        // content hash produced earlier in this run — no extra
+                        // warehouse query. The output is recorded regardless so
+                        // a downstream content-addressed model can resolve THIS
+                        // model as a content-hash upstream. Best-effort and
+                        // additive: it never changes what was materialized.
+                        // First slice is unpartitioned-only (the partitioned
+                        // ledger is last-group-only — see the Phase 6 TODO
+                        // above); a multi-group write records no spine entry.
+                        if reuse_enabled {
+                            let target_identity = target_table_full_name.clone();
+                            reuse_outputs
+                                .insert(target_identity.clone(), summary.blake3_hash.clone());
+                            let is_unpartitioned = !matches!(
+                                &model_ir.materialization,
+                                MaterializationStrategy::ContentAddressed { partition_columns, .. }
+                                    if !partition_columns.is_empty()
+                            );
+                            if is_unpartitioned
+                                && let Some(upstreams) = resolve_strong_upstreams(
+                                    model_name,
+                                    &reuse_depends_on,
+                                    &reuse_target_by_model,
+                                    &reuse_outputs,
+                                )
+                            {
+                                let outputs = vec![rocky_core::reuse::OutputArtifact {
+                                    blake3_hash: summary.blake3_hash.clone(),
+                                    file_path: summary.file_path.clone(),
+                                }];
+                                if let Some((entry, prov)) = rocky_core::reuse::build_records(
+                                    &model_ir,
+                                    run_id,
+                                    &upstreams,
+                                    &outputs,
+                                    Utc::now(),
+                                ) {
+                                    reuse_index_entries.push(entry);
+                                    reuse_provenance.push(prov);
+                                }
+                            }
+                        }
                         if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
                             let _ = reg
                                 .fire(&HookContext::after_model_run(
@@ -4608,8 +4709,63 @@ pub(crate) async fn execute_models(
         }
     }
 
+    // Flush the auditable-reuse spine in one transaction at end-of-run, only
+    // on the success path (a failed run returns early above and discards the
+    // accumulator — dormant Stage-1 indexes only fully-successful builds).
+    // Best-effort: a write failure logs and continues, mirroring the
+    // `record_artifact` posture — the run itself is already durable.
+    if reuse_enabled
+        && !(reuse_index_entries.is_empty() && reuse_provenance.is_empty())
+        && let Some(store) = state_store
+    {
+        if let Err(e) = store.record_reuse_spine(&reuse_index_entries, &reuse_provenance) {
+            warn!(
+                error = %e,
+                entries = reuse_index_entries.len(),
+                "failed to persist auditable-reuse spine (run still successful; \
+                 index/provenance may be incomplete)"
+            );
+        } else {
+            info!(
+                entries = reuse_index_entries.len(),
+                "recorded auditable-reuse input-match spine (dormant)"
+            );
+        }
+    }
+
     info!(models = models_executed, "model execution complete");
     Ok(())
+}
+
+/// Resolve a content-addressed model's immediate upstreams to STRONG
+/// content-hash identities for the auditable-reuse spine.
+///
+/// Looks each upstream **model** name (from the DAG edges) up to its target
+/// `catalog.schema.table` identity, then to the output blake3 it produced
+/// earlier in this run (`outputs_by_target`). Returns `Some(_)` only when
+/// **every** upstream resolves to a content hash — the all-strong Stage-1
+/// path that needs no warehouse query. Returns `None` if any upstream is
+/// unresolved (a raw source, a non-content-addressed model, or an upstream
+/// not built this run): such models are simply not indexed in Stage 1, since
+/// watermark/heuristic upstream population is deferred. An upstream-free model
+/// resolves to an empty (vacuously strong) set.
+fn resolve_strong_upstreams(
+    model_name: &str,
+    depends_on: &std::collections::HashMap<String, Vec<String>>,
+    target_by_model: &std::collections::HashMap<String, String>,
+    outputs_by_target: &std::collections::HashMap<String, String>,
+) -> Option<Vec<rocky_core::reuse::UpstreamIdentity>> {
+    let upstream_models = depends_on.get(model_name).map(Vec::as_slice).unwrap_or(&[]);
+    let mut identities = Vec::with_capacity(upstream_models.len());
+    for upstream in upstream_models {
+        let target = target_by_model.get(upstream)?;
+        let blake3_hash = outputs_by_target.get(target)?;
+        identities.push(rocky_core::reuse::UpstreamIdentity::Content {
+            upstream_key: target.clone(),
+            blake3_hash: blake3_hash.clone(),
+        });
+    }
+    Some(identities)
 }
 
 /// Map a `MaterializationStrategy` (post-`to_plan()`) onto the string used
@@ -8104,6 +8260,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
+            false,
         )
         .await;
         (output, result)
@@ -8187,6 +8344,7 @@ merge_keys = ["id"]
             false,
             &defer_opts,
             super::SkipGateConfig::off(),
+            false,
         )
         .await
         .expect("deferred run must succeed");
@@ -8301,6 +8459,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             super::SkipGateConfig::off(),
+            false,
         )
         .await;
 
@@ -8536,6 +8695,7 @@ merge_keys = ["id"]
             false,
             &DeferOptions::default(),
             gate,
+            false,
         )
         .await
         .expect("gate run must succeed");
@@ -9425,6 +9585,7 @@ merge_keys = ["id"]
                 false,
                 &DeferOptions::default(),
                 active_gate(true, 0),
+                false,
             )
             .await
             .unwrap();

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4132,43 +4132,36 @@ pub(crate) async fn execute_models(
     // when reuse is off, so the default path pays nothing.
     //
     // `reuse_outputs` maps a built model's fully-qualified target identity to
-    // its output blake3, so a *downstream* content-addressed model in a later
-    // layer can resolve its upstreams to STRONG content-hash identities
-    // without any extra warehouse query. Stage 1 indexes only models whose
-    // every upstream resolves to a content hash; watermark/heuristic upstream
-    // population is deferred (it needs the freshness-signal machinery).
+    // its output blake3 keyed by its target identity, so a *downstream*
+    // content-addressed model in a later layer can resolve a table it reads to
+    // a STRONG content-hash identity without any extra warehouse query. Stage 1
+    // indexes a model only when EVERY table it reads resolves to a content
+    // hash; a raw-source read (or any unresolved read) leaves the model
+    // unindexed rather than mislabeled strong.
     let mut reuse_index_entries: Vec<rocky_core::state::InputIndexEntry> = Vec::new();
     let mut reuse_provenance: Vec<rocky_core::state::ProvenanceRecord> = Vec::new();
     let mut reuse_outputs: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
 
-    // Static lookups for upstream resolution, built once when reuse is on:
-    // model name → its immediate upstream **model** names (DAG edges), and
-    // model name → its target `catalog.schema.table` identity. Empty when
-    // reuse is off so the default path allocates nothing.
-    let (reuse_depends_on, reuse_target_by_model): (
-        std::collections::HashMap<String, Vec<String>>,
-        std::collections::HashMap<String, String>,
-    ) = if reuse_enabled {
-        let depends = compile_result
-            .project
-            .dag_nodes
-            .iter()
-            .map(|n| (n.name.clone(), n.depends_on.clone()))
-            .collect();
-        let targets = compile_result
-            .project
-            .models
-            .iter()
-            .map(|m| {
-                let t = &m.config.target;
-                (
-                    m.config.name.to_string(),
-                    format!("{}.{}.{}", t.catalog, t.schema, t.table),
-                )
-            })
-            .collect();
-        (depends, targets)
+    // Static lookup built once when reuse is on: every lowercased identity a
+    // model can be *read by* in SQL (its bare name and its `schema.table`
+    // form) → that model's target `catalog.schema.table` full name. Lets the
+    // read-set resolver map a table reference from SQL lineage to the producing
+    // model's recorded output. Empty when reuse is off so the default path
+    // allocates nothing. Mirrors the identity set `skip_gate` builds for the
+    // same raw-source-vs-project-model distinction.
+    let reuse_target_by_model: std::collections::HashMap<String, String> = if reuse_enabled {
+        let mut map = std::collections::HashMap::new();
+        for m in &compile_result.project.models {
+            let t = &m.config.target;
+            let target_full = format!("{}.{}.{}", t.catalog, t.schema, t.table);
+            map.insert(m.config.name.to_lowercase(), target_full.clone());
+            map.insert(
+                format!("{}.{}", t.schema, t.table).to_lowercase(),
+                target_full,
+            );
+        }
+        map
     } else {
         Default::default()
     };
@@ -4537,47 +4530,58 @@ pub(crate) async fn execute_models(
                         }
                         // Auditable-reuse spine (dormant). When `[reuse]` is
                         // enabled, accumulate this model's input-match index
-                        // entry + provenance record. Stage 1 indexes only when
-                        // every immediate upstream resolves to a STRONG
+                        // entry + provenance record. Stage 1 indexes a model
+                        // only when EVERY table it reads resolves to a STRONG
                         // content hash produced earlier in this run — no extra
-                        // warehouse query. The output is recorded regardless so
-                        // a downstream content-addressed model can resolve THIS
-                        // model as a content-hash upstream. Best-effort and
-                        // additive: it never changes what was materialized.
-                        // First slice is unpartitioned-only (the partitioned
-                        // ledger is last-group-only — see the Phase 6 TODO
-                        // above); a multi-group write records no spine entry.
+                        // warehouse query. A read of a raw source, a model not
+                        // written content-addressed, or a model not built this
+                        // run means the chain is not byte-verifiable
+                        // end-to-end, so the model is left unindexed rather
+                        // than mislabeled strong (heuristic/watermark
+                        // population is deferred). Best-effort and additive: it
+                        // never changes what was materialized.
+                        //
+                        // Only UNPARTITIONED writes participate: the
+                        // partitioned ledger is last-group-only (the Phase 6
+                        // TODO above), so a partitioned hash is incomplete and
+                        // is recorded neither as this model's identity nor as a
+                        // resolvable upstream.
                         if reuse_enabled {
-                            let target_identity = target_table_full_name.clone();
-                            reuse_outputs
-                                .insert(target_identity.clone(), summary.blake3_hash.clone());
                             let is_unpartitioned = !matches!(
                                 &model_ir.materialization,
                                 MaterializationStrategy::ContentAddressed { partition_columns, .. }
                                     if !partition_columns.is_empty()
                             );
-                            if is_unpartitioned
-                                && let Some(upstreams) = resolve_strong_upstreams(
-                                    model_name,
-                                    &reuse_depends_on,
+                            if is_unpartitioned {
+                                if let Some(upstreams) = resolve_read_set_content_upstreams(
+                                    &model_ir.sql,
                                     &reuse_target_by_model,
                                     &reuse_outputs,
-                                )
-                            {
-                                let outputs = vec![rocky_core::reuse::OutputArtifact {
-                                    blake3_hash: summary.blake3_hash.clone(),
-                                    file_path: summary.file_path.clone(),
-                                }];
-                                if let Some((entry, prov)) = rocky_core::reuse::build_records(
-                                    &model_ir,
-                                    run_id,
-                                    &upstreams,
-                                    &outputs,
-                                    Utc::now(),
                                 ) {
-                                    reuse_index_entries.push(entry);
-                                    reuse_provenance.push(prov);
+                                    let outputs = vec![rocky_core::reuse::OutputArtifact {
+                                        blake3_hash: summary.blake3_hash.clone(),
+                                        file_path: summary.file_path.clone(),
+                                    }];
+                                    if let Some((entry, prov)) = rocky_core::reuse::build_records(
+                                        &model_ir,
+                                        run_id,
+                                        &upstreams,
+                                        &outputs,
+                                        Utc::now(),
+                                    ) {
+                                        reuse_index_entries.push(entry);
+                                        reuse_provenance.push(prov);
+                                    }
                                 }
+                                // Record THIS model's content identity only
+                                // after the resolve above, and only for an
+                                // unpartitioned (complete-hash) write, so a
+                                // downstream can resolve it as a STRONG
+                                // upstream without inheriting a partial hash.
+                                reuse_outputs.insert(
+                                    target_table_full_name.clone(),
+                                    summary.blake3_hash.clone(),
+                                );
                             }
                         }
                         if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
@@ -4740,32 +4744,48 @@ pub(crate) async fn execute_models(
 /// Resolve a content-addressed model's immediate upstreams to STRONG
 /// content-hash identities for the auditable-reuse spine.
 ///
-/// Looks each upstream **model** name (from the DAG edges) up to its target
-/// `catalog.schema.table` identity, then to the output blake3 it produced
-/// earlier in this run (`outputs_by_target`). Returns `Some(_)` only when
-/// **every** upstream resolves to a content hash — the all-strong Stage-1
-/// path that needs no warehouse query. Returns `None` if any upstream is
-/// unresolved (a raw source, a non-content-addressed model, or an upstream
-/// not built this run): such models are simply not indexed in Stage 1, since
-/// watermark/heuristic upstream population is deferred. An upstream-free model
-/// resolves to an empty (vacuously strong) set.
-fn resolve_strong_upstreams(
-    model_name: &str,
-    depends_on: &std::collections::HashMap<String, Vec<String>>,
+/// Enumerates **every table the model reads** from its SQL lineage — not just
+/// its project-model dependencies — and resolves each to the content blake3 a
+/// project model produced earlier in this run. The read set is trusted only
+/// when [`rocky_sql::lineage_complete::lineage_is_provably_complete`] holds
+/// (a plain `SELECT` over bare tables, no CTEs/subqueries that the lineage
+/// walk could silently drop); any other shape returns `None` so an
+/// un-enumerable read can never be mistaken for "no raw-source reads". This is
+/// the same completeness fail-safe `skip_gate` uses.
+///
+/// Returns `Some(_)` **only when every** read table maps (via
+/// `target_by_model`, keyed by lowercased bare name and `schema.table`) to a
+/// producing model whose unpartitioned content hash is in `outputs_by_target`.
+/// A read of a raw source (absent from `target_by_model`), a model not written
+/// content-addressed, or a model not built this run leaves the read unresolved
+/// ⇒ `None` ⇒ the model is not indexed. A model that reads nothing resolves to
+/// an empty (vacuously strong) set. This keeps a `strong` label honest: a
+/// mixed-input model is never mislabeled — it is simply deferred.
+fn resolve_read_set_content_upstreams(
+    sql: &str,
     target_by_model: &std::collections::HashMap<String, String>,
     outputs_by_target: &std::collections::HashMap<String, String>,
 ) -> Option<Vec<rocky_core::reuse::UpstreamIdentity>> {
-    let upstream_models = depends_on.get(model_name).map(Vec::as_slice).unwrap_or(&[]);
-    let mut identities = Vec::with_capacity(upstream_models.len());
-    for upstream in upstream_models {
-        let target = target_by_model.get(upstream)?;
-        let blake3_hash = outputs_by_target.get(target)?;
-        identities.push(rocky_core::reuse::UpstreamIdentity::Content {
-            upstream_key: target.clone(),
-            blake3_hash: blake3_hash.clone(),
-        });
+    // Fail-safe: only trust the read-set enumeration for SQL shapes where the
+    // lineage walk provably surfaces every upstream.
+    if !rocky_sql::lineage_complete::lineage_is_provably_complete(sql) {
+        return None;
     }
-    Some(identities)
+    let lineage = rocky_sql::lineage::extract_lineage(sql).ok()?;
+    let read_tables: Vec<String> = lineage
+        .source_tables
+        .iter()
+        .map(|t| t.name.to_lowercase())
+        .collect();
+    // Any unparseable "(subquery)" marker means the read set is incomplete.
+    if read_tables.iter().any(|t| t == "(subquery)") {
+        return None;
+    }
+    rocky_core::reuse::resolve_content_upstreams(&read_tables, |table| {
+        let target = target_by_model.get(table)?;
+        let blake3_hash = outputs_by_target.get(target)?;
+        Some((target.clone(), blake3_hash.clone()))
+    })
 }
 
 /// Map a `MaterializationStrategy` (post-`to_plan()`) onto the string used

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -84,6 +84,7 @@ pub async fn run_transformation(
             // run_local has no `--model` selection; defer is a no-op here.
             &super::run::DeferOptions::default(),
             skip_gate,
+            rocky_cfg.reuse.enabled,
         )
         .await?;
     } else {

--- a/engine/crates/rocky-core/src/bridge.rs
+++ b/engine/crates/rocky-core/src/bridge.rs
@@ -315,6 +315,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2139,6 +2139,14 @@ pub struct RockyConfig {
     /// before the gate existed. See [`RunConfig`].
     #[serde(default)]
     pub run: RunConfig,
+
+    /// Opt-in population of the auditable-reuse input-match spine.
+    /// Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and
+    /// cost-identical (no per-model hashing, no extra state write). Dormant
+    /// in Stage 1 even when enabled — it only records the index + provenance,
+    /// it makes no reuse decision. See [`ReuseConfig`].
+    #[serde(default)]
+    pub reuse: ReuseConfig,
 }
 
 /// `[run]` — opt-in tuning for the model-skip gate.
@@ -2174,6 +2182,29 @@ pub struct RunConfig {
     /// `0`: any movement at all forces a rebuild.
     #[serde(default)]
     pub lag_tolerance_seconds: u64,
+}
+
+/// `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+///
+/// When `enabled = true`, a successful run records, per model, an input-match
+/// index entry and an offline-verifiable provenance record (the model's
+/// logic key, upstream input identities, output blake3(s), and proof class).
+/// This is the *input* side of reuse — the index that a future reuse
+/// decision will read.
+///
+/// **Dormant by default.** `enabled = false` (the default) keeps `rocky run`
+/// byte- *and* cost-identical to before the spine existed: no extra
+/// normalize+hash work, no extra state write. Even when enabled, Stage 1
+/// only *populates* the spine — it makes no reuse decision and skips nothing.
+/// The spine attests an *input-logic match*, never that re-running a model
+/// would reproduce its output.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReuseConfig {
+    /// Master switch for input-match spine population. `false` (default) ⇒
+    /// the spine is never written and no per-model hashing cost is paid.
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 impl RockyConfig {

--- a/engine/crates/rocky-core/src/cross_engine.rs
+++ b/engine/crates/rocky-core/src/cross_engine.rs
@@ -592,6 +592,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -723,6 +723,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         };
 
         let models = vec![
@@ -815,6 +816,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         };
 
         let models = vec![Model {
@@ -897,6 +899,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         };
 
         let index = build_doc_index(&[], &config, None);

--- a/engine/crates/rocky-core/src/lib.rs
+++ b/engine/crates/rocky-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod redacted;
 pub mod retention;
 pub mod retry;
 pub mod retry_budget;
+pub mod reuse;
 pub mod role_graph;
 pub mod schema;
 pub mod schema_cache;

--- a/engine/crates/rocky-core/src/reuse.rs
+++ b/engine/crates/rocky-core/src/reuse.rs
@@ -226,6 +226,89 @@ pub fn proof_class_for(upstreams: &[UpstreamIdentity]) -> ProofClass {
     ProofClass::min(upstreams.iter().map(UpstreamIdentity::proof_class))
 }
 
+/// The output a model produced for one content-addressed file.
+///
+/// Index-aligned `(blake3, path)` pairs flow from the writer's `WriteResult`
+/// straight into the index entry + provenance record. A model with no
+/// content-addressed output passes an empty slice.
+#[derive(Debug, Clone)]
+pub struct OutputArtifact {
+    /// Hex-encoded blake3 of the output parquet.
+    pub blake3_hash: String,
+    /// Object-store path of the output parquet.
+    pub file_path: String,
+}
+
+/// Build the [`crate::state::InputIndexEntry`] +
+/// [`crate::state::ProvenanceRecord`] pair for one successfully-built model.
+///
+/// This is the pure heart of spine population: given the model's typed IR,
+/// the run it built in, its resolved immediate-upstream identities, and the
+/// output artifact(s) it produced, it assembles both records — computing the
+/// `input_hash`, the `proof_class` (MIN over upstreams), and embedding the
+/// canonical `ModelIr` JSON for the offline verifier. It performs no I/O, so
+/// the warehouse-agnostic population logic is unit-testable without a live
+/// adapter.
+///
+/// # Returns
+///
+/// `None` when the model cannot be safely canonicalised — its
+/// [`rocky_ir::ModelIr::skip_hash`] is `None` (empty typed columns or SQL
+/// that does not re-normalise). A non-canonicalisable model is **not
+/// indexed**: a never-equal logic key must never be presented as a reuse
+/// candidate. Otherwise returns `Some((index_entry, provenance))`.
+///
+/// # What the records attest
+///
+/// An *input-logic match* plus the *byte-identity of the recorded output
+/// bytes* — never that re-executing the model would reproduce them.
+pub fn build_records(
+    model_ir: &rocky_ir::ModelIr,
+    run_id: &str,
+    upstreams: &[UpstreamIdentity],
+    outputs: &[OutputArtifact],
+    recorded_at: chrono::DateTime<chrono::Utc>,
+) -> Option<(
+    crate::state::InputIndexEntry,
+    crate::state::ProvenanceRecord,
+)> {
+    let skip_hash = model_ir.skip_hash()?.to_hex().to_string();
+    let target_identity = format!(
+        "{}.{}.{}",
+        model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
+    );
+    let input_hash = compute_input_hash(&skip_hash, &target_identity, upstreams)
+        .to_hex()
+        .to_string();
+    let proof_class = proof_class_for(upstreams).as_str().to_string();
+    let model_name = model_ir.name.to_string();
+
+    let output_blake3: Vec<String> = outputs.iter().map(|o| o.blake3_hash.clone()).collect();
+    let output_path: Vec<String> = outputs.iter().map(|o| o.file_path.clone()).collect();
+
+    let index_entry = crate::state::InputIndexEntry {
+        input_hash: input_hash.clone(),
+        run_id: run_id.to_string(),
+        model_name: model_name.clone(),
+        output_blake3: output_blake3.clone(),
+        output_path: output_path.clone(),
+        proof_class: proof_class.clone(),
+        recorded_at,
+    };
+    let provenance = crate::state::ProvenanceRecord {
+        run_id: run_id.to_string(),
+        model_name,
+        input_hash,
+        skip_hash,
+        model_ir_canonical_json: model_ir.canonical_json(),
+        output_blake3,
+        output_path,
+        proof_class,
+        recorded_at,
+    };
+    Some((index_entry, provenance))
+}
+
 /// Canonical-JSON encoder mirroring [`rocky_ir::ModelIr::canonical_json`]'s
 /// key-sorted, whitespace-free form so spine keys are stable across machines.
 fn canonical_json<T: Serialize>(value: &T) -> String {
@@ -374,6 +457,115 @@ mod tests {
         assert_eq!(
             ProofClass::min([ProofClass::Strong, ProofClass::Strong]),
             ProofClass::Strong
+        );
+    }
+
+    // -- pure record builder ------------------------------------------------
+
+    fn model_ir(table: &str, sql: &str, canonicalisable: bool) -> rocky_ir::ModelIr {
+        let mut m = rocky_ir::ModelIr::transformation(
+            rocky_ir::TargetRef {
+                catalog: "analytics".to_string(),
+                schema: "marts".to_string(),
+                table: table.to_string(),
+            },
+            rocky_ir::MaterializationStrategy::FullRefresh,
+            Vec::new(),
+            sql.to_string(),
+            rocky_ir::GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            None,
+            None,
+        );
+        m.name = std::sync::Arc::from(table);
+        if canonicalisable {
+            // skip_hash returns None on empty typed_columns; populate one.
+            m.typed_columns = vec![rocky_ir::TypedColumn {
+                name: "id".into(),
+                data_type: rocky_ir::RockyType::Int64,
+                nullable: false,
+            }];
+        }
+        m
+    }
+
+    fn output(hash: &str, path: &str) -> OutputArtifact {
+        OutputArtifact {
+            blake3_hash: hash.to_string(),
+            file_path: path.to_string(),
+        }
+    }
+
+    #[test]
+    fn build_records_assembles_index_and_provenance() {
+        let m = model_ir("fct_orders", "SELECT id FROM raw.orders", true);
+        let ups = vec![content("analytics.marts.dim_x", "up-hash")];
+        let outs = vec![output("out-hash", "s3://b/p/out.parquet")];
+        let now = chrono::Utc::now();
+
+        let (entry, prov) = build_records(&m, "run-1", &ups, &outs, now).expect("canonicalisable");
+
+        assert_eq!(entry.run_id, "run-1");
+        assert_eq!(entry.model_name, "fct_orders");
+        assert_eq!(entry.proof_class, "strong");
+        assert_eq!(entry.output_blake3, vec!["out-hash".to_string()]);
+        assert_eq!(entry.output_path, vec!["s3://b/p/out.parquet".to_string()]);
+
+        // Both records key off the same input_hash, derived from skip_hash.
+        assert_eq!(entry.input_hash, prov.input_hash);
+        let expected_skip = m.skip_hash().unwrap().to_hex().to_string();
+        assert_eq!(prov.skip_hash, expected_skip);
+
+        // Provenance embeds the round-trippable canonical IR.
+        let reparsed: rocky_ir::ModelIr =
+            serde_json::from_str(&prov.model_ir_canonical_json).expect("round-trips");
+        assert_eq!(
+            reparsed.skip_hash().unwrap().to_hex().to_string(),
+            prov.skip_hash,
+            "offline skip_hash recompute matches the recorded value"
+        );
+    }
+
+    #[test]
+    fn build_records_input_hash_matches_compute_input_hash() {
+        // The builder's input_hash must equal what an offline verifier would
+        // recompute from the same skip_hash + target + upstreams.
+        let m = model_ir("fct_orders", "SELECT id FROM raw.orders", true);
+        let ups = vec![content("analytics.marts.dim_x", "up-hash")];
+        let (entry, _) =
+            build_records(&m, "run-1", &ups, &[], chrono::Utc::now()).expect("canonicalisable");
+
+        let skip = m.skip_hash().unwrap().to_hex().to_string();
+        let expected = compute_input_hash(&skip, "analytics.marts.fct_orders", &ups)
+            .to_hex()
+            .to_string();
+        assert_eq!(entry.input_hash, expected);
+    }
+
+    #[test]
+    fn build_records_proof_class_is_min_over_upstreams() {
+        let m = model_ir("fct_orders", "SELECT id FROM raw.orders", true);
+        let mixed = vec![
+            content("analytics.marts.a", "h1"),
+            watermark("raw.src.b", Some("2026-06-04T00:00:00Z"), None),
+        ];
+        let (entry, prov) =
+            build_records(&m, "run-1", &mixed, &[], chrono::Utc::now()).expect("canonicalisable");
+        assert_eq!(entry.proof_class, "heuristic");
+        assert_eq!(prov.proof_class, "heuristic");
+    }
+
+    #[test]
+    fn build_records_skips_non_canonicalisable_model() {
+        // Empty typed_columns ⇒ skip_hash None ⇒ not indexed.
+        let m = model_ir("fct_orders", "SELECT id FROM raw.orders", false);
+        assert!(m.skip_hash().is_none());
+        assert!(
+            build_records(&m, "run-1", &[], &[], chrono::Utc::now()).is_none(),
+            "a non-canonicalisable model must not be indexed"
         );
     }
 }

--- a/engine/crates/rocky-core/src/reuse.rs
+++ b/engine/crates/rocky-core/src/reuse.rs
@@ -226,6 +226,46 @@ pub fn proof_class_for(upstreams: &[UpstreamIdentity]) -> ProofClass {
     ProofClass::min(upstreams.iter().map(UpstreamIdentity::proof_class))
 }
 
+/// Resolve a model's **entire read set** to STRONG content-hash upstream
+/// identities, or refuse.
+///
+/// `read_tables` is every table the model reads, as enumerated from its SQL
+/// lineage — *not* just its project-model dependencies. `resolve` maps a read
+/// table to the content blake3 hash + canonical upstream key for the artifact
+/// it produced this run, or `None` when that table has no content hash
+/// available (a raw source, a model not written content-addressed, a model
+/// not built this run, or a partitioned write whose ledger hash is
+/// incomplete).
+///
+/// # Returns
+///
+/// `Some(_)` **only when every** read table resolves to a content hash — the
+/// all-strong chain that is legitimately `b3sum`-verifiable end-to-end. A
+/// single unresolved read (most importantly a raw source, which `skip_hash`
+/// captures by name but cannot byte-verify) returns `None` so the caller does
+/// **not** index the model. This is the fail-safe that keeps a `strong`
+/// label honest: a mixed-input model is never mislabeled strong — it is
+/// simply not indexed in this slice (heuristic/watermark population for such
+/// models is deferred). A model that reads nothing resolves to an empty
+/// (vacuously strong) set.
+pub fn resolve_content_upstreams<F>(
+    read_tables: &[String],
+    mut resolve: F,
+) -> Option<Vec<UpstreamIdentity>>
+where
+    F: FnMut(&str) -> Option<(String, String)>,
+{
+    let mut identities = Vec::with_capacity(read_tables.len());
+    for table in read_tables {
+        let (upstream_key, blake3_hash) = resolve(table)?;
+        identities.push(UpstreamIdentity::Content {
+            upstream_key,
+            blake3_hash,
+        });
+    }
+    Some(identities)
+}
+
 /// The output a model produced for one content-addressed file.
 ///
 /// Index-aligned `(blake3, path)` pairs flow from the writer's `WriteResult`
@@ -567,5 +607,47 @@ mod tests {
             build_records(&m, "run-1", &[], &[], chrono::Utc::now()).is_none(),
             "a non-canonicalisable model must not be indexed"
         );
+    }
+
+    // -- read-set resolver --------------------------------------------------
+
+    #[test]
+    fn resolve_content_upstreams_all_resolved_is_some() {
+        let reads = vec!["a".to_string(), "b".to_string()];
+        let got = resolve_content_upstreams(&reads, |t| {
+            Some((format!("cat.sch.{t}"), format!("hash-{t}")))
+        })
+        .expect("every read resolved");
+        assert_eq!(got.len(), 2);
+        assert!(
+            got.iter()
+                .all(|u| matches!(u, UpstreamIdentity::Content { .. }))
+        );
+        assert_eq!(proof_class_for(&got), ProofClass::Strong);
+    }
+
+    #[test]
+    fn resolve_content_upstreams_any_unresolved_is_none() {
+        let reads = vec!["a".to_string(), "raw_source".to_string()];
+        let got = resolve_content_upstreams(&reads, |t| {
+            // The raw source has no content hash.
+            if t == "raw_source" {
+                None
+            } else {
+                Some((format!("cat.sch.{t}"), format!("hash-{t}")))
+            }
+        });
+        assert!(
+            got.is_none(),
+            "a single unresolved read (raw source) must refuse to index, not mislabel strong"
+        );
+    }
+
+    #[test]
+    fn resolve_content_upstreams_empty_read_set_is_strong() {
+        let got = resolve_content_upstreams(&[], |_| unreachable!("no reads"))
+            .expect("an empty read set resolves");
+        assert!(got.is_empty());
+        assert_eq!(proof_class_for(&got), ProofClass::Strong);
     }
 }

--- a/engine/crates/rocky-core/src/reuse.rs
+++ b/engine/crates/rocky-core/src/reuse.rs
@@ -1,0 +1,379 @@
+//! Input-match spine for auditable reuse — warehouse-agnostic, additive,
+//! and **dormant**.
+//!
+//! This module builds the *input* side of reuse: a pre-execution-style key
+//! that identifies a model build by its **declared inputs** rather than by
+//! the bytes it produced. It is the missing half of the shipped
+//! content-addressed ledger ([`crate::state::ArtifactRecord`]), which records
+//! the blake3 of the *output* parquet and so can only be read *after* a build
+//! has already run.
+//!
+//! ## What "input identity" means here
+//!
+//! For a model `M`, the input-match key folds three things:
+//!
+//! 1. `M`'s own cosmetic-invariant logic key — [`rocky_ir::ModelIr::skip_hash`]
+//!    (normalised SQL + typed structural facts, already including `M`'s
+//!    target identity).
+//! 2. The target `catalog.schema.table` identity, folded in explicitly so a
+//!    match can never point at bytes for a *different* target (it is also
+//!    inside `skip_hash`, but folding it explicitly keeps the key robust to
+//!    any future change in `skip_hash`'s projection).
+//! 3. Each immediate upstream's **input identity**, of two strengths:
+//!    - [`UpstreamIdentity::Content`] — the upstream's recorded output blake3
+//!      (available only where the upstream itself was written
+//!      content-addressed). This is the **strong** signal.
+//!    - [`UpstreamIdentity::Watermark`] — the upstream's `MAX(ts)` / rowcount
+//!      freshness signal (available everywhere). This is the **heuristic**
+//!      signal.
+//!
+//! ## Proof strength
+//!
+//! [`ProofClass`] for a model is the **minimum** over its upstreams: a model
+//! is [`ProofClass::Strong`] only when *every* upstream contributes a content
+//! hash. A single watermark-only upstream degrades the whole model to
+//! [`ProofClass::Heuristic`]. A model with no upstreams at all is
+//! vacuously [`ProofClass::Strong`] (there is no weaker input to drag it
+//! down) — its identity rests entirely on its own logic key.
+//!
+//! ## What this is NOT (the precise claim)
+//!
+//! Matching input identity attests that two builds **declared the same
+//! inputs and the same logic** — an *input-logic match*. It does **not**
+//! assert that re-executing the model would reproduce a given output;
+//! determinism is not assumed (see the caveat on
+//! [`rocky_ir::ModelIr::skip_hash`]). The byte-identity half of the
+//! auditable-reuse claim is carried separately by the output blake3 recorded
+//! in the ledger, not by this key.
+//!
+//! ## Dormant in Stage 1
+//!
+//! Nothing in this module changes run behavior. The index it backs (see
+//! [`crate::state::StateStore`]) is *populated* on a successful run and
+//! *read back* only by a future reuse decision — no skip, point-to, or clone
+//! happens in Stage 1. Population is gated behind the opt-in `[reuse]` config
+//! ([`crate::config::ReuseConfig`]) so the default run path is byte- and
+//! cost-identical to before this module existed.
+
+use serde::{Deserialize, Serialize};
+
+/// Strength of a reuse claim, derived as the minimum over a model's
+/// upstream input identities.
+///
+/// Ordering is meaningful: [`Heuristic`](Self::Heuristic) is *weaker* than
+/// [`Strong`](Self::Strong). [`ProofClass::min`] uses the derived `Ord`
+/// (declaration order: `Heuristic < Strong`) to fold a set of per-upstream
+/// strengths into the model's class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProofClass {
+    /// At least one upstream input identity is a freshness heuristic
+    /// (`MAX(ts)` / rowcount) rather than a content hash. Attests freshness,
+    /// not byte-identity.
+    Heuristic,
+    /// Every upstream input identity is a content hash (the model is on the
+    /// content-addressed path end-to-end). The strong claim — offline
+    /// byte-verifiable once a reuse backend lands (Stage 2).
+    Strong,
+}
+
+impl ProofClass {
+    /// Fold an iterator of per-upstream strengths into a model's class by
+    /// taking the **minimum** (`Heuristic` wins over `Strong`).
+    ///
+    /// An empty iterator yields [`ProofClass::Strong`]: a model with no
+    /// upstreams has no weaker input to degrade it, so its class rests
+    /// entirely on its own logic key.
+    pub fn min<I>(strengths: I) -> ProofClass
+    where
+        I: IntoIterator<Item = ProofClass>,
+    {
+        strengths.into_iter().min().unwrap_or(ProofClass::Strong)
+    }
+
+    /// Lowercase string form for logs and persisted records.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProofClass::Heuristic => "heuristic",
+            ProofClass::Strong => "strong",
+        }
+    }
+}
+
+/// One immediate upstream's contribution to a model's input-match key.
+///
+/// The two arms map 1:1 to the two proof strengths. The enum is hashed (via
+/// its canonical-JSON encoding) into the model's `input_hash`, so a change of
+/// *kind* (a content hash replacing a watermark, or vice-versa) — not just a
+/// change of value — alters the key. That is intentional: an upstream that
+/// gains a content hash is genuinely a different (stronger) input identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UpstreamIdentity {
+    /// **Strong.** The upstream's recorded output blake3 from the
+    /// content-addressed ledger. Available only where the upstream was
+    /// itself written content-addressed.
+    Content {
+        /// Fully-qualified `catalog.schema.table` identity of the upstream.
+        upstream_key: String,
+        /// Hex-encoded blake3 of the upstream's output parquet.
+        blake3_hash: String,
+    },
+    /// **Heuristic.** The upstream's freshness signal — latest tracked
+    /// timestamp and/or observed row count. Attests freshness, not
+    /// byte-identity.
+    Watermark {
+        /// Fully-qualified `catalog.schema.table` identity of the upstream.
+        upstream_key: String,
+        /// Latest observed `MAX(ts)` (RFC-3339), when a tracked timestamp
+        /// column is available. `None` when only a rowcount was observed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_ts: Option<String>,
+        /// Observed `COUNT(*)`, when the rowcount fallback is enabled.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        row_count: Option<u64>,
+    },
+}
+
+impl UpstreamIdentity {
+    /// The proof strength this upstream contributes.
+    #[must_use]
+    pub fn proof_class(&self) -> ProofClass {
+        match self {
+            UpstreamIdentity::Content { .. } => ProofClass::Strong,
+            UpstreamIdentity::Watermark { .. } => ProofClass::Heuristic,
+        }
+    }
+
+    /// The upstream's fully-qualified identity key, regardless of arm.
+    #[must_use]
+    pub fn upstream_key(&self) -> &str {
+        match self {
+            UpstreamIdentity::Content { upstream_key, .. }
+            | UpstreamIdentity::Watermark { upstream_key, .. } => upstream_key,
+        }
+    }
+}
+
+/// Borrowed projection hashed into a model's `input_hash`.
+///
+/// Serialised through canonical JSON (key-sorted, whitespace-free) so the
+/// resulting key is deterministic across runs and machines for the same
+/// logical inputs. `upstreams` is sorted by `upstream_key` before hashing so
+/// the key is independent of upstream enumeration order.
+#[derive(Serialize)]
+struct InputHashProjection<'a> {
+    /// Version byte; bump to deterministically invalidate every previously
+    /// recorded `input_hash` if this projection's shape changes.
+    spine_version: u8,
+    /// Hex of the model's own [`rocky_ir::ModelIr::skip_hash`].
+    skip_hash: &'a str,
+    /// The target `catalog.schema.table` identity, folded in explicitly.
+    target_identity: &'a str,
+    /// Immediate upstream identities, pre-sorted by key.
+    upstreams: &'a [UpstreamIdentity],
+}
+
+/// Version byte folded into every [`compute_input_hash`] result.
+///
+/// Bump this whenever the input-hash projection changes in a way that could
+/// alter the key for unchanged inputs. The bump deterministically
+/// invalidates every previously-stored `input_hash`, so a stale index entry
+/// can never be mistaken for a current one across spine versions.
+const SPINE_VERSION: u8 = 1;
+
+/// Compute a model's deterministic input-match key.
+///
+/// Folds the model's own logic key (`skip_hash`), its target identity, and
+/// its immediate upstreams' input identities into a single blake3 hash. The
+/// upstream set is sorted by key first, so the result is independent of the
+/// order in which upstreams were enumerated.
+///
+/// # Determinism
+///
+/// Byte-identical inputs yield a byte-identical hash. Changing the model's
+/// logic (a different `skip_hash`), any upstream's identity (a different
+/// content hash, a moved watermark, or a content↔watermark kind change), or
+/// the target identity changes the hash.
+///
+/// # What it attests
+///
+/// An *input-logic match* — same declared inputs and logic — only. Not
+/// reproduction of any output (see this module's docs).
+pub fn compute_input_hash(
+    skip_hash: &str,
+    target_identity: &str,
+    upstreams: &[UpstreamIdentity],
+) -> blake3::Hash {
+    let mut sorted: Vec<UpstreamIdentity> = upstreams.to_vec();
+    sorted.sort_by(|a, b| a.upstream_key().cmp(b.upstream_key()));
+    let projection = InputHashProjection {
+        spine_version: SPINE_VERSION,
+        skip_hash,
+        target_identity,
+        upstreams: &sorted,
+    };
+    let canonical = canonical_json(&projection);
+    blake3::hash(canonical.as_bytes())
+}
+
+/// The proof class for a model given its upstreams (minimum over them).
+///
+/// Thin wrapper over [`ProofClass::min`] for callers that hold a slice.
+#[must_use]
+pub fn proof_class_for(upstreams: &[UpstreamIdentity]) -> ProofClass {
+    ProofClass::min(upstreams.iter().map(UpstreamIdentity::proof_class))
+}
+
+/// Canonical-JSON encoder mirroring [`rocky_ir::ModelIr::canonical_json`]'s
+/// key-sorted, whitespace-free form so spine keys are stable across machines.
+fn canonical_json<T: Serialize>(value: &T) -> String {
+    let raw = serde_json::to_value(value)
+        .expect("input-hash projection must be JSON-encodable; programming error");
+    let canonical = canonicalize(raw);
+    serde_json::to_string(&canonical)
+        .expect("BTreeMap-based serde_json::Value is always serializable")
+}
+
+fn canonicalize(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let sorted: std::collections::BTreeMap<String, serde_json::Value> =
+                map.into_iter().map(|(k, v)| (k, canonicalize(v))).collect();
+            serde_json::to_value(sorted).expect("BTreeMap<String, Value> always converts to Value")
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(canonicalize).collect())
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn content(key: &str, hash: &str) -> UpstreamIdentity {
+        UpstreamIdentity::Content {
+            upstream_key: key.to_string(),
+            blake3_hash: hash.to_string(),
+        }
+    }
+
+    fn watermark(key: &str, ts: Option<&str>, rows: Option<u64>) -> UpstreamIdentity {
+        UpstreamIdentity::Watermark {
+            upstream_key: key.to_string(),
+            max_ts: ts.map(str::to_string),
+            row_count: rows,
+        }
+    }
+
+    #[test]
+    fn input_hash_is_deterministic() {
+        let ups = vec![content("cat.sch.up", "abc123")];
+        let a = compute_input_hash("logic-key-1", "cat.sch.tgt", &ups);
+        let b = compute_input_hash("logic-key-1", "cat.sch.tgt", &ups);
+        assert_eq!(a, b, "same inputs must yield the same hash");
+    }
+
+    #[test]
+    fn input_hash_independent_of_upstream_order() {
+        let ordered = vec![content("cat.sch.a", "h1"), content("cat.sch.b", "h2")];
+        let reversed = vec![content("cat.sch.b", "h2"), content("cat.sch.a", "h1")];
+        assert_eq!(
+            compute_input_hash("logic", "cat.sch.tgt", &ordered),
+            compute_input_hash("logic", "cat.sch.tgt", &reversed),
+            "upstream enumeration order must not affect the key"
+        );
+    }
+
+    #[test]
+    fn input_hash_changes_on_logic_change() {
+        let ups = vec![content("cat.sch.up", "abc123")];
+        let a = compute_input_hash("logic-key-1", "cat.sch.tgt", &ups);
+        let b = compute_input_hash("logic-key-2", "cat.sch.tgt", &ups);
+        assert_ne!(a, b, "a different skip_hash must change the input_hash");
+    }
+
+    #[test]
+    fn input_hash_changes_on_upstream_change() {
+        let before = vec![content("cat.sch.up", "abc123")];
+        let after = vec![content("cat.sch.up", "def456")];
+        assert_ne!(
+            compute_input_hash("logic", "cat.sch.tgt", &before),
+            compute_input_hash("logic", "cat.sch.tgt", &after),
+            "a changed upstream identity must change the input_hash"
+        );
+    }
+
+    #[test]
+    fn input_hash_changes_on_target_change() {
+        let ups = vec![content("cat.sch.up", "abc123")];
+        assert_ne!(
+            compute_input_hash("logic", "cat.sch.tgt_a", &ups),
+            compute_input_hash("logic", "cat.sch.tgt_b", &ups),
+            "a different target identity must change the input_hash"
+        );
+    }
+
+    #[test]
+    fn input_hash_changes_on_identity_kind_switch() {
+        let as_content = vec![content("cat.sch.up", "abc123")];
+        let as_watermark = vec![watermark("cat.sch.up", Some("2026-06-04T00:00:00Z"), None)];
+        assert_ne!(
+            compute_input_hash("logic", "cat.sch.tgt", &as_content),
+            compute_input_hash("logic", "cat.sch.tgt", &as_watermark),
+            "a content↔watermark kind switch must change the input_hash"
+        );
+    }
+
+    #[test]
+    fn proof_class_all_content_is_strong() {
+        let ups = vec![content("cat.sch.a", "h1"), content("cat.sch.b", "h2")];
+        assert_eq!(proof_class_for(&ups), ProofClass::Strong);
+    }
+
+    #[test]
+    fn proof_class_mixed_is_heuristic() {
+        let ups = vec![
+            content("cat.sch.a", "h1"),
+            watermark("cat.sch.b", Some("2026-06-04T00:00:00Z"), None),
+        ];
+        assert_eq!(
+            proof_class_for(&ups),
+            ProofClass::Heuristic,
+            "a single watermark upstream degrades the whole model to heuristic"
+        );
+    }
+
+    #[test]
+    fn proof_class_no_upstreams_is_strong() {
+        assert_eq!(
+            proof_class_for(&[]),
+            ProofClass::Strong,
+            "a model with no upstreams rests on its own logic key — vacuously strong"
+        );
+    }
+
+    #[test]
+    fn proof_class_all_watermark_is_heuristic() {
+        let ups = vec![
+            watermark("cat.sch.a", Some("2026-06-04T00:00:00Z"), None),
+            watermark("cat.sch.b", None, Some(42)),
+        ];
+        assert_eq!(proof_class_for(&ups), ProofClass::Heuristic);
+    }
+
+    #[test]
+    fn proof_class_min_ordering() {
+        assert_eq!(
+            ProofClass::min([ProofClass::Strong, ProofClass::Heuristic]),
+            ProofClass::Heuristic
+        );
+        assert_eq!(
+            ProofClass::min([ProofClass::Strong, ProofClass::Strong]),
+            ProofClass::Strong
+        );
+    }
+}

--- a/engine/crates/rocky-core/src/reuse.rs
+++ b/engine/crates/rocky-core/src/reuse.rs
@@ -341,6 +341,10 @@ pub fn build_records(
         input_hash,
         skip_hash,
         model_ir_canonical_json: model_ir.canonical_json(),
+        // Persist the exact upstream identities folded into `input_hash` so an
+        // offline auditor can recompute it (and re-verify each strong
+        // upstream's blake3) without trusting the runtime.
+        upstreams: upstreams.to_vec(),
         output_blake3,
         output_path,
         proof_class,
@@ -558,6 +562,21 @@ mod tests {
         assert_eq!(entry.input_hash, prov.input_hash);
         let expected_skip = m.skip_hash().unwrap().to_hex().to_string();
         assert_eq!(prov.skip_hash, expected_skip);
+
+        // The provenance record persists the exact upstreams folded into
+        // input_hash, so an offline recompute is possible without the runtime.
+        assert_eq!(prov.upstreams, ups);
+        let recomputed = compute_input_hash(
+            &prov.skip_hash,
+            "analytics.marts.fct_orders",
+            &prov.upstreams,
+        )
+        .to_hex()
+        .to_string();
+        assert_eq!(
+            recomputed, prov.input_hash,
+            "input_hash must recompute from the persisted skip_hash + target + upstreams"
+        );
 
         // Provenance embeds the round-trippable canonical IR.
         let reparsed: rocky_ir::ModelIr =

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -112,6 +112,36 @@ const IDEMPOTENCY_KEYS: TableDefinition<&str, &[u8]> = TableDefinition::new("ide
 /// treats the artifact ledger as global ground truth, not machine-local
 /// scratch.
 const OUTPUT_ARTIFACTS: TableDefinition<&str, &[u8]> = TableDefinition::new("output_artifacts");
+/// Pre-execution-style input-match index for auditable reuse.
+///
+/// Key format: the model's `input_hash` (hex) — see
+/// [`crate::reuse::compute_input_hash`]. Value: serialized
+/// [`InputIndexEntry`], locating the prior run that produced those inputs.
+///
+/// The complement of [`OUTPUT_ARTIFACTS`]: that ledger is keyed by the
+/// **output** blake3 and read after execution by GC; this index is keyed by
+/// the **inputs** (logic key + upstream identities + target) and is the
+/// surface a future reuse decision reads *before* execution. In Stage 1 it
+/// is written on a successful run and read back only by tests — nothing
+/// consults it for a reuse decision yet (the index is dormant).
+///
+/// Replicates across backends by default — like [`OUTPUT_ARTIFACTS`], the
+/// reuse spine is global ground truth, not machine-local scratch.
+const INPUT_INDEX: TableDefinition<&str, &[u8]> = TableDefinition::new("input_index");
+/// Offline-verifiable provenance for each indexed model build.
+///
+/// Key format: `"{run_id}|{model_name}"`. Value: serialized
+/// [`ProvenanceRecord`], embedding the model's canonical `ModelIr` JSON plus
+/// the output blake3(s), recorded `skip_hash`, and `proof_class`. An auditor
+/// with the state store and object store — and no trust in the runtime — can
+/// later deserialize the embedded IR, recompute its `skip_hash`, and `b3sum`
+/// the recorded parquet to verify the *input-logic match* and the
+/// *byte-identity of the recorded bytes*. It does **not** attest that a fresh
+/// re-run would reproduce them.
+///
+/// State-internal: never part of any `*Output` JSON schema, so it carries no
+/// codegen. Replicates across backends by default.
+const INPUT_PROVENANCE: TableDefinition<&str, &[u8]> = TableDefinition::new("input_provenance");
 /// Key/value store for internal metadata (e.g. `"schema_version"`).
 const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 
@@ -158,7 +188,14 @@ pub const LOCAL_ONLY_TABLE_NAMES: &[&str] = &["schema_cache"];
 ///   A v7-recorded run with entries still in the header blob continues to
 ///   resume — the readers fall back to the header's `tables` when the
 ///   per-entry scan is empty.
-const CURRENT_SCHEMA_VERSION: u32 = 8;
+/// - **v9** — adds the [`INPUT_INDEX`] + [`INPUT_PROVENANCE`] tables for the
+///   auditable-reuse input-match spine. Pure additive schema change: v8
+///   databases auto-create both empty tables on next open and stamp
+///   themselves as v9. No blob migration needed; existing tables are
+///   untouched. Both tables are dormant in Stage 1 — populated on a
+///   successful run when `[reuse]` is enabled, never read for a reuse
+///   decision yet.
+const CURRENT_SCHEMA_VERSION: u32 = 9;
 
 /// Errors from the embedded redb state store.
 #[derive(Debug, Error)]
@@ -354,6 +391,8 @@ impl StateStore {
             let _table = txn.open_table(SCHEMA_CACHE)?;
             let _table = txn.open_table(IDEMPOTENCY_KEYS)?;
             let _table = txn.open_table(OUTPUT_ARTIFACTS)?;
+            let _table = txn.open_table(INPUT_INDEX)?;
+            let _table = txn.open_table(INPUT_PROVENANCE)?;
         }
         txn.commit()?;
 
@@ -2083,6 +2122,108 @@ impl StateStore {
         Ok(())
     }
 
+    // -----------------------------------------------------------------------
+    // Input-match index + provenance (auditable-reuse spine — dormant)
+    // -----------------------------------------------------------------------
+
+    /// Record input-index entries and provenance records for a run in a
+    /// single write transaction.
+    ///
+    /// Called once per successful run, from the persist path, when `[reuse]`
+    /// is enabled. Batching both tables into one `begin_write` / `commit`
+    /// keeps the cost to a single extra fsync per run regardless of model
+    /// count — the same posture [`Self::batch_set_watermarks`] takes.
+    ///
+    /// The two slices are written independently (a model may contribute an
+    /// index entry, a provenance record, or both); callers typically pass
+    /// index entries and provenance records for the same set of models. An
+    /// empty pair is a no-op (no transaction is opened).
+    ///
+    /// **Dormant in Stage 1.** This only *writes* the spine; no reuse
+    /// decision reads it. The index attests an *input-logic match*, never
+    /// reproduction of an output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError`] if any record fails to serialize or the
+    /// transaction fails. The whole batch is atomic — a partial write is
+    /// never observable.
+    pub fn record_reuse_spine(
+        &self,
+        index_entries: &[InputIndexEntry],
+        provenance: &[ProvenanceRecord],
+    ) -> Result<(), StateError> {
+        if index_entries.is_empty() && provenance.is_empty() {
+            return Ok(());
+        }
+        let txn = self.db.begin_write()?;
+        {
+            let mut index = txn.open_table(INPUT_INDEX)?;
+            for entry in index_entries {
+                let bytes = serde_json::to_vec(entry)?;
+                index.insert(entry.input_hash.as_str(), bytes.as_slice())?;
+            }
+            let mut prov = txn.open_table(INPUT_PROVENANCE)?;
+            for record in provenance {
+                let key = provenance_key(&record.run_id, &record.model_name);
+                let bytes = serde_json::to_vec(record)?;
+                prov.insert(key.as_str(), bytes.as_slice())?;
+            }
+        }
+        txn.commit()?;
+        Ok(())
+    }
+
+    /// Look up the indexed prior run for a model's `input_hash`.
+    ///
+    /// **Provided for Stage 2 to consume — nothing in Stage 1 calls this for
+    /// a reuse decision.** Returns the [`InputIndexEntry`] (locating the
+    /// prior run + its output artifact) when an entry exists for the given
+    /// `input_hash`, else `None`.
+    ///
+    /// A hit attests an *input-logic match* against a prior build. It is a
+    /// reuse *candidate* lookup only: a fail-closed Stage-2 decision must
+    /// still verify the artifact and refcount before reusing any bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError`] when the read transaction or deserialize fails.
+    pub fn get_by_input_hash(
+        &self,
+        input_hash: &str,
+    ) -> Result<Option<InputIndexEntry>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(INPUT_INDEX)?;
+        match table.get(input_hash)? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Fetch the provenance record for a `(run_id, model_name)` build.
+    ///
+    /// The input to the offline-verify recipe: an auditor reads this,
+    /// deserializes the embedded canonical `ModelIr` JSON, recomputes its
+    /// `skip_hash`, and `b3sum`s the recorded parquet. Returns `None` when no
+    /// provenance was recorded for that build.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateError`] when the read transaction or deserialize fails.
+    pub fn get_provenance(
+        &self,
+        run_id: &str,
+        model_name: &str,
+    ) -> Result<Option<ProvenanceRecord>, StateError> {
+        let key = provenance_key(run_id, model_name);
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(INPUT_PROVENANCE)?;
+        match table.get(key.as_str())? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
     /// Return every artifact record whose `blake3_hash` matches.
     ///
     /// Phase 6 VACUUM uses this to answer "is this file still referenced
@@ -2400,6 +2541,16 @@ fn artifact_key(run_id: &str, model_name: &str, file_path: &str) -> String {
     format!("{run_id}|{model_name}|{file_path}")
 }
 
+/// Builds the key for the [`INPUT_PROVENANCE`] table.
+///
+/// Composition: `"{run_id}|{model_name}"` — unique per (run, model). The
+/// trailing-`|`-free pair is unambiguous because `model_name` is a validated
+/// identifier with no `|`. Mirrors the per-run anchoring of
+/// [`artifact_key`].
+fn provenance_key(run_id: &str, model_name: &str) -> String {
+    format!("{run_id}|{model_name}")
+}
+
 /// One row in the content-addressed write ledger ([`OUTPUT_ARTIFACTS`]).
 ///
 /// Recorded once per `WriteResult` from
@@ -2439,6 +2590,102 @@ pub struct ArtifactRecord {
     /// same as the write's Delta `modification_time_millis` (that's in
     /// the log); close enough for retention sweep windows.
     pub written_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// One row in the input-match index ([`INPUT_INDEX`]).
+///
+/// Keyed by the model's `input_hash` (see
+/// [`crate::reuse::compute_input_hash`]), it locates the prior run that
+/// produced a build with those declared inputs. A future reuse decision
+/// reads this *before* execution to find a candidate run `R`; the shipped
+/// [`OUTPUT_ARTIFACTS`] ledger + [`StateStore::refcount_for_hash`] then make
+/// any reuse of `R`'s bytes safe.
+///
+/// **Dormant in Stage 1.** This record is written on a successful run and
+/// read back only by tests — nothing consults the index for a reuse
+/// decision yet. It attests an *input-logic match*, never that re-running
+/// the model would reproduce its output.
+///
+/// Forward-compatible via `#[serde(default)]` on any field added later,
+/// the same pattern that carried [`ArtifactRecord`] and [`RunRecord`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct InputIndexEntry {
+    /// Hex-encoded `input_hash` this entry is keyed by. Stored redundantly
+    /// inside the value so a by-value scan (e.g. for diagnostics) is
+    /// self-describing.
+    pub input_hash: String,
+    /// Run that produced the inputs. Joins to `RunRecord.run_id`.
+    pub run_id: String,
+    /// Model these inputs belong to. Matches `ModelExecution.model_name`
+    /// for the same `run_id`.
+    pub model_name: String,
+    /// Output blake3 hash(es) the run produced for this model — one per
+    /// content-addressed file (one entry for an unpartitioned model). Empty
+    /// when the model was not written content-addressed.
+    #[serde(default)]
+    pub output_blake3: Vec<String>,
+    /// Object-store path(s) of the output parquet, index-aligned with
+    /// [`Self::output_blake3`]. Empty when the model was not written
+    /// content-addressed.
+    #[serde(default)]
+    pub output_path: Vec<String>,
+    /// Strength of the match this entry would back: `"strong"` (every
+    /// upstream identity is a content hash) or `"heuristic"` (at least one
+    /// upstream is a freshness signal). See [`crate::reuse::ProofClass`].
+    pub proof_class: String,
+    /// Best-effort wall clock when the entry was recorded.
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Offline-verifiable provenance for one indexed model build
+/// ([`INPUT_PROVENANCE`]).
+///
+/// Keyed `"{run_id}|{model_name}"`. Embeds everything an auditor needs to
+/// re-derive the claim *without trusting the runtime*:
+///
+/// - the canonical `ModelIr` JSON (via
+///   [`rocky_ir::ModelIr::canonical_json`]) — deserialize it and recompute
+///   [`rocky_ir::ModelIr::skip_hash`], compare to [`Self::skip_hash`];
+/// - the recorded output blake3(s) — re-fetch the parquet at the recorded
+///   path and `b3sum` it, compare to the recorded hash (the byte-identity
+///   half of the claim);
+/// - the [`Self::proof_class`] label so a consumer never mistakes a
+///   freshness heuristic for a byte-proof.
+///
+/// The claim is narrow: an *input-logic match* plus *byte-identity of the
+/// recorded bytes*. It is **not** a reproducibility guarantee — re-executing
+/// the model need not reproduce these bytes (non-deterministic SQL, session
+/// settings, UDFs). State-internal; carries no codegen.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ProvenanceRecord {
+    /// Run that produced this build. Joins to `RunRecord.run_id`.
+    pub run_id: String,
+    /// Model this provenance describes.
+    pub model_name: String,
+    /// The model's `input_hash` (hex) — the [`INPUT_INDEX`] key this build
+    /// is reachable through.
+    pub input_hash: String,
+    /// Hex of the model's [`rocky_ir::ModelIr::skip_hash`] at build time.
+    /// The auditor recomputes this from [`Self::model_ir_canonical_json`]
+    /// and compares.
+    pub skip_hash: String,
+    /// Canonical `ModelIr` JSON (key-sorted, whitespace-free) — the exact
+    /// form [`rocky_ir::ModelIr::canonical_json`] emits, round-trippable
+    /// back into a `ModelIr` for the offline `skip_hash` recompute.
+    pub model_ir_canonical_json: String,
+    /// Output blake3 hash(es) for the build, one per content-addressed
+    /// file. Empty when the model was not written content-addressed.
+    #[serde(default)]
+    pub output_blake3: Vec<String>,
+    /// Object-store path(s) of the output parquet, index-aligned with
+    /// [`Self::output_blake3`].
+    #[serde(default)]
+    pub output_path: Vec<String>,
+    /// Match-strength label: `"strong"` or `"heuristic"`. See
+    /// [`crate::reuse::ProofClass`].
+    pub proof_class: String,
+    /// Best-effort wall clock when the provenance was recorded.
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Result of splitting a batch of candidate artifacts by refcount.
@@ -5607,5 +5854,174 @@ mod tests {
         // Two unique hashes ("h-dup", "h-other") → exactly two lookups.
         assert_eq!(hits, 2);
         assert_eq!(partition.safe_to_delete.len(), 3);
+    }
+
+    // ---------------------------------------------------------------------
+    // Auditable-reuse spine: INPUT_INDEX + INPUT_PROVENANCE round-trips
+    // ---------------------------------------------------------------------
+
+    fn make_index_entry(input_hash: &str, run_id: &str, model: &str) -> InputIndexEntry {
+        InputIndexEntry {
+            input_hash: input_hash.to_string(),
+            run_id: run_id.to_string(),
+            model_name: model.to_string(),
+            output_blake3: vec!["blake3:out".to_string()],
+            output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
+            proof_class: "strong".to_string(),
+            recorded_at: Utc::now(),
+        }
+    }
+
+    /// A real, canonicalisable `ModelIr` for the offline-recompute test.
+    fn sample_model_ir() -> rocky_ir::ModelIr {
+        let mut model_ir = rocky_ir::ModelIr::transformation(
+            rocky_ir::TargetRef {
+                catalog: "analytics".to_string(),
+                schema: "marts".to_string(),
+                table: "fct_orders".to_string(),
+            },
+            rocky_ir::MaterializationStrategy::FullRefresh,
+            Vec::new(),
+            "SELECT id, amount FROM raw.orders".to_string(),
+            rocky_ir::GovernanceConfig {
+                permissions_file: None,
+                auto_create_catalogs: false,
+                auto_create_schemas: false,
+            },
+            None,
+            None,
+        );
+        model_ir.typed_columns = vec![
+            rocky_ir::TypedColumn {
+                name: "id".into(),
+                data_type: rocky_ir::RockyType::Int64,
+                nullable: false,
+            },
+            rocky_ir::TypedColumn {
+                name: "amount".into(),
+                data_type: rocky_ir::RockyType::Float64,
+                nullable: true,
+            },
+        ];
+        model_ir
+    }
+
+    #[test]
+    fn input_index_put_get_round_trip() {
+        let (store, _dir) = temp_store();
+        let entry = make_index_entry("ih-abc", "run-1", "fct_orders");
+        store
+            .record_reuse_spine(std::slice::from_ref(&entry), &[])
+            .unwrap();
+
+        let got = store.get_by_input_hash("ih-abc").unwrap();
+        assert_eq!(got.as_ref(), Some(&entry), "index entry must round-trip");
+
+        // A different input_hash → no hit (the index is dormant: lookup only).
+        assert!(store.get_by_input_hash("ih-not-there").unwrap().is_none());
+    }
+
+    #[test]
+    fn provenance_put_get_round_trip() {
+        let (store, _dir) = temp_store();
+        let model_ir = sample_model_ir();
+        let skip_hash = model_ir.skip_hash().expect("sample model canonicalises");
+        let record = ProvenanceRecord {
+            run_id: "run-7".to_string(),
+            model_name: "fct_orders".to_string(),
+            input_hash: "ih-xyz".to_string(),
+            skip_hash: skip_hash.to_hex().to_string(),
+            model_ir_canonical_json: model_ir.canonical_json(),
+            output_blake3: vec!["blake3:out".to_string()],
+            output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
+            proof_class: "strong".to_string(),
+            recorded_at: Utc::now(),
+        };
+        store
+            .record_reuse_spine(&[], std::slice::from_ref(&record))
+            .unwrap();
+
+        let got = store.get_provenance("run-7", "fct_orders").unwrap();
+        assert_eq!(got.as_ref(), Some(&record), "provenance must round-trip");
+
+        // Wrong key → no hit.
+        assert!(
+            store
+                .get_provenance("run-7", "other_model")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn provenance_offline_ir_hash_recompute_matches() {
+        // The offline-verify recipe's step 1: an auditor deserializes the
+        // embedded canonical ModelIr JSON, recomputes its skip_hash, and
+        // compares against the recorded value. This must match what produced
+        // the record — without re-running the model.
+        let (store, _dir) = temp_store();
+        let model_ir = sample_model_ir();
+        let recorded_skip_hash = model_ir
+            .skip_hash()
+            .expect("canonicalises")
+            .to_hex()
+            .to_string();
+        let record = ProvenanceRecord {
+            run_id: "run-9".to_string(),
+            model_name: "fct_orders".to_string(),
+            input_hash: "ih-9".to_string(),
+            skip_hash: recorded_skip_hash.clone(),
+            model_ir_canonical_json: model_ir.canonical_json(),
+            output_blake3: vec!["blake3:out".to_string()],
+            output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
+            proof_class: "strong".to_string(),
+            recorded_at: Utc::now(),
+        };
+        store
+            .record_reuse_spine(&[], std::slice::from_ref(&record))
+            .unwrap();
+
+        // Read the record back and recompute the IR hash from the embedded
+        // canonical JSON exactly as an offline verifier would.
+        let got = store
+            .get_provenance("run-9", "fct_orders")
+            .unwrap()
+            .unwrap();
+        let reparsed: rocky_ir::ModelIr =
+            serde_json::from_str(&got.model_ir_canonical_json).expect("canonical JSON round-trips");
+        let recomputed = reparsed.skip_hash().expect("reparsed model canonicalises");
+        assert_eq!(
+            recomputed.to_hex().to_string(),
+            got.skip_hash,
+            "offline skip_hash recompute must equal the recorded value"
+        );
+        assert_eq!(got.skip_hash, recorded_skip_hash);
+    }
+
+    #[test]
+    fn reuse_spine_empty_batch_is_noop() {
+        let (store, _dir) = temp_store();
+        // No transaction should be opened; nothing recorded.
+        store.record_reuse_spine(&[], &[]).unwrap();
+        assert!(store.get_by_input_hash("anything").unwrap().is_none());
+    }
+
+    #[test]
+    fn input_index_entry_forward_deserializes_without_optional_fields() {
+        // A v9 reader must accept a record written without the
+        // `#[serde(default)]` output_* arrays (the minimum a future heuristic
+        // entry might carry). Forward-deserialize safety for new fields.
+        let minimal = serde_json::json!({
+            "input_hash": "ih-min",
+            "run_id": "run-x",
+            "model_name": "m",
+            "proof_class": "heuristic",
+            "recorded_at": Utc::now(),
+        });
+        let parsed: InputIndexEntry =
+            serde_json::from_value(minimal).expect("optional output_* fields default to empty");
+        assert!(parsed.output_blake3.is_empty());
+        assert!(parsed.output_path.is_empty());
+        assert_eq!(parsed.proof_class, "heuristic");
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -2646,6 +2646,12 @@ pub struct InputIndexEntry {
 /// - the canonical `ModelIr` JSON (via
 ///   [`rocky_ir::ModelIr::canonical_json`]) — deserialize it and recompute
 ///   [`rocky_ir::ModelIr::skip_hash`], compare to [`Self::skip_hash`];
+/// - the resolved [`Self::upstreams`] — the exact `Vec<UpstreamIdentity>`
+///   that justified [`Self::proof_class`], so an auditor can recompute
+///   [`Self::input_hash`] offline (via
+///   [`crate::reuse::compute_input_hash`]) and, for each `strong` upstream,
+///   independently cross-check its recorded blake3 against that upstream's
+///   own provenance record;
 /// - the recorded output blake3(s) — re-fetch the parquet at the recorded
 ///   path and `b3sum` it, compare to the recorded hash (the byte-identity
 ///   half of the claim);
@@ -2673,6 +2679,21 @@ pub struct ProvenanceRecord {
     /// form [`rocky_ir::ModelIr::canonical_json`] emits, round-trippable
     /// back into a `ModelIr` for the offline `skip_hash` recompute.
     pub model_ir_canonical_json: String,
+    /// The resolved immediate-upstream identities that justified
+    /// [`Self::proof_class`] and were folded into [`Self::input_hash`].
+    ///
+    /// Persisting them is what makes the input side offline-auditable: an
+    /// auditor recomputes `input_hash` via
+    /// [`crate::reuse::compute_input_hash`] from [`Self::skip_hash`], the
+    /// target identity (parsed back out of [`Self::model_ir_canonical_json`]),
+    /// and this list — no trust in the runtime required. Each `strong`
+    /// ([`crate::reuse::UpstreamIdentity::Content`]) entry carries the
+    /// upstream's recorded blake3, which the auditor cross-checks against that
+    /// upstream's *own* provenance record (whose `output_path` locates the
+    /// bytes to `b3sum`). Empty for a model that reads nothing (vacuously
+    /// strong). `#[serde(default)]` keeps pre-field records readable.
+    #[serde(default)]
+    pub upstreams: Vec<crate::reuse::UpstreamIdentity>,
     /// Output blake3 hash(es) for the build, one per content-addressed
     /// file. Empty when the model was not written content-addressed.
     #[serde(default)]
@@ -5932,6 +5953,10 @@ mod tests {
             input_hash: "ih-xyz".to_string(),
             skip_hash: skip_hash.to_hex().to_string(),
             model_ir_canonical_json: model_ir.canonical_json(),
+            upstreams: vec![crate::reuse::UpstreamIdentity::Content {
+                upstream_key: "analytics.marts.dim_x".to_string(),
+                blake3_hash: "up-hash".to_string(),
+            }],
             output_blake3: vec!["blake3:out".to_string()],
             output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
             proof_class: "strong".to_string(),
@@ -5972,6 +5997,7 @@ mod tests {
             input_hash: "ih-9".to_string(),
             skip_hash: recorded_skip_hash.clone(),
             model_ir_canonical_json: model_ir.canonical_json(),
+            upstreams: Vec::new(),
             output_blake3: vec!["blake3:out".to_string()],
             output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
             proof_class: "strong".to_string(),
@@ -6043,6 +6069,79 @@ mod tests {
             serde_json::from_value(minimal).expect("optional output_* fields default to empty");
         assert!(parsed.output_blake3.is_empty());
         assert!(parsed.output_path.is_empty());
+        assert!(
+            parsed.upstreams.is_empty(),
+            "a pre-field record must deserialize with an empty upstreams list"
+        );
         assert_eq!(parsed.proof_class, "strong");
+    }
+
+    #[test]
+    fn provenance_offline_input_hash_recompute_matches() {
+        // The offline-verify recipe's input-side step: an auditor holding ONLY
+        // a persisted ProvenanceRecord recomputes the model's input_hash from
+        // the bytes in that record — skip_hash, the target identity parsed back
+        // out of the canonical ModelIr JSON, and the persisted upstreams — and
+        // it must equal the recorded input_hash. Nothing here touches the live
+        // model: every input is derived from the deserialized record.
+        let (store, _dir) = temp_store();
+        let model_ir = sample_model_ir();
+        let skip_hash = model_ir
+            .skip_hash()
+            .expect("canonicalises")
+            .to_hex()
+            .to_string();
+        let upstreams = vec![crate::reuse::UpstreamIdentity::Content {
+            upstream_key: "analytics.marts.dim_x".to_string(),
+            blake3_hash: "up-hash".to_string(),
+        }];
+        let target_identity = format!(
+            "{}.{}.{}",
+            model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
+        );
+        let input_hash = crate::reuse::compute_input_hash(&skip_hash, &target_identity, &upstreams)
+            .to_hex()
+            .to_string();
+        let record = ProvenanceRecord {
+            run_id: "run-11".to_string(),
+            model_name: "fct_orders".to_string(),
+            input_hash: input_hash.clone(),
+            skip_hash,
+            model_ir_canonical_json: model_ir.canonical_json(),
+            upstreams,
+            output_blake3: vec!["blake3:out".to_string()],
+            output_path: vec!["s3://bucket/prefix/out.parquet".to_string()],
+            proof_class: "strong".to_string(),
+            recorded_at: Utc::now(),
+        };
+        store
+            .record_reuse_spine(&[], std::slice::from_ref(&record))
+            .unwrap();
+
+        // Read the record back and recompute input_hash purely from its bytes.
+        let got = store
+            .get_provenance("run-11", "fct_orders")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            got.upstreams.len(),
+            1,
+            "the persisted upstreams must round-trip"
+        );
+        let reparsed: rocky_ir::ModelIr =
+            serde_json::from_str(&got.model_ir_canonical_json).expect("canonical JSON round-trips");
+        let recomputed_target = format!(
+            "{}.{}.{}",
+            reparsed.target.catalog, reparsed.target.schema, reparsed.target.table
+        );
+        let recomputed =
+            crate::reuse::compute_input_hash(&got.skip_hash, &recomputed_target, &got.upstreams)
+                .to_hex()
+                .to_string();
+        assert_eq!(
+            recomputed, got.input_hash,
+            "offline input_hash recompute from the persisted record must equal the recorded value"
+        );
+        assert_eq!(got.input_hash, input_hash);
     }
 }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -6024,4 +6024,25 @@ mod tests {
         assert!(parsed.output_path.is_empty());
         assert_eq!(parsed.proof_class, "heuristic");
     }
+
+    #[test]
+    fn provenance_record_forward_deserializes_without_optional_fields() {
+        // Symmetric to the index-entry forward test: a v9 reader must accept a
+        // provenance record written without the `#[serde(default)]` output_*
+        // arrays. Forward-deserialize safety for new fields.
+        let minimal = serde_json::json!({
+            "run_id": "run-x",
+            "model_name": "m",
+            "input_hash": "ih",
+            "skip_hash": "sh",
+            "model_ir_canonical_json": "{}",
+            "proof_class": "strong",
+            "recorded_at": Utc::now(),
+        });
+        let parsed: ProvenanceRecord =
+            serde_json::from_value(minimal).expect("optional output_* fields default to empty");
+        assert!(parsed.output_blake3.is_empty());
+        assert!(parsed.output_path.is_empty());
+        assert_eq!(parsed.proof_class, "strong");
+    }
 }

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -934,6 +934,7 @@ mod tests {
             freshness: Default::default(),
             imports: Default::default(),
             run: Default::default(),
+            reuse: Default::default(),
         }
     }
 

--- a/engine/crates/rocky-ir/src/ir.rs
+++ b/engine/crates/rocky-ir/src/ir.rs
@@ -789,6 +789,30 @@ impl ModelIr {
         blake3::hash(canonical.as_bytes())
     }
 
+    /// Canonical-JSON encoding of this model.
+    ///
+    /// The exact byte string [`Self::recipe_hash`] hashes: keys sorted at
+    /// every nesting level, no insignificant whitespace, `Option::None`
+    /// fields absent. Round-trips through [`serde_json`] back into a
+    /// [`ModelIr`] without loss.
+    ///
+    /// This is the form an **offline verifier** embeds and re-reads: given
+    /// the stored canonical JSON, a third party can deserialize it back into
+    /// a [`ModelIr`] and recompute [`Self::skip_hash`] independently, without
+    /// trusting the runtime that produced it. It attests an *input-logic
+    /// match* only — never that re-executing the model would reproduce a
+    /// given output (see [`Self::skip_hash`]'s caveat on non-deterministic
+    /// SQL).
+    ///
+    /// # Panics
+    ///
+    /// Panics under the same condition as [`Self::recipe_hash`]: a
+    /// programming error that makes `self` non-JSON-encodable.
+    #[must_use]
+    pub fn canonical_json(&self) -> String {
+        canonical_json(self)
+    }
+
     /// Best-effort *cosmetic-invariant* key for this model's logic.
     ///
     /// Unlike [`Self::recipe_hash`] — which hashes the raw `sql` text so a

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1000,6 +1000,24 @@ class RetryConfig(BaseModel):
     """
 
 
+class ReuseConfig(BaseModel):
+    """
+    `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+
+    When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.
+
+    **Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    enabled: bool | None = False
+    """
+    Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.
+    """
+
+
 class RoleConfig(BaseModel):
     """
     A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.
@@ -3108,6 +3126,10 @@ class RockyConfig(BaseModel):
     When set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.
 
     Unset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits.
+    """
+    reuse: ReuseConfig | None = Field({"enabled": False}, validate_default=True)
+    """
+    Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`].
     """
     role: dict[str, RoleConfig] | None = Field({}, validate_default=True)
     """

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2662,6 +2662,18 @@
       },
       "type": "object"
     },
+    "ReuseConfig": {
+      "additionalProperties": false,
+      "description": "`[reuse]` — opt-in population of the auditable-reuse input-match spine.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.\n\n**Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "RoleConfig": {
       "additionalProperties": false,
       "description": "A single entry in the top-level `[role.*]` block, declaring a hierarchical role with optional inheritance and a list of permissions.\n\n```toml [role.reader] permissions = [\"SELECT\", \"USE CATALOG\", \"USE SCHEMA\"]\n\n[role.analytics_engineer] inherits = [\"reader\"] permissions = [\"MODIFY\"]\n\n[role.admin] inherits = [\"analytics_engineer\"] permissions = [\"MANAGE\"] ```\n\nResolution happens at reconcile time via [`crate::role_graph::flatten_role_graph`], which walks the `inherits` DAG and unions permissions from the role and every transitive ancestor. Cycles and unknown parents are caught as structured [`crate::role_graph::RoleGraphError`] values.\n\nPermission strings must match the canonical uppercase spellings of [`rocky_ir::Permission`] (`\"SELECT\"`, `\"USE CATALOG\"`, ...).",
@@ -3726,6 +3738,17 @@
       ],
       "default": null,
       "description": "Run-level retry budget shared across every adapter for this run.\n\nWhen set, `rocky run` builds a single [`crate::retry_budget::RetryBudget`] from [`RunRetryConfig::max_retries_per_run`] and passes it to every connector via `with_retry_budget(...)`. One bad table that burns through retries on adapter A then has less budget available for adapter B's retries — the protection §P2.7 added within a single adapter now extends across the whole run.\n\nUnset (the default) preserves per-adapter semantics: each adapter still honours its own `retry.max_retries_per_run` independently. That's the backward-compatible path and stays the right choice when adapters have wildly different rate limits."
+    },
+    "reuse": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ReuseConfig"
+        }
+      ],
+      "default": {
+        "enabled": false
+      },
+      "description": "Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`]."
     },
     "role": {
       "additionalProperties": {


### PR DESCRIPTION
## What

Stage 1 of auditable reuse: the warehouse-agnostic, additive, **dormant** input-match spine. It builds the *input* side of reuse — a key that identifies a model build by its **declared inputs**, the missing half of the content-addressed output ledger (which is keyed by output bytes and can only be read after a build has run).

This slice **does not change run behavior**: it records an index + provenance, and reads nothing back to skip, point-to, or clone. The behavior-changing reuse backends are a later stage.

## Deliverables

1. **`INPUT_INDEX`** (`rocky-core::state`) — a redb table keyed by `input_hash` = blake3 over `(skip_hash ‖ target identity ‖ sorted upstream input-identities)`. Value locates the prior run + its output artifact(s) + `proof_class`. `proof_class` is the MIN over upstreams — `strong` only when every upstream is a content hash, else `heuristic`. `get_by_input_hash` is provided for a later stage to consume; nothing reads it for a reuse decision here.
2. **`INPUT_PROVENANCE`** — a redb table embedding the canonical `ModelIr` JSON + output blake3(s) + recorded `skip_hash` + `proof_class`, so an auditor can verify offline. (Chose a state-internal redb table over a `RunRecord` field or a CLI-output struct: zero CLI-output codegen, no hot-path bloat, round-trips by key.)
3. **Offline-verify recipe** — a new section in the existing auditor guide (`docs/.../guides/verify-a-run.md`): recompute `skip_hash` from the embedded canonical IR, `b3sum` the recorded parquet, and the `refcount_for_hash ≥ 2` contract a reuse backend enables. Framed precisely: this attests an **input-logic match + byte-identity of the recorded bytes**, never that a fresh re-run would reproduce them.
4. **Zero behavior change** — population is gated behind an opt-in `[reuse]` block (default off), so the default run is byte- and cost-identical (no per-model hashing, no extra state write). The new config field is the only codegen delta.

## Soundness

A model is indexed `strong` only when **every table it reads** (enumerated from SQL lineage behind the same provable-completeness gate the skip gate uses) resolves to a this-run **unpartitioned** content hash. A raw-source read, a non-content-addressed upstream, or a partitioned (incomplete-hash) upstream leaves the model unindexed rather than mislabeled — keeping the `strong` claim honest.

## Notes for review

- **Transaction placement.** The design memo said to write the index inside the `persist_run_record` transaction. That isn't literally implementable — `persist_run_record` doesn't carry the `ModelIr`, and each `record_*` already opens its own redb txn. The single-writer constraint protects against a *second concurrent writer process*, which a sibling `StateStore::record_reuse_spine` (one extra commit at end-of-run, through the same locked handle) does not violate. Population lives in `execute_models`, which already holds the write-capable store, the typed IR, and the per-model output hash — a single flush point, no new writer.
- **Scope.** The runner populates the spine on the **unpartitioned content-addressed** path. Watermark/heuristic upstream population and partitioned writes are deferred (the partitioned ledger is last-group-only today).
- **Tests.** The hash + record assembly + read-set resolution are pure `rocky-core` functions, unit-tested without a warehouse (determinism, logic/upstream/target sensitivity, identity-kind switch, MIN over mixed strengths, all-resolve-vs-any-unresolved, non-canonicalisable skip). State round-trips + the offline `skip_hash` recompute are tested against redb. The content-addressed runner glue is Databricks-gated and exercised by the existing `#[ignore]` live harness.

## Verification

`cargo build` / `clippy --all-targets --all-features` / `fmt --check` clean; `rocky-core` (1321) + `rocky-ir` (79) + `rocky-cli --features duckdb` (662) tests green; `just codegen` no-diff except the new `[reuse]` field.

Draft — do not merge. Stage 2 (Iceberg point-to / native clone) requires a live Databricks sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)