### PR TITLE
feat(engine): fail-closed point-to reuse decision for --reuse (B5, Databricks-live-gated)

### DIFF
--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -46,6 +46,7 @@ mod profile_storage;
 mod publish_ir;
 mod replay;
 mod retention_status;
+mod reuse_decision;
 mod review;
 mod run;
 mod run_audit;

--- a/engine/crates/rocky-cli/src/commands/reuse_decision.rs
+++ b/engine/crates/rocky-cli/src/commands/reuse_decision.rs
@@ -1,0 +1,480 @@
+//! Fail-closed reuse decision (B5 capstone) — the gate that decides whether a
+//! content-addressed model may **point-to** a prior run `R`'s already-written
+//! parquet instead of executing its SQL.
+//!
+//! # The trust rule
+//!
+//! A wrong reuse is a *silent wrong production output* — the same blast radius
+//! as a wrong skip. So the gate is **fail-closed**: a model reuses `R`'s output
+//! **iff every** clause below holds, and **any** false answer or error means
+//! **BUILD** (execute the SQL). There is no "probably fine" branch.
+//!
+//! # The six clauses (all must hold to reuse)
+//!
+//! 1. **Enabled.** `[reuse]` is on in config AND the run was not invoked with
+//!    `--no-reuse`. (Evaluated by the caller; passed in as
+//!    [`ReuseInputs::enabled`].)
+//! 2. **Eligible shape.** The model is content-addressed, **unpartitioned**,
+//!    and **non-rowTracking** — the only shape the point-to writer supports
+//!    today (a partitioned/rowTracking point-to needs per-group commits /
+//!    re-allocated `baseRowId` ranges; deferred). ([`ReuseInputs::eligible_shape`].)
+//! 3. **Input match.** This run's recomputed `input_hash` (its resolved
+//!    upstream content identities ‖ `skip_hash` ‖ target) hits the
+//!    `INPUT_INDEX`, yielding a candidate prior run `R`
+//!    ([`ReuseInputs::candidate`]). No hit ⇒ BUILD.
+//! 4. **Strong proof.** `R`'s `proof_class` is exactly `"strong"`. A
+//!    `"heuristic"` (or any other) class is a watermark/freshness attestation,
+//!    **not** a byte-identity claim — never point-to on it.
+//! 5. **Artifact resolves.** `R`'s recorded output blake3 resolves to an
+//!    [`ArtifactRecord`] (a `(blake3, path, commit_version)` we can locate) and
+//!    its refcount is **sane** (`>= 1` — `R`'s own row exists; the reusing run
+//!    adds the second). ([`ReuseInputs::artifact`] + [`ReuseInputs::refcount`].)
+//! 6. **Liveness.** `R`'s `add` action is **still live** in the *target's
+//!    current `_delta_log`* — not VACUUM'd, compacted, or superseded by a later
+//!    `remove`. If the file is gone or the log can't be read, BUILD.
+//!    ([`ReuseInputs::add_is_live`].)
+//!
+//! # Stage-1 posture — ONLY-BUILD
+//!
+//! The runner computes the full verdict and, on a positive
+//! [`ReuseVerdict::WouldReuse`], **logs** the candidate but **still executes
+//! the SQL**. A decision that can only BUILD cannot produce a wrong output, so
+//! this is the provably-safe first slice. Wiring the live
+//! `commit_pointer_with_state` invocation behind the same verdict is the next
+//! step (tracked as a follow-up); the verdict shape here is already what that
+//! step consumes.
+
+use rocky_core::state::{ArtifactRecord, InputIndexEntry};
+
+/// Why a model must BUILD rather than reuse — one variant per fail-closed
+/// clause (and the error/doubt cases that also force a build).
+///
+/// Every variant is a *safe* outcome: BUILD always produces correct output.
+/// The variants exist for observability (logging *why* a reuse was declined),
+/// not for control flow beyond "do not reuse".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildReason {
+    /// Clause 1 — `[reuse]` disabled or `--no-reuse` passed. The default.
+    Disabled,
+    /// Clause 2 — the model is partitioned, rowTracking, or otherwise not the
+    /// supported unpartitioned content-addressed shape.
+    IneligibleShape,
+    /// Clause 3 — this run's `input_hash` could not be computed (the read set
+    /// did not resolve to an all-strong content-hash chain: a raw source, a
+    /// mixed/heuristic input, an ambiguous read, or a non-canonicalisable
+    /// model). No candidate was even looked up.
+    NoInputHash,
+    /// Clause 3 — `input_hash` was computed but missed the `INPUT_INDEX`: no
+    /// prior run produced these exact declared inputs for this target.
+    NoIndexMatch,
+    /// Clause 4 — the candidate `R`'s `proof_class` is not `"strong"`.
+    NotStrong,
+    /// Clause 5 — `R` recorded no output blake3 (nothing to point at).
+    NoRecordedOutput,
+    /// Clause 5 — `R`'s output blake3 resolved to no [`ArtifactRecord`] (the
+    /// ledger row is gone) — cannot locate the bytes to reference.
+    ArtifactUnresolved,
+    /// Clause 5 — refcount sanity failed (`< 1`): `R`'s own ledger row is
+    /// missing, so a point-to would not be refcount-protected against VACUUM.
+    RefcountInsufficient,
+    /// Clause 6 — `R`'s `add` is no longer live in the target's `_delta_log`
+    /// (VACUUM'd / superseded by a `remove`). Pointing at it would reference
+    /// removed bytes.
+    NotLive,
+}
+
+impl BuildReason {
+    /// Lowercase, stable string for structured logs.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BuildReason::Disabled => "disabled",
+            BuildReason::IneligibleShape => "ineligible_shape",
+            BuildReason::NoInputHash => "no_input_hash",
+            BuildReason::NoIndexMatch => "no_index_match",
+            BuildReason::NotStrong => "not_strong",
+            BuildReason::NoRecordedOutput => "no_recorded_output",
+            BuildReason::ArtifactUnresolved => "artifact_unresolved",
+            BuildReason::RefcountInsufficient => "refcount_insufficient",
+            BuildReason::NotLive => "not_live",
+        }
+    }
+}
+
+/// A fully-validated reuse candidate — every clause passed. Carries exactly
+/// what the live point-to invocation needs (`R`'s commit, blake3, path, and
+/// the resolved artifact) plus the proof class for the reuse-provenance entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReuseCandidate {
+    /// Prior run `R` whose bytes would be reused.
+    pub run_id: String,
+    /// `R`'s output blake3 (hex) — the shared content hash the reusing run's
+    /// fresh `ArtifactRecord` is recorded at, driving refcount `>= 2`.
+    pub blake3_hash: String,
+    /// `R`'s parquet object-store path (relative form lives in the `add`).
+    pub file_path: String,
+    /// Delta commit version of `R`'s `add` — the direct pointer the
+    /// point-to writer GETs to lift the `add` verbatim.
+    pub commit_version: u64,
+    /// Parquet size in bytes (from `R`'s `ArtifactRecord`).
+    pub size_bytes: u64,
+    /// `R`'s proof class — always `"strong"` here (clause 4), carried through
+    /// to the reuse-provenance record so the label is never lost.
+    pub proof_class: String,
+}
+
+/// The fail-closed verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReuseVerdict {
+    /// Execute the SQL. Carries the reason for observability.
+    Build(BuildReason),
+    /// Every clause passed — `R`'s bytes are reusable. In the Stage-1
+    /// ONLY-BUILD posture the runner logs this and **still builds**; the live
+    /// point-to invocation is wired behind the same verdict next.
+    WouldReuse(ReuseCandidate),
+}
+
+/// Already-resolved inputs to the **pure** decision. Every field is gathered
+/// by the caller (config read, shape inspection, state-store lookups, the
+/// writer liveness check) so the decision logic itself does no I/O and is
+/// fully unit-testable with stubs.
+///
+/// The ordering of the fields mirrors clause order. A `None`/empty in an
+/// earlier-clause field short-circuits to BUILD before a later clause is even
+/// consulted — so the caller may pass `None` for fields it never had to fetch
+/// (e.g. it need not run the liveness GET when there was no index match).
+pub struct ReuseInputs<'a> {
+    /// Clause 1 — `[reuse]` enabled AND not `--no-reuse`.
+    pub enabled: bool,
+    /// Clause 2 — content-addressed, unpartitioned, non-rowTracking.
+    pub eligible_shape: bool,
+    /// Clause 3 — this run's recomputed `input_hash`, or `None` when the read
+    /// set did not resolve to an all-strong chain (so no lookup was possible).
+    pub input_hash: Option<&'a str>,
+    /// Clause 3 — the `INPUT_INDEX` hit for [`Self::input_hash`], or `None` on
+    /// a miss.
+    pub candidate: Option<&'a InputIndexEntry>,
+    /// Clause 5 — the [`ArtifactRecord`] for `R`'s output blake3, or `None`
+    /// when the ledger row could not be resolved.
+    pub artifact: Option<&'a ArtifactRecord>,
+    /// Clause 5 — refcount of `R`'s output blake3 in the ledger. `None` when
+    /// the caller short-circuited before counting.
+    pub refcount: Option<u64>,
+    /// Clause 6 — whether `R`'s `add` is still live in the target's
+    /// `_delta_log`. `None` when the caller short-circuited before checking.
+    pub add_is_live: Option<bool>,
+}
+
+/// Decide — purely — whether a content-addressed model may reuse a prior run.
+///
+/// Evaluates clauses 1–6 in order; the **first** failing clause yields its
+/// [`BuildReason`]. Only an all-pass produces [`ReuseVerdict::WouldReuse`].
+///
+/// This function performs **no I/O**: the caller resolves every input first.
+/// That keeps the trust-critical logic small and exhaustively testable — each
+/// clause's false branch is a unit test, and the all-true branch is a unit
+/// test, with the index + writer stubbed.
+#[must_use]
+pub fn decide_reuse(inputs: &ReuseInputs<'_>) -> ReuseVerdict {
+    // Clause 1 — enabled.
+    if !inputs.enabled {
+        return ReuseVerdict::Build(BuildReason::Disabled);
+    }
+    // Clause 2 — eligible shape.
+    if !inputs.eligible_shape {
+        return ReuseVerdict::Build(BuildReason::IneligibleShape);
+    }
+    // Clause 3 — input hash + index match.
+    if inputs.input_hash.is_none() {
+        return ReuseVerdict::Build(BuildReason::NoInputHash);
+    }
+    let Some(candidate) = inputs.candidate else {
+        return ReuseVerdict::Build(BuildReason::NoIndexMatch);
+    };
+    // Clause 4 — strong proof only. Never point-to on a heuristic/watermark
+    // match: it attests freshness, not byte-identity.
+    if candidate.proof_class != "strong" {
+        return ReuseVerdict::Build(BuildReason::NotStrong);
+    }
+    // Clause 5 — artifact resolves + refcount sane. `R` must have recorded an
+    // output blake3 to point at.
+    let Some(blake3_hash) = candidate.output_blake3.first() else {
+        return ReuseVerdict::Build(BuildReason::NoRecordedOutput);
+    };
+    let Some(artifact) = inputs.artifact else {
+        return ReuseVerdict::Build(BuildReason::ArtifactUnresolved);
+    };
+    // The resolved artifact must be the very blake3 the index entry names —
+    // a defence-in-depth guard so a caller bug can never point at the wrong
+    // bytes.
+    if &artifact.blake3_hash != blake3_hash {
+        return ReuseVerdict::Build(BuildReason::ArtifactUnresolved);
+    }
+    // Refcount sanity: `R`'s own ledger row must exist (>= 1). The reusing run
+    // records the second reference, taking it to >= 2, which is what keeps the
+    // shared bytes VACUUM-safe by construction.
+    match inputs.refcount {
+        Some(n) if n >= 1 => {}
+        _ => return ReuseVerdict::Build(BuildReason::RefcountInsufficient),
+    }
+    // Clause 6 — liveness. Any doubt (None) is fail-closed to BUILD.
+    if inputs.add_is_live != Some(true) {
+        return ReuseVerdict::Build(BuildReason::NotLive);
+    }
+
+    ReuseVerdict::WouldReuse(ReuseCandidate {
+        run_id: candidate.run_id.clone(),
+        blake3_hash: blake3_hash.clone(),
+        file_path: artifact.file_path.clone(),
+        commit_version: artifact.commit_version,
+        size_bytes: artifact.size_bytes,
+        proof_class: candidate.proof_class.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn index_entry(proof_class: &str, blake3: &str) -> InputIndexEntry {
+        InputIndexEntry {
+            input_hash: "ih-1".to_string(),
+            run_id: "run-R".to_string(),
+            model_name: "fct_orders".to_string(),
+            output_blake3: if blake3.is_empty() {
+                vec![]
+            } else {
+                vec![blake3.to_string()]
+            },
+            output_path: vec!["s3://b/p/out.parquet".to_string()],
+            proof_class: proof_class.to_string(),
+            recorded_at: Utc::now(),
+        }
+    }
+
+    fn artifact(blake3: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            blake3_hash: blake3.to_string(),
+            run_id: "run-R".to_string(),
+            model_name: "fct_orders".to_string(),
+            file_path: "s3://b/p/out.parquet".to_string(),
+            commit_version: 3,
+            size_bytes: 4096,
+            written_at: Utc::now(),
+        }
+    }
+
+    /// The all-true fixture: every clause passes. Individual tests below mutate
+    /// exactly one field to false and assert the matching BUILD reason.
+    fn all_pass<'a>(entry: &'a InputIndexEntry, art: &'a ArtifactRecord) -> ReuseInputs<'a> {
+        ReuseInputs {
+            enabled: true,
+            eligible_shape: true,
+            input_hash: Some("ih-1"),
+            candidate: Some(entry),
+            artifact: Some(art),
+            refcount: Some(1),
+            add_is_live: Some(true),
+        }
+    }
+
+    #[test]
+    fn all_clauses_true_yields_would_reuse() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let verdict = decide_reuse(&all_pass(&entry, &art));
+        match verdict {
+            ReuseVerdict::WouldReuse(c) => {
+                assert_eq!(c.run_id, "run-R");
+                assert_eq!(c.blake3_hash, "out-hash");
+                assert_eq!(c.commit_version, 3);
+                assert_eq!(c.size_bytes, 4096);
+                assert_eq!(c.proof_class, "strong");
+            }
+            other => panic!("expected WouldReuse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clause1_disabled_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.enabled = false;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::Disabled)
+        );
+    }
+
+    #[test]
+    fn clause2_ineligible_shape_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.eligible_shape = false;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::IneligibleShape)
+        );
+    }
+
+    #[test]
+    fn clause3_no_input_hash_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.input_hash = None;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NoInputHash)
+        );
+    }
+
+    #[test]
+    fn clause3_no_index_match_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.candidate = None;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NoIndexMatch)
+        );
+    }
+
+    #[test]
+    fn clause4_heuristic_builds() {
+        let entry = index_entry("heuristic", "out-hash");
+        let art = artifact("out-hash");
+        let inp = all_pass(&entry, &art);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NotStrong),
+            "a heuristic match must never point-to — it attests freshness, not bytes"
+        );
+    }
+
+    #[test]
+    fn clause4_unknown_proof_class_builds() {
+        let entry = index_entry("none", "out-hash");
+        let art = artifact("out-hash");
+        let inp = all_pass(&entry, &art);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NotStrong)
+        );
+    }
+
+    #[test]
+    fn clause5_no_recorded_output_builds() {
+        let entry = index_entry("strong", ""); // empty output_blake3
+        let art = artifact("out-hash");
+        let inp = all_pass(&entry, &art);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NoRecordedOutput)
+        );
+    }
+
+    #[test]
+    fn clause5_artifact_unresolved_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.artifact = None;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::ArtifactUnresolved)
+        );
+    }
+
+    #[test]
+    fn clause5_artifact_hash_mismatch_builds() {
+        // The resolved artifact's blake3 disagrees with the index entry's —
+        // defence-in-depth: never point at the wrong bytes.
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("DIFFERENT-hash");
+        let inp = all_pass(&entry, &art);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::ArtifactUnresolved)
+        );
+    }
+
+    #[test]
+    fn clause5_refcount_zero_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.refcount = Some(0);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::RefcountInsufficient)
+        );
+    }
+
+    #[test]
+    fn clause5_refcount_none_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.refcount = None;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::RefcountInsufficient)
+        );
+    }
+
+    #[test]
+    fn clause6_not_live_builds() {
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.add_is_live = Some(false);
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NotLive),
+            "a removed/VACUUM'd file must fall back to BUILD"
+        );
+    }
+
+    #[test]
+    fn clause6_liveness_unknown_builds() {
+        // A None liveness (e.g. the caller could not read the log) is a doubt
+        // ⇒ fail-closed to BUILD.
+        let entry = index_entry("strong", "out-hash");
+        let art = artifact("out-hash");
+        let mut inp = all_pass(&entry, &art);
+        inp.add_is_live = None;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::NotLive)
+        );
+    }
+
+    #[test]
+    fn first_failing_clause_wins() {
+        // Disabled AND ineligible AND no match: clause 1 (Disabled) reports.
+        let mut inp = ReuseInputs {
+            enabled: false,
+            eligible_shape: false,
+            input_hash: None,
+            candidate: None,
+            artifact: None,
+            refcount: None,
+            add_is_live: None,
+        };
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::Disabled)
+        );
+        // With clause 1 satisfied, clause 2 (IneligibleShape) reports next.
+        inp.enabled = true;
+        assert_eq!(
+            decide_reuse(&inp),
+            ReuseVerdict::Build(BuildReason::IneligibleShape)
+        );
+    }
+}

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -252,12 +252,14 @@ pub struct DeferOptions {
     pub defer_to: Option<String>,
 }
 
