### PR TITLE
feat(engine): Iceberg point-to reuse for --reuse (B5 stage 2, Databricks-live-gated)

### DIFF
--- a/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/commit.rs
@@ -142,6 +142,96 @@ pub fn build_commit_jsonl(inputs: &CommitInputs) -> Result<Vec<u8>> {
     Ok(out)
 }
 
+/// Build a point-to commit body that lifts a prior run's `add` action
+/// verbatim — **no live batch, no recomputed stats, no byte copy.**
+///
+/// This is the commit half of an Iceberg content-addressed *point-to*: the
+/// reusing run references a prior run `R`'s already-written, blake3-named
+/// parquet file instead of executing SQL and re-writing bytes. `recovered_add`
+/// is `R`'s `add` action object (the inner body of the `{"add": {...}}` line),
+/// obtained from `R`'s `_delta_log/{version}.json` via
+/// [`super::discover::recover_add_action_for_version`]. Its `path`, `size`,
+/// `stats` (with `numRecords` + min/max/nullCount keyed by physical UUID), and
+/// `dataChange` carry over byte-for-byte; only `modificationTime` is refreshed
+/// to the reusing commit's wall clock.
+///
+/// Lines emitted, in order:
+/// 1. `commitInfo` (operation `WRITE`, blind append) — fresh for this commit.
+/// 2. the lifted `add` action — `R`'s, with `modificationTime` refreshed.
+///
+/// # Scope — unpartitioned, non-rowTracking only (a hard second guard)
+///
+/// This entry point refuses to lift a partitioned or rowTracking `add` and
+/// returns [`UniformWriterError::DeltaLog`]:
+/// - a non-empty `partitionValues` ⇒ the partitioned point-to (last-group
+///   ledger is incomplete — deferred follow-up);
+/// - a present `baseRowId` ⇒ the rowTracking point-to (the reusing commit
+///   needs a *freshly re-allocated* `baseRowId` range; `R`'s cannot be lifted
+///   verbatim — deferred follow-up).
+///
+/// The runner's decision gate already restricts point-to to unpartitioned,
+/// non-rowTracking tables; this refusal is the defence-in-depth guard so a
+/// mis-routed call can never silently emit a structurally wrong commit.
+pub fn build_commit_jsonl_from_add(
+    recovered_add: &Map<String, Value>,
+    engine_info: &str,
+    modification_time_millis: i64,
+    partition_columns: &[String],
+) -> Result<Vec<u8>> {
+    // Guard 1: refuse a partitioned `add`. A non-empty partitionValues means
+    // this file belongs to a partition group; the partitioned point-to is a
+    // deferred follow-up (the ledger records only the last group's hash).
+    if let Some(Value::Object(pv)) = recovered_add.get("partitionValues")
+        && !pv.is_empty()
+    {
+        return Err(UniformWriterError::DeltaLog(format!(
+            "point-to refuses a partitioned `add` (partitionValues={pv:?}); \
+             partitioned point-to is a deferred follow-up"
+        )));
+    }
+    // Guard 2: refuse a rowTracking `add`. A present baseRowId means the
+    // reusing commit would need a freshly re-allocated row-id range; lifting
+    // R's verbatim would collide in row-id space. Deferred follow-up.
+    if recovered_add.contains_key("baseRowId")
+        || recovered_add.contains_key("defaultRowCommitVersion")
+    {
+        return Err(UniformWriterError::DeltaLog(
+            "point-to refuses a rowTracking `add` (baseRowId/defaultRowCommitVersion present); \
+             rowTracking point-to is a deferred follow-up"
+                .to_string(),
+        ));
+    }
+
+    let partition_by_json = serde_json::to_string(partition_columns)?;
+    let commit_info = json!({
+        "commitInfo": {
+            "timestamp": modification_time_millis,
+            "operation": "WRITE",
+            "operationParameters": {"mode": "Append", "partitionBy": partition_by_json},
+            "isolationLevel": "Serializable",
+            "isBlindAppend": true,
+            "engineInfo": engine_info,
+        }
+    });
+
+    // Lift the recovered `add` verbatim, refreshing only modificationTime so
+    // the reusing commit's add carries this run's wall clock (path, size,
+    // stats, dataChange all carry over byte-for-byte from R).
+    let mut add_obj = recovered_add.clone();
+    add_obj.insert(
+        "modificationTime".into(),
+        Value::from(modification_time_millis),
+    );
+    let add_action = json!({ "add": Value::Object(add_obj) });
+
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(serde_json::to_string(&commit_info)?.as_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(serde_json::to_string(&add_action)?.as_bytes());
+    out.push(b'\n');
+    Ok(out)
+}
+
 fn translate_partition_values(inputs: &CommitInputs) -> Result<Map<String, Value>> {
     let table_partitions: HashSet<&str> = inputs
         .state
@@ -565,6 +655,108 @@ mod tests {
         assert_eq!(min["col-name"], "a");
         assert_eq!(max["col-name"], "c");
         assert_eq!(nc["col-id"], 0);
+    }
+
+    // -- point-to (build_commit_jsonl_from_add) -----------------------------
+
+    /// A realistic unpartitioned, non-rowTracking `add` action as a prior
+    /// run would have written it (stats keyed by physical UUID).
+    fn recovered_unpartitioned_add() -> Map<String, Value> {
+        let stats = json!({
+            "numRecords": 3,
+            "minValues": {"col-id": 0},
+            "maxValues": {"col-id": 2},
+            "nullCount": {"col-id": 0},
+        });
+        let mut add = Map::new();
+        add.insert("path".into(), Value::String("abc123.parquet".into()));
+        add.insert("partitionValues".into(), json!({}));
+        add.insert("size".into(), Value::from(4096_u64));
+        add.insert(
+            "modificationTime".into(),
+            Value::from(1_000_000_000_000_i64),
+        );
+        add.insert("dataChange".into(), Value::Bool(true));
+        add.insert(
+            "stats".into(),
+            Value::String(serde_json::to_string(&stats).unwrap()),
+        );
+        add
+    }
+
+    #[test]
+    fn point_to_lifts_add_verbatim_and_refreshes_modification_time() {
+        let add = recovered_unpartitioned_add();
+        let new_mod_time = 1_700_000_000_123_i64;
+        let body =
+            build_commit_jsonl_from_add(&add, "rocky-iceberg/test", new_mod_time, &[]).unwrap();
+        let lines: Vec<&str> = std::str::from_utf8(&body).unwrap().lines().collect();
+        assert_eq!(lines.len(), 2, "point-to emits commitInfo + the lifted add");
+
+        let info: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(info["commitInfo"]["operation"], "WRITE");
+        assert_eq!(info["commitInfo"]["timestamp"], new_mod_time);
+        assert_eq!(info["commitInfo"]["engineInfo"], "rocky-iceberg/test");
+
+        let lifted: Value = serde_json::from_str(lines[1]).unwrap();
+        let lifted_add = lifted.get("add").unwrap();
+        // path / size / dataChange carry over byte-for-byte.
+        assert_eq!(lifted_add["path"], "abc123.parquet");
+        assert_eq!(lifted_add["size"], 4096);
+        assert_eq!(lifted_add["dataChange"], true);
+        // modificationTime is the ONLY field refreshed.
+        assert_eq!(lifted_add["modificationTime"], new_mod_time);
+        // stats (numRecords + min/max/nullCount keyed by physical UUID) lift
+        // verbatim — no recompute, no live batch.
+        let stats: Value = serde_json::from_str(lifted_add["stats"].as_str().unwrap()).unwrap();
+        assert_eq!(stats["numRecords"], 3);
+        assert_eq!(stats["minValues"]["col-id"], 0);
+        assert_eq!(stats["maxValues"]["col-id"], 2);
+        assert_eq!(stats["nullCount"]["col-id"], 0);
+    }
+
+    #[test]
+    fn point_to_refuses_partitioned_add() {
+        let mut add = recovered_unpartitioned_add();
+        add.insert("partitionValues".into(), json!({"col-region": "eu"}));
+        add.insert("path".into(), Value::String("region=eu/abc.parquet".into()));
+        match build_commit_jsonl_from_add(&add, "t", 0, &["region".to_string()]) {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("partitioned"),
+                    "must refuse a partitioned add: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_to_refuses_row_tracking_add() {
+        let mut add = recovered_unpartitioned_add();
+        add.insert("baseRowId".into(), Value::from(100_i64));
+        add.insert("defaultRowCommitVersion".into(), Value::from(7_i64));
+        match build_commit_jsonl_from_add(&add, "t", 0, &[]) {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(
+                    msg.contains("rowTracking"),
+                    "must refuse a rowTracking add: {msg}"
+                );
+            }
+            other => panic!("expected DeltaLog refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn point_to_emits_no_extra_actions() {
+        // The point-to is exactly 2 lines — no domainMetadata, no second add.
+        let add = recovered_unpartitioned_add();
+        let body = build_commit_jsonl_from_add(&add, "t", 42, &[]).unwrap();
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap().lines().count(),
+            2,
+            "a point-to commit is commitInfo + one add only"
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -432,6 +432,65 @@ pub(super) fn commit_jsonl_contains_add_path(body: &[u8], add_file_path: &str) -
     Ok(false)
 }
 
+/// Extract the first `add` action object from a `_delta_log` commit body
+/// (JSONL).
+///
+/// Pure parsing — no I/O — so it is unit-testable. Returns the inner object
+/// of the `{"add": {...}}` line (the action body, *not* the one-key wrapper),
+/// or `None` when the commit carries no `add`. Used by the point-to writer to
+/// lift a prior run's `add` action verbatim (path, size, stats,
+/// partitionValues, rowTracking fields) for a zero-byte-copy reuse commit.
+///
+/// A point-to recovery targets a single content-addressed commit, which
+/// always carries exactly one `add` (the writer emits one `add` per commit —
+/// see `commit::build_commit_jsonl`), so returning the first is sufficient.
+pub(super) fn first_add_action(
+    body: &[u8],
+) -> Result<Option<serde_json::Map<String, serde_json::Value>>> {
+    let text = std::str::from_utf8(body)
+        .map_err(|e| UniformWriterError::DeltaLog(format!("non-utf8 _delta_log: {e}")))?;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| UniformWriterError::DeltaLog(format!("scan add action: {e}")))?;
+        if let Some(serde_json::Value::Object(add)) = value.get("add") {
+            return Ok(Some(add.clone()));
+        }
+    }
+    Ok(None)
+}
+
+/// GET a single `_delta_log/{version:020}.json` commit and return its `add`
+/// action object.
+///
+/// Addresses the commit directly by version — no listing, one GET — because
+/// the caller already holds the exact `commit_version` (joined from the prior
+/// run's `ArtifactRecord`). The returned object is the prior run's complete,
+/// correct `add` (path, partitionValues, size, stats, and rowTracking fields
+/// if present), written when that run executed. The point-to writer lifts it
+/// verbatim, refreshing only `modificationTime`, so min/max/nullCount and
+/// `numRecords` carry over byte-for-byte without re-reading the parquet.
+///
+/// Returns [`UniformWriterError::DeltaLog`] when the commit is missing the
+/// `add` action; the underlying object-store GET error (e.g. a missing log
+/// file) surfaces as [`UniformWriterError::ObjectStore`].
+pub(super) async fn recover_add_action_for_version<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+    commit_version: u64,
+) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let log_path = Path::from(format!("{prefix}/_delta_log/{commit_version:020}.json"));
+    let body = store.get(&log_path).await?.bytes().await?;
+    first_add_action(&body)?.ok_or_else(|| {
+        UniformWriterError::DeltaLog(format!(
+            "commit version {commit_version} carries no `add` action; \
+             cannot recover a point-to source"
+        ))
+    })
+}
+
 /// Scan every `_delta_log/<20-digit>.json` commit for an `add` action that
 /// already references `add_file_path`, returning the commit version that did.
 ///
