### PR TITLE
feat(engine): detect cross-source collisions at discover time

### DIFF
--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -869,6 +869,15 @@
           "description": "Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `\"default\"`.",
           "type": "string"
         },
+        "on_collision": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/OnCollision"
+            }
+          ],
+          "default": "off",
+          "description": "What to do when discover finds the same external object id mapped to more than one target path (likely the same object onboarded twice). `off` (default) skips detection entirely; `warn` reports `collision_candidates` + emits an event; `error` additionally fails the discover. Only adapters that supply `external_object_id` (e.g. Fivetran) participate; others are silently skipped."
+        },
         "report_new_sources": {
           "default": false,
           "description": "When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.",
@@ -1777,6 +1786,32 @@
         "threshold"
       ],
       "type": "object"
+    },
+    "OnCollision": {
+      "description": "Action when `rocky discover` detects a cross-source collision — the same external object id mapped to more than one target path.",
+      "oneOf": [
+        {
+          "description": "Collision detection disabled (default — fully backwards compatible).",
+          "enum": [
+            "off"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Report collisions in `collision_candidates` and emit an event, but do not fail the discover.",
+          "enum": [
+            "warn"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Report collisions and fail the discover, so a colliding onboard cannot silently create a catalog/table.",
+          "enum": [
+            "error"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "PipelineConfig": {
       "anyOf": [

--- a/editors/vscode/src/types/generated/discover.ts
+++ b/editors/vscode/src/types/generated/discover.ts
@@ -13,6 +13,10 @@ export interface DiscoverOutput {
    * Pipeline-level data quality check configuration. Present when the pipeline declares a `[checks]` block in `rocky.toml`. Downstream orchestrators (e.g. Dagster) consume this to attach asset-level freshness policies and check expectations without re-reading `rocky.toml` themselves.
    */
   checks?: ChecksConfigOutput | null;
+  /**
+   * Groups of ≥2 discovered sources sharing the SAME external object id but resolving to DIFFERENT target paths — the same underlying object onboarded twice. Populated only when discovery's `on_collision` is `warn`/`error` and the adapter supplies `external_object_id`; empty (and omitted from the wire format) otherwise.
+   */
+  collision_candidates?: CollisionCandidateOutput[];
   command: string;
   /**
    * Tables filtered out of `sources` because they were reported by the discovery adapter but do not exist in the source warehouse. Same shape as `RunOutput.excluded_tables` so consumers can use one parser. Empty when nothing was filtered.
@@ -52,6 +56,20 @@ export interface ChecksConfigOutput {
  */
 export interface FreshnessConfigOutput {
   threshold_seconds: number;
+  [k: string]: unknown;
+}
+/**
+ * A cross-source collision: one external object id mapped to more than one target path (the same object onboarded twice under different schemas).
+ */
+export interface CollisionCandidateOutput {
+  /**
+   * The shared external object id (e.g. a Fivetran ad-account id).
+   */
+  external_object_id: string;
+  /**
+   * The distinct source schemas that resolve to it (≥2), sorted.
+   */
+  sources: string[];
   [k: string]: unknown;
 }
 /**

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -293,6 +293,10 @@ export type QuarantineMode = "split" | "tag" | "drop";
  */
 export type ConcurrencyMode = "adaptive" | number;
 /**
+ * Action when `rocky discover` detects a cross-source collision — the same external object id mapped to more than one target path.
+ */
+export type OnCollision = "off" | "warn" | "error";
+/**
  * Workspace binding access level.
  */
 export type BindingType = "READ_WRITE" | "READ_ONLY";
@@ -1242,6 +1246,10 @@ export interface DiscoveryConfig {
    * Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `"default"`.
    */
   adapter?: string;
+  /**
+   * What to do when discover finds the same external object id mapped to more than one target path (likely the same object onboarded twice). `off` (default) skips detection entirely; `warn` reports `collision_candidates` + emits an event; `error` additionally fails the discover. Only adapters that supply `external_object_id` (e.g. Fivetran) participate; others are silently skipped.
+   */
+  on_collision?: OnCollision & string;
   /**
    * When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.
    */

--- a/engine/crates/rocky-airbyte/src/adapter.rs
+++ b/engine/crates/rocky-airbyte/src/adapter.rs
@@ -130,7 +130,7 @@ fn map_connection(conn: Connection) -> DiscoveredConnector {
         last_sync_at: conn.last_sync_at,
         tables,
         metadata: Default::default(),
-        external_object_id: None,
+        external_object_ids: Vec::new(),
     }
 }
 

--- a/engine/crates/rocky-airbyte/src/adapter.rs
+++ b/engine/crates/rocky-airbyte/src/adapter.rs
@@ -130,6 +130,7 @@ fn map_connection(conn: Connection) -> DiscoveredConnector {
         last_sync_at: conn.last_sync_at,
         tables,
         metadata: Default::default(),
+        external_object_id: None,
     }
 }
 

--- a/engine/crates/rocky-bigquery/src/discovery.rs
+++ b/engine/crates/rocky-bigquery/src/discovery.rs
@@ -117,7 +117,7 @@ impl DiscoveryAdapter for BigQueryDiscoveryAdapter {
                 last_sync_at: None,
                 tables,
                 metadata: Default::default(),
-                external_object_id: None,
+                external_object_ids: Vec::new(),
             });
         }
 

--- a/engine/crates/rocky-bigquery/src/discovery.rs
+++ b/engine/crates/rocky-bigquery/src/discovery.rs
@@ -117,6 +117,7 @@ impl DiscoveryAdapter for BigQueryDiscoveryAdapter {
                 last_sync_at: None,
                 tables,
                 metadata: Default::default(),
+                external_object_id: None,
             });
         }
 

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -211,6 +211,44 @@ pub async fn discover(
         Vec::new()
     };
 
+    // Collision detection (opt-in). Group discovered sources by their stable
+    // external object id; an id mapped to >1 distinct source schema is a
+    // collision — likely the same underlying object onboarded twice under two
+    // paths. Only adapters that supply `external_object_id` (e.g. Fivetran)
+    // participate; the rest contribute nothing, so this is a no-op for them.
+    let on_collision = pipeline
+        .source
+        .discovery
+        .as_ref()
+        .map(|d| d.on_collision)
+        .unwrap_or(rocky_core::config::OnCollision::Off);
+    let collision_candidates = if on_collision == rocky_core::config::OnCollision::Off {
+        Vec::new()
+    } else {
+        let found = detect_collisions(connectors);
+        if !found.is_empty() {
+            let bus = rocky_observe::events::global_event_bus();
+            for c in &found {
+                bus.emit(
+                    rocky_observe::events::PipelineEvent::new("source_collision_detected")
+                        .with_metadata(
+                            "external_object_id",
+                            serde_json::json!(c.external_object_id),
+                        )
+                        .with_metadata("sources", serde_json::json!(c.sources)),
+                );
+            }
+            warn!(
+                count = found.len(),
+                "discover: cross-source collision(s) detected — same external object id under \
+                 >1 target path; see `collision_candidates` in JSON output"
+            );
+        }
+        found
+    };
+    let collision_failure =
+        on_collision == rocky_core::config::OnCollision::Error && !collision_candidates.is_empty();
+
     // Schema-cache warm-up. Only runs when `--with-schemas` is set;
     // config gating already happened at the top of this function.
     // Errors inside the warm-up are logged and counted as misses — a
@@ -235,7 +273,8 @@ pub async fn discover(
         .with_excluded_tables(excluded_tables)
         .with_failed_sources(failed_sources)
         .with_schemas_cached(schemas_cached)
-        .with_new_sources(new_sources);
+        .with_new_sources(new_sources)
+        .with_collision_candidates(collision_candidates);
     if output_json {
         print_json(&output)?;
     } else {
@@ -251,6 +290,17 @@ pub async fn discover(
         if with_schemas {
             println!("schemas cached: {schemas_cached}");
         }
+    }
+
+    // `on_collision = "error"` fails the discover after the output is emitted,
+    // so a colliding onboard surfaces a non-zero exit (the JSON still carries
+    // the `collision_candidates` detail for the orchestrator).
+    if collision_failure {
+        anyhow::bail!(
+            "discover: cross-source collision detected (on_collision = error) — \
+             the same external object id is mapped to more than one target path; \
+             see `collision_candidates`"
+        );
     }
     Ok(())
 }
@@ -391,6 +441,32 @@ fn dedup_schemas(connectors: &[rocky_core::source::DiscoveredConnector]) -> Vec<
             } else {
                 None
             }
+        })
+        .collect()
+}
+
+/// Group discovered sources by their stable external object id and return the
+/// ids mapped to more than one distinct source schema — cross-source
+/// collisions (likely the same object onboarded twice under two paths).
+///
+/// Sources without an `external_object_id` are skipped (collision detection is
+/// opt-in per adapter). Deterministic: ids and their source schemas are sorted.
+fn detect_collisions(
+    connectors: &[rocky_core::source::DiscoveredConnector],
+) -> Vec<CollisionCandidateOutput> {
+    use std::collections::{BTreeMap, BTreeSet};
+    let mut by_id: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for conn in connectors {
+        if let Some(id) = conn.external_object_id.as_deref() {
+            by_id.entry(id).or_default().insert(conn.schema.as_str());
+        }
+    }
+    by_id
+        .into_iter()
+        .filter(|(_, schemas)| schemas.len() >= 2)
+        .map(|(id, schemas)| CollisionCandidateOutput {
+            external_object_id: id.to_string(),
+            sources: schemas.into_iter().map(str::to_string).collect(),
         })
         .collect()
 }
@@ -891,6 +967,7 @@ mod tests {
                 row_count: None,
             }],
             metadata: Default::default(),
