### PR TITLE
feat(engine): column-level downstream-impact preview (D2)

### DIFF
--- a/editors/vscode/src/types/generated/column_lineage.ts
+++ b/editors/vscode/src/types/generated/column_lineage.ts
@@ -15,9 +15,18 @@ export interface ColumnLineageOutput {
    * Direction of the trace walk: `"upstream"` (producers) or `"downstream"` (consumers). Defaults to upstream when `--column` is set without direction flags, matching pre-Arc-1 behaviour.
    */
   direction: string;
+  /**
+   * Every downstream column that transitively consumes `(model, column)`, deduplicated and deterministically sorted. An author-time "what does changing this column affect" signal, always populated regardless of `direction` so the default (upstream) trace still carries the blast radius. Inspection only — this never feeds a build/skip/reuse decision. Empty when the column has no consumers.
+   */
+  downstream_consumers?: LineageQualifiedColumn[];
   model: string;
   trace: LineageEdgeRecord[];
   version: string;
+  [k: string]: unknown;
+}
+export interface LineageQualifiedColumn {
+  column: string;
+  model: string;
   [k: string]: unknown;
 }
 export interface LineageEdgeRecord {
@@ -27,10 +36,5 @@ export interface LineageEdgeRecord {
    * Transform kind: "direct", "cast", "expression", etc. Stringified from `rocky_sql::lineage::TransformKind` to avoid pulling schemars into rocky-sql.
    */
   transform: string;
-  [k: string]: unknown;
-}
-export interface LineageQualifiedColumn {
-  column: string;
-  model: string;
   [k: string]: unknown;
 }

--- a/engine/crates/rocky-cli/src/commands/lineage.rs
+++ b/engine/crates/rocky-cli/src/commands/lineage.rs
@@ -315,6 +315,28 @@ pub fn column_lineage_output(
     };
     let trace: Vec<LineageEdgeRecord> = trace_edges.iter().map(|e| to_edge_record(e)).collect();
 
+    // Author-time downstream-impact preview: every column that transitively
+    // consumes `(model_name, column)`. Always computed (independent of
+    // `direction`) so the default upstream trace still surfaces the blast
+    // radius. Deduped + sorted via a BTreeSet keyed on (model, column) — the
+    // graph walk's order is unspecified and `LineageQualifiedColumn` is not
+    // `Eq`, so `.dedup()` wouldn't apply. Mirrors `lineage_diff.rs`.
+    // Inspection only: this never gates a build/skip/reuse decision.
+    let mut seen: std::collections::BTreeSet<(String, String)> = std::collections::BTreeSet::new();
+    for edge in result
+        .semantic_graph
+        .trace_column_downstream(model_name, column)
+    {
+        seen.insert((
+            edge.target.model.to_string(),
+            edge.target.column.to_string(),
+        ));
+    }
+    let downstream_consumers: Vec<LineageQualifiedColumn> = seen
+        .into_iter()
+        .map(|(model, column)| LineageQualifiedColumn { model, column })
+        .collect();
+
     Ok(ColumnLineageOutput {
         version: VERSION.to_string(),
         command: "lineage".to_string(),
@@ -322,5 +344,110 @@ pub fn column_lineage_output(
         column: column.to_string(),
         direction: direction.to_string(),
         trace,
+        downstream_consumers,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Write a `.sql` model plus its `.toml` sidecar into `dir`. Mirrors
+    /// the helper in `ci_diff.rs`'s tests so the compile path is faithful.
+    fn write_model(dir: &Path, name: &str, sql: &str) {
+        fs::write(dir.join(format!("{name}.sql")), sql).unwrap();
+        fs::write(
+            dir.join(format!("{name}.toml")),
+            format!(
+                "name = \"{name}\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"{name}\"\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn compile_chain(models_dir: &Path) -> compile::CompileResult {
+        let config = CompilerConfig {
+            models_dir: models_dir.to_path_buf(),
+            contracts_dir: None,
+            source_schemas: HashMap::new(),
+            source_column_info: HashMap::new(),
+            ..Default::default()
+        };
+        compile::compile(&config).expect("chain compiles")
+    }
+
+    /// The default (upstream) column output must still carry the
+    /// downstream-impact preview: every column that transitively consumes
+    /// the target. Chain: a -> b -> c, so `a.id` reaches `b.id` and `c.id`.
+    #[test]
+    fn upstream_output_carries_downstream_consumers() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path();
+        write_model(models_dir, "a", "SELECT id, name FROM source.raw.users");
+        write_model(models_dir, "b", "SELECT id, name FROM a");
+        write_model(models_dir, "c", "SELECT id FROM b");
+
+        let result = compile_chain(models_dir);
+        // `downstream = false` is the default upstream trace.
+        let out = column_lineage_output(&result, "a", "id", false).unwrap();
+
+        assert_eq!(out.direction, "upstream");
+        let consumers: Vec<(&str, &str)> = out
+            .downstream_consumers
+            .iter()
+            .map(|c| (c.model.as_str(), c.column.as_str()))
+            .collect();
+        assert!(
+            consumers.contains(&("b", "id")),
+            "expected b.id in {consumers:?}"
+        );
+        assert!(
+            consumers.contains(&("c", "id")),
+            "expected c.id in {consumers:?}"
+        );
+
+        // Deterministic: BTreeSet ordering, no duplicates.
+        let mut sorted = consumers.clone();
+        sorted.sort();
+        assert_eq!(consumers, sorted, "consumers must be sorted");
+        assert_eq!(
+            consumers.len(),
+            consumers
+                .iter()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            "consumers must be deduplicated"
+        );
+    }
+
+    /// A leaf column (consumed by nobody) yields an empty consumer set,
+    /// which serde then omits via `skip_serializing_if`.
+    #[test]
+    fn leaf_column_has_no_downstream_consumers() {
+        let dir = TempDir::new().unwrap();
+        let models_dir = dir.path();
+        write_model(models_dir, "a", "SELECT id FROM source.raw.users");
+        write_model(models_dir, "b", "SELECT id FROM a");
+
+        let result = compile_chain(models_dir);
+        // `b.id` is the leaf — nothing downstream consumes it.
+        let out = column_lineage_output(&result, "b", "id", false).unwrap();
+        assert!(
+            out.downstream_consumers.is_empty(),
+            "leaf column should have no consumers, got {:?}",
+            out.downstream_consumers
+        );
+
+        let json = serde_json::to_string(&out).unwrap();
+        assert!(
+            !json.contains("downstream_consumers"),
+            "empty consumer set must be omitted from JSON"
+        );
+    }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -2173,6 +2173,15 @@ pub struct ColumnLineageOutput {
     /// direction flags, matching pre-Arc-1 behaviour.
     pub direction: String,
     pub trace: Vec<LineageEdgeRecord>,
+    /// Every downstream column that transitively consumes
+    /// `(model, column)`, deduplicated and deterministically sorted. An
+    /// author-time "what does changing this column affect" signal,
+    /// always populated regardless of `direction` so the default
+    /// (upstream) trace still carries the blast radius. Inspection only —
+    /// this never feeds a build/skip/reuse decision. Empty when the
+    /// column has no consumers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub downstream_consumers: Vec<LineageQualifiedColumn>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/integrations/dagster/src/dagster_rocky/types_generated/column_lineage_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/column_lineage_schema.py
@@ -31,6 +31,10 @@ class ColumnLineageOutput(BaseModel):
     """
     Direction of the trace walk: `"upstream"` (producers) or `"downstream"` (consumers). Defaults to upstream when `--column` is set without direction flags, matching pre-Arc-1 behaviour.
     """
+    downstream_consumers: list[LineageQualifiedColumn] | None = None
+    """
+    Every downstream column that transitively consumes `(model, column)`, deduplicated and deterministically sorted. An author-time "what does changing this column affect" signal, always populated regardless of `direction` so the default (upstream) trace still carries the blast radius. Inspection only — this never feeds a build/skip/reuse decision. Empty when the column has no consumers.
+    """
     model: str
     trace: list[LineageEdgeRecord]
     version: str

--- a/schemas/column_lineage.schema.json
+++ b/schemas/column_lineage.schema.json
@@ -49,6 +49,13 @@
       "description": "Direction of the trace walk: `\"upstream\"` (producers) or `\"downstream\"` (consumers). Defaults to upstream when `--column` is set without direction flags, matching pre-Arc-1 behaviour.",
       "type": "string"
     },
+    "downstream_consumers": {
+      "description": "Every downstream column that transitively consumes `(model, column)`, deduplicated and deterministically sorted. An author-time \"what does changing this column affect\" signal, always populated regardless of `direction` so the default (upstream) trace still carries the blast radius. Inspection only — this never feeds a build/skip/reuse decision. Empty when the column has no consumers.",
+      "items": {
+        "$ref": "#/definitions/LineageQualifiedColumn"
+      },
+      "type": "array"
+    },
     "model": {
       "type": "string"
     },


### PR DESCRIPTION
## What

Adds a `downstream_consumers` section to `rocky lineage <model> --column <col> --output json`. For a given model + column, it lists every downstream column that **transitively** consumes it — an author-time "what does changing this column affect" signal.

Today the command surfaces a column's *upstream* provenance (and a separate `--downstream` flag *swaps* the trace direction). Neither gives the default invocation an additive blast-radius view. This fills that gap.

## JSON shape

`downstream_consumers` is a new field on `ColumnLineageOutput`, populated **regardless of direction** so the default upstream trace still carries the impact list. Deduplicated + deterministically sorted (BTreeSet on `(model, column)`). Omitted when empty.

```jsonc
// rocky lineage raw_orders --column customer_id --output json
{
  "version": "1.49.0",
  "command": "lineage",
  "model": "raw_orders",
  "column": "customer_id",
  "direction": "upstream",
  "trace": [ /* upstream provenance, unchanged */ ],
  "downstream_consumers": [
    { "model": "customer_orders", "column": "customer_id" },
    { "model": "revenue_summary",  "column": "customer_id" }
  ]
}
```

## Implementation

- Reuses the semantic graph's existing `trace_column_downstream` walk and mirrors the BTreeSet dedup/sort pattern already used by `lineage-diff`.
- One field on `ColumnLineageOutput` + ~12 lines in `column_lineage_output`.
- Regenerated the `column_lineage` JSON schema, dagster Pydantic model, and vscode TypeScript interface via `just codegen` (no other schema drift).

## Inspection only

By design this **never** feeds a build/skip/reuse decision. Lineage is schema-structural, so schema-stable value changes are invisible to it — gating materialization on it would be unsound. It lands only on `ColumnLineageOutput`, nowhere near any run/plan path.

## Tests

- `upstream_output_carries_downstream_consumers` — default (upstream) output on an `a → b → c` chain lists `b` and `c` as consumers, sorted, deduplicated.
- `leaf_column_has_no_downstream_consumers` — empty set is omitted from JSON.
- Verified end-to-end against the playground default POC.
- `cargo test -p rocky-cli -p rocky-sql`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all green; a 2nd `just codegen` shows no drift.

> Note: a sibling PR concurrently edits `output.rs`. This change is localized to `ColumnLineageOutput` + its generated bindings; expect a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
