### PR TITLE
feat(engine/rocky-cli): run row-level assertions at replication time

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2259,6 +2259,26 @@
           "type": "object"
         },
         {
+          "description": "Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.\n\n`key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.\n\nSet-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).",
+          "properties": {
+            "key_expr": {
+              "description": "SQL scalar expression whose value must be unique across rows.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unique_expr"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "key_expr",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).",
           "properties": {
             "type": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -239,6 +239,14 @@ export type QualityAssertion1 =
       [k: string]: unknown;
     }
   | {
+      /**
+       * SQL scalar expression whose value must be unique across rows.
+       */
+      key_expr: string;
+      type: "unique_expr";
+      [k: string]: unknown;
+    }
+  | {
       type: "not_in_future";
       [k: string]: unknown;
     }

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -50,6 +50,11 @@ struct TableResult {
     freshness_batch_ref: Option<TableRef>,
     asset_key: Vec<String>,
     target_full_name: String,
+    /// Fully-qualified target table ref, populated unconditionally (unlike
+    /// `target_batch_ref`, which is gated on `check_row_count`). The assertion
+    /// phase needs it for every materialized table so uniqueness/assertions run
+    /// even when row-count and freshness checks are disabled.
+    target_ref: TableRef,
     /// Deferred governance tags — applied in a post-run batch phase instead
     /// of inside the per-table concurrent loop, avoiding sequential SQL waits
     /// that block the concurrency semaphore.
@@ -1376,6 +1381,9 @@ pub async fn run(
     let mut target_batch_refs: Vec<TableRef> = Vec::new();
     let mut freshness_batch_refs: Vec<TableRef> = Vec::new();
     let mut batch_asset_keys: Vec<(String, Vec<String>)> = Vec::new();
+    // (target_ref, asset_key) per materialized table — populated unconditionally
+    // so row-level assertions run regardless of row_count/freshness config.
+    let mut assertion_targets: Vec<(TableRef, Vec<String>)> = Vec::new();
     let mut pending_checks: HashMap<String, PendingCheck> = HashMap::new();
     let mut tables_to_process: Vec<TableTask> = Vec::new();
     // PR-B3: count how many `(connector, table)` pairs matched each
@@ -2384,6 +2392,7 @@ pub async fn run(
                     target_batch_refs.push(tgt_ref);
                 }
                 batch_asset_keys.push((tr.target_full_name.clone(), tr.asset_key.clone()));
+                assertion_targets.push((tr.target_ref.clone(), tr.asset_key.clone()));
 
                 if let Some(fresh_ref) = tr.freshness_batch_ref {
                     freshness_batch_refs.push(fresh_ref);
@@ -2744,6 +2753,7 @@ pub async fn run(
                         if let Some(tgt_ref) = tr.target_batch_ref {
                             target_batch_refs.push(tgt_ref);
                         }
+                        assertion_targets.push((tr.target_ref.clone(), tr.asset_key.clone()));
                         batch_asset_keys.push((tr.target_full_name.clone(), tr.asset_key));
                         if let Some(tags) = tr.deferred_tags {
                             deferred_tags.push(tags);
@@ -3131,6 +3141,50 @@ pub async fn run(
                     });
                     entry.checks.push(check);
                 }
+            }
+        }
+    }
+
+    // Row-level assertions (uniqueness, etc.) on each replication target.
+    // The replication runner runs the SAME `[checks].assertions` the quality
+    // runner does, so uniqueness fires at replication time. Driven by
+    // `assertion_targets` (populated per materialized table, independent of
+    // row_count/freshness) so it runs even when those checks are disabled.
+    // Results are surfaced advisorily — like every other check in this runner,
+    // the run does not bail; the orchestrator decides from the JSON
+    // CheckResult + severity. (The data has already landed by check time, so
+    // bailing would only change the exit code, not prevent the write.)
+    if !pipeline.checks.assertions.is_empty() {
+        let dialect = shared_warehouse.dialect();
+        for (tref, asset_key) in &assertion_targets {
+            let full = match dialect.format_table_ref(&tref.catalog, &tref.schema, &tref.table) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(
+                        table = %tref.full_name(),
+                        error = %e,
+                        "assertion table ref formatting failed — skipping"
+                    );
+                    continue;
+                }
+            };
+            let results = super::run_local::run_table_assertions(
+                shared_warehouse.as_ref(),
+                dialect,
+                &full,
+                &tref.table,
+                &pipeline.checks.assertions,
+            )
+            .await;
+            if !results.is_empty() {
+                let entry =
+                    pending_checks
+                        .entry(tref.full_name())
+                        .or_insert_with(|| PendingCheck {
+                            asset_key: asset_key.clone(),
+                            checks: Vec::new(),
+                        });
+                entry.checks.extend(results);
             }
         }
     }
