### PR TITLE
Reuse enable-gate (T1, increment 1): live-verify fall-back-to-build 4/4 + correct stale "dormant" reuse docs

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Regenerated the `rocky-project` schema + TypeScript bindings to pick up the corrected `[reuse]` config descriptions (auditable reuse performs a real zero-copy point-to when enabled, not a no-op). (#860)
+
 ## [1.32.0] — 2026-06-06
 
 ### Changed

--- a/editors/vscode/schemas/rocky-project.schema.json
+++ b/editors/vscode/schemas/rocky-project.schema.json
@@ -2781,11 +2781,11 @@
     },
     "ReuseConfig": {
       "additionalProperties": false,
-      "description": "`[reuse]` — opt-in population of the auditable-reuse input-match spine.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.\n\n**Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.",
+      "description": "`[reuse]` — opt-in auditable reuse for content-addressed models.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.\n\n**Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.",
       "properties": {
         "enabled": {
           "default": false,
-          "description": "Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.",
+          "description": "Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.",
           "type": "boolean"
         }
       },
@@ -3865,7 +3865,7 @@
       "default": {
         "enabled": false
       },
-      "description": "Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`]."
+      "description": "Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`]."
     },
     "role": {
       "additionalProperties": {

--- a/editors/vscode/src/types/generated/rocky_project.ts
+++ b/editors/vscode/src/types/generated/rocky_project.ts
@@ -426,7 +426,7 @@ export interface RockyConfig {
    */
   retry?: RunRetryConfig | null;
   /**
-   * Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`].
+   * Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`].
    */
   reuse?: ReuseConfig;
   /**
@@ -1741,15 +1741,15 @@ export interface RunRetryConfig {
   max_retries_per_run?: number | null;
 }
 /**
- * `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+ * `[reuse]` — opt-in auditable reuse for content-addressed models.
  *
- * When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.
+ * When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.
  *
- * **Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.
+ * **Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.
  */
 export interface ReuseConfig {
   /**
-   * Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.
+   * Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.
    */
   enabled?: boolean;
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Auditable reuse is now live-verified end-to-end (4/4) on Databricks-Iceberg.** The fail-closed *fall-back-to-BUILD when a prior run's file is no longer live* safety path — previously the one un-runnable leg of the reuse live suite — is now exercised by a self-contained live test. It tombstones the prior run's file with a `DELETE` of that run's rows (the append-only UniForm writer never lets `VACUUM RETAIN 0 HOURS` remove the live current version, and the test refuses to mutate shared warehouse config), so `add_path_is_live` returns false and the run correctly builds instead of pointing at a removed file. Reuse stays **experimental and default-off**; with `[reuse]` unset, `rocky run` is byte- and cost-identical. (#860)
+- Corrected stale "Stage-1 / dormant / ONLY-BUILD" doc-comments across the reuse path (the `[reuse]` config, the reuse decision, and the content-addressed runner) that still described an earlier slice where a positive reuse verdict was only *logged*. With `[reuse]` enabled, an eligible input-match against a prior **strong** run now performs a real zero-copy point-to and skips the model's SQL. The `[reuse]` descriptions in `rocky-project.schema.json` and the regenerated Dagster / VS Code bindings were updated to match. (#860)
+
 ## [1.50.0] — 2026-06-06
 
 ### Added

--- a/engine/crates/rocky-cli/src/commands/reuse_decision.rs
+++ b/engine/crates/rocky-cli/src/commands/reuse_decision.rs
@@ -34,15 +34,16 @@
 //!    `remove`. If the file is gone or the log can't be read, BUILD.
 //!    ([`ReuseInputs::add_is_live`].)
 //!
-//! # Stage-1 posture — ONLY-BUILD
+//! # Posture — wired to the live point-to
 //!
-//! The runner computes the full verdict and, on a positive
-//! [`ReuseVerdict::WouldReuse`], **logs** the candidate but **still executes
-//! the SQL**. A decision that can only BUILD cannot produce a wrong output, so
-//! this is the provably-safe first slice. Wiring the live
-//! `commit_pointer_with_state` invocation behind the same verdict is the next
-//! step (tracked as a follow-up); the verdict shape here is already what that
-//! step consumes.
+//! On a positive [`ReuseVerdict::WouldReuse`] the runner performs a real
+//! **zero-copy point-to**: it commits a pointer to `R`'s existing parquet via
+//! `commit_pointer_with_state` and **skips the model's SQL entirely**. Any
+//! doubt while recovering or re-confirming `R`'s bytes (the commit-time
+//! liveness re-check, a basename or blake3 mismatch) falls closed to BUILD, so
+//! a wrong point-to can never reach production. Gated default-OFF behind
+//! `[reuse]` (clause 1); see `run_content_addressed::attempt_point_to_reuse`
+//! for the point-to itself.
 
 use rocky_core::state::{ArtifactRecord, InputIndexEntry};
 
@@ -128,9 +129,9 @@ pub struct ReuseCandidate {
 pub enum ReuseVerdict {
     /// Execute the SQL. Carries the reason for observability.
     Build(BuildReason),
-    /// Every clause passed — `R`'s bytes are reusable. In the Stage-1
-    /// ONLY-BUILD posture the runner logs this and **still builds**; the live
-    /// point-to invocation is wired behind the same verdict next.
+    /// Every clause passed — `R`'s bytes are reusable. The runner acts on this
+    /// by committing a zero-copy point-to to `R`'s parquet and skipping the
+    /// SQL, falling closed to BUILD on any recovery/re-confirmation doubt.
     WouldReuse(ReuseCandidate),
 }
 

--- a/engine/crates/rocky-cli/src/commands/run.rs
+++ b/engine/crates/rocky-cli/src/commands/run.rs
@@ -4212,11 +4212,12 @@ pub(crate) async fn execute_models(
     // the gate is inert and this function builds every selected model
     // exactly as before — no extra state reads or warehouse queries.
     skip_gate: SkipGateConfig,
-    // Opt-in `[reuse]` spine population. When `false` (the default) no
-    // input-match index entry or provenance record is written and no
-    // per-model spine hashing cost is paid — the run is byte- and
-    // cost-identical. Dormant even when `true`: it only records the index,
-    // it makes no reuse decision and skips nothing.
+    // Opt-in `[reuse]` (= `[reuse].enabled && !--no-reuse`). When `false`
+    // (the default) no input-match index entry or provenance record is
+    // written and no per-model spine hashing cost is paid — the run is byte-
+    // and cost-identical, and no model reuses. When `true`, the spine is
+    // populated AND an eligible model whose inputs match a prior strong run
+    // points-to that run's parquet instead of executing its SQL.
     reuse_enabled: bool,
 ) -> Result<()> {
     info!(models_dir = %models_dir.display(), "compiling and executing transformation models");
@@ -4306,11 +4307,12 @@ pub(crate) async fn execute_models(
 
     let dialect = warehouse.dialect();
 
-    // Auditable-reuse spine accumulator (dormant). When `[reuse]` is enabled,
-    // each successfully-built content-addressed model contributes an
-    // input-match index entry + an offline-verifiable provenance record,
-    // flushed in one transaction at end-of-run. Empty (and never touched)
-    // when reuse is off, so the default path pays nothing.
+    // Auditable-reuse spine accumulator. When `[reuse]` is enabled, each
+    // successfully-built content-addressed model contributes an input-match
+    // index entry + an offline-verifiable provenance record, flushed in one
+    // transaction at end-of-run; that index is what a later run's reuse
+    // decision reads to point-to a prior run. Empty (and never touched) when
+    // reuse is off, so the default path pays nothing.
     //
     // `reuse_outputs` maps a built model's fully-qualified target identity to
     // its output blake3 keyed by its target identity, so a *downstream*
@@ -4815,11 +4817,11 @@ pub(crate) async fn execute_models(
                                 );
                             }
                         }
-                        // Auditable-reuse spine (dormant). When `[reuse]` is
-                        // enabled, accumulate this model's input-match index
-                        // entry + provenance record. Stage 1 indexes a model
-                        // only when EVERY table it reads resolves to a STRONG
-                        // content hash produced earlier in this run — no extra
+                        // Auditable-reuse spine. When `[reuse]` is enabled,
+                        // accumulate this model's input-match index entry +
+                        // provenance record. A model is indexed only when
+                        // EVERY table it reads resolves to a STRONG content
+                        // hash produced earlier in this run — no extra
                         // warehouse query. A read of a raw source, a model not
                         // written content-addressed, or a model not built this
                         // run means the chain is not byte-verifiable
@@ -5016,7 +5018,7 @@ pub(crate) async fn execute_models(
 
     // Flush the auditable-reuse spine in one transaction at end-of-run, only
     // on the success path (a failed run returns early above and discards the
-    // accumulator — dormant Stage-1 indexes only fully-successful builds).
+    // accumulator — only fully-successful builds are indexed).
     // Best-effort: a write failure logs and continues, mirroring the
     // `record_artifact` posture — the run itself is already durable.
     if reuse_enabled
@@ -5033,7 +5035,7 @@ pub(crate) async fn execute_models(
         } else {
             info!(
                 entries = reuse_index_entries.len(),
-                "recorded auditable-reuse input-match spine (dormant)"
+                "recorded auditable-reuse input-match spine"
             );
         }
     }

--- a/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
+++ b/engine/crates/rocky-cli/src/commands/run_content_addressed.rs
@@ -613,17 +613,18 @@ async fn evaluate_reuse_decision(
 /// partitioned (one `write_partitioned_batch` commit per partition tuple)
 /// targets.
 ///
-/// # Reuse decision (Stage 1 — ONLY-BUILD)
+/// # Reuse decision
 ///
 /// When `reuse_ctx` is `Some`, the **fail-closed reuse decision** runs after
 /// `discover()` and *before* `execute_query`: if every clause holds (enabled,
 /// eligible shape, input-hash match to a STRONG prior run `R`, `R`'s artifact
 /// resolves with a sane refcount, and `R`'s file is still live in the target's
-/// `_delta_log`), the model *could* point-to `R`'s bytes. In this slice the
-/// decision is **ONLY-BUILD**: a positive verdict is *logged* (`would-reuse
-/// R`) and the model is **still built**. A decision that can only BUILD is
-/// incapable of producing a wrong output, which is the safe first step before
-/// the live point-to invocation is wired behind the same verdict.
+/// `_delta_log`), the model **points-to** `R`'s bytes — `attempt_point_to_reuse`
+/// commits a pointer to `R`'s parquet (zero-copy) and the SQL is **not
+/// executed**. Any doubt while recovering or re-confirming `R`'s bytes (a
+/// commit-time liveness re-check, a basename or blake3 mismatch) falls closed
+/// to a normal BUILD, so a wrong point-to can never reach production. Gated
+/// default-OFF behind `[reuse]`; absent a context, this is a plain build.
 pub async fn execute_content_addressed_model(
     model_ir: &ModelIr,
     warehouse: &dyn rocky_core::traits::WarehouseAdapter,
@@ -2647,14 +2648,22 @@ mod live_tests {
         );
     }
 
-    /// (b) VACUUM R's file then re-run ⇒ BUILD. A point-to into a removed file
-    /// would be a silent wrong reuse; the liveness clause (and the commit-time
-    /// re-check that closes the TOCTOU window) must catch the removal and fall
-    /// back to a build. `VACUUM ... RETAIN 0 HOURS` physically removes R's
-    /// no-longer-referenced bytes, making its `add` not-live.
+    /// (b) Remove R's file from the table, then re-run with reuse on ⇒ BUILD.
+    /// A point-to into a removed file would be a silent wrong reuse, so the
+    /// decision's liveness clause must catch the `remove` and fall back to a
+    /// build. We force the removal deterministically with a `DELETE` of exactly
+    /// R's rows: the UniForm writer is append-only, so the only way R's `add`
+    /// becomes not-live is a later `remove` commit landing in the `_delta_log`
+    /// — which is precisely what a `DELETE` (or a VACUUM/compaction) emits.
+    ///
+    /// We deliberately do *not* use `VACUUM ... RETAIN 0 HOURS` here: it needs
+    /// `delta.retentionDurationCheck.enabled = false` set on the warehouse
+    /// (out-of-band, shared state we refuse to mutate from a test), and an
+    /// append-only writer never tombstones the live current version for VACUUM
+    /// to collect anyway, so that premise can't make R's own `add` not-live.
     #[tokio::test]
     #[ignore]
-    async fn reuse_falls_back_to_build_when_file_vacuumed() {
+    async fn reuse_falls_back_to_build_when_file_not_live() {
         let Some(env) = try_load_env() else {
             eprintln!("skipping: ROCKY_TEST_* env vars not set");
             return;
@@ -2671,42 +2680,46 @@ mod live_tests {
         let store = rocky_core::state::StateStore::open(&dir.path().join("state.redb")).unwrap();
 
         // Run 1 — build R.
-        let model_ir = reuse_model(&env, 9071);
+        let seed = 9071;
+        let model_ir = reuse_model(&env, seed);
         let r_summary = execute_content_addressed_model(&model_ir, warehouse_dyn, None)
             .await
             .expect("first build must succeed");
         let input_hash = record_r_build(&store, &model_ir, "run-R", &r_summary);
 
-        // VACUUM the table with retention 0 so R's add is no longer live.
-        // (Requires `spark.databricks.delta.retentionDurationCheck.enabled =
-        // false` on the sandbox; the sandbox is configured for it.)
+        // Tombstone R's file: a DELETE of exactly R's rows lands a `remove` of
+        // R's `add` in the `_delta_log`, making it not-live. (IcebergCompatV2
+        // is incompatible with deletion vectors, so this is a real copy-on-
+        // write file removal, not a DV — R's `add` is genuinely superseded.)
         warehouse_dyn
-            .execute_statement(&format!("VACUUM {fqtn} RETAIN 0 HOURS"))
+            .execute_statement(&format!(
+                "DELETE FROM {fqtn} WHERE id IN ({seed}01, {seed}02, {seed}03)"
+            ))
             .await
-            .expect("VACUUM must succeed on the sandbox");
+            .expect("DELETE of R's rows must succeed on the sandbox");
 
         let count_before_reuse = count_rows(warehouse_dyn, &fqtn).await;
 
-        // Run 2 — reuse on, but R's file is gone ⇒ the decision's liveness
-        // clause (or the commit-time re-check) fails ⇒ BUILD.
+        // Run 2 — reuse on, but R's file is no longer live ⇒ the decision's
+        // liveness clause fails ⇒ BUILD (never point-to a removed file).
         let ctx = ReuseDecisionCtx {
             input_hash: Some(input_hash),
             state_store: &store,
-            run_id: "run-after-vacuum",
+            run_id: "run-after-remove",
         };
         let summary = execute_content_addressed_model(&model_ir, warehouse_dyn, Some(ctx))
             .await
             .expect("the run must succeed as a BUILD");
         assert!(
             summary.reused_from.is_none(),
-            "with R's file VACUUM'd, the run must BUILD, never point-to a missing file"
+            "with R's file removed, the run must BUILD, never point-to a missing file"
         );
-        // A fresh build wrote 3 rows back.
+        // A fresh build re-materialized R's 3 rows.
         let count_after = count_rows(warehouse_dyn, &fqtn).await;
         assert_eq!(
             count_after,
             count_before_reuse + 3,
-            "the fallback BUILD must re-materialize the 3 rows"
+            "the fallback BUILD must re-materialize R's 3 rows"
         );
     }
 

--- a/engine/crates/rocky-core/src/config.rs
+++ b/engine/crates/rocky-core/src/config.rs
@@ -2214,11 +2214,12 @@ pub struct RockyConfig {
     #[serde(default)]
     pub run: RunConfig,
 
-    /// Opt-in population of the auditable-reuse input-match spine.
-    /// Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and
-    /// cost-identical (no per-model hashing, no extra state write). Dormant
-    /// in Stage 1 even when enabled — it only records the index + provenance,
-    /// it makes no reuse decision. See [`ReuseConfig`].
+    /// Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps
+    /// `rocky run` byte- and cost-identical (no per-model hashing, no extra
+    /// state write). When enabled, an eligible content-addressed model whose
+    /// inputs match a prior strong run may **point-to** that run's parquet
+    /// (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on
+    /// any doubt. See [`ReuseConfig`].
     #[serde(default)]
     pub reuse: ReuseConfig,
 }
@@ -2258,25 +2259,28 @@ pub struct RunConfig {
     pub lag_tolerance_seconds: u64,
 }
 
-/// `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+/// `[reuse]` — opt-in auditable reuse for content-addressed models.
 ///
 /// When `enabled = true`, a successful run records, per model, an input-match
-/// index entry and an offline-verifiable provenance record (the model's
-/// logic key, upstream input identities, output blake3(s), and proof class).
-/// This is the *input* side of reuse — the index that a future reuse
-/// decision will read.
+/// index entry and an offline-verifiable provenance record (the model's logic
+/// key, upstream input identities, output blake3(s), and proof class). That
+/// spine is the *input* side; on a later run, an eligible model whose
+/// recomputed `input_hash` hits the index for a prior **strong** run may
+/// **point-to** that run's already-written parquet — a zero-copy commit that
+/// skips the SQL — provided every clause of the runner's fail-closed reuse
+/// decision holds. Any doubt builds.
 ///
-/// **Dormant by default.** `enabled = false` (the default) keeps `rocky run`
-/// byte- *and* cost-identical to before the spine existed: no extra
-/// normalize+hash work, no extra state write. Even when enabled, Stage 1
-/// only *populates* the spine — it makes no reuse decision and skips nothing.
-/// The spine attests an *input-logic match*, never that re-running a model
-/// would reproduce its output.
+/// **Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte-
+/// *and* cost-identical to before the spine existed: no extra normalize+hash
+/// work, no extra state write, no reuse decision. The point-to path is strong
+/// (byte-identical) only on the content-addressed/UniForm write path;
+/// experimental, opt-in.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ReuseConfig {
-    /// Master switch for input-match spine population. `false` (default) ⇒
-    /// the spine is never written and no per-model hashing cost is paid.
+    /// Master switch for auditable reuse: populates the input-match spine and
+    /// arms the point-to decision. `false` (default) ⇒ the spine is never
+    /// written, no per-model hashing cost is paid, and no model reuses.
     #[serde(default)]
     pub enabled: bool,
 }

--- a/engine/crates/rocky-core/src/reuse.rs
+++ b/engine/crates/rocky-core/src/reuse.rs
@@ -1,5 +1,5 @@
 //! Input-match spine for auditable reuse — warehouse-agnostic, additive,
-//! and **dormant**.
+//! and opt-in.
 //!
 //! This module builds the *input* side of reuse: a pre-execution-style key
 //! that identifies a model build by its **declared inputs** rather than by
@@ -46,14 +46,15 @@
 //! auditable-reuse claim is carried separately by the output blake3 recorded
 //! in the ledger, not by this key.
 //!
-//! ## Dormant in Stage 1
+//! ## Input side only
 //!
-//! Nothing in this module changes run behavior. The index it backs (see
-//! [`crate::state::StateStore`]) is *populated* on a successful run and
-//! *read back* only by a future reuse decision — no skip, point-to, or clone
-//! happens in Stage 1. Population is gated behind the opt-in `[reuse]` config
-//! ([`crate::config::ReuseConfig`]) so the default run path is byte- and
-//! cost-identical to before this module existed.
+//! This module just builds and folds the key; it makes no reuse decision. The
+//! index it backs (see [`crate::state::StateStore`]) is *populated* on a
+//! successful run and *read back* by the runner's fail-closed reuse decision,
+//! which acts on a match by pointing-to a prior run's parquet. Population —
+//! and therefore reuse — is gated behind the opt-in `[reuse]` config
+//! ([`crate::config::ReuseConfig`]); with it off the default run path is byte-
+//! and cost-identical to before this module existed.
 
 use serde::{Deserialize, Serialize};
 

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Regenerated the `rocky_project` Pydantic bindings to pick up the corrected `[reuse]` config descriptions (auditable reuse performs a real zero-copy point-to when enabled, not a no-op). (#860)
+
 ## [1.46.0] — 2026-06-06
 
 ### Added

--- a/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
+++ b/integrations/dagster/src/dagster_rocky/types_generated/rocky_project_schema.py
@@ -1016,11 +1016,11 @@ class RetryConfig(BaseModel):
 
 class ReuseConfig(BaseModel):
     """
-    `[reuse]` — opt-in population of the auditable-reuse input-match spine.
+    `[reuse]` — opt-in auditable reuse for content-addressed models.
 
-    When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.
+    When `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.
 
-    **Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.
+    **Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.
     """
 
     model_config = ConfigDict(
@@ -1028,7 +1028,7 @@ class ReuseConfig(BaseModel):
     )
     enabled: bool | None = False
     """
-    Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.
+    Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.
     """
 
 
@@ -3242,7 +3242,7 @@ class RockyConfig(BaseModel):
     """
     reuse: ReuseConfig | None = Field({"enabled": False}, validate_default=True)
     """
-    Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`].
+    Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`].
     """
     role: dict[str, RoleConfig] | None = Field({}, validate_default=True)
     """

--- a/schemas/rocky_project.schema.json
+++ b/schemas/rocky_project.schema.json
@@ -2780,11 +2780,11 @@
     },
     "ReuseConfig": {
       "additionalProperties": false,
-      "description": "`[reuse]` — opt-in population of the auditable-reuse input-match spine.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). This is the *input* side of reuse — the index that a future reuse decision will read.\n\n**Dormant by default.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write. Even when enabled, Stage 1 only *populates* the spine — it makes no reuse decision and skips nothing. The spine attests an *input-logic match*, never that re-running a model would reproduce its output.",
+      "description": "`[reuse]` — opt-in auditable reuse for content-addressed models.\n\nWhen `enabled = true`, a successful run records, per model, an input-match index entry and an offline-verifiable provenance record (the model's logic key, upstream input identities, output blake3(s), and proof class). That spine is the *input* side; on a later run, an eligible model whose recomputed `input_hash` hits the index for a prior **strong** run may **point-to** that run's already-written parquet — a zero-copy commit that skips the SQL — provided every clause of the runner's fail-closed reuse decision holds. Any doubt builds.\n\n**Default-OFF.** `enabled = false` (the default) keeps `rocky run` byte- *and* cost-identical to before the spine existed: no extra normalize+hash work, no extra state write, no reuse decision. The point-to path is strong (byte-identical) only on the content-addressed/UniForm write path; experimental, opt-in.",
       "properties": {
         "enabled": {
           "default": false,
-          "description": "Master switch for input-match spine population. `false` (default) ⇒ the spine is never written and no per-model hashing cost is paid.",
+          "description": "Master switch for auditable reuse: populates the input-match spine and arms the point-to decision. `false` (default) ⇒ the spine is never written, no per-model hashing cost is paid, and no model reuses.",
           "type": "boolean"
         }
       },
@@ -3864,7 +3864,7 @@
       "default": {
         "enabled": false
       },
-      "description": "Opt-in population of the auditable-reuse input-match spine. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). Dormant in Stage 1 even when enabled — it only records the index + provenance, it makes no reuse decision. See [`ReuseConfig`]."
+      "description": "Opt-in auditable reuse. Default-OFF: an absent `[reuse]` block keeps `rocky run` byte- and cost-identical (no per-model hashing, no extra state write). When enabled, an eligible content-addressed model whose inputs match a prior strong run may **point-to** that run's parquet (zero-copy) instead of re-executing its SQL — fail-closed to BUILD on any doubt. See [`ReuseConfig`]."
     },
     "role": {
       "additionalProperties": {


### PR DESCRIPTION
First increment of the **T1 reuse enable-gate** from the reinvention/DX backlog. Auditable reuse was already wired and active when `[reuse]` is enabled (a verified input-match does a zero-copy point-to and skips the SQL), and live-verified **3/4** — the one un-runnable leg was the fall-back-to-BUILD safety path. This PR greens it to **4/4** and scrubs the stale Stage-1/"dormant" comments that previously misled an audit into reporting reuse as inert.

## What's in this PR

**Test — green the 4th leg (fall-back-to-BUILD when a prior file is no longer live).**
The old `reuse_falls_back_to_build_when_file_vacuumed` was structurally unrunnable:
- `VACUUM <t> RETAIN 0 HOURS` errors unless `delta.retentionDurationCheck.enabled = false` is set on the warehouse — shared, out-of-band state a test must not mutate.
- And it could never make R's *own* file not-live anyway: the UniForm writer is append-only, so `VACUUM` only collects an already-tombstoned predecessor, never the live current version.

Replaced with a self-contained `DELETE` of exactly R's rows, which lands a real `remove` of R's `add` in the `_delta_log` (IcebergCompatV2 rules out deletion vectors, so it's a true copy-on-write removal). `add_path_is_live` then returns false, the decision short-circuits to `Build(NotLive)`, and the run correctly BUILDs instead of pointing at a removed file. Renamed → `reuse_falls_back_to_build_when_file_not_live`.

**Docs — correct stale "Stage-1 / dormant / ONLY-BUILD" comments** across `reuse_decision.rs`, `run_content_addressed.rs`, `run.rs`, `config.rs`, `reuse.rs` (incl. a user-facing log line that said "(dormant)"). They claimed a positive reuse verdict was only *logged* while the SQL still ran; in reality, with `[reuse]` enabled an eligible match performs a real zero-copy point-to. These are the same comments that caused the earlier false "reuse is dormant" reading.

**Codegen** — regenerated `rocky_project.schema.json`, the VS Code project schema + TS bindings, and the Dagster Pydantic bindings to pick up the corrected `[reuse]` descriptions (description-only; no structural change).

## Verification

- **4/4 reuse `#[ignore]` live tests pass** on the Databricks-Iceberg sandbox: `reuse_second_run_points_to_first_no_copy`, `reuse_builds_when_input_hash_differs`, `reuse_falls_back_to_build_when_file_not_live`, and rocky-iceberg `point_to_same_target_is_noop_live_sandbox`.
- The commit-time recovery guards inside `attempt_point_to_reuse` remain unit-covered (`point_to_basename_mismatch_routes_to_build`); the live test exercises the decision-time liveness path. Clean division, no coverage gap.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` (rocky-cli + rocky-core), and the non-ignored reuse unit tests all pass. No `package-lock.json` drift.

## Behavior

Reuse stays **experimental and default-off**. With `[reuse]` unset, `rocky run` is byte- and cost-identical.

## Still open (later T1 increments, not this PR)

- The **offline-verify guide** (the backlog's headline for T1).
- User-facing "how to enable `[reuse]`" docs — the opt-in is confirmed at the schema-description level, but there's no end-user enable guide yet, so the enable-gate isn't fully closed.
- The verifiable dev→prod **env-promotion generalization** (the Iceberg half of T3 folded into T1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)