### PR TITLE
fix(dagster): coalesce tenant-collapsed ops + dedup collapsed materializations

### DIFF
--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`RockyComponent.op_tags`.** Dagster `op_tags` applied to every generated rocky-executing op, so a host can place rocky ops in a Dagster pool and bound how many `rocky run` invocations hit a shared (e.g. pod-local) `.rocky-state.redb` at once. The engine takes an exclusive single-writer lock per state file and fails fast on contention, and run-queue `tag_concurrency_limits` only serialize *across* runs — so this is the host-side knob for cross-run serialization (the complement to the tenant-collapse coalescing below and to `state_namespace`'s per-resource isolation). (#861)
+
 ### Changed
 
 - Regenerated the `rocky_project` Pydantic bindings to pick up the corrected `[reuse]` config descriptions (auditable reuse performs a real zero-copy point-to when enabled, not a no-op). (#860)
+
+### Fixed
+
+- **Tenant-collapse now materialises a tenant in one op.** A collapsed tenant with several connectors previously produced one partitioned `multi_asset` op per `(source_type, non-tenant components)` group, and each op ran the byte-identical full-tenant `rocky run`. Selecting the whole graph in one run fanned them out as parallel ops that collided on the engine's single-writer state lock (`state store … is locked by another process`) and did N× redundant work. The collapse path now builds a single partitioned op that issues one `rocky run` per `(run, partition)` and demuxes the result across all the tenant's collapsed keys. Asset keys are unchanged (materialisation/check history is preserved); the op name changes from `rocky_<connector>` to `rocky_tenant_<partitions_name>`. With `surface_derived_models=True` the source op and derived-model ops can still contend within a run — use the new `op_tags` to pool them. (#861)
+- **Tenant-collapse no longer double-emits when two results fold onto one key.** When a tenant had a duplicate source record for a single `(tenant, table)` (e.g. a dead + live connector replicating the same table), `rocky run` returned two results that remapped to the same collapsed asset key and the op crashed with `DagsterInvariantViolationError` after the copy ran. `_emit_results` now dedups materialisations on emit (first wins, with a warning), mirroring the existing check/anomaly guards. (#861)
 
 ## [1.46.0] — 2026-06-06
 

--- a/integrations/dagster/src/dagster_rocky/component.py
+++ b/integrations/dagster/src/dagster_rocky/component.py
@@ -466,6 +466,23 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
     #:   single source of truth for run events, so running both would
     #:   double-emit.
     execution_mode: Literal["streaming", "pipes"] = "streaming"
+    #: Optional Dagster ``op_tags`` applied to every generated rocky-executing
+    #: op (the source-replication multi-assets and, when surfaced, the
+    #: derived-model multi-assets). The intended use is op-level concurrency:
+    #: each ``rocky run`` opens the engine's single-writer state store
+    #: (``.rocky-state.redb``) for the watermark write and *fails fast* if
+    #: another writer holds the exclusive lock, so two rocky ops executing
+    #: concurrently against the same state file collide. Run-queue
+    #: ``tag_concurrency_limits`` only serialize *across* runs; to bound rocky
+    #: ops within and across runs, place them in a Dagster pool — e.g.
+    #: ``op_tags={"dagster/concurrency_key": "rocky"}`` (or the newer
+    #: ``{"dagster/pool": "rocky"}``) — and cap that pool at 1 in the
+    #: instance's concurrency config. The tenant-collapse path already
+    #: coalesces a run's per-tenant work into one op (see
+    #: :func:`_coalesce_collapsed_groups`), so within-run contention does not
+    #: arise there; this knob covers cross-run contention on a shared (e.g.
+    #: pod-local) state file. Empty (default) sets no tags.
+    op_tags: dict[str, str] = {}
     #: When ``True``, run ``rocky doctor`` at resource startup and fail
     #: fast on critical checks. Forwarded to
     #: :attr:`RockyResource.strict_doctor`. Default ``False`` preserves
@@ -1119,6 +1136,16 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 model_policies,
                 translation=self.translation,
             )
+            # Coalesce all of a tenant's collapsed connector-groups into ONE
+            # partitioned op. Every group derives the same tenant --filter and
+            # runs the byte-identical full-tenant `rocky run`, so running them
+            # as parallel ops in one run (a) collides on the engine's
+            # single-writer state lock and (b) does N× redundant work. One op
+            # issues one `rocky run` per (run, partition) and demuxes the
+            # result across all the tenant's collapsed keys.
+            groups = _coalesce_collapsed_groups(
+                groups, name=f"tenant_{_safe_asset_name(self.tenant.partitions_name)}"
+            )
         else:
             groups = _build_group_contexts(
                 discover,
@@ -1171,6 +1198,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                 execution_mode=self.execution_mode,
                 surface_compliance=self.surface_compliance,
                 surface_retention_status=self.surface_retention_status,
+                op_tags=self.op_tags or None,
             )
             for group in groups
         ]
@@ -1193,6 +1221,7 @@ class RockyComponent(StateBackedComponent, dg.Model, dg.Resolvable):
                         models_dir=self.models_dir,
                         fallback_filter=_first_source_filter(discover),
                         compile_state=compile_state,
+                        op_tags=self.op_tags or None,
                     )
                 )
 