@@ -530,6 +589,38 @@ mod tests {
         assert!(
             !commit_jsonl_contains_add_path(body, "data/abc123.parquet").unwrap(),
             "a remove action must not be treated as a live add"
+        );
+    }
+
+    #[test]
+    fn first_add_action_returns_the_add_body() {
+        let body = br#"{"commitInfo":{"timestamp":1700000000000}}
+{"add":{"path":"data/abc123.parquet","size":42,"dataChange":true,"stats":"{\"numRecords\":3}"}}"#;
+        let add = first_add_action(body).unwrap().expect("an add is present");
+        // Returns the inner action body, not the {"add": ...} wrapper.
+        assert_eq!(add.get("path").unwrap(), "data/abc123.parquet");
+        assert_eq!(add.get("size").unwrap(), 42);
+        assert_eq!(add.get("stats").unwrap(), "{\"numRecords\":3}");
+    }
+
+    #[test]
+    fn first_add_action_skips_commit_info_and_blank_lines() {
+        let body = br#"
+{"commitInfo":{"operation":"WRITE"}}
+
+{"add":{"path":"x.parquet"}}
+"#;
+        let add = first_add_action(body).unwrap().expect("add present");
+        assert_eq!(add.get("path").unwrap(), "x.parquet");
+    }
+
+    #[test]
+    fn first_add_action_returns_none_without_an_add() {
+        let body = br#"{"commitInfo":{"operation":"WRITE"}}
+{"remove":{"path":"gone.parquet"}}"#;
+        assert!(
+            first_add_action(body).unwrap().is_none(),
+            "a commit with no add action yields None"
         );
     }
 

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -107,6 +107,38 @@ pub struct WriteResult {
     pub size_bytes: u64,
 }
 