-/// CLI overlay for the opt-in `--skip-unchanged` model-skip gate.
+/// CLI overlay for the run command's build-decision gates — the
+/// `--skip-unchanged` model-skip gate and the `--no-reuse` reuse override.
 ///
-/// Both fields default to `false`, which keeps the gate off and the run
-/// byte-identical to before the gate existed. The gate is a best-effort
-/// optimization, not a result-equivalence guarantee — see
-/// [`rocky_core::config::RunConfig`] and `ModelIr::skip_hash`.
+/// Every field defaults to `false`, which keeps both gates off and the run
+/// byte-identical to before they existed. Neither gate is a result-equivalence
+/// guarantee — see [`rocky_core::config::RunConfig`] and `ModelIr::skip_hash`
+/// for the skip gate, and the fail-closed reuse decision
+/// ([`crate::commands::reuse_decision`]) for reuse.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SkipRunOptions {
     /// Whether `--skip-unchanged` was passed. Turns the gate on for this
@@ -268,6 +270,11 @@ pub struct SkipRunOptions {
     /// model builds unconditionally — the gate's escape hatch. Takes
     /// precedence over `skip_unchanged` and over any config.
     pub force_rebuild: bool,
+    /// Whether `--no-reuse` was passed. When `true`, the content-addressed
+    /// reuse decision is disabled for this invocation even if `[reuse]` is
+    /// enabled in config — clause 1 of the fail-closed gate. The escape
+    /// hatch that forces every content-addressed model to BUILD.
+    pub no_reuse: bool,
 }
 
 /// Fully-resolved configuration for the model-skip gate, assembled in
