### PR TITLE
feat(engine): surface breaking-change verdict in plan (D3, decision-support)

### DIFF
--- a/docs/src/content/docs/guides/ci-cd.md
+++ b/docs/src/content/docs/guides/ci-cd.md
@@ -64,6 +64,18 @@ rocky ci-diff --semantic --output json | jq '.breaking_findings'
 
 Each finding has a tagged `change.kind` (e.g. `column_dropped`, `column_type_changed`, `target_renamed`) and a `severity` (`breaking` / `warning` / `info`). `ci-diff --semantic` is **informational**: even a `breaking` finding does not change `ci-diff`'s exit code. Use it on every PR to make breaking changes visible to reviewers before promotion.
 
+`rocky plan --semantic` surfaces the same verdict at plan time as **decision-support for the author** — it diffs your *working tree* (uncommitted edits included) against `--base` (default `main`) and attaches the verdict under `breaking_verdict` in the JSON output:
+
+```bash
+rocky plan --semantic --base main --output json | jq '.breaking_verdict'
+```
+
+This is **reporting-only**: the verdict never gates the plan. Planned statements and the exit code are unchanged even on a `breaking` finding, and `breaking_verdict` is omitted (never fabricated) when no baseline is available — no `models/` directory, or the `--base` ref's models don't compile. The hard gate is still `rocky plan promote` (below).
+
+:::caution[The classifier diffs OUTPUT SCHEMA — it is blind to value changes]
+The breaking-change classifier compares the typed **output schema** of each model (columns, types, nullability, materialization keys, masks, target). It is **blind to schema-stable value changes**: a `WHERE` / `JOIN`-key / `CASE` rewrite that changes every output row but leaves the column list and types untouched produces **no finding**. An empty `breaking_verdict.findings` therefore means "no output-schema change was detected" — it is **not** a completeness or safety signal that the data is unchanged. The verdict carries this statement verbatim in its `caveat` field so a JSON-only consumer can't miss it. To see whether values moved, pair it with [`rocky preview`](/guides/preview-a-pr/) (row-level diff on real data).
+:::
+
 The hard gate lives on `rocky plan promote` + `rocky apply`. When promoting a branch to production, Rocky runs the same classifier against `--base-ref` (default `main`); any finding with `severity == "breaking"` blocks the promote at plan time and the apply step refuses to execute the plan. To override (e.g. a planned breaking release with downstream consumers already migrated), pass `--allow-breaking` at plan time. The override emits a `breaking_changes_allowed` audit event so the bypass leaves a paper trail.
 
 ```bash

--- a/docs/src/content/docs/reference/commands/core-pipeline.md
+++ b/docs/src/content/docs/reference/commands/core-pipeline.md
@@ -244,6 +244,10 @@ rocky plan --filter <key=value> [flags]
 |------|------|---------|-------------|
 | `--filter <key=value>` | `string` | **(required)** | Filter sources by component value (e.g., `client=acme`). |
 | `--pipeline <NAME>` | `string` | | Pipeline name (required if multiple pipelines are defined). |
+| `--semantic` | `bool` | `false` | Also run the breaking-change classifier against `--base` and attach the change-impact verdict under `breaking_verdict`. Decision-support only — never gates the plan and never changes the exit code. |
+| `--base <ref>` | `string` | `main` | Git ref the working tree is diffed against for `--semantic`. Ignored without `--semantic`. |
+
+> The `--semantic` verdict diffs **output schema** only and is **blind to schema-stable value changes** (a `WHERE` / `JOIN`-key / `CASE` rewrite that changes values but not the schema). An empty `findings` list is not a safety signal — the verdict's `caveat` field states this verbatim. See the [CI/CD guide](/guides/ci-cd/#semantic-breaking-change-findings-and-the-promote-gate) for the full flow and the [`plan` schema](https://github.com/rocky-data/rocky/blob/main/schemas/plan.schema.json) for the `SemanticPlanVerdict` shape.
 
 ### Examples
 

--- a/editors/vscode/src/types/generated/plan.ts
+++ b/editors/vscode/src/types/generated/plan.ts
@@ -6,6 +6,135 @@
  */
 
 /**
+ * A single typed semantic change between two `ProjectIr` snapshots.
+ *
+ * Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
+ */
+export type BreakingChange =
+  | {
+      kind: "model_removed";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "model_added";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_dropped";
+      model: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      data_type: string;
+      kind: "column_added";
+      model: string;
+      nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_type_changed";
+      model: string;
+      /**
+       * `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+       */
+      narrowing: boolean;
+      new_type: string;
+      old_type: string;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_nullability_changed";
+      model: string;
+      new_nullable: boolean;
+      old_nullable: boolean;
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_reordered";
+      model: string;
+      new_index: number;
+      old_index: number;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "materialization_strategy_changed";
+      model: string;
+      new_strategy: string;
+      old_strategy: string;
+      [k: string]: unknown;
+    }
+  | {
+      /**
+       * Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+       */
+      key_kind: string;
+      kind: "materialization_key_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "replication_columns_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "partition_by_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      kind: "target_renamed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "source_changed";
+      model: string;
+      new: string[];
+      old: string[];
+      [k: string]: unknown;
+    }
+  | {
+      column: string;
+      kind: "column_mask_changed";
+      model: string;
+      new_strategy?: string | null;
+      old_strategy?: string | null;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "lakehouse_format_changed";
+      model: string;
+      new: string;
+      old: string;
+      [k: string]: unknown;
+    }
+  | {
+      kind: "sql_body_changed";
+      model: string;
+      [k: string]: unknown;
+    };
+/**
+ * Severity classification for a single semantic change.
+ */
+export type BreakingSeverity = "breaking" | "warning" | "info";
+/**
  * Severity level of a diagnostic.
  *
  * Serialized in PascalCase (`"Error"`, `"Warning"`, `"Info"`) to stay compatible with existing dagster fixtures and the hand-written `Severity` StrEnum in `integrations/dagster/src/dagster_rocky/types.py`.
@@ -22,6 +151,10 @@ export type Severity = "Error" | "Warning" | "Info";
  * `plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.
  */
 export interface PlanOutput {
+  /**
+   * Semantic change-impact verdict from the typed-IR breaking-change classifier, surfaced as decision-support at plan time. Present only when `--semantic` ran with a usable baseline. See [`SemanticPlanVerdict`] — note its `caveat`: the classifier diffs OUTPUT SCHEMA only and is blind to schema-stable value changes.
+   */
+  breaking_verdict?: SemanticPlanVerdict | null;
   /**
    * Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`"warn"` or `"error"`). Empty when no ceiling was exceeded or no real stats were available.
    */
@@ -70,6 +203,40 @@ export interface PlanOutput {
   retention_actions?: RetentionAction[];
   statements: PlannedStatement[];
   version: string;
+  [k: string]: unknown;
+}
+/**
+ * Decision-support verdict from the typed-IR breaking-change classifier, attached to `PlanOutput` when `rocky plan --semantic` runs against a usable baseline.
+ *
+ * # Scope and blindness
+ *
+ * The classifier diffs the typed **output schema** of each model between the baseline git ref and the working tree (column drop/add/type narrowing, nullability, materialization keys, masks, target rename). It is **blind to schema-stable value changes**: a `WHERE` / `JOIN`-key / `CASE` rewrite that changes every output row but leaves the column list and types untouched produces **no finding**. An empty `findings` list therefore means "no output-schema change was detected" — it is **not** a completeness or safety signal that the data is unchanged. The [`Self::caveat`] field carries this statement verbatim so a consumer that only reads the JSON cannot miss it.
+ *
+ * # Reporting-only
+ *
+ * This verdict never gates the plan. Even a `breaking`-severity finding leaves the planned statements and the process exit code unchanged. The hard gate (which blocks on `breaking`) lives on `rocky plan promote`.
+ */
+export interface SemanticPlanVerdict {
+  /**
+   * The git ref the working tree was diffed against (the `--base` value, default `"main"`).
+   */
+  base_ref: string;
+  /**
+   * Verbatim statement of what the classifier does and does not see. Always populated — present even when `findings` is empty, because "no findings" is the case most easily misread as "safe". See the type-level docs for why this is load-bearing.
+   */
+  caveat: string;
+  /**
+   * Classified output-schema findings (one per detected change), including `info`-severity entries. Each finding carries its own `model`, tagged `change.kind`, and `severity` (`breaking` / `warning` / `info`). Empty when no output-schema change was detected — which, per `caveat`, is not a safety signal.
+   */
+  findings: BreakingFinding[];
+  [k: string]: unknown;
+}
+/**
+ * A classified finding produced by [`diff_project_ir`].
+ */
+export interface BreakingFinding {
+  change: BreakingChange;
+  severity: BreakingSeverity;
   [k: string]: unknown;
 }
 /**

--- a/engine/crates/rocky-cli/src/commands/plan.rs
+++ b/engine/crates/rocky-cli/src/commands/plan.rs
@@ -53,12 +53,28 @@ pub struct PlanRunOptions {
 /// re-deriving the `ProjectIr` by recompiling. Full IR persistence is
 /// deferred — the operational-metadata approach covers the deterministic
 /// re-application requirement at acceptable cost.
+///
+/// ## Semantic verdict (decision-support)
+///
+/// When `semantic` is set, `rocky plan` additionally compiles the project at
+/// `base_ref` (default `"main"`), diffs the typed output schema against the
+/// working tree via the [`rocky_core::breaking_change`] classifier, and
+/// attaches the classified findings to `output.breaking_verdict`. This is
+/// **reporting-only**: it never gates, skips, or reorders the planned
+/// statements, and a `breaking` finding does not change the exit code. The
+/// hard gate lives on `rocky plan promote`. When no baseline is available
+/// (the `base_ref` models do not compile, or there is no `models/`
+/// directory) the verdict is omitted — never fabricated.
+#[allow(clippy::too_many_arguments)]
 pub async fn plan(
     config_path: &Path,
     filter: Option<&str>,
     pipeline_name: Option<&str>,
     env: Option<&str>,
     run_options: &PlanRunOptions,
+    semantic: bool,
+    base_ref: &str,
+    state_path: &Path,
     output_json: bool,
 ) -> Result<()> {
     let rocky_cfg = rocky_core::config::load_rocky_config(config_path).context(format!(
@@ -312,6 +328,22 @@ pub async fn plan(
         output.has_budget_errors = has_errors;
     }
 
+    // --- Semantic breaking-change verdict (D3 — decision-support) --------
+    //
+    // REPORTING ONLY. Computed AFTER the budget check and BEFORE plan
+    // persistence so the classifier's findings live on `output` but never
+    // enter the persisted `RunPlan` / `ReplicationPlan` payloads (those are
+    // content-hashed into `plan_id`; including findings would shift the id).
+    // The verdict never gates: planned statements and the exit code are
+    // unchanged regardless of severity. The hard gate is `rocky plan
+    // promote`. Skipped (verdict omitted) unless `--semantic` is set; on
+    // `--semantic` with no usable baseline the verdict is omitted rather
+    // than fabricated.
+    if semantic {
+        output.breaking_verdict =
+            compute_semantic_verdict(config_path, &models_dir, base_ref, state_path);
+    }
+
     // --- Plan-spine persistence (Cluster 3 B, Phase 2 + Phase 5b) ---------
     //
     // Persist a `RunPlan` when the project has compiled models, or a
@@ -401,6 +433,7 @@ pub async fn plan(
         }
         render_governance_preview_text(&output);
         render_budget_diagnostics_text(&output);
+        render_semantic_verdict_text(&output);
         if let Some(ref plan_id) = output.plan_id {
             println!();
             match output.plan_kind.as_deref() {
@@ -1211,6 +1244,129 @@ fn render_budget_diagnostics_text(output: &PlanOutput) {
             println!("  hint: {suggestion}");
         }
     }
+}
+
+/// Compute the decision-support semantic verdict for `rocky plan --semantic`.
+///
+/// Compiles the **working tree** (head) and the project as it stood at
+/// `base_ref` (the same baseline mechanism `rocky ci-diff` /
+/// `rocky plan promote` use — [`super::ci_diff::extract_base_compile`]),
+/// lowers both to [`rocky_ir::ProjectIr`] via
+/// [`super::ci_diff::project_ir_from_compile`], and runs
+/// [`rocky_core::breaking_change::diff_project_ir`].
+///
+/// Returns `None` (verdict omitted) when there is no baseline to diff
+/// against — no `models/` directory, the working tree fails to compile, or
+/// the `base_ref` models cannot be materialized / do not compile. A `None`
+/// is the honest "nothing to report" outcome; the caller never fabricates a
+/// verdict.
+///
+/// Both compiles are seeded with the **current** cached source schemas so
+/// the per-model type diff measures real schema drift rather than
+/// `Unknown`-vs-`Unknown` noise — identical to the seeding `ci-diff` and the
+/// promote gate use. The returned verdict's `findings` is the full
+/// classified list (including `info`-severity entries); it always carries
+/// the [`SEMANTIC_VERDICT_CAVEAT`] so a JSON-only consumer sees that the
+/// classifier is blind to schema-stable value changes.
+fn compute_semantic_verdict(
+    config_path: &Path,
+    models_dir: &Path,
+    base_ref: &str,
+    state_path: &Path,
+) -> Option<SemanticPlanVerdict> {
+    use rocky_compiler::compile::{self, CompilerConfig};
+
+    if !models_dir.is_dir() {
+        tracing::debug!(
+            models_dir = %models_dir.display(),
+            "plan --semantic: no models directory — verdict omitted"
+        );
+        return None;
+    }
+
+    // Seed both compiles from the current warehouse schema cache so the IR
+    // carries real leaf types. Degrade to an empty map on config / cache
+    // failure rather than blocking the preview.
+    let source_schemas = match rocky_core::config::load_rocky_config(config_path) {
+        Ok(cfg) => {
+            let schema_cfg = cfg.cache.schemas.with_ttl_override(None);
+            crate::source_schemas::load_cached_source_schemas(&schema_cfg, state_path)
+        }
+        Err(_) => std::collections::HashMap::new(),
+    };
+
+    let head_compile = {
+        let config = CompilerConfig {
+            models_dir: models_dir.to_path_buf(),
+            contracts_dir: None,
+            source_schemas: source_schemas.clone(),
+            source_column_info: std::collections::HashMap::new(),
+            ..Default::default()
+        };
+        match compile::compile(&config) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "plan --semantic: working-tree compile failed — verdict omitted"
+                );
+                return None;
+            }
+        }
+    };
+
+    let base_compile =
+        match super::ci_diff::extract_base_compile(base_ref, models_dir, source_schemas) {
+            Ok(r) => r,
+            Err(reason) => {
+                tracing::debug!(
+                    reason = %reason,
+                    "plan --semantic: base ref '{base_ref}' compile unavailable — verdict omitted"
+                );
+                return None;
+            }
+        };
+
+    let base_ir = super::ci_diff::project_ir_from_compile(&base_compile);
+    let head_ir = super::ci_diff::project_ir_from_compile(&head_compile);
+    let findings = rocky_core::breaking_change::diff_project_ir(&base_ir, &head_ir);
+
+    Some(SemanticPlanVerdict {
+        caveat: SEMANTIC_VERDICT_CAVEAT.to_string(),
+        base_ref: base_ref.to_string(),
+        findings,
+    })
+}
+
+/// Render the semantic verdict under the text output mode.
+///
+/// Prints the per-finding severity + change, then the caveat verbatim. The
+/// caveat is printed even when `findings` is empty, mirroring the JSON
+/// payload: "no findings" is the case most easily misread as "safe".
+fn render_semantic_verdict_text(output: &PlanOutput) {
+    let Some(verdict) = &output.breaking_verdict else {
+        return;
+    };
+    use rocky_core::breaking_change::BreakingSeverity;
+
+    println!();
+    println!(
+        "-- semantic verdict (vs {base}, decision-support) --",
+        base = verdict.base_ref
+    );
+    if verdict.findings.is_empty() {
+        println!("no output-schema changes detected");
+    } else {
+        for f in &verdict.findings {
+            let sev = match f.severity {
+                BreakingSeverity::Breaking => "BREAKING",
+                BreakingSeverity::Warning => "WARNING",
+                BreakingSeverity::Info => "INFO",
+            };
+            println!("[{sev}] {:?}", f.change);
+        }
+    }
+    println!("note: {}", verdict.caveat);
 }
 
 // ---------------------------------------------------------------------------
@@ -2052,5 +2208,127 @@ table = "m"
         assert_eq!(json[0]["source_type"], "duckdb");
         assert_eq!(json[0]["tables"][0]["name"], "t1");
         assert_eq!(json[0]["tables"][0]["row_count"], 10);
+    }
+
+    // ------------------------------------------------------------------
+    // Semantic verdict (D3 — decision-support)
+    // ------------------------------------------------------------------
+
+    /// The caveat constant must plainly state that the classifier diffs
+    /// OUTPUT SCHEMA and is blind to schema-stable value changes, and that
+    /// an empty finding list is not a completeness signal. This guards the
+    /// disclaimer text — required by the task's second hard constraint —
+    /// against a silent edit that would weaken it.
+    #[test]
+    fn caveat_states_output_schema_scope_and_value_blindness() {
+        let c = SEMANTIC_VERDICT_CAVEAT;
+        assert!(
+            c.contains("OUTPUT SCHEMA"),
+            "caveat must name OUTPUT SCHEMA"
+        );
+        assert!(c.contains("BLIND"), "caveat must state the blindness");
+        // The canonical value-change example the constraint calls out.
+        assert!(
+            c.contains("WHERE") && c.contains("JOIN") && c.contains("CASE"),
+            "caveat must give the WHERE/JOIN/CASE value-rewrite example",
+        );
+        assert!(
+            c.contains("NOT") && c.to_lowercase().contains("unchanged"),
+            "caveat must deny that an empty result means the data is unchanged",
+        );
+    }
+
+    /// The verdict's `caveat` is carried even when `findings` is empty —
+    /// the case most easily misread as "safe". A JSON-only consumer must
+    /// still see the disclaimer. This encodes the second hard constraint.
+    #[test]
+    fn empty_findings_verdict_still_serializes_the_caveat() {
+        let verdict = SemanticPlanVerdict {
+            caveat: SEMANTIC_VERDICT_CAVEAT.to_string(),
+            base_ref: "main".to_string(),
+            findings: vec![],
+        };
+        let json = serde_json::to_value(&verdict).expect("verdict serializes");
+        assert_eq!(json["base_ref"], "main");
+        assert!(
+            json["findings"]
+                .as_array()
+                .expect("findings array")
+                .is_empty(),
+            "findings must be present and empty",
+        );
+        let caveat = json["caveat"].as_str().expect("caveat is a string");
+        assert!(caveat.contains("OUTPUT SCHEMA"));
+        assert!(caveat.contains("BLIND"));
+    }
+
+    /// A populated verdict round-trips: severity + change kind reach the
+    /// JSON exactly as the classifier emits them, alongside the caveat.
+    #[test]
+    fn populated_verdict_carries_findings_and_caveat() {
+        use rocky_core::breaking_change::{BreakingChange, BreakingFinding, BreakingSeverity};
+        let verdict = SemanticPlanVerdict {
+            caveat: SEMANTIC_VERDICT_CAVEAT.to_string(),
+            base_ref: "origin/main".to_string(),
+            findings: vec![BreakingFinding {
+                change: BreakingChange::ColumnDropped {
+                    model: "c.s.orders".to_string(),
+                    column: "legacy_flag".to_string(),
+                    data_type: "String".to_string(),
+                },
+                severity: BreakingSeverity::Breaking,
+            }],
+        };
+        let json = serde_json::to_value(&verdict).expect("verdict serializes");
+        assert_eq!(json["findings"][0]["severity"], "breaking");
+        assert_eq!(json["findings"][0]["change"]["kind"], "column_dropped");
+        assert_eq!(json["findings"][0]["change"]["column"], "legacy_flag");
+        assert!(json["caveat"].as_str().unwrap().contains("OUTPUT SCHEMA"));
+    }
+
+    /// No `models/` directory ⇒ no baseline ⇒ verdict omitted (`None`).
+    /// The verdict is never fabricated when there is nothing to diff.
+    #[test]
+    fn no_models_dir_yields_no_verdict() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("rocky.toml");
+        fs::write(&cfg_path, "[adapter.default]\ntype = \"duckdb\"\n").unwrap();
+        let missing_models = tmp.path().join("models"); // not created
+        let state_path = tmp.path().join("state.redb");
+        let verdict = compute_semantic_verdict(&cfg_path, &missing_models, "main", &state_path);
+        assert!(
+            verdict.is_none(),
+            "absent models directory must omit the verdict, not fabricate one",
+        );
+    }
+
+    /// A models directory that exists but whose base ref cannot be
+    /// materialized from git (the temp project is not a committed tree at
+    /// `no-such-ref`) ⇒ no baseline ⇒ verdict omitted. Reuses the same
+    /// `extract_base_compile` baseline mechanism as `ci-diff`, so a missing
+    /// base ref degrades to `None` rather than erroring.
+    #[test]
+    fn unresolvable_base_ref_yields_no_verdict() {
+        let tmp = TempDir::new().unwrap();
+        let (cfg_path, models_dir) = write_project(
+            &tmp,
+            "[adapter.default]\ntype = \"duckdb\"\n",
+            &[(
+                "orders",
+                "name = \"orders\"\n\n[strategy]\ntype = \"full_refresh\"\n\n\
+                 [target]\ncatalog = \"c\"\nschema = \"s\"\ntable = \"orders\"\n",
+            )],
+        );
+        let state_path = tmp.path().join("state.redb");
+        let verdict = compute_semantic_verdict(
+            &cfg_path,
+            &models_dir,
+            "definitely-not-a-real-ref-xyz",
+            &state_path,
+        );
+        assert!(
+            verdict.is_none(),
+            "an unresolvable base ref must omit the verdict (no fabricated baseline)",
+        );
     }
 }

--- a/engine/crates/rocky-cli/src/output.rs
+++ b/engine/crates/rocky-cli/src/output.rs
@@ -1208,7 +1208,79 @@ pub struct PlanOutput {
     /// re-derived at apply time. Empty for replication-only plans.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub execution_layers: Vec<Vec<String>>,
+
+    // ---- Semantic breaking-change verdict (decision-support) ------------
+    //
+    // Populated only when `rocky plan --semantic` runs AND a baseline
+    // compile is available (the `--base` git ref's models compiled
+    // cleanly alongside the working tree). The verdict is REPORTING-ONLY:
+    // it never gates, skips, or alters which statements are planned, and
+    // a `breaking` finding does not change the exit code. The hard gate
+    // lives on `rocky plan promote`.
+    //
+    // `None` (omitted) on a default `rocky plan`, when `--semantic` is
+    // absent, or when no baseline could be materialized — so existing
+    // consumers and fixtures stay byte-stable.
+    /// Semantic change-impact verdict from the typed-IR breaking-change
+    /// classifier, surfaced as decision-support at plan time. Present only
+    /// when `--semantic` ran with a usable baseline. See
+    /// [`SemanticPlanVerdict`] — note its `caveat`: the classifier diffs
+    /// OUTPUT SCHEMA only and is blind to schema-stable value changes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub breaking_verdict: Option<SemanticPlanVerdict>,
 }
+
+/// Decision-support verdict from the typed-IR breaking-change classifier,
+/// attached to `PlanOutput` when `rocky plan --semantic` runs against a
+/// usable baseline.
+///
+/// # Scope and blindness
+///
+/// The classifier diffs the typed **output schema** of each model between
+/// the baseline git ref and the working tree (column drop/add/type
+/// narrowing, nullability, materialization keys, masks, target rename).
+/// It is **blind to schema-stable value changes**: a `WHERE` / `JOIN`-key
+/// / `CASE` rewrite that changes every output row but leaves the column
+/// list and types untouched produces **no finding**. An empty `findings`
+/// list therefore means "no output-schema change was detected" — it is
+/// **not** a completeness or safety signal that the data is unchanged.
+/// The [`Self::caveat`] field carries this statement verbatim so a
+/// consumer that only reads the JSON cannot miss it.
+///
+/// # Reporting-only
+///
+/// This verdict never gates the plan. Even a `breaking`-severity finding
+/// leaves the planned statements and the process exit code unchanged. The
+/// hard gate (which blocks on `breaking`) lives on `rocky plan promote`.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SemanticPlanVerdict {
+    /// Verbatim statement of what the classifier does and does not see.
+    /// Always populated — present even when `findings` is empty, because
+    /// "no findings" is the case most easily misread as "safe". See the
+    /// type-level docs for why this is load-bearing.
+    pub caveat: String,
+    /// The git ref the working tree was diffed against (the `--base`
+    /// value, default `"main"`).
+    pub base_ref: String,
+    /// Classified output-schema findings (one per detected change),
+    /// including `info`-severity entries. Each finding carries its own
+    /// `model`, tagged `change.kind`, and `severity`
+    /// (`breaking` / `warning` / `info`). Empty when no output-schema
+    /// change was detected — which, per `caveat`, is not a safety signal.
+    pub findings: Vec<rocky_core::breaking_change::BreakingFinding>,
+}
+
+/// Verbatim caveat text embedded in every [`SemanticPlanVerdict::caveat`].
+///
+/// Single source of truth so the JSON payload and the text-mode render
+/// never drift. States plainly that the classifier diffs OUTPUT SCHEMA and
+/// is blind to schema-stable value changes, and that an empty finding list
+/// is not a completeness signal.
+pub const SEMANTIC_VERDICT_CAVEAT: &str = "This verdict diffs OUTPUT SCHEMA only \
+(columns, types, nullability, materialization keys, masks, target). It is BLIND to \
+schema-stable value changes: a WHERE / JOIN-key / CASE rewrite that changes every output \
+row but not the schema produces no finding. An empty findings list means no output-schema \
+change was detected — it is NOT a signal that the data or the model is unchanged.";
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct PlannedStatement {
@@ -4050,6 +4122,7 @@ impl PlanOutput {
             created_at: None,
             models: vec![],
             execution_layers: vec![],
+            breaking_verdict: None,
         }
     }
 }

--- a/engine/rocky/src/main.rs
+++ b/engine/rocky/src/main.rs
@@ -504,6 +504,27 @@ enum Command {
         /// Applies to the default plan subcommand only.
         #[arg(long, global = false)]
         env: Option<String>,
+
+        /// Also run the typed-IR breaking-change classifier against `--base`
+        /// and attach the change-impact verdict under `breaking_verdict` in
+        /// the JSON output (and a `-- semantic verdict --` block in text
+        /// mode).
+        ///
+        /// Decision-support only: the verdict NEVER gates the plan — planned
+        /// statements and the exit code are unchanged even on a `breaking`
+        /// finding, and the verdict is omitted (never fabricated) when no
+        /// baseline is available. The classifier diffs OUTPUT SCHEMA and is
+        /// blind to schema-stable value changes (a WHERE / JOIN-key / CASE
+        /// rewrite that changes values but not the schema). The hard gate
+        /// lives on `rocky plan promote`.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, global = false)]
+        semantic: bool,
+        /// Git ref the working tree is diffed against for `--semantic`
+        /// (default: main). Ignored unless `--semantic` is set.
+        /// Applies to the default plan subcommand only.
+        #[arg(long, default_value = "main", global = false)]
+        base: String,
     },
 
     /// Execute the full pipeline in one step: discover → drift → create → copy → check.
@@ -2268,6 +2289,8 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
             dag,
             idempotency_key,
             env,
+            semantic,
+            base,
         } => match subcommand {
             None => {
                 // Mirror the `rocky run` guard: --idempotency-key is mutually
@@ -2320,6 +2343,9 @@ async fn run_async(cli: Cli, json: bool) -> Result<()> {
                     pipeline.as_deref(),
                     env.as_deref(),
                     &run_options,
+                    semantic,
+                    &base,
+                    &state_path,
                     json,
                 )
                 .await
@@ -3660,6 +3686,12 @@ mod tests {
                 dag,
                 idempotency_key,
                 env,
+                // `--semantic` / `--base` are decision-support flags (D3) and
+                // are exercised by their own tests in
+                // `crates/rocky-cli/src/commands/plan.rs`; this run/plan
+                // flag-parity helper does not thread them.
+                semantic: _,
+                base: _,
             } => extract(
                 filter,
                 pipeline,

--- a/integrations/dagster/src/dagster_rocky/types_generated/plan_promote_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/plan_promote_schema.py
@@ -83,61 +83,61 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind39(StrEnum):
+class Kind55(StrEnum):
     model_added = "model_added"
 
 
-class BreakingChange36(BaseModel):
+class BreakingChange53(BaseModel):
     """
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind39
+    kind: Kind55
     model: str
 
 
-class Kind40(StrEnum):
+class Kind56(StrEnum):
     column_dropped = "column_dropped"
 
 
-class BreakingChange37(BaseModel):
+class BreakingChange54(BaseModel):
     """
     A column present on the base side is absent on the head side.
     """
 
     column: str
     data_type: str
-    kind: Kind40
+    kind: Kind56
     model: str
 
 
-class Kind41(StrEnum):
+class Kind57(StrEnum):
     column_added = "column_added"
 
 
-class BreakingChange38(BaseModel):
+class BreakingChange55(BaseModel):
     """
     A column was added.
     """
 
     column: str
     data_type: str
-    kind: Kind41
+    kind: Kind57
     model: str
     nullable: bool
 
 
-class Kind42(StrEnum):
+class Kind58(StrEnum):
     column_type_changed = "column_type_changed"
 
 
-class BreakingChange39(BaseModel):
+class BreakingChange56(BaseModel):
     """
     A column's data type changed.
     """
 
     column: str
-    kind: Kind42
+    kind: Kind58
     model: str
     narrowing: bool
     """
@@ -147,58 +147,58 @@ class BreakingChange39(BaseModel):
     old_type: str
 
 
-class Kind43(StrEnum):
+class Kind59(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
-class BreakingChange40(BaseModel):
+class BreakingChange57(BaseModel):
     """
     A column's nullability flipped.
     """
 
     column: str
-    kind: Kind43
+    kind: Kind59
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind44(StrEnum):
+class Kind60(StrEnum):
     column_reordered = "column_reordered"
 
 
-class BreakingChange41(BaseModel):
+class BreakingChange58(BaseModel):
     """
     A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
     """
 
     column: str
-    kind: Kind44
+    kind: Kind60
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind45(StrEnum):
+class Kind61(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
-class BreakingChange42(BaseModel):
+class BreakingChange59(BaseModel):
     """
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind45
+    kind: Kind61
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind46(StrEnum):
+class Kind62(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
-class BreakingChange43(BaseModel):
+class BreakingChange60(BaseModel):
     """
     Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
     """
@@ -207,117 +207,117 @@ class BreakingChange43(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind46
+    kind: Kind62
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind47(StrEnum):
+class Kind63(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange44(BaseModel):
+class BreakingChange61(BaseModel):
     """
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind47
+    kind: Kind63
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind48(StrEnum):
+class Kind64(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
-class BreakingChange45(BaseModel):
+class BreakingChange62(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
     """
 
-    kind: Kind48
+    kind: Kind64
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind49(StrEnum):
+class Kind65(StrEnum):
     target_renamed = "target_renamed"
 
 
-class BreakingChange46(BaseModel):
+class BreakingChange63(BaseModel):
     """
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind49
+    kind: Kind65
     model: str
     new: str
     old: str
 
 
-class Kind50(StrEnum):
+class Kind66(StrEnum):
     source_changed = "source_changed"
 
 
-class BreakingChange47(BaseModel):
+class BreakingChange64(BaseModel):
     """
     Source reference rebound to a different table.
     """
 
-    kind: Kind50
+    kind: Kind66
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind51(StrEnum):
+class Kind67(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
-class BreakingChange48(BaseModel):
+class BreakingChange65(BaseModel):
     """
     A column mask was added, removed, or its strategy changed.
     """
 
     column: str
-    kind: Kind51
+    kind: Kind67
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind52(StrEnum):
+class Kind68(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
-class BreakingChange49(BaseModel):
+class BreakingChange66(BaseModel):
     """
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind52
+    kind: Kind68
     model: str
     new: str
     old: str
 
 
-class Kind53(StrEnum):
+class Kind69(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
-class BreakingChange50(BaseModel):
+class BreakingChange67(BaseModel):
     """
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind53
+    kind: Kind69
     model: str
 
 
-class BreakingSeverity7(StrEnum):
+class BreakingSeverity10(StrEnum):
     """
     Will break a downstream consumer that reads the model's prior shape.
     """
@@ -325,7 +325,7 @@ class BreakingSeverity7(StrEnum):
     breaking = "breaking"
 
 
-class BreakingSeverity8(StrEnum):
+class BreakingSeverity11(StrEnum):
     """
     May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
     """
@@ -333,7 +333,7 @@ class BreakingSeverity8(StrEnum):
     warning = "warning"
 
 
-class BreakingSeverity9(StrEnum):
+class BreakingSeverity12(StrEnum):
     """
     Informational only — purely additive or backwards-compatible.
     """
@@ -426,28 +426,28 @@ class BreakingFinding(BaseModel):
 
     change: (
         BreakingChange
-        | BreakingChange36
-        | BreakingChange37
-        | BreakingChange38
-        | BreakingChange39
-        | BreakingChange40
-        | BreakingChange41
-        | BreakingChange42
-        | BreakingChange43
-        | BreakingChange44
-        | BreakingChange45
-        | BreakingChange46
-        | BreakingChange47
-        | BreakingChange48
-        | BreakingChange49
-        | BreakingChange50
+        | BreakingChange53
+        | BreakingChange54
+        | BreakingChange55
+        | BreakingChange56
+        | BreakingChange57
+        | BreakingChange58
+        | BreakingChange59
+        | BreakingChange60
+        | BreakingChange61
+        | BreakingChange62
+        | BreakingChange63
+        | BreakingChange64
+        | BreakingChange65
+        | BreakingChange66
+        | BreakingChange67
     )
     """
     A single typed semantic change between two `ProjectIr` snapshots.
 
     Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
     """
-    severity: BreakingSeverity7 | BreakingSeverity8 | BreakingSeverity9
+    severity: BreakingSeverity10 | BreakingSeverity11 | BreakingSeverity12
     """
     Severity classification for a single semantic change.
     """

--- a/integrations/dagster/src/dagster_rocky/types_generated/plan_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/plan_schema.py
@@ -8,6 +8,277 @@ from enum import StrEnum
 from pydantic import AwareDatetime, BaseModel, conint
 
 
+class Kind(StrEnum):
+    model_removed = "model_removed"
+
+
+class BreakingChange(BaseModel):
+    """
+    A model present on the base side is absent on the head side.
+    """
+
+    kind: Kind
+    model: str
+
+
+class Kind39(StrEnum):
+    model_added = "model_added"
+
+
+class BreakingChange36(BaseModel):
+    """
+    A model present on the head side is absent on the base side.
+    """
+
+    kind: Kind39
+    model: str
+
+
+class Kind40(StrEnum):
+    column_dropped = "column_dropped"
+
+
+class BreakingChange37(BaseModel):
+    """
+    A column present on the base side is absent on the head side.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind40
+    model: str
+
+
+class Kind41(StrEnum):
+    column_added = "column_added"
+
+
+class BreakingChange38(BaseModel):
+    """
+    A column was added.
+    """
+
+    column: str
+    data_type: str
+    kind: Kind41
+    model: str
+    nullable: bool
+
+
+class Kind42(StrEnum):
+    column_type_changed = "column_type_changed"
+
+
+class BreakingChange39(BaseModel):
+    """
+    A column's data type changed.
+    """
+
+    column: str
+    kind: Kind42
+    model: str
+    narrowing: bool
+    """
+    `true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).
+    """
+    new_type: str
+    old_type: str
+
+
+class Kind43(StrEnum):
+    column_nullability_changed = "column_nullability_changed"
+
+
+class BreakingChange40(BaseModel):
+    """
+    A column's nullability flipped.
+    """
+
+    column: str
+    kind: Kind43
+    model: str
+    new_nullable: bool
+    old_nullable: bool
+
+
+class Kind44(StrEnum):
+    column_reordered = "column_reordered"
+
+
+class BreakingChange41(BaseModel):
+    """
+    A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
+    """
+
+    column: str
+    kind: Kind44
+    model: str
+    new_index: conint(ge=0)
+    old_index: conint(ge=0)
+
+
+class Kind45(StrEnum):
+    materialization_strategy_changed = "materialization_strategy_changed"
+
+
+class BreakingChange42(BaseModel):
+    """
+    The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
+    """
+
+    kind: Kind45
+    model: str
+    new_strategy: str
+    old_strategy: str
+
+
+class Kind46(StrEnum):
+    materialization_key_changed = "materialization_key_changed"
+
+
+class BreakingChange43(BaseModel):
+    """
+    Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
+    """
+
+    key_kind: str
+    """
+    Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
+    """
+    kind: Kind46
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind47(StrEnum):
+    replication_columns_changed = "replication_columns_changed"
+
+
+class BreakingChange44(BaseModel):
+    """
+    Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
+    """
+
+    kind: Kind47
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind48(StrEnum):
+    partition_by_changed = "partition_by_changed"
+
+
+class BreakingChange45(BaseModel):
+    """
+    `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
+    """
+
+    kind: Kind48
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind49(StrEnum):
+    target_renamed = "target_renamed"
+
+
+class BreakingChange46(BaseModel):
+    """
+    Target table reference renamed (catalog, schema, or table component).
+    """
+
+    kind: Kind49
+    model: str
+    new: str
+    old: str
+
+
+class Kind50(StrEnum):
+    source_changed = "source_changed"
+
+
+class BreakingChange47(BaseModel):
+    """
+    Source reference rebound to a different table.
+    """
+
+    kind: Kind50
+    model: str
+    new: list[str]
+    old: list[str]
+
+
+class Kind51(StrEnum):
+    column_mask_changed = "column_mask_changed"
+
+
+class BreakingChange48(BaseModel):
+    """
+    A column mask was added, removed, or its strategy changed.
+    """
+
+    column: str
+    kind: Kind51
+    model: str
+    new_strategy: str | None = None
+    old_strategy: str | None = None
+
+
+class Kind52(StrEnum):
+    lakehouse_format_changed = "lakehouse_format_changed"
+
+
+class BreakingChange49(BaseModel):
+    """
+    Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
+    """
+
+    kind: Kind52
+    model: str
+    new: str
+    old: str
+
+
+class Kind53(StrEnum):
+    sql_body_changed = "sql_body_changed"
+
+
+class BreakingChange50(BaseModel):
+    """
+    SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
+    """
+
+    kind: Kind53
+    model: str
+
+
+class BreakingSeverity7(StrEnum):
+    """
+    Will break a downstream consumer that reads the model's prior shape.
+    """
+
+    breaking = "breaking"
+
+
+class BreakingSeverity8(StrEnum):
+    """
+    May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
+    """
+
+    warning = "warning"
+
+
+class BreakingSeverity9(StrEnum):
+    """
+    Informational only — purely additive or backwards-compatible.
+    """
+
+    info = "info"
+
+
 class ClassificationAction(BaseModel):
     """
     Classification-tag application row in `PlanOutput.classification_actions`.
@@ -97,6 +368,40 @@ class SourceSpan(BaseModel):
     line: conint(ge=0)
 
 
+class BreakingFinding(BaseModel):
+    """
+    A classified finding produced by [`diff_project_ir`].
+    """
+
+    change: (
+        BreakingChange
+        | BreakingChange36
+        | BreakingChange37
+        | BreakingChange38
+        | BreakingChange39
+        | BreakingChange40
+        | BreakingChange41
+        | BreakingChange42
+        | BreakingChange43
+        | BreakingChange44
+        | BreakingChange45
+        | BreakingChange46
+        | BreakingChange47
+        | BreakingChange48
+        | BreakingChange49
+        | BreakingChange50
+    )
+    """
+    A single typed semantic change between two `ProjectIr` snapshots.
+
+    Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
+    """
+    severity: BreakingSeverity7 | BreakingSeverity8 | BreakingSeverity9
+    """
+    Severity classification for a single semantic change.
+    """
+
+
 class Diagnostic(BaseModel):
     """
     A compiler diagnostic (error, warning, or informational message).
@@ -130,6 +435,33 @@ class Diagnostic(BaseModel):
     """
 
 
+class SemanticPlanVerdict(BaseModel):
+    """
+    Decision-support verdict from the typed-IR breaking-change classifier, attached to `PlanOutput` when `rocky plan --semantic` runs against a usable baseline.
+
+    # Scope and blindness
+
+    The classifier diffs the typed **output schema** of each model between the baseline git ref and the working tree (column drop/add/type narrowing, nullability, materialization keys, masks, target rename). It is **blind to schema-stable value changes**: a `WHERE` / `JOIN`-key / `CASE` rewrite that changes every output row but leaves the column list and types untouched produces **no finding**. An empty `findings` list therefore means "no output-schema change was detected" — it is **not** a completeness or safety signal that the data is unchanged. The [`Self::caveat`] field carries this statement verbatim so a consumer that only reads the JSON cannot miss it.
+
+    # Reporting-only
+
+    This verdict never gates the plan. Even a `breaking`-severity finding leaves the planned statements and the process exit code unchanged. The hard gate (which blocks on `breaking`) lives on `rocky plan promote`.
+    """
+
+    base_ref: str
+    """
+    The git ref the working tree was diffed against (the `--base` value, default `"main"`).
+    """
+    caveat: str
+    """
+    Verbatim statement of what the classifier does and does not see. Always populated — present even when `findings` is empty, because "no findings" is the case most easily misread as "safe". See the type-level docs for why this is load-bearing.
+    """
+    findings: list[BreakingFinding]
+    """
+    Classified output-schema findings (one per detected change), including `info`-severity entries. Each finding carries its own `model`, tagged `change.kind`, and `severity` (`breaking` / `warning` / `info`). Empty when no output-schema change was detected — which, per `caveat`, is not a safety signal.
+    """
+
+
 class PlanOutput(BaseModel):
     """
     JSON output for `rocky plan`.
@@ -141,6 +473,10 @@ class PlanOutput(BaseModel):
     `plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.
     """
 
+    breaking_verdict: SemanticPlanVerdict | None = None
+    """
+    Semantic change-impact verdict from the typed-IR breaking-change classifier, surfaced as decision-support at plan time. Present only when `--semantic` ran with a usable baseline. See [`SemanticPlanVerdict`] — note its `caveat`: the classifier diffs OUTPUT SCHEMA only and is blind to schema-stable value changes.
+    """
     budget_diagnostics: list[Diagnostic] | None = None
     """
     Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`"warn"` or `"error"`). Empty when no ceiling was exceeded or no real stats were available.

--- a/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/preview_diff_schema.py
@@ -73,7 +73,7 @@ class Kind(StrEnum):
     sampled = "sampled"
 
 
-class Kind55(StrEnum):
+class Kind71(StrEnum):
     bisection = "bisection"
 
 
@@ -173,7 +173,7 @@ class PreviewModelDiffAlgorithm2(BaseModel):
 
     bisection_stats: BisectionStatsOutput
     diff: PreviewBisectionRowDiff
-    kind: Kind55
+    kind: Kind71
 
 
 class PreviewModelDiff(BaseModel):

--- a/integrations/dagster/src/dagster_rocky/types_generated/review_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/review_schema.py
@@ -21,61 +21,61 @@ class BreakingChange(BaseModel):
     model: str
 
 
-class Kind57(StrEnum):
+class Kind73(StrEnum):
     model_added = "model_added"
 
 
-class BreakingChange53(BaseModel):
+class BreakingChange70(BaseModel):
     """
     A model present on the head side is absent on the base side.
     """
 
-    kind: Kind57
+    kind: Kind73
     model: str
 
 
-class Kind58(StrEnum):
+class Kind74(StrEnum):
     column_dropped = "column_dropped"
 
 
-class BreakingChange54(BaseModel):
+class BreakingChange71(BaseModel):
     """
     A column present on the base side is absent on the head side.
     """
 
     column: str
     data_type: str
-    kind: Kind58
+    kind: Kind74
     model: str
 
 
-class Kind59(StrEnum):
+class Kind75(StrEnum):
     column_added = "column_added"
 
 
-class BreakingChange55(BaseModel):
+class BreakingChange72(BaseModel):
     """
     A column was added.
     """
 
     column: str
     data_type: str
-    kind: Kind59
+    kind: Kind75
     model: str
     nullable: bool
 
 
-class Kind60(StrEnum):
+class Kind76(StrEnum):
     column_type_changed = "column_type_changed"
 
 
-class BreakingChange56(BaseModel):
+class BreakingChange73(BaseModel):
     """
     A column's data type changed.
     """
 
     column: str
-    kind: Kind60
+    kind: Kind76
     model: str
     narrowing: bool
     """
@@ -85,58 +85,58 @@ class BreakingChange56(BaseModel):
     old_type: str
 
 
-class Kind61(StrEnum):
+class Kind77(StrEnum):
     column_nullability_changed = "column_nullability_changed"
 
 
-class BreakingChange57(BaseModel):
+class BreakingChange74(BaseModel):
     """
     A column's nullability flipped.
     """
 
     column: str
-    kind: Kind61
+    kind: Kind77
     model: str
     new_nullable: bool
     old_nullable: bool
 
 
-class Kind62(StrEnum):
+class Kind78(StrEnum):
     column_reordered = "column_reordered"
 
 
-class BreakingChange58(BaseModel):
+class BreakingChange75(BaseModel):
     """
     A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.
     """
 
     column: str
-    kind: Kind62
+    kind: Kind78
     model: str
     new_index: conint(ge=0)
     old_index: conint(ge=0)
 
 
-class Kind63(StrEnum):
+class Kind79(StrEnum):
     materialization_strategy_changed = "materialization_strategy_changed"
 
 
-class BreakingChange59(BaseModel):
+class BreakingChange76(BaseModel):
     """
     The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).
     """
 
-    kind: Kind63
+    kind: Kind79
     model: str
     new_strategy: str
     old_strategy: str
 
 
-class Kind64(StrEnum):
+class Kind80(StrEnum):
     materialization_key_changed = "materialization_key_changed"
 
 
-class BreakingChange60(BaseModel):
+class BreakingChange77(BaseModel):
     """
     Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).
     """
@@ -145,117 +145,117 @@ class BreakingChange60(BaseModel):
     """
     Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.
     """
-    kind: Kind64
+    kind: Kind80
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind65(StrEnum):
+class Kind81(StrEnum):
     replication_columns_changed = "replication_columns_changed"
 
 
-class BreakingChange61(BaseModel):
+class BreakingChange78(BaseModel):
     """
     Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.
     """
 
-    kind: Kind65
+    kind: Kind81
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind66(StrEnum):
+class Kind82(StrEnum):
     partition_by_changed = "partition_by_changed"
 
 
-class BreakingChange62(BaseModel):
+class BreakingChange79(BaseModel):
     """
     `LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.
     """
 
-    kind: Kind66
+    kind: Kind82
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind67(StrEnum):
+class Kind83(StrEnum):
     target_renamed = "target_renamed"
 
 
-class BreakingChange63(BaseModel):
+class BreakingChange80(BaseModel):
     """
     Target table reference renamed (catalog, schema, or table component).
     """
 
-    kind: Kind67
+    kind: Kind83
     model: str
     new: str
     old: str
 
 
-class Kind68(StrEnum):
+class Kind84(StrEnum):
     source_changed = "source_changed"
 
 
-class BreakingChange64(BaseModel):
+class BreakingChange81(BaseModel):
     """
     Source reference rebound to a different table.
     """
 
-    kind: Kind68
+    kind: Kind84
     model: str
     new: list[str]
     old: list[str]
 
 
-class Kind69(StrEnum):
+class Kind85(StrEnum):
     column_mask_changed = "column_mask_changed"
 
 
-class BreakingChange65(BaseModel):
+class BreakingChange82(BaseModel):
     """
     A column mask was added, removed, or its strategy changed.
     """
 
     column: str
-    kind: Kind69
+    kind: Kind85
     model: str
     new_strategy: str | None = None
     old_strategy: str | None = None
 
 
-class Kind70(StrEnum):
+class Kind86(StrEnum):
     lakehouse_format_changed = "lakehouse_format_changed"
 
 
-class BreakingChange66(BaseModel):
+class BreakingChange83(BaseModel):
     """
     Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).
     """
 
-    kind: Kind70
+    kind: Kind86
     model: str
     new: str
     old: str
 
 
-class Kind71(StrEnum):
+class Kind87(StrEnum):
     sql_body_changed = "sql_body_changed"
 
 
-class BreakingChange67(BaseModel):
+class BreakingChange84(BaseModel):
     """
     SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.
     """
 
-    kind: Kind71
+    kind: Kind87
     model: str
 
 
-class BreakingSeverity10(StrEnum):
+class BreakingSeverity13(StrEnum):
     """
     Will break a downstream consumer that reads the model's prior shape.
     """
@@ -263,7 +263,7 @@ class BreakingSeverity10(StrEnum):
     breaking = "breaking"
 
 
-class BreakingSeverity11(StrEnum):
+class BreakingSeverity14(StrEnum):
     """
     May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.
     """
@@ -271,7 +271,7 @@ class BreakingSeverity11(StrEnum):
     warning = "warning"
 
 
-class BreakingSeverity12(StrEnum):
+class BreakingSeverity15(StrEnum):
     """
     Informational only — purely additive or backwards-compatible.
     """
@@ -286,28 +286,28 @@ class BreakingFinding(BaseModel):
 
     change: (
         BreakingChange
-        | BreakingChange53
-        | BreakingChange54
-        | BreakingChange55
-        | BreakingChange56
-        | BreakingChange57
-        | BreakingChange58
-        | BreakingChange59
-        | BreakingChange60
-        | BreakingChange61
-        | BreakingChange62
-        | BreakingChange63
-        | BreakingChange64
-        | BreakingChange65
-        | BreakingChange66
-        | BreakingChange67
+        | BreakingChange70
+        | BreakingChange71
+        | BreakingChange72
+        | BreakingChange73
+        | BreakingChange74
+        | BreakingChange75
+        | BreakingChange76
+        | BreakingChange77
+        | BreakingChange78
+        | BreakingChange79
+        | BreakingChange80
+        | BreakingChange81
+        | BreakingChange82
+        | BreakingChange83
+        | BreakingChange84
     )
     """
     A single typed semantic change between two `ProjectIr` snapshots.
 
     Each variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.
     """
-    severity: BreakingSeverity10 | BreakingSeverity11 | BreakingSeverity12
+    severity: BreakingSeverity13 | BreakingSeverity14 | BreakingSeverity15
     """
     Severity classification for a single semantic change.
     """

--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -1,6 +1,523 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BreakingChange": {
+      "description": "A single typed semantic change between two `ProjectIr` snapshots.\n\nEach variant carries the minimum identifying context (model + column + before/after values) needed for a CLI / PR-preview surface to render a useful message without re-loading either IR.",
+      "oneOf": [
+        {
+          "description": "A model present on the base side is absent on the head side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_removed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A model present on the head side is absent on the base side.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "model_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column present on the base side is absent on the head side.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_dropped"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column was added.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "data_type": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_added"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "data_type",
+            "kind",
+            "model",
+            "nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's data type changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_type_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "narrowing": {
+              "description": "`true` when the new type cannot represent every value of the old type (Int64 → Int32, Decimal precision shrink, Timestamp → Date).",
+              "type": "boolean"
+            },
+            "new_type": {
+              "type": "string"
+            },
+            "old_type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "narrowing",
+            "new_type",
+            "old_type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's nullability flipped.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_nullability_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_nullable": {
+              "type": "boolean"
+            },
+            "old_nullable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_nullable",
+            "old_nullable"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column's position in the output schema changed. `SELECT *` downstream consumers see different positional projection.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_reordered"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "old_index": {
+              "format": "uint",
+              "minimum": 0.0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model",
+            "new_index",
+            "old_index"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The materialization strategy switched between top-level variants (e.g. `FullRefresh` → `Incremental`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "materialization_strategy_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": "string"
+            },
+            "old_strategy": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new_strategy",
+            "old_strategy"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Materialization-specific key columns changed without the top-level variant changing (e.g. `Merge` `unique_key` rewritten, `Incremental` `timestamp_column` swapped).",
+          "properties": {
+            "key_kind": {
+              "description": "Which key changed: `unique_key`, `timestamp_column`, `partition_by`, `time_column`, `granularity`, `target_lag`, `update_columns`, `storage_prefix`, or `partition_columns`.",
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "materialization_key_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "key_kind",
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Replication column-selection mode flipped between `All` and `Explicit(...)` or the explicit list changed.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "replication_columns_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "`LakehouseOptions::partition_by` changed without the strategy changing. Distinct from `MaterializationKeyChanged` since this lives on `format_options` rather than the strategy enum.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "partition_by_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Target table reference renamed (catalog, schema, or table component).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "target_renamed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Source reference rebound to a different table.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "source_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "old": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A column mask was added, removed, or its strategy changed.",
+          "properties": {
+            "column": {
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "column_mask_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "old_strategy": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "column",
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Lakehouse format switched (e.g. `DeltaTable` → `IcebergTable`).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "lakehouse_format_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "new": {
+              "type": "string"
+            },
+            "old": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "new",
+            "old"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "SQL body changed without any other detectable structural change. Surfaced as `Info` because the typed-output shape is unchanged, but runtime row contents may differ.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "sql_body_changed"
+              ],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "model"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "BreakingFinding": {
+      "description": "A classified finding produced by [`diff_project_ir`].",
+      "properties": {
+        "change": {
+          "$ref": "#/definitions/BreakingChange"
+        },
+        "severity": {
+          "$ref": "#/definitions/BreakingSeverity"
+        }
+      },
+      "required": [
+        "change",
+        "severity"
+      ],
+      "type": "object"
+    },
+    "BreakingSeverity": {
+      "description": "Severity classification for a single semantic change.",
+      "oneOf": [
+        {
+          "description": "Will break a downstream consumer that reads the model's prior shape.",
+          "enum": [
+            "breaking"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "May break consumers depending on usage; e.g. nullable → NOT NULL, column reordered.",
+          "enum": [
+            "warning"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Informational only — purely additive or backwards-compatible.",
+          "enum": [
+            "info"
+          ],
+          "type": "string"
+        }
+      ]
+    },
     "ClassificationAction": {
       "description": "Classification-tag application row in `PlanOutput.classification_actions`.",
       "properties": {
@@ -148,6 +665,32 @@
       ],
       "type": "object"
     },
+    "SemanticPlanVerdict": {
+      "description": "Decision-support verdict from the typed-IR breaking-change classifier, attached to `PlanOutput` when `rocky plan --semantic` runs against a usable baseline.\n\n# Scope and blindness\n\nThe classifier diffs the typed **output schema** of each model between the baseline git ref and the working tree (column drop/add/type narrowing, nullability, materialization keys, masks, target rename). It is **blind to schema-stable value changes**: a `WHERE` / `JOIN`-key / `CASE` rewrite that changes every output row but leaves the column list and types untouched produces **no finding**. An empty `findings` list therefore means \"no output-schema change was detected\" — it is **not** a completeness or safety signal that the data is unchanged. The [`Self::caveat`] field carries this statement verbatim so a consumer that only reads the JSON cannot miss it.\n\n# Reporting-only\n\nThis verdict never gates the plan. Even a `breaking`-severity finding leaves the planned statements and the process exit code unchanged. The hard gate (which blocks on `breaking`) lives on `rocky plan promote`.",
+      "properties": {
+        "base_ref": {
+          "description": "The git ref the working tree was diffed against (the `--base` value, default `\"main\"`).",
+          "type": "string"
+        },
+        "caveat": {
+          "description": "Verbatim statement of what the classifier does and does not see. Always populated — present even when `findings` is empty, because \"no findings\" is the case most easily misread as \"safe\". See the type-level docs for why this is load-bearing.",
+          "type": "string"
+        },
+        "findings": {
+          "description": "Classified output-schema findings (one per detected change), including `info`-severity entries. Each finding carries its own `model`, tagged `change.kind`, and `severity` (`breaking` / `warning` / `info`). Empty when no output-schema change was detected — which, per `caveat`, is not a safety signal.",
+          "items": {
+            "$ref": "#/definitions/BreakingFinding"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "base_ref",
+        "caveat",
+        "findings"
+      ],
+      "type": "object"
+    },
     "Severity": {
       "description": "Severity level of a diagnostic.\n\nSerialized in PascalCase (`\"Error\"`, `\"Warning\"`, `\"Info\"`) to stay compatible with existing dagster fixtures and the hand-written `Severity` StrEnum in `integrations/dagster/src/dagster_rocky/types.py`.",
       "enum": [
@@ -184,6 +727,17 @@
   },
   "description": "JSON output for `rocky plan`.\n\n`statements` enumerates the warehouse SQL Rocky would emit. The three `*_actions` collections are a parallel view of the control-plane governance work `rocky run` would do *after* a successful DAG — the classification / masking / retention reconcile pass. These never show up as SQL; they fire through [`rocky_core::traits::GovernanceAdapter`] methods (e.g. `apply_column_tags`, `apply_masking_policy`, `apply_retention_policy`). Projects without any `[classification]`, `[mask]`, or `retention` config get empty lists — the fields `skip_serializing_if = Vec::is_empty`, so JSON consumers written against the pre-Wave A shape are byte-stable.\n\n## Phase 2 additions (Cluster 3 B)\n\n`plan_id`, `plan_kind`, `created_at`, `models`, and `execution_layers` are additive — all have `skip_serializing_if` so existing fixtures and consumers that do not include a compile step remain byte-stable. When `rocky plan` runs against a project with a `models/` directory, these fields are populated and the plan is persisted to `.rocky/plans/`.",
   "properties": {
+    "breaking_verdict": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SemanticPlanVerdict"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Semantic change-impact verdict from the typed-IR breaking-change classifier, surfaced as decision-support at plan time. Present only when `--semantic` ran with a usable baseline. See [`SemanticPlanVerdict`] — note its `caveat`: the classifier diffs OUTPUT SCHEMA only and is blind to schema-stable value changes."
+    },
     "budget_diagnostics": {
       "description": "Per-model E027 budget-exceeded diagnostics produced at plan time using real catalog statistics. Severity reflects the model's `on_breach` policy (`\"warn\"` or `\"error\"`). Empty when no ceiling was exceeded or no real stats were available.",
       "items": {


### PR DESCRIPTION
Backlog **D3**: surface the existing typed-IR breaking-change classifier's verdict in `rocky plan` as **decision-support** — *not* an auto-skip.

⚠️ **Recovered work — needs my verification + rebase.** The agent that implemented this completed ~90 tool-uses but hit a transient socket error before committing/verifying. I preserved the work; **CI on this PR is the first real verification**, and it must be **rebased onto D2 (#856)** (both touch `output.rs` + codegen) before it's marked ready.

Scope (per the brief): reporting only (no rebuild/skip gating), with the honest caveat that the classifier diffs *output schema* and is **blind to schema-stable value changes** (a WHERE/JOIN/CASE rewrite). Touches `plan.rs`, `output.rs`, `main.rs`, docs, + regenerated bindings.