+            external_object_id: None,
         }
     }
 
@@ -937,6 +1014,36 @@ mod tests {
         let p2 =
             diff_and_record_new_sources(&state, "p2", &["a".to_string(), "b".to_string()]).unwrap();
         assert!(p2.is_empty());
+    }
+
+    #[test]
+    fn detect_collisions_groups_by_external_object_id() {
+        let mk = |schema: &str, ext: Option<&str>| DiscoveredConnector {
+            id: format!("conn_{schema}"),
+            schema: schema.to_string(),
+            source_type: "fivetran".to_string(),
+            last_sync_at: None,
+            tables: vec![],
+            metadata: Default::default(),
+            external_object_id: ext.map(String::from),
+        };
+        let connectors = vec![
+            mk("src__acme__shopify", Some("acct_42")),
+            mk("src__coke__shopify", Some("acct_42")), // same object id, different path
+            mk("src__beta__shopify", Some("acct_99")), // unique id → no collision
+            mk("src__gamma__stripe", None),            // no id → skipped entirely
+        ];
+        let collisions = detect_collisions(&connectors);
+        assert_eq!(collisions.len(), 1, "exactly one colliding object id");
+        assert_eq!(collisions[0].external_object_id, "acct_42");
+        // Sources are sorted (deterministic).
+        assert_eq!(
+            collisions[0].sources,
+            vec![
+                "src__acme__shopify".to_string(),
+                "src__coke__shopify".to_string()
+            ]
+        );
     }
 
     #[tokio::test]

