### PR TITLE
chore(release): triple-cut engine 1.50.1 / dagster 1.46.1 / vscode 1.32.1

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.1] — 2026-06-06
+
 ### Changed
 
 - Regenerated the `rocky-project` schema + TypeScript bindings to pick up the corrected `[reuse]` config descriptions (auditable reuse performs a real zero-copy point-to when enabled, not a no-op). (#860)

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rocky",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rocky",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "rocky",
   "displayName": "Rocky",
   "description": "Language support for Rocky SQL transformation engine",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "publisher": "rocky-data",
   "license": "Apache-2.0",
   "repository": {

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.50.1] — 2026-06-06
+
 ### Changed
 
 - **Auditable reuse is now live-verified end-to-end (4/4) on Databricks-Iceberg.** The fail-closed *fall-back-to-BUILD when a prior run's file is no longer live* safety path — previously the one un-runnable leg of the reuse live suite — is now exercised by a self-contained live test. It tombstones the prior run's file with a `DELETE` of that run's rows (the append-only UniForm writer never lets `VACUUM RETAIN 0 HOURS` remove the live current version, and the test refuses to mutate shared warehouse config), so `add_path_is_live` returns false and the run correctly builds instead of pointing at a removed file. Reuse stays **experimental and default-off**; with `[reuse]` unset, `rocky run` is byte- and cost-identical. (#860)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rocky"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-adapter-sdk"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ai"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "indexmap",
  "reqwest 0.12.28",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-airbyte"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-bigquery"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cache"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "redis",
  "serde",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-catalog-core"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-cli"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-compiler"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-core"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-databricks"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-duckdb"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-engine"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-fivetran"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-iceberg"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-ir"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lang"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "logos",
  "miette",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-lsp"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "rocky-server",
  "rustls",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-mcp"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-observe"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-server"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-snowflake"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-sql"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "miette",
  "regex",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-trino"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rocky-wasm"
-version = "1.50.0"
+version = "1.50.1"
 dependencies = [
  "rocky-lang",
  "rocky-sql",

--- a/engine/crates/rocky-adapter-sdk/Cargo.toml
+++ b/engine/crates/rocky-adapter-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-adapter-sdk"
-version = "1.50.0"
+version = "1.50.1"
 description = "Adapter SDK for Rocky — stable traits, process protocol, and conformance harness"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ai/Cargo.toml
+++ b/engine/crates/rocky-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ai"
-version = "1.50.0"
+version = "1.50.1"
 description = "AI intent layer for Rocky: natural language to model generation"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-airbyte/Cargo.toml
+++ b/engine/crates/rocky-airbyte/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-airbyte"
-version = "1.50.0"
+version = "1.50.1"
 description = "Airbyte source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-bigquery/Cargo.toml
+++ b/engine/crates/rocky-bigquery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-bigquery"
-version = "1.50.0"
+version = "1.50.1"
 description = "BigQuery warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cache/Cargo.toml
+++ b/engine/crates/rocky-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cache"
-version = "1.50.0"
+version = "1.50.1"
 description = "Caching layer for Rocky (memory LRU + distributed cache)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-catalog-core/Cargo.toml
+++ b/engine/crates/rocky-catalog-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-catalog-core"
-version = "1.50.0"
+version = "1.50.1"
 description = "Catalog client abstraction for Rocky (Iceberg REST, Unity Catalog, Polaris, Nessie)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-cli/Cargo.toml
+++ b/engine/crates/rocky-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-cli"
-version = "1.50.0"
+version = "1.50.1"
 description = "CLI framework for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-compiler/Cargo.toml
+++ b/engine/crates/rocky-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-compiler"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rocky SQL compiler: dependency resolution, semantic analysis, type checking, contracts"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-core/Cargo.toml
+++ b/engine/crates/rocky-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-core"
-version = "1.50.0"
+version = "1.50.1"
 description = "Core SQL transformation engine for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-databricks/Cargo.toml
+++ b/engine/crates/rocky-databricks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-databricks"
-version = "1.50.0"
+version = "1.50.1"
 description = "Databricks warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-duckdb/Cargo.toml
+++ b/engine/crates/rocky-duckdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-duckdb"
-version = "1.50.0"
+version = "1.50.1"
 description = "DuckDB local execution adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-engine/Cargo.toml
+++ b/engine/crates/rocky-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-engine"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rocky local execution engine: DataFusion-based testing, branching, CI"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-fivetran/Cargo.toml
+++ b/engine/crates/rocky-fivetran/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-fivetran"
-version = "1.50.0"
+version = "1.50.1"
 description = "Fivetran source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-iceberg/Cargo.toml
+++ b/engine/crates/rocky-iceberg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-iceberg"
-version = "1.50.0"
+version = "1.50.1"
 description = "Apache Iceberg source adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-ir/Cargo.toml
+++ b/engine/crates/rocky-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-ir"
-version = "1.50.0"
+version = "1.50.1"
 description = "Typed intermediate representation (IR) for Rocky transformation pipelines"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-lang/Cargo.toml
+++ b/engine/crates/rocky-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lang"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rocky DSL: pipeline-oriented language for SQL transformations"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-mcp/Cargo.toml
+++ b/engine/crates/rocky-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-mcp"
-version = "1.50.0"
+version = "1.50.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/engine/crates/rocky-observe/Cargo.toml
+++ b/engine/crates/rocky-observe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-observe"
-version = "1.50.0"
+version = "1.50.1"
 description = "Observability for Rocky (structured logging, metrics, events)"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-server/Cargo.toml
+++ b/engine/crates/rocky-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-server"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rocky HTTP API server and LSP for IDE integration"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-snowflake/Cargo.toml
+++ b/engine/crates/rocky-snowflake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-snowflake"
-version = "1.50.0"
+version = "1.50.1"
 description = "Snowflake warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-sql/Cargo.toml
+++ b/engine/crates/rocky-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-sql"
-version = "1.50.0"
+version = "1.50.1"
 description = "SQL parsing, validation, and dialect support for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-trino/Cargo.toml
+++ b/engine/crates/rocky-trino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-trino"
-version = "1.50.0"
+version = "1.50.1"
 description = "Trino warehouse adapter for Rocky"
 edition.workspace = true
 license.workspace = true

--- a/engine/crates/rocky-wasm/Cargo.toml
+++ b/engine/crates/rocky-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-wasm"
-version = "1.50.0"
+version = "1.50.1"
 description = "WASM bindings for Rocky's pure-Rust compiler pipeline"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky-lsp/Cargo.toml
+++ b/engine/rocky-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky-lsp"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rocky Language Server Protocol binary (minimal, adapter-free)"
 edition.workspace = true
 license.workspace = true

--- a/engine/rocky/Cargo.toml
+++ b/engine/rocky/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocky"
-version = "1.50.0"
+version = "1.50.1"
 description = "Rust SQL transformation engine"
 edition.workspace = true
 license.workspace = true

--- a/integrations/dagster/CHANGELOG.md
+++ b/integrations/dagster/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.46.1] — 2026-06-06
+
 ### Added
 
 - **`RockyComponent.op_tags`.** Dagster `op_tags` applied to every generated rocky-executing op, so a host can place rocky ops in a Dagster pool and bound how many `rocky run` invocations hit a shared (e.g. pod-local) `.rocky-state.redb` at once. The engine takes an exclusive single-writer lock per state file and fails fast on contention, and run-queue `tag_concurrency_limits` only serialize *across* runs — so this is the host-side knob for cross-run serialization (the complement to the tenant-collapse coalescing below and to `state_namespace`'s per-resource isolation). (#861)

--- a/integrations/dagster/pyproject.toml
+++ b/integrations/dagster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dagster-rocky"
-version = "1.46.0"
+version = "1.46.1"
 description = "Dagster integration for the Rocky SQL transformation engine"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Consolidated triple-cut. All three artifacts had unreleased work on `main` since the last tags (engine-v1.50.0 / dagster-v1.46.0 / vscode-v1.32.0); shipping together keeps the regenerated `[reuse]` bindings in lockstep with the engine schema descriptions that produced them.

## engine 1.50.0 → 1.50.1
- Auditable reuse fall-back-to-BUILD now live-verified 4/4 on Databricks-Iceberg; corrected stale "dormant"/"no-op" `[reuse]` doc-comments + `rocky-project.schema.json` descriptions (#860). Reuse stays experimental/default-off — `rocky run` is byte- and cost-identical with `[reuse]` unset.

## dagster 1.46.0 → 1.46.1
- **Tenant-collapse execution-gaps fix (#861):** coalesce a tenant's N connector-ops into one partitioned op (one `rocky run` per `(run, partition)`) — kills the single-writer state-lock contention + N× redundant work; dedup collapsed materializations on emit (no more `DagsterInvariantViolationError` from a duplicate/dead-connector source record); new `RockyComponent.op_tags` for cross-run pool serialization.
- Regenerated `[reuse]` Pydantic bindings (#860).

## vscode 1.32.0 → 1.32.1
- Regenerated `rocky-project` schema + TypeScript bindings for the corrected `[reuse]` descriptions (#860).

## Mechanics
- 25 engine crate versions + `Cargo.lock` synced; `pyproject.toml`; `package.json` + `package-lock.json` (root only). CHANGELOGs rolled `[Unreleased]` → versioned (2026-06-06).
- Tag after merge: `engine-v1.50.1`, `dagster-v1.46.1`, `vscode-v1.32.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)