### PR TITLE
feat(engine): surface per-model build/skip/reuse decision + reason (D1)

### DIFF
--- a/editors/vscode/src/types/generated/run.ts
+++ b/editors/vscode/src/types/generated/run.ts
@@ -93,6 +93,12 @@ export type FailureKind =
   | "not-found"
   | "unknown";
 /**
+ * The per-model build decision the engine made this run — what the skip-gate and content-addressed reuse machinery actually decided.
+ *
+ * Reporting-only: this never changes build behavior, it surfaces a decision that today only reaches the run log. Populated on [`RunOutput::model_decisions`] only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; a default run (both off) emits an empty list and the field is omitted.
+ */
+export type ModelDecision = "build" | "skip" | "reused";
+/**
  * Status of a pipeline run.
  *
  * `Success` / `PartialFailure` / `Failure` cover the terminal outcomes of a run that actually executed. `SkippedIdempotent` / `SkippedInFlight` are the short-circuit outcomes of `rocky run --idempotency-key` — see [`crate::idempotency`].
@@ -133,6 +139,10 @@ export interface RunOutput {
   interrupted: boolean;
   materializations: MaterializationOutput[];
   metrics?: MetricsSnapshot | null;
+  /**
+   * Per-model build/skip/reuse decision + reason, surfaced for transformation runs so orchestrators can explain *why* each model ran, was skipped, or was reused. Populated only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; empty (and omitted) for a default run, which stays byte-identical.
+   */
+  model_decisions?: ModelDecisionOutput[];
   /**
    * Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.
    */
