### PR TITLE
feat(dagster): surface discover collisions/new-sources + validate graph schema_version

### DIFF
--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -118,6 +118,17 @@ _FIVETRAN_QUOTA_COOLDOWN_DEFAULT_SECONDS: int = 300
 #: Matches the codegen'd ``FailureKind5.quota_exceeded`` value.
 _QUOTA_EXCEEDED_FAILURE_KIND: str = "quota-exceeded"
 
+#: Graph-export ``schema_version`` this build of ``dagster-rocky`` was
+#: generated against (matches the ``DagOutput.schema_version`` default in
+#: ``types_generated/dag_schema.py``). ``rocky dag --output json`` carries
+#: its own ``schema_version`` identifying the *shape* of the graph export.
+#: When the engine bumps it on a backward-incompatible change,
+#: :func:`_warn_if_dag_schema_newer` logs a tolerant warning so an older
+#: integration loading a newer graph degrades gracefully instead of
+#: hard-failing — additive field additions never bump it, so a matching or
+#: older version is always safe to consume.
+_SUPPORTED_DAG_SCHEMA_VERSION: str = "1"
+
 
 def _engine_schema_mismatch_failure(command: str, exc: ValidationError) -> dg.Failure:
     """Build a ``dg.Failure`` for a Pydantic schema-mismatch on ``rocky <command>``.
@@ -817,6 +828,8 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         # (e.g., "from" → from_, "schema" → schema_).
         dag_result = DagResult.model_validate_json(json.dumps(raw["dag"]))
         discover_result = DiscoverResult.model_validate_json(json.dumps(raw["discover"]))
+        _warn_if_dag_schema_newer(dag_result)
+        _warn_discover_signals(discover_result)
         translator = self._get_translator()
         rocky = self._get_rocky_resource()
 
@@ -1008,6 +1021,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         DAG mode (no ``"dag"`` key).
         """
         discover, compile_result, optimize_result = _load_state(state_path)
