### PR TITLE
fix(engine/rocky-cli): contract gate accepts hyphenated BigQuery catalogs

### DIFF
--- a/engine/crates/rocky-cli/src/commands/load.rs
+++ b/engine/crates/rocky-cli/src/commands/load.rs
@@ -477,10 +477,15 @@ async fn load_with_contract_gate(
         .with_context(|| format!("invalid target table name '{}'", target.table))?;
     rocky_sql::validation::validate_identifier(&target.schema)
         .with_context(|| format!("invalid target schema '{}'", target.schema))?;
-    if !target.catalog.is_empty() {
-        rocky_sql::validation::validate_identifier(&target.catalog)
-            .with_context(|| format!("invalid target catalog '{}'", target.catalog))?;
-    }
+    // The catalog is intentionally NOT validated with the strict
+    // `validate_identifier` here. It's the project/catalog component, which on
+    // BigQuery is a GCP project ID containing hyphens (`my-project-123`) that
+    // the strict rule rejects. It's validated dialect-appropriately by
+    // `dialect.format_table_ref` below — BigQuery via `validate_gcp_project_id`
+    // (blocks injection chars, permits hyphens), every other dialect via the
+    // strict `validate_identifier` — and that runs before any SQL touches the
+    // warehouse (see the `format_table_ref` calls preceding the first
+    // `execute_statement`). This matches the non-gate `rocky load` path.
     // staging_name is derived from the already-validated table name + a static
     // suffix, so it's guaranteed valid; validate anyway as a belt-and-braces.
     rocky_sql::validation::validate_identifier(&staging_name)


### PR DESCRIPTION
The typed load **contract gate** (`load_with_contract_gate`, staging-promote) strict-validated the target **catalog** with the generic `validate_identifier` (`^[a-zA-Z0-9_]+$`). BigQuery's catalog component *is* the GCP project ID, which contains hyphens (`rocky-sandbox-hc-test-63874`) — so the gate aborted with `invalid target catalog '…'` before loading anything. **The contract gate could never run on BigQuery.**

The non-gate `rocky load` path never had this problem (and works live on BQ — #833): it relies on the dialect's `format_table_ref`, which validates the catalog **dialect-appropriately** — `validate_gcp_project_id` for BigQuery (blocks injection chars, permits hyphens), strict `validate_identifier` for every other dialect — and backtick-quotes it.

**Fix:** remove the redundant strict catalog pre-check from the gate path and rely on the dialect, exactly like the non-gate path.

**Injection defense is unchanged.** `dialect.format_table_ref(&target.catalog, …)` runs *before* the first `execute_statement`, `loader.load`, and `describe_table`, so the catalog is validated (and quoted) before it can reach any SQL. Only the *wrong* (generic) validator was removed; the *correct* dialect-aware one was already in the path. Switching the pre-check to `validate_gcp_project_id` would be wrong — it's BigQuery-specific and rejects valid short/uppercase Databricks catalogs.

**Tested:** all 4 DuckDB-backed contract-gate tests (`test_contract_gate_pass_lands_rows`, `…_fail_leaves_target_absent`, `…_pass_surfaces_unenforceable_warning`, `…_json_output_reports_violations`) *run* green; fmt + clippy `--all-targets` clean. The `format_table_ref`/`validate_gcp_project_id` seam (hyphen-accept + injection-block) is covered by the BigQuery dialect's `ground_table_ref_*` tests.

**Live-verify:** running the full BigQuery contract gate end-to-end against the sandbox on a combined tree with #836 (the arms that make the type-check precise on BQ type names) — pass-probe + a bad-probe asserted to fail with a `ContractGateError` citing the `id` DATE-vs-INT64 mismatch. Result posted below.