@@ -398,6 +408,26 @@ export interface MetricsSnapshot {
   table_duration_p95_ms: number;
   tables_failed: number;
   tables_processed: number;
+  [k: string]: unknown;
+}
+/**
+ * One per-model decision entry on [`RunOutput::model_decisions`].
+ *
+ * Surfaces the skip/build/reuse verdict the engine reached for a single transformation model, plus a short human-readable reason that mirrors the gate's actual decision point (never re-derived — threaded from the evaluation result). Orchestrators (Dagster) and the VS Code extension use it to explain *why* a model ran, was skipped, or was reused.
+ */
+export interface ModelDecisionOutput {
+  /**
+   * What the engine decided for this model.
+   */
+  decision: ModelDecision;
+  /**
+   * The model's name (matches the model entry in the project DAG).
+   */
+  model: string;
+  /**
+   * Short human-readable justification reflecting the exact decision the gate made (e.g. "logic and upstream data unchanged since last build", "not skip-eligible", "upstream data may have changed", "reused prior run's bytes (strong proof)").
+   */
+  reason: string;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4430,16 +4430,43 @@ pub(crate) async fn execute_models(
                     .evaluate(model, &typed_ir, warehouse, state_store)
                     .await
                 {
-                    super::skip_gate::GateDecision::Skip => {
+                    super::skip_gate::GateDecision::Skip { reason } => {
                         gate.record(name, super::skip_gate::Verdict::Skipped);
                         output.tables_skipped += 1;
+                        // Surface the per-model decision (reporting-only —
+                        // mirrors the log line below, never changes behavior).
+                        output
+                            .model_decisions
+                            .push(crate::output::ModelDecisionOutput {
+                                model: name.to_string(),
+                                decision: crate::output::ModelDecision::Skip,
+                                reason: reason.message().to_string(),
+                            });
                         info!(
                             model = name.as_str(),
+                            reason = reason.as_str(),
                             "skip-unchanged: logic and upstream data both appear \
                              unchanged — skipping re-materialization (best-effort)"
                         );
                     }
-                    super::skip_gate::GateDecision::Build { skip_state } => {
+                    super::skip_gate::GateDecision::Build { skip_state, reason } => {
+                        // Record the Build decision here for the *plain*
+                        // strategies the gate actually adjudicates. The two
+                        // special strategies (`content_addressed`,
+                        // `time_interval`) are never skip-eligible and own
+                        // their own decision entry at their execution site
+                        // (content_addressed surfaces Build/Reused there,
+                        // time_interval surfaces Build), so suppress a
+                        // duplicate here.
+                        if is_plain_strategy(model) {
+                            output
+                                .model_decisions
+                                .push(crate::output::ModelDecisionOutput {
+                                    model: name.to_string(),
+                                    decision: crate::output::ModelDecision::Build,
+                                    reason: reason.message().to_string(),
+                                });
+                        }
                         to_build.push((idx, name, model, Some(skip_state)));
                     }
                 }
@@ -4692,6 +4719,39 @@ pub(crate) async fn execute_models(
                             // content_addressed is never skip-eligible.
                             skip_internal: None,
                         });
+                        // Per-model decision (reporting-only). A
+                        // content_addressed model is never skip-eligible, so it
+                        // is suppressed in the skip-gate loop above and owns its
+                        // decision here: `Reused` when the zero-copy point-to
+                        // landed (no SQL ran), else `Build`. Only emitted when
+                        // the skip gate is active or `[reuse]` is enabled so a
+                        // default run's output stays byte-identical.
+                        if gate.config().is_active() || reuse_enabled {
+                            let (decision, reason) = match &summary.reused_from {
+                                Some(reuse) => (
+                                    crate::output::ModelDecision::Reused,
+                                    format!(
+                                        "reused prior run {}'s bytes ({} proof)",
+                                        reuse.reused_run_id, reuse.proof_class
+                                    ),
+                                ),
+                                None if reuse_enabled => (
+                                    crate::output::ModelDecision::Build,
+                                    "content-addressed: no reusable prior run; built".to_string(),
+                                ),
+                                None => (
+                                    crate::output::ModelDecision::Build,
+                                    "content-addressed: built".to_string(),
+                                ),
+                            };
+                            output
+                                .model_decisions
+                                .push(crate::output::ModelDecisionOutput {
+                                    model: model_name.to_string(),
+                                    decision,
+                                    reason,
+                                });
+                        }
                         info!(
                             model = model_name,
                             target = target_table_full_name.as_str(),
@@ -4868,6 +4928,20 @@ pub(crate) async fn execute_models(
                         .await;
                 }
                 time_interval_res?;
+                // Per-model decision (reporting-only). time_interval is never
+                // skip-eligible, so it is suppressed in the skip-gate loop above
+                // and owns its `Build` entry here. Gated on the skip gate being
+                // active (reuse does not apply to time_interval) so a default
+                // run's output stays byte-identical.
+                if gate.config().is_active() {
+                    output
+                        .model_decisions
+                        .push(crate::output::ModelDecisionOutput {
+                            model: model_name.to_string(),
+                            decision: crate::output::ModelDecision::Build,
+                            reason: "time_interval: built (not skip-eligible)".to_string(),
+                        });
+                }
                 if let (Some(reg), Some(pipe)) = (hook_registry, pipeline_name) {
                     let _ = reg
                         .fire(&HookContext::after_model_run(
@@ -7193,6 +7267,7 @@ mod tests {
             resumed_from: None,
             shadow: false,
             materializations: vec![],
+            model_decisions: vec![],
             check_results: vec![],
             quarantine: vec![],
             anomalies: vec![],
@@ -9079,6 +9154,21 @@ merge_keys = ["id"]
             .any(|m| m.asset_key.last().map(String::as_str) == Some(model))
     }
 
+    /// The `(decision, reason)` the run surfaced for `model`, if any. Used by
+    /// the gate tests to assert the per-model decision entry mirrors what the
+    /// gate actually decided (not just the build-vs-skip outcome).
+    #[cfg(feature = "duckdb")]
+    fn decision_for<'a>(
+        output: &'a RunOutput,
+        model: &str,
+    ) -> Option<(crate::output::ModelDecision, &'a str)> {
+        output
+            .model_decisions
+            .iter()
+            .find(|d| d.model == model)
+            .map(|d| (d.decision, d.reason.as_str()))
+    }
+
     /// Write a full_refresh model `name.sql`/`name.toml` into `main`, with an
     /// optional `[skip]` block appended to the sidecar.
     #[cfg(feature = "duckdb")]
@@ -9195,6 +9285,43 @@ merge_keys = ["id"]
             4,
             "a skip must NOT rewrite the target — sentinel row survives"
         );
+        // The per-model decision entry must report Skip with the matching
+        // reason — the surfaced justification mirrors the gate's actual path.
+        assert_eq!(
+            decision_for(&out2, "agg"),
+            Some((
+                crate::output::ModelDecision::Skip,
+                "logic and upstream data unchanged since last build"
+            )),
+            "skip decision + reason must be surfaced"
+        );
+        // The first (baseline) run built because there was no prior baseline.
+        assert_eq!(
+            decision_for(&out1, "agg"),
+            Some((
+                crate::output::ModelDecision::Build,
+                "no prior successful build to compare against"
+            )),
+            "first build must report the no-prior-baseline reason"
+        );
+        // A default (gate-off) run surfaces NO decisions — byte-identical.
+        let tmp_off = tempfile::TempDir::new().unwrap();
+        let db_off = tmp_off.path().join("off.duckdb");
+        let state_off = StateStore::open(&tmp_off.path().join("state")).unwrap();
+        seed_src(&db_off, 3).await;
+        let out_off = run_with_gate(
+            &models_dir,
+            &db_off,
+            &state_off,
+            SkipGateConfig::off(),
+            "run-off",
+            rocky_core::state::RunStatus::Success,
+        )
+        .await;
+        assert!(
+            out_off.model_decisions.is_empty(),
+            "a gate-off run must surface no per-model decisions"
+        );
     }
 
     /// Logic changed (a different WHERE predicate) ⇒ BUILD even when upstream
@@ -9242,6 +9369,14 @@ merge_keys = ["id"]
         )
         .await;
         assert!(built(&out2, "agg"), "a changed predicate must rebuild");
+        assert_eq!(
+            decision_for(&out2, "agg"),
+            Some((
+                crate::output::ModelDecision::Build,
+                "model logic changed since last build"
+            )),
+            "a changed predicate must surface the B2 (logic-changed) reason"
+        );
     }
 
     /// Upstream rowcount changed ⇒ BUILD (rowcount-fallback signal).
@@ -9280,6 +9415,14 @@ merge_keys = ["id"]
         assert!(
             built(&out2, "agg"),
             "a changed upstream rowcount must rebuild"
+        );
+        assert_eq!(
+            decision_for(&out2, "agg"),
+            Some((
+                crate::output::ModelDecision::Build,
+                "upstream data may have changed since last build"
+            )),
+            "a changed upstream rowcount must surface the B3 (upstream-changed) reason"
         );
     }
 

--- a/engine/crates/rocky-cli/src/commands/skip_gate.rs
+++ b/engine/crates/rocky-cli/src/commands/skip_gate.rs
@@ -62,15 +62,99 @@ pub(crate) enum Verdict {
     Skipped,
 }
 
-/// Outcome of evaluating the gate for one model.
+/// Why the gate reached a given build-or-skip outcome for one model.
+///
+/// One variant per *actual return point* in [`SkipGate::evaluate`] — the
+/// reason is recorded at the point the gate decided, never re-derived, so the
+/// surfaced justification cannot drift from what the gate did. Mirrors the
+/// fail-closed [`super::reuse_decision::BuildReason`] pattern: each `Build`
+/// variant names the first clause that did not hold (first-failing-point), and
+/// there is exactly one `Skip` reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GateReason {
+    // ---- Skip (the single all-clauses-hold path) ----
+    /// Clauses (B)–(G) all held: logic key matched and every upstream is
+    /// provably unchanged.
+    Skipped,
+
+    // ---- Build (first failing clause) ----
+    /// (B) the model is not skip-eligible — explicit opt-out, a
+    /// non-plain strategy (`content_addressed` / `time_interval`), or
+    /// non-deterministic SQL.
+    NotEligible,
+    /// (G, source side) the model's upstreams could not be provably
+    /// enumerated — a CTE, a subquery, a set operation, or any other shape
+    /// the conservative lineage whitelist rejects — so B3 is unprovable.
+    UpstreamsNotEnumerable,
+    /// (C) no state store is available to read a prior baseline from.
+    NoStateStore,
+    /// (C) no prior successful build of this model exists to compare against.
+    NoPriorBuild,
+    /// (C) the latest recorded build of this model did not succeed, so it is
+    /// not a trustworthy baseline.
+    LastBuildNotSuccess,
+    /// (D)/(E) the prior build or the current IR has no comparable logic key.
+    NoLogicKey,
+    /// (F) the model's logic key changed since the last build — **B2** failed.
+    LogicChanged,
+    /// (G) an upstream may have changed since the last build (an upstream
+    /// Rocky model was rebuilt, or a raw source's freshness signature moved
+    /// or could not be proven stable) — **B3** failed.
+    UpstreamChanged,
+}
+
+impl GateReason {
+    /// Stable lowercase token for structured logs / programmatic branching.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            GateReason::Skipped => "skipped_unchanged",
+            GateReason::NotEligible => "not_eligible",
+            GateReason::UpstreamsNotEnumerable => "upstreams_not_enumerable",
+            GateReason::NoStateStore => "no_state_store",
+            GateReason::NoPriorBuild => "no_prior_build",
+            GateReason::LastBuildNotSuccess => "last_build_not_success",
+            GateReason::NoLogicKey => "no_logic_key",
+            GateReason::LogicChanged => "logic_changed",
+            GateReason::UpstreamChanged => "upstream_changed",
+        }
+    }
+
+    /// Short human-readable justification for the run output's per-model
+    /// `reason` field. Phrased to read truthfully whichever way the gate went.
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            GateReason::Skipped => "logic and upstream data unchanged since last build",
+            GateReason::NotEligible => {
+                "not skip-eligible (non-deterministic, opt-out, or special strategy)"
+            }
+            GateReason::UpstreamsNotEnumerable => {
+                "upstreams not provably enumerable (e.g. CTE or subquery)"
+            }
+            GateReason::NoStateStore => "no state store to compare against",
+            GateReason::NoPriorBuild => "no prior successful build to compare against",
+            GateReason::LastBuildNotSuccess => "last build did not succeed",
+            GateReason::NoLogicKey => "no comparable logic key",
+            GateReason::LogicChanged => "model logic changed since last build",
+            GateReason::UpstreamChanged => "upstream data may have changed since last build",
+        }
+    }
+}
+
+/// Outcome of evaluating the gate for one model. Both variants carry the
+/// [`GateReason`] recorded at the decision point so the run output can surface
+/// an accurate per-model justification.
 pub(crate) enum GateDecision {
     /// Build the model. On a *successful* build the caller stamps `skip_state`
     /// onto the `MaterializationOutput` so the current logic key + upstream
-    /// signatures are persisted for the next run's comparison.
-    Build { skip_state: ModelSkipState },
+    /// signatures are persisted for the next run's comparison. `reason` is the
+    /// first clause that did not permit a skip.
+    Build {
+        skip_state: ModelSkipState,
+        reason: GateReason,
+    },
     /// Skip the model — do not re-materialize, do not advance any watermark
     /// or rowcount; the prior successful state stays authoritative.
-    Skip,
+    Skip { reason: GateReason },
 }
 
 /// Per-run gate context shared across the layer loop in `execute_models`.