+        _warn_discover_signals(discover)
         if self.strict_build and not discover.sources:
             raise dg.Failure(
                 description=(
@@ -1123,6 +1137,88 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             assets=assets,
             sensors=sensors or None,
             resources={"rocky": rocky},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Discover / DAG signal surfacing
+# ---------------------------------------------------------------------------
+
+
+def _warn_discover_signals(discover: DiscoverResult) -> None:
+    """Log build-time warnings for cross-source collisions and new sources.
+
+    ``rocky discover`` surfaces two onboarding signals that the component
+    would otherwise parse and drop:
+
+    * ``collision_candidates`` — groups of ≥2 sources sharing the SAME
+      external object id but resolving to DIFFERENT target paths (the same
+      underlying object onboarded twice under different schemas). Populated
+      only when discovery's ``on_collision`` is ``warn``/``error``.
+    * ``new_sources`` — source schemas seen for the first time relative to
+      the prior persisted discover snapshot (the catch-a-duplicate-at-
+      onboarding signal). Populated only when ``report_new_sources`` is set.
+
+    Both are *build-time* discover data, not ``rocky run`` output, so they
+    surface as module-logger warnings here (called from both the discover
+    and DAG build paths) rather than as run-time asset checks. They are
+    deliberately not attached as per-asset metadata: ``SourceOutput``
+    decomposes the source schema into ``components`` and carries no raw
+    schema-name field, so a collision/new-source schema string cannot be
+    reliably mapped back to a specific Dagster asset key.
+    """
+    collisions = discover.collision_candidates or []
+    for collision in collisions:
+        _log.warning(
+            "rocky discover: cross-source collision — external object id %r "
+            "resolves to %d sources (%s). The same underlying object appears "
+            "to be onboarded more than once under different schemas; review "
+            "the listed sources for a duplicate.",
+            collision.external_object_id,
+            len(collision.sources),
+            ", ".join(collision.sources),
+        )
+
+    new_sources = discover.new_sources or []
+    if new_sources:
+        _log.warning(
+            "rocky discover: %d new source schema(s) seen for the first time "
+            "since the last discover snapshot (%s). Confirm these are "
+            "intentional onboardings and not duplicates of existing sources.",
+            len(new_sources),
+            ", ".join(new_sources),
+        )
+
+
+def _warn_if_dag_schema_newer(dag_result: DagResult) -> None:
+    """Warn (never fail) when the graph-export ``schema_version`` is newer.
+
+    ``rocky dag --output json`` carries a ``schema_version`` identifying the
+    *shape* of the graph export. This integration was generated against
+    :data:`_SUPPORTED_DAG_SCHEMA_VERSION`. Forward-compat contract: an older
+    integration must still load a newer graph (additive field additions
+    don't bump the version), so a newer ``schema_version`` is surfaced as a
+    tolerant warning, never a hard failure.
+
+    The comparison is numeric — a lexical string compare would order
+    ``"10"`` before ``"2"``. A non-numeric or absent value is treated as
+    "no newer signal" and silently ignored so a future non-integer scheme
+    can't crash an older integration.
+    """
+    try:
+        payload_version = int(dag_result.schema_version or _SUPPORTED_DAG_SCHEMA_VERSION)
+        supported_version = int(_SUPPORTED_DAG_SCHEMA_VERSION)
+    except (TypeError, ValueError):
+        return
+    if payload_version > supported_version:
+        _log.warning(
+            "rocky dag schema_version=%s is newer than the version this "
+            "dagster-rocky build was generated against (%s). The asset graph "
+            "was built tolerantly and may not reflect newer graph-export "
+            "fields — upgrade dagster-rocky to match the rocky binary to pick "
+            "them up.",
+            dag_result.schema_version,
+            _SUPPORTED_DAG_SCHEMA_VERSION,
         )
 
 

--- a/integrations/dagster/src/dagster_rocky/types.py
+++ b/integrations/dagster/src/dagster_rocky/types.py
@@ -87,6 +87,21 @@ class DiscoverResult(BaseModel):
     #: round 9 bridge block below — ``from __future__ import annotations``
     #: defers evaluation so the forward reference resolves at runtime.
     failed_sources: list[FailedSourceOutput] = []
+    #: Groups of ≥2 discovered sources sharing the SAME external object id
+    #: but resolving to DIFFERENT target paths — the same underlying object
+    #: onboarded twice under different schemas. Populated only when
+    #: discovery's ``on_collision`` is ``warn``/``error`` and the adapter
+    #: supplies an ``external_object_id``; empty otherwise. Forward-references
+    #: :class:`CollisionCandidate` (defined with the run-output classes
+    #: below); ``from __future__ import annotations`` defers evaluation so
+    #: the reference resolves at runtime.
+    collision_candidates: list[CollisionCandidate] = []
+    #: Source schemas seen for the first time relative to the prior persisted
+    #: ``discover`` snapshot — the catch-a-duplicate-at-onboarding signal.
+    #: Populated only when the pipeline's discovery config sets
+    #: ``report_new_sources``; empty otherwise. The first-ever discover of a
+    #: pipeline establishes the baseline and reports none.
+    new_sources: list[str] = []
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +295,25 @@ class ExcludedTable(BaseModel):
     #: kept open so future causes (disabled, sync_paused, ...) can be
     #: added without a schema break.
     reason: str
+
+
+class CollisionCandidate(BaseModel):
+    """A cross-source collision: one external object id that resolves to
+    more than one target path (the same underlying object onboarded twice
+    under different schemas).
+
+    Surfaced on :attr:`DiscoverResult.collision_candidates` when discovery's
+    ``on_collision`` is ``warn``/``error`` and the adapter supplies an
+    ``external_object_id``. Mirrors the engine-side
+    ``CollisionCandidateOutput`` shape.
+    """
+
+    #: The shared external object id (e.g. a Fivetran ad-account id) that
+    #: more than one discovered source resolves to.
+    external_object_id: str
+    #: The distinct source schemas (≥2, sorted) that resolve to the shared
+    #: object id. Review these for a duplicate onboarding.
+    sources: list[str]
 
 
 class ExecutionSummary(BaseModel):

--- a/integrations/dagster/tests/conftest.py
+++ b/integrations/dagster/tests/conftest.py
@@ -32,6 +32,14 @@ def discover_json() -> str:
 
 
 @pytest.fixture
+def discover_with_collisions_json() -> str:
+    """DiscoverResult carrying the cross-source ``collision_candidates`` and
+    ``new_sources`` onboarding signals. Used to assert the component surfaces
+    them as build-time warnings."""
+    return json.dumps(scenarios.DISCOVER_WITH_COLLISIONS)
+
+
+@pytest.fixture
 def discover_multi_source_type_json() -> str:
     """DiscoverResult with three source types (fivetran, airbyte, manual)
     and three different component hierarchies. Used by translator and

--- a/integrations/dagster/tests/scenarios.py
+++ b/integrations/dagster/tests/scenarios.py
@@ -69,6 +69,30 @@ DISCOVER: dict[str, Any] = {
 }
 
 # ---------------------------------------------------------------------------
+# discover — cross-source collision + new-source onboarding signals
+#
+# Same two sources as DISCOVER above, plus the two onboarding signals the
+# component surfaces as build-time warnings: ``collision_candidates`` (one
+# external object id resolving to ≥2 source schemas — the same object
+# onboarded twice) and ``new_sources`` (schemas seen for the first time
+# since the last discover snapshot). Used by test_component to assert the
+# warning surfacing without reconstructing per-asset metadata.
+# ---------------------------------------------------------------------------
+
+DISCOVER_WITH_COLLISIONS: dict[str, Any] = {
+    "version": "0.1.0",
+    "command": "discover",
+    "sources": DISCOVER["sources"],
+    "collision_candidates": [
+        {
+            "external_object_id": "ad_account_42",
+            "sources": ["acme_us_west_shopify", "globex_eu_central_stripe"],
+        },
+    ],
+    "new_sources": ["globex_eu_central_stripe"],
+}
+
+# ---------------------------------------------------------------------------
 # discover — multi-source-type coverage
 #
 # Exercises the generic shape of DiscoverResult: the engine may emit

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -646,6 +646,13 @@ def test_write_state_emits_alias_keys_and_round_trips(
                     "message": "transient fetch failure",
                 }
             ],
+            "collision_candidates": [
+                {
+                    "external_object_id": "ad_account_42",
+                    "sources": ["acme_shopify", "globex_stripe"],
+                }
+            ],
+            "new_sources": ["globex_stripe"],
         }
     )
     stub = _StubResource(discover_result=discover)
@@ -665,10 +672,16 @@ def test_write_state_emits_alias_keys_and_round_trips(
     # On-disk JSON carries the canonical alias key, not the Python attribute.
     assert "schema" in failed_source
     assert "schema_" not in failed_source
+    # The new onboarding-signal fields survive the discover() → model_dump_json
+    # write hop (not just the read hop) so the warning has data in production.
+    assert state["discover"]["collision_candidates"][0]["external_object_id"] == "ad_account_42"
+    assert state["discover"]["new_sources"] == ["globex_stripe"]
 
     # The persisted discover slot round-trips cleanly back through the model.
     round_tripped = DiscoverResult.model_validate(state["discover"])
     assert round_tripped.failed_sources[0].schema_ == "raw_shopify"
+    assert round_tripped.collision_candidates[0].sources == ["acme_shopify", "globex_stripe"]
+    assert round_tripped.new_sources == ["globex_stripe"]
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/dagster/tests/test_component.py
+++ b/integrations/dagster/tests/test_component.py
@@ -14,9 +14,16 @@ import pydantic
 import pytest
 
 from dagster_rocky import component as component_module
-from dagster_rocky.component import RockyComponent, _load_state
+from dagster_rocky.component import (
+    _SUPPORTED_DAG_SCHEMA_VERSION,
+    RockyComponent,
+    _load_state,
+    _warn_discover_signals,
+    _warn_if_dag_schema_newer,
+)
 from dagster_rocky.translator import RockyDagsterTranslator
 from dagster_rocky.types import (
+    DagResult,
     DiscoverResult,
     LineageEdge,
     ModelLineageResult,
@@ -1586,3 +1593,158 @@ def test_strict_build_write_state_optimize_slot_stays_best_effort(
     state = json.loads(state_path.read_text())
     assert "discover" in state
     assert "optimize" not in state
+
+
+# ---------------------------------------------------------------------------
+# Discover signal surfacing — cross-source collisions + new sources
+# ---------------------------------------------------------------------------
+
+
+def test_warn_discover_signals_logs_collisions_and_new_sources(
+    discover_with_collisions_json: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``_warn_discover_signals`` logs one warning per collision and one for
+    the new-source batch."""
+    discover = DiscoverResult.model_validate_json(discover_with_collisions_json)
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        _warn_discover_signals(discover)
+
+    messages = [r.getMessage() for r in caplog.records]
+    collision_msgs = [m for m in messages if "cross-source collision" in m]
+    new_source_msgs = [m for m in messages if "new source schema" in m]
+    assert len(collision_msgs) == 1
+    assert len(new_source_msgs) == 1
+    # The collision warning names the shared external object id and the
+    # colliding source schemas.
+    assert "ad_account_42" in collision_msgs[0]
+    assert "acme_us_west_shopify" in collision_msgs[0]
+    assert "globex_eu_central_stripe" in collision_msgs[0]
+    assert "globex_eu_central_stripe" in new_source_msgs[0]
+
+
+def test_warn_discover_signals_silent_without_signals(
+    discover_json: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A plain discover payload (no collision/new-source fields) logs nothing."""
+    discover = DiscoverResult.model_validate_json(discover_json)
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        _warn_discover_signals(discover)
+    assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+def test_build_defs_from_discover_surfaces_collision_warnings(
+    discover_with_collisions_json: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The discover build path surfaces the onboarding signals as warnings
+    while still building the asset graph."""
+    state_file = _write_state(discover_with_collisions_json, tmp_path)
+    component = RockyComponent(config_path="rocky.toml")
+
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    # Assets still built — surfacing is additive, not a gate.
+    assert len(list(defs.assets or [])) > 0
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("cross-source collision" in m for m in messages)
+    assert any("new source schema" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Graph-export schema_version validation
+# ---------------------------------------------------------------------------
+
+
+def _make_dag_result(schema_version: str | None) -> DagResult:
+    """Build a minimal one-node DagResult, optionally pinning schema_version."""
+    payload: dict[str, Any] = {
+        "version": "1.0.0",
+        "command": "dag",
+        "nodes": [
+            {
+                "id": "transformation:m1",
+                "kind": "transformation",
+                "label": "m1",
+                "target": {"catalog": "w", "schema": "s", "table": "m1"},
+            }
+        ],
+        "edges": [],
+        "execution_layers": [],
+        "summary": {
+            "total_nodes": 1,
+            "total_edges": 0,
+            "execution_layers": 0,
+            "counts_by_kind": {},
+        },
+    }
+    if schema_version is not None:
+        payload["schema_version"] = schema_version
+    return DagResult.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "schema_version",
+    [None, "1", _SUPPORTED_DAG_SCHEMA_VERSION, "abc"],
+)
+def test_warn_if_dag_schema_newer_silent_for_supported_or_unparseable(
+    schema_version: str | None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning for absent / supported / non-numeric schema_version — the
+    last must not crash (forward-compat for a future non-integer scheme)."""
+    dag_result = _make_dag_result(schema_version)
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        _warn_if_dag_schema_newer(dag_result)
+    assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+def test_warn_if_dag_schema_newer_warns_for_newer_version(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A schema_version numerically greater than the supported one warns."""
+    dag_result = _make_dag_result("2")
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        _warn_if_dag_schema_newer(dag_result)
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "schema_version=2" in warnings[0]
+
+
+def test_warn_if_dag_schema_newer_uses_numeric_compare_not_lexical(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``"10"`` is newer than ``"1"`` numerically — a lexical compare would
+    miss double-digit majors entirely."""
+    dag_result = _make_dag_result("10")
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        _warn_if_dag_schema_newer(dag_result)
+    assert any(
+        r.levelname == "WARNING" and "schema_version=10" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_dag_mode_build_warns_on_newer_schema_version(
+    discover_json: str,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``dag_mode`` build path tolerantly warns (never fails) on a newer
+    graph-export schema_version and still builds the asset graph."""
+    dag_payload = _make_dag_result("2").model_dump(by_alias=True, mode="json")
+    state = {
+        "discover": json.loads(discover_json),
+        "dag": dag_payload,
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(state))
+
+    component = RockyComponent(config_path="rocky.toml", dag_mode=True)
+    with caplog.at_level("WARNING", logger=component_module._log.name):
+        defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    assert len(list(defs.assets or [])) > 0
+    assert any("schema_version=2" in r.getMessage() for r in caplog.records)

--- a/integrations/dagster/tests/test_types.py
+++ b/integrations/dagster/tests/test_types.py
@@ -50,6 +50,20 @@ def test_parse_discover(discover_json: str):
     assert globex.components["tenant"] == "globex"
     assert len(globex.tables) == 3
     assert globex.tables[2].row_count is None
+    # A plain discover payload carries no onboarding signals.
+    assert result.collision_candidates == []
+    assert result.new_sources == []
+
+
+def test_parse_discover_collision_and_new_source_signals(discover_with_collisions_json: str):
+    """``DiscoverResult`` retains the cross-source collision and new-source
+    onboarding signals instead of silently dropping them at parse time."""
+    result = DiscoverResult.model_validate_json(discover_with_collisions_json)
+    assert len(result.collision_candidates) == 1
+    collision = result.collision_candidates[0]
+    assert collision.external_object_id == "ad_account_42"
+    assert collision.sources == ["acme_us_west_shopify", "globex_eu_central_stripe"]
+    assert result.new_sources == ["globex_eu_central_stripe"]
 
 
 def test_parse_discover_multi_source_type(discover_multi_source_type_json: str):


### PR DESCRIPTION
## What

Two small follow-ups that surface engine 1.49 data the Dagster integration was parsing but silently dropping.

### 1. Surface `rocky discover` cross-source collisions + new sources

The engine emits `collision_candidates` (same external object id onboarded under ≥2 schemas) and `new_sources` (schemas seen for the first time since the last snapshot). The component consumes the hand-written `DiscoverResult`, which **did not declare these fields** — so Pydantic discarded the engine-emitted keys at parse time (the generated `DiscoverOutput` has them, but that's not what the component path uses).

- Added `collision_candidates` + `new_sources` to `DiscoverResult` (plus a small `CollisionCandidate` model), mirroring the existing `excluded_tables` / `failed_sources` fields.
- New `_warn_discover_signals()` logs a build-time warning per collision and one for the new-source batch, wired into **both** the discover and DAG build paths.
- **Not** surfaced as per-asset metadata: `SourceInfo` decomposes the source schema into `components` and carries no raw schema-name field, so a collision/new-source schema string cannot be reliably mapped back to a Dagster asset key. A logged warning is the correct, target-free primitive for build-time discover data (run-time emit helpers in `observability.py` consume `RunResult`, not `DiscoverResult`).

### 2. Validate the graph-export `schema_version`

`rocky dag --output json` now carries a `schema_version` identifying the *shape* of the graph export. The component parsed `DagResult` but never checked it.

- New `_warn_if_dag_schema_newer()` does a **tolerant numeric** comparison against the version this build was generated against (`_SUPPORTED_DAG_SCHEMA_VERSION = "1"`). It warns — never hard-fails — when the payload is newer, so an older integration still loads a newer graph (forward-compat: additive field additions don't bump the version). Non-numeric / absent values are ignored (a lexical compare would mis-order `"10"` vs `"2"`).
- Uses the module logger, not `context.log`, since build runs may pass `context=None`.

## Tests

- `_warn_discover_signals`: direct unit tests (logs collisions + new sources; silent without signals) + a build-path test asserting the warnings surface while assets still build.
- `_warn_if_dag_schema_newer`: parametrized (absent / supported / non-numeric → silent), newer → warns, `"10"` vs `"1"` numeric-not-lexical, and a `dag_mode` build-path test (tolerant warning, graph still built).
- `test_types.py`: parse assertions pinning that `DiscoverResult` now retains both fields.
- New `DISCOVER_WITH_COLLISIONS` scenario + `discover_with_collisions_json` fixture.

No generated bindings, Rust, or other subprojects touched — the change is confined to `integrations/dagster/`. No `just codegen` / `regen-fixtures` needed (only hand-written `types.py` + the component changed).

### Verification
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean (48 files)
- `uv run pytest -q` — 587 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)