@@ -6354,6 +6408,11 @@ async fn process_table(
         freshness_batch_ref,
         asset_key,
         target_full_name: target_table_full_name,
+        target_ref: TableRef {
+            catalog: target_table.catalog.clone(),
+            schema: target_table.schema.clone(),
+            table: target_table.table.clone(),
+        },
         deferred_tags,
         deferred_watermark,
     })

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -146,7 +146,6 @@ pub async fn run_quality(
     output_json: bool,
 ) -> Result<()> {
     use rocky_core::checks::{CheckDetails, CheckResult};
-    use rocky_core::tests::generate_test_sql_with_dialect;
 
     let start = Instant::now();
 
@@ -305,62 +304,19 @@ pub async fn run_quality(
                 }
 
                 // Row-level assertions — match by unqualified table name.
-                for assertion in &pipeline.checks.assertions {
-                    if assertion.table != *table_name {
-                        continue;
-                    }
-                    let test = &assertion.test;
-                    let sql = match generate_test_sql_with_dialect(test, &full_table, dialect) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            warn!(
-                                error = %e,
-                                table = %full_table,
-                                "failed to generate assertion SQL — skipping"
-                            );
-                            continue;
-                        }
-                    };
-                    let kind = test_type_kind(&test.test_type);
-                    let name = assertion.name.clone().unwrap_or_else(|| {
-                        format!("{kind}:{}", test.column.as_deref().unwrap_or("-"))
-                    });
-
-                    match warehouse_adapter.execute_query(&sql).await {
-                        Ok(result) => {
-                            let (passed, failing_rows) =
-                                classify_assertion(&test.test_type, &result.rows);
-                            checks.push(CheckResult {
-                                name,
-                                passed,
-                                severity: test.severity,
-                                details: CheckDetails::Assertion {
-                                    kind: kind.to_string(),
-                                    column: test.column.clone(),
-                                    failing_rows,
-                                },
-                            });
-                        }
-                        Err(e) => {
-                            warn!(
-                                error = %e,
-                                table = %full_table,
-                                assertion = %name,
-                                "assertion query failed"
-                            );
-                            checks.push(CheckResult {
-                                name,
-                                passed: false,
-                                severity: test.severity,
-                                details: CheckDetails::Assertion {
-                                    kind: kind.to_string(),
-                                    column: test.column.clone(),
-                                    failing_rows: 0,
-                                },
-                            });
-                        }
-                    }
-                }
+                // Shared with the replication runner (run.rs) via
+                // `run_table_assertions` so uniqueness and the other assertions
+                // fire identically on both surfaces.
+                checks.extend(
+                    run_table_assertions(
+                        warehouse_adapter.as_ref(),
+                        dialect,
+                        &full_table,
+                        table_name,
+                        &pipeline.checks.assertions,
+                    )
+                    .await,
+                );
 
                 output.check_results.push(TableCheckOutput {
                     asset_key: asset_key.clone(),
@@ -444,6 +400,80 @@ pub async fn run_quality(
     }
 
     Ok(())
+}
+
+/// Execute every assertion targeting `table_unqualified` against `full_table`,
+/// returning one [`CheckResult`] per matching assertion.
+///
+/// Shared by the quality runner (this module) and the replication runner
+/// (`run.rs`) so uniqueness and the other row-level assertions fire on both
+/// surfaces with identical pass/fail classification. `full_table` must already
+/// be dialect-formatted (quoted/qualified). Degradation is graceful: an
+/// SQL-generation error skips that assertion; a query error records a failed
+/// `CheckResult` — neither aborts the caller.
+pub(crate) async fn run_table_assertions(
+    warehouse: &dyn rocky_core::traits::WarehouseAdapter,
+    dialect: &dyn rocky_core::traits::SqlDialect,
+    full_table: &str,
+    table_unqualified: &str,
+    assertions: &[rocky_core::config::QualityAssertion],
+) -> Vec<rocky_core::checks::CheckResult> {
+    use rocky_core::checks::{CheckDetails, CheckResult};
+    use rocky_core::tests::generate_test_sql_with_dialect;
+
+    let mut results = Vec::new();
+    for assertion in assertions {
+        if assertion.table.as_str() != table_unqualified {
+            continue;
+        }
+        let test = &assertion.test;
+        let sql = match generate_test_sql_with_dialect(test, full_table, dialect) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    table = %full_table,
+                    "failed to generate assertion SQL — skipping"
+                );
+                continue;
+            }
+        };
+        let kind = test_type_kind(&test.test_type);
+        let name = assertion
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("{kind}:{}", test.column.as_deref().unwrap_or("-")));
+
+        match warehouse.execute_query(&sql).await {
+            Ok(result) => {
+                let (passed, failing_rows) = classify_assertion(&test.test_type, &result.rows);
+                results.push(CheckResult {
+                    name,
+                    passed,
+                    severity: test.severity,
+                    details: CheckDetails::Assertion {
+                        kind: kind.to_string(),
+                        column: test.column.clone(),
+                        failing_rows,
+                    },
+                });
+            }
+            Err(e) => {
+                warn!(error = %e, table = %full_table, assertion = %name, "assertion query failed");
+                results.push(CheckResult {
+                    name,
+                    passed: false,
+                    severity: test.severity,
+                    details: CheckDetails::Assertion {
+                        kind: kind.to_string(),
+                        column: test.column.clone(),
+                        failing_rows: 0,
+                    },
+                });
+            }
+        }
+    }
+    results
 }
 
 /// Short snake_case tag for each `TestType` variant — embedded in check

