### PR TITLE
chore(release): triple-cut engine 1.50.0 / dagster 1.46.0 / vscode 1.32.0

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.32.0] — 2026-06-05
+## [1.32.0] — 2026-06-06
 
 ### Changed
 
 - Migrated the React webviews from Tailwind CSS v3 to v4. (#813)
-- Regenerated the TypeScript bindings for the engine 1.49 output schemas (`discover`, `dag`, `load`, `run`, project).
+- Regenerated the TypeScript bindings for the engine 1.49–1.50 output schemas (`discover`, `dag`, `load`, `run` decisions, `plan` semantic verdict, column lineage, project). (#853, #856, #857)
 - Bumped dependencies to their latest minor versions and refreshed the lockfile (0 vulnerabilities). (#812)
 
 ## [1.31.2] — 2026-06-02

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.50.0] — 2026-06-06
+
+### Added
+
+- **Decision-support output for `plan` and `run` — reporting-only, opt-in, default-inert.** New surfaces explain *why* the engine made each build decision and what a schema change touches downstream. They are purely informational and **never change build behavior**; a default `rocky run` / `rocky plan` is byte-identical to before.
+  - **`rocky run` per-model decision + reason.** `RunOutput.model_decisions` reports, for each transformation model, the **build / skip / reused** verdict the engine reached plus a short human-readable reason (e.g. "logic and upstream data unchanged since last build", "reused prior run's bytes (strong proof)"). Populated only when the `--skip-unchanged` gate is active or `[reuse]` is enabled; omitted entirely on a default run. Lets orchestrators (Dagster) and the VS Code extension explain skip/reuse decisions. (#853)
+  - **`rocky plan --semantic` column-level impact + breaking-change verdict.** When `--semantic` is passed and a baseline ref is available, `plan` attaches a semantic verdict describing the changes vs. the baseline at column granularity — added/removed models, added/dropped columns, column type changes (with a `narrowing` flag), nullability changes, reordering, and materialization-strategy changes — i.e. a downstream-impact preview (#856) and a breaking-change verdict (#857). Omitted on a default `rocky plan` or when no usable baseline exists.
+
 ## [1.49.0] — 2026-06-05
 
 ### Added

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "logos",
  "miette",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "miette",
  "regex",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.49.0"
+version = "1.50.0"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.49.0"
+version = "1.50.0"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.49.0"
+version = "1.50.0"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.49.0"
+version = "1.50.0"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.49.0"
+version = "1.50.0"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.49.0"
+version = "1.50.0"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.49.0"
+version = "1.50.0"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.49.0"
+version = "1.50.0"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.49.0"
+version = "1.50.0"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.49.0"
+version = "1.50.0"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.49.0"
+version = "1.50.0"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.49.0"
+version = "1.50.0"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.49.0"
+version = "1.50.0"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.49.0"
+version = "1.50.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.49.0"
+version = "1.50.0"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.49.0"
+version = "1.50.0"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.49.0"
+version = "1.50.0"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.49.0"
+version = "1.50.0"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.49.0"
+version = "1.50.0"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.49.0"
+version = "1.50.0"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.0] — 2026-06-06
+
+### Added
+
+- **Surface `discover` cross-source collisions + new sources.** `RockyComponent` / the discover-parsing path now expose the engine's cross-source collision detection (tables that collide across sources) and the `new_sources` first-seen diff, so an operator sees ambiguous or newly-appeared source tables in Dagster instead of only in the CLI. (#852)
+- **Validate the graph-export `schema_version`.** The integration now checks the versioned `rocky dag` graph-export contract's `schema_version` and fails fast on an incompatible engine rather than silently mis-parsing. (#852)
+- **Tenant-as-partition collapse for `RockyComponent`.** Collapse per-tenant assets onto a single partitioned definition (tenant = partition key) with per-partition asset-check history, instead of one asset per tenant. (#858)
+
+### Changed
+
+- Regenerated the Pydantic bindings for the engine 1.50 decision-support output schemas — `RunOutput.model_decisions` and the `rocky plan --semantic` verdict. (#853, #856, #857)
+
 ## [1.45.0] — 2026-06-05
 
 ### Added

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.45.0"
+version = "1.46.0"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"

--- a/integrations/dagster/uv.lock
+++ b/integrations/dagster/uv.lock
@@ -267,7 +267,7 @@ wheels = [
 
 [[package]]
 name = "dagster-rocky"
-version = "1.45.0"
+version = "1.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
Consolidated triple-cut for the decision-support burst that landed since the last release, plus the VS Code arm that was prepared but never tagged in the previous cut.

## Releases

| Artifact | Version | Highlights |
|---|---|---|
| **engine** | `1.49.0 → 1.50.0` | Decision-support output for `plan` / `run` — reporting-only, opt-in, default-inert |
| **dagster-rocky** | `1.45.0 → 1.46.0` | `discover` cross-source collisions + new-sources; graph `schema_version` validation; tenant-as-partition `RockyComponent` |
| **vscode** | `1.31.2 → 1.32.0` | Ships the previously-prepared 1.32.0 (Tailwind v4 migration + bindings) — see note below |

## Engine 1.50.0 — decision-support (reporting-only)

New surfaces explain *why* the engine made each build decision and what a schema change touches downstream. They are purely informational and **never change build behavior** — a default `rocky run` / `rocky plan` is byte-identical to before.

- **`rocky run` per-model decision + reason** — `RunOutput.model_decisions` reports the build / skip / reused verdict per model with a short reason. Populated only when `--skip-unchanged` is active or `[reuse]` is enabled; omitted on a default run. (#853)
- **`rocky plan --semantic`** — attaches a column-level downstream-impact preview (#856) and a breaking-change verdict (#857) against a baseline ref. Omitted on a default `rocky plan` or when no usable baseline exists.

## Dagster 1.46.0

- Surface `discover` cross-source collisions + the `new_sources` first-seen diff; validate the versioned graph-export `schema_version`. (#852)
- Tenant-as-partition collapse for `RockyComponent` (tenant = partition key, per-partition check history). (#858)
- Regenerated Pydantic bindings for the 1.50 decision-support schemas.

## VS Code 1.32.0

The previous release bumped `package.json` to 1.32.0 and wrote the changelog, but the `vscode-v1.32.0` tag was never pushed — so the Marketplace is still on 1.31.2 and the Tailwind v4 migration (#813) + dep refresh (#812) are unshipped. This cut ships them, tagged against current HEAD so the binding regen for the 1.50 schemas is included.

## Pre-flight

- All 25 engine crate versions bumped (incl. `rocky-bigquery`, which is on the main version track); `engine/Cargo.lock`, `uv.lock`, and `package-lock.json` consistent.
- No `output.rs` / schema changes in this PR → codegen bindings unchanged (the 1.50 bindings were generated by #853/#856/#857 and are already on `main`); schemas/bindings carry no version string, so no codegen-drift.
- All shipped code is unchanged from already-merged, CI-green PRs (#852–#858); this PR is version + changelog + lockfiles only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)