@@ -1115,7 +1122,11 @@ pub async fn run(
             false, // model-only entry point has no pipeline governance context
             defer_opts,
             skip_gate,
-            rocky_cfg.reuse.enabled,
+            // Reuse is active iff `[reuse]` is enabled AND `--no-reuse` was
+            // not passed (clause 1 of the fail-closed decision). `--no-reuse`
+            // suppresses the whole reuse path for this invocation — both the
+            // point-to decision and the spine population it would feed.
+            rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
         )
         .await?;
 
@@ -3212,7 +3223,9 @@ pub async fn run(
                     // set (a full run builds every model).
                     defer_opts,
                     skip_gate,
-                    rocky_cfg.reuse.enabled,
+                    // Reuse is active iff `[reuse]` is enabled AND `--no-reuse`
+                    // was not passed (clause 1 of the fail-closed decision).
+                    rocky_cfg.reuse.enabled && !skip_opts.no_reuse,
                 )
                 .await?;
                 Ok(())
@@ -4448,8 +4461,40 @@ pub(crate) async fn execute_models(
                     model_ir.target.schema.clone(),
                     model_ir.target.table.clone(),
                 ];
+                // Build the fail-closed reuse-decision context (clauses 1–3
+                // input side). Only for an unpartitioned (clause 2) model when
+                // `[reuse]` is active (clause 1) and a state store exists —
+                // otherwise pass `None` for a zero-cost pure BUILD. The
+                // decision-time `input_hash` is recomputed from the SAME
+                // all-strong upstream chain + `skip_hash` + target that spine
+                // population uses, so a hit is only possible when the inputs
+                // genuinely match a prior strong run.
+                let reuse_ctx = if reuse_enabled {
+                    let model_is_unpartitioned = !matches!(
+                        &model_ir.materialization,
+                        MaterializationStrategy::ContentAddressed { partition_columns, .. }
+                            if !partition_columns.is_empty()
+                    );
+                    match (model_is_unpartitioned, state_store) {
+                        (true, Some(store)) => {
+                            let input_hash = compute_decision_input_hash(
+                                &model_ir,
+                                &reuse_target_by_model,
+                                &reuse_outputs,
+                            );
+                            Some(super::run_content_addressed::ReuseDecisionCtx {
+                                input_hash,
+                                state_store: store,
+                                run_id,
+                            })
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
                 let summary = super::run_content_addressed::execute_content_addressed_model(
-                    &model_ir, warehouse,
+                    &model_ir, warehouse, reuse_ctx,
                 )
                 .await
                 .with_context(|| format!("model '{model_name}' failed"));
@@ -4797,6 +4842,37 @@ where
 /// not indexed. A model that reads nothing resolves to an empty (vacuously
 /// strong) set. This keeps a `strong` label honest: a mixed-input or ambiguous
 /// model is never mislabeled — it is simply deferred.
+/// Recompute a content-addressed model's decision-time `input_hash` for the
+/// fail-closed reuse gate, using the **same** all-strong upstream chain +
+/// `skip_hash` + target identity that spine population
+/// ([`rocky_core::reuse::build_records`]) folds into the key it stores. This
+/// symmetry is load-bearing: the gate can only hit a prior run's `INPUT_INDEX`
+/// entry when the inputs genuinely match.
+///
+/// Returns `None` — a guaranteed BUILD (clause 3) — when the read set does not
+/// resolve to an all-strong content-hash chain (a raw source, a mixed/heuristic
+/// or ambiguous read, a model not built this run) or the model cannot be
+/// canonicalised (`skip_hash` is `None`). A `None` here is the same fail-safe
+/// that keeps a `strong` label honest on the population side.
+fn compute_decision_input_hash(
+    model_ir: &rocky_ir::ModelIr,
+    target_by_model: &std::collections::HashMap<String, String>,
+    outputs_by_target: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    let upstreams =
+        resolve_read_set_content_upstreams(&model_ir.sql, target_by_model, outputs_by_target)?;
+    let skip_hash = model_ir.skip_hash()?.to_hex().to_string();
+    let target_identity = format!(
+        "{}.{}.{}",
+        model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
+    );
+    Some(
+        rocky_core::reuse::compute_input_hash(&skip_hash, &target_identity, &upstreams)
+            .to_hex()
+            .to_string(),
+    )
+}
+
 fn resolve_read_set_content_upstreams(
     sql: &str,
     target_by_model: &std::collections::HashMap<String, String>,

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -35,6 +35,7 @@ use rocky_iceberg::uniform_writer::{
     Result as UfResult, SqlClient, UniformWriter, UniformWriterConfig, UniformWriterError,
 };
 use rocky_ir::{MaterializationStrategy, ModelIr, RockyType, TypedColumn};
+use tracing::{debug, info, warn};
 use url::Url;
 
 /// Placeholder SqlClient used at writer construction time.
@@ -477,15 +478,143 @@ fn parse_decimal_to_i128(s: &str, scale: u8) -> Result<i128> {
     Ok(sign * magnitude)
 }
 
+/// Reuse-decision context handed to [`execute_content_addressed_model`] when
+/// `[reuse]` is active (clause 1 already satisfied by the caller passing a
+/// `Some`).
+///
+/// The caller resolves the *cheap* inputs (the model's recomputed `input_hash`
+/// from its all-strong upstream chain, plus a state-store handle and the run
+/// id). The expensive, writer-bound clause — liveness against the target's
+/// live `_delta_log` — is evaluated *inside* `execute_content_addressed_model`,
+/// where the `UniformWriter` already exists. Passing `None` (reuse off, no
+/// resolvable input hash, partitioned, …) is a zero-cost pure BUILD.
+pub struct ReuseDecisionCtx<'a> {
+    /// This run's recomputed `input_hash` (hex) — `None` when the model's read
+    /// set did not resolve to an all-strong content-hash chain, in which case
+    /// the decision is a guaranteed BUILD (clause 3).
+    pub input_hash: Option<String>,
+    /// State store for the `INPUT_INDEX` / `OUTPUT_ARTIFACTS` lookups.
+    pub state_store: &'a rocky_core::state::StateStore,
+    /// This run's id (for the would-reuse log line).
+    pub run_id: &'a str,
+}
+
+/// Evaluate the **fail-closed reuse decision** for a content-addressed model.
+///
+/// Resolves clauses 3–6 (the caller has already established clauses 1–2 by
+/// passing a `Some(ctx)` for an unpartitioned, non-rowTracking model) and
+/// returns the verdict. Any lookup error or unreadable log is mapped to a
+/// BUILD verdict — never propagated — so a state-store or object-store hiccup
+/// can only ever cause a (safe) rebuild, never a wrong reuse.
+async fn evaluate_reuse_decision(
+    ctx: &ReuseDecisionCtx<'_>,
+    writer: &UniformWriter,
+    state: &rocky_iceberg::uniform_writer::UniformTableState,
+) -> crate::commands::reuse_decision::ReuseVerdict {
+    use crate::commands::reuse_decision::{BuildReason, ReuseInputs, ReuseVerdict, decide_reuse};
+
+    // Clause 2 (runtime confirmation): the discovered table must itself be
+    // unpartitioned + non-rowTracking. The caller gates on the *model's*
+    // declared shape; this re-checks the *table's* actual shape so a drift
+    // between the two can only fall back to BUILD.
+    let eligible_shape = state.partition_columns.is_empty() && !state.row_tracking_enabled;
+
+    // Clause 3 — input hash present + index hit. Any lookup error ⇒ BUILD.
+    let Some(input_hash) = ctx.input_hash.as_deref() else {
+        return decide_reuse(&ReuseInputs {
+            enabled: true,
+            eligible_shape,
+            input_hash: None,
+            candidate: None,
+            artifact: None,
+            refcount: None,
+            add_is_live: None,
+        });
+    };
+    let candidate = match ctx.state_store.get_by_input_hash(input_hash) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, input_hash, "reuse: INPUT_INDEX lookup failed; building");
+            None
+        }
+    };
+
+    // Clauses 5–6 need the candidate's recorded output blake3. Resolve the
+    // artifact + refcount + liveness only when there is a strong candidate to
+    // resolve — every failure path here is fail-closed to BUILD.
+    let mut artifact: Option<rocky_core::state::ArtifactRecord> = None;
+    let mut refcount: Option<u64> = None;
+    let mut add_is_live: Option<bool> = None;
+    if let Some(c) = candidate.as_ref()
+        && c.proof_class == "strong"
+        && let Some(blake3) = c.output_blake3.first()
+    {
+        match ctx.state_store.list_artifacts_by_hash(blake3) {
+            Ok(records) => artifact = records.into_iter().next(),
+            Err(e) => warn!(error = %e, blake3, "reuse: artifact lookup failed; building"),
+        }
+        match ctx.state_store.refcount_for_hash(blake3) {
+            Ok(n) => refcount = Some(n),
+            Err(e) => warn!(error = %e, blake3, "reuse: refcount lookup failed; building"),
+        }
+        // Liveness (clause 6): the recovered `add`'s path must still be live
+        // in THIS table's `_delta_log`. The `add.path` is relative to the
+        // table prefix — derive it from the artifact's full object path.
+        if let Some(a) = artifact.as_ref() {
+            let add_file_path = a.file_path.rsplit('/').next().unwrap_or(&a.file_path);
+            match writer.add_path_is_live(add_file_path).await {
+                Ok(live) => add_is_live = Some(live),
+                Err(e) => warn!(
+                    error = %e,
+                    add_file_path,
+                    "reuse: liveness check failed; building"
+                ),
+            }
+        }
+    }
+
+    let verdict = decide_reuse(&ReuseInputs {
+        enabled: true,
+        eligible_shape,
+        input_hash: Some(input_hash),
+        candidate: candidate.as_ref(),
+        artifact: artifact.as_ref(),
+        refcount,
+        add_is_live,
+    });
+    if let ReuseVerdict::Build(BuildReason::NotLive) = &verdict
+        && add_is_live == Some(false)
+    {
+        info!(
+            input_hash,
+            "reuse: candidate found but its file is no longer live in the target log; building"
+        );
+    }
+    verdict
+}
+
 /// Materialize a single model whose strategy is
 /// [`MaterializationStrategy::ContentAddressed`].
 ///
 /// Handles both unpartitioned (single `write_batch` commit) and
 /// partitioned (one `write_partitioned_batch` commit per partition tuple)
 /// targets.