+/// Inputs to a content-addressed *point-to* commit
+/// ([`UniformWriter::commit_pointer_with_state`]).
+///
+/// Carries everything needed to reference a prior run `R`'s existing
+/// blake3-named parquet **without re-reading the bytes**:
+/// - `recovered_add` — `R`'s `add` action object, lifted verbatim from its
+///   `_delta_log/{version}.json` (via
+///   [`discover::recover_add_action_for_version`]). Its `stats`
+///   (`numRecords` + min/max/nullCount) carry over byte-for-byte.
+/// - `add_file_path` — the content-addressed path (`<hash>.parquet`) the new
+///   commit references; used both as the `add.path` and as the
+///   double-count pre-check key. It is `recovered_add["path"]`, surfaced
+///   explicitly so the writer never has to re-parse the lifted action.
+/// - `blake3_hash` / `num_records` / `size_bytes` — `R`'s recorded artifact
+///   identity, flowed straight into the returned [`WriteResult`] so the
+///   runner records a fresh `ArtifactRecord` at the *same* blake3 (driving
+///   `refcount_for_hash` ≥ 2 — shared bytes, not copied).
+#[derive(Debug, Clone)]
+pub struct PointerInputs {
+    /// `R`'s `add` action object, lifted verbatim.
+    pub recovered_add: serde_json::Map<String, serde_json::Value>,
+    /// The content-addressed parquet path the commit references
+    /// (`recovered_add["path"]`).
+    pub add_file_path: String,
+    /// `R`'s output blake3 (hex) — unchanged; the reusing run shares it.
+    pub blake3_hash: String,
+    /// `R`'s row count, carried into the result for the runner's summary.
+    pub num_records: usize,
+    /// `R`'s parquet size in bytes.
+    pub size_bytes: u64,
+}
+
 /// Minimal SQL execution surface the writer needs.
 ///
 /// Phase 1 only uses this for `MSCK REPAIR TABLE ... SYNC METADATA` after