@@ -168,24 +252,29 @@ impl<'a> SkipGate<'a> {
             skip_hash: current_skip_hash.clone(),
             upstream_freshness: upstream_sigs.clone().unwrap_or_default(),
         };
-        let build = || GateDecision::Build {
+        // Build outcome carrying the first-failing-clause reason. The reason
+        // is recorded at the return point so it cannot drift from the actual
+        // decision (mirrors `reuse_decision::BuildReason`).
+        let build = |reason: GateReason| GateDecision::Build {
             skip_state: skip_state.clone(),
+            reason,
         };
 
         // (B) eligibility.
         if !self.is_eligible(model, typed_ir) {
-            return build();
+            return build(GateReason::NotEligible);
         }
 
-        // Raw-source upstreams must be enumerable to prove B3. Unparseable
-        // SQL ⇒ unknown upstreams ⇒ build.
+        // Raw-source upstreams must be enumerable to prove B3. A lineage shape
+        // the conservative whitelist rejects (CTE, subquery, set op, …) or
+        // unparseable SQL ⇒ unknown upstreams ⇒ build.
         let Some(upstream_sigs) = upstream_sigs else {
-            return build();
+            return build(GateReason::UpstreamsNotEnumerable);
         };
 
         // State store is required to read a prior baseline. No store ⇒ build.
         let Some(store) = state_store else {
-            return build();
+            return build(GateReason::NoStateStore);
         };
 
         // (C) a prior *successful* execution — the single latest execution,
@@ -194,31 +283,33 @@ impl<'a> SkipGate<'a> {
         // build attempt is the authoritative baseline).
         let prior = match store.get_model_history(&model.config.name, 1) {
             Ok(mut history) => history.pop(),
-            Err(_) => return build(),
+            Err(_) => return build(GateReason::NoPriorBuild),
         };
         let Some(prior) = prior else {
-            return build();
+            return build(GateReason::NoPriorBuild);
         };
         if prior.status != "success" {
-            return build();
+            return build(GateReason::LastBuildNotSuccess);
         }
 
         // (D)/(E)/(F) — B2. Both hashes present and equal.
         let (Some(prior_hash), Some(current_hash)) =
             (prior.skip_hash.as_deref(), current_skip_hash.as_deref())
         else {
-            return build();
+            return build(GateReason::NoLogicKey);
         };
         if prior_hash != current_hash {
-            return build();
+            return build(GateReason::LogicChanged);
         }
 
         // (G) — B3. Every upstream provably unchanged.
         if !self.upstream_unchanged(model, &prior, &upstream_sigs) {
-            return build();
+            return build(GateReason::UpstreamChanged);
         }
 
-        GateDecision::Skip
+        GateDecision::Skip {
+            reason: GateReason::Skipped,
+        }
     }
 
     /// Clause (B): is this model eligible to be skipped at all?
@@ -471,4 +562,47 @@ fn parse_timestamp_cell(cell: &serde_json::Value) -> Option<chrono::DateTime<chr
             .ok()
             .map(|naive| naive.and_utc())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every `GateReason` carries a stable, distinct log token and a
+    /// non-empty human message. Guards against a silent reason-table drift
+    /// (a trust-sensitive surface: a misleading reason is worse than none).
+    #[test]
+    fn gate_reason_tables_are_stable_and_distinct() {
+        let all = [
+            GateReason::Skipped,
+            GateReason::NotEligible,
+            GateReason::UpstreamsNotEnumerable,
+            GateReason::NoStateStore,
+            GateReason::NoPriorBuild,
+            GateReason::LastBuildNotSuccess,
+            GateReason::NoLogicKey,
+            GateReason::LogicChanged,
+            GateReason::UpstreamChanged,
+        ];
+        let mut tokens = std::collections::HashSet::new();
+        for r in all {
+            assert!(!r.as_str().is_empty(), "as_str must be non-empty");
+            assert!(!r.message().is_empty(), "message must be non-empty");
+            assert!(
+                tokens.insert(r.as_str()),
+                "as_str token must be unique: {}",
+                r.as_str()
+            );
+        }
+        // Spot-check the two load-bearing build reasons so a careless edit
+        // that swaps B2/B3 wording trips the test.
+        assert_eq!(
+            GateReason::LogicChanged.message(),
+            "model logic changed since last build"
+        );
+        assert_eq!(
+            GateReason::UpstreamChanged.message(),
+            "upstream data may have changed since last build"
+        );
+    }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -230,6 +230,13 @@ pub struct RunOutput {
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub shadow: bool,
     pub materializations: Vec<MaterializationOutput>,
+    /// Per-model build/skip/reuse decision + reason, surfaced for
+    /// transformation runs so orchestrators can explain *why* each model
+    /// ran, was skipped, or was reused. Populated only when the
+    /// `--skip-unchanged` gate is active or `[reuse]` is enabled; empty (and
+    /// omitted) for a default run, which stays byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub model_decisions: Vec<ModelDecisionOutput>,
     pub check_results: Vec<TableCheckOutput>,
     /// Row-quarantine outcomes — one entry per table the quality
     /// pipeline quarantined. Empty for runs that did not use
@@ -914,6 +921,49 @@ pub struct ModelSkipState {
     pub skip_hash: Option<String>,
     /// Per-upstream freshness signatures observed for this build.
     pub upstream_freshness: Vec<rocky_core::state::UpstreamSig>,
+}
+
+/// The per-model build decision the engine made this run — what the
+/// skip-gate and content-addressed reuse machinery actually decided.
+///
+/// Reporting-only: this never changes build behavior, it surfaces a decision
+/// that today only reaches the run log. Populated on
+/// [`RunOutput::model_decisions`] only when the `--skip-unchanged` gate is
+/// active or `[reuse]` is enabled; a default run (both off) emits an empty
+/// list and the field is omitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelDecision {
+    /// The model was (re-)materialized this run — its SQL ran (or its
+    /// content-addressed write executed).
+    Build,
+    /// The `--skip-unchanged` gate proved the model's logic and upstream
+    /// data unchanged since the last successful build and skipped
+    /// re-materialization.
+    Skip,
+    /// A content-addressed model pointed-to a prior run's already-written
+    /// parquet via a zero-copy commit instead of executing its SQL.
+    Reused,
+}
+
+/// One per-model decision entry on [`RunOutput::model_decisions`].
+///
+/// Surfaces the skip/build/reuse verdict the engine reached for a single
+/// transformation model, plus a short human-readable reason that mirrors the
+/// gate's actual decision point (never re-derived — threaded from the
+/// evaluation result). Orchestrators (Dagster) and the VS Code extension use
+/// it to explain *why* a model ran, was skipped, or was reused.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ModelDecisionOutput {
+    /// The model's name (matches the model entry in the project DAG).
+    pub model: String,
+    /// What the engine decided for this model.
+    pub decision: ModelDecision,
+    /// Short human-readable justification reflecting the exact decision the
+    /// gate made (e.g. "logic and upstream data unchanged since last build",
+    /// "not skip-eligible", "upstream data may have changed", "reused prior
+    /// run's bytes (strong proof)").
+    pub reason: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -3656,6 +3706,7 @@ impl RunOutput {
             resumed_from: None,
             shadow: false,
             materializations: vec![],
+            model_decisions: vec![],
             check_results: vec![],
             quarantine: vec![],
             anomalies: vec![],

--- a/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/run_schema.py
@@ -205,6 +205,51 @@ class ModelCostEntry(BaseModel):
     duration_ms: conint(ge=0)
 
 
+class ModelDecision1(StrEnum):
+    """
+    The model was (re-)materialized this run — its SQL ran (or its content-addressed write executed).
+    """
+
+    build = "build"
+
+
+class ModelDecision2(StrEnum):
+    """
+    The `--skip-unchanged` gate proved the model's logic and upstream data unchanged since the last successful build and skipped re-materialization.
+    """
+
+    skip = "skip"
+
+
+class ModelDecision3(StrEnum):
+    """
+    A content-addressed model pointed-to a prior run's already-written parquet via a zero-copy commit instead of executing its SQL.
+    """
+
+    reused = "reused"
+
+
+class ModelDecisionOutput(BaseModel):
+    """
+    One per-model decision entry on [`RunOutput::model_decisions`].
+
+    Surfaces the skip/build/reuse verdict the engine reached for a single transformation model, plus a short human-readable reason that mirrors the gate's actual decision point (never re-derived — threaded from the evaluation result). Orchestrators (Dagster) and the VS Code extension use it to explain *why* a model ran, was skipped, or was reused.
+    """
+
+    decision: ModelDecision1 | ModelDecision2 | ModelDecision3
+    """
+    What the engine decided for this model.
+    """
+    model: str
+    """
+    The model's name (matches the model entry in the project DAG).
+    """
+    reason: str
+    """
+    Short human-readable justification reflecting the exact decision the gate made (e.g. "logic and upstream data unchanged since last build", "not skip-eligible", "upstream data may have changed", "reused prior run's bytes (strong proof)").
+    """
+
+
 class OverrideWarningOutput(BaseModel):
     """
     Soft warning surfaced on [`RunOutput::override_warnings`] when an override rule matched no tables this run.
@@ -623,6 +668,10 @@ class RunOutput(BaseModel):
     """
     materializations: list[MaterializationOutput]
     metrics: MetricsSnapshot | None = None
+    model_decisions: list[ModelDecisionOutput] | None = None
+    """
+    Per-model build/skip/reuse decision + reason, surfaced for transformation runs so orchestrators can explain *why* each model ran, was skipped, or was reused. Populated only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; empty (and omitted) for a default run, which stays byte-identical.
+    """
     override_warnings: list[OverrideWarningOutput] | None = None
     """
     Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -675,6 +675,59 @@
       ],
       "type": "object"
     },
+    "ModelDecision": {
+      "description": "The per-model build decision the engine made this run — what the skip-gate and content-addressed reuse machinery actually decided.\n\nReporting-only: this never changes build behavior, it surfaces a decision that today only reaches the run log. Populated on [`RunOutput::model_decisions`] only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; a default run (both off) emits an empty list and the field is omitted.",
+      "oneOf": [
+        {
+          "description": "The model was (re-)materialized this run — its SQL ran (or its content-addressed write executed).",
+          "enum": [
+            "build"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The `--skip-unchanged` gate proved the model's logic and upstream data unchanged since the last successful build and skipped re-materialization.",
+          "enum": [
+            "skip"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "A content-addressed model pointed-to a prior run's already-written parquet via a zero-copy commit instead of executing its SQL.",
+          "enum": [
+            "reused"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "ModelDecisionOutput": {
+      "description": "One per-model decision entry on [`RunOutput::model_decisions`].\n\nSurfaces the skip/build/reuse verdict the engine reached for a single transformation model, plus a short human-readable reason that mirrors the gate's actual decision point (never re-derived — threaded from the evaluation result). Orchestrators (Dagster) and the VS Code extension use it to explain *why* a model ran, was skipped, or was reused.",
+      "properties": {
+        "decision": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModelDecision"
+            }
+          ],
+          "description": "What the engine decided for this model."
+        },
+        "model": {
+          "description": "The model's name (matches the model entry in the project DAG).",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Short human-readable justification reflecting the exact decision the gate made (e.g. \"logic and upstream data unchanged since last build\", \"not skip-eligible\", \"upstream data may have changed\", \"reused prior run's bytes (strong proof)\").",
+          "type": "string"
+        }
+      },
+      "required": [
+        "decision",
+        "model",
+        "reason"
+      ],
+      "type": "object"
+    },
     "OverrideWarningOutput": {
       "description": "Soft warning surfaced on [`RunOutput::override_warnings`] when an override rule matched no tables this run.\n\nDistinct kinds let orchestrators (Dagster) branch on cause without parsing free-form messages.",
       "properties": {
@@ -1110,6 +1163,13 @@
           "type": "null"
         }
       ]
+    },
+    "model_decisions": {
+      "description": "Per-model build/skip/reuse decision + reason, surfaced for transformation runs so orchestrators can explain *why* each model ran, was skipped, or was reused. Populated only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; empty (and omitted) for a default run, which stays byte-identical.",
+      "items": {
+        "$ref": "#/definitions/ModelDecisionOutput"
+      },
+      "type": "array"
     },
     "override_warnings": {
       "description": "Soft warnings raised by the per-table override resolver — one entry per `[[table_overrides]]` rule that matched zero `(connector, table)` pairs this run, or whose connector half resolved nothing. Discovery-time-only — the pipeline runs to completion regardless. Empty for runs whose pipeline declares no overrides.",


### PR DESCRIPTION
## What

Surfaces Rocky's per-model build **decision** in `rocky run --output json`. The `--skip-unchanged` gate and content-addressed reuse machinery already decide, per model, whether to **build / skip / reuse** — but that decision only ever reached the run log. This makes it a first-class part of the run output so Dagster and the VS Code extension can explain *why* each model ran.

## JSON shape

New optional `model_decisions` array on `RunOutput`:

```jsonc
"model_decisions": [
  { "model": "clean_events", "decision": "build",  "reason": "no prior successful build to compare against" },
  { "model": "clean_events", "decision": "skip",   "reason": "logic and upstream data unchanged since last build" },
  { "model": "clean_events", "decision": "build",  "reason": "upstream data may have changed since last build" },
  { "model": "fct_daily_orders", "decision": "build", "reason": "time_interval: built (not skip-eligible)" }
]
```

- `decision` ∈ `"build"` | `"skip"` | `"reused"`.
- `reason` is a short human-readable justification.
- The field is **omitted (empty)** unless the `--skip-unchanged` gate is active or `[reuse]` is enabled, so a default run's output stays byte-identical.

## How the reason stays accurate (trust-sensitive)

The reason is **recorded at the exact decision point**, never re-derived:

- `skip_gate.rs`: `GateDecision` now carries a `GateReason` set at each return point in `evaluate()` (first-failing-clause, mirroring `reuse_decision::BuildReason`). One variant per real return point — so the surfaced reason cannot drift from what the gate actually did.
- `run.rs`: `model_decisions` is populated from the existing gate verdict in the evaluation loop (plain strategies) and from the content-addressed / time_interval execution sites (`reused` / `build`). Special strategies are suppressed in the gate loop to avoid a duplicate entry.

## Design notes

- **`reused`, not `reuse-candidate`.** Reuse is no longer ONLY-BUILD: a positive verdict now performs a real zero-copy point-to commit (`reused_from.is_some()` ⇒ R's bytes were referenced and the model SQL did **not** run). Labeling it `reuse-candidate` would be misleading, so the decision is `reused`. (The stale "Stage-1 ONLY-BUILD / still executes the SQL" doc-comments in `reuse_decision.rs` / `execute_content_addressed_model` are out of scope here — noted for a follow-up cleanup.)
- **No `--explain` flag.** Skip/reuse only evaluate during a real run, so enriching run output is the right home — a separate dry-run command would have to re-implement the gate.
- **Reporting-only.** No skip/reuse/build behavior changes; default-off paths do no extra work.

## Verification

- `cargo build` (full workspace), `cargo test -p rocky-cli --features duckdb` (697 passed, 0 failed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all green.
- Extended the DuckDB gate tests to assert decision **and** reason per return point (skip, B2 logic-changed, B3 upstream-changed, first-build no-baseline) plus a gate-off run surfaces no decisions. New `skip_gate` unit test pins the reason table.
- `just codegen` regenerates exactly 3 binding surfaces (schema + Pydantic + TS); a second run shows **no further drift**. `just regen-fixtures` shows **no fixture diff** (default replication path is byte-identical). Dagster `test_generated_fixtures.py`: 45 passed.
- Live-verified against the `14-skip-unchanged` POC (build → skip → build with accurate reasons) and the `03-partition-checksum` POC (time_interval → `build`).
- The `reused` branch is code-reviewed but not executed in CI (needs S3/Iceberg infra); it's accurate by construction — the entry is only emitted when `reused_from` is genuinely `Some`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