+///
+/// # Reuse decision (Stage 1 — ONLY-BUILD)
+///
+/// When `reuse_ctx` is `Some`, the **fail-closed reuse decision** runs after
+/// `discover()` and *before* `execute_query`: if every clause holds (enabled,
+/// eligible shape, input-hash match to a STRONG prior run `R`, `R`'s artifact
+/// resolves with a sane refcount, and `R`'s file is still live in the target's
+/// `_delta_log`), the model *could* point-to `R`'s bytes. In this slice the
+/// decision is **ONLY-BUILD**: a positive verdict is *logged* (`would-reuse
+/// R`) and the model is **still built**. A decision that can only BUILD is
+/// incapable of producing a wrong output, which is the safe first step before
+/// the live point-to invocation is wired behind the same verdict.
 pub async fn execute_content_addressed_model(
     model_ir: &ModelIr,
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    reuse_ctx: Option<ReuseDecisionCtx<'_>>,
 ) -> Result<ContentAddressedRunSummary> {
     let MaterializationStrategy::ContentAddressed {
         storage_prefix,
@@ -532,6 +661,39 @@ pub async fn execute_content_addressed_model(
             partition_columns,
             state.partition_columns
         ));
+    }
+
+    // 3b. Fail-closed reuse decision (Stage 1 — ONLY-BUILD). Computed only
+    // when `[reuse]` is active (caller passed `Some`). On a would-reuse
+    // verdict we LOG and still BUILD: a decision that can only build cannot
+    // produce a wrong output. The live point-to invocation is wired behind
+    // this same verdict next.
+    if let Some(ctx) = &reuse_ctx {
+        let verdict = evaluate_reuse_decision(ctx, &writer, &state).await;
+        match verdict {
+            crate::commands::reuse_decision::ReuseVerdict::WouldReuse(candidate) => {
+                info!(
+                    model = %model_ir.name,
+                    run_id = ctx.run_id,
+                    target = %format!(
+                        "{}.{}.{}",
+                        model_ir.target.catalog, model_ir.target.schema, model_ir.target.table
+                    ),
+                    reuse_run_id = candidate.run_id.as_str(),
+                    blake3 = candidate.blake3_hash.as_str(),
+                    commit_version = candidate.commit_version,
+                    proof_class = candidate.proof_class.as_str(),
+                    "reuse: would point-to prior run R (ONLY-BUILD: still executing the SQL this run)"
+                );
+            }
+            crate::commands::reuse_decision::ReuseVerdict::Build(reason) => {
+                debug!(
+                    model = %model_ir.name,
+                    reason = reason.as_str(),
+                    "reuse: building (no eligible point-to candidate)"
+                );
+            }
+        }
     }
 
     // 4. Execute the model SQL.