@@ -260,6 +292,209 @@ impl UniformWriter {
             format!("{partition_prefix}{hash}.parquet")
         })
         .await
+    }
+
+    /// Recover the [`PointerInputs`] for a point-to from a prior run `R`'s
+    /// recorded artifact identity.
+    ///
+    /// Given `R`'s `commit_version` (joined from its `ArtifactRecord`), its
+    /// output blake3, and the parquet size + row count, this GETs `R`'s
+    /// `_delta_log/{commit_version}.json` and lifts its `add` action — one
+    /// GET, no listing, no parquet byte read (the `add`'s `stats` already
+    /// hold `numRecords` + min/max/nullCount). The returned `PointerInputs`
+    /// feeds straight into [`Self::commit_pointer_with_state`].
+    ///
+    /// # Errors
+    ///
+    /// [`UniformWriterError::DeltaLog`] when the recovered commit carries no
+    /// `add` action; the object-store GET error when the log file is missing.
+    pub async fn recover_pointer_inputs(
+        &self,
+        commit_version: u64,
+        blake3_hash: String,
+        num_records: usize,
+        size_bytes: u64,
+    ) -> Result<PointerInputs> {
+        let prefix = self.config.prefix.trim_end_matches('/').to_string();
+        let recovered_add =
+            discover::recover_add_action_for_version(&*self.store, &prefix, commit_version).await?;
+        let add_file_path = recovered_add
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                UniformWriterError::DeltaLog(format!(
+                    "recovered `add` at commit {commit_version} has no `path`"
+                ))
+            })?
+            .to_string();
+        Ok(PointerInputs {
+            recovered_add,
+            add_file_path,
+            blake3_hash,
+            num_records,
+            size_bytes,
+        })
+    }
+
+    /// Reuse a prior run `R`'s already-written content-addressed parquet by
+    /// emitting a Delta commit that **references R's existing blake3-named
+    /// file — with zero byte copy.** No SQL executes, no parquet is built,
+    /// nothing is uploaded.
+    ///
+    /// This is the strong (offline-byte-verifiable) reuse backend: the
+    /// reusing run's target gains a commit whose lone `add` action points at
+    /// the same object `R` wrote. `pointer.blake3_hash` and the underlying
+    /// bytes are `R`'s; only a new `_delta_log` entry (and, recorded
+    /// separately by the runner, a fresh `ArtifactRecord` at the same blake3)
+    /// distinguish the reusing run.
+    ///
+    /// # Append-only safety — the double-count guard
+    ///
+    /// Delta is append-only: two live `add` actions for the same `path`
+    /// **double-count** that file's rows (the writer's own cond-put handler
+    /// documents this — see [`Self::write_internal`]). A point-to therefore
+    /// **pre-checks** the live `_delta_log` for an existing `add` referencing
+    /// `pointer.add_file_path`:
+    /// - **already present** ⇒ the target already holds R's file; the reuse
+    ///   is satisfied with **no new commit** — returns that commit's version
+    ///   so the caller records the shared-bytes reference without
+    ///   re-counting.
+    /// - **absent** ⇒ land a fresh pointer commit at `next_commit_version`
+    ///   via the conditional-put loop (retrying on a genuine version race).
+    ///
+    /// # Scope
+    ///
+    /// Unpartitioned, non-rowTracking tables only — validated against the
+    /// discovered `state` (and guarded again in
+    /// [`commit::build_commit_jsonl_from_add`]). A partitioned or rowTracking
+    /// table returns an error rather than a partial point-to; the caller
+    /// falls back to a normal BUILD.
+    ///
+    /// # Errors
+    ///
+    /// - [`UniformWriterError::PartitionedUnsupported`] / a `DeltaLog` error
+    ///   when the table is partitioned or rowTracking;
+    /// - [`UniformWriterError::CondPutRetryExhausted`] when the version race
+    ///   never settles;
+    /// - the underlying object-store / JSON errors otherwise.
+    pub async fn commit_pointer_with_state(
+        &self,
+        pointer: &PointerInputs,
+        mut state: UniformTableState,
+    ) -> Result<WriteResult> {
+        // Scope guard: unpartitioned, non-rowTracking only. A partial
+        // point-to is never emitted — the caller falls back to a BUILD.
+        if !state.partition_columns.is_empty() {
+            return Err(UniformWriterError::PartitionedUnsupported(
+                state.partition_columns.clone(),
+            ));
+        }
+        if state.row_tracking_enabled {
+            return Err(UniformWriterError::DeltaLog(
+                "point-to does not support rowTracking tables (the reusing commit needs a \
+                 freshly re-allocated baseRowId range); falling back to a normal build is the \
+                 caller's responsibility"
+                    .to_string(),
+            ));
+        }
+
+        let prefix = self.config.prefix.trim_end_matches('/').to_string();
+        let parquet_path = Path::from(format!("{prefix}/{}", pointer.add_file_path));
+
+        // Double-count guard: if a live commit already references this exact
+        // content-addressed file, the target already holds R's bytes. Reuse
+        // is already satisfied — return that version, emit NO new commit.
+        if let Some(existing_version) =
+            discover::find_commit_with_add_path(&*self.store, &prefix, &pointer.add_file_path)
+                .await?
+        {
+            tracing::info!(
+                add_file_path = %pointer.add_file_path,
+                existing_version,
+                "point-to: target already references this content-addressed file; \
+                 reuse satisfied with no new commit (append-only double-count guard)"
+            );
+            return Ok(WriteResult {
+                file_path: parquet_path.to_string(),
+                blake3_hash: pointer.blake3_hash.clone(),
+                commit_version: existing_version,
+                num_records: pointer.num_records,
+                size_bytes: pointer.size_bytes,
+            });
+        }
+
+        // File absent on the target: land a fresh pointer commit referencing
+        // R's parquet. Same cond-put loop as a build, minus build_parquet +
+        // the parquet PUT.
+        let modification_time_millis = chrono::Utc::now().timestamp_millis();
+        for attempt in 0..COND_PUT_RETRY_BUDGET {
+            let target_version = state.next_commit_version;
+            let commit_body = commit::build_commit_jsonl_from_add(
+                &pointer.recovered_add,
+                &self.config.engine_info,
+                modification_time_millis,
+                &state.partition_columns,
+            )?;
+            let log_path = Path::from(format!("{prefix}/_delta_log/{target_version:020}.json"));
+            let opts = PutOptions {
+                mode: PutMode::Create,
+                ..Default::default()
+            };
+            match self
+                .store
+                .put_opts(&log_path, PutPayload::from(Bytes::from(commit_body)), opts)
+                .await
+            {
+                Ok(_) => {
+                    return Ok(WriteResult {
+                        file_path: parquet_path.to_string(),
+                        blake3_hash: pointer.blake3_hash.clone(),
+                        commit_version: target_version,
+                        num_records: pointer.num_records,
+                        size_bytes: pointer.size_bytes,
+                    });
+                }
+                Err(object_store::Error::AlreadyExists { .. }) => {
+                    // Re-run the double-count pre-check before retrying: a
+                    // concurrent point-to of the *same* file may have landed
+                    // while we raced on the version. If so, return its
+                    // version rather than adding the file a second time.
+                    if let Some(existing_version) = discover::find_commit_with_add_path(
+                        &*self.store,
+                        &prefix,
+                        &pointer.add_file_path,
+                    )
+                    .await?
+                    {
+                        tracing::info!(
+                            add_file_path = %pointer.add_file_path,
+                            existing_version,
+                            "point-to cond-put 412: file landed concurrently; returning \
+                             existing commit (double-count guard)"
+                        );
+                        return Ok(WriteResult {
+                            file_path: parquet_path.to_string(),
+                            blake3_hash: pointer.blake3_hash.clone(),
+                            commit_version: existing_version,
+                            num_records: pointer.num_records,
+                            size_bytes: pointer.size_bytes,
+                        });
+                    }
+                    let observed = discover::next_commit_version(&*self.store, &prefix).await?;
+                    state.next_commit_version = observed.max(target_version.saturating_add(1));
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        previous_target = target_version,
+                        new_target = state.next_commit_version,
+                        "point-to cond-put 412 on _delta_log entry; retrying"
+                    );
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Err(UniformWriterError::CondPutRetryExhausted(format!(
+            "exhausted {COND_PUT_RETRY_BUDGET} retries chasing next_commit_version for a point-to"
+        )))
     }
 
     /// Shared write pipeline used by both unpartitioned and partitioned
@@ -894,6 +1129,191 @@ mod tests {
         // Discover again — next_commit_version should now be 2.
         let state2 = writer.discover().await.expect("discover after write");
         assert_eq!(state2.next_commit_version, 2);
+    }
+
+    // -- point-to (commit_pointer_with_state / recover_pointer_inputs) ------
+
+    fn make_unpartitioned_writer(store: Arc<dyn ObjectStore>, prefix: &str) -> UniformWriter {
+        UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-iceberg/test".into(),
+            },
+            store,
+            Arc::new(PanicSqlClient),
+        )
+    }
+
+    #[tokio::test]
+    async fn point_to_recover_then_commit_into_fresh_table() {
+        // R writes a batch into table A (the build). A *separate* fresh
+        // table B then points to R's parquet with zero byte copy: recover
+        // R's add, commit a pointer into B, assert B's new commit references
+        // the same content-addressed path + same blake3, and no second
+        // parquet object is created under B.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+
+        // R's build into table A.
+        seed_bootstrap(&store, "tbl_a").await;
+        let writer_a = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl_a");
+        let r = writer_a.write_batch(make_batch(7)).await.unwrap();
+        assert_eq!(r.commit_version, 1);
+
+        // Point-to into a fresh table B (its own bootstrap, no data yet).
+        seed_bootstrap(&store, "tbl_b").await;
+        let writer_b = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl_b");
+        let state_b = writer_b.discover().await.unwrap();
+        assert_eq!(state_b.next_commit_version, 1);
+
+        let pointer = writer_a
+            .recover_pointer_inputs(
+                r.commit_version,
+                r.blake3_hash.clone(),
+                r.num_records,
+                r.size_bytes,
+            )
+            .await
+            .unwrap();
+        // The recovered path is R's content-addressed file.
+        assert!(pointer.add_file_path.ends_with(".parquet"));
+        assert_eq!(pointer.blake3_hash, r.blake3_hash);
+
+        let pr = writer_b
+            .commit_pointer_with_state(&pointer, state_b)
+            .await
+            .unwrap();
+        // B's pointer commit lands at version 1, references R's bytes, copies
+        // nothing.
+        assert_eq!(pr.commit_version, 1);
+        assert_eq!(pr.blake3_hash, r.blake3_hash, "shared bytes — same blake3");
+        assert_eq!(pr.num_records, r.num_records);
+
+        // B's _delta_log/...001.json references the SAME content-addressed
+        // path R wrote (the file name; the prefix differs per table).
+        let log_b = store
+            .get(&object_store::path::Path::from(
+                "tbl_b/_delta_log/00000000000000000001.json",
+            ))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let lines: Vec<&str> = std::str::from_utf8(&log_b).unwrap().lines().collect();
+        assert_eq!(lines.len(), 2, "point-to commit is commitInfo + lifted add");
+        let add: Value = serde_json::from_str(lines[1]).unwrap();
+        let r_file = r.file_path.split('/').next_back().unwrap();
+        assert_eq!(
+            add["add"]["path"], r_file,
+            "B's commit must reference R's content-addressed file name"
+        );
+
+        // No parquet object was written under tbl_b — the point-to copied
+        // zero bytes (the only tbl_b objects are _delta_log/*).
+        use futures::TryStreamExt;
+        let mut stream = store.list(Some(&object_store::path::Path::from("tbl_b")));
+        let mut saw_parquet = false;
+        while let Some(meta) = stream.try_next().await.unwrap() {
+            if meta.location.to_string().ends_with(".parquet") {
+                saw_parquet = true;
+            }
+        }
+        assert!(
+            !saw_parquet,
+            "a point-to must not write any parquet object under the target table"
+        );
+    }
+
+    #[tokio::test]
+    async fn point_to_is_a_noop_when_file_already_referenced() {
+        // Double-count guard: if the target already holds R's file, a
+        // point-to emits NO new commit and returns the existing version.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_bootstrap(&store, "tbl").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl");
+
+        // R's build lands at v=1 in THIS table.
+        let r = writer.write_batch(make_batch(4)).await.unwrap();
+        assert_eq!(r.commit_version, 1);
+
+        // Recover R's add and attempt a point-to into the SAME table — the
+        // file is already referenced, so this must be a no-op.
+        let pointer = writer
+            .recover_pointer_inputs(
+                r.commit_version,
+                r.blake3_hash.clone(),
+                r.num_records,
+                r.size_bytes,
+            )
+            .await
+            .unwrap();
+        let state = writer.discover().await.unwrap();
+        assert_eq!(state.next_commit_version, 2, "v=1 already taken by R");
+
+        let pr = writer
+            .commit_pointer_with_state(&pointer, state)
+            .await
+            .unwrap();
+        assert_eq!(
+            pr.commit_version, 1,
+            "must return R's existing version, not land a new commit"
+        );
+
+        // No v=2 commit was written — the table still tops out at v=1.
+        let v2 = store
+            .get(&object_store::path::Path::from(
+                "tbl/_delta_log/00000000000000000002.json",
+            ))
+            .await;
+        assert!(
+            v2.is_err(),
+            "the double-count guard must NOT land a second commit for the same file"
+        );
+    }
+
+    #[tokio::test]
+    async fn point_to_rejects_partitioned_table() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_partitioned_bootstrap(&store, "ptbl").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "ptbl");
+        let state = writer.discover().await.unwrap();
+        let pointer = PointerInputs {
+            recovered_add: serde_json::Map::new(),
+            add_file_path: "x.parquet".into(),
+            blake3_hash: "deadbeef".into(),
+            num_records: 1,
+            size_bytes: 1,
+        };
+        match writer.commit_pointer_with_state(&pointer, state).await {
+            Err(UniformWriterError::PartitionedUnsupported(cols)) => {
+                assert_eq!(cols, vec!["region".to_string()]);
+            }
+            other => panic!("expected PartitionedUnsupported, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn point_to_rejects_row_tracking_table() {
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_row_tracking_bootstrap(&store, "rt").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "rt");
+        let state = writer.discover().await.unwrap();
+        let pointer = PointerInputs {
+            recovered_add: serde_json::Map::new(),
+            add_file_path: "x.parquet".into(),
+            blake3_hash: "deadbeef".into(),
+            num_records: 1,
+            size_bytes: 1,
+        };
+        match writer.commit_pointer_with_state(&pointer, state).await {
+            Err(UniformWriterError::DeltaLog(msg)) => {
+                assert!(msg.contains("rowTracking"), "must name rowTracking: {msg}");
+            }
+            other => panic!("expected DeltaLog rowTracking refusal, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
+++ b/engine/crates/rocky-iceberg/tests/uniform_writer_live.rs
@@ -716,3 +716,149 @@ async fn schema_evolution_e2e_live_sandbox() {
         .expect("post-ALTER write must succeed");
     assert_eq!(result.num_records, 2);
 }
+
+/// Live end-to-end **point-to** (content-addressed reuse) against the
+/// UniForm sandbox — the Databricks-gated verification of B5 stage 2's
+/// strong reuse backend.
+///
+/// Two claims, kept separate (mirroring the provenance record's two-claim
+/// framing):
+/// 1. **Zero byte copy.** `recover_pointer_inputs` lifts a prior run's `add`
+///    from its `_delta_log/{version}.json` (one GET, no parquet read) and
+///    `commit_pointer_with_state` references that same blake3-named file —
+///    no `build_parquet`, no parquet PUT.
+/// 2. **Append-only correctness (the double-count guard).** On a *same-target*
+///    point-to, the target already references the file. The pre-check must
+///    make the commit a **no-op** (return the existing version, land no new
+///    `_delta_log` entry), so Photon's `SELECT COUNT(*)` stays **unchanged**.
+///    A double-counted row count here is the bug this test exists to catch —
+///    it is why the runner-side reuse DECISION stays unwired until this
+///    passes.
+///
+/// Requires the same env as `round_trip_phase1_compatible_sandbox`: the
+/// `ROCKY_TEST_*` (catalog/schema/table/bucket/prefix) + AWS creds + the
+/// `DATABRICKS_*` connection, against an unpartitioned, non-rowTracking
+/// UniForm table with `(id BIGINT, name STRING, ts TIMESTAMP)`. All
+/// workspace identifiers come from the environment — none are hard-coded.
+#[tokio::test]
+#[ignore]
+async fn point_to_same_target_is_noop_live_sandbox() {
+    let Some(cfg) = try_load_config() else {
+        eprintln!("skipping: ROCKY_TEST_* env vars not set");
+        return;
+    };
+    let Some(store) = build_s3_store(&cfg) else {
+        eprintln!("skipping: failed to build S3 store from environment");
+        return;
+    };
+    let Some(connector) = connector_from_env() else {
+        eprintln!("skipping: DATABRICKS_* env vars not set");
+        return;
+    };
+
+    let sql_client = Arc::new(DatabricksSqlClient { connector });
+    let fqtn = format!("{}.{}.{}", cfg.catalog, cfg.schema, cfg.table);
+    let count_sql = format!("SELECT COUNT(*) AS n FROM {fqtn}");
+
+    let read_count = |sql_client: Arc<DatabricksSqlClient>, sql: String| async move {
+        let res = sql_client.connector.execute_sql(&sql).await.expect("count");
+        let cell = &res.rows[0][0];
+        cell.as_i64()
+            .or_else(|| cell.as_str().and_then(|s| s.parse().ok()))
+            .expect("count parses as i64")
+    };
+
+    let writer = UniformWriter::new(
+        UniformWriterConfig {
+            catalog: cfg.catalog.clone(),
+            schema: cfg.schema.clone(),
+            table: cfg.table.clone(),
+            prefix: cfg.prefix.clone(),
+            engine_info: "rocky-iceberg/point-to-live-test".into(),
+        },
+        store.clone(),
+        sql_client.clone() as Arc<dyn SqlClient>,
+    );
+
+    let state = writer.discover().await.expect("discover");
+    if !state.partition_columns.is_empty() || state.row_tracking_enabled {
+        eprintln!("skipping: point-to needs an unpartitioned, non-rowTracking table");
+        return;
+    }
+    let expected_cols: std::collections::BTreeSet<&str> =
+        ["id", "name", "ts"].into_iter().collect();
+    let actual_cols: std::collections::BTreeSet<&str> =
+        state.physical.keys().map(String::as_str).collect();
+    if expected_cols != actual_cols {
+        eprintln!("skipping: this test expects schema (id, name, ts); table has {actual_cols:?}");
+        return;
+    }
+
+    // Step 1 — R's build: a fresh content-addressed file (unique ts so it
+    // never collides with a prior run's blake3).
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        ),
+    ]));
+    let ids = Int64Array::from(vec![900_701_i64, 900_702, 900_703]);
+    let names = StringArray::from(vec!["point-to-a", "point-to-b", "point-to-c"]);
+    let ts = TimestampMicrosecondArray::from(vec![now_micros, now_micros + 1, now_micros + 2])
+        .with_timezone("UTC");
+    let batch =
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names), Arc::new(ts)]).unwrap();
+
+    let r = writer
+        .write_batch(batch)
+        .await
+        .expect("R build write_batch");
+    writer
+        .sync_iceberg_metadata()
+        .await
+        .expect("MSCK after build");
+    let count_after_build = read_count(sql_client.clone(), count_sql.clone()).await;
+
+    // Step 2 — recover R's add (one GET, no parquet read) and attempt a
+    // same-target point-to.
+    let pointer = writer
+        .recover_pointer_inputs(
+            r.commit_version,
+            r.blake3_hash.clone(),
+            r.num_records,
+            r.size_bytes,
+        )
+        .await
+        .expect("recover_pointer_inputs");
+    assert_eq!(
+        pointer.blake3_hash, r.blake3_hash,
+        "shared bytes — same blake3"
+    );
+
+    let fresh_state = writer.discover().await.expect("discover before point-to");
+    let pr = writer
+        .commit_pointer_with_state(&pointer, fresh_state)
+        .await
+        .expect("point-to commit");
+    writer
+        .sync_iceberg_metadata()
+        .await
+        .expect("MSCK after point-to");
+
+    // Claim 2 — the double-count guard held: the point-to was a no-op
+    // (returned R's version) and Photon's count did NOT change.
+    assert_eq!(
+        pr.commit_version, r.commit_version,
+        "same-target point-to must return R's existing commit version (no new commit)"
+    );
+    let count_after_pointto = read_count(sql_client.clone(), count_sql.clone()).await;
+    assert_eq!(
+        count_after_pointto, count_after_build,
+        "same-target point-to must NOT double-count R's rows \
+         (after_build={count_after_build}, after_point_to={count_after_pointto})"
+    );
+}


