### PR TITLE
feat(dagster): tenant-as-partition collapse for RockyComponent

### DIFF
--- a/integrations/dagster/src/dagster_rocky/__init__.py
+++ b/integrations/dagster/src/dagster_rocky/__init__.py
@@ -16,7 +16,7 @@ from .checks import (
     emit_materializations,
 )
 from .column_lineage import build_column_lineage
-from .component import RockyComponent, RockyMetadataSet, RockyTableProps
+from .component import RockyComponent, RockyMetadataSet, RockyTableProps, TenantConfig
 from .contracts import (
     CONTRACT_COLUMN_CONSTRAINTS_CHECK,
     CONTRACT_PROTECTED_COLUMNS_CHECK,
@@ -159,6 +159,7 @@ __all__ = [
     "RockyComponent",
     "RockyMetadataSet",
     "RockyTableProps",
+    "TenantConfig",
     "RockyResource",
     "MIN_ROCKY_VERSION",
     "Resolver",

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1432,6 +1432,7 @@ def _build_check_specs(
     contract_rules_by_model: dict[str, ContractRules] | None = None,
     *,
     surface_compliance: bool = False,
+    partitions_def: dg.PartitionsDefinition | None = None,
 ) -> list[dg.AssetCheckSpec]:
     """Pre-declare check specs for every asset in every group.
 
@@ -1450,6 +1451,15 @@ def _build_check_specs(
     pattern (check exists even if the current run produces no exceptions,
     in which case :func:`_emit_placeholder_checks` emits a passing
     placeholder).
+
+    When ``partitions_def`` is provided, every emitted check spec is
+    partitioned by it. This is the tenant-as-partition path: with the
+    collapsed asset's tenant ``DynamicPartitionsDefinition`` attached,
+    check verdicts are recorded per partition (per tenant) instead of
+    collapsing to one last-writer-wins result on the shared
+    ``(asset_key, check_name)``. Must equal the collapsed asset's
+    ``partitions_def`` (Dagster enforces the match). Defaults to ``None``
+    — the unpartitioned, byte-identical-to-prior path.
     """
     contract_rules_by_model = contract_rules_by_model or {}
     specs: list[dg.AssetCheckSpec] = []
@@ -1482,17 +1492,27 @@ def _build_check_specs(
         for spec in group.specs:
             # Default checks (4 per asset)
             for check_name in DEFAULT_CHECK_NAMES:
-                _add(dg.AssetCheckSpec(name=check_name, asset=spec.key))
+                _add(
+                    dg.AssetCheckSpec(
+                        name=check_name, asset=spec.key, partitions_def=partitions_def
+                    )
+                )
 
             # Governance compliance check (Wave B, opt-in)
             if surface_compliance:
-                _add(dg.AssetCheckSpec(name=COMPLIANCE_CHECK_NAME, asset=spec.key))
+                _add(
+                    dg.AssetCheckSpec(
+                        name=COMPLIANCE_CHECK_NAME, asset=spec.key, partitions_def=partitions_def
+                    )
+                )
 
             # Contract checks (per declared rule kind, when matched)
             table_name = spec.key.path[-1]
             rules = contract_rules_by_model.get(table_name)
             if rules is not None:
-                for contract_spec in contract_check_specs_for_model(spec.key, rules):
+                for contract_spec in contract_check_specs_for_model(
+                    spec.key, rules, partitions_def=partitions_def
+                ):
                     _add(contract_spec)
 
     return specs

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -25,6 +25,7 @@ import importlib
 import json
 import logging
 import os
+import re
 from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -1503,19 +1504,26 @@ def _union_member_tables(members: list[SourceInfo]) -> list[TableInfo]:
 
 
 def _unique_collapsed_group_name(representative: SourceInfo, used: set[str]) -> str:
-    """Return a unique op-name stem for a collapsed group.
+    """Return a unique, op-name-safe stem for a collapsed group.
 
     Built from ``source_type`` + every (non-tenant) component value — i.e.
     the collapsed asset-key prefix — so it is 1:1 with the group key, unlike
     ``get_group_name`` (only the first string component), which collides
     across groups that share that component and crashes the implicit
-    ``__ASSET_JOB`` on duplicate op names. ``used`` guards the residual
-    separator-collision edge by appending an index.
+    ``__ASSET_JOB`` on duplicate op names.
+
+    Each part is sanitised to ``[A-Za-z0-9_]`` (the valid op-name charset)
+    and ``used`` is keyed on the *sanitised* result — so two raw stems that
+    differ only in characters sanitisation collapses (``a-b`` vs ``a.b``)
+    still get distinct op names instead of silently re-colliding after
+    ``_safe_asset_name``. Deterministic: dict order of ``components`` is
+    stable, so the same discover state yields the same name (no asset churn
+    across reloads).
     """
     parts = [representative.source_type]
     for value in representative.components.values():
         parts.append("__".join(value) if isinstance(value, list) else str(value))
-    base = "_".join(parts)
+    base = re.sub(r"[^A-Za-z0-9_]", "_", "_".join(parts))
     name = base
     suffix = 2
     while name in used:

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1488,7 +1488,7 @@ _PER_TENANT_METADATA_KEYS: frozenset[str] = frozenset(
 def _union_member_tables(members: list[SourceInfo]) -> list[TableInfo]:
     """Union the tables across all members of a collapsed group, by name.
 
-    A collapsed spec must cover every table any tenant has (FR Q2): if
+    A collapsed spec must cover every table any tenant has: if
     tenant A has a table tenant B lacks, the table still gets an asset; the
     partition for a tenant missing it simply no-ops at ``rocky run`` time.
     First occurrence of each name wins (stable order by first appearance).
@@ -1534,7 +1534,7 @@ def _unique_collapsed_group_name(representative: SourceInfo, used: set[str]) -> 
 
 
 def _neutralize_tenant_metadata(spec: dg.AssetSpec) -> dg.AssetSpec:
-    """Drop per-tenant metadata keys from a collapsed spec (FR §4.2 n1).
+    """Drop per-tenant metadata keys from a collapsed spec.
 
     The spec is built from one representative member, so ``source_id`` /
     ``last_sync_at`` / ``row_count`` reflect that single tenant. Removing

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -265,6 +265,9 @@ class _GroupBuild:
     partitions_def: dg.PartitionsDefinition | None = None
     tenant_component: str | None = None
     partition_key_to_filter_value: dict[str, str] = field(default_factory=dict)
+    #: table name → collapsed asset key, the run-time fallback for engine
+    #: materialization keys whose tenant is not yet in the load-time map.
+    collapsed_key_by_table: dict[str, dg.AssetKey] = field(default_factory=dict)
 
 
 @dataclass
@@ -1499,6 +1502,29 @@ def _union_member_tables(members: list[SourceInfo]) -> list[TableInfo]:
     return tables
 
 
+def _unique_collapsed_group_name(representative: SourceInfo, used: set[str]) -> str:
+    """Return a unique op-name stem for a collapsed group.
+
+    Built from ``source_type`` + every (non-tenant) component value — i.e.
+    the collapsed asset-key prefix — so it is 1:1 with the group key, unlike
+    ``get_group_name`` (only the first string component), which collides
+    across groups that share that component and crashes the implicit
+    ``__ASSET_JOB`` on duplicate op names. ``used`` guards the residual
+    separator-collision edge by appending an index.
+    """
+    parts = [representative.source_type]
+    for value in representative.components.values():
+        parts.append("__".join(value) if isinstance(value, list) else str(value))
+    base = "_".join(parts)
+    name = base
+    suffix = 2
+    while name in used:
+        name = f"{base}_{suffix}"
+        suffix += 1
+    used.add(name)
+    return name
+
+
 def _neutralize_tenant_metadata(spec: dg.AssetSpec) -> dg.AssetSpec:
     """Drop per-tenant metadata keys from a collapsed spec (FR §4.2 n1).
 
@@ -1544,10 +1570,13 @@ def _build_collapsed_group_contexts(
     model_policies = model_policies or {}
     default_policy = freshness_policy_from_checks(discover.checks)
 
-    # Group by the frozen set of non-tenant components. Sorted items make
-    # the key deterministic regardless of dict ordering.
-    grouped: dict[tuple[tuple[str, str | tuple[str, ...]], ...], list[SourceInfo]] = defaultdict(
-        list
+    # Group by (source_type, non-tenant components). source_type MUST be in
+    # the key: the collapsed asset key is [source_type, *non_tenant, table],
+    # so two sources that share components but differ in source_type are
+    # genuinely distinct assets and must not collapse together. Sorted items
+    # make the key deterministic regardless of dict ordering.
+    grouped: dict[tuple[str, tuple[tuple[str, str | tuple[str, ...]], ...]], list[SourceInfo]] = (
+        defaultdict(list)
     )
     for source in discover.sources:
         tenant_value = source.components.get(tenant.component)
@@ -1561,15 +1590,22 @@ def _build_collapsed_group_contexts(
             )
             continue
         non_tenant = {k: v for k, v in source.components.items() if k != tenant.component}
-        group_key = tuple(
+        component_key = tuple(
             sorted((k, tuple(v) if isinstance(v, list) else v) for k, v in non_tenant.items())
         )
-        grouped[group_key].append(source)
+        grouped[(source.source_type, component_key)].append(source)
 
+    # Op names must be unique across the location: the implicit __ASSET_JOB
+    # rejects two ops with the same name. The default path keys groups *by*
+    # get_group_name (unique by construction), but the collapse keys by the
+    # full (source_type, non-tenant) tuple — get_group_name (first string
+    # component) is NOT unique across those, so derive a name from the whole
+    # group key and disambiguate defensively.
+    used_names: set[str] = set()
     groups: list[_GroupBuild] = []
     for members in grouped.values():
         representative = strip_tenant_component(members[0], tenant.component)
-        group = _GroupBuild(name=translator.get_group_name(representative))
+        group = _GroupBuild(name=_unique_collapsed_group_name(representative, used_names))
         group.partitions_def = partitions_def
         group.tenant_component = tenant.component
         group.source_ids = {m.id for m in members}
@@ -1581,7 +1617,23 @@ def _build_collapsed_group_contexts(
         for member in members:
             raw_value = member.components[tenant.component]
             assert isinstance(raw_value, str)  # guarded above
-            partition_key = translator.get_partition_key(member) or raw_value
+            override = translator.get_partition_key(member)
+            partition_key = raw_value if override is None else override
+            existing = group.partition_key_to_filter_value.get(partition_key)
+            if existing is not None and existing != raw_value:
+                # A custom get_partition_key folded two distinct catalogs onto
+                # one key — the second would silently shadow the first and make
+                # its catalog unreachable. Surface it instead of dropping data.
+                _log.warning(
+                    "Tenant collapse: partition key %r maps to multiple catalog "
+                    "values (%r and %r); get_partition_key must be 1:1 with the "
+                    "tenant component. Keeping %r.",
+                    partition_key,
+                    existing,
+                    raw_value,
+                    existing,
+                )
+                continue
             group.partition_key_to_filter_value[partition_key] = raw_value
 
         seen_keys: set[dg.AssetKey] = set()
@@ -1609,6 +1661,11 @@ def _build_collapsed_group_contexts(
             seen_keys.add(spec.key)
             group.specs.append(spec)
             spec_key_by_table[table.name] = spec.key
+
+        # Run-time fallback for a tenant the sensor added after the last state
+        # refresh (absent from the with-tenant map below): table-name leaf →
+        # collapsed key. Unique per table within a group, so unambiguous.
+        group.collapsed_key_by_table = dict(spec_key_by_table)
 
         # Map every member's WITH-tenant native key back to the collapsed
         # spec key. The engine runs the *real* (un-collapsed) source under
@@ -1703,12 +1760,20 @@ def _build_check_specs(
 
     When ``partitions_def`` is provided, every emitted check spec is
     partitioned by it. This is the tenant-as-partition path: with the
-    collapsed asset's tenant ``DynamicPartitionsDefinition`` attached,
-    check verdicts are recorded per partition (per tenant) instead of
-    collapsing to one last-writer-wins result on the shared
-    ``(asset_key, check_name)``. Must equal the collapsed asset's
-    ``partitions_def`` (Dagster enforces the match). Defaults to ``None``
-    — the unpartitioned, byte-identical-to-prior path.
+    collapsed asset's tenant ``DynamicPartitionsDefinition`` attached, each
+    check *evaluation* is recorded against its tenant partition, so the
+    per-partition execution **history** (``get_asset_check_execution_history``
+    with a partition filter) retains a distinct verdict per tenant rather
+    than the unpartitioned shared ``(asset_key, check_name)`` row.
+
+    Caveat (Dagster 1.13.x): ``AssetCheckSpec(partitions_def=...)`` is a
+    **preview** API, and the *latest/summary* status that drives the UI
+    check badge (``AssetCheckSummaryRecord``) is still last-writer-wins
+    across partitions — only the raw history is per-partition. In-run
+    blocking-check gating is unaffected (it reads the yielded result, not
+    storage). Must equal the collapsed asset's ``partitions_def`` (Dagster
+    enforces the match). Defaults to ``None`` — the unpartitioned,
+    byte-identical-to-prior path.
     """
     contract_rules_by_model = contract_rules_by_model or {}
     specs: list[dg.AssetCheckSpec] = []
@@ -2059,6 +2124,7 @@ def _make_rocky_asset(
                 selected_keys=selected_keys,
                 rocky_key_to_dagster_key=group.rocky_key_to_dagster_key,
                 extra_yielded_checks=compliance_yielded,
+                collapsed_key_by_table=group.collapsed_key_by_table or None,
             )
 
             # If a filter surfaced the Fivetran-storm signal, raise the
@@ -2424,6 +2490,7 @@ def _emit_results(
     selected_keys: set[dg.AssetKey],
     rocky_key_to_dagster_key: dict[tuple[str, ...], dg.AssetKey],
     extra_yielded_checks: set[tuple[dg.AssetKey, str]] | None = None,
+    collapsed_key_by_table: dict[str, dg.AssetKey] | None = None,
 ) -> Iterator[dg.MaterializeResult | dg.AssetCheckResult | dg.AssetObservation]:
     """Yield Dagster events for every materialization, check, drift event and anomaly.
 
@@ -2451,7 +2518,22 @@ def _emit_results(
     """
 
     def remap(raw_key: list[str]) -> dg.AssetKey:
-        return rocky_key_to_dagster_key.get(tuple(raw_key)) or dg.AssetKey(raw_key)
+        exact = rocky_key_to_dagster_key.get(tuple(raw_key))
+        if exact is not None:
+            return exact
+        # Tenant-collapse fallback: the engine emits keys WITH the tenant
+        # component, and the load-time map is built from cached discover
+        # state — so a tenant the sensor added *after* the last state refresh
+        # (the self-service-onboarding flow) is absent from the map and its
+        # materialization would otherwise be dropped. Within a collapsed
+        # group the table-name leaf is 1:1 with the collapsed key, so fall
+        # back to it. Only collapsed groups pass this map; the default path
+        # is unchanged.
+        if collapsed_key_by_table and raw_key:
+            collapsed = collapsed_key_by_table.get(raw_key[-1])
+            if collapsed is not None:
+                return collapsed
+        return dg.AssetKey(raw_key)
 
     selected_resolver = _build_table_resolver(rocky_key_to_dagster_key, selected_keys)
 

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -1585,6 +1585,7 @@ def _build_collapsed_group_contexts(
             group.partition_key_to_filter_value[partition_key] = raw_value
 
         seen_keys: set[dg.AssetKey] = set()
+        spec_key_by_table: dict[str, dg.AssetKey] = {}
         for table in _union_member_tables(members):
             policy = model_policies.get(table.name, default_policy)
             spec = _build_asset_spec(
@@ -1607,7 +1608,25 @@ def _build_collapsed_group_contexts(
                 continue
             seen_keys.add(spec.key)
             group.specs.append(spec)
-            group.rocky_key_to_dagster_key[_native_rocky_key(representative, table.name)] = spec.key
+            spec_key_by_table[table.name] = spec.key
+
+        # Map every member's WITH-tenant native key back to the collapsed
+        # spec key. The engine runs the *real* (un-collapsed) source under
+        # `rocky run --filter {component}={tenant}`, so its materialization
+        # keys always carry the tenant component
+        # (``[source_type, *components-incl-tenant, table]``). _emit_results
+        # remaps those engine keys via this map — registering the stripped
+        # representative key alone would miss every per-tenant
+        # materialization and silently drop it. One entry per (member,
+        # table) → the shared collapsed spec key; at run time only the
+        # active partition's keys are emitted.
+        for member in members:
+            for member_table in member.tables:
+                spec_key = spec_key_by_table.get(member_table.name)
+                if spec_key is not None:
+                    group.rocky_key_to_dagster_key[_native_rocky_key(member, member_table.name)] = (
+                        spec_key
+                    )
         groups.append(group)
 
     return groups

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -71,7 +71,7 @@ from .observability import (
 )
 from .resource import DEFAULT_TIMEOUT_SECONDS, Resolver, RockyResource
 from .sensor import rocky_source_sensor
-from .translator import RockyDagsterTranslator
+from .translator import RockyDagsterTranslator, strip_tenant_component
 from .types import (
     CompileResult,
     DagResult,
@@ -1202,6 +1202,14 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                     translator=translator,
                     name=f"rocky_source_sensor_{_safe_asset_name(self.config_path)}",
                     minimum_interval_seconds=self.sensor_interval_seconds,
+                    # Tenant-as-partition mode: when configured, the sensor
+                    # adds new tenant values to the partition set and emits
+                    # one partitioned RunRequest per triggered source.
+                    tenant_component=self.tenant.component if self.tenant else None,
+                    tenant_partitions_name=(self.tenant.partitions_name if self.tenant else None),
+                    sync_partitions_from_discover=(
+                        self.tenant.sync_partitions_from_discover if self.tenant else True
+                    ),
                 )
             )
 
@@ -1473,18 +1481,6 @@ _PER_TENANT_METADATA_KEYS: frozenset[str] = frozenset(
 )
 
 
-def _strip_tenant_component(source: SourceInfo, tenant_component: str) -> SourceInfo:
-    """Return a copy of ``source`` with the tenant component removed.
-
-    The collapsed key/group/tags fall out of the *stock* translator with
-    no API change: every translator method reads ``source.components``, so
-    dropping the tenant entry yields ``[source_type, *non_tenant, table]``
-    and omits the per-tenant ``rocky/{component}`` tag automatically.
-    """
-    remaining = {k: v for k, v in source.components.items() if k != tenant_component}
-    return source.model_copy(update={"components": remaining})
-
-
 def _union_member_tables(members: list[SourceInfo]) -> list[TableInfo]:
     """Union the tables across all members of a collapsed group, by name.
 
@@ -1572,7 +1568,7 @@ def _build_collapsed_group_contexts(
 
     groups: list[_GroupBuild] = []
     for members in grouped.values():
-        representative = _strip_tenant_component(members[0], tenant.component)
+        representative = strip_tenant_component(members[0], tenant.component)
         group = _GroupBuild(name=translator.get_group_name(representative))
         group.partitions_def = partitions_def
         group.tenant_component = tenant.component

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -243,6 +243,16 @@ class _GroupBuild:
     A "group" is the unit of execution: one Dagster ``multi_asset`` per
     Rocky group (typically tenant/client). The group bundles every spec,
     every source id and the filter that materializes them.
+
+    Tenant-as-partition collapse (when ``RockyComponent.tenant`` is set):
+    a group instead bundles the sources that differ *only* by the tenant
+    component, collapsed into one partitioned spec per
+    ``(non-tenant components, table)``. The extra fields below carry the
+    tenant ``PartitionsDefinition``, the tenant component name, and a
+    ``partition_key → original filter value`` map so the execution
+    ``--filter`` always targets the right per-tenant catalog even if a
+    custom :meth:`RockyDagsterTranslator.get_partition_key` canonicalises
+    the key. They are unset (``None`` / empty) on the default path.
     """
 
     name: str
@@ -251,6 +261,10 @@ class _GroupBuild:
     filter: str = ""
     key_to_source_id: dict[dg.AssetKey, str] = field(default_factory=dict)
     rocky_key_to_dagster_key: dict[tuple[str, ...], dg.AssetKey] = field(default_factory=dict)
+    # Tenant-as-partition collapse fields (default path leaves these unset).
+    partitions_def: dg.PartitionsDefinition | None = None
+    tenant_component: str | None = None
+    partition_key_to_filter_value: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -302,6 +316,37 @@ def _reject_resolver_callable_in_yaml(field_name: str, value: object) -> None:
             config_value=value,
         )
     return None
+
+
+class TenantConfig(dg.Model, dg.Resolvable):
+    """Declares one source component as the *tenant axis* for the
+    tenant-as-partition collapse.
+
+    When set on :attr:`RockyComponent.tenant`, sources that differ *only*
+    by ``component`` are collapsed into one client-agnostic
+    ``AssetSpec`` (+ ``AssetCheckSpec``) per ``(non-tenant components,
+    table)``, partitioned by a :class:`dagster.DynamicPartitionsDefinition`
+    whose keys are the tenant values. This removes the
+    ``O(tenants × connectors × tables)`` asset-spec growth that OOMs the
+    code-server snapshot, while keeping per-tenant physical isolation
+    (each partition still materialises via ``rocky run --filter
+    {component}={partition_key}`` into that tenant's own catalog).
+
+    Attributes:
+        component: Which ``source.components`` key is the tenant axis
+            (e.g. ``"client"``).
+        partitions_name: Name of the ``DynamicPartitionsDefinition`` that
+            holds the tenant values. Reused across the location, so pick a
+            stable, unique name (e.g. ``"rocky_clients"``).
+        sync_partitions_from_discover: When ``True`` (default), the
+            component's sensor adds newly-discovered tenant values to the
+            partition set on each tick (via ``dynamic_partitions_requests``).
+            Set ``False`` to manage the partition set out-of-band.
+    """
+
+    component: str
+    partitions_name: str
+    sync_partitions_from_discover: bool = True
 
 
 class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
@@ -586,6 +631,15 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #: who rely on "best-effort load with empty graph" as their failure
     #: mode.
     strict_build: bool = False
+    #: Opt-in tenant-as-partition collapse. When set, sources that differ
+    #: only by the named tenant component are collapsed into one
+    #: partitioned ``AssetSpec`` (+ ``AssetCheckSpec``) per
+    #: ``(non-tenant components, table)``, partitioned by a
+    #: ``DynamicPartitionsDefinition`` of tenant values — removing the
+    #: ``O(tenants)`` asset-spec growth that OOMs the code-server snapshot.
+    #: ``None`` (default) is byte-identical to today's one-spec-per-source
+    #: behaviour. See :class:`TenantConfig`.
+    tenant: TenantConfig | None = None
 
     @property
     def defs_state_config(self) -> DefsStateConfig:
@@ -1045,12 +1099,29 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
         # `[checks.freshness]` is the fallback for everything else.
         model_policies = per_model_freshness_policies(compile_result)
 
-        groups = _build_group_contexts(
-            discover,
-            translator,
-            model_policies,
-            translation=self.translation,
-        )
+        # Tenant-as-partition collapse (opt-in). When configured, sources
+        # differing only by the tenant component collapse into one
+        # partitioned spec per (non-tenant components, table); the tenant
+        # value becomes a DynamicPartitionsDefinition key. Otherwise the
+        # default one-spec-per-source path runs unchanged.
+        tenant_partitions_def: dg.DynamicPartitionsDefinition | None = None
+        if self.tenant is not None:
+            tenant_partitions_def = dg.DynamicPartitionsDefinition(name=self.tenant.partitions_name)
+            groups = _build_collapsed_group_contexts(
+                discover,
+                translator,
+                self.tenant,
+                tenant_partitions_def,
+                model_policies,
+                translation=self.translation,
+            )
+        else:
+            groups = _build_group_contexts(
+                discover,
+                translator,
+                model_policies,
+                translation=self.translation,
+            )
 
         # Optimize metadata — merged into AssetSpec.metadata at load time
         # when surface_optimize_metadata=True. The model_to_key map is
@@ -1081,6 +1152,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
             groups,
             contract_rules_by_model,
             surface_compliance=self.surface_compliance,
+            partitions_def=tenant_partitions_def,
         )
 
         assets: list[dg.AssetsDefinition] = [
@@ -1381,6 +1453,168 @@ def _build_group_contexts(
             group.rocky_key_to_dagster_key[_native_rocky_key(source, table.name)] = spec.key
 
     return list(groups.values())
+
+
+# ---------------------------------------------------------------------------
+# Tenant-as-partition collapse
+# ---------------------------------------------------------------------------
+
+#: Per-tenant metadata keys that are meaningless on a collapsed (client-
+#: agnostic) spec — they describe one arbitrary member source, not the
+#: union. Stripped from the collapsed spec so the asset never advertises a
+#: single tenant's id / sync time / row count as if it were the whole.
+_PER_TENANT_METADATA_KEYS: frozenset[str] = frozenset(
+    {
+        "source_id",
+        "last_sync_at",
+        "row_count",
+        "dagster-rocky/source_id",
+    }
+)
+
+
+def _strip_tenant_component(source: SourceInfo, tenant_component: str) -> SourceInfo:
+    """Return a copy of ``source`` with the tenant component removed.
+
+    The collapsed key/group/tags fall out of the *stock* translator with
+    no API change: every translator method reads ``source.components``, so
+    dropping the tenant entry yields ``[source_type, *non_tenant, table]``
+    and omits the per-tenant ``rocky/{component}`` tag automatically.
+    """
+    remaining = {k: v for k, v in source.components.items() if k != tenant_component}
+    return source.model_copy(update={"components": remaining})
+
+
+def _union_member_tables(members: list[SourceInfo]) -> list[TableInfo]:
+    """Union the tables across all members of a collapsed group, by name.
+
+    A collapsed spec must cover every table any tenant has (FR Q2): if
+    tenant A has a table tenant B lacks, the table still gets an asset; the
+    partition for a tenant missing it simply no-ops at ``rocky run`` time.
+    First occurrence of each name wins (stable order by first appearance).
+    """
+    seen: set[str] = set()
+    tables: list[TableInfo] = []
+    for member in members:
+        for table in member.tables:
+            if table.name not in seen:
+                seen.add(table.name)
+                tables.append(table)
+    return tables
+
+
+def _neutralize_tenant_metadata(spec: dg.AssetSpec) -> dg.AssetSpec:
+    """Drop per-tenant metadata keys from a collapsed spec (FR §4.2 n1).
+
+    The spec is built from one representative member, so ``source_id`` /
+    ``last_sync_at`` / ``row_count`` reflect that single tenant. Removing
+    them prevents the collapsed asset from advertising one tenant's values
+    as the whole. ``source_type`` (shared across tenants) is retained.
+    """
+    if not spec.metadata:
+        return spec
+    cleaned = {k: v for k, v in spec.metadata.items() if k not in _PER_TENANT_METADATA_KEYS}
+    if len(cleaned) == len(spec.metadata):
+        return spec
+    return spec.replace_attributes(metadata=cleaned)
+
+
+def _build_collapsed_group_contexts(
+    discover: DiscoverResult,
+    translator: RockyDagsterTranslator,
+    tenant: TenantConfig,
+    partitions_def: dg.PartitionsDefinition,
+    model_policies: dict[str, dg.FreshnessPolicy] | None = None,
+    *,
+    translation: TranslationFn[RockyTableProps] | None = None,
+) -> list[_GroupBuild]:
+    """Collapse sources differing only by the tenant component.
+
+    Groups discovered sources by *every component except* the tenant axis,
+    and emits **one partitioned spec per ``(non-tenant components, table)``**
+    instead of one spec per ``(tenant, …, table)``. The tenant value
+    becomes a Dagster partition key (on ``partitions_def``); execution
+    routes it back to ``--filter {component}={value}`` via
+    :attr:`_GroupBuild.partition_key_to_filter_value`.
+
+    Distinct from :func:`_build_group_contexts` on purpose: that path's
+    per-source ``seen_keys`` de-dup would treat the intended N-sources →
+    1-key collapse as N−1 "duplicate discover records" and warn/drop them.
+
+    Sources that lack the tenant component, or whose tenant value is not a
+    scalar string, are skipped (logged) — they cannot be placed on the
+    tenant partition axis.
+    """
+    model_policies = model_policies or {}
+    default_policy = freshness_policy_from_checks(discover.checks)
+
+    # Group by the frozen set of non-tenant components. Sorted items make
+    # the key deterministic regardless of dict ordering.
+    grouped: dict[tuple[tuple[str, str | tuple[str, ...]], ...], list[SourceInfo]] = defaultdict(
+        list
+    )
+    for source in discover.sources:
+        tenant_value = source.components.get(tenant.component)
+        if not isinstance(tenant_value, str):
+            _log.warning(
+                "Tenant collapse: skipping source id=%s — tenant component %r is %s "
+                "(expected a scalar string).",
+                source.id,
+                tenant.component,
+                "missing" if tenant_value is None else "list-valued",
+            )
+            continue
+        non_tenant = {k: v for k, v in source.components.items() if k != tenant.component}
+        group_key = tuple(
+            sorted((k, tuple(v) if isinstance(v, list) else v) for k, v in non_tenant.items())
+        )
+        grouped[group_key].append(source)
+
+    groups: list[_GroupBuild] = []
+    for members in grouped.values():
+        representative = _strip_tenant_component(members[0], tenant.component)
+        group = _GroupBuild(name=translator.get_group_name(representative))
+        group.partitions_def = partitions_def
+        group.tenant_component = tenant.component
+        group.source_ids = {m.id for m in members}
+
+        # Single chokepoint for the tenant key: translator.get_partition_key
+        # (default None → raw component value). Map each key back to the raw
+        # component value so --filter targets the real per-tenant catalog
+        # even if a custom hook canonicalises the key.
+        for member in members:
+            raw_value = member.components[tenant.component]
+            assert isinstance(raw_value, str)  # guarded above
+            partition_key = translator.get_partition_key(member) or raw_value
+            group.partition_key_to_filter_value[partition_key] = raw_value
+
+        seen_keys: set[dg.AssetKey] = set()
+        for table in _union_member_tables(members):
+            policy = model_policies.get(table.name, default_policy)
+            spec = _build_asset_spec(
+                representative,
+                table,
+                translator,
+                policy,
+                translation=translation,
+            )
+            spec = _neutralize_tenant_metadata(spec)
+            spec = spec.replace_attributes(partitions_def=partitions_def)
+            if spec.key in seen_keys:
+                # Two non-tenant tables collapsing to the same key — keep
+                # the first, as the non-collapsed path does.
+                _log.warning(
+                    "Tenant collapse: dropping duplicate collapsed key %s (table=%s).",
+                    spec.key.to_user_string(),
+                    table.name,
+                )
+                continue
+            seen_keys.add(spec.key)
+            group.specs.append(spec)
+            group.rocky_key_to_dagster_key[_native_rocky_key(representative, table.name)] = spec.key
+        groups.append(group)
+
+    return groups
 
 
 def _build_asset_spec(
@@ -1712,12 +1946,19 @@ def _make_rocky_asset(
         specs=group.specs,
         check_specs=check_specs,
         can_subset=True,
+        partitions_def=group.partitions_def,
     )
     def _asset(context):
         _log_compile_diagnostics(context, compile_state)
 
         selected_keys = set(context.selected_asset_keys)
-        filters = _select_filters(group, selected_keys, context)
+        # Tenant-collapsed groups derive their filter from the run's tenant
+        # partition key (→ that tenant's own catalog); the default path
+        # uses the group / per-source filter.
+        if group.partitions_def is not None and group.tenant_component is not None:
+            filters = _tenant_partition_filters(group, context)
+        else:
+            filters = _select_filters(group, selected_keys, context)
 
         # Governance events (Waves B + C-2, opt-in). Collected first so
         # the compliance check pairs can be passed into ``_emit_results``
@@ -1991,6 +2232,42 @@ def _select_filters(
         f"selected for group '{group.name}'"
     )
     return [f"id={sid}" for sid in sorted(needed_source_ids)]
+
+
+def _tenant_partition_filters(
+    group: _GroupBuild,
+    context: dg.AssetExecutionContext,
+) -> list[str]:
+    """Build the per-tenant ``--filter`` for a collapsed, partitioned run.
+
+    Maps the run's tenant partition key back to the original component
+    value (via :attr:`_GroupBuild.partition_key_to_filter_value`, falling
+    back to the key itself for the clean no-canonicalisation case) and
+    returns ``["{tenant_component}={value}"]`` — scoping ``rocky run`` to
+    that one tenant's catalog, preserving physical isolation.
+
+    Each partition materialises in its own run (Dagster's default
+    multi-run backfill), so exactly one partition key is present.
+    ``BackfillPolicy.single_run()`` (a partition *range* in one run) is
+    rejected: a single ``--filter`` value cannot span tenant catalogs.
+    """
+    if not context.has_partition_key:
+        raise dg.Failure(
+            description=(
+                "Tenant-collapsed Rocky asset materialised without a single partition "
+                "key. Tenant partitions require one run per tenant — select a tenant "
+                "partition or run a per-partition (multi-run) backfill. "
+                "BackfillPolicy.single_run() is not supported: one --filter value "
+                "cannot target multiple tenant catalogs."
+            ),
+        )
+    partition_key = context.partition_key
+    filter_value = group.partition_key_to_filter_value.get(partition_key, partition_key)
+    assert group.tenant_component is not None  # set whenever partitions_def is
+    context.log.info(
+        f"Tenant partition '{partition_key}' → --filter {group.tenant_component}={filter_value}"
+    )
+    return [f"{group.tenant_component}={filter_value}"]
 
 
 def _run_filters(

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -173,6 +173,8 @@ def _parse_contract_rules(path: Path) -> ContractRules:
 def contract_check_specs_for_model(
     asset_key: dg.AssetKey,
     rules: ContractRules,
+    *,
+    partitions_def: dg.PartitionsDefinition | None = None,
 ) -> Iterator[dg.AssetCheckSpec]:
     """Yield one ``AssetCheckSpec`` per rule kind present in the contract.
 
@@ -183,6 +185,15 @@ def contract_check_specs_for_model(
     Args:
         asset_key: The Dagster asset key the checks belong to.
         rules: ContractRules describing which rule kinds are present.
+        partitions_def: Optional ``PartitionsDefinition`` to attach to each
+            emitted check spec. Must equal the ``partitions_def`` of the
+            asset the checks target (Dagster enforces this — see
+            :class:`dagster.AssetCheckSpec`). When set to a tenant
+            ``DynamicPartitionsDefinition``, check verdicts are recorded
+            and queryable per partition (per tenant) rather than collapsing
+            to a single last-writer-wins result. Defaults to ``None``
+            (unpartitioned check), which is byte-identical to prior
+            behaviour.
 
     Yields:
         ``dg.AssetCheckSpec`` instances. Empty when ``rules.is_empty``.
@@ -192,12 +203,14 @@ def contract_check_specs_for_model(
             name=CONTRACT_REQUIRED_COLUMNS_CHECK,
             asset=asset_key,
             description="Required columns from .contract.toml are present in model output",
+            partitions_def=partitions_def,
         )
     if rules.has_protected:
         yield dg.AssetCheckSpec(
             name=CONTRACT_PROTECTED_COLUMNS_CHECK,
             asset=asset_key,
             description="Protected columns from .contract.toml have not been removed",
+            partitions_def=partitions_def,
         )
     if rules.has_column_constraints:
         yield dg.AssetCheckSpec(
@@ -206,6 +219,7 @@ def contract_check_specs_for_model(
             description=(
                 "Column types and nullability constraints from .contract.toml are satisfied"
             ),
+            partitions_def=partitions_def,
         )
 
 

--- a/integrations/dagster/src/dagster_rocky/contracts.py
+++ b/integrations/dagster/src/dagster_rocky/contracts.py
@@ -189,11 +189,13 @@ def contract_check_specs_for_model(
             emitted check spec. Must equal the ``partitions_def`` of the
             asset the checks target (Dagster enforces this — see
             :class:`dagster.AssetCheckSpec`). When set to a tenant
-            ``DynamicPartitionsDefinition``, check verdicts are recorded
-            and queryable per partition (per tenant) rather than collapsing
-            to a single last-writer-wins result. Defaults to ``None``
-            (unpartitioned check), which is byte-identical to prior
-            behaviour.
+            ``DynamicPartitionsDefinition``, each check evaluation is
+            recorded against its tenant partition, so the per-partition
+            execution *history* retains a distinct verdict per tenant.
+            Note (Dagster 1.13.x): this is a **preview** API and the UI
+            summary/badge status remains last-writer-wins across partitions
+            — only the raw history is per-partition. Defaults to ``None``
+            (unpartitioned check), byte-identical to prior behaviour.
 
     Yields:
         ``dg.AssetCheckSpec`` instances. Empty when ``rules.is_empty``.

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -270,7 +270,7 @@ def rocky_source_sensor(
         # processed). Supersedes per_source/per_group granularity.
         dynamic_partitions_requests: list[dg.AddDynamicPartitionsRequest] = []
         if tenant_component is not None and tenant_partitions_name is not None:
-            request_pairs, dynamic_partitions_requests = _tenant_request_pairs(
+            request_pairs, dynamic_partitions_requests, skipped_ids = _tenant_request_pairs(
                 triggered,
                 translator,
                 tenant_component=tenant_component,
@@ -278,6 +278,15 @@ def rocky_source_sensor(
                 sync_partitions=sync_partitions_from_discover,
                 context=context,
             )
+            # Roll back the cursor for sources we did NOT emit (skipped because
+            # their partition doesn't exist yet under sync-off, or a non-scalar
+            # tenant). Advancing their cursor would silently drop this sync —
+            # the source would not re-fire until a strictly-newer last_sync_at.
+            for sid in skipped_ids:
+                if sid in cursor_data:
+                    new_cursor[sid] = cursor_data[sid]
+                else:
+                    new_cursor.pop(sid, None)
         elif granularity == "per_source":
             request_pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = [
                 (_per_source_request(source, translator), (source,)) for source in triggered
@@ -463,6 +472,7 @@ def _tenant_request_pairs(
 ) -> tuple[
     list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]],
     list[dg.AddDynamicPartitionsRequest],
+    set[str],
 ]:
     """Build tenant-partition ``RunRequest``s + the dynamic-partition adds.
 
@@ -473,11 +483,16 @@ def _tenant_request_pairs(
     the run requests) when ``sync_partitions`` is on; when off, sources
     whose partition does not yet exist are skipped (the partition set is
     managed out-of-band).
+
+    Returns ``(request_pairs, add_requests, skipped_source_ids)``. The
+    caller MUST NOT advance the cursor for ``skipped_source_ids`` — those
+    sources emitted no run, so advancing would silently drop the sync.
     """
     existing = set(context.instance.get_dynamic_partitions(tenant_partitions_name))
     pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = []
     keys_to_add: list[str] = []
     queued_new: set[str] = set()
+    skipped_ids: set[str] = set()
 
     for source in triggered:
         raw_value = source.components.get(tenant_component)
@@ -487,8 +502,10 @@ def _tenant_request_pairs(
                 f"tenant component {tenant_component!r} is "
                 f"{'missing' if raw_value is None else 'list-valued'}."
             )
+            skipped_ids.add(source.id)
             continue
-        partition_key = translator.get_partition_key(source) or raw_value
+        override = translator.get_partition_key(source)
+        partition_key = raw_value if override is None else override
         is_known = partition_key in existing or partition_key in queued_new
         if not is_known:
             if not sync_partitions:
@@ -497,6 +514,7 @@ def _tenant_request_pairs(
                     f"'{tenant_partitions_name}' and sync_partitions_from_discover is off — "
                     f"skipping source id={source.id}."
                 )
+                skipped_ids.add(source.id)
                 continue
             keys_to_add.append(partition_key)
             queued_new.add(partition_key)
@@ -514,4 +532,4 @@ def _tenant_request_pairs(
                 keys_to_add
             )
         )
-    return pairs, add_requests
+    return pairs, add_requests, skipped_ids

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Literal, NamedTuple
 import dagster as dg
 
 from .resource import RockyResource
-from .translator import RockyDagsterTranslator
+from .translator import RockyDagsterTranslator, strip_tenant_component
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
@@ -116,6 +116,9 @@ def rocky_source_sensor(
     on_run_request_emitted: Callable[[EmitContext], None] | None = None,
     on_failed_sources: Callable[[FailedSourcesContext], None] | None = None,
     on_skip: Callable[[SkipContext], None] | None = None,
+    tenant_component: str | None = None,
+    tenant_partitions_name: str | None = None,
+    sync_partitions_from_discover: bool = True,
 ) -> dg.SensorDefinition:
     """Build a Dagster sensor that watches Rocky sources for new syncs.
 
@@ -259,7 +262,23 @@ def rocky_source_sensor(
                 skip_reason=dg.SkipReason(skip_reason),
             )
 
-        if granularity == "per_source":
+        # Tenant-as-partition mode: one RunRequest per triggered source,
+        # carrying the tenant partition key + the collapsed (tenant-agnostic)
+        # asset selection, and adding any newly-seen tenant values to the
+        # DynamicPartitionsDefinition in the same SensorResult (so a
+        # brand-new tenant self-heals: the add applies before its run is
+        # processed). Supersedes per_source/per_group granularity.
+        dynamic_partitions_requests: list[dg.AddDynamicPartitionsRequest] = []
+        if tenant_component is not None and tenant_partitions_name is not None:
+            request_pairs, dynamic_partitions_requests = _tenant_request_pairs(
+                triggered,
+                translator,
+                tenant_component=tenant_component,
+                tenant_partitions_name=tenant_partitions_name,
+                sync_partitions=sync_partitions_from_discover,
+                context=context,
+            )
+        elif granularity == "per_source":
             request_pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = [
                 (_per_source_request(source, translator), (source,)) for source in triggered
             ]
@@ -326,6 +345,7 @@ def rocky_source_sensor(
         return dg.SensorResult(
             run_requests=run_requests,
             cursor=json.dumps(new_cursor),
+            dynamic_partitions_requests=dynamic_partitions_requests or None,
         )
 
     return _sensor
@@ -391,3 +411,107 @@ def _per_group_request_pairs(
             },
         )
         yield rr, tuple(sources)
+
+
+# ---------------------------------------------------------------------------
+# Tenant-as-partition mode
+# ---------------------------------------------------------------------------
+
+
+def _tenant_partition_request(
+    source: SourceInfo,
+    translator: RockyDagsterTranslator,
+    tenant_component: str,
+    partition_key: str,
+) -> dg.RunRequest:
+    """Build one ``RunRequest`` materialising a tenant partition of the
+    collapsed asset.
+
+    ``asset_selection`` is the *collapsed* (tenant-agnostic) keys for this
+    source's tables — derived via :func:`strip_tenant_component` + the stock
+    translator, the same path the component uses to build the specs, so the
+    selection always lines up. ``partition_key`` carries the tenant; the raw
+    tenant value is also stamped as a ``rocky/{component}`` run tag, and the
+    execution body re-derives ``--filter {component}={value}`` from the
+    partition key, so governance resolvers keyed on the run (tag or
+    ``--filter``) keep working.
+    """
+    stripped = strip_tenant_component(source, tenant_component)
+    asset_keys = [translator.get_asset_key(stripped, table) for table in source.tables]
+    sync_iso = source.last_sync_at.isoformat() if source.last_sync_at else ""
+    raw_value = source.components[tenant_component]
+    return dg.RunRequest(
+        run_key=f"{source.id}-{sync_iso}",
+        asset_selection=asset_keys,
+        partition_key=partition_key,
+        tags={
+            f"rocky/{tenant_component}": str(raw_value),
+            "rocky/source_id": source.id,
+            "rocky/sync_at": sync_iso,
+        },
+    )
+
+
+def _tenant_request_pairs(
+    triggered: Sequence[SourceInfo],
+    translator: RockyDagsterTranslator,
+    *,
+    tenant_component: str,
+    tenant_partitions_name: str,
+    sync_partitions: bool,
+    context: dg.SensorEvaluationContext,
+) -> tuple[
+    list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]],
+    list[dg.AddDynamicPartitionsRequest],
+]:
+    """Build tenant-partition ``RunRequest``s + the dynamic-partition adds.
+
+    For each triggered source, derives the tenant partition key via the
+    single chokepoint (:meth:`RockyDagsterTranslator.get_partition_key`,
+    default = raw component value). Newly-seen keys are batched into one
+    :class:`dagster.AddDynamicPartitionsRequest` (applied atomically with
+    the run requests) when ``sync_partitions`` is on; when off, sources
+    whose partition does not yet exist are skipped (the partition set is
+    managed out-of-band).
+    """
+    existing = set(context.instance.get_dynamic_partitions(tenant_partitions_name))
+    pairs: list[tuple[dg.RunRequest, tuple[SourceInfo, ...]]] = []
+    keys_to_add: list[str] = []
+    queued_new: set[str] = set()
+
+    for source in triggered:
+        raw_value = source.components.get(tenant_component)
+        if not isinstance(raw_value, str):
+            context.log.warning(
+                f"rocky_source_sensor (tenant mode): skipping source id={source.id} — "
+                f"tenant component {tenant_component!r} is "
+                f"{'missing' if raw_value is None else 'list-valued'}."
+            )
+            continue
+        partition_key = translator.get_partition_key(source) or raw_value
+        is_known = partition_key in existing or partition_key in queued_new
+        if not is_known:
+            if not sync_partitions:
+                context.log.warning(
+                    f"rocky_source_sensor (tenant mode): partition {partition_key!r} not in "
+                    f"'{tenant_partitions_name}' and sync_partitions_from_discover is off — "
+                    f"skipping source id={source.id}."
+                )
+                continue
+            keys_to_add.append(partition_key)
+            queued_new.add(partition_key)
+        pairs.append(
+            (
+                _tenant_partition_request(source, translator, tenant_component, partition_key),
+                (source,),
+            )
+        )
+
+    add_requests: list[dg.AddDynamicPartitionsRequest] = []
+    if keys_to_add:
+        add_requests.append(
+            dg.DynamicPartitionsDefinition(name=tenant_partitions_name).build_add_request(
+                keys_to_add
+            )
+        )
+    return pairs, add_requests

--- a/integrations/dagster/src/dagster_rocky/sensor.py
+++ b/integrations/dagster/src/dagster_rocky/sensor.py
@@ -180,6 +180,18 @@ def rocky_source_sensor(
     is_keyed = isinstance(rocky_resource, str)
     resource_keys: set[str] = {rocky_resource} if is_keyed else set()  # type: ignore[arg-type]
 
+    # Tenant mode needs BOTH the component and the partitions name. Reject a
+    # half-configured call at definition time rather than silently falling
+    # through to the per_source path and emitting unpartitioned RunRequests
+    # against a partitioned asset (which would fail confusingly at run time).
+    if (tenant_component is None) != (tenant_partitions_name is None):
+        raise ValueError(
+            "rocky_source_sensor tenant mode requires both tenant_component and "
+            "tenant_partitions_name, or neither — got "
+            f"tenant_component={tenant_component!r}, "
+            f"tenant_partitions_name={tenant_partitions_name!r}."
+        )
+
     if translator is None:
         translator = RockyDagsterTranslator()
 
@@ -346,9 +358,10 @@ def rocky_source_sensor(
                 except Exception:
                     context.log.warning("on_run_request_emitted hook raised", exc_info=True)
 
+        mode_label = "tenant" if tenant_component is not None else granularity
         context.log.info(
             f"rocky_source_sensor: {len(triggered)} source(s) triggered, "
-            f"emitting {len(run_requests)} run request(s) ({granularity})"
+            f"emitting {len(run_requests)} run request(s) ({mode_label})"
         )
 
         return dg.SensorResult(

--- a/integrations/dagster/src/dagster_rocky/translator.py
+++ b/integrations/dagster/src/dagster_rocky/translator.py
@@ -124,6 +124,33 @@ class RockyDagsterTranslator:
         """
         return []
 
+    def get_partition_key(self, source: SourceInfo) -> str | None:
+        """Returns the tenant partition key for a source, or ``None``.
+
+        Only consulted on the tenant-as-partition collapse path (when
+        ``RockyComponent.tenant`` is configured). It is the **single
+        chokepoint** for deriving a source's tenant partition key: the
+        component, the sensor (dynamic-partition sync + ``RunRequest``),
+        and the execution ``--filter`` all route through it, so a custom
+        derivation can never drift between "which partition" and "which
+        tenant gets materialized."
+
+        Default: ``None`` — meaning "use the raw value of the configured
+        tenant component verbatim" (the component supplies
+        ``source.components[tenant.component]``). Rocky's ``discover``
+        already emits component values as clean, lowercased SQL
+        identifiers, which are valid Dagster partition keys, so the raw
+        value is correct out of the box.
+
+        Override **only** when the raw component value is not a valid /
+        canonical partition key — e.g. to fold case variants onto a
+        canonical client code. If you do, the component keeps a
+        ``partition_key → original component value`` map so the execution
+        ``--filter`` still targets the real per-tenant catalog; your
+        returned key is what the partition set and ``RunRequest`` use.
+        """
+        return None
+
     # ------------------------------------------------------------------ #
     # Derived-model translation (T-derived-models)                       #
     # ------------------------------------------------------------------ #

--- a/integrations/dagster/src/dagster_rocky/translator.py
+++ b/integrations/dagster/src/dagster_rocky/translator.py
@@ -21,6 +21,22 @@ def _sanitize_key_part(s: str) -> str:
     return _INVALID_CHARS.sub("_", s)
 
 
+def strip_tenant_component(source: SourceInfo, tenant_component: str) -> SourceInfo:
+    """Return a copy of ``source`` with the tenant component removed.
+
+    Single source of truth for the tenant-as-partition collapse key shape:
+    the component (when building collapsed specs) and the sensor (when
+    selecting collapsed assets for a tenant partition) both derive keys by
+    calling the *stock* translator on the stripped source, so they can
+    never disagree on which collapsed asset a tenant maps to. Dropping the
+    tenant entry yields ``[source_type, *non_tenant, table]`` and omits the
+    per-tenant ``rocky/{component}`` tag automatically — no translator API
+    change required.
+    """
+    remaining = {k: v for k, v in source.components.items() if k != tenant_component}
+    return source.model_copy(update={"components": remaining})
+
+
 class RockyDagsterTranslator:
     """Translates Rocky source/table/model info into Dagster asset keys, tags, and groups.
 

--- a/integrations/dagster/tests/test_partitioned_checks.py
+++ b/integrations/dagster/tests/test_partitioned_checks.py
@@ -1,0 +1,155 @@
+"""Regression coverage for per-tenant (partitioned) asset checks under the
+tenant-as-partition collapse.  Drop into ``integrations/dagster/tests/`` in the FR PR.
+
+Two groups:
+
+GROUP B — behavioral guards, run TODAY (public Dagster APIs only):
+  * ``test_partitioned_check_specs_retain_per_partition_verdicts`` is the
+    TRIPWIRE for a PREVIEW feature. On dagster 1.13.8, setting ``partitions_def``
+    on an ``AssetCheckSpec`` is explicitly flagged: *"currently in preview, may
+    have breaking changes in patch version releases, not considered ready for
+    production use."* This test goes RED the moment a Dagster bump breaks
+    per-partition verdict retention — pin the patch and watch this.
+  * ``test_unpartitioned_collapsed_checks_clobber`` documents the GA default
+    (no preview): an unpartitioned collapsed check stores a single None-keyed
+    verdict, so per-tenant signal must come from the event axis (run tag +
+    result metadata), not the check badge.
+
+GROUP A — unit coverage for the dagster-rocky threading change (REVIEW §10,
+  Edits 1-2: ``_build_check_specs`` / ``contract_check_specs_for_model`` gain a
+  ``partitions_def`` kwarg). Skipped until that change lands; the skip MUST be
+  gone in the merged PR.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import dagster as dg
+import pytest
+from dagster import AssetCheckKey, AssetKey
+
+from dagster_rocky import DiscoverResult, SourceInfo, TableInfo
+from dagster_rocky.component import _build_check_specs, _build_group_contexts
+from dagster_rocky.contracts import ContractRules, contract_check_specs_for_model
+from dagster_rocky.translator import RockyDagsterTranslator
+
+# Activates GROUP A once Edits 1-2 add the `partitions_def` kwarg.
+_THREADED = "partitions_def" in inspect.signature(_build_check_specs).parameters
+requires_threading = pytest.mark.skipif(
+    not _THREADED, reason="Edits 1-2 (partitions_def threading) not yet applied — see REVIEW §10"
+)
+
+
+def _status(rec) -> str:
+    return str(rec.status).split(".")[-1]
+
+
+def _discover_two_tables() -> DiscoverResult:
+    return DiscoverResult(
+        version="0.3.0",
+        command="discover",
+        sources=[
+            SourceInfo(
+                id="src_001",
+                components={"tenant": "acme", "region": "us_west", "source": "shopify"},
+                source_type="fivetran",
+                tables=[TableInfo(name="orders"), TableInfo(name="payments")],
+            )
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# GROUP B — behavioral guards (run today)
+# --------------------------------------------------------------------------- #
+
+
+def _verdicts_for(*, partition_the_check: bool) -> dict[str | None, str]:
+    """Materialize a collapsed multi_asset over two tenant partitions and
+    return ``{partition: status}`` for its single row_count check."""
+    tenants = dg.DynamicPartitionsDefinition(name="tenants")
+    check_spec = dg.AssetCheckSpec(
+        name="row_count",
+        asset="collapsed_table",
+        partitions_def=tenants if partition_the_check else None,
+    )
+
+    @dg.multi_asset(
+        specs=[dg.AssetSpec("collapsed_table")],
+        check_specs=[check_spec],
+        partitions_def=tenants,
+        can_subset=True,
+    )
+    def collapsed(context):
+        pk = context.partition_key
+        yield dg.MaterializeResult(asset_key="collapsed_table")
+        yield dg.AssetCheckResult(
+            asset_key="collapsed_table", check_name="row_count", passed=(pk != "pepsi")
+        )
+
+    inst = dg.DagsterInstance.ephemeral()
+    inst.add_dynamic_partitions("tenants", ["coca_cola", "pepsi"])
+    for pk in ("coca_cola", "pepsi"):
+        assert dg.materialize([collapsed], partition_key=pk, instance=inst).success
+
+    ck = AssetCheckKey(AssetKey("collapsed_table"), "row_count")
+    recs = inst.event_log_storage.get_asset_check_execution_history(check_key=ck, limit=10)
+    return {rec.partition: _status(rec) for rec in recs}
+
+
+def test_partitioned_check_specs_retain_per_partition_verdicts():
+    """PREVIEW TRIPWIRE: partitioned check spec → distinct per-tenant verdicts.
+
+    This is the load-bearing assumption behind collapsing the check axis while
+    keeping native per-tenant DQ history. Relies on the preview
+    ``AssetCheckSpec(partitions_def=...)`` feature — if a Dagster patch breaks
+    it, this fails loudly instead of silently clobbering governance verdicts.
+    """
+    verdicts = _verdicts_for(partition_the_check=True)
+    assert verdicts == {"coca_cola": "SUCCEEDED", "pepsi": "FAILED"}
+
+
+def test_unpartitioned_collapsed_checks_clobber():
+    """GA default (no preview): an unpartitioned collapsed check keeps only a
+    single None-keyed verdict. Per-tenant signal must come from the event axis
+    (run tag + ``AssetCheckResult.metadata``), not the check itself."""
+    verdicts = _verdicts_for(partition_the_check=False)
+    assert set(verdicts) == {None}
+
+
+# --------------------------------------------------------------------------- #
+# GROUP A — threading unit tests (land with Edits 1-2)
+# --------------------------------------------------------------------------- #
+
+
+@requires_threading
+def test_build_check_specs_threads_partitions_def_to_every_spec():
+    groups = _build_group_contexts(_discover_two_tables(), RockyDagsterTranslator())
+    pdef = dg.DynamicPartitionsDefinition(name="tenants")
+
+    specs = _build_check_specs(groups, surface_compliance=True, partitions_def=pdef)
+
+    assert specs, "expected default + compliance check specs"
+    assert all(s.partitions_def is pdef for s in specs)
+
+
+@requires_threading
+def test_build_check_specs_defaults_to_unpartitioned():
+    groups = _build_group_contexts(_discover_two_tables(), RockyDagsterTranslator())
+
+    specs = _build_check_specs(groups)
+
+    assert specs
+    assert all(s.partitions_def is None for s in specs)
+
+
+@requires_threading
+def test_contract_check_specs_thread_partitions_def():
+    pdef = dg.DynamicPartitionsDefinition(name="tenants")
+    rules = ContractRules(has_required=True, has_protected=True, has_column_constraints=True)
+
+    specs = list(contract_check_specs_for_model(AssetKey(["orders"]), rules, partitions_def=pdef))
+
+    assert len(specs) == 3
+    assert all(s.partitions_def is pdef for s in specs)

--- a/integrations/dagster/tests/test_partitioned_checks.py
+++ b/integrations/dagster/tests/test_partitioned_checks.py
@@ -1,9 +1,9 @@
 """Regression coverage for per-tenant (partitioned) asset checks under the
-tenant-as-partition collapse.  Drop into ``integrations/dagster/tests/`` in the FR PR.
+tenant-as-partition collapse.
 
 Two groups:
 
-GROUP B — behavioral guards, run TODAY (public Dagster APIs only):
+GROUP B — behavioral guards (public Dagster APIs only):
   * ``test_partitioned_check_specs_retain_per_partition_verdicts`` is the
     TRIPWIRE for a PREVIEW feature. On dagster 1.13.8, setting ``partitions_def``
     on an ``AssetCheckSpec`` is explicitly flagged: *"currently in preview, may
@@ -15,30 +15,19 @@ GROUP B — behavioral guards, run TODAY (public Dagster APIs only):
     verdict, so per-tenant signal must come from the event axis (run tag +
     result metadata), not the check badge.
 
-GROUP A — unit coverage for the dagster-rocky threading change (REVIEW §10,
-  Edits 1-2: ``_build_check_specs`` / ``contract_check_specs_for_model`` gain a
-  ``partitions_def`` kwarg). Skipped until that change lands; the skip MUST be
-  gone in the merged PR.
+GROUP A — unit coverage for the ``partitions_def`` threading through
+  ``_build_check_specs`` / ``contract_check_specs_for_model``.
 """
 
 from __future__ import annotations
 
-import inspect
-
 import dagster as dg
-import pytest
 from dagster import AssetCheckKey, AssetKey
 
 from dagster_rocky import DiscoverResult, SourceInfo, TableInfo
 from dagster_rocky.component import _build_check_specs, _build_group_contexts
 from dagster_rocky.contracts import ContractRules, contract_check_specs_for_model
 from dagster_rocky.translator import RockyDagsterTranslator
-
-# Activates GROUP A once Edits 1-2 add the `partitions_def` kwarg.
-_THREADED = "partitions_def" in inspect.signature(_build_check_specs).parameters
-requires_threading = pytest.mark.skipif(
-    not _THREADED, reason="Edits 1-2 (partitions_def threading) not yet applied — see REVIEW §10"
-)
 
 
 def _status(rec) -> str:
@@ -119,11 +108,10 @@ def test_unpartitioned_collapsed_checks_clobber():
 
 
 # --------------------------------------------------------------------------- #
-# GROUP A — threading unit tests (land with Edits 1-2)
+# GROUP A — partitions_def threading unit tests
 # --------------------------------------------------------------------------- #
 
 
-@requires_threading
 def test_build_check_specs_threads_partitions_def_to_every_spec():
     groups = _build_group_contexts(_discover_two_tables(), RockyDagsterTranslator())
     pdef = dg.DynamicPartitionsDefinition(name="tenants")
@@ -134,7 +122,6 @@ def test_build_check_specs_threads_partitions_def_to_every_spec():
     assert all(s.partitions_def is pdef for s in specs)
 
 
-@requires_threading
 def test_build_check_specs_defaults_to_unpartitioned():
     groups = _build_group_contexts(_discover_two_tables(), RockyDagsterTranslator())
 
@@ -144,7 +131,6 @@ def test_build_check_specs_defaults_to_unpartitioned():
     assert all(s.partitions_def is None for s in specs)
 
 
-@requires_threading
 def test_contract_check_specs_thread_partitions_def():
     pdef = dg.DynamicPartitionsDefinition(name="tenants")
     rules = ContractRules(has_required=True, has_protected=True, has_column_constraints=True)

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -390,11 +390,16 @@ def test_tenant_omitted_resolves_to_none():
 
 
 def test_collapsed_execution_remaps_engine_key_to_collapsed_asset(tmp_path):
-    """The engine runs the *real* source under ``--filter client=<tenant>`` and
-    emits materializations keyed WITH the tenant. The collapsed asset must
-    remap those engine keys back to the tenant-agnostic key (+ partition),
-    not drop them. Exercises the full build_defs_from_state → materialize →
-    _emit_results path, which the builder-level tests don't.
+    """End-to-end happy path: a known tenant's engine materialization (keyed
+    WITH the tenant) lands on the collapsed key + partition through the full
+    build_defs_from_state → materialize → _emit_results path.
+
+    Note: this exercises the remap but does not *isolate* the with-tenant map
+    (the table-leaf fallback would also rescue a known tenant). The
+    with-tenant registration itself is pinned directly by
+    ``test_collapse_maps_engine_with_tenant_keys_to_collapsed_spec``, and the
+    leaf fallback by
+    ``test_collapsed_execution_new_tenant_falls_back_to_table_leaf``.
     """
     discover = {
         "version": "0.3.0",
@@ -703,3 +708,18 @@ def test_sensor_tenant_mode_sync_off_does_not_advance_cursor_for_skipped():
     # The skipped source's cursor stays absent → it re-fires next tick.
     cursor = json.loads(result.cursor)
     assert "src_coca_cola" not in cursor
+
+
+def test_sensor_tenant_mode_requires_both_args():
+    """rocky_source_sensor is public; a half-configured tenant call must be
+    rejected at definition time, not silently fall through to per_source."""
+    rocky = RockyResource()
+    target = dg.AssetSelection.all()
+    with pytest.raises(ValueError, match="both tenant_component"):
+        rocky_source_sensor(rocky_resource=rocky, target=target, tenant_component="client")
+    with pytest.raises(ValueError, match="both tenant_component"):
+        rocky_source_sensor(
+            rocky_resource=rocky, target=target, tenant_partitions_name="rocky_clients"
+        )
+    # Both unset is fine (default non-tenant sensor).
+    assert rocky_source_sensor(rocky_resource=rocky, target=target) is not None

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -481,3 +481,67 @@ def test_collapsed_execution_remaps_engine_key_to_collapsed_asset(tmp_path):
     assert mat_events[0].asset_key == collapsed_key
     # …attributed to the coca_cola partition.
     assert mat_events[0].materialization.partition == "coca_cola"
+
+
+def test_component_entry_builds_collapsed_defs_with_optimize_and_sensor(tmp_path):
+    """Full component entry point with tenant set: the optimize-metadata
+    merge (default on) does replace_attributes on the collapsed specs — must
+    preserve partitions_def so the asset/check partition-match invariant
+    holds after the round-trip — and the sensor is bundled."""
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": f"src_{c}",
+                "source_type": "fivetran",
+                "components": {"client": c, "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            }
+            for c in ("coca_cola", "pepsi")
+        ],
+    }
+    # Optimize recommendation keyed to the collapsed table leaf ("orders") so
+    # _merge_optimize_metadata actually merges onto the partitioned spec.
+    optimize = {
+        "version": "0.3.0",
+        "command": "optimize",
+        "total_models_analyzed": 1,
+        "recommendations": [
+            {
+                "model_name": "orders",
+                "current_strategy": "table",
+                "compute_cost_per_run": 0.01,
+                "storage_cost_per_month": 1.0,
+                "downstream_references": 1,
+                "recommended_strategy": "view",
+                "estimated_monthly_savings": 0.5,
+                "reasoning": "cheap",
+            }
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover, "optimize": optimize}))
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+        enable_sensor=True,
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    all_keys = {k for a in asset_defs for k in a.keys}
+    assert dg.AssetKey(["fivetran", "usa", "facebookads", "orders"]) in all_keys
+    assert not any("coca_cola" in k.to_user_string() for k in all_keys)
+
+    # partitions_def survived the optimize-metadata merge on every spec + check.
+    for a in asset_defs:
+        for spec in a.specs:
+            assert spec.partitions_def is not None and spec.partitions_def.name == "rocky_clients"
+        for cspec in a.check_specs:
+            assert cspec.partitions_def is not None
+    # Sensor bundled.
+    assert defs.sensors
+    # Whole graph resolves (asset/check partition-match invariant holds).
+    defs.resolve_asset_graph().get_all_asset_keys()

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -535,7 +535,15 @@ def test_component_entry_builds_collapsed_defs_with_optimize_and_sensor(tmp_path
     assert dg.AssetKey(["fivetran", "usa", "facebookads", "orders"]) in all_keys
     assert not any("coca_cola" in k.to_user_string() for k in all_keys)
 
-    # partitions_def survived the optimize-metadata merge on every spec + check.
+    # The optimize merge actually RAN on the collapsed spec (not vacuous):
+    # the recommendation keyed to leaf "orders" landed as metadata.
+    collapsed_key = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    collapsed_spec = next(spec for a in asset_defs for spec in a.specs if spec.key == collapsed_key)
+    assert "rocky/recommended_strategy" in (collapsed_spec.metadata or {}), (
+        "optimize metadata did not merge onto the collapsed spec — the "
+        "partitions-survive-the-merge guard would be vacuous"
+    )
+    # …and partitions_def survived that merge on every spec + check.
     for a in asset_defs:
         for spec in a.specs:
             assert spec.partitions_def is not None and spec.partitions_def.name == "rocky_clients"
@@ -545,3 +553,153 @@ def test_component_entry_builds_collapsed_defs_with_optimize_and_sensor(tmp_path
     assert defs.sensors
     # Whole graph resolves (asset/check partition-match invariant holds).
     defs.resolve_asset_graph().get_all_asset_keys()
+
+
+# --------------------------------------------------------------------------- #
+# Regression: op-name uniqueness across connectors (code-location load crash)
+# --------------------------------------------------------------------------- #
+
+
+def test_collapse_op_names_unique_across_connectors(tmp_path):
+    """Two connectors under the same first-string component (region=usa) must
+    not collide on the multi_asset op name. get_group_name returns only the
+    first string component, so naming ops by it produced duplicate
+    'rocky_usa' ops → DagsterInvalidDefinitionError when the implicit
+    __ASSET_JOB builds (the code-location load path)."""
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": f"cc_{s}",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": s},
+                "tables": [{"name": "orders"}],
+            }
+            for s in ("facebookads", "googleads")
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    # Forcing all job defs builds the implicit __ASSET_JOB, where duplicate op
+    # names raise. No exception = unique op names.
+    jobs = defs.get_repository_def().get_all_jobs()
+    assert jobs
+
+
+def test_collapse_does_not_merge_distinct_source_types():
+    """Sources with identical components but different source_type are distinct
+    assets ([source_type, *components, table]) and must not collapse together."""
+    a = SourceInfo(
+        id="a",
+        source_type="fivetran",
+        components={"client": "coca_cola", "region": "usa", "source": "shopify"},
+        tables=[TableInfo(name="orders")],
+    )
+    b = SourceInfo(
+        id="b",
+        source_type="airbyte",
+        components={"client": "coca_cola", "region": "usa", "source": "shopify"},
+        tables=[TableInfo(name="orders")],
+    )
+    groups, _ = _collapse(_discover(a, b))
+    assert len(groups) == 2
+    assert {g.name for g in groups} == {"fivetran_usa_shopify", "airbyte_usa_shopify"}
+
+
+def test_collapsed_execution_new_tenant_falls_back_to_table_leaf(tmp_path):
+    """A tenant the sensor added AFTER the last state refresh is absent from the
+    load-time with-tenant map; its engine materialization must still remap to
+    the collapsed key via the table-leaf fallback, not be dropped."""
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "src_coca_cola",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            }
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    collapsed_key = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+
+    # Engine emits a brand-new tenant 'zara' (NOT in the cached discover state).
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=zara",
+            "duration_ms": 100,
+            "tables_copied": 1,
+            "tables_failed": 0,
+            "materializations": [
+                {
+                    "asset_key": ["fivetran", "zara", "usa", "facebookads", "orders"],
+                    "rows_copied": 10,
+                    "duration_ms": 50,
+                    "metadata": {"strategy": "full_refresh"},
+                }
+            ],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 1, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["zara"])
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+    ):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[collapsed_key],
+            partition_key="zara",
+            instance=instance,
+            raise_on_error=False,
+        )
+
+    assert result.success
+    mat_events = list(result.get_asset_materialization_events())
+    assert len(mat_events) == 1
+    assert mat_events[0].asset_key == collapsed_key
+    assert mat_events[0].materialization.partition == "zara"
+
+
+def test_sensor_tenant_mode_sync_off_does_not_advance_cursor_for_skipped():
+    """Cursor must NOT advance for a source the tenant branch skipped (sync off
+    + partition not yet created): advancing would permanently drop that sync —
+    the source would only re-fire on a strictly-newer last_sync_at."""
+    rocky = RockyResource()
+    discover = _discover(_synced("coca_cola", datetime(2026, 4, 8, 10, tzinfo=UTC)))
+    instance = dg.DagsterInstance.ephemeral()  # partition set empty
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _tenant_sensor(rocky, sync=False)
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    assert result.run_requests == []
+    # The skipped source's cursor stays absent → it re-fires next tick.
+    cursor = json.loads(result.cursor)
+    assert "src_coca_cola" not in cursor

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -8,11 +8,13 @@ default (tenant unset) path is unchanged.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
+from unittest.mock import patch
 
 import dagster as dg
 import pytest
 
-from dagster_rocky import DiscoverResult, RockyResource, SourceInfo, TableInfo
+from dagster_rocky import DiscoverResult, RockyResource, SourceInfo, TableInfo, rocky_source_sensor
 from dagster_rocky.component import (
     TenantConfig,
     _build_check_specs,
@@ -256,3 +258,86 @@ def test_default_path_unchanged_keeps_tenant_in_key():
     assert "fivetran/coca_cola/usa/facebookads/orders" in keys
     assert "fivetran/pepsi/usa/facebookads/orders" in keys
     assert all(g.partitions_def is None for g in groups)
+
+
+# --------------------------------------------------------------------------- #
+# Sensor: tenant-partition mode (Layer 6)
+# --------------------------------------------------------------------------- #
+
+
+def _synced(client: str, when: datetime, tables: list[str] | None = None) -> SourceInfo:
+    return SourceInfo(
+        id=f"src_{client}",
+        components={"client": client, "region": "usa", "source": "facebookads"},
+        source_type="fivetran",
+        last_sync_at=when,
+        tables=[TableInfo(name=t) for t in (tables or ["orders"])],
+    )
+
+
+def _tenant_sensor(rocky: RockyResource, *, sync: bool = True) -> dg.SensorDefinition:
+    return rocky_source_sensor(
+        rocky_resource=rocky,
+        target=dg.AssetSelection.assets(dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])),
+        minimum_interval_seconds=60,
+        tenant_component="client",
+        tenant_partitions_name="rocky_clients",
+        sync_partitions_from_discover=sync,
+    )
+
+
+def test_sensor_tenant_mode_adds_partitions_and_emits_partitioned_requests():
+    rocky = RockyResource()
+    discover = _discover(
+        _synced("coca_cola", datetime(2026, 4, 8, 10, tzinfo=UTC)),
+        _synced("pepsi", datetime(2026, 4, 8, 11, tzinfo=UTC)),
+    )
+    instance = dg.DagsterInstance.ephemeral()
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _tenant_sensor(rocky)
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # One partitioned RunRequest per triggered tenant.
+    assert len(result.run_requests) == 2
+    by_pk = {rr.partition_key: rr for rr in result.run_requests}
+    assert set(by_pk) == {"coca_cola", "pepsi"}
+    # Collapsed (tenant-agnostic) asset selection.
+    assert by_pk["coca_cola"].asset_selection == [
+        dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    ]
+    # Tenant value rides a run tag too (governance fallback).
+    assert by_pk["coca_cola"].tags["rocky/client"] == "coca_cola"
+    # New tenant values added to the partition set, atomically with the runs.
+    assert result.dynamic_partitions_requests is not None
+    added = {k for req in result.dynamic_partitions_requests for k in req.partition_keys}
+    assert added == {"coca_cola", "pepsi"}
+
+
+def test_sensor_tenant_mode_only_adds_unseen_partitions():
+    rocky = RockyResource()
+    discover = _discover(
+        _synced("coca_cola", datetime(2026, 4, 8, 10, tzinfo=UTC)),
+        _synced("pepsi", datetime(2026, 4, 8, 11, tzinfo=UTC)),
+    )
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["coca_cola"])  # already known
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _tenant_sensor(rocky)
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    added = {k for req in (result.dynamic_partitions_requests or []) for k in req.partition_keys}
+    assert added == {"pepsi"}  # coca_cola already present, not re-added
+    assert len(result.run_requests) == 2  # both still get a run
+
+
+def test_sensor_tenant_mode_sync_off_skips_unknown_partition():
+    rocky = RockyResource()
+    discover = _discover(_synced("coca_cola", datetime(2026, 4, 8, 10, tzinfo=UTC)))
+    instance = dg.DagsterInstance.ephemeral()  # partition set empty
+    with patch.object(RockyResource, "discover", return_value=discover):
+        sensor = _tenant_sensor(rocky, sync=False)
+        result = sensor(dg.build_sensor_context(cursor=None, instance=instance))
+
+    # sync off + partition doesn't exist → no run, no add.
+    assert result.run_requests == []
+    assert not result.dynamic_partitions_requests

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -341,3 +341,27 @@ def test_sensor_tenant_mode_sync_off_skips_unknown_partition():
     # sync off + partition doesn't exist → no run, no add.
     assert result.run_requests == []
     assert not result.dynamic_partitions_requests
