### PR TITLE
feat(engine/rocky-core): add unique_expr assertion for derived-key uniqueness

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2259,6 +2259,26 @@
           "type": "object"
         },
         {
+          "description": "Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.\n\n`key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.\n\nSet-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).",
+          "properties": {
+            "key_expr": {
+              "description": "SQL scalar expression whose value must be unique across rows.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unique_expr"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "key_expr",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).",
           "properties": {
             "type": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -239,6 +239,14 @@ export type QualityAssertion1 =
       [k: string]: unknown;
     }
   | {
+      /**
+       * SQL scalar expression whose value must be unique across rows.
+       */
+      key_expr: string;
+      type: "unique_expr";
+      [k: string]: unknown;
+    }
+  | {
       type: "not_in_future";
       [k: string]: unknown;
     }

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -453,6 +453,7 @@ fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
     match t {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",
@@ -501,6 +502,7 @@ fn classify_assertion(
         }
         // Row-set-based: every returned row is a violation.
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::AcceptedValues { .. }
         | TestType::Relationships { .. }
         | TestType::Composite { .. } => {

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -387,8 +387,10 @@ fn interpret_result(
             }
         }
 
-        // unique / accepted_values / relationships / composite: rows returned = failures
+        // unique / unique_expr / accepted_values / relationships / composite:
+        // rows returned = failures
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::AcceptedValues { .. }
         | TestType::Relationships { .. }
         | TestType::Composite { .. } => {
@@ -398,6 +400,7 @@ fn interpret_result(
             } else {
                 let what = match test_type {
                     TestType::Unique => "duplicate value(s)",
+                    TestType::UniqueExpr { .. } => "duplicate key(s)",
                     TestType::AcceptedValues { .. } => "unexpected value(s)",
                     TestType::Relationships { .. } => "orphaned row(s)",
                     TestType::Composite { .. } => "duplicate key(s)",
@@ -453,6 +456,7 @@ fn test_type_label(tt: &TestType) -> &'static str {
     match tt {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -401,6 +401,7 @@ fn test_type_label(test_type: &crate::tests::TestType) -> String {
     match test_type {
         crate::tests::TestType::NotNull => "not_null".into(),
         crate::tests::TestType::Unique => "unique".into(),
+        crate::tests::TestType::UniqueExpr { .. } => "unique_expr".into(),
         crate::tests::TestType::AcceptedValues { .. } => "accepted_values".into(),
         crate::tests::TestType::Relationships { .. } => "relationships".into(),
         crate::tests::TestType::Expression { .. } => "expression".into(),

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -272,6 +272,7 @@ fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Expression { .. } => "expression",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::Relationships { .. } => "relationships",
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
@@ -389,6 +390,7 @@ fn lower_valid_predicate(
         }
         // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::Relationships { .. }
         | TestType::RowCountRange { .. }
         | TestType::Aggregate { .. }

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -22,6 +22,9 @@ pub enum TestGenError {
     #[error("expression test requires an 'expression' field")]
     MissingExpression,
 
+    #[error("unique_expr test requires a non-empty 'key_expr' field")]
+    EmptyKeyExpr,
+
     #[error("row_count_range test requires at least one of 'min' or 'max'")]
     MissingRange,
 
@@ -163,6 +166,24 @@ pub enum TestType {
         /// Columns that together form the key. Must have at least two
         /// entries (single-column uniqueness is covered by `Unique`).
         columns: Vec<String>,
+    },
+    /// Assert that a derived **key expression** is unique across all rows —
+    /// the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique`
+    /// (single column) nor `Composite` (column tuple) can express. The
+    /// meaningful identity is a *computed* value (e.g. a surrogate built to
+    /// be stable across a multi-tenant union), not any stored column.
+    ///
+    /// `key_expr` is a SQL scalar expression evaluated against the target
+    /// (e.g. `md5(databasename || '-' || id)`). It is passed through
+    /// **verbatim** — the same trusted-config contract as
+    /// [`TestType::Expression`] — so the caller is responsible for sandboxing
+    /// execution.
+    ///
+    /// Set-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL
+    /// keys are not excluded; use `filter` to scope them out).
+    UniqueExpr {
+        /// SQL scalar expression whose value must be unique across rows.
+        key_expr: String,
     },
     /// First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp
     /// in the future. Row-level; quarantinable (NULL column values pass).
@@ -515,6 +536,21 @@ fn generate_test_sql_inner(
                     "SELECT {cols}, COUNT(*) FROM {table}{where_clause} GROUP BY {cols} HAVING COUNT(*) > 1"
                 )),
             }
+        }
+        TestType::UniqueExpr { key_expr } => {
+            if key_expr.trim().is_empty() {
+                return Err(TestGenError::EmptyKeyExpr);
+            }
+            // key_expr is user-supplied SQL (same contract as Expression) —
+            // not an identifier, so it's passed through verbatim, wrapped in
+            // parens. NULL handling mirrors `Unique` (no auto-exclusion; use
+            // `filter` to scope NULL keys out). The expression is repeated in
+            // GROUP BY rather than referencing the `_k` alias because not all
+            // dialects (Databricks, BigQuery) allow grouping by a select alias.
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
+            Ok(format!(
+                "SELECT ({key_expr}) AS _k, COUNT(*) FROM {table}{where_clause} GROUP BY ({key_expr}) HAVING COUNT(*) > 1"
+            ))
         }
         TestType::NotInFuture => {
             let col = require_column(test, "not_in_future")?;
@@ -1392,6 +1428,56 @@ value = "0"
         assert_eq!(
             sql,
             "SELECT order_id, line_item_id, COUNT(*) FROM order_lines GROUP BY order_id, line_item_id HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_unique_expr_sql() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "md5(databasename || '-' || id)".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "dims").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT (md5(databasename || '-' || id)) AS _k, COUNT(*) FROM dims GROUP BY (md5(databasename || '-' || id)) HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_unique_expr_empty_rejected() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "   ".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        assert!(matches!(
+            generate_test_sql(&decl, "dims"),
+            Err(TestGenError::EmptyKeyExpr)
+        ));
+    }
+
+    #[test]
+    fn test_unique_expr_with_filter() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "lower(email)".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: Some("is_active".into()),
+        };
+        let sql = generate_test_sql(&decl, "users").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT (lower(email)) AS _k, COUNT(*) FROM users WHERE (is_active) GROUP BY (lower(email)) HAVING COUNT(*) > 1"
         );
     }
 

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -613,6 +613,7 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
     let type_str = match &test.test_type {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -747,6 +747,54 @@ async fn test_seed_produces_queryable_data() {
     assert!(orphans < 1000, "too many orphan orders: {orphans}");
 }
 
+/// The `unique_expr` assertion's generated SQL actually executes on DuckDB and
+/// catches a duplicated *derived* surrogate — the case column-level uniqueness
+/// can't express. The PASS case is the crux: `databasename` repeats and `id`
+/// repeats, yet the surrogate `md5(name || '-' || id)` is unique per row.
+#[tokio::test]
+async fn test_unique_expr_assertion_executes_on_duckdb() {
+    use rocky_core::tests::{TestDecl, TestSeverity, TestType, generate_test_sql};
+
+    let key_expr = "md5(databasename || '-' || CAST(id AS VARCHAR))";
+    let gen_sql = |table: &str| {
+        generate_test_sql(
+            &TestDecl {
+                test_type: TestType::UniqueExpr {
+                    key_expr: key_expr.to_string(),
+                },
+                column: None,
+                severity: TestSeverity::Error,
+                filter: None,
+            },
+            table,
+        )
+        .unwrap()
+    };
+
+    let p = TestPipeline::new();
+    p.execute("CREATE SCHEMA IF NOT EXISTS t").await.unwrap();
+
+    // FAIL — two identical onboards collide on the surrogate.
+    p.execute("CREATE TABLE t.dup (databasename VARCHAR, id INTEGER)")
+        .await
+        .unwrap();
+    p.execute("INSERT INTO t.dup VALUES ('acme', 1), ('acme', 1), ('beta', 2)")
+        .await
+        .unwrap();
+    let fail = p.query(&gen_sql("t.dup")).await.unwrap();
+    assert_eq!(fail.rows.len(), 1, "duplicated surrogate must be caught");
+
+    // PASS — name repeats and id repeats, but every surrogate is distinct.
+    p.execute("CREATE TABLE t.ok (databasename VARCHAR, id INTEGER)")
+        .await
+        .unwrap();
+    p.execute("INSERT INTO t.ok VALUES ('acme', 1), ('beta', 2), ('acme', 2)")
+        .await
+        .unwrap();
+    let pass = p.query(&gen_sql("t.ok")).await.unwrap();
+    assert!(pass.rows.is_empty(), "distinct surrogates must pass");
+}
+
 #[tokio::test]
 async fn test_full_refresh_on_seeded_data() {
     let (p, _stats) = TestPipeline::with_seed(SeedScale::Small);

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -898,10 +898,14 @@ class Type36(StrEnum):
 
 
 class Type37(StrEnum):
-    not_in_future = "not_in_future"
+    unique_expr = "unique_expr"
 
 
 class Type38(StrEnum):
+    not_in_future = "not_in_future"
+
+
+class Type39(StrEnum):
     older_than_n_days = "older_than_n_days"
 
 
@@ -2137,6 +2141,46 @@ class QualityAssertion10(BaseModel):
 
 class QualityAssertion11(BaseModel):
     """
+    Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.
+
+    `key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.
+
+    Set-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).
+    """
+
+    column: str | None = None
+    """
+    Column under test. Required for `not_null`, `unique`, `accepted_values`, `relationships`, `in_range`, `regex_match`. Ignored for `expression` and `row_count_range`.
+    """
+    filter: str | None = None
+    """
+    Optional SQL boolean predicate that scopes the assertion to a subset of rows. When set, only rows where `(filter)` evaluates to `TRUE` are subject to the assertion — rows where the filter is `FALSE` or `NULL` pass unconditionally.
+
+    Filter is user-supplied SQL; the caller is responsible for sandboxing execution (same contract as `expression`).
+
+    Example: `filter = "created_at > current_date - interval 30 day"` restricts a `not_null` check to rows created in the last 30 days.
+    """
+    name: str | None = None
+    """
+    Optional identifier used as the `CheckResult.name` in the JSON output. When unset, a synthesized `"{kind}:{column}"` name is used — which can collide if multiple assertions share the same table, kind, and column. Set `name` explicitly to disambiguate.
+    """
+    severity: TestSeverity5 | TestSeverity6 | None = "error"
+    """
+    Severity of failure. Defaults to `error`.
+    """
+    table: str
+    """
+    Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
+    """
+    key_expr: str
+    """
+    SQL scalar expression whose value must be unique across rows.
+    """
+    type: Type37
+
+
+class QualityAssertion12(BaseModel):
+    """
     First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).
     """
 
@@ -2164,10 +2208,10 @@ class QualityAssertion11(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type37
+    type: Type38
 
 
-class QualityAssertion12(BaseModel):
+class QualityAssertion13(BaseModel):
     """
     First-class sugar for `col <= CURRENT_DATE - N days` — every row's timestamp must be at least `days` days old. Row-level; quarantinable (NULL column values pass). Dialect-specific: uses [`SqlDialect::date_minus_days_expr`].
     """
@@ -2200,7 +2244,7 @@ class QualityAssertion12(BaseModel):
     """
     N — days in the past. Must be > 0.
     """
-    type: Type38
+    type: Type39
 
 
 class QuarantineConfig(BaseModel):
@@ -2296,6 +2340,7 @@ class ChecksConfig(BaseModel):
             | QualityAssertion10
             | QualityAssertion11
             | QualityAssertion12
+            | QualityAssertion13
         ]
         | None
     ) = Field([], validate_default=True)

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2258,6 +2258,26 @@
           "type": "object"
         },
         {
+          "description": "Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.\n\n`key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.\n\nSet-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).",
+          "properties": {
+            "key_expr": {
+              "description": "SQL scalar expression whose value must be unique across rows.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unique_expr"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "key_expr",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).",
           "properties": {
             "type": {


### PR DESCRIPTION
**PR 2/5** of cross-source duplicate detection (mechanism 2, detective). Independent of PR 1.

## What

Adds `TestType::UniqueExpr { key_expr }` — a uniqueness assertion over a **computed key expression**, the `GROUP BY <expr> HAVING COUNT(*) > 1` form that the existing `unique` (single column) and `composite` (column tuple) assertions can't express.

```toml
[[pipeline.<name>.checks.assertions]]
table    = "dims"
type     = "unique_expr"
key_expr = "md5(databasename || '-' || id)"
severity = "error"
```

This is the crux for "same entity onboarded twice" on non-Fivetran sources: the duplicate is only visible on a **derived surrogate** — the raw rows aren't byte-identical (different ingest metadata) and share no single natural key. No column list can express a hash/concat.

## Reframe note

`unique` (single) and `composite` (tuple) uniqueness **already exist** via `[checks].assertions` and generate exactly this `GROUP BY … HAVING` shape — the FR's appendix missed the `TestDecl` assertion surface. The genuine gap was only the *derived-expression* form, which this PR adds.

## How

- `tests.rs`: new `UniqueExpr` variant + SQL gen (mirrors `unique`; `key_expr` passed through verbatim — same trusted-config contract as `expression`; empty rejected; NULL handling mirrors `unique`). Set-based, not quarantinable.
- Wired through every exhaustive `TestType` match site (run_local + `test` command kind/classification, quarantine label, docs, unified DAG).
- Flows through the existing `[checks].assertions` surface → runs on transformation/quality/snapshot today; replication wiring is **PR 3**.
- Regenerated project schema + dagster/vscode bindings via `just codegen` (no lockfile drift).

## Tested

- Unit: SQL shape, empty-`key_expr` rejection, `filter` weaving.
- **DuckDB live-execute**: the generated SQL catches a duplicated surrogate and **passes when surrogates are distinct even though `name` repeats and `id` repeats** — the exact case column-level uniqueness can't see.
- Full suites *run*: rocky-core / rocky-compiler / rocky-cli (684), fmt, clippy `--all-targets`, dagster ruff — all clean.