--- a/engine/crates/rocky-cli/src/commands/discover.rs
+++ b/engine/crates/rocky-cli/src/commands/discover.rs
@@ -51,12 +51,38 @@ pub async fn discover(
 
     let adapter_registry = registry::AdapterRegistry::from_config(&rocky_cfg)?;
 
+    // Collision detection is opt-in; resolve the mode up front because it gates
+    // the extra per-connector external-object-id enrichment pass below (skip the
+    // N detail fetches entirely when detection is off).
+    let on_collision = pipeline
+        .source
+        .discovery
+        .as_ref()
+        .map(|d| d.on_collision)
+        .unwrap_or(rocky_core::config::OnCollision::Off);
+
     let discovery_result = if let Some(ref disc) = pipeline.source.discovery {
         let discovery_adapter = adapter_registry.discovery_adapter(&disc.adapter)?;
-        discovery_adapter
+        let mut result = discovery_adapter
             .discover(&pattern.prefix)
             .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        // Populate each source's external object id(s) for collision detection.
+        // Separate from `discover` because it can cost one API call per
+        // connector — only worth paying when detection is on. Best-effort: a
+        // failure logs and leaves ids empty (a missed detection, never a false
+        // one), never aborting discover.
+        if on_collision != rocky_core::config::OnCollision::Off
+            && let Err(e) = discovery_adapter
+                .enrich_external_object_ids(&mut result.connectors)
+                .await
+        {
+            warn!(
+                error = %e,
+                "discover: external-object-id enrichment failed — collision detection may under-report"
+            );
+        }
+        result
     } else {
         anyhow::bail!(
             "{}",
@@ -211,17 +237,12 @@ pub async fn discover(
         Vec::new()
     };
 
-    // Collision detection (opt-in). Group discovered sources by their stable
-    // external object id; an id mapped to >1 distinct source schema is a
-    // collision — likely the same underlying object onboarded twice under two
-    // paths. Only adapters that supply `external_object_id` (e.g. Fivetran)
-    // participate; the rest contribute nothing, so this is a no-op for them.
-    let on_collision = pipeline
-        .source
-        .discovery
-        .as_ref()
-        .map(|d| d.on_collision)
-        .unwrap_or(rocky_core::config::OnCollision::Off);
+    // Collision detection (opt-in, mode resolved as `on_collision` above). Group
+    // discovered sources by their stable external object id(s); an id mapped to
+    // >1 distinct source schema is a collision — likely the same underlying
+    // object onboarded twice under two paths. Only adapters that populate
+    // `external_object_ids` (e.g. Fivetran, via the enrichment pass) participate;
+    // the rest contribute nothing, so this is a no-op for them.
     let collision_candidates = if on_collision == rocky_core::config::OnCollision::Off {
         Vec::new()
     } else {
@@ -445,26 +466,39 @@ fn dedup_schemas(connectors: &[rocky_core::source::DiscoveredConnector]) -> Vec<
         .collect()
 }
 
-/// Group discovered sources by their stable external object id and return the
-/// ids mapped to more than one distinct source schema — cross-source
+/// Group discovered sources by the external object id(s) each replicates and
+/// return ids mapped to more than one distinct source schema — cross-source
 /// collisions (likely the same object onboarded twice under two paths).
 ///
-/// Sources without an `external_object_id` are skipped (collision detection is
-/// opt-in per adapter). Deterministic: ids and their source schemas are sorted.
+/// Grouping is keyed by `(source_type, id)`, not the bare id: two *different*
+/// services that happen to reuse the same id string (e.g. a Google `customer_id`
+/// and a numeric advertiser id elsewhere) are distinct objects in distinct id
+/// namespaces, so conflating them would be a false collision. Within any one
+/// reported collision every source shares a source_type, so the bare
+/// `external_object_id` in the output is unambiguous.
+///
+/// A connector can replicate many objects, so each id in its
+/// `external_object_ids` contributes that connector's schema to the id's set.
+/// Sources with no ids are skipped (collision detection is opt-in per adapter).
+/// Deterministic: ids and their source schemas are sorted.
 fn detect_collisions(
     connectors: &[rocky_core::source::DiscoveredConnector],
 ) -> Vec<CollisionCandidateOutput> {
     use std::collections::{BTreeMap, BTreeSet};
-    let mut by_id: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    // key = (source_type, external_object_id) → set of distinct source schemas
+    let mut by_id: BTreeMap<(&str, &str), BTreeSet<&str>> = BTreeMap::new();
     for conn in connectors {
-        if let Some(id) = conn.external_object_id.as_deref() {
-            by_id.entry(id).or_default().insert(conn.schema.as_str());
+        for id in &conn.external_object_ids {
+            by_id
+                .entry((conn.source_type.as_str(), id.as_str()))
+                .or_default()
+                .insert(conn.schema.as_str());
         }
     }
     by_id
         .into_iter()
         .filter(|(_, schemas)| schemas.len() >= 2)
-        .map(|(id, schemas)| CollisionCandidateOutput {
+        .map(|((_, id), schemas)| CollisionCandidateOutput {
             external_object_id: id.to_string(),
             sources: schemas.into_iter().map(str::to_string).collect(),
         })
@@ -967,7 +1001,7 @@ mod tests {
                 row_count: None,
             }],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         }
     }
 
@@ -1016,22 +1050,28 @@ mod tests {
         assert!(p2.is_empty());
     }
 
-    #[test]
-    fn detect_collisions_groups_by_external_object_id() {
-        let mk = |schema: &str, ext: Option<&str>| DiscoveredConnector {
+    fn discovered_with(schema: &str, source_type: &str, ids: &[&str]) -> DiscoveredConnector {
+        DiscoveredConnector {
             id: format!("conn_{schema}"),
             schema: schema.to_string(),
-            source_type: "fivetran".to_string(),
+            source_type: source_type.to_string(),
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: ext.map(String::from),
-        };
+            external_object_ids: ids.iter().copied().map(str::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn detect_collisions_groups_by_external_object_id() {
         let connectors = vec![
-            mk("src__acme__shopify", Some("acct_42")),
-            mk("src__coke__shopify", Some("acct_42")), // same object id, different path
-            mk("src__beta__shopify", Some("acct_99")), // unique id → no collision
-            mk("src__gamma__stripe", None),            // no id → skipped entirely
+            discovered_with("src__acme__fb", "facebook_ads", &["acct_42"]),
+            // same object id + service, different path → collision
+            discovered_with("src__coke__fb", "facebook_ads", &["acct_42"]),
+            // unique id → no collision
+            discovered_with("src__beta__fb", "facebook_ads", &["acct_99"]),
+            // no id → skipped entirely
+            discovered_with("src__gamma__stripe", "stripe", &[]),
         ];
         let collisions = detect_collisions(&connectors);
         assert_eq!(collisions.len(), 1, "exactly one colliding object id");
@@ -1039,10 +1079,41 @@ mod tests {
         // Sources are sorted (deterministic).
         assert_eq!(
             collisions[0].sources,
-            vec![
-                "src__acme__shopify".to_string(),
-                "src__coke__shopify".to_string()
-            ]
+            vec!["src__acme__fb".to_string(), "src__coke__fb".to_string()]
+        );
+    }
+
+    #[test]
+    fn detect_collisions_does_not_conflate_across_source_types() {
+        // The SAME id string under two DIFFERENT services in two schemas is NOT
+        // a collision — the ids live in separate namespaces (e.g. a Google
+        // `customer_id` vs a numeric advertiser id elsewhere). This is the whole
+        // reason grouping is keyed by (source_type, id), not the bare id.
+        let connectors = vec![
+            discovered_with("src__a__google", "google_ads", &["1234567890"]),
+            discovered_with("src__b__pin", "pinterest_ads", &["1234567890"]),
+        ];
+        assert!(
+            detect_collisions(&connectors).is_empty(),
+            "same id under different source_types must not collide"
+        );
+    }
+
+    #[test]
+    fn detect_collisions_flags_multi_account_connector() {
+        // A connector syncing many accounts contributes each id, so a collision
+        // on ANY one of them is surfaced — the prior `Option<String>` model
+        // would have missed every account but the first.
+        let connectors = vec![
+            discovered_with("src__x__fb", "facebook_ads", &["acct_1", "acct_shared"]),
+            discovered_with("src__y__fb", "facebook_ads", &["acct_2", "acct_shared"]),
+        ];
+        let collisions = detect_collisions(&connectors);
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0].external_object_id, "acct_shared");
+        assert_eq!(
+            collisions[0].sources,
+            vec!["src__x__fb".to_string(), "src__y__fb".to_string()]
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -283,6 +283,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
@@ -300,6 +301,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([
@@ -321,6 +323,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([(
@@ -342,6 +345,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
@@ -361,6 +365,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),

--- a/engine/crates/rocky-cli/src/commands/mod.rs
+++ b/engine/crates/rocky-cli/src/commands/mod.rs
@@ -283,7 +283,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
@@ -301,7 +301,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([
@@ -323,7 +323,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([(
@@ -345,7 +345,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),
@@ -365,7 +365,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let parsed = ParsedSchema {
             values: IndexMap::from([("client".into(), SchemaValue::Single("acme".into()))]),

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1989,7 +1989,7 @@ table = "m"
                 "fivetran.rate_limit_used".to_string(),
                 serde_json::json!(42),
             )]),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         }
     }
 

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -1989,6 +1989,7 @@ table = "m"
                 "fivetran.rate_limit_used".to_string(),
                 serde_json::json!(42),
             )]),
+            external_object_id: None,
         }
     }
 

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -110,6 +110,23 @@ pub struct DiscoverOutput {
     /// baseline and reports none.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub new_sources: Vec<String>,
+    /// Groups of ≥2 discovered sources sharing the SAME external object id but
+    /// resolving to DIFFERENT target paths — the same underlying object
+    /// onboarded twice. Populated only when discovery's `on_collision` is
+    /// `warn`/`error` and the adapter supplies `external_object_id`; empty (and
+    /// omitted from the wire format) otherwise.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub collision_candidates: Vec<CollisionCandidateOutput>,
+}
+
+/// A cross-source collision: one external object id mapped to more than one
+/// target path (the same object onboarded twice under different schemas).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CollisionCandidateOutput {
+    /// The shared external object id (e.g. a Fivetran ad-account id).
+    pub external_object_id: String,
+    /// The distinct source schemas that resolve to it (≥2), sorted.
+    pub sources: Vec<String>,
 }
 
 /// Pipeline-level checks configuration projected into the discover output.
@@ -3510,6 +3527,7 @@ impl DiscoverOutput {
             failed_sources: vec![],
             schemas_cached: 0,
             new_sources: vec![],
+            collision_candidates: vec![],
         }
     }
 
@@ -3551,6 +3569,14 @@ impl DiscoverOutput {
     #[must_use]
     pub fn with_new_sources(mut self, new_sources: Vec<String>) -> Self {
         self.new_sources = new_sources;
+        self
+    }
+
+    /// Attach detected cross-source collisions (opt-in via discovery's
+    /// `on_collision`) and return self.
+    #[must_use]
+    pub fn with_collision_candidates(mut self, candidates: Vec<CollisionCandidateOutput>) -> Self {
+        self.collision_candidates = candidates;
         self
     }
 }

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -4275,6 +4275,22 @@ pub struct PipelineSourceConfig {
     pub discovery: Option<DiscoveryConfig>,
 }
 
+/// Action when `rocky discover` detects a cross-source collision — the same
+/// external object id mapped to more than one target path.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OnCollision {
+    /// Collision detection disabled (default — fully backwards compatible).
+    #[default]
+    Off,
+    /// Report collisions in `collision_candidates` and emit an event, but do
+    /// not fail the discover.
+    Warn,
+    /// Report collisions and fail the discover, so a colliding onboard cannot
+    /// silently create a catalog/table.
+    Error,
+}
+
 /// Discovery configuration within a pipeline source.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -4290,6 +4306,15 @@ pub struct DiscoveryConfig {
     /// when opted in, so existing projects pay nothing.
     #[serde(default)]
     pub report_new_sources: bool,
+
+    /// What to do when discover finds the same external object id mapped to
+    /// more than one target path (likely the same object onboarded twice).
+    /// `off` (default) skips detection entirely; `warn` reports
+    /// `collision_candidates` + emits an event; `error` additionally fails the
+    /// discover. Only adapters that supply `external_object_id` (e.g. Fivetran)
+    /// participate; others are silently skipped.
+    #[serde(default)]
+    pub on_collision: OnCollision,
 }
 
 /// Pipeline target configuration.
@@ -4682,6 +4707,7 @@ fn apply_single_adapter_discovery_default(config: &mut RockyConfig) {
             replication.source.discovery = Some(DiscoveryConfig {
                 adapter: sole_adapter.clone(),
                 report_new_sources: false,
+                on_collision: OnCollision::Off,
             });
         }
     }

--- a/engine/crates/rocky-core/src/source.rs
+++ b/engine/crates/rocky-core/src/source.rs
@@ -27,6 +27,14 @@ pub struct DiscoveredConnector {
     /// the dagster fixture corpus + codegen-drift CI).
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, serde_json::Value>,
+    /// Stable identity of the underlying external object this source
+    /// replicates (e.g. a Fivetran ad-account id recovered from connector
+    /// config). `None` when the adapter can't determine one — collision
+    /// detection is then skipped for this source. The schema *name*
+    /// deliberately does not encode this, which is exactly why two onboards of
+    /// the same object under different paths can collide unnoticed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_object_id: Option<String>,
 }
 
 /// A discovered table within a connector.
@@ -180,6 +188,7 @@ mod tests {
                 },
             ],
             metadata: IndexMap::new(),
+            external_object_id: None,
         };
         let json = serde_json::to_string(&conn).unwrap();
         // Empty metadata is skipped from the wire form so adapters that
@@ -211,6 +220,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata,
+            external_object_id: None,
         };
 
         let json = serde_json::to_string(&conn).unwrap();