+
+
+# --------------------------------------------------------------------------- #
+# Config: YAML resolution of the nested tenant block
+# --------------------------------------------------------------------------- #
+
+
+def test_tenant_block_resolves_from_yaml():
+    from dagster_rocky import RockyComponent
+
+    component = RockyComponent.resolve_from_yaml(
+        "config_path: rocky.toml\ntenant:\n  component: client\n  partitions_name: rocky_clients\n"
+    )
+    assert component.tenant is not None
+    assert component.tenant.component == "client"
+    assert component.tenant.partitions_name == "rocky_clients"
+    assert component.tenant.sync_partitions_from_discover is True
+
+
+def test_tenant_omitted_resolves_to_none():
+    from dagster_rocky import RockyComponent
+
+    component = RockyComponent.resolve_from_yaml("config_path: rocky.toml\n")
+    assert component.tenant is None

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -1,0 +1,258 @@
+"""Tests for the tenant-as-partition collapse (RockyComponent.tenant).
+
+Covers the collapse builder, the partition→filter execution mapping, the
+union-of-tables semantics, the get_partition_key chokepoint, and that the
+default (tenant unset) path is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dagster as dg
+import pytest
+
+from dagster_rocky import DiscoverResult, RockyResource, SourceInfo, TableInfo
+from dagster_rocky.component import (
+    TenantConfig,
+    _build_check_specs,
+    _build_collapsed_group_contexts,
+    _build_group_contexts,
+    _CompileState,
+    _make_rocky_asset,
+    _tenant_partition_filters,
+)
+from dagster_rocky.translator import RockyDagsterTranslator
+
+
+def _source(client: str, tables: list[str]) -> SourceInfo:
+    return SourceInfo(
+        id=f"src_{client}",
+        components={"client": client, "region": "usa", "source": "facebookads"},
+        source_type="fivetran",
+        last_sync_at=None,
+        tables=[TableInfo(name=t, row_count=1) for t in tables],
+    )
+
+
+def _discover(*sources: SourceInfo) -> DiscoverResult:
+    return DiscoverResult(version="0.3.0", command="discover", sources=list(sources))
+
+
+def _tenant() -> TenantConfig:
+    return TenantConfig(component="client", partitions_name="rocky_clients")
+
+
+def _collapse(discover: DiscoverResult, translator: RockyDagsterTranslator | None = None):
+    pdef = dg.DynamicPartitionsDefinition(name="rocky_clients")
+    groups = _build_collapsed_group_contexts(
+        discover, translator or RockyDagsterTranslator(), _tenant(), pdef
+    )
+    return groups, pdef
+
+
+# --------------------------------------------------------------------------- #
+# Cardinality + key shape
+# --------------------------------------------------------------------------- #
+
+
+def test_collapse_is_constant_in_tenant_count():
+    # 3 tenants × 2 tables → 2 specs (not 6).
+    discover = _discover(
+        _source("coca_cola", ["account_history", "campaigns"]),
+        _source("pepsi", ["account_history", "campaigns"]),
+        _source("nestle", ["account_history", "campaigns"]),
+    )
+    groups, _ = _collapse(discover)
+    assert len(groups) == 1
+    assert len(groups[0].specs) == 2
+
+
+def test_collapse_drops_tenant_from_key():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"])))
+    keys = {s.key.to_user_string() for s in groups[0].specs}
+    assert keys == {"fivetran/usa/facebookads/orders"}
+    assert "coca_cola" not in str(keys) and "pepsi" not in str(keys)
+
+
+def test_collapse_attaches_partitions_def_to_specs():
+    groups, pdef = _collapse(_discover(_source("coca_cola", ["orders"])))
+    assert all(s.partitions_def is pdef for s in groups[0].specs)
+
+
+def test_collapse_moves_tenant_off_static_tags():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
+    spec = groups[0].specs[0]
+    assert "rocky/client" not in (spec.tags or {})
+    # non-tenant components stay as tags
+    assert spec.tags.get("rocky/region") == "usa"
+    assert spec.tags.get("rocky/source") == "facebookads"
+
+
+def test_collapse_neutralizes_per_tenant_metadata():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
+    meta = groups[0].specs[0].metadata or {}
+    assert "source_id" not in meta
+    assert "row_count" not in meta
+    assert "last_sync_at" not in meta
+    assert "dagster-rocky/source_id" not in meta
+
+
+# --------------------------------------------------------------------------- #
+# Filter map + chokepoint
+# --------------------------------------------------------------------------- #
+
+
+def test_partition_key_to_filter_value_identity_by_default():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"])))
+    assert groups[0].partition_key_to_filter_value == {
+        "coca_cola": "coca_cola",
+        "pepsi": "pepsi",
+    }
+    assert groups[0].tenant_component == "client"
+
+
+def test_get_partition_key_override_canonicalizes_but_filter_maps_to_raw():
+    class UpperTranslator(RockyDagsterTranslator):
+        def get_partition_key(self, source):
+            return source.components["client"].upper()
+
+    discover = _discover(_source("coca_cola", ["orders"]))
+    pdef = dg.DynamicPartitionsDefinition(name="rocky_clients")
+    groups = _build_collapsed_group_contexts(discover, UpperTranslator(), _tenant(), pdef)
+    # Partition key is canonicalized; --filter still targets the raw catalog value.
+    assert groups[0].partition_key_to_filter_value == {"COCA_COLA": "coca_cola"}
+
+
+# --------------------------------------------------------------------------- #
+# Union of tables across tenants (Gap 2)
+# --------------------------------------------------------------------------- #
+
+
+def test_collapse_unions_tables_across_tenants():
+    # Tenant A: orders. Tenant B: orders + refunds. → union = 2 specs.
+    discover = _discover(
+        _source("coca_cola", ["orders"]),
+        _source("pepsi", ["orders", "refunds"]),
+    )
+    groups, _ = _collapse(discover)
+    tables = {s.key.path[-1] for s in groups[0].specs}
+    assert tables == {"orders", "refunds"}
+
+
+# --------------------------------------------------------------------------- #
+# Grouping by non-tenant components
+# --------------------------------------------------------------------------- #
+
+
+def test_collapse_separates_distinct_non_tenant_groups():
+    a = SourceInfo(
+        id="a",
+        components={"client": "coca_cola", "region": "usa", "source": "facebookads"},
+        source_type="fivetran",
+        tables=[TableInfo(name="orders")],
+    )
+    b = SourceInfo(
+        id="b",
+        components={"client": "coca_cola", "region": "emea", "source": "facebookads"},
+        source_type="fivetran",
+        tables=[TableInfo(name="orders")],
+    )
+    groups, _ = _collapse(_discover(a, b))
+    # Different region → different non-tenant group → 2 groups.
+    assert len(groups) == 2
+
+
+def test_collapse_skips_source_missing_tenant_component(caplog):
+    good = _source("coca_cola", ["orders"])
+    bad = SourceInfo(
+        id="bad",
+        components={"region": "usa", "source": "facebookads"},  # no client
+        source_type="fivetran",
+        tables=[TableInfo(name="orders")],
+    )
+    with caplog.at_level(logging.WARNING):
+        groups, _ = _collapse(_discover(good, bad))
+    assert len(groups) == 1
+    assert "coca_cola" in groups[0].partition_key_to_filter_value
+    assert any("skipping source id=bad" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Full build: asset + partitioned checks construct together
+# --------------------------------------------------------------------------- #
+
+
+def test_collapsed_asset_with_partitioned_checks_builds():
+    discover = _discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"]))
+    groups, pdef = _collapse(discover)
+    check_specs = _build_check_specs(groups, surface_compliance=True, partitions_def=pdef)
+    assert check_specs and all(c.partitions_def is pdef for c in check_specs)
+
+    rocky = RockyResource(binary_path="rocky", config_path="rocky.toml")
+    asset = _make_rocky_asset(
+        group=groups[0],
+        check_specs=[c for c in check_specs if any(c.asset_key == s.key for s in groups[0].specs)],
+        rocky=rocky,
+        compile_state=_CompileState(),
+    )
+    defs = dg.Definitions(assets=[asset], resources={"rocky": rocky})
+    keys = defs.resolve_asset_graph().get_all_asset_keys()
+    assert dg.AssetKey(["fivetran", "usa", "facebookads", "orders"]) in keys
+    assert asset.partitions_def is not None and asset.partitions_def.name == "rocky_clients"
+    assert asset.can_subset
+
+
+# --------------------------------------------------------------------------- #
+# Execution: partition_key → --filter
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCtx:
+    def __init__(self, partition_key: str | None):
+        self._pk = partition_key
+        self.log = logging.getLogger("test")
+
+    @property
+    def has_partition_key(self) -> bool:
+        return self._pk is not None
+
+    @property
+    def partition_key(self) -> str:
+        assert self._pk is not None
+        return self._pk
+
+
+def test_tenant_partition_filters_maps_key_to_filter():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"])))
+    filters = _tenant_partition_filters(groups[0], _FakeCtx("pepsi"))
+    assert filters == ["client=pepsi"]
+
+
+def test_tenant_partition_filters_uses_raw_value_for_unknown_key():
+    # A brand-new tenant partition (added by the sensor before the next state
+    # refresh) isn't in the map yet → fall back to the key itself.
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
+    filters = _tenant_partition_filters(groups[0], _FakeCtx("newtenant"))
+    assert filters == ["client=newtenant"]
+
+
+def test_tenant_partition_filters_rejects_single_run_backfill():
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"])))
+    with pytest.raises(dg.Failure, match="single_run"):
+        _tenant_partition_filters(groups[0], _FakeCtx(None))
+
+
+# --------------------------------------------------------------------------- #
+# Default path unchanged when tenant is unset
+# --------------------------------------------------------------------------- #
+
+
+def test_default_path_unchanged_keeps_tenant_in_key():
+    discover = _discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"]))
+    groups = _build_group_contexts(discover, RockyDagsterTranslator())
+    keys = {s.key.to_user_string() for s in (s for g in groups for s in g.specs)}
+    # Without collapse, the client stays in the key (one spec per tenant).
+    assert "fivetran/coca_cola/usa/facebookads/orders" in keys
+    assert "fivetran/pepsi/usa/facebookads/orders" in keys
+    assert all(g.partitions_def is None for g in groups)

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -7,6 +7,7 @@ default (tenant unset) path is unchanged.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from unittest.mock import patch
@@ -14,7 +15,14 @@ from unittest.mock import patch
 import dagster as dg
 import pytest
 
-from dagster_rocky import DiscoverResult, RockyResource, SourceInfo, TableInfo, rocky_source_sensor
+from dagster_rocky import (
+    DiscoverResult,
+    RockyComponent,
+    RockyResource,
+    SourceInfo,
+    TableInfo,
+    rocky_source_sensor,
+)
 from dagster_rocky.component import (
     TenantConfig,
     _build_check_specs,
@@ -25,6 +33,7 @@ from dagster_rocky.component import (
     _tenant_partition_filters,
 )
 from dagster_rocky.translator import RockyDagsterTranslator
+from dagster_rocky.types import RunResult
 
 
 def _source(client: str, tables: list[str]) -> SourceInfo:
@@ -112,6 +121,16 @@ def test_partition_key_to_filter_value_identity_by_default():
         "pepsi": "pepsi",
     }
     assert groups[0].tenant_component == "client"
+
+
+def test_collapse_maps_engine_with_tenant_keys_to_collapsed_spec():
+    # The engine emits materializations keyed WITH the tenant component;
+    # every member's with-tenant key must remap to the single collapsed key.
+    groups, _ = _collapse(_discover(_source("coca_cola", ["orders"]), _source("pepsi", ["orders"])))
+    collapsed = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    mapping = groups[0].rocky_key_to_dagster_key
+    assert mapping[("fivetran", "coca_cola", "usa", "facebookads", "orders")] == collapsed
+    assert mapping[("fivetran", "pepsi", "usa", "facebookads", "orders")] == collapsed
 
 
 def test_get_partition_key_override_canonicalizes_but_filter_maps_to_raw():
@@ -361,7 +380,104 @@ def test_tenant_block_resolves_from_yaml():
 
 
 def test_tenant_omitted_resolves_to_none():
-    from dagster_rocky import RockyComponent
-
     component = RockyComponent.resolve_from_yaml("config_path: rocky.toml\n")
     assert component.tenant is None
+
+
+# --------------------------------------------------------------------------- #
+# Execution end-to-end: engine key (with tenant) remaps to collapsed asset
+# --------------------------------------------------------------------------- #
+
+
+def test_collapsed_execution_remaps_engine_key_to_collapsed_asset(tmp_path):
+    """The engine runs the *real* source under ``--filter client=<tenant>`` and
+    emits materializations keyed WITH the tenant. The collapsed asset must
+    remap those engine keys back to the tenant-agnostic key (+ partition),
+    not drop them. Exercises the full build_defs_from_state → materialize →
+    _emit_results path, which the builder-level tests don't.
+    """
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "src_coca_cola",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            },
+            {
+                "id": "src_pepsi",
+                "source_type": "fivetran",
+                "components": {"client": "pepsi", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            },
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+
+    # Collapsed graph: one tenant-agnostic asset, partitioned.
+    collapsed_key = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    all_keys = {k for a in asset_defs for k in a.keys}
+    assert collapsed_key in all_keys
+    assert not any("coca_cola" in k.to_user_string() for k in all_keys)
+
+    # Engine RunResult for --filter client=coca_cola: key carries the tenant.
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=coca_cola",
+            "duration_ms": 100,
+            "tables_copied": 1,
+            "tables_failed": 0,
+            "materializations": [
+                {
+                    "asset_key": ["fivetran", "coca_cola", "usa", "facebookads", "orders"],
+                    "rows_copied": 10,
+                    "duration_ms": 50,
+                    "metadata": {"strategy": "full_refresh"},
+                }
+            ],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 1, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["coca_cola", "pepsi"])
+
+    with (
+        patch.object(RockyResource, "run", return_value=run_result),
+        patch.object(RockyResource, "run_streaming", return_value=run_result),
+    ):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[collapsed_key],
+            partition_key="coca_cola",
+            instance=instance,
+            raise_on_error=False,
+        )
+
+    assert result.success
+    mat_events = list(result.get_asset_materialization_events())
+    # The engine's tenant-keyed materialization landed on the collapsed key…
+    assert len(mat_events) == 1
+    assert mat_events[0].asset_key == collapsed_key
+    # …attributed to the coca_cola partition.
+    assert mat_events[0].materialization.partition == "coca_cola"


### PR DESCRIPTION
## Problem

When `rocky discover` emits many sources that differ only by one "tenant"
component (e.g. `client`), `dagster-rocky` materialises **one `AssetSpec` +
`AssetCheckSpec` per `(tenant, …components, table)`**. Spec count grows
`O(tenants × connectors × tables)`, so a large multi-tenant deployment can OOM
the Dagster code-server while serialising the repository snapshot — and every
new tenant adds hundreds of specs.

## Solution

Add an **opt-in** `RockyComponent.tenant` switch that collapses sources
differing only by a named tenant component into **one client-agnostic,
partitioned asset** per `(non-tenant components, table)` — the tenant value
becomes a `DynamicPartitionsDefinition` key. Per-tenant physical isolation is
preserved: each partition still materialises via
`rocky run --filter {component}={partition_key}` into that tenant's own target.
Default behaviour (tenant unset) is byte-identical to before.

```yaml
# defs.yaml
type: dagster_rocky.RockyComponent
attributes:
  tenant:
    component: client
    partitions_name: rocky_clients
```

## What's included

- `TenantConfig` + `RockyComponent.tenant` (opt-in; nested YAML resolves)
- Collapse builder: group by `(source_type, non-tenant components)`, union
  tables across tenants, one partitioned spec per `(components, table)`
- `partitions_def` threaded onto asset check specs so per-tenant check
  **history** is recorded per partition
- `RockyDagsterTranslator.get_partition_key` hook — the single chokepoint for
  the tenant partition key (default = the raw component value)
- Execution maps the run's partition key → `--filter`; relies on Dagster's
  default multi-run backfill (`BackfillPolicy.single_run()` is rejected — one
  `--filter` value can't span tenant targets)
- Sensor tenant mode: adds newly-discovered tenant values to the partition set
  and emits one partitioned `RunRequest` per source

## Notes

- `AssetCheckSpec(partitions_def=...)` is a Dagster 1.13.x **preview** API:
  per-partition check *history* is retained (queryable with a partition
  filter), but the UI summary/badge status is still last-writer-wins across
  partitions. Pin the Dagster patch if you rely on per-partition check badges.
- The first commit (*thread partitions_def through asset check specs*) is a
  self-contained, GA-safe change that is useful on its own.

## Testing

- New `test_tenant_partition.py` + `test_partitioned_checks.py` cover:
  cardinality collapse, key/tag/metadata shape, table union, op-name
  uniqueness across connectors, `source_type` separation, partition→`--filter`
  mapping + `single_run` rejection, new-tenant remap fallback, sensor partition
  sync + cursor semantics, and a full component build with optimize + sensor.
- Full `dagster-rocky` suite green; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