@@ -1350,7 +1512,7 @@ mod live_tests {
             },
         ];
 
-        let summary = execute_content_addressed_model(&model_ir, warehouse_dyn)
+        let summary = execute_content_addressed_model(&model_ir, warehouse_dyn, None)
             .await
             .expect("partitioned end-to-end must succeed");
         assert_eq!(
@@ -1470,7 +1632,7 @@ mod live_tests {
             },
         ];
 
-        let summary = execute_content_addressed_model(&model_ir, warehouse_dyn)
+        let summary = execute_content_addressed_model(&model_ir, warehouse_dyn, None)
             .await
             .expect("end-to-end runner must succeed");
         assert_eq!(summary.num_rows, 3);

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -549,8 +549,21 @@ async fn evaluate_reuse_decision(
         && c.proof_class == "strong"
         && let Some(blake3) = c.output_blake3.first()
     {
+        // `list_artifacts_by_hash` returns *every* ledger row carrying this
+        // blake3. Because the hash is a CONTENT hash, byte-identical parquet
+        // across virtual branches / replayed runs (the documented refcount > 1
+        // case) yields multiple same-blake3 rows for *different* tables — so a
+        // bare `.next()` could resolve a row belonging to some other
+        // `(run_id, model_name)`, corrupting the candidate's `file_path` +
+        // `commit_version` that the live point-to GET is load-bearing on.
+        // Pin the row to R's own `(run_id, model_name)`. A no-match falls
+        // through to the existing `ArtifactUnresolved` fail-closed BUILD.
         match ctx.state_store.list_artifacts_by_hash(blake3) {
-            Ok(records) => artifact = records.into_iter().next(),
+            Ok(records) => {
+                artifact = records
+                    .into_iter()
+                    .find(|r| r.run_id == c.run_id && r.model_name == c.model_name);
+            }
             Err(e) => warn!(error = %e, blake3, "reuse: artifact lookup failed; building"),
         }
         match ctx.state_store.refcount_for_hash(blake3) {
@@ -1347,6 +1360,200 @@ mod tests {
         assert!(!arr.is_null(0));
         assert!(arr.is_null(1));
         assert!(!arr.is_null(2));
+    }
+
+    // --- Cross-table artifact resolution (clause 5) ------------------------
+    //
+    // `list_artifacts_by_hash` returns a row per `{run_id, model_name,
+    // file_path}`. Because blake3 is a CONTENT hash, byte-identical parquet
+    // across virtual branches / replayed runs produces multiple same-blake3
+    // rows for *different* tables. `evaluate_reuse_decision` must resolve R's
+    // OWN ledger row (its correct `file_path`/`commit_version`), not whichever
+    // row the redb key order happens to surface first.
+
+    use object_store::PutPayload;
+    use object_store::memory::InMemory;
+    use object_store::path::Path as ObjPath;
+
+    /// Seed an unpartitioned, non-rowTracking bootstrap commit (`v=0`) plus a
+    /// single `add` commit (`v=1`) that adds `live_basename`. After this, only
+    /// `live_basename` is live in the table's `_delta_log`.
+    async fn seed_unpartitioned_with_live_add(store: &InMemory, prefix: &str, live_basename: &str) {
+        let bootstrap = serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 2,
+                "minWriterVersion": 7,
+                "writerFeatures": ["columnMapping", "icebergCompatV2", "invariants", "appendOnly"],
+            }
+        });
+        let metadata = serde_json::json!({
+            "metaData": {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": serde_json::to_string(&serde_json::json!({
+                    "type": "struct",
+                    "fields": [
+                        {"name": "id", "type": "long", "nullable": false, "metadata": {
+                            "delta.columnMapping.id": 1,
+                            "delta.columnMapping.physicalName": "col-id-uuid"
+                        }}
+                    ]
+                })).unwrap(),
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.columnMapping.mode": "name",
+                    "delta.universalFormat.enabledFormats": "iceberg",
+                    "delta.enableIcebergCompatV2": "true"
+                },
+                "createdTime": 0
+            }
+        });
+        let bootstrap_body = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&bootstrap).unwrap(),
+            serde_json::to_string(&metadata).unwrap(),
+        );
+        store
+            .put(
+                &ObjPath::from(format!("{prefix}/_delta_log/00000000000000000000.json")),
+                PutPayload::from(bootstrap_body.into_bytes()),
+            )
+            .await
+            .unwrap();
+
+        // v=1: an `add` for the live file. This is the *only* path the
+        // liveness scan will classify as `Added`.
+        let add_commit = serde_json::json!({"add": {"path": live_basename}});
+        let add_body = format!("{}\n", serde_json::to_string(&add_commit).unwrap());
+        store
+            .put(
+                &ObjPath::from(format!("{prefix}/_delta_log/00000000000000000001.json")),
+                PutPayload::from(add_body.into_bytes()),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn artifact_row(
+        run_id: &str,
+        model_name: &str,
+        blake3: &str,
+        file_path: &str,
+        commit_version: u64,
+    ) -> rocky_core::state::ArtifactRecord {
+        rocky_core::state::ArtifactRecord {
+            blake3_hash: blake3.to_string(),
+            run_id: run_id.to_string(),
+            model_name: model_name.to_string(),
+            file_path: file_path.to_string(),
+            commit_version,
+            size_bytes: 4096,
+            written_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn evaluate_reuse_resolves_r_own_artifact_row_not_another_tables() {
+        // Two byte-identical (same-blake3) writes exist in the ledger:
+        //  - run-A / other_model wrote a DIFFERENT table's file (sorts FIRST
+        //    in the redb `{run_id}|...` key order, so a bare `.next()` picks it)
+        //  - run-R / fct_orders wrote THIS table's file (the correct row)
+        // Only run-R's file is live in this table's `_delta_log`.
+        let prefix = "tbl";
+        let r_basename = "rrrrrrrrrrrrrrrrrrrrrrrr.parquet";
+        let r_file_path = format!("s3://bucket/{prefix}/{r_basename}");
+        let r_commit_version = 7_u64;
+        let other_file_path = "s3://bucket/other-tbl/aaaaaaaaaaaaaaaaaaaaaaaa.parquet";
+
+        // State store with the INPUT_INDEX entry + two same-blake3 rows.
+        let dir = tempfile::TempDir::new().unwrap();
+        let state_store =
+            rocky_core::state::StateStore::open(&dir.path().join("state.redb")).unwrap();
+        let index_entry = rocky_core::state::InputIndexEntry {
+            input_hash: "ih-cross-table".to_string(),
+            run_id: "run-R".to_string(),
+            model_name: "fct_orders".to_string(),
+            output_blake3: vec!["shared-blake3".to_string()],
+            output_path: vec![r_file_path.clone()],
+            proof_class: "strong".to_string(),
+            recorded_at: chrono::Utc::now(),
+        };
+        state_store
+            .record_reuse_spine(std::slice::from_ref(&index_entry), &[])
+            .unwrap();
+        // Seed the OTHER table's row first — its `run-A` key sorts before
+        // `run-R`, so the pre-fix `.next()` would surface it.
+        state_store
+            .record_artifact(&artifact_row(
+                "run-A",
+                "other_model",
+                "shared-blake3",
+                other_file_path,
+                99,
+            ))
+            .unwrap();
+        state_store
+            .record_artifact(&artifact_row(
+                "run-R",
+                "fct_orders",
+                "shared-blake3",
+                &r_file_path,
+                r_commit_version,
+            ))
+            .unwrap();
+
+        // Writer + discovered state over an InMemory store where only R's
+        // file is live.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_unpartitioned_with_live_add(&store, prefix, r_basename).await;
+        let writer = UniformWriter::new(
+            UniformWriterConfig {
+                catalog: "c".into(),
+                schema: "s".into(),
+                table: "t".into(),
+                prefix: prefix.into(),
+                engine_info: "rocky-cli/test".into(),
+            },
+            store.clone() as Arc<dyn ObjectStore>,
+            Arc::new(NoOpSqlClient),
+        );
+        let state = writer
+            .discover()
+            .await
+            .expect("discover unpartitioned state");
+        assert!(
+            state.partition_columns.is_empty() && !state.row_tracking_enabled,
+            "fixture must be the eligible unpartitioned, non-rowTracking shape"
+        );
+
+        let ctx = ReuseDecisionCtx {
+            input_hash: Some("ih-cross-table".to_string()),
+            state_store: &state_store,
+            run_id: "run-current",
+        };
+        let verdict = evaluate_reuse_decision(&ctx, &writer, &state).await;
+
+        // Load-bearing: pre-fix, `.next()` resolves run-A's row (other table),
+        // whose basename is NOT live ⇒ Build(NotLive). Post-fix, `.find`
+        // resolves run-R's own row ⇒ WouldReuse with R's commit_version.
+        match verdict {
+            crate::commands::reuse_decision::ReuseVerdict::WouldReuse(c) => {
+                assert_eq!(c.run_id, "run-R");
+                assert_eq!(
+                    c.commit_version, r_commit_version,
+                    "must carry R's OWN commit_version, not the other table's"
+                );
+                assert_eq!(
+                    c.file_path, r_file_path,
+                    "must carry R's OWN file_path, not the other table's"
+                );
+            }
+            other => panic!(
+                "expected WouldReuse resolved to R's own row; got {other:?} \
+                 (a Build(NotLive) here is the pre-fix bug: the wrong table's \
+                 row was resolved and its file is not live in this log)"
+            ),
+        }
     }
 }
 

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -611,6 +611,20 @@ pub(super) fn commit_jsonl_reference_for_path(
 /// — as "not provably live" and BUILDs. A `false` return (provably removed or
 /// absent) is the explicit "do not reuse" answer.
 ///
+/// # Limitations
+///
+/// This scans only the `_delta_log/<20-digit>.json` commit files; it does
+/// **not** consult Delta **checkpoint** parquet files (`*.checkpoint.parquet`,
+/// `_last_checkpoint`). On a table whose log has been **truncated** behind a
+/// checkpoint, `R`'s original `add` commit JSON is no longer present, so this
+/// returns `Absent` ⇒ not-live ⇒ BUILD even though the file is still active.
+/// That is **fail-closed** (a missed reuse, never a wrong reuse), so the gate
+/// stays correct — but it silently disables reuse on large/old (checkpointed)
+/// tables. Folding in checkpoint state (read `_last_checkpoint`, then the
+/// referenced checkpoint parquet's surviving `add`s before the JSON tail) is a
+/// tracked follow-up; until then, an invocation author must expect reuse to
+/// quietly degrade to BUILD once a table accumulates a checkpoint.
+///
 /// # Errors
 ///
 /// [`UniformWriterError::ObjectStore`] when the listing or a GET fails;

--- a/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/discover.rs
@@ -528,6 +528,127 @@ pub(super) async fn find_commit_with_add_path<S: ObjectStore + ?Sized>(
     Ok(None)
 }
 
+/// Per-commit reference outcome for a single content-addressed file path.
+///
+/// Returned by [`commit_jsonl_reference_for_path`] for one `_delta_log` commit
+/// body. The point-to liveness check folds these across commits in version
+/// order: a file is **live** iff the highest-versioned commit that references
+/// it does so with an `add`, not a `remove`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PathReference {
+    /// The commit contains an `add` action for the path.
+    Added,
+    /// The commit contains a `remove` action for the path (and no `add`).
+    Removed,
+    /// The commit does not reference the path at all.
+    Absent,
+}
+
+/// Classify how a single `_delta_log` commit body (JSONL) references
+/// `file_path`: as an `add`, as a `remove`, or not at all.
+///
+/// Pure parsing — no I/O — so it is unit-testable. A single content-addressed
+/// commit carries exactly one `add` (see `commit::build_commit_jsonl`); a
+/// compaction/VACUUM commit carries a `remove`. If a commit somehow contains
+/// both for the same path (it never does in practice), `Added` wins for that
+/// commit — but the cross-commit fold in [`add_path_is_live`] is what carries
+/// the real ordering, so a later `remove` commit still supersedes an earlier
+/// `add` commit.
+pub(super) fn commit_jsonl_reference_for_path(
+    body: &[u8],
+    file_path: &str,
+) -> Result<PathReference> {
+    let text = std::str::from_utf8(body)
+        .map_err(|e| UniformWriterError::DeltaLog(format!("non-utf8 _delta_log: {e}")))?;
+    let mut saw_remove = false;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| UniformWriterError::DeltaLog(format!("scan path reference: {e}")))?;
+        if let Some(add) = value.get("add")
+            && add.get("path").and_then(|v| v.as_str()) == Some(file_path)
+        {
+            return Ok(PathReference::Added);
+        }
+        if let Some(remove) = value.get("remove")
+            && remove.get("path").and_then(|v| v.as_str()) == Some(file_path)
+        {
+            saw_remove = true;
+        }
+    }
+    if saw_remove {
+        Ok(PathReference::Removed)
+    } else {
+        Ok(PathReference::Absent)
+    }
+}
+
+/// Determine whether `add_file_path` is **still live** in the target table's
+/// current `_delta_log` — i.e. it was `add`ed and has NOT since been
+/// `remove`d (VACUUM'd / compacted / superseded).
+///
+/// This is the liveness gate the fail-closed reuse decision needs **before**
+/// pointing a new commit at a prior run `R`'s parquet: if `R`'s file is no
+/// longer active in the target table's log, reusing it would point a commit at
+/// a file Delta considers removed — a no-op into removed bytes. The decision
+/// must fall back to a normal BUILD in that case.
+///
+/// # Semantics
+///
+/// Scans every `_delta_log/<20-digit>.json` commit, classifies each via
+/// [`commit_jsonl_reference_for_path`], and takes the reference from the
+/// **highest-versioned** commit that mentions the path. The file is live iff
+/// that reference is an `add`. A path that no commit references (it was never
+/// added to *this* table, or its add was rewritten away with no surviving add)
+/// is **not** live.
+///
+/// # Fail-closed
+///
+/// Any object-store error (cannot list, cannot GET a commit) or a malformed
+/// commit body returns `Err`; the caller treats that — like every other doubt
+/// — as "not provably live" and BUILDs. A `false` return (provably removed or
+/// absent) is the explicit "do not reuse" answer.
+///
+/// # Errors
+///
+/// [`UniformWriterError::ObjectStore`] when the listing or a GET fails;
+/// [`UniformWriterError::DeltaLog`] when a commit body cannot be parsed.
+pub(super) async fn add_path_is_live<S: ObjectStore + ?Sized>(
+    store: &S,
+    prefix: &str,
+    add_file_path: &str,
+) -> Result<bool> {
+    use futures::TryStreamExt;
+    let log_prefix = Path::from(format!("{prefix}/_delta_log"));
+    let mut versions: Vec<(u64, Path)> = Vec::new();
+    let mut stream = store.list(Some(&log_prefix));
+    while let Some(meta) = stream.try_next().await? {
+        let key = meta.location.to_string();
+        if let Some((_, last)) = key.rsplit_once('/')
+            && let Some(stem) = last.strip_suffix(".json")
+            && stem.len() == 20
+            && let Ok(v) = stem.parse::<u64>()
+        {
+            versions.push((v, meta.location));
+        }
+    }
+    // Newest → oldest: the first commit that references the path decides
+    // liveness (a later remove supersedes an earlier add).
+    versions.sort_by_key(|(v, _)| std::cmp::Reverse(*v));
+    for (_version, path) in versions {
+        let body = store.get(&path).await?.bytes().await?;
+        match commit_jsonl_reference_for_path(&body, add_file_path)? {
+            PathReference::Added => return Ok(true),
+            PathReference::Removed => return Ok(false),
+            PathReference::Absent => {}
+        }
+    }
+    // No commit references the path at all — not live in this table.
+    Ok(false)
+}
+
 /// Scan `_delta_log/` for the highest `<20-digit>.json` and return that + 1.
 pub(super) async fn next_commit_version<S: ObjectStore + ?Sized>(
     store: &S,
@@ -621,6 +742,42 @@ mod tests {
         assert!(
             first_add_action(body).unwrap().is_none(),
             "a commit with no add action yields None"
+        );
+    }
+
+    #[test]
+    fn commit_reference_classifies_add_remove_absent() {
+        let added = br#"{"commitInfo":{}}
+{"add":{"path":"data/h.parquet","size":42}}"#;
+        assert_eq!(
+            commit_jsonl_reference_for_path(added, "data/h.parquet").unwrap(),
+            PathReference::Added
+        );
+
+        let removed = br#"{"commitInfo":{}}
+{"remove":{"path":"data/h.parquet","dataChange":true}}"#;
+        assert_eq!(
+            commit_jsonl_reference_for_path(removed, "data/h.parquet").unwrap(),
+            PathReference::Removed
+        );
+
+        let other = br#"{"add":{"path":"data/other.parquet"}}"#;
+        assert_eq!(
+            commit_jsonl_reference_for_path(other, "data/h.parquet").unwrap(),
+            PathReference::Absent,
+            "a commit referencing a different path does not reference ours"
+        );
+    }
+
+    #[test]
+    fn commit_reference_add_wins_within_a_single_commit() {
+        // A single commit carrying both (it never does in practice) reports
+        // Added — the cross-commit fold in add_path_is_live carries ordering.
+        let both = br#"{"add":{"path":"data/h.parquet"}}
+{"remove":{"path":"data/h.parquet"}}"#;
+        assert_eq!(
+            commit_jsonl_reference_for_path(both, "data/h.parquet").unwrap(),
+            PathReference::Added
         );
     }
 

--- a/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
+++ b/engine/crates/rocky-iceberg/src/uniform_writer/mod.rs
@@ -497,6 +497,30 @@ impl UniformWriter {
         )))
     }
 