--- a/engine/crates/rocky-core/src/source.rs
+++ b/engine/crates/rocky-core/src/source.rs
@@ -27,14 +27,19 @@ pub struct DiscoveredConnector {
     /// the dagster fixture corpus + codegen-drift CI).
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub metadata: IndexMap<String, serde_json::Value>,
-    /// Stable identity of the underlying external object this source
-    /// replicates (e.g. a Fivetran ad-account id recovered from connector
-    /// config). `None` when the adapter can't determine one — collision
-    /// detection is then skipped for this source. The schema *name*
+    /// Stable identities of the underlying external object(s) this source
+    /// replicates (e.g. the Fivetran ad-account ids recovered from connector
+    /// config). A single connector can replicate MANY objects (Fivetran's
+    /// `accounts: ["act_1", "act_2"]`), so this is a set, not a scalar. Empty
+    /// when the adapter can't determine any — collision detection is then
+    /// skipped for this source. Populated lazily by
+    /// [`crate::traits::DiscoveryAdapter::enrich_external_object_ids`], not by
+    /// [`crate::traits::DiscoveryAdapter::discover`], because recovering the
+    /// ids can cost an extra API call per connector. The schema *name*
     /// deliberately does not encode this, which is exactly why two onboards of
     /// the same object under different paths can collide unnoticed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub external_object_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_object_ids: Vec<String>,
 }
 
 /// A discovered table within a connector.
@@ -188,7 +193,7 @@ mod tests {
                 },
             ],
             metadata: IndexMap::new(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         let json = serde_json::to_string(&conn).unwrap();
         // Empty metadata is skipped from the wire form so adapters that
@@ -220,7 +225,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata,
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
 
         let json = serde_json::to_string(&conn).unwrap();

--- a/engine/crates/rocky-core/src/traits.rs
+++ b/engine/crates/rocky-core/src/traits.rs
@@ -17,7 +17,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::retention::RetentionPolicy;
-use crate::source::DiscoveryResult;
+use crate::source::{DiscoveredConnector, DiscoveryResult};
 use rocky_ir::{
     ColumnInfo, ColumnSelection, Grant, GrantTarget, MaskStrategy, MetadataColumn, TableRef,
 };
@@ -188,6 +188,27 @@ pub trait DiscoveryAdapter: Send + Sync {
     /// downstream consumers depend on to avoid mistaking a fetch failure
     /// for a deletion (FR-014).
     async fn discover(&self, schema_prefix: &str) -> AdapterResult<DiscoveryResult>;
+
+    /// Enrich already-discovered connectors with the stable external object
+    /// id(s) each one replicates (e.g. the ad-account ids a Fivetran connector
+    /// syncs), populating [`DiscoveredConnector::external_object_ids`] in place.
+    ///
+    /// Default: **no-op** — adapters that can't determine object identity leave
+    /// the set empty, and cross-source collision detection is simply skipped
+    /// for their sources (a *missed* detection, never a false one).
+    ///
+    /// This is a SEPARATE pass from [`Self::discover`] because recovering the
+    /// id(s) can cost one extra API call per connector (e.g. Fivetran's
+    /// per-connector detail endpoint), which is only worth paying when the
+    /// caller has opted into collision detection. Implementations MUST be
+    /// best-effort: a per-connector failure leaves that connector's ids empty
+    /// and is logged, never aborting the whole pass.
+    async fn enrich_external_object_ids(
+        &self,
+        _connectors: &mut [DiscoveredConnector],
+    ) -> AdapterResult<()> {
+        Ok(())
+    }
 
     /// Cheap connectivity check for the discovery API.
     ///

--- a/engine/crates/rocky-duckdb/src/discovery.rs
+++ b/engine/crates/rocky-duckdb/src/discovery.rs
@@ -78,7 +78,7 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
                 last_sync_at: None,
                 tables,
                 metadata: Default::default(),
-                external_object_id: None,
+                external_object_ids: Vec::new(),
             });
         }
 

--- a/engine/crates/rocky-duckdb/src/discovery.rs
+++ b/engine/crates/rocky-duckdb/src/discovery.rs
@@ -78,6 +78,7 @@ impl DiscoveryAdapter for DuckDbDiscoveryAdapter {
                 last_sync_at: None,
                 tables,
                 metadata: Default::default(),
+                external_object_id: None,
             });
         }
 

--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -73,6 +73,7 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
                         .collect();
                     let tables = dedup_tables_by_name(raw_tables, &conn.id);
                     let metadata = metadata_from_connector(&conn);