--- a/engine/crates/rocky-cli/src/commands/run_local.rs
+++ b/engine/crates/rocky-cli/src/commands/run_local.rs
@@ -453,6 +453,7 @@ fn test_type_kind(t: &rocky_core::tests::TestType) -> &'static str {
     match t {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",
@@ -501,6 +502,7 @@ fn classify_assertion(
         }
         // Row-set-based: every returned row is a violation.
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::AcceptedValues { .. }
         | TestType::Relationships { .. }
         | TestType::Composite { .. } => {

--- a/engine/crates/rocky-cli/src/commands/test.rs
+++ b/engine/crates/rocky-cli/src/commands/test.rs
@@ -387,8 +387,10 @@ fn interpret_result(
             }
         }
 
-        // unique / accepted_values / relationships / composite: rows returned = failures
+        // unique / unique_expr / accepted_values / relationships / composite:
+        // rows returned = failures
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::AcceptedValues { .. }
         | TestType::Relationships { .. }
         | TestType::Composite { .. } => {
@@ -398,6 +400,7 @@ fn interpret_result(
             } else {
                 let what = match test_type {
                     TestType::Unique => "duplicate value(s)",
+                    TestType::UniqueExpr { .. } => "duplicate key(s)",
                     TestType::AcceptedValues { .. } => "unexpected value(s)",
                     TestType::Relationships { .. } => "orphaned row(s)",
                     TestType::Composite { .. } => "duplicate key(s)",
@@ -453,6 +456,7 @@ fn test_type_label(tt: &TestType) -> &'static str {
     match tt {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",

--- a/engine/crates/rocky-core/src/docs.rs
+++ b/engine/crates/rocky-core/src/docs.rs
@@ -401,6 +401,7 @@ fn test_type_label(test_type: &crate::tests::TestType) -> String {
     match test_type {
         crate::tests::TestType::NotNull => "not_null".into(),
         crate::tests::TestType::Unique => "unique".into(),
+        crate::tests::TestType::UniqueExpr { .. } => "unique_expr".into(),
         crate::tests::TestType::AcceptedValues { .. } => "accepted_values".into(),
         crate::tests::TestType::Relationships { .. } => "relationships".into(),
         crate::tests::TestType::Expression { .. } => "expression".into(),

--- a/engine/crates/rocky-core/src/quarantine.rs
+++ b/engine/crates/rocky-core/src/quarantine.rs
@@ -272,6 +272,7 @@ fn synthesize_label(test_type: &TestType, column: Option<&str>) -> String {
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Expression { .. } => "expression",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::Relationships { .. } => "relationships",
         TestType::RowCountRange { .. } => "row_count_range",
         TestType::InRange { .. } => "in_range",
@@ -389,6 +390,7 @@ fn lower_valid_predicate(
         }
         // Non-quarantinable kinds filtered upstream by `is_quarantinable`.
         TestType::Unique
+        | TestType::UniqueExpr { .. }
         | TestType::Relationships { .. }
         | TestType::RowCountRange { .. }
         | TestType::Aggregate { .. }

--- a/engine/crates/rocky-core/src/tests.rs
+++ b/engine/crates/rocky-core/src/tests.rs
@@ -22,6 +22,9 @@ pub enum TestGenError {
     #[error("expression test requires an 'expression' field")]
     MissingExpression,
 
+    #[error("unique_expr test requires a non-empty 'key_expr' field")]
+    EmptyKeyExpr,
+
     #[error("row_count_range test requires at least one of 'min' or 'max'")]
     MissingRange,
 
@@ -163,6 +166,24 @@ pub enum TestType {
         /// Columns that together form the key. Must have at least two
         /// entries (single-column uniqueness is covered by `Unique`).
         columns: Vec<String>,
+    },
+    /// Assert that a derived **key expression** is unique across all rows —
+    /// the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique`
+    /// (single column) nor `Composite` (column tuple) can express. The
+    /// meaningful identity is a *computed* value (e.g. a surrogate built to
+    /// be stable across a multi-tenant union), not any stored column.
+    ///
+    /// `key_expr` is a SQL scalar expression evaluated against the target
+    /// (e.g. `md5(databasename || '-' || id)`). It is passed through
+    /// **verbatim** — the same trusted-config contract as
+    /// [`TestType::Expression`] — so the caller is responsible for sandboxing
+    /// execution.
+    ///
+    /// Set-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL
+    /// keys are not excluded; use `filter` to scope them out).
+    UniqueExpr {
+        /// SQL scalar expression whose value must be unique across rows.
+        key_expr: String,
     },
     /// First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp
     /// in the future. Row-level; quarantinable (NULL column values pass).
@@ -515,6 +536,21 @@ fn generate_test_sql_inner(
                     "SELECT {cols}, COUNT(*) FROM {table}{where_clause} GROUP BY {cols} HAVING COUNT(*) > 1"
                 )),
             }
+        }
+        TestType::UniqueExpr { key_expr } => {
+            if key_expr.trim().is_empty() {
+                return Err(TestGenError::EmptyKeyExpr);
+            }
+            // key_expr is user-supplied SQL (same contract as Expression) —
+            // not an identifier, so it's passed through verbatim, wrapped in
+            // parens. NULL handling mirrors `Unique` (no auto-exclusion; use
+            // `filter` to scope NULL keys out). The expression is repeated in
+            // GROUP BY rather than referencing the `_k` alias because not all
+            // dialects (Databricks, BigQuery) allow grouping by a select alias.
+            let where_clause = filter.map(|f| format!(" WHERE ({f})")).unwrap_or_default();
+            Ok(format!(
+                "SELECT ({key_expr}) AS _k, COUNT(*) FROM {table}{where_clause} GROUP BY ({key_expr}) HAVING COUNT(*) > 1"
+            ))
         }
         TestType::NotInFuture => {
             let col = require_column(test, "not_in_future")?;
@@ -1392,6 +1428,56 @@ value = "0"
         assert_eq!(
             sql,
             "SELECT order_id, line_item_id, COUNT(*) FROM order_lines GROUP BY order_id, line_item_id HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_unique_expr_sql() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "md5(databasename || '-' || id)".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        let sql = generate_test_sql(&decl, "dims").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT (md5(databasename || '-' || id)) AS _k, COUNT(*) FROM dims GROUP BY (md5(databasename || '-' || id)) HAVING COUNT(*) > 1"
+        );
+    }
+
+    #[test]
+    fn test_unique_expr_empty_rejected() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "   ".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: None,
+        };
+        assert!(matches!(
+            generate_test_sql(&decl, "dims"),
+            Err(TestGenError::EmptyKeyExpr)
+        ));
+    }
+
+    #[test]
+    fn test_unique_expr_with_filter() {
+        let decl = TestDecl {
+            test_type: TestType::UniqueExpr {
+                key_expr: "lower(email)".into(),
+            },
+            column: None,
+            severity: TestSeverity::Error,
+            filter: Some("is_active".into()),
+        };
+        let sql = generate_test_sql(&decl, "users").unwrap();
+        assert_eq!(
+            sql,
+            "SELECT (lower(email)) AS _k, COUNT(*) FROM users WHERE (is_active) GROUP BY (lower(email)) HAVING COUNT(*) > 1"
         );
     }
 

--- a/engine/crates/rocky-core/src/unified_dag.rs
+++ b/engine/crates/rocky-core/src/unified_dag.rs
@@ -613,6 +613,7 @@ fn format_test_label(model_name: &str, test: &crate::tests::TestDecl, index: usi
     let type_str = match &test.test_type {
         TestType::NotNull => "not_null",
         TestType::Unique => "unique",
+        TestType::UniqueExpr { .. } => "unique_expr",
         TestType::AcceptedValues { .. } => "accepted_values",
         TestType::Relationships { .. } => "relationships",
         TestType::Expression { .. } => "expression",

--- a/engine/crates/rocky-core/tests/integration.rs
+++ b/engine/crates/rocky-core/tests/integration.rs
@@ -747,6 +747,54 @@ async fn test_seed_produces_queryable_data() {
     assert!(orphans < 1000, "too many orphan orders: {orphans}");
 }
 
+/// The `unique_expr` assertion's generated SQL actually executes on DuckDB and
+/// catches a duplicated *derived* surrogate — the case column-level uniqueness
+/// can't express. The PASS case is the crux: `databasename` repeats and `id`
+/// repeats, yet the surrogate `md5(name || '-' || id)` is unique per row.
+#[tokio::test]
+async fn test_unique_expr_assertion_executes_on_duckdb() {
+    use rocky_core::tests::{TestDecl, TestSeverity, TestType, generate_test_sql};
+
+    let key_expr = "md5(databasename || '-' || CAST(id AS VARCHAR))";
+    let gen_sql = |table: &str| {
+        generate_test_sql(
+            &TestDecl {
+                test_type: TestType::UniqueExpr {
+                    key_expr: key_expr.to_string(),
+                },
+                column: None,
+                severity: TestSeverity::Error,
+                filter: None,
+            },
+            table,
+        )
+        .unwrap()
+    };
+
+    let p = TestPipeline::new();
+    p.execute("CREATE SCHEMA IF NOT EXISTS t").await.unwrap();
+
+    // FAIL — two identical onboards collide on the surrogate.
+    p.execute("CREATE TABLE t.dup (databasename VARCHAR, id INTEGER)")
+        .await
+        .unwrap();
+    p.execute("INSERT INTO t.dup VALUES ('acme', 1), ('acme', 1), ('beta', 2)")
+        .await
+        .unwrap();
+    let fail = p.query(&gen_sql("t.dup")).await.unwrap();
+    assert_eq!(fail.rows.len(), 1, "duplicated surrogate must be caught");
+
+    // PASS — name repeats and id repeats, but every surrogate is distinct.
+    p.execute("CREATE TABLE t.ok (databasename VARCHAR, id INTEGER)")
+        .await
+        .unwrap();
+    p.execute("INSERT INTO t.ok VALUES ('acme', 1), ('beta', 2), ('acme', 2)")
+        .await
+        .unwrap();
+    let pass = p.query(&gen_sql("t.ok")).await.unwrap();
+    assert!(pass.rows.is_empty(), "distinct surrogates must pass");
+}
+
 #[tokio::test]
 async fn test_full_refresh_on_seeded_data() {
     let (p, _stats) = TestPipeline::with_seed(SeedScale::Small);

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -898,10 +898,14 @@ class Type36(StrEnum):
 
 
 class Type37(StrEnum):
-    not_in_future = "not_in_future"
+    unique_expr = "unique_expr"
 
 
 class Type38(StrEnum):
+    not_in_future = "not_in_future"
+
+
+class Type39(StrEnum):
     older_than_n_days = "older_than_n_days"
 
 
@@ -2137,6 +2141,46 @@ class QualityAssertion10(BaseModel):
 
 class QualityAssertion11(BaseModel):
     """
+    Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.
+
+    `key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.
+
+    Set-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).
+    """
+
+    column: str | None = None
+    """
+    Column under test. Required for `not_null`, `unique`, `accepted_values`, `relationships`, `in_range`, `regex_match`. Ignored for `expression` and `row_count_range`.
+    """
+    filter: str | None = None
+    """
+    Optional SQL boolean predicate that scopes the assertion to a subset of rows. When set, only rows where `(filter)` evaluates to `TRUE` are subject to the assertion — rows where the filter is `FALSE` or `NULL` pass unconditionally.
+
+    Filter is user-supplied SQL; the caller is responsible for sandboxing execution (same contract as `expression`).
+
+    Example: `filter = "created_at > current_date - interval 30 day"` restricts a `not_null` check to rows created in the last 30 days.
+    """
+    name: str | None = None
+    """
+    Optional identifier used as the `CheckResult.name` in the JSON output. When unset, a synthesized `"{kind}:{column}"` name is used — which can collide if multiple assertions share the same table, kind, and column. Set `name` explicitly to disambiguate.
+    """
+    severity: TestSeverity5 | TestSeverity6 | None = "error"
+    """
+    Severity of failure. Defaults to `error`.
+    """
+    table: str
+    """
+    Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
+    """
+    key_expr: str
+    """
+    SQL scalar expression whose value must be unique across rows.
+    """
+    type: Type37
+
+
+class QualityAssertion12(BaseModel):
+    """
     First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).
     """
 
@@ -2164,10 +2208,10 @@ class QualityAssertion11(BaseModel):
     """
     Table name this assertion applies to. Must match a table discovered from one of the pipeline's `[[tables]]` entries (by unqualified table name).
     """
-    type: Type37
+    type: Type38
 
 
-class QualityAssertion12(BaseModel):
+class QualityAssertion13(BaseModel):
     """
     First-class sugar for `col <= CURRENT_DATE - N days` — every row's timestamp must be at least `days` days old. Row-level; quarantinable (NULL column values pass). Dialect-specific: uses [`SqlDialect::date_minus_days_expr`].
     """
@@ -2200,7 +2244,7 @@ class QualityAssertion12(BaseModel):
     """
     N — days in the past. Must be > 0.
     """
-    type: Type38
+    type: Type39
 
 
 class QuarantineConfig(BaseModel):
@@ -2296,6 +2340,7 @@ class ChecksConfig(BaseModel):
             | QualityAssertion10
             | QualityAssertion11
             | QualityAssertion12
+            | QualityAssertion13
         ]
         | None
     ) = Field([], validate_default=True)

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2258,6 +2258,26 @@
           "type": "object"
         },
         {
+          "description": "Assert that a derived **key expression** is unique across all rows — the `GROUP BY <expr> HAVING COUNT(*) > 1` form that neither `Unique` (single column) nor `Composite` (column tuple) can express. The meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union), not any stored column.\n\n`key_expr` is a SQL scalar expression evaluated against the target (e.g. `md5(databasename || '-' || id)`). It is passed through **verbatim** — the same trusted-config contract as [`TestType::Expression`] — so the caller is responsible for sandboxing execution.\n\nSet-based; not quarantinable. Mirrors `Unique`'s NULL handling (NULL keys are not excluded; use `filter` to scope them out).",
+          "properties": {
+            "key_expr": {
+              "description": "SQL scalar expression whose value must be unique across rows.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unique_expr"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "key_expr",
+            "type"
+          ],
+          "type": "object"
+        },
+        {
           "description": "First-class sugar for `col <= CURRENT_TIMESTAMP()` — no timestamp in the future. Row-level; quarantinable (NULL column values pass).",
           "properties": {
             "type": {


### PR DESCRIPTION
**PR 3/5** of cross-source duplicate detection (mechanism 2). ⚠️ **Stacked on #842** — review against that base; I'll rebase onto `main` once #842 merges. Diff here is just `run.rs` + `run_local.rs`.

## ⚠️ One decision for you (surface vs. bail)

An error-severity assertion that **fails** is **surfaced, not bailed** in the replication runner — `rocky run` still exits 0; the `CheckResult` (`passed:false` + `severity`) carries the signal to the orchestrator. This matches how *every* check already behaves in the replication runner (row_count/freshness are advisory there too). **Quality pipelines still bail** per `fail_on_error`.

Rationale: by check time the data has already landed, so bailing wouldn't *prevent* anything — only change the exit code; and making assertions bail while row_count/freshness don't would be inconsistent *within* the replication runner. **If you'd rather honor `fail_on_error` for replication assertions too, it's a few lines — say the word.**

## What

The replication runner (`run.rs`) ran only row_count / freshness / column_match / anomaly — **not** `[checks].assertions`. The assertion executor lived only in `run_local.rs` (quality/transformation/snapshot), so `unique` / `composite` / `unique_expr` never ran on replication pipelines — the headline target for uniqueness-at-ingest.

## How

- Extracted assertion execution + classification into a shared `run_local::run_table_assertions` (`pub(crate)`); `run_local` now calls it (no behavior change), and the replication runner calls it per materialized target.
- **Gating-bug fix (the subtle part):** `target_batch_refs` is gated on `check_row_count`, so it's **empty for an assertions-only pipeline**. Driving assertions off it would silently skip them. Instead, a new *ungated* `TableResult.target_ref` + an unconditional `assertion_targets` collection drive the assertion phase — so it runs **regardless of row_count/freshness config**.

## Tested

- **Live-verified** on the DuckDB replication POC: a `unique` assertion on a duplicated column, with **`row_count` AND `column_match` OFF**, ran and reported `passed:false` / `failing_rows:50` — proving assertions fire at replication time independent of the batch-check path (the discriminating test for the gating bug).
- Full rocky-cli suite (684) *run* green; `run_local` behavior unchanged; fmt + clippy `--all-targets` clean. No output-struct change → no codegen.