### PR TITLE
docs: document cross-source duplicate detection + add quality POC

### DIFF
--- a/docs/src/content/docs/concepts/data-quality-checks.md
+++ b/docs/src/content/docs/concepts/data-quality-checks.md
@@ -8,7 +8,9 @@ sidebar:
 Rocky ships two complementary quality surfaces, both executed inline against the warehouse — there is no separate testing step like `dbt test`:
 
 1. **Pipeline-level checks** — configured per pipeline in `rocky.toml` under `[pipeline.<name>.checks]`. These run after each table is replicated: row count, column match, freshness, null rate, anomaly detection, custom SQL.
-2. **Model-level declarative assertions** — configured per model in the model's sidecar TOML (or directly under `[pipeline.<name>.checks]`) via repeated `[[assertions]]` blocks. These cover the DQX parity surface: `not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`, `composite`, plus the time-window sugar `not_in_future` and `older_than_n_days`.
+2. **Model-level declarative assertions** — configured per model in the model's sidecar TOML (or directly under `[pipeline.<name>.checks]`) via repeated `[[assertions]]` blocks. These cover the DQX parity surface: `not_null`, `unique`, `unique_expr`, `accepted_values`, `relationships`, `expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`, `composite`, plus the time-window sugar `not_in_future` and `older_than_n_days`.
+
+Assertions run on **every** pipeline type — including **replication**, not just transformation/quality — so a target table doubled by the same source arriving twice is caught at load time. For the cross-*table* variant (the same key arriving through two sibling sources that later get `UNION`-ed together), see [Cross-source overlap](#cross-source-overlap).
 
 Both surfaces share the same JSON output shape (`check_results[]`) and the same severity / quarantine plumbing, so orchestrators don't need to distinguish between them.
 
@@ -124,6 +126,7 @@ filter = "region = 'US'"
 |---|---|---|---|
 | `not_null` | row | — | Column contains no NULL values. |
 | `unique` | set | — | Column contains only unique values. |
+| `unique_expr` | set | `key_expr: String` | A derived **key expression** is unique across rows (`GROUP BY <expr> HAVING COUNT(*) > 1`). For when the meaningful identity is a *computed* value (e.g. a surrogate built to be stable across a multi-tenant union) that neither `unique` (single column) nor `composite` (column tuple) can express. `key_expr` is passed through verbatim (trusted config, like `expression`); NULL keys are not excluded — use `filter` to scope them out. |
 | `accepted_values` | row | `values: [String]` | Every non-NULL value is in the fixed set. |
 | `relationships` | row | `to_table`, `to_column` | Every non-NULL value exists in `to_table.to_column` (referential integrity). |
 | `expression` | row | `expression: String` | Custom SQL boolean predicate must hold per row. |
@@ -135,7 +138,7 @@ filter = "region = 'US'"
 | `not_in_future` | row | — (sugar for `col <= CURRENT_TIMESTAMP()`) | Timestamp column cannot contain future values. NULLs pass. |
 | `older_than_n_days` | row | `days: u32` | Every timestamp must be at least `days` old. NULLs pass. Dialect-aware. |
 
-Row-level assertions are **quarantinable** (see below). Set-based and table-level assertions (`unique`, `composite`, `row_count_range`, `aggregate`) are evaluated post-hoc and cannot be quarantined.
+Row-level assertions are **quarantinable** (see below). Set-based and table-level assertions (`unique`, `unique_expr`, `composite`, `row_count_range`, `aggregate`) are evaluated post-hoc and cannot be quarantined.
 
 ### Severity and `fail_on_error`
 
@@ -210,3 +213,57 @@ Every assertion produces a `check_results[]` entry in the `rocky apply` JSON out
 ```
 
 Consumers (dagster-rocky, the VS Code lineage view, custom scripts) parse this shape via the generated Pydantic / TypeScript bindings — see the [JSON Output](/reference/json-output/) reference.
+
+## Cross-source overlap
+
+The assertions above check one table at a time. They can't catch a subtler duplication: the **same business key arriving through two different sources** that later get `UNION`-ed into one consolidation target. Each source table is internally unique — every per-table `unique` check passes — yet the consolidation double-counts every shared key.
+
+This is the classic "same account onboarded twice under two paths" failure. `cross_source_overlap` is the cross-table check that sees it.
+
+```toml
+[pipeline.bronze.checks.cross_source_overlap]
+keys = ["order_id"]          # or: key_expr = "md5(a || '-' || b)"
+severity = "warning"
+max_overlap_rows = 0          # any overlap fails; raise to tolerate a known set
+sample = 20                   # overlapping keys attached to the result for triage
+```
+
+Exactly one of `keys` (a column tuple) or `key_expr` (a derived SQL expression, passed through verbatim) is required — mirroring `unique` / `unique_expr`.
+
+**How it works.** The runner buckets the pipeline's managed source tables into **sibling groups** — tables with the same source type and table name that landed in more than one target schema (the tenant/region fan-out that gets unioned downstream). It tags each sibling's rows with its source identity and runs:
+
+```sql
+SELECT order_id, COUNT(DISTINCT _src) AS _n_src
+FROM (
+  SELECT order_id, '<table_1>' AS _src FROM <table_1> WHERE order_id IS NOT NULL
+  UNION ALL
+  SELECT order_id, '<table_2>' AS _src FROM <table_2> WHERE order_id IS NOT NULL
+  -- … one arm per sibling
+) _u
+GROUP BY order_id
+HAVING COUNT(DISTINCT _src) > 1
+```
+
+The `COUNT(DISTINCT _src)` is the crux: it counts how many *distinct sources* a key appears in, so a single source's own internal duplicates never false-flag — only a key spanning two or more siblings does. (With a `key_expr` or multi-column `keys`, the projected key list changes accordingly.) A key appearing under more than one source is an overlap. Sibling tables whose key can't be evaluated (missing column / keyless) are **skipped with a logged reason** rather than failing the check. The result is a `check_results[]` entry named `cross_source_overlap:<source_type>.<table>`, carrying the overlap count, the contributing tables, and a bounded `sample` of overlapping keys (the detail fields are flattened onto the result, consistent with every other check):
+
+```json
+{
+  "name": "cross_source_overlap:shopify.orders",
+  "passed": false,
+  "severity": "warning",
+  "overlap_count": 3,
+  "contributing_tables": ["raw__us__shopify.orders", "raw__eu__shopify.orders"],
+  "sample": ["ord_1001", "ord_1002", "ord_1003"]
+}
+```
+
+### Preventive vs detective
+
+Rocky catches cross-source duplication at two points:
+
+| Layer | Mechanism | When it runs | Config |
+|---|---|---|---|
+| **Preventive** | `on_collision` | `rocky discover` — before a stray catalog is even created | `[pipeline.NAME.source.discovery] on_collision` → `collision_candidates` |
+| **Detective** | `cross_source_overlap` | `rocky run` — after the sibling tables are materialized | `[pipeline.NAME.checks.cross_source_overlap]` |
+
+The preventive layer needs an adapter that resolves external object ids (e.g. Fivetran) and inspects connector metadata; the detective layer works on any warehouse by querying the materialized tables directly. They're complementary — use both for defense in depth, or just the detective check if your sources don't expose object ids at discover time. See [discovery configuration](/reference/configuration/#pipelinenamesourcediscovery) for `on_collision`.

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -200,6 +200,29 @@ Discover a specific pipeline when multiple are defined:
 rocky discover --pipeline shopify_us
 ```
 
+### New sources and cross-source collisions
+
+Two opt-in discover-time signals help catch onboarding problems before any catalog is created. Both are configured under [`[pipeline.NAME.source.discovery]`](/reference/configuration/#pipelinenamesourcediscovery) and appear as extra fields on the JSON output (omitted entirely when not enabled).
+
+- **`new_sources`** — set `report_new_sources = true` to diff the discovered inventory against the prior persisted snapshot. First-seen source schemas are listed here; the first discover of a pipeline records the baseline and reports nothing.
+- **`collision_candidates`** — set `on_collision = "warn"` (or `"error"`) to flag the same external object onboarded under more than one schema. Each entry pairs the shared `external_object_id` with the `sources` (schemas) it resolves to. With `"error"`, discover also exits non-zero. Only adapters that resolve external object ids (e.g. Fivetran) populate this.
+
+```json
+{
+  "command": "discover",
+  "sources": [ /* … */ ],
+  "new_sources": ["src__acme__ca_central__shopify"],
+  "collision_candidates": [
+    {
+      "external_object_id": "act_1234567890",
+      "sources": ["src__acme__us_west__shopify", "src__acme__eu_central__shopify"]
+    }
+  ]
+}
+```
+
+`collision_candidates` is the **preventive** half of cross-source duplicate detection; its **detective** counterpart, [`cross_source_overlap`](/concepts/data-quality-checks/#cross-source-overlap), runs at `rocky run` time against the materialized tables.
+
 ### Related Commands
 
 - [`rocky plan`](#rocky-plan) -- generate SQL from discovered sources

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -318,16 +318,20 @@ adapter = "fivetran"
 
 Optional override for the adapter that lists schemas/tables. Useful when the source is discovered from one system (e.g., DuckDB) but its data lives somewhere else.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `adapter` | string | Yes | Adapter name to use for discovery. |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `adapter` | string | Yes | — | Adapter name to use for discovery. |
+| `report_new_sources` | bool | No | `false` | Diff the discovered source inventory against the prior persisted snapshot and report first-seen schemas in the discover output's `new_sources`. The first discover of a pipeline records the baseline and reports nothing. Off by default — the diff and its state write only happen when opted in. |
+| `on_collision` | `"off"` \| `"warn"` \| `"error"` | No | `"off"` | Cross-source collision detection. When the same external object (e.g. an ad account) is onboarded under two schemas, its data lands in two target tables and silently doubles any downstream `UNION ALL`. `warn` reports the pairs in the discover output's `collision_candidates` and emits a `source_collision_detected` event; `error` additionally fails the discover so a colliding onboard can't silently create a catalog. `off` (default) skips detection entirely. Only adapters that resolve external object ids (e.g. Fivetran) participate; others contribute nothing. |
 
 ```toml
 [pipeline.bronze.source.discovery]
 adapter = "fivetran"
+report_new_sources = true   # surface freshly-onboarded sources in `new_sources`
+on_collision = "warn"       # surface same-object-twice onboards in `collision_candidates`
 ```
 
-If omitted, Rocky uses the source `adapter` for discovery.
+If omitted, Rocky uses the source `adapter` for discovery. See [Cross-source duplicate detection](#cross-source-duplicate-detection) for the detective counterpart that runs during replication.
 
 ### `[pipeline.NAME.source.schema_pattern]`
 
@@ -456,6 +460,7 @@ Rocky runs quality checks inline during replication. Two surfaces share this sec
 | `anomaly_threshold_pct` | float | `50.0` | Row count deviation percentage that triggers an anomaly. Set to 0 to disable. |
 | `quarantine` | table | | `{ mode = "split" \| "tag" \| "drop" }`. See below. |
 | `assertions` | list | `[]` | Repeated `[[assertions]]` blocks (DQX parity). See below. |
+| `cross_source_overlap` | table | | Flags the same business key appearing across sibling sources that feed one consolidation target. See [Cross-source duplicate detection](#cross-source-duplicate-detection). |
 
 ```toml
 [pipeline.bronze.checks]
@@ -472,7 +477,9 @@ Declarative model-level assertions. Each block declares a `type` and type-specif
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `type` | string | (required) | One of: `not_null`, `unique`, `accepted_values`, `relationships`, `expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`, `composite`, `not_in_future`, `older_than_n_days`. |
+| `table` | string | (required) | Unqualified target table the assertion runs against. When assertions live in a model's sidecar TOML the table is implied; in pipeline-level `[[checks.assertions]]` blocks (shown below) it must be set explicitly. |
+| `name` | string | | Optional identifier used as the result's `name`; synthesized from `{kind}:{column}` when unset. Set it to disambiguate multiple assertions on the same table/kind/column. |
+| `type` | string | (required) | One of: `not_null`, `unique`, `unique_expr`, `accepted_values`, `relationships`, `expression`, `row_count_range`, `in_range`, `regex_match`, `aggregate`, `composite`, `not_in_future`, `older_than_n_days`. |
 | `column` | string | | Required for row-level column kinds (`not_null`, `unique`, `accepted_values`, `relationships`, `in_range`, `regex_match`, `not_in_future`, `older_than_n_days`). |
 | `severity` | string | `"error"` | `error` fails the pipeline (subject to `fail_on_error`); `warning` reports but never fails. |
 | `filter` | string | | SQL boolean predicate that scopes the assertion to a subset of rows. |
@@ -489,26 +496,31 @@ Type-specific parameters:
 | `regex_match` | `pattern: String` (dialect-specific regex; no single quotes, backticks, or semicolons) |
 | `aggregate` | `op: sum\|count\|avg\|min\|max`, `cmp: lt\|lte\|gt\|gte\|eq\|ne`, `value: String` |
 | `composite` | `kind: "unique"`, `columns: [String]` (≥2) |
+| `unique_expr` | `key_expr: String` (derived SQL key, e.g. `md5(tenant \|\| '-' \|\| id)`; passed through verbatim) |
 | `older_than_n_days` | `days: u32` |
 
 ```toml
 [[pipeline.silver.checks.assertions]]
+table = "orders"
 type = "not_null"
 column = "order_id"
 
 [[pipeline.silver.checks.assertions]]
+table = "orders"
 type = "accepted_values"
 column = "status"
 values = ["pending", "shipped", "delivered"]
 severity = "warning"
 
 [[pipeline.silver.checks.assertions]]
+table = "orders"
 type = "in_range"
 column = "amount_cents"
 min = "0"
 filter = "region = 'US' AND status != 'cancelled'"
 
 [[pipeline.silver.checks.assertions]]
+table = "orders"
 type = "aggregate"
 op = "sum"
 cmp = "gt"
@@ -516,10 +528,18 @@ value = "0"
 column = "amount_cents"
 
 [[pipeline.silver.checks.assertions]]
+table = "order_lines"
 type = "composite"
 kind = "unique"
 columns = ["order_id", "line_item_id"]
+
+[[pipeline.silver.checks.assertions]]
+table = "orders"
+type = "unique_expr"
+key_expr = "md5(tenant_id || '-' || order_id)"
 ```
+
+Use `unique_expr` when the meaningful identity is a *computed* value rather than any stored column — for example a surrogate key built to be stable across a multi-tenant union, which neither `unique` (single column) nor `composite` (column tuple) can express.
 
 #### `[pipeline.NAME.checks.quarantine]`
 
@@ -531,7 +551,32 @@ Route failing rows from row-level assertions into a dedicated table or column in
 | `tag` | Adds `__dqx_valid` boolean column; failing rows stay with `__dqx_valid = FALSE`. |
 | `drop` | Drops failing rows from `<target>`. |
 
-Set-based and table-level assertions (`unique`, `composite`, `row_count_range`, `aggregate`) run as post-hoc checks regardless of mode.
+Set-based and table-level assertions (`unique`, `unique_expr`, `composite`, `row_count_range`, `aggregate`) run as post-hoc checks regardless of mode.
+
+#### Cross-source duplicate detection
+
+The assertions above (especially `unique` / `unique_expr` / `composite`) also run on **replication** pipelines, not just transformation/quality ones — so a target table that's silently doubled by the same source arriving twice is caught at load time, not three models downstream.
+
+For the cross-*table* case — the same business key arriving through two **sibling** sources that later get `UNION`-ed into one consolidation target — use `[pipeline.NAME.checks.cross_source_overlap]`. A per-table `unique` check passes on each table individually; only an overlap check spanning the siblings sees the duplication.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `keys` | list of strings | `[]` | Business-key columns whose shared value across sibling tables signals a duplicate. Mutually exclusive with `key_expr`. |
+| `key_expr` | string | | Derived business-key expression (e.g. `md5(a \|\| '-' \|\| b)`) for sources without a single natural key. Mutually exclusive with `keys`. Passed through verbatim. |
+| `severity` | string | `"error"` | `error` fails the pipeline (subject to `fail_on_error`); `warning` reports but never fails. |
+| `max_overlap_rows` | integer | `0` | Overlap-key count above which the check fails. `0` means any overlap fails. |
+| `sample` | integer | `20` | Maximum overlapping keys attached to the result for triage. |
+
+Exactly one of `keys` or `key_expr` is required. Sibling tables whose key can't be evaluated (missing column / keyless) are skipped with a logged reason rather than erroring.
+
+```toml
+[pipeline.bronze.checks.cross_source_overlap]
+keys = ["order_id"]
+severity = "warning"
+max_overlap_rows = 0
+```
+
+This is the **detective** counterpart to discover-time `on_collision` (the **preventive** catch). See [Data Quality Checks](/concepts/data-quality-checks/#cross-source-overlap) for the full semantics.
 
 ### `[pipeline.NAME.execution]`
 

--- a/docs/src/content/docs/reference/json-output.md
+++ b/docs/src/content/docs/reference/json-output.md
@@ -76,7 +76,14 @@ Returns all discovered sources and their tables.
   ],
   "checks": {
     "freshness": { "threshold_seconds": 86400 }
-  }
+  },
+  "new_sources": ["src__acme__ca_central__shopify"],
+  "collision_candidates": [
+    {
+      "external_object_id": "act_1234567890",
+      "sources": ["src__acme__us_west__shopify", "src__acme__eu_central__shopify"]
+    }
+  ]
 }
 ```
 
@@ -99,8 +106,14 @@ Returns all discovered sources and their tables.
 | `failed_sources[].message` | string | Free-form error detail for human inspection. |
 | `checks` | object or absent | Pipeline-level check configuration, when `[checks]` is declared in `rocky.toml`. |
 | `checks.freshness.threshold_seconds` | integer | Freshness threshold in seconds. |
+| `new_sources` | array or absent | Source schemas seen for the first time since the prior snapshot. Present only when `[…source.discovery] report_new_sources = true`; absent (omitted) otherwise. The first discover of a pipeline establishes the baseline and reports none. |
+| `collision_candidates` | array or absent | Cross-source collisions — the same external object onboarded under more than one schema. Present only when `[…source.discovery] on_collision` is `"warn"` or `"error"`; absent otherwise. With `"error"`, discover also exits non-zero. |
+| `collision_candidates[].external_object_id` | string | The shared external object id (e.g. an ad-account id) found under more than one schema. |
+| `collision_candidates[].sources` | array | The distinct source schemas that resolve to this object id. |
 
 Consumers diffing successive discover snapshots **must** treat ids that appear in `failed_sources` but not in `sources` as "unknown state, do not delete"; that's the contract that distinguishes a fetch failure from a deletion. Available since engine `1.17.4`.
+
+`new_sources` and `collision_candidates` are the discover-time signals for [cross-source duplicate detection](/concepts/data-quality-checks/#cross-source-overlap); both are opt-in and omitted from the payload when their feature is off.
 
 ---
 

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -38,7 +38,7 @@ cd pocs/02-performance/01-incremental-watermark
 
 **Prerequisites:** Rocky CLI on PATH. Most POCs only need the [DuckDB CLI](https://duckdb.org) for seeding (`brew install duckdb`).
 
-**75 of 87 POCs run with no external credentials.** See each POC's README for prerequisites.
+**76 of 88 POCs run with no external credentials.** See each POC's README for prerequisites.
 
 ## The catalog
 
@@ -63,9 +63,9 @@ DSL syntax, materialization basics, playground baseline, the trust-arc 1 storage
 | [11-plan-apply-workflow](pocs/00-foundations/11-plan-apply-workflow) | `rocky plan` persists a content-addressed plan to `.rocky/plans/<id>.json`; `rocky apply <id>` executes it. Re-planning the same intent yields the same `plan_id` |
 | [12-init-scaffolding](pocs/00-foundations/12-init-scaffolding) | `rocky init --template duckdb` scaffolds a project that validates + compiles out of the box; `--template snowflake` shows the layout changes per warehouse |
 
-### 01 — Quality (7 POCs · DuckDB)
+### 01 — Quality (8 POCs · DuckDB)
 
-Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs.
+Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs, cross-source overlap.
 
 | POC | Feature |
 |---|---|
@@ -76,6 +76,7 @@ Contracts, inline checks, anomaly detection, local testing, SCD-2 snapshots, sta
 | [05-snapshot-scd2](pocs/01-quality/05-snapshot-scd2) | `type = "snapshot"` pipeline — SCD Type 2 with `unique_key`, `updated_at`, `invalidate_hard_deletes` |
 | [06-quality-pipeline-standalone](pocs/01-quality/06-quality-pipeline-standalone) | `type = "quality"` pipeline — standalone checks (row_count, freshness, null_rate) with `depends_on` chaining |
 | [07-freshness-sla](pocs/01-quality/07-freshness-sla) | Per-model + project `[freshness]` SLAs (`expected_lag_seconds` alias); the **W005** coverage diagnostic fires on a temporal-output model with no freshness declaration (`compile --with-seed`), suppressed by a per-model block or a project default; also surfaces in the editor with an AI fix |
+| [08-cross-source-overlap](pocs/01-quality/08-cross-source-overlap) | The same data arriving via two sibling sources — `cross_source_overlap` flags a business key shared across siblings (which per-table `unique` can't see) + `unique_expr` catches a derived-key duplicate, both at replication time |
 
 ### 02 — Performance (14 POCs · DuckDB)
 

--- a/examples/playground/pocs/01-quality/08-cross-source-overlap/README.md
+++ b/examples/playground/pocs/01-quality/08-cross-source-overlap/README.md
@@ -1,0 +1,93 @@
+# 09-cross-source-overlap — the same data arriving via two sources
+
+> **Category:** 01-quality
+> **Credentials:** none (DuckDB)
+> **Runtime:** < 30s
+> **Rocky features:** `cross_source_overlap` check, `unique_expr` assertion, replication-time checks
+
+## What it shows
+
+Two regional Shopify connectors (`us`, `eu`) each land an `orders` table. Some
+orders were onboarded under **both** connectors, so the same `order_id` exists in
+two source schemas — and any downstream `UNION` of the two would silently
+double-count them. Every per-table `unique` check still passes, because each
+table is internally unique. This POC catches the duplication with two detective
+checks that run during replication:
+
+- **`cross_source_overlap`** — a cross-table check that flags a business key
+  (`order_id`) appearing in more than one sibling source.
+- **`unique_expr`** — a derived-key uniqueness assertion: the surrogate
+  `order_id` is unique, but the *logical* order (`customer_id` + day) must not
+  repeat. The EU source has one such duplicate that `unique` / `composite` on
+  `order_id` can't see.
+
+Both are configured as `severity = "warning"`, so they surface in the JSON
+output without failing the run.
+
+## Why it's distinctive
+
+- A per-table uniqueness test — the only kind dbt tests express — passes on both
+  tables yet misses the duplication entirely. Only a check that spans the sibling
+  tables sees it.
+- `unique_expr` asserts a *computed* key (`md5(customer || '|' || day)`), which
+  neither single-column `unique` nor multi-column `composite` can express.
+- Both checks run at **replication** time, not just on transformation models, so
+  the doubling is caught at load — before it reaches a downstream model.
+
+## Layout
+
+```
+.
+├── README.md         this file
+├── rocky.toml        replication pipeline + cross_source_overlap + unique_expr
+├── run.sh            seed → discover → run → show the detective check results
+└── data/
+    └── seed.sql      two sibling sources (raw__us__shopify, raw__eu__shopify)
+```
+
+## Prerequisites
+
+- `rocky` on PATH
+- `duckdb` CLI for seeding (`brew install duckdb`)
+- `python3` (pretty-prints the check results from the run JSON)
+
+## Run
+
+```bash
+./run.sh
+```
+
+## Expected output
+
+```text
+=== cross_source_overlap — order_ids shared across the us/eu siblings ===
+  cross_source_overlap:duckdb.orders: passed=False overlap_count=3 contributing_tables=['poc.staging__eu__shopify.orders', 'poc.staging__us__shopify.orders'] sample=['1004', '1005', '1006']
+
+=== unique_expr — derived (customer, day) key duplicated within a source ===
+  orders_one_per_customer_per_day: passed=False failing_rows=1
+  orders_one_per_customer_per_day: passed=True failing_rows=0
+```
+
+`overlap_count=3` is order_ids 1004/1005/1006 (the three shared orders). The
+`unique_expr` assertion fails on the EU table (customer 8 ordered twice on the
+same day under two surrogate ids) and passes on US. The check name's
+`duckdb` segment is the source type — against a Fivetran source it would read
+`cross_source_overlap:shopify.orders`.
+
+## What happened
+
+1. `discover` parsed `raw__us__shopify` and `raw__eu__shopify` into siblings
+   (region + source components, same `source = shopify`).
+2. `run` replicated both into `staging__us__shopify.orders` and
+   `staging__eu__shopify.orders`.
+3. The replication runner grouped the two targets (same source type + table
+   name) and ran `cross_source_overlap`, flagging the 3 shared `order_id`s.
+4. It ran the `unique_expr` assertion on each target, catching the EU
+   derived-key duplicate.
+
+## Related
+
+- Concept: [Cross-source overlap](https://rocky-data.dev/concepts/data-quality-checks/#cross-source-overlap)
+- The **preventive** counterpart (discover-time `on_collision`) is documented under
+  [discovery configuration](https://rocky-data.dev/reference/configuration/#pipelinenamesourcediscovery).
+- Source: `engine/crates/rocky-core/src/checks.rs` (`generate_cross_source_overlap_sql`)

--- a/examples/playground/pocs/01-quality/08-cross-source-overlap/data/seed.sql
+++ b/examples/playground/pocs/01-quality/08-cross-source-overlap/data/seed.sql
@@ -1,0 +1,44 @@
+-- Seed for the cross-source-overlap POC.
+--
+-- Two regional Shopify connectors land an `orders` table each. The schema
+-- pattern (prefix `raw__`, components region + source) parses them as
+-- region=us/eu, source=shopify — siblings that replicate to two target
+-- schemas but share the same table name.
+--
+-- For the discover/run flow, load this into the persistent DuckDB first:
+--   duckdb poc.duckdb < data/seed.sql
+
+CREATE SCHEMA IF NOT EXISTS raw__us__shopify;
+CREATE SCHEMA IF NOT EXISTS raw__eu__shopify;
+
+-- US region. order_ids 1001–1006; one order per (customer, day).
+CREATE OR REPLACE TABLE raw__us__shopify.orders (
+    order_id    INTEGER,
+    customer_id INTEGER,
+    order_date  DATE,
+    amount      DECIMAL(10, 2)
+);
+INSERT INTO raw__us__shopify.orders VALUES
+    (1001, 1, DATE '2026-01-01', 50.00),
+    (1002, 2, DATE '2026-01-02', 60.00),
+    (1003, 3, DATE '2026-01-03', 70.00),
+    (1004, 4, DATE '2026-01-04', 80.00),   -- also onboarded under EU
+    (1005, 5, DATE '2026-01-05', 90.00),   -- also onboarded under EU
+    (1006, 6, DATE '2026-01-06', 100.00);  -- also onboarded under EU
+
+-- EU region. order_ids 1004–1009 — the first three collide with US (the same
+-- orders onboarded under both connectors). Order 1009 is a derived-key dup:
+-- same customer + day as 1008 under a fresh surrogate order_id.
+CREATE OR REPLACE TABLE raw__eu__shopify.orders (
+    order_id    INTEGER,
+    customer_id INTEGER,
+    order_date  DATE,
+    amount      DECIMAL(10, 2)
+);
+INSERT INTO raw__eu__shopify.orders VALUES
+    (1004, 4, DATE '2026-01-04', 80.00),   -- shared order_id with US
+    (1005, 5, DATE '2026-01-05', 90.00),   -- shared order_id with US
+    (1006, 6, DATE '2026-01-06', 100.00),  -- shared order_id with US
+    (1007, 7, DATE '2026-01-07', 110.00),
+    (1008, 8, DATE '2026-01-08', 120.00),
+    (1009, 8, DATE '2026-01-08', 125.00);  -- same (customer 8, 2026-01-08) as 1008

--- a/examples/playground/pocs/01-quality/08-cross-source-overlap/rocky.toml
+++ b/examples/playground/pocs/01-quality/08-cross-source-overlap/rocky.toml
@@ -1,0 +1,51 @@
+# 09-cross-source-overlap — detect the same business key arriving via two sources.
+#
+# Two regional Shopify connectors (us, eu) both land an `orders` table. They
+# share some order_ids (the same orders onboarded under two paths), which a
+# per-table `unique` check can never see — only a cross-table overlap check can.
+#
+# `rocky test` auto-loads data/seed.sql into an in-memory DuckDB. For the
+# discover/run flow, seed the persistent file first:
+#   duckdb poc.duckdb < data/seed.sql
+
+[adapter]
+type = "duckdb"
+path = "poc.duckdb"
+
+[pipeline.poc]
+strategy = "full_refresh"
+
+[pipeline.poc.source.discovery]
+adapter = "default"
+
+[pipeline.poc.source.schema_pattern]
+prefix = "raw__"
+separator = "__"
+components = ["region", "source"]
+
+[pipeline.poc.target]
+catalog_template = "poc"
+schema_template = "staging__{region}__{source}"
+
+[pipeline.poc.target.governance]
+auto_create_schemas = true
+
+[pipeline.poc.checks]
+enabled = true
+
+# DETECTIVE, cross-table: flag a business key (order_id) that appears in more
+# than one sibling source (same source type + table name, different target
+# schema). Advisory — surfaces in the JSON, never fails the replication.
+[pipeline.poc.checks.cross_source_overlap]
+keys = ["order_id"]
+severity = "warning"
+
+# DETECTIVE, derived-key: assert a *computed* business key is unique per table —
+# the surrogate `order_id` is unique, but the same logical order (customer +
+# day) must not appear twice. Neither `unique` nor `composite` can express this.
+[[pipeline.poc.checks.assertions]]
+name = "orders_one_per_customer_per_day"
+table = "orders"
+type = "unique_expr"
+key_expr = "md5(CAST(customer_id AS VARCHAR) || '|' || CAST(order_date AS VARCHAR))"
+severity = "warning"

--- a/examples/playground/pocs/01-quality/08-cross-source-overlap/run.sh
+++ b/examples/playground/pocs/01-quality/08-cross-source-overlap/run.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# 09-cross-source-overlap — the same business key arriving via two sources.
+set -euo pipefail
+
+export ROCKY_SUPPRESS_DEPRECATION=1
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+mkdir -p expected
+rm -f .rocky-state.redb .rocky-state.redb.lock poc.duckdb
+rm -f models/.rocky-state.redb models/.rocky-state.redb.lock
+
+echo "=== seed two sibling Shopify sources (us, eu) ==="
+duckdb poc.duckdb < data/seed.sql
+
+echo "=== discover (raw__<region>__<source>) ==="
+rocky discover > expected/discover.json
+
+echo "=== run (replicate both regions, then the detective checks) ==="
+rocky run --filter source=shopify --output json > expected/run.json
+
+echo
+echo "=== cross_source_overlap — order_ids shared across the us/eu siblings ==="
+python3 - expected/run.json <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+def walk(o):
+    if isinstance(o, dict):
+        if isinstance(o.get("name"), str) and o["name"].startswith("cross_source_overlap:"):
+            yield o
+        for v in o.values():
+            yield from walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from walk(v)
+found = list(walk(data))
+if not found:
+    print("  (no cross_source_overlap result found)")
+for c in found:
+    print(f"  {c['name']}: passed={c['passed']} "
+          f"overlap_count={c.get('overlap_count')} "
+          f"contributing_tables={c.get('contributing_tables')} "
+          f"sample={c.get('sample')}")
+PY
+
+echo
+echo "=== unique_expr — derived (customer, day) key duplicated within a source ==="
+python3 - expected/run.json <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+def walk(o):
+    if isinstance(o, dict):
+        if o.get("kind") == "unique_expr":
+            yield o
+        for v in o.values():
+            yield from walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from walk(v)
+found = list(walk(data))
+if not found:
+    print("  (no unique_expr result found)")
+for c in found:
+    print(f"  {c['name']}: passed={c['passed']} failing_rows={c.get('failing_rows')}")
+PY
+
+echo
+echo "POC complete: cross_source_overlap flagged the shared order_ids;"
+echo "unique_expr flagged the derived-key dup. Both are advisory (severity=warning)."

--- a/examples/playground/pocs/README.md
+++ b/examples/playground/pocs/README.md
@@ -5,7 +5,7 @@
 ## Categories
 
 - [00-foundations](00-foundations/) — DSL syntax + materialization basics + trust-arc 1 branches/replay/lineage + config layering + branch approve/promote + file-format ingest + per-tenant routing + plan/apply workflow + project scaffolding (13 POCs · DuckDB)
-- [01-quality](01-quality/) — Contracts, checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs (7 POCs · DuckDB)
+- [01-quality](01-quality/) — Contracts, checks, anomaly detection, local testing, SCD-2 snapshots, standalone quality pipeline, freshness SLAs, cross-source overlap (8 POCs · DuckDB)
 - [02-performance](02-performance/) — Incremental, merge, drift, optimization, ephemeral CTE, delete+insert, adaptive concurrency, trust-arc 2 cost+budgets, strategy showcase, EXPLAIN cost estimation, skip-unchanged gate (14 POCs · DuckDB)
 - [03-ai](03-ai/) — AI generation, sync, test generation, trust-arc 5 schema-grounded validation, MCP data-grounding (6 POCs · `ANTHROPIC_API_KEY` for 5, DuckDB for the MCP-grounding POC)
 - [04-governance](04-governance/) — Unity Catalog grants, isolation, tagging, classification + masking, retention, auto-create schemas, cross-team contracts (8 POCs · Databricks / DuckDB)


### PR DESCRIPTION
Documents the cross-source duplicate detection feature (shipped in #839/#842/#843/#844/#847) — it had no prose docs or runnable example. Audited the user-facing surfaces; IDE autocomplete was already covered by the autogenerated project schema, the rest were missing.

## Docs

- **`reference/configuration.md`** — `report_new_sources` + `on_collision` under `[…source.discovery]`; `cross_source_overlap` under `[checks]`; the `unique_expr` assertion. Also fixes the existing `[[checks.assertions]]` examples, which omitted the required `table` field (they would not parse).
- **`concepts/data-quality-checks.md`** — the `unique_expr` kind + a new `cross_source_overlap` section (the actual generated SQL, a preventive-vs-detective table) + a note that assertions run at replication time, not just on transformation models.
- **`reference/commands/core-pipeline.md`** + **`reference/json-output.md`** — the `new_sources` and `collision_candidates` discover output fields.

## POC

`examples/playground/pocs/01-quality/08-cross-source-overlap` — two sibling Shopify sources (us/eu) share order_ids; `cross_source_overlap` flags them and `unique_expr` catches a derived-key dup, both at replication time. DuckDB, no credentials.

## Verification

- POC runs end-to-end (`run.sh` exits 0 — `cross_source_overlap` reports `overlap_count=3`, `unique_expr` fires on the EU table); `rocky validate` clean.
- JSON/SQL examples checked against source (`CheckDetails` is untagged + flattened, so detail fields sit on the result; the overlap SQL is `COUNT(DISTINCT _src)`).
- Docs build locally (Astro, 85 pages); all new anchor links resolve in the built HTML.

No engine code changed.