+                    let external_object_id = external_object_id_from_config(&conn.config);
                     connectors.push(DiscoveredConnector {
                         id: conn.id,
                         schema: conn.schema,
@@ -80,6 +81,7 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
                         last_sync_at: conn.succeeded_at,
                         tables,
                         metadata,
+                        external_object_id,
                     });
                 }
                 Err(e) => {
@@ -239,6 +241,45 @@ fn dedup_tables_by_name(tables: Vec<DiscoveredTable>, source_id: &str) -> Vec<Di
 /// Iteration order is stable (insertion order via [`IndexMap`]) so the
 /// discover JSON output stays byte-stable across runs — important for the
 /// dagster fixture corpus and the `codegen-drift` CI check.
+/// Best-effort recovery of the underlying external object's stable id from a
+/// Fivetran connector's `config` blob — the account/object the connector
+/// actually replicates, which the schema name deliberately does not encode (so
+/// two teams can onboard the same account under different schemas unnoticed).
+///
+/// Fivetran has no universal account-id key; it is service-specific. We probe a
+/// prioritized list of the common single-value identifiers and take the first
+/// non-empty string (or a numeric id stringified). Returns `None` when none is
+/// present — collision detection is then simply skipped for this source, which
+/// means a *missed* detection, never a false one.
+///
+/// NOTE: the key list is best-effort and has not been tuned against live
+/// Fivetran configs across services (no Fivetran sandbox available). It is
+/// covered by a stub-config unit test only; extend the list as real configs
+/// are observed.
+fn external_object_id_from_config(config: &serde_json::Value) -> Option<String> {
+    const ID_KEYS: &[&str] = &[
+        "account_id",
+        "external_id",
+        "advertiser_id",
+        "merchant_id",
+        "customer_id",
+        "shop",
+        "site_url",
+        "account",
+        "account_name",
+    ];
+    for key in ID_KEYS {
+        match config.get(key) {
+            Some(serde_json::Value::String(s)) if !s.trim().is_empty() => {
+                return Some(s.clone());
+            }
+            Some(v) if v.is_number() => return Some(v.to_string()),
+            _ => {}
+        }
+    }
+    None
+}
+
 fn metadata_from_connector(conn: &Connector) -> IndexMap<String, serde_json::Value> {
     let mut metadata = IndexMap::new();
     // Core identity — always populated even when `config` is empty so
@@ -307,6 +348,37 @@ mod tests {
         assert_eq!(metadata["fivetran.connector_id"], "conn_ads");
         assert!(!metadata.contains_key("fivetran.custom_reports"));
         assert!(!metadata.contains_key("fivetran.custom_tables"));
+    }
+
+    #[test]
+    fn external_object_id_probes_known_config_keys() {
+        // A string account id is taken verbatim.
+        assert_eq!(
+            external_object_id_from_config(&serde_json::json!({"account_id": "act_123"}))
+                .as_deref(),
+            Some("act_123")
+        );
+        // A numeric id is stringified.
+        assert_eq!(
+            external_object_id_from_config(&serde_json::json!({"advertiser_id": 98765})).as_deref(),
+            Some("98765")
+        );
+        // No known key → None (collision detection is then skipped — a missed
+        // detection, never a false one).
+        assert_eq!(
+            external_object_id_from_config(&serde_json::json!({"unrelated": "y"})),
+            None
+        );
+        // Empty / whitespace id is ignored.
+        assert_eq!(
+            external_object_id_from_config(&serde_json::json!({"account_id": "  "})),
+            None
+        );
+        // A non-object config (null) yields None rather than panicking.
+        assert_eq!(
+            external_object_id_from_config(&serde_json::Value::Null),
+            None
+        );
     }
 
     #[test]

--- a/engine/crates/rocky-fivetran/src/adapter.rs
+++ b/engine/crates/rocky-fivetran/src/adapter.rs
@@ -73,7 +73,11 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
                         .collect();
                     let tables = dedup_tables_by_name(raw_tables, &conn.id);
                     let metadata = metadata_from_connector(&conn);
-                    let external_object_id = external_object_id_from_config(&conn.config);
+                    // `external_object_ids` is populated lazily by
+                    // `enrich_external_object_ids` (a per-connector DETAIL fetch)
+                    // only when collision detection is on — the LIST endpoint
+                    // that produced `conn` omits the `config` blob entirely, so
+                    // there is nothing to extract here.
                     connectors.push(DiscoveredConnector {
                         id: conn.id,
                         schema: conn.schema,
@@ -81,7 +85,7 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
                         last_sync_at: conn.succeeded_at,
                         tables,
                         metadata,
-                        external_object_id,
+                        external_object_ids: Vec::new(),
                     });
                 }
                 Err(e) => {
@@ -109,6 +113,58 @@ impl DiscoveryAdapter for FivetranDiscoveryAdapter {
         }
 
         Ok(DiscoveryResult { connectors, failed })
+    }
+
+    /// Populate each connector's `external_object_ids` from its DETAIL endpoint.
+    ///
+    /// The LIST endpoint (`/v1/groups/{id}/connectors`, used by `discover`)
+    /// omits the per-connector `config` blob, so the account/object ids are
+    /// only recoverable via `GET /v1/connectors/{id}`. We fetch those
+    /// concurrently (same `buffer_unordered` cap as discovery) and extract the
+    /// id set per connector via [`external_object_ids_from_config`].
+    ///
+    /// Best-effort: a failed detail fetch leaves that connector's ids empty and
+    /// is logged — a *missed* collision, never a false one — and never aborts
+    /// the pass. The whole method is only invoked when the caller has opted into
+    /// collision detection, so the extra N calls are paid only when wanted.
+    async fn enrich_external_object_ids(
+        &self,
+        connectors: &mut [DiscoveredConnector],
+    ) -> AdapterResult<()> {
+        let enrich_concurrency = 10;
+        // Decouple from `connectors` for the duration of the concurrent fetch:
+        // collect (index, id) up front so the stream owns its inputs and the
+        // mutable write-back below is unambiguous to the borrow checker.
+        let targets: Vec<(usize, String)> = connectors
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| (idx, c.id.clone()))
+            .collect();
+        let resolved: Vec<(usize, Vec<String>)> = stream::iter(targets)
+            .map(|(idx, id)| {
+                let client = &self.client;
+                async move {
+                    match ft_connector::get_connector(client, &id).await {
+                        Ok(detail) => (idx, external_object_ids_from_config(&detail.config)),
+                        Err(e) => {
+                            warn!(
+                                connector = id.as_str(),
+                                error = %e,
+                                "external-object-id detail fetch failed; leaving ids empty \
+                                 (collision detection skips this source)"
+                            );
+                            (idx, Vec::new())
+                        }
+                    }
+                }
+            })
+            .buffer_unordered(enrich_concurrency)
+            .collect()
+            .await;
+        for (idx, ids) in resolved {
+            connectors[idx].external_object_ids = ids;
+        }
+        Ok(())
     }
 }
 
@@ -241,43 +297,83 @@ fn dedup_tables_by_name(tables: Vec<DiscoveredTable>, source_id: &str) -> Vec<Di
 /// Iteration order is stable (insertion order via [`IndexMap`]) so the
 /// discover JSON output stays byte-stable across runs — important for the
 /// dagster fixture corpus and the `codegen-drift` CI check.
-/// Best-effort recovery of the underlying external object's stable id from a
-/// Fivetran connector's `config` blob — the account/object the connector
-/// actually replicates, which the schema name deliberately does not encode (so
-/// two teams can onboard the same account under different schemas unnoticed).
+/// Best-effort recovery of the external object id(s) a Fivetran connector
+/// replicates — the account(s)/object(s) it actually syncs, which the schema
+/// name deliberately does not encode (so two teams can onboard the same account
+/// under different schemas unnoticed).
 ///
-/// Fivetran has no universal account-id key; it is service-specific. We probe a
-/// prioritized list of the common single-value identifiers and take the first
-/// non-empty string (or a numeric id stringified). Returns `None` when none is
-/// present — collision detection is then simply skipped for this source, which
-/// means a *missed* detection, never a false one.
+/// A single connector can sync MANY accounts (`accounts: ["act_1", "act_2"]`),
+/// so this returns a *set*, not a scalar — `Option<String>` would silently miss
+/// a collision on every account but the first.
 ///