+    /// Whether a prior run `R`'s content-addressed file is **still live** in
+    /// this table's current `_delta_log` — added and not since removed
+    /// (VACUUM'd / compacted / superseded).
+    ///
+    /// The liveness gate the fail-closed reuse decision consults **before**
+    /// pointing a new commit at `R`'s parquet. A `false` answer (the file was
+    /// `remove`d, or no commit in this table references it) means a point-to
+    /// would reference removed bytes — the caller must fall back to a normal
+    /// BUILD. Any error (cannot read the log) is propagated so the caller can
+    /// treat the doubt as "not provably live" and BUILD.
+    ///
+    /// `add_file_path` is the path relative to the table prefix
+    /// (`<hash>.parquet`), i.e. [`PointerInputs::add_file_path`].
+    ///
+    /// # Errors
+    ///
+    /// [`UniformWriterError::ObjectStore`] when the `_delta_log` listing or a
+    /// commit GET fails; [`UniformWriterError::DeltaLog`] when a commit body
+    /// cannot be parsed.
+    pub async fn add_path_is_live(&self, add_file_path: &str) -> Result<bool> {
+        let prefix = self.config.prefix.trim_end_matches('/').to_string();
+        discover::add_path_is_live(&*self.store, &prefix, add_file_path).await
+    }
+
     /// Shared write pipeline used by both unpartitioned and partitioned
     /// entry points. `path_for_hash` produces the `add.path` (relative to
     /// the table prefix) given the blake3 hash of the Parquet bytes.
