### PR TITLE
feat(engine): report first-seen sources via discover new_sources diff

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -812,6 +812,11 @@
           "default": "default",
           "description": "Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `\"default\"`.",
           "type": "string"
+        },
+        "report_new_sources": {
+          "default": false,
+          "description": "When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -23,6 +23,10 @@ export interface DiscoverOutput {
    */
   failed_sources?: FailedSourceOutput[];
   /**
+   * Source schemas seen for the first time relative to the prior persisted `discover` snapshot — the catch-a-duplicate-at-onboarding signal. Populated only when the pipeline's discovery config sets `report_new_sources`; empty (and omitted from the wire format) otherwise. The first-ever discover of a pipeline establishes the baseline and reports none.
+   */
+  new_sources?: string[];
+  /**
    * Number of schema-cache entries written by this invocation.
    *
    * Populated by `rocky discover --with-schemas` — the explicit warm-up path for the schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1203,6 +1203,10 @@ export interface DiscoveryConfig {
    * Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `"default"`.
    */
   adapter?: string;
+  /**
+   * When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.
+   */
+  report_new_sources?: boolean;
 }
 /**
  * Schema pattern configuration from TOML, converted to [`SchemaPattern`] at runtime.

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -171,6 +171,46 @@ pub async fn discover(
         });
     }
 
+    // New-source diff (opt-in). Diff the discovered source inventory against
+    // the prior persisted snapshot so a freshly-onboarded source surfaces in
+    // `new_sources` — the catch-at-onboarding signal. The first discover of a
+    // pipeline only establishes the baseline. A state-store failure degrades
+    // to "no new sources" + a warn rather than aborting discovery.
+    let report_new_sources = pipeline
+        .source
+        .discovery
+        .as_ref()
+        .map(|d| d.report_new_sources)
+        .unwrap_or(false);
+    let new_sources = if report_new_sources {
+        let mut current = dedup_schemas(connectors);
+        current.sort();
+        match diff_and_record_new_sources(state_path, name, &current) {
+            Ok(found) => {
+                if !found.is_empty() {
+                    let bus = rocky_observe::events::global_event_bus();
+                    for schema in &found {
+                        bus.emit(
+                            rocky_observe::events::PipelineEvent::new("new_source_discovered")
+                                .with_target(schema.clone()),
+                        );
+                    }
+                    warn!(
+                        count = found.len(),
+                        "discover: new source(s) since last run — see `new_sources` in JSON output"
+                    );
+                }
+                found
+            }
+            Err(e) => {
+                warn!(error = %e, "discover: new-source diff failed — skipping (state unavailable)");
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
     // Schema-cache warm-up. Only runs when `--with-schemas` is set;
     // config gating already happened at the top of this function.
     // Errors inside the warm-up are logged and counted as misses — a
@@ -194,7 +234,8 @@ pub async fn discover(
         .with_checks(checks_output)
         .with_excluded_tables(excluded_tables)
         .with_failed_sources(failed_sources)
-        .with_schemas_cached(schemas_cached);
+        .with_schemas_cached(schemas_cached)
+        .with_new_sources(new_sources);
     if output_json {
         print_json(&output)?;
     } else {
@@ -352,6 +393,37 @@ fn dedup_schemas(connectors: &[rocky_core::source::DiscoveredConnector]) -> Vec<
             }
         })
         .collect()
+}
+
+/// Diff the current discovered source schemas against the prior persisted
+/// snapshot for `pipeline`, then overwrite the snapshot with `current`.
+///
+/// Returns the schemas present now but absent from the prior snapshot. The
+/// first call for a pipeline (no prior snapshot) records the baseline and
+/// returns an empty vec — a first discover is a baseline, not a wave of "new"
+/// sources. `current` must be deduplicated + sorted so the stored baseline is
+/// deterministic. The diff is per-pipeline (keyed by pipeline name), so two
+/// pipelines sharing a state store don't cross-contaminate.
+fn diff_and_record_new_sources(
+    state_path: &Path,
+    pipeline: &str,
+    current: &[String],
+) -> Result<Vec<String>> {
+    let store = StateStore::open(state_path)
+        .with_context(|| format!("failed to open state store at {}", state_path.display()))?;
+    let new_sources = match store.get_discover_snapshot(pipeline)? {
+        Some(prior) => {
+            let prior: HashSet<&String> = prior.iter().collect();
+            current
+                .iter()
+                .filter(|s| !prior.contains(s))
+                .cloned()
+                .collect()
+        }
+        None => Vec::new(),
+    };
+    store.put_discover_snapshot(pipeline, current)?;
+    Ok(new_sources)
 }
 
 /// Inner warm-up loop — split out so unit tests can drive it with a stub
@@ -831,6 +903,40 @@ mod tests {
         ];
         let schemas = dedup_schemas(&connectors);
         assert_eq!(schemas, vec!["raw__shopify", "raw__netsuite"]);
+    }
+
+    #[test]
+    fn new_source_diff_reports_only_unseen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state.redb");
+        let baseline = vec!["src__a__shopify".to_string(), "src__b__shopify".to_string()];
+
+        // First run establishes the baseline and reports nothing.
+        let first = diff_and_record_new_sources(&state, "raw", &baseline).unwrap();
+        assert!(first.is_empty(), "first discover is baseline-only");
+
+        // Second run with one added schema reports exactly that schema.
+        let mut grown = baseline.clone();
+        grown.push("src__c__shopify".to_string());
+        grown.sort();
+        let second = diff_and_record_new_sources(&state, "raw", &grown).unwrap();
+        assert_eq!(second, vec!["src__c__shopify".to_string()]);
+
+        // Third identical run is idempotent — nothing new.
+        let third = diff_and_record_new_sources(&state, "raw", &grown).unwrap();
+        assert!(third.is_empty());
+    }
+
+    #[test]
+    fn new_source_diff_is_per_pipeline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = tmp.path().join("state.redb");
+        diff_and_record_new_sources(&state, "p1", &["a".to_string()]).unwrap();
+        // A different pipeline has its own baseline — its first run reports
+        // none, not "a"/"b" as new (no cross-pipeline contamination).
+        let p2 =
+            diff_and_record_new_sources(&state, "p2", &["a".to_string(), "b".to_string()]).unwrap();
+        assert!(p2.is_empty());
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -102,6 +102,14 @@ pub struct DiscoverOutput {
     /// captured without the flag stay byte-stable.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub schemas_cached: usize,
+    /// Source schemas seen for the first time relative to the prior persisted
+    /// `discover` snapshot — the catch-a-duplicate-at-onboarding signal.
+    /// Populated only when the pipeline's discovery config sets
+    /// `report_new_sources`; empty (and omitted from the wire format)
+    /// otherwise. The first-ever discover of a pipeline establishes the
+    /// baseline and reports none.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub new_sources: Vec<String>,
 }
 
 /// Pipeline-level checks configuration projected into the discover output.
@@ -3501,6 +3509,7 @@ impl DiscoverOutput {
             excluded_tables: vec![],
             failed_sources: vec![],
             schemas_cached: 0,
+            new_sources: vec![],
         }
     }
 
@@ -3534,6 +3543,14 @@ impl DiscoverOutput {
     #[must_use]
     pub fn with_schemas_cached(mut self, schemas_cached: usize) -> Self {
         self.schemas_cached = schemas_cached;
+        self
+    }
+
+    /// Attach the list of first-seen source schemas (opt-in via the
+    /// discovery config's `report_new_sources`) and return self.
+    #[must_use]
+    pub fn with_new_sources(mut self, new_sources: Vec<String>) -> Self {
+        self.new_sources = new_sources;
         self
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -4209,6 +4209,13 @@ pub struct DiscoveryConfig {
     /// Defaults to `"default"`.
     #[serde(default = "default_adapter_name")]
     pub adapter: String,
+
+    /// When `true`, `rocky discover` diffs the discovered source inventory
+    /// against the prior persisted snapshot and reports first-seen sources in
+    /// `new_sources`. Off by default — the diff and its state write only happen
+    /// when opted in, so existing projects pay nothing.
+    #[serde(default)]
+    pub report_new_sources: bool,
 }
 
 /// Pipeline target configuration.
@@ -4600,6 +4607,7 @@ fn apply_single_adapter_discovery_default(config: &mut RockyConfig) {
         if replication.source.discovery.is_none() {
             replication.source.discovery = Some(DiscoveryConfig {
                 adapter: sole_adapter.clone(),
+                report_new_sources: false,
             });
         }
     }

--- a/engine/crates/rocky-core/src/state.rs
+++ b/engine/crates/rocky-core/src/state.rs
@@ -142,6 +142,12 @@ const INPUT_INDEX: TableDefinition<&str, &[u8]> = TableDefinition::new("input_in
 /// State-internal: never part of any `*Output` JSON schema, so it carries no
 /// codegen. Replicates across backends by default.
 const INPUT_PROVENANCE: TableDefinition<&str, &[u8]> = TableDefinition::new("input_provenance");
+
+/// Prior `rocky discover` source inventory, keyed by pipeline name →
+/// JSON-encoded sorted `Vec<String>` of discovered source schemas. Read and
+/// rewritten each `discover` run when `report_new_sources` is set, so the next
+/// run can diff "sources present now but absent before" into `new_sources`.
+const DISCOVER_SNAPSHOTS: TableDefinition<&str, &[u8]> = TableDefinition::new("discover_snapshots");
 /// Key/value store for internal metadata (e.g. `"schema_version"`).
 const METADATA: TableDefinition<&str, &str> = TableDefinition::new("metadata");
 
@@ -393,6 +399,7 @@ impl StateStore {
             let _table = txn.open_table(OUTPUT_ARTIFACTS)?;
             let _table = txn.open_table(INPUT_INDEX)?;
             let _table = txn.open_table(INPUT_PROVENANCE)?;
+            let _table = txn.open_table(DISCOVER_SNAPSHOTS)?;
         }
         txn.commit()?;
 
@@ -2444,6 +2451,39 @@ impl StateStore {
         }
         txn.commit()?;
         Ok(entries.len())
+    }
+
+    /// Read the prior `rocky discover` source inventory for `pipeline`.
+    ///
+    /// Returns the JSON-decoded `Vec<String>` of source schemas persisted by
+    /// the last [`Self::put_discover_snapshot`], or `None` when this pipeline
+    /// has never been discovered (the first-run baseline case).
+    pub fn get_discover_snapshot(&self, pipeline: &str) -> Result<Option<Vec<String>>, StateError> {
+        let txn = self.db.begin_read()?;
+        let table = txn.open_table(DISCOVER_SNAPSHOTS)?;
+        match table.get(pipeline)? {
+            Some(value) => Ok(Some(serde_json::from_slice(value.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Persist the current `rocky discover` source inventory for `pipeline`,
+    /// overwriting any prior snapshot. `sources` should be the deduplicated,
+    /// sorted list of discovered source schemas so the stored baseline is
+    /// deterministic.
+    pub fn put_discover_snapshot(
+        &self,
+        pipeline: &str,
+        sources: &[String],
+    ) -> Result<(), StateError> {
+        let bytes = serde_json::to_vec(sources)?;
+        let txn = self.db.begin_write()?;
+        {
+            let mut table = txn.open_table(DISCOVER_SNAPSHOTS)?;
+            table.insert(pipeline, bytes.as_slice())?;
+        }
+        txn.commit()?;
+        Ok(())
     }
 
     /// Delete a single schema cache entry. Returns `true` when a row was

--- a/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
@@ -130,6 +130,10 @@ class DiscoverOutput(BaseModel):
     """
     Sources the discovery adapter attempted to fetch metadata for and failed (transient HTTP error, timeout, rate-limit budget exhausted, auth blip). Their absence from `sources` does NOT mean they were removed upstream — consumers diffing against a prior run must treat failed sources as "unknown state, do not delete." Empty when discovery completed cleanly. See FR-014.
     """
+    new_sources: list[str] | None = None
+    """
+    Source schemas seen for the first time relative to the prior persisted `discover` snapshot — the catch-a-duplicate-at-onboarding signal. Populated only when the pipeline's discovery config sets `report_new_sources`; empty (and omitted from the wire format) otherwise. The first-ever discover of a pipeline establishes the baseline and reports none.
+    """
     schemas_cached: conint(ge=0) | None = None
     """
     Number of schema-cache entries written by this invocation.

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -322,6 +322,10 @@ class DiscoveryConfig(BaseModel):
     """
     Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `"default"`.
     """
+    report_new_sources: bool | None = False
+    """
+    When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.
+    """
 
 
 class ExecutionConfig(BaseModel):

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -195,6 +195,13 @@
       },
       "type": "array"
     },
+    "new_sources": {
+      "description": "Source schemas seen for the first time relative to the prior persisted `discover` snapshot — the catch-a-duplicate-at-onboarding signal. Populated only when the pipeline's discovery config sets `report_new_sources`; empty (and omitted from the wire format) otherwise. The first-ever discover of a pipeline establishes the baseline and reports none.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "schemas_cached": {
       "description": "Number of schema-cache entries written by this invocation.\n\nPopulated by `rocky discover --with-schemas` — the explicit warm-up path for the schema cache. Zero — and omitted from the wire format — when `--with-schemas` isn't set, so fixtures captured without the flag stay byte-stable.",
       "format": "uint",

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -811,6 +811,11 @@
           "default": "default",
           "description": "Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `\"default\"`.",
           "type": "string"
+        },
+        "report_new_sources": {
+          "default": false,
+          "description": "When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.",
+          "type": "boolean"
         }
       },
       "type": "object"


### PR DESCRIPTION
First slice of **cross-source duplicate detection** (a phased feature; see below). This is the *preventive*, discover-time half's foundation — catch a duplicate at onboarding, before data lands.

## What

`rocky discover` now diffs the discovered source inventory against a persisted prior snapshot and reports first-seen source schemas in a new **`new_sources`** field. When the same external object is onboarded twice under a new source path, it surfaces the first time `discover` sees it — before a stray catalog/table is auto-created.

**Opt-in**, off by default:
```toml
[pipeline.<name>.source.discovery]
report_new_sources = true
```
When unset: no diff, no state write, and **no JSON-output change** (the field is omitted when empty), so existing projects are unaffected. The **first** discover of a pipeline establishes the baseline and reports none (a first run is a baseline, not a wave of "new" sources).

## How

- **`state.rs`**: new redb `DISCOVER_SNAPSHOTS` table (per-pipeline source inventory) + `get`/`put_discover_snapshot`, mirroring the existing `SCHEMA_CACHE` pattern.
- **`discover.rs`**: `diff_and_record_new_sources` (read prior → diff → overwrite), emits a `new_source_discovered` `PipelineEvent` per new source. A state-store failure degrades to "no new sources" + a warn — never aborts discovery.
- **`output.rs`**: `DiscoverOutput.new_sources` (+ builder), skip-when-empty.
- Regenerated CLI-output + project schemas and dagster/vscode bindings via `just codegen` (no lockfile drift).

## Tested

- New diff logic unit-tested **against the real `StateStore`** (temp dir): first-run baseline reports none; an added source reports exactly itself; idempotent re-run reports none; per-pipeline isolation (no cross-contamination).
- Full suites *run*: rocky-core (1326) + rocky-cli (668), `cargo fmt`, `clippy --all-targets`, dagster `ruff check`/`format --check` all clean.

## Context — phased feature

Cross-source duplicate detection ships as 5 independent slices. This is **PR 1/5** (`new_sources`). Next: `key_expr` uniqueness → uniqueness at replication time → `cross_source_overlap` → `collision_candidates`. Each is independently shippable; this one stands alone as the FR's "high-value-alone" onboarding net.