-/// NOTE: the key list is best-effort and has not been tuned against live
-/// Fivetran configs across services (no Fivetran sandbox available). It is
-/// covered by a stub-config unit test only; extend the list as real configs
-/// are observed.
-fn external_object_id_from_config(config: &serde_json::Value) -> Option<String> {
-    const ID_KEYS: &[&str] = &[
+/// Fivetran has no universal account-id key; it is service-specific. Verified
+/// live across 16 ad services, the identity lives under one of a small set of
+/// top-level keys — usually a string array (`accounts`), occasionally a single
+/// scalar (`customer_id`). We collect from every known key and dedup. Returns
+/// empty when none is present — collision detection is then skipped for this
+/// source (a *missed* detection, never a false one).
+///
+/// Known-uncovered, documented as safe misses: services that carry no top-level
+/// id (`amazon_ads`; `yougov_brandindex`/`integral_ad_science` use
+/// username/password), and services whose identity is nested inside report
+/// objects (`google_display_and_video_360` → `reports[].partners`). Extend the
+/// key lists as new services are observed.
+///
+/// CAVEAT: the per-service meaning of these id arrays is not uniformly verified.
+/// For some services the array is the accounts the connector *syncs*; for others
+/// it may be the accounts the credential can *access*. The two are
+/// indistinguishable from config alone, so a shared id across schemas is a
+/// *candidate* for human confirmation — which is exactly why the discover-level
+/// check is `collision_candidates` and defaults to surface-not-bail, never an
+/// auto-fail.
+fn external_object_ids_from_config(config: &serde_json::Value) -> Vec<String> {
+    // Top-level keys whose value is a string array of account/object ids.
+    // Verified live: `accounts` (twitter/facebook/tiktok/linkedin/bing/
+    // snapchat_ads), `business_accounts` (reddit_ads), `advertisers`
+    // (pinterest_ads), `user_profiles` (double_click_campaign_manager),
+    // `profiles` (amazon_dsp), `partners` (walmart_dsp).
+    const ARRAY_KEYS: &[&str] = &[
+        "accounts",
+        "business_accounts",
+        "advertisers",
+        "user_profiles",
+        "profiles",
+        "partners",
+    ];
+    // Top-level keys whose value is a single id (string or number). Verified
+    // live: `customer_id` (google_ads). The rest are generic single-account
+    // fallbacks retained from the prior key probe.
+    const SCALAR_KEYS: &[&str] = &[
+        "customer_id",
         "account_id",
-        "external_id",
         "advertiser_id",
         "merchant_id",
-        "customer_id",
-        "shop",
-        "site_url",
-        "account",
-        "account_name",
+        "external_id",
     ];
-    for key in ID_KEYS {
-        match config.get(key) {
-            Some(serde_json::Value::String(s)) if !s.trim().is_empty() => {
-                return Some(s.clone());
+
+    let mut ids: Vec<String> = Vec::new();
+    let push_non_empty = |ids: &mut Vec<String>, v: &serde_json::Value| match v {
+        serde_json::Value::String(s) if !s.trim().is_empty() => ids.push(s.trim().to_string()),
+        v if v.is_number() => ids.push(v.to_string()),
+        _ => {}
+    };
+    for key in ARRAY_KEYS {
+        if let Some(arr) = config.get(key).and_then(|v| v.as_array()) {
+            for el in arr {
+                push_non_empty(&mut ids, el);
             }
-            Some(v) if v.is_number() => return Some(v.to_string()),
-            _ => {}
         }
     }
-    None
+    for key in SCALAR_KEYS {
+        if let Some(v) = config.get(key) {
+            push_non_empty(&mut ids, v);
+        }
+    }
+    // Deterministic, de-duplicated set: a connector listing an account twice,
+    // or the same id surfacing under two synonym keys, counts once.
+    ids.sort();
+    ids.dedup();
+    ids
 }
 
 fn metadata_from_connector(conn: &Connector) -> IndexMap<String, serde_json::Value> {
@@ -351,33 +447,153 @@ mod tests {
     }
 
     #[test]
-    fn external_object_id_probes_known_config_keys() {
-        // A string account id is taken verbatim.
+    fn external_object_ids_extracts_known_config_keys() {
+        // A string-array account key → all elements (a connector syncs many
+        // accounts); duplicates collapse.
         assert_eq!(
-            external_object_id_from_config(&serde_json::json!({"account_id": "act_123"}))
-                .as_deref(),
-            Some("act_123")
+            external_object_ids_from_config(
+                &serde_json::json!({"accounts": ["act_1", "act_2", "act_2"]})
+            ),
+            vec!["act_1".to_string(), "act_2".to_string()]
         );
-        // A numeric id is stringified.
+        // Service-specific array synonym (pinterest_ads).
         assert_eq!(
-            external_object_id_from_config(&serde_json::json!({"advertiser_id": 98765})).as_deref(),
-            Some("98765")
+            external_object_ids_from_config(&serde_json::json!({"advertisers": ["adv_9"]})),
+            vec!["adv_9".to_string()]
         );
-        // No known key → None (collision detection is then skipped — a missed
+        // A single scalar id (google_ads `customer_id`), numeric stringified.
+        assert_eq!(
+            external_object_ids_from_config(&serde_json::json!({"customer_id": 1234567890_i64})),
+            vec!["1234567890".to_string()]
+        );
+        // Empty / whitespace elements are dropped.
+        assert_eq!(
+            external_object_ids_from_config(&serde_json::json!({"accounts": ["  ", "act_3"]})),
+            vec!["act_3".to_string()]
+        );
+        // No known key → empty (collision detection is then skipped — a missed
         // detection, never a false one).
+        assert!(external_object_ids_from_config(&serde_json::json!({"unrelated": "y"})).is_empty());
+        // A non-object config (null) yields empty rather than panicking.
+        assert!(external_object_ids_from_config(&serde_json::Value::Null).is_empty());
+        // The result is sorted + de-duplicated across synonym keys: an id under
+        // both `accounts` and `account_id` is counted once.
         assert_eq!(
-            external_object_id_from_config(&serde_json::json!({"unrelated": "y"})),
-            None
+            external_object_ids_from_config(&serde_json::json!({
+                "accounts": ["b", "a"],
+                "account_id": "a"
+            })),
+            vec!["a".to_string(), "b".to_string()]
         );
-        // Empty / whitespace id is ignored.
-        assert_eq!(
-            external_object_id_from_config(&serde_json::json!({"account_id": "  "})),
-            None
+    }
+
+    /// Live verification of the real adapter path — gated on `FIVETRAN_API_KEY`/
+    /// `FIVETRAN_API_SECRET`/`FIVETRAN_DESTINATION_ID`. Runs `discover` (LIST,
+    /// no ids) then `enrich_external_object_ids` (per-connector DETAIL) against
+    /// the live destination and asserts the extractor actually recovers ids from
+    /// real connector configs — the piece the synthetic-JSON unit test can't.
+    ///
+    /// Success criterion is **ids populate** across services, not "collisions
+    /// found": zero collisions is the expected, correct result on a real account
+    /// (no duplicate is synthesized into the live destination to force one).
+    ///
+    /// Honors "careful with the creds": read-only (only GETs), and the output is
+    /// value-free — it prints per-service id *counts* and the collision *count*,
+    /// never an id value. Run with:
+    ///   cargo test -p rocky-fivetran enrich_external_object_ids_live -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live Fivetran creds (FIVETRAN_API_KEY/SECRET/DESTINATION_ID)"]
+    async fn enrich_external_object_ids_live() {
+        let (key, secret, dest) = match (
+            std::env::var("FIVETRAN_API_KEY"),
+            std::env::var("FIVETRAN_API_SECRET"),
+            std::env::var("FIVETRAN_DESTINATION_ID"),
+        ) {
+            (Ok(k), Ok(s), Ok(d)) => (k, s, d),
+            _ => {
+                eprintln!(
+                    "skipping enrich_external_object_ids_live — set FIVETRAN_API_KEY/SECRET/DESTINATION_ID"
+                );
+                return;
+            }
+        };
+
+        let client = crate::client::FivetranClient::new(key, secret);
+        let adapter = FivetranDiscoveryAdapter::new(client, dest);
+
+        // 1. discover (LIST endpoint): ids are NOT populated here.
+        let mut result = adapter.discover("").await.expect("discover");
+        assert!(
+            result
+                .connectors
+                .iter()
+                .all(|c| c.external_object_ids.is_empty()),
+            "discover() must not populate ids (LIST omits config); enrichment does"
         );
-        // A non-object config (null) yields None rather than panicking.
-        assert_eq!(
-            external_object_id_from_config(&serde_json::Value::Null),
-            None
+
+        // 2. enrich (per-connector DETAIL): ids are populated in place.
+        adapter
+            .enrich_external_object_ids(&mut result.connectors)
+            .await
+            .expect("enrich_external_object_ids");
+
+        // Per-service coverage map (value-free: service → connectors,
+        // connectors-with-≥1-id, total id count). Surfaces which services the
+        // key allowlist covers so new/uncovered services are visible.
+        use std::collections::BTreeMap;
+        let mut by_service: BTreeMap<&str, (usize, usize, usize)> = BTreeMap::new();
+        for c in &result.connectors {
+            let e = by_service.entry(c.source_type.as_str()).or_default();
+            e.0 += 1;
+            if !c.external_object_ids.is_empty() {
+                e.1 += 1;
+            }
+            e.2 += c.external_object_ids.len();
+        }
+        let connectors_with_ids: usize = by_service.values().map(|(_, w, _)| w).sum();
+        for (service, (conns, with_ids, ids)) in &by_service {
+            eprintln!(
+                "service={service:35} connectors={conns:3} with_ids={with_ids:3} ids={ids:4}"
+            );
+        }
+        eprintln!(
+            "{}/{} connector(s) resolved ≥1 external object id across {} service(s)",
+            connectors_with_ids,
+            result.connectors.len(),
+            by_service.len()
+        );
+
+        // 3. Collision grouping (mirrors the CLI's detect_collisions, keyed by
+        //    (source_type, id)). 0 collisions is the EXPECTED, correct result on
+        //    a real account — we only print the count, never the colliding id.
+        let mut seen: BTreeMap<(&str, &str), std::collections::BTreeSet<&str>> = BTreeMap::new();
+        for c in &result.connectors {
+            for id in &c.external_object_ids {
+                seen.entry((c.source_type.as_str(), id.as_str()))
+                    .or_default()
+                    .insert(c.schema.as_str());
+            }
+        }
+        let collisions = seen.values().filter(|s| s.len() >= 2).count();
+        eprintln!("cross-source collision candidates: {collisions}");
+        // Value-free per-collision breakdown to distinguish a TRUE positive
+        // (a real account-shaped id under 2+ distinct schemas) from a logic
+        // artifact: print only service, distinct-schema count, and id LENGTH
+        // (a length is not the value) — never the id or the schema names.
+        for ((service, id), schemas) in seen.iter().filter(|(_, s)| s.len() >= 2) {
+            eprintln!(
+                "  collision: service={service} distinct_schemas={} id_len={}",
+                schemas.len(),
+                id.len()
+            );
+        }
+
+        // The load-bearing assertion: the extractor recovers ids from REAL
+        // configs. (If the destination genuinely has no id-bearing services,
+        // this would need relaxing — but the shape probe confirmed it does.)
+        assert!(
+            connectors_with_ids > 0,
+            "expected ≥1 connector to resolve an external object id from live config"
         );
     }
 

--- a/engine/crates/rocky-iceberg/src/adapter.rs
+++ b/engine/crates/rocky-iceberg/src/adapter.rs
@@ -75,7 +75,7 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
                         last_sync_at: None,
                         tables,
                         metadata: Default::default(),
-                        external_object_id: None,
+                        external_object_ids: Vec::new(),
                     });
                 }
                 Err(e) => {
@@ -237,7 +237,7 @@ mod tests {
                 },
             ],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
 
         assert_eq!(connector.id, "raw_shopify");
@@ -281,7 +281,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
-            external_object_id: None,
+            external_object_ids: Vec::new(),
         };
         assert_eq!(connector.source_type, "iceberg");
     }

--- a/engine/crates/rocky-iceberg/src/adapter.rs
+++ b/engine/crates/rocky-iceberg/src/adapter.rs
@@ -75,6 +75,7 @@ impl DiscoveryAdapter for IcebergDiscoveryAdapter {
                         last_sync_at: None,
                         tables,
                         metadata: Default::default(),
+                        external_object_id: None,
                     });
                 }
                 Err(e) => {
@@ -236,6 +237,7 @@ mod tests {
                 },
             ],
             metadata: Default::default(),
+            external_object_id: None,
         };
 
         assert_eq!(connector.id, "raw_shopify");
@@ -279,6 +281,7 @@ mod tests {
             last_sync_at: None,
             tables: vec![],
             metadata: Default::default(),
+            external_object_id: None,
         };
         assert_eq!(connector.source_type, "iceberg");
     }