@@ -1352,5 +1376,68 @@ mod tests {
 
         let result = writer.write_batch(make_batch(3)).await.unwrap();
         assert_eq!(result.commit_version, 2, "writer must skip the parked v=1");
+    }
+
+    #[tokio::test]
+    async fn add_path_is_live_true_for_a_freshly_written_file() {
+        // After a normal build, the file's `add` is live (no later remove).
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_bootstrap(&store, "tbl").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl");
+        let r = writer.write_batch(make_batch(4)).await.unwrap();
+        let add_file = r.file_path.split('/').next_back().unwrap();
+
+        assert!(
+            writer.add_path_is_live(add_file).await.unwrap(),
+            "a just-added file must be live"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_path_is_live_false_after_a_later_remove() {
+        // Build, then land a later commit that `remove`s the file (the
+        // VACUUM/compaction case). Liveness must flip to false so the reuse
+        // decision falls back to BUILD rather than pointing at removed bytes.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_bootstrap(&store, "tbl").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl");
+        let r = writer.write_batch(make_batch(4)).await.unwrap();
+        let add_file = r.file_path.split('/').next_back().unwrap();
+
+        // Land v=2: a remove of R's file (what a VACUUM/compaction emits).
+        let remove_body = format!(
+            "{{\"commitInfo\":{{\"operation\":\"VACUUM END\"}}}}\n\
+             {{\"remove\":{{\"path\":\"{add_file}\",\"dataChange\":false}}}}\n"
+        );
+        store
+            .put(
+                &object_store::path::Path::from(
+                    "tbl/_delta_log/00000000000000000002.json".to_string(),
+                ),
+                PutPayload::from(Bytes::from(remove_body)),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !writer.add_path_is_live(add_file).await.unwrap(),
+            "a removed file must NOT be live — reuse must fall back to BUILD"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_path_is_live_false_for_a_path_no_commit_references() {
+        // A path that was never added to this table is not live.
+        let store: Arc<InMemory> = Arc::new(InMemory::new());
+        seed_bootstrap(&store, "tbl").await;
+        let writer = make_unpartitioned_writer(store.clone() as Arc<dyn ObjectStore>, "tbl");
+
+        assert!(
+            !writer
+                .add_path_is_live("never-added.parquet")
+                .await
+                .unwrap(),
+            "a path no commit references is not live in this table"
+        );
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -699,6 +699,18 @@ enum Command {
         /// can't see, like a UDF redefinition or a session-setting change).
         #[arg(long)]
         force_rebuild: bool,
+
+        /// Disable the content-addressed reuse decision for this invocation,
+        /// even when `[reuse]` is enabled in config.
+        ///
+        /// When `[reuse]` is on, a content-addressed model whose declared
+        /// inputs byte-for-byte match a prior strong run may point a new Delta
+        /// commit at that run's already-written parquet instead of executing
+        /// its SQL — a fail-closed decision that BUILDs on any doubt. This
+        /// flag is the escape hatch that forces every model to BUILD,
+        /// parallel to `--force-rebuild` for `--skip-unchanged`. Default OFF.
+        #[arg(long)]
+        no_reuse: bool,
     },
 
     /// Compare shadow tables against production tables
@@ -2365,6 +2377,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             defer_to,
             skip_unchanged,
             force_rebuild,
+            no_reuse,
         } => {
             // --idempotency-key is mutually exclusive with --resume / --resume-latest:
             // a resume is an explicit override and should never be short-circuited.
@@ -2425,6 +2438,7 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             let skip_opts = rocky_cli::commands::SkipRunOptions {
                 skip_unchanged,
                 force_rebuild,
+                no_reuse,
             };
 
             if watch {


### PR DESCRIPTION
## What

Wires the **content-addressed reuse DECISION** on top of the input-match spine (#835) and the point-to writer (#838). A wrong reuse is a *silent wrong production output* — same blast radius as a wrong skip — so the gate is **fail-closed**: a model reuses a prior run `R`'s output **iff every** clause holds, and **any** false answer or error means **BUILD** (execute the SQL).

## The fail-closed contract (the six clauses)

A content-addressed model may point-to `R`'s already-written parquet **only when all** hold; **any** false/error ⇒ BUILD:

1. **Enabled** — `[reuse]` on in config **AND** `--no-reuse` not passed.
2. **Eligible shape** — content-addressed, **unpartitioned**, **non-rowTracking** (the only shape the point-to writer supports; partitioned/rowTracking point-to deferred). Re-checked against the *table's actual* discovered shape, not just the model's declared shape.
3. **Input match** — this run's `input_hash` (resolved all-strong upstream content identities ‖ `skip_hash` ‖ target, recomputed via the **same** path spine population uses) hits the `INPUT_INDEX`, yielding candidate prior run `R`. A read set that doesn't resolve to an all-strong chain (raw source, mixed/heuristic, ambiguous, not-built-this-run) ⇒ no hit ⇒ BUILD.
4. **Strong proof** — `R.proof_class == "strong"`. A `heuristic`/watermark match attests *freshness*, not byte-identity — never point-to on it.
5. **Artifact resolves** — `R`'s recorded output blake3 resolves to an `ArtifactRecord` whose hash matches (defence-in-depth) and whose refcount is sane (`>= 1`; the reusing run takes it to `>= 2`, keeping the shared bytes VACUUM-safe by construction).
6. **Liveness** — `R`'s `add` is **still live** in the *target's current `_delta_log`* — not VACUUM'd, compacted, or superseded by a later `remove`. If the file is gone or the log can't be read ⇒ BUILD.

The decision logic (`commands/reuse_decision.rs`) is **pure and I/O-free**: the caller resolves every input first (config, shape, state-store lookups, the writer liveness check), so the trust-critical core is exhaustively unit-testable. Every lookup/log-read error is mapped to BUILD, never propagated — a state-store or object-store hiccup can only ever cause a **safe rebuild**, never a wrong reuse.

## Stage 1 — ONLY-BUILD (this PR)

The runner computes the **full verdict** inside `execute_content_addressed_model` (after `discover()`, before `execute_query`), **logs** a would-reuse candidate (`reuse: would point-to prior run R`), and **always executes the SQL**. A decision that can only BUILD is incapable of producing a wrong output — the provably-safe first slice before the live `commit_pointer_with_state` invocation is wired behind this same verdict.

## Default-off ⇒ byte-identical

With `[reuse]` disabled (the default) the runner passes `None` for the reuse context: no `input_hash` compute, no index lookup, no liveness GET. The run is byte- and cost-identical to before this PR. `--no-reuse` is the escape hatch (a clap flag, **no codegen** — `just codegen` is a verified no-op).

> Note: this flips `reuse.enabled` from #835's documented "populate-only / dormant" contract to "also decide". That is the intended B5 semantics and is safe because all of it is unreleased and default-off.

## Verify

- `cargo build -p rocky-cli -p rocky-core` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo fmt -- --check` ✓
- `cargo test -p rocky-cli -p rocky-core -p rocky-iceberg --features duckdb` ✓ (incl. the per-clause fail-closed unit set + the liveness add/remove/absent tests)
- `just codegen` ✓ no-op (no schema/Pydantic/TS drift)

## 🚦 LIVE-VERIFY GATE (before this leaves draft)

The reuse path touches Databricks UniForm clone/commit SQL, which has shipped structural bugs that only live runs catch. **Before marking ready**, run the `#[ignore]` live tests against the Databricks `hc_`/`hcv2_` UniForm sandbox:

- **same-target reuse no-op** — second run finds the candidate, the decision is would-reuse, refcount stays correct;
- **VACUUM / later `remove` ⇒ BUILD** — liveness flips and the run rebuilds rather than pointing at removed bytes;
- **changed upstream ⇒ BUILD** — a moved upstream content hash misses the index and rebuilds.

(The pure decision + liveness layers are fully unit-tested here; the live tests are the merge gate for the warehouse path.)

## Follow-ups

- **Live `commit_pointer_with_state` invocation** behind the same verdict (skip `execute_query`, record the reusing run's `ArtifactRecord` at the shared blake3 → refcount `>= 2`, and a reuse-provenance entry). This PR is ONLY-BUILD; the verdict shape already carries exactly what that step consumes (`R`'s `run_id`, blake3, path, commit_version, size).
- Live `#[ignore]` Databricks reuse tests (the gate above).
- Partitioned / rowTracking point-to (deferred — needs per-group commits / re-allocated `baseRowId`).