### PR TITLE
feat(engine): add cross_source_overlap check for cross-source duplicates

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -579,6 +579,17 @@
           ],
           "default": false
         },
+        "cross_source_overlap": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CrossSourceOverlapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Cross-source overlap check — flags the same business key appearing in more than one sibling source feeding a shared consolidation target. Disabled when unset. See [`CrossSourceOverlapConfig`]."
+        },
         "custom": {
           "default": [],
           "items": {
@@ -739,6 +750,51 @@
           "default": "Medium",
           "description": "Warehouse size for cost estimation (e.g., \"Small\", \"Medium\", \"Large\").",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CrossSourceOverlapConfig": {
+      "additionalProperties": false,
+      "description": "Cross-source overlap check: flags the same business key appearing in more than one *sibling* source feeding a shared consolidation target (the \"same account onboarded twice under two paths\" case). Siblings are grouped by the runner; this config carries only the key + thresholds.\n\n`keys` (a column tuple) and `key_expr` (a derived SQL expression) are mutually exclusive — exactly one must be set, mirroring `unique` / `unique_expr`.",
+      "properties": {
+        "key_expr": {
+          "description": "Derived business-key expression (e.g. `md5(a || '-' || b)`), for sources without a single natural key. Mutually exclusive with `keys`. Passed through verbatim (trusted config, like `unique_expr`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keys": {
+          "default": [],
+          "description": "Business-key columns whose shared value across sibling tables signals a duplicate. Mutually exclusive with `key_expr`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_overlap_rows": {
+          "default": 0,
+          "description": "Overlap-key count above which the check fails. Default 0 — any overlap fails.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sample": {
+          "default": 20,
+          "description": "Maximum overlapping keys attached to the result for triage.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "severity": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestSeverity"
+            }
+          ],
+          "default": "error",
+          "description": "Severity reported when the overlap-key count exceeds `max_overlap_rows`."
         }
       },
       "type": "object"

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -1070,6 +1070,10 @@ export interface ChecksConfig {
    */
   assertions?: QualityAssertion[];
   column_match?: AggregateCheckToggle & boolean;
+  /**
+   * Cross-source overlap check — flags the same business key appearing in more than one sibling source feeding a shared consolidation target. Disabled when unset. See [`CrossSourceOverlapConfig`].
+   */
+  cross_source_overlap?: CrossSourceOverlapConfig | null;
   custom?: CustomCheckConfig[];
   enabled?: boolean;
   /**
@@ -1083,6 +1087,33 @@ export interface ChecksConfig {
    */
   quarantine?: QuarantineConfig | null;
   row_count?: AggregateCheckToggle & boolean;
+}
+/**
+ * Cross-source overlap check: flags the same business key appearing in more than one *sibling* source feeding a shared consolidation target (the "same account onboarded twice under two paths" case). Siblings are grouped by the runner; this config carries only the key + thresholds.
+ *
+ * `keys` (a column tuple) and `key_expr` (a derived SQL expression) are mutually exclusive — exactly one must be set, mirroring `unique` / `unique_expr`.
+ */
+export interface CrossSourceOverlapConfig {
+  /**
+   * Derived business-key expression (e.g. `md5(a || '-' || b)`), for sources without a single natural key. Mutually exclusive with `keys`. Passed through verbatim (trusted config, like `unique_expr`).
+   */
+  key_expr?: string | null;
+  /**
+   * Business-key columns whose shared value across sibling tables signals a duplicate. Mutually exclusive with `key_expr`.
+   */
+  keys?: string[];
+  /**
+   * Overlap-key count above which the check fails. Default 0 — any overlap fails.
+   */
+  max_overlap_rows?: number;
+  /**
+   * Maximum overlapping keys attached to the result for triage.
+   */
+  sample?: number;
+  /**
+   * Severity reported when the overlap-key count exceeds `max_overlap_rows`.
+   */
+  severity?: TestSeverity & string;
 }
 /**
  * A user-defined SQL check with a name, query template, and pass/fail threshold.

--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -59,6 +59,21 @@ export type CheckResult1 =
       result_value: number;
       threshold: number;
       [k: string]: unknown;
+    }
+  | {
+      /**
+       * Fully-qualified sibling tables that were compared.
+       */
+      contributing_tables: string[];
+      /**
+       * Count of distinct keys that appear in more than one sibling table.
+       */
+      overlap_count: number;
+      /**
+       * Bounded sample of overlapping key values (stringified) for triage.
+       */
+      sample: string[];
+      [k: string]: unknown;
     };
 /**
  * Severity of a test failure.

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -3189,6 +3189,103 @@ pub async fn run(
         }
     }
 
+    // Cross-source overlap — flag a business key shared across SIBLING targets:
+    // tables with the same source type + table name that landed in more than
+    // one target schema (the hierarchy/tenant fan-out that gets unioned
+    // downstream, doubling rows). Generic — groups by the discovered source
+    // type (asset_key[0]) + table name, with no schema-pattern-component
+    // assumptions. Self-limiting: only groups of ≥2 siblings are checked, so a
+    // single-target pipeline runs nothing. Surfaced advisorily like the other
+    // replication checks; a missing-key/keyless table is skipped with a logged
+    // reason rather than failing.
+    if let Some(ref overlap_cfg) = pipeline.checks.cross_source_overlap {
+        match overlap_cfg.resolved_key_exprs() {
+            Ok(key_exprs) => {
+                // (source_type, table) -> sibling members (target ref, asset key).
+                type SiblingGroups = HashMap<(String, String), Vec<(TableRef, Vec<String>)>>;
+                let mut groups: SiblingGroups = HashMap::new();
+                for (tref, asset_key) in &assertion_targets {
+                    let source_type = asset_key.first().cloned().unwrap_or_default();
+                    groups
+                        .entry((source_type, tref.table.clone()))
+                        .or_default()
+                        .push((tref.clone(), asset_key.clone()));
+                }
+                // Deterministic order for stable output.
+                let mut group_keys: Vec<&(String, String)> = groups.keys().collect();
+                group_keys.sort();
+
+                let dialect = shared_warehouse.dialect();
+                for gk in group_keys {
+                    let members = &groups[gk];
+                    if members.len() < 2 {
+                        continue; // a single target cannot overlap with itself
+                    }
+                    let (source_type, table) = gk;
+                    let siblings: Vec<TableRef> =
+                        members.iter().map(|(t, _)| t.clone()).collect();
+                    let sql = match rocky_core::checks::generate_cross_source_overlap_sql(
+                        &siblings, &key_exprs, dialect,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!(source_type, table, error = %e, "cross_source_overlap SQL generation failed — skipping group");
+                            continue;
+                        }
+                    };
+                    let name = format!("cross_source_overlap:{source_type}.{table}");
+                    match shared_warehouse.execute_query(&sql).await {
+                        Ok(result) => {
+                            let overlap_count = result.rows.len() as u64;
+                            let sample: Vec<String> = result
+                                .rows
+                                .iter()
+                                .take(overlap_cfg.sample)
+                                .map(|row| {
+                                    row.iter()
+                                        .take(key_exprs.len())
+                                        .map(|v| {
+                                            v.as_str()
+                                                .map(str::to_string)
+                                                .unwrap_or_else(|| v.to_string())
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(" | ")
+                                })
+                                .collect();
+                            let contributing: Vec<String> =
+                                siblings.iter().map(TableRef::full_name).collect();
+                            let check = rocky_core::checks::check_cross_source_overlap(
+                                name,
+                                overlap_count,
+                                overlap_cfg.max_overlap_rows,
+                                contributing,
+                                sample,
+                                overlap_cfg.severity,
+                            );
+                            // Attach to the first sibling's asset (the result's
+                            // contributing_tables lists the whole group).
+                            let entry = pending_checks
+                                .entry(siblings[0].full_name())
+                                .or_insert_with(|| PendingCheck {
+                                    asset_key: members[0].1.clone(),
+                                    checks: Vec::new(),
+                                });
+                            entry.checks.push(check);
+                        }
+                        Err(e) => {
+                            // A missing key column / keyless table surfaces as a
+                            // query error — skip the group with a reason, don't
+                            // fail (FR acceptance criterion).
+                            warn!(source_type, table, error = %e, "cross_source_overlap query failed (missing key column / keyless table?) — skipping group");
+                        }
+                    }
+                }
+            }
+            Err(e) => warn!(error = %e, "cross_source_overlap misconfigured — skipping"),
+        }
+    }
+
     // Assemble check results
     for (_table_key, pending) in pending_checks {
         if !pending.checks.is_empty() {

--- a/engine/crates/rocky-core/src/checks.rs
+++ b/engine/crates/rocky-core/src/checks.rs
@@ -74,6 +74,16 @@ pub enum CheckDetails {
         result_value: u64,
         threshold: u64,
     },
+    /// Cross-source overlap: the same business key found in more than one
+    /// sibling source feeding a shared consolidation target.
+    CrossSourceOverlap {
+        /// Count of distinct keys that appear in more than one sibling table.
+        overlap_count: u64,
+        /// Fully-qualified sibling tables that were compared.
+        contributing_tables: Vec<String>,
+        /// Bounded sample of overlapping key values (stringified) for triage.
+        sample: Vec<String>,
+    },
 }
 
 /// Generates a batched null rate query using the given dialect's TABLESAMPLE syntax.
@@ -150,6 +160,66 @@ pub fn generate_custom_check_sql(
 ) -> Result<String, SqlGenError> {
     let ref_str = dialect.format_table_ref(&table.catalog, &table.schema, &table.table)?;
     Ok(sql_template.replace("{target}", &ref_str))
+}
+
+/// Generates the cross-source overlap query for a set of ≥2 sibling tables.
+///
+/// `key_exprs` is the business key — a list of column names (a composite tuple)
+/// or a single derived expression — already vetted by the caller (columns
+/// validated as identifiers; a `key_expr` is trusted config, passed verbatim).
+/// Each sibling is tagged with its fully-qualified ref and `UNION ALL`'d; the
+/// outer query returns the key values appearing in more than one sibling, so
+/// the result's row count is the overlap count and the rows are the sample.
+pub fn generate_cross_source_overlap_sql(
+    siblings: &[TableRef],
+    key_exprs: &[String],
+    dialect: &dyn SqlDialect,
+) -> Result<String, SqlGenError> {
+    let key_list = key_exprs.join(", ");
+    let not_null = key_exprs
+        .iter()
+        .map(|k| format!("{k} IS NOT NULL"))
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let mut union = String::new();
+    for (i, t) in siblings.iter().enumerate() {
+        let ref_str = dialect.format_table_ref(&t.catalog, &t.schema, &t.table)?;
+        if i > 0 {
+            union.push_str("\n  UNION ALL\n  ");
+        }
+        // Tag each row with its source table as a string literal so the outer
+        // query can count distinct contributing sources per key.
+        let src_lit = ref_str.replace('\'', "''");
+        let _ = write!(
+            union,
+            "SELECT {key_list}, '{src_lit}' AS _src FROM {ref_str} WHERE {not_null}"
+        );
+    }
+    Ok(format!(
+        "SELECT {key_list}, COUNT(DISTINCT _src) AS _n_src FROM (\n  {union}\n) _u GROUP BY {key_list} HAVING COUNT(DISTINCT _src) > 1"
+    ))
+}
+
+/// Builds a `CheckResult` for a cross-source overlap check. Passes when the
+/// distinct-overlap-key count is within `max_overlap_rows`.
+pub fn check_cross_source_overlap(
+    name: impl Into<String>,
+    overlap_count: u64,
+    max_overlap_rows: u64,
+    contributing_tables: Vec<String>,
+    sample: Vec<String>,
+    severity: TestSeverity,
+) -> CheckResult {
+    CheckResult {
+        name: name.into(),
+        passed: overlap_count <= max_overlap_rows,
+        severity,
+        details: CheckDetails::CrossSourceOverlap {
+            overlap_count,
+            contributing_tables,
+            sample,
+        },
+    }
 }
 
 /// Compares source and target row counts.
@@ -565,5 +635,59 @@ mod tests {
         let r = check_custom("my_check", "SELECT 1", 0, 0);
         let json = serde_json::to_string(&r).unwrap();
         assert!(json.contains("my_check"));
+    }
+
+    fn sibling(schema: &str, table: &str) -> TableRef {
+        TableRef {
+            catalog: "cat".into(),
+            schema: schema.into(),
+            table: table.into(),
+        }
+    }
+
+    #[test]
+    fn test_cross_source_overlap_sql_single_key() {
+        let siblings = vec![sibling("s1", "orders"), sibling("s2", "orders")];
+        let sql =
+            generate_cross_source_overlap_sql(&siblings, &["_fivetran_id".into()], &dialect())
+                .unwrap();
+        assert!(sql.contains("UNION ALL"), "must union the siblings: {sql}");
+        assert!(sql.contains("COUNT(DISTINCT _src) > 1"));
+        assert!(sql.contains("GROUP BY _fivetran_id"));
+        assert!(sql.contains("'cat.s1.orders' AS _src FROM cat.s1.orders"));
+        assert!(sql.contains("'cat.s2.orders' AS _src FROM cat.s2.orders"));
+        assert!(sql.contains("_fivetran_id IS NOT NULL"));
+    }
+
+    #[test]
+    fn test_cross_source_overlap_sql_composite_key() {
+        let siblings = vec![sibling("s1", "t"), sibling("s2", "t")];
+        let sql = generate_cross_source_overlap_sql(
+            &siblings,
+            &["clientid".into(), "databaseid".into()],
+            &dialect(),
+        )
+        .unwrap();
+        assert!(sql.contains("clientid, databaseid"));
+        assert!(sql.contains("clientid IS NOT NULL AND databaseid IS NOT NULL"));
+        assert!(sql.contains("GROUP BY clientid, databaseid"));
+    }
+
+    #[test]
+    fn test_cross_source_overlap_check_pass_fail() {
+        let pass = check_cross_source_overlap("x", 0, 0, vec![], vec![], TestSeverity::Warning);
+        assert!(pass.passed);
+        let fail = check_cross_source_overlap(
+            "x",
+            3,
+            0,
+            vec!["cat.s1.t".into(), "cat.s2.t".into()],
+            vec!["k1".into()],
+            TestSeverity::Error,
+        );
+        assert!(!fail.passed);
+        // max_overlap_rows tolerance.
+        let within = check_cross_source_overlap("x", 2, 5, vec![], vec![], TestSeverity::Error);
+        assert!(within.passed);
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -855,6 +855,11 @@ pub struct ChecksConfig {
     pub null_rate: Option<NullRateConfig>,
     #[serde(default)]
     pub custom: Vec<CustomCheckConfig>,
+    /// Cross-source overlap check — flags the same business key appearing in
+    /// more than one sibling source feeding a shared consolidation target.
+    /// Disabled when unset. See [`CrossSourceOverlapConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cross_source_overlap: Option<CrossSourceOverlapConfig>,
     /// Row-level assertions (`not_null`, `unique`, `accepted_values`,
     /// `relationships`, `expression`, `row_count_range`) executed against
     /// specific tables in the quality pipeline. Each entry targets a single
@@ -1124,6 +1129,75 @@ pub struct CustomCheckConfig {
     /// Severity reported when this check fails.
     #[serde(default)]
     pub severity: crate::tests::TestSeverity,
+}
+
+/// Cross-source overlap check: flags the same business key appearing in more
+/// than one *sibling* source feeding a shared consolidation target (the
+/// "same account onboarded twice under two paths" case). Siblings are grouped
+/// by the runner; this config carries only the key + thresholds.
+///
+/// `keys` (a column tuple) and `key_expr` (a derived SQL expression) are
+/// mutually exclusive — exactly one must be set, mirroring `unique` /
+/// `unique_expr`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CrossSourceOverlapConfig {
+    /// Business-key columns whose shared value across sibling tables signals a
+    /// duplicate. Mutually exclusive with `key_expr`.
+    #[serde(default)]
+    pub keys: Vec<String>,
+    /// Derived business-key expression (e.g. `md5(a || '-' || b)`), for sources
+    /// without a single natural key. Mutually exclusive with `keys`. Passed
+    /// through verbatim (trusted config, like `unique_expr`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_expr: Option<String>,
+    /// Severity reported when the overlap-key count exceeds `max_overlap_rows`.
+    #[serde(default)]
+    pub severity: crate::tests::TestSeverity,
+    /// Overlap-key count above which the check fails. Default 0 — any overlap
+    /// fails.
+    #[serde(default)]
+    pub max_overlap_rows: u64,
+    /// Maximum overlapping keys attached to the result for triage.
+    #[serde(default = "default_overlap_sample")]
+    pub sample: usize,
+}
+
+fn default_overlap_sample() -> usize {
+    20
+}
+
+impl CrossSourceOverlapConfig {
+    /// Resolve the configured key into a list of SQL key-expressions: the
+    /// `keys` column list, or a single-element list holding `key_expr`.
+    ///
+    /// Enforces the mutual-exclusion invariant: exactly one of `keys` /
+    /// `key_expr` must be set (both-set or neither-set is an error). Column
+    /// names in `keys` are validated as SQL identifiers; `key_expr` is trusted
+    /// config and passed through verbatim.
+    pub fn resolved_key_exprs(&self) -> Result<Vec<String>, String> {
+        let has_keys = !self.keys.is_empty();
+        let has_expr = self
+            .key_expr
+            .as_deref()
+            .is_some_and(|e| !e.trim().is_empty());
+        match (has_keys, has_expr) {
+            (true, true) => Err(
+                "cross_source_overlap: set exactly one of `keys` or `key_expr`, not both".into(),
+            ),
+            (false, false) => {
+                Err("cross_source_overlap: one of `keys` or `key_expr` is required".into())
+            }
+            (true, false) => {
+                for c in &self.keys {
+                    rocky_sql::validation::validate_identifier(c)
+                        .map_err(|e| format!("cross_source_overlap key column '{c}': {e}"))?;
+                }
+                Ok(self.keys.clone())
+            }
+            (false, true) => Ok(vec![self.key_expr.clone().unwrap()]),
+        }
+    }
 }
 
 /// Governance settings: auto-creation of catalogs/schemas, tags, isolation, and grants.
@@ -9487,5 +9561,31 @@ schema_template = "raw__{source}"
         assert_eq!(fv.retry.max_retries, 8);
         assert_eq!(fv.retry.initial_backoff_ms, 1000);
         assert_eq!(fv.retry.max_backoff_ms, 60000);
+    }
+
+    #[test]
+    fn test_cross_source_overlap_key_mutual_exclusion() {
+        let cfg = |keys: Vec<&str>, key_expr: Option<&str>| CrossSourceOverlapConfig {
+            keys: keys.into_iter().map(String::from).collect(),
+            key_expr: key_expr.map(String::from),
+            severity: crate::tests::TestSeverity::Error,
+            max_overlap_rows: 0,
+            sample: 20,
+        };
+        // keys only → the column list.
+        assert_eq!(
+            cfg(vec!["a", "b"], None).resolved_key_exprs().unwrap(),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        // key_expr only → single-element list.
+        assert_eq!(
+            cfg(vec![], Some("md5(a||b)")).resolved_key_exprs().unwrap(),
+            vec!["md5(a||b)".to_string()]
+        );
+        // both set → error; neither set → error.
+        assert!(cfg(vec!["a"], Some("x")).resolved_key_exprs().is_err());
+        assert!(cfg(vec![], None).resolved_key_exprs().is_err());
+        // invalid column name is rejected (injection guard on `keys`).
+        assert!(cfg(vec!["a; DROP"], None).resolved_key_exprs().is_err());
     }
 }

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1611,6 +1611,38 @@ class ContractConfig(BaseModel):
     """
 
 
+class CrossSourceOverlapConfig(BaseModel):
+    """
+    Cross-source overlap check: flags the same business key appearing in more than one *sibling* source feeding a shared consolidation target (the "same account onboarded twice under two paths" case). Siblings are grouped by the runner; this config carries only the key + thresholds.
+
+    `keys` (a column tuple) and `key_expr` (a derived SQL expression) are mutually exclusive — exactly one must be set, mirroring `unique` / `unique_expr`.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key_expr: str | None = None
+    """
+    Derived business-key expression (e.g. `md5(a || '-' || b)`), for sources without a single natural key. Mutually exclusive with `keys`. Passed through verbatim (trusted config, like `unique_expr`).
+    """
+    keys: list[str] | None = []
+    """
+    Business-key columns whose shared value across sibling tables signals a duplicate. Mutually exclusive with `key_expr`.
+    """
+    max_overlap_rows: conint(ge=0) | None = 0
+    """
+    Overlap-key count above which the check fails. Default 0 — any overlap fails.
+    """
+    sample: conint(ge=0) | None = 20
+    """
+    Maximum overlapping keys attached to the result for triage.
+    """
+    severity: TestSeverity5 | TestSeverity6 | None = "error"
+    """
+    Severity reported when the overlap-key count exceeds `max_overlap_rows`.
+    """
+
+
 class CustomCheckConfig(BaseModel):
     """
     A user-defined SQL check with a name, query template, and pass/fail threshold.
@@ -2356,6 +2388,10 @@ class ChecksConfig(BaseModel):
     ```toml # Legacy — still supported row_count = true
 
     # New — per-check severity [pipeline.x.checks.row_count] enabled  = true severity = "warning" ```
+    """
+    cross_source_overlap: CrossSourceOverlapConfig | None = None
+    """
+    Cross-source overlap check — flags the same business key appearing in more than one sibling source feeding a shared consolidation target. Disabled when unset. See [`CrossSourceOverlapConfig`].
     """
     custom: list[CustomCheckConfig] | None = Field([], validate_default=True)
     enabled: bool | None = False

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -515,6 +515,31 @@ class CheckResult6(BaseModel):
     threshold: conint(ge=0)
 
 
+class CheckResult7(BaseModel):
+    """
+    Cross-source overlap: the same business key found in more than one sibling source feeding a shared consolidation target.
+    """
+
+    name: str
+    passed: bool
+    severity: TestSeverity7 | TestSeverity8 | None = "error"
+    """
+    Severity reported when the check fails. `error` causes the quality pipeline to exit non-zero (subject to `fail_on_error`); `warning` is advisory and does not fail the run.
+    """
+    contributing_tables: list[str]
+    """
+    Fully-qualified sibling tables that were compared.
+    """
+    overlap_count: conint(ge=0)
+    """
+    Count of distinct keys that appear in more than one sibling table.
+    """
+    sample: list[str]
+    """
+    Bounded sample of overlapping key values (stringified) for triage.
+    """
+
+
 class MaterializationOutput(BaseModel):
     asset_key: list[str]
     bytes_scanned: conint(ge=0) | None = None
@@ -559,6 +584,7 @@ class TableCheckOutput(BaseModel):
         | CheckResult4
         | CheckResult5
         | CheckResult6
+        | CheckResult7
     ]
 
 

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -578,6 +578,17 @@
           ],
           "default": false
         },
+        "cross_source_overlap": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CrossSourceOverlapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Cross-source overlap check — flags the same business key appearing in more than one sibling source feeding a shared consolidation target. Disabled when unset. See [`CrossSourceOverlapConfig`]."
+        },
         "custom": {
           "default": [],
           "items": {
@@ -738,6 +749,51 @@
           "default": "Medium",
           "description": "Warehouse size for cost estimation (e.g., \"Small\", \"Medium\", \"Large\").",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CrossSourceOverlapConfig": {
+      "additionalProperties": false,
+      "description": "Cross-source overlap check: flags the same business key appearing in more than one *sibling* source feeding a shared consolidation target (the \"same account onboarded twice under two paths\" case). Siblings are grouped by the runner; this config carries only the key + thresholds.\n\n`keys` (a column tuple) and `key_expr` (a derived SQL expression) are mutually exclusive — exactly one must be set, mirroring `unique` / `unique_expr`.",
+      "properties": {
+        "key_expr": {
+          "description": "Derived business-key expression (e.g. `md5(a || '-' || b)`), for sources without a single natural key. Mutually exclusive with `keys`. Passed through verbatim (trusted config, like `unique_expr`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keys": {
+          "default": [],
+          "description": "Business-key columns whose shared value across sibling tables signals a duplicate. Mutually exclusive with `key_expr`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "max_overlap_rows": {
+          "default": 0,
+          "description": "Overlap-key count above which the check fails. Default 0 — any overlap fails.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "sample": {
+          "default": 20,
+          "description": "Maximum overlapping keys attached to the result for triage.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "severity": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestSeverity"
+            }
+          ],
+          "default": "error",
+          "description": "Severity reported when the overlap-key count exceeds `max_overlap_rows`."
         }
       },
       "type": "object"

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -192,6 +192,37 @@
             "threshold"
           ],
           "type": "object"
+        },
+        {
+          "description": "Cross-source overlap: the same business key found in more than one sibling source feeding a shared consolidation target.",
+          "properties": {
+            "contributing_tables": {
+              "description": "Fully-qualified sibling tables that were compared.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "overlap_count": {
+              "description": "Count of distinct keys that appear in more than one sibling table.",
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "sample": {
+              "description": "Bounded sample of overlapping key values (stringified) for triage.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "contributing_tables",
+            "overlap_count",
+            "sample"
+          ],
+          "type": "object"
         }
       ],
       "description": "Result of a single data quality check.",


### PR DESCRIPTION
**PR 4/5** — the **headline** of cross-source duplicate detection (mechanism 2). Independent; off clean `main`.

## What

`[pipeline.<name>.checks.cross_source_overlap]` flags the **same business key in more than one sibling target table** — the "same entity onboarded twice under two paths" case that had *no signal anywhere*: each table passes every per-table check, then a downstream `UNION ALL` silently doubles every row.

```toml
[pipeline.repl.checks.cross_source_overlap]
keys = ["_fivetran_id"]        # OR key_expr = "md5(a || '-' || b)" (mutually exclusive)
severity = "error"
max_overlap_rows = 0
sample = 20
```

## Grouping — generic, not Fivetran/GOLD-shaped

Siblings are grouped by **`(source_type, table_name)`** — both universal: every discovery adapter sets `source_type`, every target has a table name. **No** assumption about `client`/`connector`/`hierarchy` component names (the playground pattern has just `source`). Self-limiting: only groups of **≥2** siblings are checked, so a normal single-target pipeline runs nothing and produces zero noise. Reuses the per-table `(ref, asset_key)` collection the replication runner already builds → **zero new threading** through the concurrent task path. (A finer `group_by: [components]` override is a clean follow-up if a project ever hits cross-client noise.)

## How

- **`config.rs`**: `CrossSourceOverlapConfig` (`keys` | `key_expr` mutually exclusive, like `unique`/`unique_expr`; `severity`; `max_overlap_rows`; `sample`).
- **`checks.rs`**: `generate_cross_source_overlap_sql` — `UNION ALL` each sibling tagged with its ref, `GROUP BY key HAVING COUNT(DISTINCT _src) > 1` — plus the `CheckDetails::CrossSourceOverlap` result variant (`overlap_count` + `contributing_tables` + bounded `sample`).
- **`run.rs`**: group siblings, run per group, surface advisorily (consistent with PR3 — orchestrator decides from JSON). A keyless / missing-key group is **skipped with a logged reason**, not a failure.
- Regenerated run + project schemas and dagster/vscode bindings via `just codegen` (no lockfile drift).

## Tested

- Unit: single-key + composite-key SQL shape; pass/fail; `keys`/`key_expr` mutual-exclusion (both-set / neither-set / bad-column all rejected).
- **DuckDB live-verify**: two onboards sharing `order_id` 1,2,3 across sibling targets → flagged **exactly those 3** (not the unique-to-one 4,5), with both contributing tables and the sample. Precise, not just present.
- Full rocky-core / rocky-cli suites *run* green; fmt; clippy `--all-targets`; dagster ruff — all clean.

## Follow-ups (noted, not blocking)

- Parse-time (`rocky validate`) rejection of bad key config — currently caught at check time (warn + skip), never silently wrong.
- Per-table (vs per-group) keyless skip.
- Non-replication (transformation/quality) pipeline support.