--- a/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/discover_schema.py
@@ -8,6 +8,21 @@ from typing import Any
 from pydantic import AwareDatetime, BaseModel, Field, conint
 
 
+class CollisionCandidateOutput(BaseModel):
+    """
+    A cross-source collision: one external object id mapped to more than one target path (the same object onboarded twice under different schemas).
+    """
+
+    external_object_id: str
+    """
+    The shared external object id (e.g. a Fivetran ad-account id).
+    """
+    sources: list[str]
+    """
+    The distinct source schemas that resolve to it (≥2), sorted.
+    """
+
+
 class ExcludedTableOutput(BaseModel):
     """
     A table that the discovery adapter reported but that is missing from the source warehouse, so the run skipped it. Tracked separately from `errors` because it is not a runtime failure — the row never made it past the pre-flight existence check.
@@ -120,6 +135,10 @@ class DiscoverOutput(BaseModel):
     checks: ChecksConfigOutput | None = None
     """
     Pipeline-level data quality check configuration. Present when the pipeline declares a `[checks]` block in `rocky.toml`. Downstream orchestrators (e.g. Dagster) consume this to attach asset-level freshness policies and check expectations without re-reading `rocky.toml` themselves.
+    """
+    collision_candidates: list[CollisionCandidateOutput] | None = None
+    """
+    Groups of ≥2 discovered sources sharing the SAME external object id but resolving to DIFFERENT target paths — the same underlying object onboarded twice. Populated only when discovery's `on_collision` is `warn`/`error` and the adapter supplies `external_object_id`; empty (and omitted from the wire format) otherwise.
     """
     command: str
     excluded_tables: list[ExcludedTableOutput] | None = None

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -310,24 +310,6 @@ class Dialect(StrEnum):
     duckdb = "duckdb"
 
 
-class DiscoveryConfig(BaseModel):
-    """
-    Discovery configuration within a pipeline source.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    adapter: str | None = "default"
-    """
-    Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `"default"`.
-    """
-    report_new_sources: bool | None = False
-    """
-    When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.
-    """
-
-
 class ExecutionConfig(BaseModel):
     """
     Controls parallelism and error handling for table processing.
@@ -815,6 +797,30 @@ class MetadataColumnConfig(BaseModel):
     name: str
     type: str
     value: str
+
+
+class OnCollision1(StrEnum):
+    """
+    Collision detection disabled (default — fully backwards compatible).
+    """
+
+    off = "off"
+
+
+class OnCollision2(StrEnum):
+    """
+    Report collisions in `collision_candidates` and emit an event, but do not fail the discover.
+    """
+
+    warn = "warn"
+
+
+class OnCollision3(StrEnum):
+    """
+    Report collisions and fail the discover, so a colliding onboard cannot silently create a catalog/table.
+    """
+
+    error = "error"
 
 
 class Type(StrEnum):
@@ -1658,6 +1664,28 @@ class CustomCheckConfig(BaseModel):
     """
     sql: str
     threshold: conint(ge=0) | None = 0