### PR DESCRIPTION
## What this is

The **Iceberg point-to writer** — the strong (offline-byte-verifiable) reuse backend for B5 stage 2. It emits a Delta commit that references a prior run `R`'s already-written, blake3-named parquet **with zero byte copy**: no SQL executes, no parquet is built, nothing is uploaded.

Builds on the reuse spine landed in #835 (now in `main`). The writer is **additive and dormant** — no runner path calls it yet, so this PR changes no run behavior. Scope: `engine/crates/rocky-iceberg/**` only.

## The four writer pieces (all on the unpartitioned + non-rowTracking slice)

1. **`discover::recover_add_action_for_version`** — GET a prior run's `_delta_log/{version}.json` (addressed directly by `commit_version` — one GET, no listing, no parquet read) and lift its `add` action. `stats` (`numRecords` + min/max/nullCount) carry over byte-for-byte. Backed by the pure, unit-tested `first_add_action` parser.
2. **`commit::build_commit_jsonl_from_add`** — emit `commitInfo` + the lifted `add` with a refreshed `modificationTime`, skipping `compute_stats` (a point-to has no live `RecordBatch`). Refuses a partitioned or rowTracking `add` as a hard second guard.
3. **`UniformWriter::commit_pointer_with_state`** (+ `recover_pointer_inputs`) — run **only** the conditional-put commit loop (no `build_parquet`, no parquet PUT). Returns a `WriteResult` at `R`'s same `blake3_hash` / `file_path`.
4. **Append-only double-count guard** — `commit_pointer_with_state` pre-checks the live `_delta_log` for an existing `add` referencing the file: **already present ⇒ no new commit** (return the existing version); **absent ⇒ land a fresh pointer commit**. This is load-bearing: Delta is append-only, so a second live `add` for the same path would double-count `R`'s rows (the writer's own cond-put handler documents this).