@@ -1697,6 +1726,132 @@ def _build_collapsed_group_contexts(
     return groups
 
 
+def _coalesce_collapsed_groups(
+    groups: list[_GroupBuild],
+    *,
+    name: str,
+) -> list[_GroupBuild]:
+    """Merge every tenant-collapsed group of a location into ONE ``_GroupBuild``.
+
+    :func:`_build_collapsed_group_contexts` keys groups by
+    ``(source_type, non-tenant components)``, so a tenant with several
+    connectors yields several groups — and, left as-is, several Dagster
+    ``multi_asset`` ops. Each op derives the *same* tenant ``--filter``
+    (:func:`_tenant_partition_filters` is group-agnostic) and runs the
+    byte-identical ``rocky run --filter {tenant}={value}`` over the whole
+    tenant, then filters the result down to its own keys. That is doubly
+    wrong against the engine's single-writer state store:
+
+    * **Lock contention** — every op opens ``.rocky-state.redb`` for the
+      watermark write (and the idempotency claim, if keyed); the store takes an
+      exclusive advisory lock and *fails fast* (``StateError::LockHeldByOther``),
+      so concurrent ops in one run collide rather than serialize.
+    * **Redundant work** — N ops re-run the identical full-tenant command, an
+      N× wall-clock and engine-work regression.
+
+    Collapsing them into one op issues exactly one ``rocky run`` per
+    ``(run, partition)`` and demuxes its results across all the tenant's
+    collapsed keys via the merged ``rocky_key_to_dagster_key``. Every
+    collapsed group already shares the tenant ``DynamicPartitionsDefinition``,
+    so the union is a single partitioned op — the natural shape for
+    "one run materialises one tenant".
+
+    The merge is collision-aware:
+
+    * **specs / native-key map** — unioned; a duplicate collapsed spec key or
+      native key (only reachable when two groups' component *values* coincide)
+      keeps the first and warns, mirroring :func:`_build_group_contexts`.
+    * **collapsed_key_by_table** (the new-tenant table-leaf fallback) — table
+      names are NOT unique across connectors, so any name mapping to more than
+      one collapsed key is *ambiguous* and is dropped from the merged fallback
+      (with a warning). The exact ``rocky_key_to_dagster_key`` lookup still
+      resolves every *known* tenant; only a tenant onboarded after the last
+      state refresh AND carrying a cross-connector duplicate table name loses
+      the fallback — and is then dropped by :func:`_emit_results` rather than
+      misattributed, the same fail-safe-over-guess stance as
+      :func:`_build_table_resolver`.
+
+    Returns ``[]`` for an empty input and ``[merged]`` otherwise (always one
+    op on the collapse path, so the op name stays stable as connectors come
+    and go).
+    """
+    if not groups:
+        return []
+
+    merged = _GroupBuild(name=name)
+    merged.partitions_def = groups[0].partitions_def
+    merged.tenant_component = groups[0].tenant_component
+
+    spec_keys: set[dg.AssetKey] = set()
+    # table name → its single collapsed key, or None once a second distinct key
+    # is seen (ambiguous across connectors → excluded from the fallback).
+    table_to_key: dict[str, dg.AssetKey | None] = {}
+
+    for group in groups:
+        merged.source_ids |= group.source_ids
+
+        for spec in group.specs:
+            if spec.key in spec_keys:
+                _log.warning(
+                    "Tenant coalesce: dropping duplicate collapsed spec %s across "
+                    "connectors; the first occurrence wins.",
+                    spec.key.to_user_string(),
+                )
+                continue
+            spec_keys.add(spec.key)
+            merged.specs.append(spec)
+
+        for asset_key, source_id in group.key_to_source_id.items():
+            merged.key_to_source_id.setdefault(asset_key, source_id)
+
+        for native_key, dagster_key in group.rocky_key_to_dagster_key.items():
+            existing = merged.rocky_key_to_dagster_key.get(native_key)
+            if existing is not None and existing != dagster_key:
+                _log.warning(
+                    "Tenant coalesce: native key %s maps to multiple collapsed keys "
+                    "across connectors (%s, %s); keeping the first.",
+                    native_key,
+                    existing.to_user_string(),
+                    dagster_key.to_user_string(),
+                )
+                continue
+            merged.rocky_key_to_dagster_key[native_key] = dagster_key
+
+        for partition_key, filter_value in group.partition_key_to_filter_value.items():
+            existing_value = merged.partition_key_to_filter_value.get(partition_key)
+            if existing_value is not None and existing_value != filter_value:
+                _log.warning(
+                    "Tenant coalesce: partition key %r maps to multiple filter values "
+                    "across connectors (%r, %r); keeping the first.",
+                    partition_key,
+                    existing_value,
+                    filter_value,
+                )
+                continue
+            merged.partition_key_to_filter_value[partition_key] = filter_value
+
+        for table_name, collapsed_key in group.collapsed_key_by_table.items():
+            if table_name not in table_to_key:
+                table_to_key[table_name] = collapsed_key
+            elif table_to_key[table_name] != collapsed_key:
+                table_to_key[table_name] = None  # ambiguous across connectors
+
+    merged.collapsed_key_by_table = {t: k for t, k in table_to_key.items() if k is not None}
+    ambiguous = sorted(t for t, k in table_to_key.items() if k is None)
+    if ambiguous:
+        _log.warning(
+            "Tenant coalesce: table name(s) %s map to more than one collapsed key "
+            "across connectors; excluded from the new-tenant table-leaf fallback. "
+            "Known tenants resolve via the exact native-key map; a tenant onboarded "
+            "after the last state refresh carrying one of these table names will be "
+            "dropped by _emit_results rather than misattributed. Refresh discover "
+            "state to register it.",
+            ambiguous,
+        )
+
+    return [merged]
+
+
 def _build_asset_spec(
     source: SourceInfo,
     table: TableInfo,
@@ -1879,6 +2034,7 @@ def _make_derived_model_asset(
     models_dir: str,
     fallback_filter: str,
     compile_state: _CompileState,
+    op_tags: dict[str, str] | None = None,
 ) -> dg.AssetsDefinition:
     """Build a multi-asset that runs every derived model in a partition shape group.
 
@@ -1907,6 +2063,7 @@ def _make_derived_model_asset(
         specs=group.specs,
         can_subset=False,
         partitions_def=group.partitions_def,
+        op_tags=op_tags,
     )
     def _asset(context):
         _log_compile_diagnostics(context, compile_state)
@@ -2002,6 +2159,7 @@ def _make_rocky_asset(
     execution_mode: Literal["streaming", "pipes"] = "streaming",
     surface_compliance: bool = False,
     surface_retention_status: bool = False,
+    op_tags: dict[str, str] | None = None,
 ) -> dg.AssetsDefinition:
     """Create a multi-asset that executes ``rocky run`` for one group.
 
@@ -2035,6 +2193,7 @@ def _make_rocky_asset(
         check_specs=check_specs,
         can_subset=True,
         partitions_def=group.partitions_def,
+        op_tags=op_tags,
     )
     def _asset(context):
         _log_compile_diagnostics(context, compile_state)
@@ -2188,10 +2347,30 @@ def _run_filters_pipes(
         key = rocky_key_to_dagster_key.get(tuple(path))
         if key is not None:
             return key
+        # Last-segment fallback — but only when unambiguous. After the tenant
+        # coalesce the map spans connectors, so a bare table name can match
+        # several collapsed keys; returning an arbitrary dict-iteration winner
+        # would misattribute the event (and Pipes' ``include_keys`` can't catch
+        # it, since the wrong key is also selected). Distinct native keys that
+        # fold onto the *same* collapsed key stay unambiguous (set of one).
+        # Mirror :func:`_build_table_resolver`: refuse to guess.
         last = path[-1]
-        for tup, candidate in rocky_key_to_dagster_key.items():
-            if tup and tup[-1] == last:
-                return candidate
+        candidates = {
+            candidate
+            for tup, candidate in rocky_key_to_dagster_key.items()
+            if tup and tup[-1] == last
+        }
+        if len(candidates) == 1:
+            return next(iter(candidates))
+        if len(candidates) > 1:
+            _log.warning(
+                "Ambiguous Rocky table identifier %r in a pipes event: matched %d "
+                "collapsed keys via the last-segment fallback. Refusing to guess; "
+                "dropping the event. Emit the schema- or catalog-qualified form to "
+                "resolve deterministically.",
+                "/".join(path),
+                len(candidates),
+            )
         return None
 
     for f in filters:
@@ -2554,6 +2733,28 @@ def _emit_results(
     for mat in materializations:
         asset_key = remap(mat.asset_key)
         if asset_key not in selected_keys:
+            continue
+        if asset_key in materialized_keys:
+            # Two engine results remapped to the same Dagster key in one op.
+            # The tenant-collapse fold (every member's with-tenant native key
+            # → one collapsed key) makes this reachable whenever a tenant has
+            # duplicate source records for a single (tenant, table) — e.g. a
+            # dead + live Fivetran connector both replicating the same table.
+            # Dagster rejects a second MaterializeResult for the same key with
+            # DagsterInvariantViolationError, so dedup on emit, mirroring the
+            # yielded_checks / anomaly guards below. Safe at run time: only one
+            # partition's tenant is active per run, so each collapsed key has
+            # exactly one legitimate result and any repeat is a true duplicate
+            # — this does NOT re-introduce the build-time N-sources→1-spec fold
+            # the collapse path deliberately keeps (that is a spec-dedup axis,
+            # not a run-time emission one).
+            _log.warning(
+                "Skipping duplicate MaterializeResult for %s — two Rocky results "
+                "mapped to the same asset key in this op (likely a duplicate "
+                "source record for one collapsed (tenant, table)); the first "
+                "occurrence wins.",
+                asset_key.to_user_string(),
+            )
             continue
         materialized_keys.add(asset_key)
         # Emit BOTH the rocky-namespaced metadata (via RockyMetadataSet) AND

--- a/integrations/dagster/tests/test_emit_results_dedup.py
+++ b/integrations/dagster/tests/test_emit_results_dedup.py
@@ -234,3 +234,117 @@ def test_emit_results_dedupes_same_key_table_check():
         e for e in events if isinstance(e, dg.AssetCheckResult) and e.check_name == "row_count"
     ]
     assert len(row_count_results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Part C — _emit_results materialization dedup-on-yield (tenant collapse)
+# ---------------------------------------------------------------------------
+
+
+def _run_result_with_materializations(materializations: list[dict]) -> RunResult:
+    return RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=acme",
+            "duration_ms": 100,
+            "tables_copied": len(materializations),
+            "tables_failed": 0,
+            "materializations": materializations,
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 0, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+
+def test_emit_results_dedupes_same_key_materialization(caplog):
+    """Two engine results that remap to the same collapsed key materialize once.
+
+    The tenant-collapse fold maps every member's with-tenant native key to one
+    collapsed key, so a tenant with a duplicate source record for a single
+    (tenant, table) — e.g. a dead + live Fivetran connector replicating the
+    same table — yields two RunResult materializations whose remapped key
+    collides. Without dedup, Dagster rejects the second MaterializeResult with
+    ``DagsterInvariantViolationError`` after the copy already ran.
+    """
+    collapsed = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    # Two distinct engine-native keys (live + dead connector) → one collapsed key.
+    mapping = {
+        ("fivetran", "acme", "usa", "facebookads", "orders"): collapsed,
+        ("fivetran", "acme_dead", "usa", "facebookads", "orders"): collapsed,
+    }
+    run_result = _run_result_with_materializations(
+        [
+            {
+                "asset_key": ["fivetran", "acme", "usa", "facebookads", "orders"],
+                "rows_copied": 10,
+                "duration_ms": 50,
+                "metadata": {"strategy": "full_refresh"},
+            },
+            {
+                "asset_key": ["fivetran", "acme_dead", "usa", "facebookads", "orders"],
+                "rows_copied": 7,
+                "duration_ms": 30,
+                "metadata": {"strategy": "full_refresh"},
+            },
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        events = list(
+            _emit_results(
+                results=[run_result],
+                check_specs=[],
+                selected_keys={collapsed},
+                rocky_key_to_dagster_key=mapping,
+            )
+        )
+
+    mats = [e for e in events if isinstance(e, dg.MaterializeResult)]
+    assert len(mats) == 1
+    assert mats[0].asset_key == collapsed
+    assert any("duplicate MaterializeResult" in r.message for r in caplog.records)
+
+
+def test_emit_results_materialization_yields_when_unique():
+    """Regression: the materialization dedup guard doesn't suppress distinct keys."""
+    orders = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    leads = dg.AssetKey(["fivetran", "usa", "googleads", "leads"])
+    mapping = {
+        ("fivetran", "acme", "usa", "facebookads", "orders"): orders,
+        ("fivetran", "acme", "usa", "googleads", "leads"): leads,
+    }
+    run_result = _run_result_with_materializations(
+        [
+            {
+                "asset_key": ["fivetran", "acme", "usa", "facebookads", "orders"],
+                "rows_copied": 10,
+                "duration_ms": 50,
+                "metadata": {"strategy": "full_refresh"},
+            },
+            {
+                "asset_key": ["fivetran", "acme", "usa", "googleads", "leads"],
+                "rows_copied": 5,
+                "duration_ms": 20,
+                "metadata": {"strategy": "full_refresh"},
+            },
+        ]
+    )
+
+    events = list(
+        _emit_results(
+            results=[run_result],
+            check_specs=[],
+            selected_keys={orders, leads},
+            rocky_key_to_dagster_key=mapping,
+        )
+    )
+
+    mat_keys = {e.asset_key for e in events if isinstance(e, dg.MaterializeResult)}
+    assert mat_keys == {orders, leads}

--- a/integrations/dagster/tests/test_pipes_mode.py
+++ b/integrations/dagster/tests/test_pipes_mode.py
@@ -429,6 +429,51 @@ def test_run_filters_pipes_falls_back_to_last_segment_for_drift_events():
     assert fn(["orders"]) == dagster_key
 
 
+def test_run_filters_pipes_last_segment_ambiguous_across_connectors_drops(caplog):
+    """After the tenant coalesce the merged map spans connectors, so a bare
+    table name can match several collapsed keys. The pipes asset_key_fn must
+    refuse to guess (return None) rather than misattribute — mirroring the
+    streaming-path table-leaf guard."""
+    import logging
+
+    from dagster_rocky.component import _GroupBuild, _run_filters_pipes
+
+    fb = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    gg = dg.AssetKey(["fivetran", "usa", "googleads", "orders"])
+    # Two connectors, same table leaf "orders", DISTINCT collapsed keys.
+    group = _GroupBuild(
+        name="tenant_clients",
+        rocky_key_to_dagster_key={
+            ("fivetran", "coca_cola", "usa", "facebookads", "orders"): fb,
+            ("fivetran", "coca_cola", "usa", "googleads", "orders"): gg,
+        },
+    )
+    context = MagicMock(spec=dg.AssetExecutionContext)
+    context.log = MagicMock()
+    rocky = MagicMock(spec=RockyResource)
+    fake_invocation = MagicMock()
+    fake_invocation.get_results = MagicMock(return_value=iter([]))
+    rocky.run_pipes = MagicMock(return_value=fake_invocation)
+
+    list(
+        _run_filters_pipes(
+            context=context,
+            rocky=rocky,
+            filters=["client=coca_cola"],
+            group=group,
+            selected_keys={fb, gg},
+        )
+    )
+
+    fn = rocky.run_pipes.call_args.kwargs["asset_key_fn"]
+    # Exact native keys still resolve deterministically.
+    assert fn(["fivetran", "coca_cola", "usa", "facebookads", "orders"]) == fb
+    # Bare ambiguous leaf → refuse to guess + warn.
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        assert fn(["orders"]) is None
+    assert any("Ambiguous Rocky table identifier" in r.message for r in caplog.records)
+
+
 def test_run_filters_pipes_yields_get_results_unchanged():
     """The asset body yields whatever `.get_results()` produces — the
     wrapper is pure plumbing, not a transform."""

--- a/integrations/dagster/tests/test_tenant_partition.py
+++ b/integrations/dagster/tests/test_tenant_partition.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import dagster as dg
 import pytest
@@ -28,6 +28,7 @@ from dagster_rocky.component import (
     _build_check_specs,
     _build_collapsed_group_contexts,
     _build_group_contexts,
+    _coalesce_collapsed_groups,
     _CompileState,
     _make_rocky_asset,
     _tenant_partition_filters,
@@ -723,3 +724,226 @@ def test_sensor_tenant_mode_requires_both_args():
         )
     # Both unset is fine (default non-tenant sensor).
     assert rocky_source_sensor(rocky_resource=rocky, target=target) is not None
+
+
+# --------------------------------------------------------------------------- #
+# Coalesce: a tenant's collapsed connector-groups → ONE op (Gap 1)
+# --------------------------------------------------------------------------- #
+
+
+def _connector(client: str, source: str, tables: list[str]) -> SourceInfo:
+    return SourceInfo(
+        id=f"{client}_{source}",
+        source_type="fivetran",
+        components={"client": client, "region": "usa", "source": source},
+        tables=[TableInfo(name=t) for t in tables],
+    )
+
+
+def test_coalesce_merges_connectors_into_one_group():
+    """The builder still returns one group per connector; coalesce folds them
+    into a single ``_GroupBuild`` so the location materialises as one op."""
+    discover = _discover(
+        _connector("coca_cola", "facebookads", ["orders"]),
+        _connector("coca_cola", "googleads", ["leads"]),
+    )
+    groups, _ = _collapse(discover)
+    assert len(groups) == 2  # one per (source_type, non-tenant) connector group
+
+    merged = _coalesce_collapsed_groups(groups, name="tenant_rocky_clients")
+    assert len(merged) == 1
+    m = merged[0]
+    assert m.name == "tenant_rocky_clients"
+    assert {s.key.to_user_string() for s in m.specs} == {
+        "fivetran/usa/facebookads/orders",
+        "fivetran/usa/googleads/leads",
+    }
+    # Every connector's with-tenant native key remaps to its collapsed key.
+    assert m.rocky_key_to_dagster_key[
+        ("fivetran", "coca_cola", "usa", "facebookads", "orders")
+    ] == dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    assert m.rocky_key_to_dagster_key[
+        ("fivetran", "coca_cola", "usa", "googleads", "leads")
+    ] == dg.AssetKey(["fivetran", "usa", "googleads", "leads"])
+    # Partition mapping + tenant metadata carried over; distinct table names
+    # both keep their new-tenant fallback entry.
+    assert m.partition_key_to_filter_value == {"coca_cola": "coca_cola"}
+    assert m.tenant_component == "client"
+    assert m.partitions_def is not None
+    assert set(m.collapsed_key_by_table) == {"orders", "leads"}
+
+
+def test_coalesce_empty_returns_empty():
+    assert _coalesce_collapsed_groups([], name="t") == []
+
+
+def test_coalesce_excludes_ambiguous_table_from_fallback(caplog):
+    """Two connectors sharing a table NAME map it to two distinct collapsed
+    keys → the name is ambiguous and dropped from the new-tenant table-leaf
+    fallback, but both KNOWN tenants still resolve via the exact native map."""
+    discover = _discover(
+        _connector("coca_cola", "facebookads", ["orders"]),
+        _connector("coca_cola", "googleads", ["orders"]),
+    )
+    groups, _ = _collapse(discover)
+    with caplog.at_level(logging.WARNING, logger="dagster_rocky.component"):
+        merged = _coalesce_collapsed_groups(groups, name="t")[0]
+
+    # Ambiguous "orders" excluded from the leaf fallback + warned.
+    assert "orders" not in merged.collapsed_key_by_table
+    assert any("more than one collapsed key" in r.message for r in caplog.records)
+    # Exact native-key lookup still resolves both connectors unambiguously.
+    assert merged.rocky_key_to_dagster_key[
+        ("fivetran", "coca_cola", "usa", "facebookads", "orders")
+    ] == dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    assert merged.rocky_key_to_dagster_key[
+        ("fivetran", "coca_cola", "usa", "googleads", "orders")
+    ] == dg.AssetKey(["fivetran", "usa", "googleads", "orders"])
+
+
+def _two_connector_state(tmp_path):
+    discover = {
+        "version": "0.3.0",
+        "command": "discover",
+        "sources": [
+            {
+                "id": "cc_fb",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": "facebookads"},
+                "tables": [{"name": "orders"}],
+            },
+            {
+                "id": "cc_gg",
+                "source_type": "fivetran",
+                "components": {"client": "coca_cola", "region": "usa", "source": "googleads"},
+                "tables": [{"name": "leads"}],
+            },
+        ],
+    }
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"discover": discover}))
+    return state_file
+
+
+def test_coalesce_runs_rocky_once_and_demuxes_across_connectors(tmp_path):
+    """End-to-end: a two-connector tenant builds ONE op that issues a single
+    ``rocky run`` per (run, partition) and demuxes the result across both
+    collapsed keys — fixing the lock contention + N× redundant-work regression.
+    """
+    state_file = _two_connector_state(tmp_path)
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+
+    # Coalesced: exactly ONE rocky multi-asset for the whole tenant.
+    assert len(asset_defs) == 1
+    fb = dg.AssetKey(["fivetran", "usa", "facebookads", "orders"])
+    gg = dg.AssetKey(["fivetran", "usa", "googleads", "leads"])
+    assert {fb, gg} <= {k for a in asset_defs for k in a.keys}
+
+    # One engine run returns materializations for BOTH connectors' tables,
+    # keyed WITH the tenant (as the engine emits them).
+    run_result = RunResult.model_validate(
+        {
+            "version": "0.3.0",
+            "command": "run",
+            "filter": "client=coca_cola",
+            "duration_ms": 100,
+            "tables_copied": 2,
+            "tables_failed": 0,
+            "materializations": [
+                {
+                    "asset_key": ["fivetran", "coca_cola", "usa", "facebookads", "orders"],
+                    "rows_copied": 10,
+                    "duration_ms": 50,
+                    "metadata": {"strategy": "full_refresh"},
+                },
+                {
+                    "asset_key": ["fivetran", "coca_cola", "usa", "googleads", "leads"],
+                    "rows_copied": 5,
+                    "duration_ms": 20,
+                    "metadata": {"strategy": "full_refresh"},
+                },
+            ],
+            "check_results": [],
+            "permissions": {
+                "grants_added": 0,
+                "grants_revoked": 0,
+                "catalogs_created": 0,
+                "schemas_created": 0,
+            },
+            "drift": {"tables_checked": 2, "tables_drifted": 0, "actions_taken": []},
+        }
+    )
+
+    instance = dg.DagsterInstance.ephemeral()
+    instance.add_dynamic_partitions("rocky_clients", ["coca_cola"])
+
+    mock_run = MagicMock(return_value=run_result)
+    with (
+        patch.object(RockyResource, "run_streaming", mock_run),
+        patch.object(RockyResource, "run", return_value=run_result),
+    ):
+        result = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[fb, gg],
+            partition_key="coca_cola",
+            instance=instance,
+            raise_on_error=False,
+        )
+
+    assert result.success
+    # The whole tenant ran in ONE `rocky run` — not one per connector.
+    assert mock_run.call_count == 1
+    mat_keys = {e.asset_key for e in result.get_asset_materialization_events()}
+    assert mat_keys == {fb, gg}
+
+    # Subset selection still works on the coalesced op (can_subset=True): pick
+    # one connector's table → one tenant run, only the selected key emitted.
+    mock_run_subset = MagicMock(return_value=run_result)
+    with (
+        patch.object(RockyResource, "run_streaming", mock_run_subset),
+        patch.object(RockyResource, "run", return_value=run_result),
+    ):
+        subset = dg.materialize(
+            asset_defs,
+            resources={"rocky": RockyResource(config_path="rocky.toml")},
+            selection=[fb],
+            partition_key="coca_cola",
+            instance=instance,
+            raise_on_error=False,
+        )
+    assert subset.success
+    assert mock_run_subset.call_count == 1
+    assert {e.asset_key for e in subset.get_asset_materialization_events()} == {fb}
+
+
+def test_op_tags_threaded_to_collapsed_op(tmp_path):
+    """``RockyComponent.op_tags`` reaches the generated multi-asset op so the
+    host can place rocky ops in a concurrency pool."""
+    state_file = _two_connector_state(tmp_path)
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+        op_tags={"dagster/concurrency_key": "rocky"},
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    assert len(asset_defs) == 1
+    assert asset_defs[0].op.tags.get("dagster/concurrency_key") == "rocky"
+
+
+def test_op_tags_absent_by_default(tmp_path):
+    """No op_tags set → no concurrency-key tag injected (zero behaviour change)."""
+    state_file = _two_connector_state(tmp_path)
+    component = RockyComponent(
+        config_path="rocky.toml",
+        tenant=TenantConfig(component="client", partitions_name="rocky_clients"),
+    )
+    defs = component.build_defs_from_state(context=None, state_path=state_file)
+    asset_defs = [a for a in (defs.assets or []) if isinstance(a, dg.AssetsDefinition)]
+    assert "dagster/concurrency_key" not in asset_defs[0].op.tags


### PR DESCRIPTION
Follow-up to the tenant-as-partition collapse (#858). The collapse **builds** correctly; these are two execution-time gaps in **running** the collapsed graph — both hard step failures that surface only at run time (`rocky validate` / code-location load are clean), against an engine whose state store is a single-writer file.

## Gap 1 — collapsed ops contended on the single-writer state store

The collapse keyed groups by `(source_type, non-tenant components)`, so a tenant with several connectors produced **one partitioned `multi_asset` op per connector-group**. Each op derived the *same* tenant `--filter` (it's group-agnostic) and ran the **byte-identical** full-tenant `rocky run`. A run that selected the whole graph fanned them out as parallel ops that each opened `.rocky-state.redb`; the engine takes an exclusive single-writer lock and **fails fast**, so all but one collided:

```
rocky: Error: state store at .rocky-state.redb is locked by another process;
only one rocky writer can run at a time against the same state file
```

It was also an N× wall-clock / engine-work regression (N identical full-tenant runs).

**Fix:** `_coalesce_collapsed_groups` merges a tenant's collapsed groups into **one** partitioned op that issues a single `rocky run` per `(run, partition)` and demuxes the result across all the tenant's collapsed keys. `_build_collapsed_group_contexts` still returns per-connector groups (so its maps stay unambiguous and its unit tests are unchanged) — coalescing is a separate transform in the build path. The merge is collision-safe: an ambiguous cross-connector table name is dropped from the new-tenant table-leaf fallback (and the symmetric Pipes `asset_key_fn` fallback) rather than misattributed, mirroring `_build_table_resolver`.

## Gap 2 — collapse path double-emitted when two results folded onto one key

When a tenant had a duplicate source record for a single `(tenant, table)` (e.g. a dead + live connector replicating the same table), `rocky run` returned two results that remapped to the same collapsed asset key. `_emit_results` built a `materialized_keys` set but never consulted it before yielding (unlike the check/anomaly loops), so the second `MaterializeResult` tripped `DagsterInvariantViolationError` after the copy already ran.

**Fix:** the materialization loop now dedups on emit (first wins, with a warning), mirroring the existing `yielded_checks` / anomaly guards. Safe at run time — only one partition's tenant is active per run, so any repeat is a true duplicate; it does not re-introduce the build-time N-sources→1-spec fold the collapse path deliberately keeps.

## Also: `RockyComponent.op_tags`

A new `op_tags` field, threaded to every rocky-executing op, so a host can place rocky ops in a Dagster pool and bound how many `rocky run` invocations hit a shared (e.g. pod-local) state file. Run-queue `tag_concurrency_limits` only serialize *across* runs and don't reach ops *within* a run; this is the host-side knob for cross-run serialization (the complement to coalescing's within-run fix and to `state_namespace`'s per-resource isolation). With `surface_derived_models=True` the source op and derived-model ops can still contend within a run — `op_tags` is how you pool them.

## Behavior notes

- Asset keys are unchanged, so materialization / check history is preserved. The collapsed op's **name** changes from `rocky_<connector>` to `rocky_tenant_<partitions_name>` (stable as connectors come and go).

## Tests

- `test_emit_results_dedup.py`: materialization dedup (Gap 2) + a uniqueness regression guard.
- `test_tenant_partition.py`: coalesce merges connectors into one group; ambiguous-table fallback exclusion; end-to-end one-`rocky run`-per-partition demux (asserts a single invocation) + subset selection; `op_tags` threading.
- `test_pipes_mode.py`: Pipes `asset_key_fn` last-segment ambiguity guard.

Full dagster suite green (629 passed); ruff check + format clean. Dagster-only change — no engine/codegen surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)