+
+
+class DiscoveryConfig(BaseModel):
+    """
+    Discovery configuration within a pipeline source.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    adapter: str | None = "default"
+    """
+    Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `"default"`.
+    """
+    on_collision: OnCollision1 | OnCollision2 | OnCollision3 | None = "off"
+    """
+    What to do when discover finds the same external object id mapped to more than one target path (likely the same object onboarded twice). `off` (default) skips detection entirely; `warn` reports `collision_candidates` + emits an event; `error` additionally fails the discover. Only adapters that supply `external_object_id` (e.g. Fivetran) participate; others are silently skipped.
+    """
+    report_new_sources: bool | None = False
+    """
+    When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.
+    """
 
 
 class FreshnessConfig(BaseModel):

--- a/schemas/discover.schema.json
+++ b/schemas/discover.schema.json
@@ -17,6 +17,27 @@
       },
       "type": "object"
     },
+    "CollisionCandidateOutput": {
+      "description": "A cross-source collision: one external object id mapped to more than one target path (the same object onboarded twice under different schemas).",
+      "properties": {
+        "external_object_id": {
+          "description": "The shared external object id (e.g. a Fivetran ad-account id).",
+          "type": "string"
+        },
+        "sources": {
+          "description": "The distinct source schemas that resolve to it (≥2), sorted.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "external_object_id",
+        "sources"
+      ],
+      "type": "object"
+    },
     "ExcludedTableOutput": {
       "description": "A table that the discovery adapter reported but that is missing from the source warehouse, so the run skipped it. Tracked separately from `errors` because it is not a runtime failure — the row never made it past the pre-flight existence check.",
       "properties": {
@@ -177,6 +198,13 @@
         }
       ],
       "description": "Pipeline-level data quality check configuration. Present when the pipeline declares a `[checks]` block in `rocky.toml`. Downstream orchestrators (e.g. Dagster) consume this to attach asset-level freshness policies and check expectations without re-reading `rocky.toml` themselves."
+    },
+    "collision_candidates": {
+      "description": "Groups of ≥2 discovered sources sharing the SAME external object id but resolving to DIFFERENT target paths — the same underlying object onboarded twice. Populated only when discovery's `on_collision` is `warn`/`error` and the adapter supplies `external_object_id`; empty (and omitted from the wire format) otherwise.",
+      "items": {
+        "$ref": "#/definitions/CollisionCandidateOutput"
+      },
+      "type": "array"
     },
     "command": {
       "type": "string"

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -868,6 +868,15 @@
           "description": "Name of the adapter to use for discovery (references a key in `[adapter.*]`). Defaults to `\"default\"`.",
           "type": "string"
         },
+        "on_collision": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/OnCollision"
+            }
+          ],
+          "default": "off",
+          "description": "What to do when discover finds the same external object id mapped to more than one target path (likely the same object onboarded twice). `off` (default) skips detection entirely; `warn` reports `collision_candidates` + emits an event; `error` additionally fails the discover. Only adapters that supply `external_object_id` (e.g. Fivetran) participate; others are silently skipped."
+        },
         "report_new_sources": {
           "default": false,
           "description": "When `true`, `rocky discover` diffs the discovered source inventory against the prior persisted snapshot and reports first-seen sources in `new_sources`. Off by default — the diff and its state write only happen when opted in, so existing projects pay nothing.",
@@ -1776,6 +1785,32 @@
         "threshold"
       ],
       "type": "object"
+    },
+    "OnCollision": {
+      "description": "Action when `rocky discover` detects a cross-source collision — the same external object id mapped to more than one target path.",
+      "oneOf": [
+        {
+          "description": "Collision detection disabled (default — fully backwards compatible).",
+          "enum": [
+            "off"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Report collisions in `collision_candidates` and emit an event, but do not fail the discover.",
+          "enum": [
+            "warn"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Report collisions and fail the discover, so a colliding onboard cannot silently create a catalog/table.",
+          "enum": [
+            "error"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "PipelineConfig": {
       "anyOf": [


### PR DESCRIPTION
**PR 5/5 — the final slice** of cross-source duplicate detection (the **preventive** mechanism). Catches the same external object onboarded twice under two paths at **discover** time — before a stray catalog is even created.

## What

When the same external object (e.g. an ad account) is onboarded twice under two different schemas, its data lands in two target tables and silently doubles any downstream `UNION ALL` — while every per-table check still passes. `rocky discover` now surfaces it via a new **`collision_candidates`** envelope field.

```toml
[pipeline.<name>.source.discovery]
on_collision = "warn"   # off (default) | warn | error
```
`warn` reports `collision_candidates` + emits a `source_collision_detected` event; `error` additionally fails the discover (non-zero exit) so a colliding onboard can't silently proceed. `off` (default) → zero cost, no output change. These are **candidates for human confirmation**, not confirmed duplicates — surface-not-bail by default (see caveat).

## How

- **`rocky-core/source.rs`**: `DiscoveredConnector.external_object_ids: Vec<String>` — the stable identities of the object(s) a source replicates, which the schema name deliberately does not encode (exactly why two onboards collide unnoticed). A single connector can sync many accounts, so this is a *set*; empty ⇒ that source is skipped (opt-in per adapter).
- **`rocky-core/traits.rs`**: new `DiscoveryAdapter::enrich_external_object_ids` (default no-op). A *separate* pass from `discover` because recovering the ids can cost one API call per connector — only worth paying when collision detection is on.
- **`rocky-fivetran`**: the connector LIST endpoint omits `config`, so the enrich pass fetches each connector's DETAIL endpoint concurrently (best-effort: a failed fetch leaves ids empty and is logged, never aborts) and extracts the account id(s) from the service-specific key set.
- **`discover.rs`**: when `on_collision != off`, enrich then group by `(source_type, id)` — two services reusing the same id string aren't conflated. An id under ≥2 distinct schemas is a candidate. Deterministic (sorted). Event emitted; `error` fails after the JSON is emitted (so the detail still reaches the orchestrator).
- **`output.rs`**: `DiscoverOutput.collision_candidates` + `CollisionCandidateOutput { external_object_id, sources }` (one shared id → many schemas, so this field stays singular).
- Other discovery adapters (duckdb/bigquery/airbyte/iceberg) inherit the default no-op.
- `just codegen` clean — the model is a `rocky-core` internal type, so the rename to a set is not an output-schema change.

## ⚠️ Caveat

The per-service meaning of Fivetran's id arrays isn't uniformly verified — for some services the array is the accounts a connector *syncs*, for others possibly the accounts a credential can *access*. The two are indistinguishable from config alone, so a shared id across schemas is a **candidate**, which is exactly why the check defaults to surface-not-bail (`warn`), never an auto-fail.

## Tested

- **Live-verified** against a real Fivetran destination (read-only): the enrich pass + extractor recover ids across **13 of 16 services** (the 3 misses are username/password or nested-id services, documented as safe misses — a missed key is a *missed* collision, never a false one). Collision grouping confirmed on live data.
- Unit: collision grouping — sharing an id → one candidate; a unique id / no id contribute nothing; **the same id under different `source_type`s does not collide**; a multi-account connector contributes each id.
- Unit: Fivetran extractor — string array, numeric, synonym keys, whitespace/empty dropped, no-known-key→empty, null-config→empty, sorted+deduped.
- DuckDB negative live-verify: `discover` with `on_collision = "warn"` runs clean (no external ids → no false positives, exit 0).
- Full rocky-core / rocky-cli / rocky-fivetran / rocky-iceberg suites green; duckdb/bigquery/airbyte compile; fmt; clippy `--all-targets`; codegen zero-drift.

## Follow-ups

- Extend the adapter-SDK `DiscoveredConnector` contract so *custom* adapters can supply external object ids (only the core type + Fivetran carry them today).
- Per-service confirmation of id-array semantics (synced vs accessible); per-service nested-id extraction (e.g. report-nested ids) where worthwhile.