Partitioned (last-group-only ledger) and rowTracking (`baseRowId` re-allocation) point-to are explicit **deferred follow-ups** — the writer bails rather than emitting a partial point-to.

## Tests

- **Unit (no warehouse):** `build_commit_jsonl_from_add` lifts path/size/stats verbatim + refreshes `modificationTime` + refuses partition/rowTracking; `commit_pointer_with_state` file-present no-op + file-absent lands a pointer (against an in-memory store); `first_add_action` parser cases. All green.
- **Live (`#[ignore]`, Databricks-gated):** `point_to_same_target_is_noop_live_sandbox` in `tests/uniform_writer_live.rs` — builds R, recovers R's add, points-to into the **same** target, and asserts the count is **unchanged** (the double-count guard held) and `commit_version` is R's. Reads sandbox config from `ROCKY_TEST_*` / `DATABRICKS_*`; no workspace identifiers committed.

## ⚠ LIVE-VERIFY GATE — why the reuse DECISION is NOT in this PR

The runner-side reuse **decision** (the fail-closed `IFF`-gated point-to in `execute_models`) is deliberately **not wired here**. Whether a same-target point-to (no-op commit + fresh `ArtifactRecord` at R's blake3 → refcount 2 → target reads R's bytes **once**) is semantically correct cannot be verified without the Databricks UniForm sandbox. Wiring a decision over unverified table semantics would risk exactly the silent-wrong-output class this feature exists to prevent.

**Run `point_to_same_target_is_noop_live_sandbox` against the UniForm sandbox before this is marked ready.** Because `target_identity` is folded into `input_hash`, a same-target re-run is the *only* scenario that ever matches the index — so the double-count semantics are the whole verification, not an edge case.

The `--no-reuse` flag (which would gate only the decision) ships **with** the decision in the follow-up, so a no-op flag never reaches users.

## Follow-ups (tracked, not in this PR)

- The runner reuse **decision** + `--no-reuse` flag (the fail-closed `IFF` gate, gated on live-verify above).
- Partitioned point-to (after the last-group-only ledger TODO is fixed) and rowTracking point-to (fresh `baseRowId` re-allocation).
- **`remove`-action awareness in the double-count guard:** `find_commit_with_add_path` ignores `remove` actions, so on a same-target reuse where R's file was later VACUUM'd / compacted away, the guard would see the stale `add`, no-op, and leave the target missing the file. It cannot fire today (this writer emits no removes; the consumer is deferred), but the decision's live-verify must cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
