### PR TITLE
feat(engine/rocky-core): recognize BigQuery type names in contract type-matching

### DIFF
--- a/engine/crates/rocky-core/src/contracts.rs
+++ b/engine/crates/rocky-core/src/contracts.rs
@@ -268,25 +268,29 @@ pub fn warehouse_type_to_rocky(warehouse_type: &str) -> RockyType {
     match upper.as_str() {
         "BOOLEAN" | "BOOL" => RockyType::Boolean,
         "TINYINT" | "BYTE" | "SMALLINT" | "SHORT" | "INT" | "INTEGER" => RockyType::Int32,
-        "BIGINT" | "LONG" => RockyType::Int64,
+        // `INT64` / `FLOAT64` / `BYTES` / `DATETIME` are BigQuery's scalar names.
+        "BIGINT" | "LONG" | "INT64" => RockyType::Int64,
         "FLOAT" | "REAL" => RockyType::Float32,
-        "DOUBLE" | "DOUBLE PRECISION" => RockyType::Float64,
+        "DOUBLE" | "DOUBLE PRECISION" | "FLOAT64" => RockyType::Float64,
         "STRING" | "VARCHAR" | "TEXT" => RockyType::String,
-        "BINARY" => RockyType::Binary,
+        "BINARY" | "BYTES" => RockyType::Binary,
         "DATE" => RockyType::Date,
         "TIMESTAMP" => RockyType::Timestamp,
-        "TIMESTAMP_NTZ" => RockyType::TimestampNtz,
+        // BigQuery `DATETIME` is a timezone-naive timestamp.
+        "TIMESTAMP_NTZ" | "DATETIME" => RockyType::TimestampNtz,
         "VARIANT" => RockyType::Variant,
         // DECIMAL / NUMERIC (ANSI, Databricks, BigQuery) and NUMBER
         // (Snowflake's fixed-point name). Snowflake's `DESCRIBE` returns
         // `NUMBER(38,0)`, so it must normalize to the same RockyType as a
         // contract written `DECIMAL(38,0)` for the contract to port.
         _ if upper.starts_with("DECIMAL")
+            || upper.starts_with("BIGNUMERIC")
             || upper.starts_with("NUMERIC")
             || upper.starts_with("NUMBER") =>
         {
             if let Some(params) = upper
                 .strip_prefix("DECIMAL(")
+                .or_else(|| upper.strip_prefix("BIGNUMERIC("))
                 .or_else(|| upper.strip_prefix("NUMERIC("))
                 .or_else(|| upper.strip_prefix("NUMBER("))
                 .and_then(|s| s.strip_suffix(')'))
@@ -534,6 +538,15 @@ mod tests {
             warehouse_type_to_rocky("SOMETHING_WEIRD"),
             RockyType::Unknown
         );
+        // BigQuery scalar names.
+        assert_eq!(warehouse_type_to_rocky("INT64"), RockyType::Int64);
+        assert_eq!(warehouse_type_to_rocky("FLOAT64"), RockyType::Float64);
+        assert_eq!(warehouse_type_to_rocky("BYTES"), RockyType::Binary);
+        assert_eq!(warehouse_type_to_rocky("DATETIME"), RockyType::TimestampNtz);
+        assert!(matches!(
+            warehouse_type_to_rocky("BIGNUMERIC(76,38)"),
+            RockyType::Decimal { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
`warehouse_type_to_rocky` (used by the load contract gate to compare a landed column's warehouse type against the contract's declared type) had no arms for BigQuery's scalar type names. BQ `DESCRIBE` returns `INT64` / `FLOAT64` / `BYTES` / `DATETIME` / `BIGNUMERIC`, all of which normalized to `Unknown` — and an `Unknown` landed type matches any contract type. So the gate's **type** check was a silent no-op on BigQuery (presence + nullability were still enforced).

Add the BQ arms so the gate type-checks precisely on BigQuery:
- `INT64` → `Int64`
- `FLOAT64` → `Float64`
- `BYTES` → `Binary`
- `DATETIME` → `TimestampNtz` (BQ `DATETIME` is timezone-naive)
- `BIGNUMERIC(p,s)` → `Decimal { .. }` (joins the existing DECIMAL/NUMERIC/NUMBER prefix chain)

**Tested:** `test_warehouse_type_to_rocky` extended with INT64/FLOAT64/BYTES/DATETIME/BIGNUMERIC assertions; the full rocky-core contract suite (23 tests) was *run*, not just compiled. fmt + clippy `--all-targets` clean. The DESCRIBE input strings are the exact names confirmed live in #833.

**Note:** the full end-to-end BQ contract-gate live-verify is blocked by a separate reachability bug — `load_with_contract_gate` strict-validates the target catalog as `[a-zA-Z0-9_]+`, which rejects hyphenated BigQuery project IDs before the gate runs. The non-gate `rocky load` path doesn't (it relies on the dialect's backtick quoting), so plain BQ loads already work. Relaxing the gate's catalog check to match the non-gate path is the fix; handled separately.